### PR TITLE
fix(#1940): Test-Fixtures verweigern laut, statt still das Falsche zu liefern

### DIFF
--- a/docs/context/fix-1940-fixture-zeitkippkante.md
+++ b/docs/context/fix-1940-fixture-zeitkippkante.md
@@ -1,0 +1,116 @@
+# Context: fix-1940-fixture-zeitkippkante
+
+Issue: #1940 — CI-Job `test` schlaegt taeglich 12:00–13:30 UTC fehl (Zeitkippkante in
+`arrival_window_fixtures`). Track: Standard.
+
+## Request Summary
+
+Der gemeinsame Test-Hilfsbaustein `tests/helpers/arrival_window_fixtures.py` verschiebt ein
+Ankunftsfenster still nach vorne, wenn der lokale Etappentag noch nicht weit genug
+fortgeschritten ist. Dadurch liegt ein Wegpunkt, den der Aufrufer ausdruecklich in die
+Vergangenheit gelegt hat, in Wahrheit in der Zukunft — die zugesicherte Segment-Konstellation
+kippt und die CI-Ampel wird taeglich rot, unabhaengig vom PR-Inhalt.
+
+## Der Mechanismus, nachgerechnet (nicht vermutet)
+
+`fenster_minuten(minuten_jetzt, *offsets_min)` (`tests/helpers/arrival_window_fixtures.py:99`)
+schiebt bei `roh[0] < 0` das GANZE Fenster nach vorne (`verschiebung = max(0, -roh[0])`,
+Zeile 144). Die Verschiebung erhaelt die Abstaende, aber **nicht das Vorzeichen** der
+gewuenschten Versaetze.
+
+Gemessen ueber alle 1440 Ortsminuten je Offset-Familie — Kriterium: „jeder negativ gewuenschte
+Wegpunkt muss bei/vor *jetzt* liegen":
+
+| Offset-Familie | Aufrufer | kaputte Ortsminuten | UTC-Fenster |
+|---|---|---|---|
+| `(-120, -30, 90)` | `test_issue_822_...py:406` (AC-3, Neuseeland UTC+12) | 90 (0–89) | **12:00–13:30** |
+| `(-120, -60, 60)` | `test_issue_822_...py:260` (AC-2, London UTC+1) | 60 (0–59) | **23:00–00:00** |
+| `(-240, -120, 120)` | `test_issue_822_...py:194` (AC-1, Tirol UTC+2) | 120 (0–119) | 22:00–00:00 (latent) |
+| `(-60, 120)` · `(-60, 180)` · `(-60, 60)` | die uebrigen 12 Dateien | **0** | — |
+
+Belegt am Prueflingscode selbst:
+
+```
+jetzt=  30 -> wp=(0, 90, 210)  seg1_aktiv=True   <- falsch, seg1 sollte vorbei sein
+jetzt=  90 -> wp=(0, 90, 210)  seg1_aktiv=False  <- richtig
+```
+
+**Zwei Befunde ueber das Ticket hinaus:**
+
+1. Das Ticket nennt nur AC-3 (12:00–13:30 UTC). **AC-2 traegt dieselbe Ursache und bricht
+   taeglich 23:00–00:00 UTC** — bisher nicht zugeordnet. Der Umzug der AC-3-Koordinaten nach
+   Neuseeland (#1667 S1) hat AC-2 in London stehen lassen; dort ist die Zusicherung nie
+   robust gewesen.
+2. AC-1 verliert die Konstellation ebenfalls (22:00–00:00 UTC), **faellt aber nicht auf**,
+   weil der Test nur Bit-Identitaet und Monotonie prueft, nicht die Vergangenheit des ersten
+   Segments. Latenter Fall derselben Klasse.
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `tests/helpers/arrival_window_fixtures.py` | Prüfling: `fenster_minuten` (Z. 99–153), `active_window_offsets` (Z. 176), `past_window_offsets` (Z. 220), `stage_date` (Z. 156) |
+| `tests/unit/test_arrival_window_fixtures.py` | Waechter des Bausteins, 11 Testfunktionen; iteriert `ALLE_MINUTEN = range(-1440, 2880)` (Z. 86) ueber `FAMILIEN` (Z. 64) |
+| `tests/tdd/test_issue_822_radar_nowcast_segment.py` | Einzige Datei mit „erstes Segment muss vorbei sein"-Bedarf: AC-1 (Z. 194), AC-2 (Z. 260), AC-3 (Z. 406) |
+| `tests/tdd/test_fixture_wallclock_ratchet.py` | Ratsche gegen Wanduhr-Fixtures — **rein statischer AST-Scanner**, prueft kein Laufzeitverhalten |
+
+## Dependents — vollstaendig ausgezaehlt
+
+14 Testdateien importieren aus dem Baustein. Nur **drei Aufrufstellen** (alle in
+`test_issue_822_radar_nowcast_segment.py`) verlangen ein bereits vergangenes erstes Segment;
+die uebrigen brauchen lediglich „ein Segment ist jetzt aktiv" und sind von der Verschiebung
+nachweislich nicht betroffen (0 kaputte Minuten). Der Aenderungsdruck ist damit eng begrenzt.
+
+Fan-out innerhalb der Dateien beachten: `_trip()` in
+`test_briefing_anchor_survives_dispatch_failure.py` wird 37× aus 25 Testfunktionen gerufen,
+`_radar_trip()` in `test_alert_channel_premium_sms.py` 6× aus 10 — eine Verhaltensaenderung
+des Bausteins schlaegt dort breit durch, auch wenn die Offsets harmlos sind.
+
+## Existing Patterns
+
+- `past_window_offsets` (Z. 220–277) macht bereits genau das Richtige: reicht der Platz auf
+  dem Etappentag nicht, **scheitert es laut** mit `ValueError` (Z. 256) statt still ein
+  Fenster zu liefern, das die Zusicherung nicht traegt. Die geforderte Haltung existiert im
+  selben Modul — nur `fenster_minuten` folgt ihr nicht.
+- Der Docstring von `active_window_offsets` (Z. 189–199) warnt bereits schriftlich: „Das
+  Vorzeichen eines Versatzes ist keine Zusicherung." Eine Warnung im Text ist kein Waechter.
+- `freezegun` ist im Waechter-Test bereits im Einsatz (`test_arrival_window_fixtures.py:47`,
+  Randzeit-Faelle Z. 323/352) — eine gestellte Uhr ist in diesem Bereich etabliertes Mittel.
+
+## Risks & Considerations
+
+- **Der Waechter selbst wird rot.** `test_arrival_window_fixtures.py` Z. 91/111/129 rufen
+  `fenster_minuten` ueber `range(-1440, 2880)` × `FAMILIEN` ohne `try/except` auf. Faellt der
+  Baustein kuenftig laut aus, muessen diese drei Tests auf den neuen Vertrag umgestellt
+  werden — sonst blockiert die eigene Ratsche den Fix.
+- **Domaene ausserhalb 0–1439.** `minuten_jetzt` ist im echten Betrieb immer 0–1439
+  (`_tagesbezug`, Z. 208). Der Waechter prueft absichtlich weit darueber hinaus; der neue
+  Vertrag muss fuer diesen erweiterten Bereich definiert sein, nicht nur fuer den realen.
+- **Trivial-gruen-Falle.** Ein lautes Scheitern allein macht die beiden Tests nicht gruen —
+  es tauscht nur „falsch rot" gegen „laut rot". Ohne eine zweite Massnahme, die die
+  Konstellation zu jeder Uhrzeit herstellbar macht, bleibt die Ampel taeglich rot.
+- **Positivkontrolle ist Pflicht** (Ticket ausdruecklich): ein Test muss beweisen, dass die
+  Konstellation ausserhalb des Bruchfensters tatsaechlich hergestellt wird. Sonst bewacht der
+  neue Waechter die leere Menge.
+- **Kein Produktivcode betroffen.** `src/services/trip_segments.py` verhaelt sich korrekt —
+  die Fehlermeldung des CI-Laufs belegt das (gewaehlte Koordinaten = `WP0`, also Segment-1,
+  zutreffend gewaehlt). Reine Test-Infrastruktur.
+- **Die Ratsche stoert nicht.** `test_fixture_wallclock_ratchet.py` scannt nur Quelltextmuster
+  (`KNOWN_VIOLATIONS_INDIREKT` ist erzwungen leer, Z. 1261) und reagiert nicht auf
+  Verhaltensaenderungen des Bausteins. Keine Ausnahmeliste zu pflegen.
+
+## Loesungsrichtung (Analyse, noch nicht freigegeben)
+
+Zwei Massnahmen, die zusammengehoeren:
+
+1. **Waechter:** `fenster_minuten` liefert kein Fenster mehr, in dem ein negativ gewuenschter
+   Wegpunkt nach *jetzt* landet — es scheitert laut, wie `past_window_offsets` es bereits tut.
+   Das schliesst die **Klasse**, nicht nur den einen Fall.
+2. **Reparatur:** Die drei Aufrufstellen mit „vergangenes erstes Segment"-Bedarf bekommen eine
+   gestellte Uhr auf eine sichere Ortszeit (Tagesmitte), damit die Konstellation zu jeder
+   Wanduhrzeit darstellbar ist. Danach ist der laute Fehler aus (1) nie erreichbar — er
+   bewacht kuenftige Aufrufer.
+
+Alternative aus dem Ticket (Etappentag auf „morgen" legen) scheidet aus: der Produktivpfad
+sucht die Etappe ueber `trip_local_today` (Ortstag), eine Etappe am Folgetag wuerde gar nicht
+gefunden.

--- a/docs/specs/modules/fix_1940_fixture_zeitkippkante.md
+++ b/docs/specs/modules/fix_1940_fixture_zeitkippkante.md
@@ -1,0 +1,235 @@
+---
+entity_id: fix_1940_fixture_zeitkippkante
+type: module
+created: 2026-08-17
+updated: 2026-08-17
+status: draft
+version: "1.0"
+tags: [test-infrastruktur, ci, zeitzone]
+---
+
+# Fix #1940 — Zeitkippkante in `arrival_window_fixtures.fenster_minuten`
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+`fenster_minuten` in `tests/helpers/arrival_window_fixtures.py` verschiebt ein
+Ankunftsfenster still nach vorne, wenn der lokale Etappentag noch nicht weit genug
+fortgeschritten ist. Dabei bleibt der Abstand zwischen den Wegpunkten erhalten, aber das
+Vorzeichen eines gewünschten Versatzes nicht: ein Wegpunkt, den ein Aufrufer bewusst in die
+Vergangenheit legen wollte, kann so in die Zukunft rutschen. Drei Aufrufstellen in
+`test_issue_822_radar_nowcast_segment.py` verlassen sich genau darauf und brechen dadurch
+täglich zu bestimmten Wanduhrzeiten (CI-Job `test`, Issue #1940). Diese Spec beschreibt, wie
+der Baustein diese Klasse von Fehlern laut statt still macht und wie die drei betroffenen
+Aufrufstellen unabhängig von der Wanduhrzeit werden.
+
+## Source
+
+- **File:** `tests/helpers/arrival_window_fixtures.py`
+- **Identifier:** `def fenster_minuten(minuten_jetzt: int, *offsets_min: int) -> tuple[int, ...]` (Zeile 99–153)
+
+> **Schicht-Hinweis:** reine Test-Infrastruktur unter `tests/`. Kein Produktivcode betroffen —
+> `src/services/trip_segments.py` verhält sich korrekt; die CI-Rot-Meldungen belegen das
+> (gewählte Koordinaten entsprechen dem ersten Wegpunkt/Segment, korrekt gewählt anhand der
+> gebrochenen Fixture-Zusicherung, nicht anhand eines Produktivfehlers).
+
+## Estimated Scope
+
+- **LoC:** ~270
+- **Files:** 3
+- **Effort:** medium
+
+Das liegt über dem Standardbudget von 250 LoC/Workflow. Grund: der Nachweis ist größer als der
+Eingriff selbst — der eigentliche Fix in `fenster_minuten` ist wenige Zeilen (ein `raise` statt
+einer stillen Verschiebung), aber der Wächter (`test_arrival_window_fixtures.py`) muss auf den
+neuen Vertrag umgestellt UND um eine Positivkontrolle über alle 1440 Ortsminuten ergänzt werden,
+und die drei Aufrufstellen in `test_issue_822_radar_nowcast_segment.py` brauchen je eine
+gestellte Uhr samt Begründung. `workflow.py set-field loc_limit_override 500` ist vorgesehen.
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `tests/helpers/arrival_window_fixtures.py::past_window_offsets` | Bestandsmuster | Liefert bereits das Vorbild für „laut scheitern statt still liefern" (`ValueError`, Zeile 256) — der neue Vertrag in `fenster_minuten` folgt diesem Muster, keine neue Idee |
+| `tests/unit/test_arrival_window_fixtures.py` | Wächter | Muss auf den neuen Vertrag (mögliches `ValueError`) umgestellt werden, sonst blockiert die eigene Ratsche den Fix |
+| `tests/tdd/test_issue_822_radar_nowcast_segment.py` | Konsument | Einzige Datei mit „erstes Segment muss bereits vorbei sein"-Bedarf (drei Stellen: Zeile 194, 260, 406); bekommt eine gestellte Uhr statt sich auf die Verschiebung zu verlassen |
+| `freezegun` | Test-Library | Bereits im Wächter-Test im Einsatz (Zeile 47, Randzeit-Fälle Zeile 323/352) — etabliertes Mittel für „gestellte Uhr" in diesem Bereich, keine neue Abhängigkeit |
+
+### Affected Files
+
+| File | Change Type | Description |
+|------|-------------|--------------|
+| `tests/helpers/arrival_window_fixtures.py` | MODIFY | `fenster_minuten` (Zeile 99–153): wirft `ValueError`, wenn ein negativ gewünschter Wegpunkt bei der gegebenen Ortsminute nicht mehr vor „jetzt" darstellbar ist, statt das Fenster still nach vorne zu verschieben |
+| `tests/unit/test_arrival_window_fixtures.py` | MODIFY | Bestehende Schleifen (Zeile 91/111/129, `range(-1440, 2880)` × `FAMILIEN`) auf `try/except ValueError` umstellen; neue Positivkontrolle ergänzt, die über alle 1440 Ortsminuten beweist, dass außerhalb der Randzone tatsächlich ein „alles vor jetzt"-Fenster entsteht |
+| `tests/tdd/test_issue_822_radar_nowcast_segment.py` | MODIFY | Die drei Aufrufstellen mit „vergangenes erstes Segment"-Bedarf (AC-1 Zeile 194, AC-2 Zeile 260, AC-3 Zeile 406) stellen ihre Uhr per `freezegun` auf eine sichere Ortszeit (Tagesmitte), bevor sie `fenster_minuten`/`active_window_offsets` aufrufen |
+
+## Implementation Details
+
+Zwei zusammengehörende Maßnahmen:
+
+1. **Wächter in `fenster_minuten` selbst:** Die Funktion prüft nach der bisherigen
+   Vorwärtsverschiebung, ob dadurch ein ursprünglich negativ gewünschter Offset das Vorzeichen
+   verloren hat (Wegpunkt läge jetzt bei oder nach `minuten_jetzt`, obwohl der Aufrufer ihn
+   davor wollte). Ist das der Fall, wirft die Funktion `ValueError` mit einer Meldung, die die
+   verletzte Zusicherung benennt (analog zur bestehenden Meldung in `past_window_offsets`,
+   Zeile 256–261) — statt ein Fenster zurückzugeben, das die vom Aufrufer gewünschte
+   Vergangenheits-Konstellation nicht mehr trägt. Das schließt die **Klasse** des Fehlers, nicht
+   nur den einen im Ticket genannten Fall (AC-3); AC-2 (bisher nicht zugeordnet) und der latente
+   AC-1-Fall werden vom selben Wächter mit erfasst.
+
+2. **Reparatur an den drei betroffenen Aufrufstellen:** `test_issue_822_radar_nowcast_segment.py`
+   Zeile 194, 260 und 406 stellen ihre Systemuhr per `freezegun.freeze_time` auf eine Ortszeit in
+   der Tagesmitte (fern von Mitternacht), bevor sie das Ankunftsfenster über
+   `active_window_offsets`/`fenster_minuten` aufbauen. Dadurch ist die von diesen Tests
+   verlangte „erstes Segment ist bereits vorbei"-Konstellation zu jeder realen Wanduhrzeit
+   herstellbar, und der neue laute Fehler aus Maßnahme 1 wird an diesen drei Stellen nie
+   ausgelöst — er bewacht künftige Aufrufer, die denselben Fehler machen würden.
+
+Die im Ticket erwogene Alternative „Etappentag auf morgen legen" scheidet aus: der Produktivpfad
+sucht die Etappe über `trip_local_today` (Ortstag, ADR-0044), eine Etappe am Folgetag würde dort
+nicht gefunden — das würde die Fixture von der Produktivlogik entkoppeln, die sie eigentlich
+nachbilden soll.
+
+## Expected Behavior
+
+- **Input:** `fenster_minuten(minuten_jetzt: int, *offsets_min: int)` — Minute seit
+  Ortszeit-Mitternacht des Etappentags, in der „jetzt" liegt (darf negativ oder >1439 sein), plus
+  mindestens zwei gewünschte Offsets relativ zu „jetzt" (können negativ sein).
+- **Output:** entweder ein Tupel von Wegpunkt-Minuten, das weiterhin allen drei bisherigen
+  Zusicherungen genügt (0–1439 für den ersten Wegpunkt, streng monoton steigend, Abstand
+  ≤1439) UND zusätzlich jeden negativ gewünschten Wegpunkt bei oder vor `minuten_jetzt` hält —
+  oder ein `ValueError`, wenn diese zweite Bedingung an der gegebenen Ortsminute strukturell
+  nicht erfüllbar ist.
+- **Side effects:** keine (reine Funktion). Die drei Aufrufstellen in
+  `test_issue_822_radar_nowcast_segment.py` bekommen als Seiteneffekt eine gestellte
+  Systemuhr für die Dauer des jeweiligen Testkörpers.
+
+## Acceptance Criteria
+
+- **AC-1 (lauter Fehler):** Given ein Aufrufer verlangt per negativem Offset einen Wegpunkt in
+  der Vergangenheit / When dieser Wegpunkt bei der aktuellen Ortsminute auf dem Etappentag nicht
+  mehr vor „jetzt" darstellbar ist / Then scheitert `fenster_minuten` laut mit einer
+  Fehlermeldung, die die verletzte Zusicherung benennt — statt ein Fenster zurückzugeben, in dem
+  der Wegpunkt nach „jetzt" liegt.
+  - Test: Parametrisierter Test ruft `fenster_minuten` für die drei bekannten kaputten
+    Minutenbereiche der betroffenen Offset-Familien auf (`(-120, -30, 90)` bei Minute 0–89,
+    `(-120, -60, 60)` bei Minute 0–59, `(-240, -120, 120)` bei Minute 0–119) und prüft, dass in
+    jedem dieser Fälle `ValueError` geworfen wird — kein Rückgabewert wird akzeptiert.
+
+- **AC-2 (Positivkontrolle, PFLICHT):** Given die aktuelle Ortsminute liegt außerhalb des nicht
+  darstellbaren Bereichs einer Offset-Familie / When `fenster_minuten` aufgerufen wird / Then
+  liefert es ein Fenster, in dem jeder negativ gewünschte Wegpunkt bei oder vor „jetzt" liegt —
+  geprüft über alle Ortsminuten eines Tages und alle betroffenen Offset-Familien, nicht an einem
+  einzelnen Stichzeitpunkt.
+  - Test: Schleife über `range(0, 1440)` je betroffener Familie; außerhalb des jeweils kaputten
+    Bereichs ruft der Test `fenster_minuten` auf und prüft für jeden negativen Offset, dass der
+    zugehörige zurückgegebene Wert `<= minuten_jetzt` ist. Der Zähler der außerhalb der
+    Randzone verletzten Minuten muss 0 sein. Ohne diesen Test bewacht AC-1 die leere Menge.
+
+- **AC-3 (die Ampel wird grün):** Given die drei Aufrufstellen in
+  `test_issue_822_radar_nowcast_segment.py`, die ein bereits vergangenes erstes Segment
+  brauchen (Zeile 194 AC-1, Zeile 260 AC-2, Zeile 406 AC-3) / When diese Tests zu einer
+  beliebigen Wanduhrzeit laufen — insbesondere in den heute roten Fenstern 12:00–13:30 UTC und
+  23:00–00:00 UTC / Then sind sie grün, weil sie ihre Uhr selbst auf eine sichere Ortszeit
+  (Tagesmitte) stellen, statt sich auf die Verschiebung in `fenster_minuten` zu verlassen.
+  - Test: Die drei AC-Tests laufen je einmal unter `freeze_time` auf 12:30 UTC und einmal auf
+    23:30 UTC (den vorher reproduzierbar roten Wanduhrzeiten) und bestehen in beiden Läufen;
+    vor der Änderung ist derselbe Lauf ohne gestellte Uhr in genau diesen Fenstern rot.
+
+- **AC-4 (bestehende Zusicherungen bleiben):** Given ein beliebiges Offset-Tupel und eine
+  beliebige Ortsminute aus `range(-1440, 2880)` / When `fenster_minuten` aufgerufen wird und
+  kein `ValueError` wirft / Then gelten für das zurückgegebene Fenster weiterhin unverändert
+  alle drei bisherigen Zusicherungen: erster Wegpunkt liegt in `[0, 1439]`, die Folge ist streng
+  monoton steigend, jeder Abstand ist höchstens 1439 Minuten. Der neue laute Fehler ersetzt
+  keine dieser drei Prüfungen.
+  - Test: Die bestehenden Wächter-Schleifen in `test_arrival_window_fixtures.py`
+    (Zeile 91/111/129) werden um `try/except ValueError` ergänzt; für jeden Fall, der NICHT
+    wirft, prüfen sie unverändert alle drei bisherigen Zusicherungen, über alle Familien und
+    den vollen `range(-1440, 2880)`.
+
+- **AC-5 (keine Kollateralschäden):** Given die 13 übrigen Testdateien nutzen `fenster_minuten`
+  nur über die Offset-Familien `(-60, 120)`, `(-60, 180)`, `(-60, 60)` für „ein Segment ist
+  jetzt aktiv" / When diese Familien über alle 1440 Ortsminuten eines Tages durchlaufen werden /
+  Then wird der neue `ValueError` nie ausgelöst und die 13 Testdateien (samt Fan-out-Helfern
+  `_trip()` in `test_briefing_anchor_survives_dispatch_failure.py` und `_radar_trip()` in
+  `test_alert_channel_premium_sms.py`) bleiben unverändert grün.
+  - Test: Schleife über `range(0, 1440)` für die drei harmlosen Familien ruft `fenster_minuten`
+    auf und zählt `ValueError`-Auslösungen; erwarteter Zähler ist 0. Zusätzlich läuft der
+    vollständige Testlauf der 13 betroffenen Dateien nach der Änderung unverändert grün durch
+    (kein neu rot gewordener Testfall).
+
+- **AC-6 (zweite Ursache im selben Zeitfenster):** Given
+  `test_ac4_mail_body_contains_segment_label_and_cooldown`
+  (`tests/tdd/test_issue_822_radar_nowcast_segment.py:484`) bestimmt den Etappentag über das
+  **Server**datum (`datetime.now(timezone.utc).date()`) statt über den Ortstag / When die
+  Testsuite zu einer Uhrzeit läuft, zu der Serverdatum und Ortsdatum auseinanderfallen
+  (London UTC+1 ab 23:00 UTC) / Then wird die Etappe nicht gefunden und kein Alarm ausgelöst —
+  nach der Änderung nutzt die Stelle `stage_date(lat, lon)` wie die fünf übrigen Stellen
+  derselben Datei, und der Test ist zu jeder Wanduhrzeit grün.
+  - Test: Die Uhrzeit-Matrix aus AC-3 nimmt diesen Testfall in den Messbereich auf; vor der
+    Änderung weicht sein Ergebnis zwischen den gemessenen Uhrzeiten ab (rot an der Kippkante,
+    grün sonst), nach der Änderung ist es an allen Messpunkten identisch grün.
+  - Herkunft: in der RED-Phase gemessen, nicht aus dem Ticket. Andere Ursache als AC-1 bis
+    AC-5 (Serverdatum statt Ortstag, nicht die stille Verschiebung), aber dasselbe
+    Zeitfenster. Ohne AC-6 bliebe die CI-Ampel trotz bestandener AC-1 bis AC-5 täglich
+    23:00–00:00 UTC rot — das Ticketziel wäre verfehlt. Vom PO am 2026-08-17 ausdrücklich in
+    den Umfang aufgenommen.
+
+- **AC-7 (dritte Fundstelle derselben Klasse — die Schwesterfunktion):** Given
+  `past_window_offsets` (`tests/helpers/arrival_window_fixtures.py:220-277`) **staucht** das
+  Fenster still auf `[0, obergrenze]`, wenn die gewünschte Spanne nicht mehr auf den
+  vergangenen Teil des Etappentags passt (Z. 270–275) / When ein Aufrufer damit ein
+  garantiert abgelaufenes Segment herstellen will und die Ortszeit früh ist (gemessen:
+  Ortsminute 0–239 in Neuseeland = 12:00–16:00 UTC, Fenster schrumpft von zwei Stunden auf
+  vier Minuten) / Then endet das Ziel-Segment erst in der Zukunft, ein Alarm feuert, und
+  `test_issue_818_radar_briefing_integration.py::test_ac5_past_segment_no_alert_guard_test`
+  scheitert — nach der Änderung verweigert `past_window_offsets` diesen Fall laut, wie
+  `fenster_minuten` es nach AC-1 tut, und die Aufrufstelle stellt ihre Uhr selbst.
+  - Test: Die Uhrzeit-Matrix nimmt `test_issue_818_radar_briefing_integration.py` in den
+    Messbereich auf; vor der Änderung weicht das Ergebnis zwischen 11:55 und 12:05 UTC ab,
+    nach der Änderung ist es an allen Messpunkten identisch grün. Zusätzlich ein
+    Wächter-Test, der die laute Verweigerung im nicht darstellbaren Bereich erwartet, mit
+    Zähler gegen trivial-grün.
+  - Herkunft: in der GREEN-Phase gemessen und unabhängig gegengeprüft (Stauchung empirisch:
+    11:55 UTC → `('19:55','21:55')`, 12:05 UTC → `('00:00','00:04')`). Dieselbe Fehlerklasse
+    wie AC-1, andere Funktion. Ohne AC-7 bliebe die CI-Ampel täglich **vier Stunden**
+    (12:00–16:00 UTC) rot — mehr als die im Ticket gemeldeten anderthalb. Vom PO am
+    2026-08-17 in den Umfang aufgenommen, Zeilenbudget auf 800 erhöht.
+
+## Known Limitations
+
+- Ein latenter dritter Fall bleibt teilweise ungeprüft: die Aufrufstelle Zeile 194 (AC-1)
+  verliert die Vergangenheits-Konstellation ebenfalls im Fenster 22:00–00:00 UTC, prüft das
+  aber selbst nicht (nur Bit-Identität und Monotonie). Sie wird von dieser Spec mitgehärtet
+  (gestellte Uhr, siehe AC-3), ist aber heute kein sichtbarer CI-Ausfall — die Härtung schließt
+  eine Lücke, bevor sie sichtbar wird, nicht eine bereits beobachtete.
+- Der reale Wertebereich von `minuten_jetzt` im Produktivpfad ist `[0, 1439]`
+  (`_tagesbezug`, Zeile 208). Der Wächter (`test_arrival_window_fixtures.py`) prüft absichtlich
+  weit darüber hinaus (`range(-1440, 2880)`); der neue Vertrag von `fenster_minuten`
+  (`ValueError` bei nicht darstellbarer Vergangenheits-Konstellation, sonst die drei
+  bestehenden Zusicherungen) muss auch für diesen erweiterten Bereich definiert und geprüft
+  sein, nicht nur für den real vorkommenden.
+- Die im Ticket erwogene Variante „Etappentag auf morgen legen" scheidet aus: der Produktivpfad
+  sucht die Etappe über den Ortstag (`trip_local_today`, ADR-0044); eine Etappe am Folgetag
+  würde dort nicht gefunden. Diese Spec verfolgt diese Richtung deshalb nicht weiter.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** reine Test-Infrastruktur unter `tests/helpers/` und `tests/tdd/` — kein
+  Produktivcode, keine Änderung an Kanälen, Providern, Datenmodell/Persistenz, Auth,
+  Editor-Paradigma oder Test-/Deploy-Strategie. Der Fix folgt zudem einem bereits im selben
+  Modul etablierten Muster (`past_window_offsets` scheitert bereits laut statt still zu
+  liefern) und führt keine neue Entscheidungsfläche ein.
+
+## Changelog
+
+- 2026-08-17: Initial spec created
+- 2026-08-17: AC-6 ergänzt — in der RED-Phase gemessener zweiter Ausfallgrund im selben
+  Zeitfenster (Serverdatum statt Ortstag, `test_issue_822_radar_nowcast_segment.py:484`).
+  Vom PO ausdrücklich in den Umfang aufgenommen, weil die CI-Ampel sonst trotz erfüllter
+  AC-1 bis AC-5 täglich 23:00–00:00 UTC rot bliebe. Erste Limitation entsprechend
+  entschärft: die Aufrufstelle Z. 194 bleibt der einzige verbliebene latente Fall.

--- a/tests/helpers/arrival_window_fixtures.py
+++ b/tests/helpers/arrival_window_fixtures.py
@@ -125,6 +125,13 @@ def fenster_minuten(minuten_jetzt: int, *offsets_min: int) -> tuple[int, ...]:
        die Uhrzeit identisch und der Tageswechsel wuerde verschluckt — die
        Rollover-Erkennung in ``convert_trip_to_segments`` greift nur bei
        STRIKT fallender Uhrzeit.
+    4. Ein NEGATIV gewuenschter Versatz liegt bei oder vor ``minuten_jetzt``
+       (Issue #1940). Ist das an der gegebenen Ortsminute nicht darstellbar,
+       wird :class:`ValueError` geworfen statt still ein Fenster geliefert, in
+       dem der Wegpunkt in der Zukunft liegt. Die Zusicherung gilt ueber den
+       ganzen Wertebereich, auch fuer negatives ``minuten_jetzt``: hat der
+       lokale Etappentag noch gar nicht begonnen, ist dort ueberhaupt kein
+       Vergangenheits-Wegpunkt darstellbar.
     """
     if len(offsets_min) < 2:
         raise ValueError(
@@ -132,7 +139,8 @@ def fenster_minuten(minuten_jetzt: int, *offsets_min: int) -> tuple[int, ...]:
             f"erhalten: {offsets_min!r}"
         )
 
-    roh = [int(minuten_jetzt) + int(v) for v in offsets_min]
+    jetzt = int(minuten_jetzt)
+    roh = [jetzt + int(v) for v in offsets_min]
 
     # Hat der lokale Etappentag noch gar nicht begonnen (westliche Zeitzonen
     # kurz nach UTC-Mitternacht), wird das GANZE Fenster nach vorne geschoben
@@ -150,6 +158,28 @@ def fenster_minuten(minuten_jetzt: int, *offsets_min: int) -> tuple[int, ...]:
         vorher = minuten[-1]
         # Zusicherungen 2 und 3.
         minuten.append(min(max(r, vorher + 1), vorher + MINUTEN_PRO_TAG - 1))
+
+    # Zusicherung 4 (#1940). Geprueft wird das FERTIGE Fenster, nicht die
+    # Zwischenrechnung: auch die Klemmungen oben koennen einen Wegpunkt nach
+    # hinten schieben.
+    verloren = [
+        (int(v), m)
+        for v, m in zip(offsets_min, minuten)
+        if int(v) < 0 and m > jetzt
+    ]
+    if verloren:
+        raise ValueError(
+            f"An Ortsminute {jetzt} des Etappentags ist die gewuenschte "
+            f"VERGANGENHEIT nicht darstellbar: die Versaetze "
+            f"{[v for v, _ in verloren]} wurden vor *jetzt* verlangt, liegen "
+            f"im geklemmten Fenster aber bei {[m for _, m in verloren]} und "
+            f"damit dahinter (vollstaendiges Fenster: {tuple(minuten)}). Der "
+            "lokale Tag ist noch nicht weit genug fortgeschritten, und ein "
+            "Wegpunkt vor Ortszeit-Mitternacht ist im Datenmodell nicht "
+            "darstellbar. Abhilfe: die Uhr des Tests auf eine Ortszeit in der "
+            "Tagesmitte stellen (freeze_time) ODER Koordinaten waehlen, deren "
+            "Etappentag zu jeder UTC-Uhrzeit weit genug fortgeschritten ist."
+        )
     return tuple(minuten)
 
 
@@ -186,17 +216,22 @@ def active_window_offsets(lat: float, lon: float, *offsets_min: int) -> tuple[st
     Tagesgrenzen es erzwingen; in der Tagesmitte kommen sie unveraendert
     heraus.
 
-    🔴 **Das Vorzeichen eines Versatzes ist keine Zusicherung.** Nahe der
-    Ortszeit-Mitternacht ist "zwei Stunden vor jetzt" auf dem Etappentag nicht
-    darstellbar; der Wegpunkt rutscht dann nach vorne und kann NACH *jetzt*
-    liegen. Ein Test, der ein bereits VERGANGENES erstes Segment braucht (z.B.
-    "der Nowcast muss die Koordinaten des ZWEITEN Segments nehmen"), darf sich
-    darauf nicht verlassen — er braucht Koordinaten weit oestlich von
-    Greenwich, damit der Etappentag am Ort immer weit genug fortgeschritten
-    ist. Nachgemessen an
-    ``test_issue_822_radar_nowcast_segment.py::test_ac3_...``: in Ligurien
-    (UTC+1) war das erste Segment um 00:00:01 UTC noch aktiv und der Test
-    fiel auf die Wegpunkt-0-Koordinaten zurueck.
+    🔴 **Das Vorzeichen eines Versatzes IST eine Zusicherung — seit Issue
+    #1940 durchgesetzt statt nur erbeten.** Nahe der Ortszeit-Mitternacht ist
+    "zwei Stunden vor jetzt" auf dem Etappentag nicht darstellbar. Frueher
+    rutschte der Wegpunkt dann still nach vorne und lag NACH *jetzt*; ein
+    Test, der ein bereits VERGANGENES erstes Segment brauchte, pruefte danach
+    eine Konstellation, die er gar nicht hergestellt hatte (nachgemessen an
+    ``test_issue_822_radar_nowcast_segment.py``: AC-3 taeglich 12:00-13:30 UTC
+    rot, AC-2 taeglich 23:00-00:00 UTC — unabhaengig vom PR-Inhalt).
+
+    Heute scheitert :func:`fenster_minuten` in diesem Fall laut mit
+    :class:`ValueError`. Ein Aufrufer mit Vergangenheits-Bedarf hat zwei Wege:
+    die Uhr selbst auf eine Ortszeit in der Tagesmitte stellen (``freeze_time``
+    — so machen es die drei Stellen in ``test_issue_822_...``), oder
+    Koordinaten waehlen, deren Etappentag zu jeder UTC-Uhrzeit weit genug
+    fortgeschritten ist. Ein Ort allein genuegt nicht: auch Neuseeland
+    (UTC+12) hat eine Ortszeit-Mitternacht, sie liegt nur bei 12:00 UTC.
     """
     tagesbeginn, minuten_jetzt = _tagesbezug(lat, lon)
     return tuple(
@@ -233,10 +268,16 @@ def past_window_offsets(lat: float, lon: float, *offsets_min: int) -> tuple[str,
     Ende vor der Ankunft liegt — dann faellt das Ziel-Segment auf das minimale
     Fenster von einer Stunde nach Ankunft zurueck.
 
-    Reicht der Platz auf dem Etappentag nicht fuer die gewuenschten Abstaende
-    (fruehe Ortszeit), wird das Fenster gestaucht statt zu scheitern; ist gar
-    kein Platz mehr, wird :class:`ValueError` geworfen — laut scheitern statt
-    still ein Fenster liefern, das die Zusicherung nicht traegt.
+    🔴 **Die gewuenschte Spanne wird eingehalten oder gar nicht geliefert**
+    (Issue #1940 AC-7). Reicht der bereits vergangene Teil des Etappentags
+    nicht fuer die gewuenschten Abstaende (fruehe Ortszeit), wird
+    :class:`ValueError` geworfen. Bis 2026-08-17 wurde hier still auf den
+    verfuegbaren Platz **gestaucht** — der letzte Wegpunkt landete dann eine
+    Minute vor *jetzt*, das Ziel-Segment blieb nach dem Randfall-Guard aber
+    noch eine Stunde offen, und der Trip galt genau dann NICHT als „vorbei",
+    wenn der Test das Gegenteil pruefen wollte. Nachgemessen an
+    ``test_issue_818_radar_briefing_integration.py::test_ac5_...``: taeglich
+    12:00-16:00 UTC rot (Neuseeland, Ortsminute 0-239).
     """
     if len(offsets_min) < 2:
         raise ValueError(
@@ -252,13 +293,6 @@ def past_window_offsets(lat: float, lon: float, *offsets_min: int) -> tuple[str,
 
     anzahl = len(offsets_min)
     obergrenze = min(MINUTEN_PRO_TAG - 1, minuten_jetzt - 1)
-    if obergrenze < anzahl - 1:
-        raise ValueError(
-            f"Auf dem Etappentag {tag} ist an dieser Ortszeit noch kein "
-            f"vergangenes Fenster mit {anzahl} Wegpunkten darstellbar "
-            f"(Platz: {obergrenze + 1} Minuten). Die Fixture braucht eine "
-            "Zeitzone, deren Etappentag weiter fortgeschritten ist."
-        )
 
     roh = [minuten_jetzt + int(v) for v in offsets_min]
     for i in range(1, anzahl):
@@ -267,11 +301,25 @@ def past_window_offsets(lat: float, lon: float, *offsets_min: int) -> tuple[str,
     # vor jetzt liegt (nach vorne wird nicht geschoben — das machte es spaeter).
     verschiebung = min(0, obergrenze - roh[-1])
     roh = [r + verschiebung for r in roh]
+
+    # EINE Bedingung statt zweier: der frueher separat gepruefte Fall „gar kein
+    # Platz mehr" (obergrenze < anzahl - 1) ist hierin enthalten — die Folge ist
+    # nach der Monotonie-Korrektur mindestens ``anzahl - 1`` Minuten lang, ihr
+    # Anfang liegt also erst recht vor Tagesbeginn. Zwei Bedingungen, von denen
+    # eine die andere umfasst, laden nur dazu ein, die falsche zu pflegen.
     if roh[0] < 0:
-        # Passt die gewuenschte Spanne nicht mehr auf den bisher vergangenen
-        # Teil des Etappentags: gleichmaessig auf [0, obergrenze] stauchen.
-        roh = [round(obergrenze * i / (anzahl - 1)) for i in range(anzahl)]
-        for i in range(1, anzahl):
-            roh[i] = max(roh[i], roh[i - 1] + 1)
+        raise ValueError(
+            f"Auf dem Etappentag {tag} ist an Ortsminute {minuten_jetzt} kein "
+            f"vergangenes Fenster mit {anzahl} Wegpunkten ueber "
+            f"{roh[-1] - roh[0]} Minuten darstellbar: vor *jetzt* liegen nur "
+            f"{max(obergrenze + 1, 0)} Minuten dieses Tages, und ein Wegpunkt "
+            "vor Ortszeit-Mitternacht ist im Datenmodell nicht darstellbar. "
+            "Frueher wurde hier still auf den verfuegbaren Platz gestaucht — "
+            "der letzte Wegpunkt landete dann eine Minute vor jetzt und das "
+            "Ziel-Segment blieb noch eine Stunde offen, der Trip war also "
+            "gerade NICHT vorbei (Issue #1940). Abhilfe: die Uhr des Tests "
+            "auf eine spaete Ortszeit stellen (freeze_time) ODER kuerzere "
+            "Versaetze waehlen."
+        )
 
     return tuple((tagesbeginn + timedelta(minutes=m)).strftime("%H:%M") for m in roh)

--- a/tests/tdd/test_issue_818_radar_briefing_integration.py
+++ b/tests/tdd/test_issue_818_radar_briefing_integration.py
@@ -30,11 +30,20 @@ from datetime import date as date_type, datetime, time, timedelta, timezone
 from pathlib import Path
 
 import pytest
+from freezegun import freeze_time
 
 from app.models import TripReportConfig
 from app.trip import Stage, Trip, Waypoint
 
 from tests.helpers.arrival_window_fixtures import past_window_offsets, stage_date
+
+# #1940 AC-7: 12:00 Ortszeit in Pacific/Auckland (UTC+12, August). Die Uhr
+# gestellt statt der Zeitzone vertraut: ein oestlicher Ort allein garantiert
+# NICHT, dass der Etappentag weit genug fortgeschritten ist — auch Neuseeland
+# hat eine Ortszeit-Mitternacht, sie liegt bei 12:00 UTC. Genau deshalb war
+# test_ac5 taeglich 12:00-16:00 UTC rot. Festes Datum, sonst verschoebe die
+# neuseelaendische Sommerzeit den Ortsbezug wieder.
+UHR_WELLINGTON = "2026-08-18T00:00:00+00:00"
 
 def _data_root_users() -> Path:
     """Nutzer-Wurzel der Compare-Preset-Ablage — Funktion statt Konstante
@@ -427,6 +436,7 @@ def test_ac4_double_alert_guard_suppresses_radar_when_forecast_recent():
 # AC-5: Alle Segmente zeitlich abgelaufen → kein Alert (Guard aus #822)
 # --------------------------------------------------------------------------
 
+@freeze_time(UHR_WELLINGTON, tick=True)
 def test_ac5_past_segment_no_alert_guard_test():
     """AC-5: REGRESSION-GUARD aus #822 — alle Segmente vorbei → kein Alert.
 
@@ -458,9 +468,12 @@ def test_ac5_past_segment_no_alert_guard_test():
     from services.trip_alert import TripAlertService
     from services.radar_service import RadarNowcastService
 
-    # Neuseeland (UTC+12): der lokale Etappentag liegt zu jeder UTC-Uhrzeit
-    # mindestens zwölf Stunden zurück, es ist also immer Platz fuer ein
-    # vergangenes Fenster.
+    # Neuseeland (UTC+12). Die frühere Begründung „der lokale Etappentag liegt
+    # zu jeder UTC-Uhrzeit weit genug zurück, es ist also immer Platz" war
+    # falsch: zwischen 12:00 und 16:00 UTC ist der Ortstag erst 0-239 Minuten
+    # alt, für das 240-Minuten-Fenster unten also zu jung. Seit #1940 AC-7
+    # sagt der Helfer das laut; die gestellte Uhr oben (12:00 Ortszeit) stellt
+    # die Voraussetzung her, statt sie zu hoffen.
     past_lat, past_lon = -41.29, 174.78
 
     uid = f"tdd-818-ac5-{uuid.uuid4().hex[:6]}"

--- a/tests/tdd/test_issue_822_radar_nowcast_segment.py
+++ b/tests/tdd/test_issue_822_radar_nowcast_segment.py
@@ -30,6 +30,7 @@ from pathlib import Path
 from zoneinfo import ZoneInfo
 
 import pytest
+from freezegun import freeze_time
 
 from app.models import TripReportConfig
 from app.trip import Stage, Trip, Waypoint
@@ -58,6 +59,18 @@ DATA_ROOT = Path(__file__).resolve().parents[2] / "data" / "users"
 WP0_LAT, WP0_LON = -41.29, 174.78   # Wellington — waypoints[0] (alter Pfad)
 SEG_LAT, SEG_LON = -41.19, 174.93   # Start-Punkt aktives Segment (neuer Pfad)
 SEG_END_LAT, SEG_END_LON = -41.09, 175.08
+
+# #1940: Die drei Tests, die ein bereits VERGANGENES erstes Segment brauchen,
+# stellen ihre Uhr selbst — ein Ort allein genuegt nicht, denn auch Neuseeland
+# hat eine Ortszeit-Mitternacht (sie liegt bei 12:00 UTC, weshalb die CI-Ampel
+# taeglich 12:00-13:30 UTC rot war). Gewaehlt ist je Aufrufstelle der
+# UTC-Zeitpunkt, zu dem am jeweiligen Ort GENAU 12:00 Ortszeit ist: maximaler
+# Abstand zu beiden Tagesgrenzen, innerhalb des Tagesfensters (4-19 Uhr
+# Ortszeit, #1584) und fern jeder Ruhezeit. Das Datum ist bewusst fest, sonst
+# verschoebe die jeweilige Sommerzeit den Ortsbezug wieder.
+UHR_TIROL = "2026-08-18T10:00:00+00:00"       # Europe/Vienna  UTC+2 -> 12:00
+UHR_LONDON = "2026-08-18T11:00:00+00:00"      # Europe/London  UTC+1 -> 12:00
+UHR_WELLINGTON = "2026-08-18T00:00:00+00:00"  # Pacific/Auckland UTC+12 -> 12:00
 
 
 # --------------------------------------------------------------------------
@@ -166,6 +179,7 @@ def _ensure_real_user_dir(uid: str) -> None:
 # AC-1: Segment-Helfer-Roundtrip (RED: ImportError)
 # --------------------------------------------------------------------------
 
+@freeze_time(UHR_TIROL, tick=True)
 def test_ac1_segment_helper_roundtrip_bit_identical():
     """AC-1: `services.trip_segments.convert_trip_to_segments` existiert noch
     NICHT → ImportError = RED-Treiber.
@@ -231,6 +245,7 @@ def test_ac1_segment_helper_roundtrip_bit_identical():
 # AC-2: Segment-Auswahl nach Zeit (RED: falsches Segment gewählt)
 # --------------------------------------------------------------------------
 
+@freeze_time(UHR_LONDON, tick=True)
 def test_ac2_segment_selection_by_time():
     """AC-2: check_radar_alerts wählt das zeitlich aktive Segment.
 
@@ -369,6 +384,7 @@ def test_ac2_segment_selection_by_time():
 # AC-3: Nowcast an Segment-Koordinaten (RED: waypoints[0] statt start_point)
 # --------------------------------------------------------------------------
 
+@freeze_time(UHR_WELLINGTON, tick=True)
 def test_ac3_nowcast_called_at_segment_coordinates():
     """AC-3: get_nowcast wird mit active.start_point.lat/lon aufgerufen, NICHT
     mit stage.waypoints[0]-Koordinaten (wenn diese abweichen).
@@ -481,8 +497,15 @@ def test_ac4_mail_body_contains_segment_label_and_cooldown():
     _ensure_real_user_dir(uid)
     try:
         now = datetime.now(timezone.utc)
-        today = now.date()
         lat, lon = 51.50, 0.00  # lon=0 → tz_for_coords returns Europe/London (BST in summer)
+        # #1940 AC-6: der Etappentag ist der ORTStag, nicht das Serverdatum.
+        # Mit ``now.date()`` liefen Etappendatum und die aus dem Helfer
+        # stammenden Ankunftszeiten ab 23:00 UTC auseinander (London UTC+1
+        # zeigt dann schon auf den Folgetag), die Etappe wurde nicht gefunden
+        # und es entstand gar kein Alarm — dieser Test war taeglich
+        # 23:00-00:00 UTC rot. Alle uebrigen Stellen dieser Datei nehmen
+        # stage_date() bereits.
+        today = stage_date(lat, lon)
         lat1, lon1 = lat + 0.10, lon + 0.10
         # #1667 S1: Ortszeit-Umrechnung und Tagesgrenzen-Klemmung im Helfer.
         arr0, arr1 = active_window_offsets(lat, lon, -60, 60)

--- a/tests/tdd/test_radar_nowcast_segment_wanduhr_unabhaengig.py
+++ b/tests/tdd/test_radar_nowcast_segment_wanduhr_unabhaengig.py
@@ -1,0 +1,194 @@
+"""Bug-Nachweis #1940 aus Nutzersicht: dieselbe Testdatei, dieselben Tests,
+UNTERSCHIEDLICHES Ergebnis je nach Wanduhrzeit.
+
+Worum es geht
+-------------
+``tests/tdd/test_issue_822_radar_nowcast_segment.py`` baut seine Trips ueber
+``tests/helpers/arrival_window_fixtures.fenster_minuten``. Liegt *jetzt* nahe
+der Ortszeit-Mitternacht des Etappentags, schiebt der Helfer das ganze Fenster
+nach vorne; die Abstaende bleiben, das VORZEICHEN eines Versatzes nicht. Ein
+Wegpunkt, den der Test bewusst in die Vergangenheit gelegt hat, ist dann noch
+aktiv — der Produktivcode waehlt zurecht das erste Segment, und die
+Testerwartung (zweites Segment) trifft nicht zu. Ergebnis: die CI-Ampel ist
+taeglich 12:00-13:30 UTC rot, unabhaengig vom PR-Inhalt (Issue #1940). Ein
+vierter Testfall derselben Datei kippt aus einem zweiten Grund an derselben
+Naht (Server- statt Ortsdatum, s. ``IM_SPEC_SCOPE``) und ist taeglich
+23:00-00:00 UTC rot.
+
+Dieselbe Klasse ein drittes Mal, in der Schwesterfunktion
+``past_window_offsets``: sie stauchte ein nicht mehr passendes
+Vergangenheits-Fenster still auf den verfuegbaren Platz, wodurch das
+Ziel-Segment noch eine Stunde offen blieb und der Trip gerade NICHT „vorbei"
+war. Betroffen ist ``test_issue_818_radar_briefing_integration.py::
+test_ac5_...``, taeglich 12:00-16:00 UTC (Spec AC-7) — deshalb wird diese
+Datei hier als zweiter Messfall mitgemessen.
+
+Dieser Test misst genau das — er liest den Fehler nicht am Code ab, sondern
+laesst die betroffenen Dateien zu mehreren gestellten Uhrzeiten laufen und
+vergleicht die Ergebnisse (``tests/helpers/wanduhr_matrix.py``, #1709: ein
+FRISCHER Betriebssystem-Prozess je Datenpunkt, nur die DIFFERENZ ist
+auswertbar).
+
+Warum der Test selbst NICHT wanduhr-abhaengig ist
+-------------------------------------------------
+Jeder Datenpunkt laeuft unter einer fest verdrahteten, gestellten Uhr — das
+Ergebnis haengt nicht davon ab, wann CI ihn startet. Waere die Uhrzeit "jetzt +
+x", reproduzierte dieser Test genau die Fehlerklasse, die er schliessen soll.
+Auch das DATUM ist bewusst fest: Neuseeland wechselt Ende September 2026 in die
+Sommerzeit und verschiebt das Bruchfenster damit auf 11:00-12:30 UTC. Ein
+gestelltes Datum im August haelt 12:30 UTC dauerhaft im Bruchfenster.
+
+Teuer gemessene Voraussetzung: die Prozess-Zeitzone
+---------------------------------------------------
+``lauf_bei_uhrzeit`` startet ``freeze_time(..., tick=True)`` im Kindprozess,
+BEVOR pytest den Root-``conftest.py`` importiert, der die Prozess-Zeitzone auf
+``America/St_Johns`` stellt (#1402). Wechselt die Zeitzone waehrend eines
+aktiven ``tick=True``-Freeze, verschiebt sich der eingefrorene Zeitpunkt um den
+neuen Ortsversatz — nachgemessen: angefordert 12:30 UTC, wirksam 10:00 UTC
+(-2:30). Erbt der Kindprozess ``TZ`` dagegen bereits beim Start, ist der
+Wechsel wirkungslos und der angeforderte Zeitpunkt trifft zu. Unter pytest ist
+das erfuellt (der Root-conftest setzt ``os.environ["TZ"]``, und
+``lauf_bei_uhrzeit`` reicht die Umgebung weiter) — deshalb wird es unten
+geprueft statt vorausgesetzt. Von Hand aus einer Shell ohne gesetztes ``TZ``
+misst dasselbe Werkzeug einen um den Ortsversatz verschobenen Zeitpunkt und
+findet nichts.
+
+Pfadregel #1409: die vermessene Datei wird relativ zu DIESER Datei aufgeloest.
+"""
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from tests.helpers.wanduhr_matrix import lauf_bei_uhrzeit, matrix_differenz
+
+VERMESSENE_DATEI = Path(__file__).resolve().parent / "test_issue_822_radar_nowcast_segment.py"
+VERMESSENE_DATEI_818 = (
+    Path(__file__).resolve().parent / "test_issue_818_radar_briefing_integration.py"
+)
+
+# Zwei Uhrzeiten im Bruchfenster, zwei ausserhalb. 12:30 UTC = 00:30 in
+# Neuseeland (UTC+12, August), 23:30 UTC = 00:30 in London (UTC+1, Sommerzeit).
+# Beide Londoner Bruchfenster beginnen ausgerechnet 23:00 UTC — nachgemessen,
+# nicht angenommen: AC-2 ueber die Ortsminute (< 60 auf dem Etappentag), AC-4
+# ueber die Datumsabweichung Ortsdatum/Serverdatum (23:00-00:00 UTC, solange
+# Sommerzeit gilt; in der Winterzeit ist London == UTC und AC-4 den ganzen Tag
+# gruen). Genau deshalb ist das gestellte Datum im August richtig: es haelt die
+# AC-4-Kante ganzjaehrig im Messbereich.
+UHRZEITEN = [
+    datetime(2026, 8, 18, 9, 0, tzinfo=timezone.utc),    # gruen erwartet
+    datetime(2026, 8, 18, 12, 30, tzinfo=timezone.utc),  # AC-3 rot erwartet
+    datetime(2026, 8, 18, 16, 0, tzinfo=timezone.utc),   # gruen erwartet
+    datetime(2026, 8, 18, 23, 30, tzinfo=timezone.utc),  # AC-2 + AC-4 rot erwartet
+]
+REFERENZZEIT = UHRZEITEN[0]
+
+# Der Spec-Umfang, ZWEI Ursachen:
+#
+# * Zeile 194/260/406 (AC-1/AC-2/AC-3) brauchen ein bereits VERGANGENES erstes
+#   Segment und verlieren es durch die Vorwaertsverschiebung in
+#   ``fenster_minuten`` (Spec AC-1 bis AC-5).
+# * Zeile 484 (AC-4) nimmt ``datetime.now(timezone.utc).date()`` — das
+#   SERVERdatum — statt ``stage_date(lat, lon)``. Ab 23:00 UTC zeigt London
+#   (UTC+1, Sommerzeit) auf den Folgetag, Etappendatum und Ankunftszeiten
+#   laufen auseinander, die Etappe wird nicht gefunden und es entsteht gar kein
+#   Alarm (Spec AC-6). Andere Ursache, dieselbe Klasse: eine Fixture, deren
+#   Zusicherung an der Ortszeit-Mitternacht kippt.
+IM_SPEC_SCOPE = {
+    "test_ac1_segment_helper_roundtrip_bit_identical",
+    "test_ac2_segment_selection_by_time",
+    "test_ac3_nowcast_called_at_segment_coordinates",
+    "test_ac4_mail_body_contains_segment_label_and_cooldown",
+}
+
+# Zweiter Messfall (Spec AC-7): dieselbe Fehlerklasse in der Schwesterfunktion
+# ``past_window_offsets``, die still auf den verfuegbaren Platz stauchte statt
+# laut zu scheitern. In Neuseeland (UTC+12) ist der Etappentag zwischen 12:00
+# und 16:00 UTC erst 0-239 Minuten alt — zu jung fuer das verlangte
+# 240-Minuten-Fenster. Die Messpunkte umschliessen BEIDE gemessenen Kanten
+# minutennah (11:55/12:05 und 15:55/16:05), sonst faende die Messung die
+# 12:00-Kante nur zufaellig.
+UHRZEITEN_818 = [
+    datetime(2026, 8, 18, 9, 0, tzinfo=timezone.utc),    # gruen erwartet
+    datetime(2026, 8, 18, 11, 55, tzinfo=timezone.utc),  # gruen erwartet
+    datetime(2026, 8, 18, 12, 5, tzinfo=timezone.utc),   # vor AC-7 rot
+    datetime(2026, 8, 18, 15, 55, tzinfo=timezone.utc),  # vor AC-7 rot
+    datetime(2026, 8, 18, 16, 5, tzinfo=timezone.utc),   # gruen erwartet
+]
+IM_SPEC_SCOPE_818 = {"test_ac5_past_segment_no_alert_guard_test"}
+
+# (Datei, Spec-Umfang, Messpunkte, Referenzzeit) — die Referenzzeit ist der
+# gruene Anker der Positivkontrolle.
+MESSFAELLE = [
+    pytest.param(
+        VERMESSENE_DATEI, IM_SPEC_SCOPE, UHRZEITEN, REFERENZZEIT,
+        id="822-nowcast-segment",
+    ),
+    pytest.param(
+        VERMESSENE_DATEI_818, IM_SPEC_SCOPE_818, UHRZEITEN_818, UHRZEITEN_818[0],
+        id="818-briefing-integration",
+    ),
+]
+
+
+def _funktionsnamen(nodeids) -> set[str]:
+    """Nur der Testfunktionsname — der Nodeid-Pfad haengt am rootdir des
+    Kindprozesses und ist als Vergleichsschluessel unnoetig zerbrechlich."""
+    return {nodeid.split("::")[-1].split("[")[0] for nodeid in nodeids}
+
+
+@pytest.mark.timeout(300)
+@pytest.mark.parametrize("datei,spec_umfang,uhrzeiten,referenzzeit", MESSFAELLE)
+def test_radar_segment_tests_liefern_zu_jeder_wanduhrzeit_dasselbe_ergebnis(
+    datei, spec_umfang, uhrzeiten, referenzzeit
+):
+    """#1940: die Testfaelle im Spec-Umfang duerfen ihr Ergebnis nicht mit der
+    Wanduhr wechseln.
+
+    Vor dem Fix: ``test_ac3_...`` faellt bei 12:30 UTC aus, ``test_ac2_...``
+    und ``test_ac4_...`` ab 23:00 UTC, ``test_ac5_past_segment_...`` (zweite
+    Datei) zwischen 12:00 und 16:00 UTC; an den uebrigen Messpunkten sind alle
+    gruen. Genau diese Differenz ist der Fehler — nicht die absolute
+    Fehlerzahl eines einzelnen Laufs (sitzungsweites ``freezegun`` zerstoert
+    pydantic-v1-Importe und erzeugt Falsch-Positive, s.
+    ``wanduhr_matrix``-Docstring, Punkt 2).
+    """
+    assert os.environ.get("TZ"), (
+        "Die Messung setzt voraus, dass der Kindprozess die Prozess-Zeitzone "
+        "schon beim Start erbt (Root-conftest.py, #1402). Ohne gesetztes TZ "
+        "verschiebt der Zeitzonenwechsel waehrend des laufenden freeze_time "
+        "den eingefrorenen Zeitpunkt um den Ortsversatz und die Messung "
+        "trifft ein anderes Zeitfenster als angefordert."
+    )
+
+    referenz = lauf_bei_uhrzeit(datei, referenzzeit)
+    ergebnis_je_name = {
+        nodeid.split("::")[-1].split("[")[0]: ausgang
+        for nodeid, ausgang in referenz.items()
+    }
+    nicht_bestanden = {
+        name: ergebnis_je_name.get(name, "nicht gelaufen")
+        for name in spec_umfang
+        if ergebnis_je_name.get(name) != "passed"
+    }
+    assert not nicht_bestanden, (
+        f"Positivkontrolle {datei.name}: bei {referenzzeit.isoformat()} muessen "
+        f"alle {len(spec_umfang)} Testfaelle im Spec-Umfang gruen sein, sind "
+        f"aber {nicht_bestanden}. Ohne diesen Anker waere die Differenz unten "
+        "auch dann leer, wenn die Tests zu ALLEN Uhrzeiten rot sind."
+    )
+
+    abweichend = _funktionsnamen(matrix_differenz(datei, uhrzeiten))
+    betroffen = sorted(abweichend & spec_umfang)
+
+    assert not betroffen, (
+        f"{datei.name}: {betroffen} liefern je nach gestellter Wanduhrzeit ein "
+        f"anderes Ergebnis (gemessen bei {[u.isoformat() for u in uhrzeiten]}). "
+        "Die Fixture stellt ihre Voraussetzung nicht zu jeder Ortszeit her — "
+        "die Segment-Konstellation (AC-1/2/3, Vorzeichen des Versatzes), den "
+        "Etappentag selbst (AC-4, Server- statt Ortsdatum) oder die verlangte "
+        "Spanne des vergangenen Fensters (AC-7, stille Stauchung). Issue #1940."
+    )

--- a/tests/unit/test_arrival_window_fixtures.py
+++ b/tests/unit/test_arrival_window_fixtures.py
@@ -55,6 +55,7 @@ from tests.helpers.arrival_window_fixtures import (
     MINUTEN_PRO_TAG,
     active_window_offsets,
     fenster_minuten,
+    past_window_offsets,
     stage_date,
 )
 
@@ -85,8 +86,86 @@ ORTE: list[tuple[str, float, float]] = [
 # schon vorbei) — beides kommt bei realen Zeitzonen vor.
 ALLE_MINUTEN = range(-MINUTEN_PRO_TAG, 2 * MINUTEN_PRO_TAG)
 
+# Seit #1940 verweigert ``fenster_minuten`` die Auskunft, wenn ein NEGATIV
+# gewuenschter Versatz an der gegebenen Ortsminute nicht mehr vor *jetzt*
+# darstellbar ist. Die drei Zusicherungs-Schleifen unten pruefen deshalb zwei
+# Aeste — geliefertes Fenster und Verweigerung — und zaehlen BEIDE mit: ohne
+# feste Erwartung koennte ein Ast still auf null Faelle zusammenfallen und die
+# Schleife waere trivial gruen (sie pruefte dann nichts mehr).
+#
+# Die Zahlen sind nachgemessen, nicht hergeleitet: 1440 Verweigerungen sind
+# stets die negativen Ortsminuten (der lokale Etappentag hat noch nicht
+# begonnen, dort ist ueberhaupt keine Vergangenheit darstellbar), dazu kommt
+# die Randzone am Tagesanfang.
+GEWORFEN_JE_FAMILIE: dict[tuple[int, ...], int] = {
+    (60, 240): 0,                    # ohne negativen Versatz -> nie
+    (120, 240): 0,                   # dito
+    (-60, 120): 1440,                # nur die negativen Ortsminuten
+    (-60, 180): 1440,                # dito
+    (-240, -120, 120): 1440 + 120,   # + Randzone Ortsminute 0-119
+    (-120, -30, 90): 1440 + 90,      # + Randzone Ortsminute 0-89
+}
+GEWORFEN_GESAMT = sum(GEWORFEN_JE_FAMILIE[versaetze] for versaetze in FAMILIEN)
+GEPRUEFT_GESAMT = len(ALLE_MINUTEN) * len(FAMILIEN) - GEWORFEN_GESAMT
+
+
+def _durchlauf(pruefung) -> list:
+    """Laeuft ``ALLE_MINUTEN x FAMILIEN`` ab und ruft ``pruefung`` fuer jedes
+    tatsaechlich gelieferte Fenster; Verweigerungen werden getrennt gezaehlt.
+
+    Die beiden Zaehler sind hier verankert und nicht in den Aufrufern, damit
+    jede der drei Zusicherungen unten dieselbe Grundgesamtheit prueft.
+    """
+    verletzt: list = []
+    geprueft = geworfen = 0
+    for m in ALLE_MINUTEN:
+        for versaetze in FAMILIEN:
+            try:
+                werte = fenster_minuten(m, *versaetze)
+            except ValueError:
+                geworfen += 1
+                continue
+            geprueft += 1
+            verletzt += pruefung(m, versaetze, werte)
+
+    assert geprueft == GEPRUEFT_GESAMT, (
+        f"{geprueft} statt {GEPRUEFT_GESAMT} gelieferte Fenster geprueft — die "
+        "Zusicherung wird an einer anderen Grundgesamtheit gemessen als "
+        "gemessen wurde (zu weit greifende Verweigerung?)"
+    )
+    assert geworfen == GEWORFEN_GESAMT, (
+        f"{geworfen} statt {GEWORFEN_GESAMT} Verweigerungen — der Bereich, in "
+        "dem fenster_minuten die Auskunft verweigert, hat sich verschoben"
+    )
+    return verletzt
+
 
 # ══════════ Schicht 1: die reine Rechnung, ueber den ganzen Tag ══════════
+
+def test_verweigerung_trifft_genau_den_gemessenen_bereich():
+    """#1940: der laute Fehler greift GENAU so weit wie gemessen — je Familie.
+
+    Die Summenzaehler in ``_durchlauf`` wuerden es nicht merken, wenn eine
+    Familie mehr und eine andere weniger verweigert. Hier steht die Verteilung
+    selbst unter Aufsicht: sie ist die Grenze zwischen "schliesst die
+    Fehlerklasse" und "macht die 13 abhaengigen Testdateien unbenutzbar".
+    """
+    gemessen = {}
+    for versaetze in FAMILIEN:
+        anzahl = 0
+        for m in ALLE_MINUTEN:
+            try:
+                fenster_minuten(m, *versaetze)
+            except ValueError:
+                anzahl += 1
+        gemessen[versaetze] = anzahl
+
+    erwartet = {versaetze: GEWORFEN_JE_FAMILIE[versaetze] for versaetze in FAMILIEN}
+    assert gemessen == erwartet, (
+        f"Verweigerungs-Bereich verschoben:\n  gemessen  {gemessen}\n"
+        f"  erwartet  {erwartet}"
+    )
+
 
 def test_erster_wegpunkt_liegt_immer_auf_dem_etappentag():
     """Zusicherung 1: ``0 <= ergebnis[0] <= 1439``.
@@ -96,12 +175,12 @@ def test_erster_wegpunkt_liegt_immer_auf_dem_etappentag():
     trotzdem auf diesen Tag gelegt — das Segment landet einen ganzen Tag
     daneben.
     """
-    verletzt = [
-        (m, versaetze, fenster_minuten(m, *versaetze)[0])
-        for m in ALLE_MINUTEN
-        for versaetze in FAMILIEN
-        if not 0 <= fenster_minuten(m, *versaetze)[0] <= MINUTEN_PRO_TAG - 1
-    ]
+    def pruefung(m, versaetze, werte):
+        if not 0 <= werte[0] <= MINUTEN_PRO_TAG - 1:
+            return [(m, versaetze, werte[0])]
+        return []
+
+    verletzt = _durchlauf(pruefung)
     assert not verletzt, (
         f"{len(verletzt)} Faelle legen den ersten Wegpunkt neben den "
         f"Etappentag, z.B. {verletzt[:3]}"
@@ -115,12 +194,12 @@ def test_wegpunkte_sind_immer_streng_monoton():
     ``convert_trip_to_segments`` kollabieren; es wird dann geloggt
     uebersprungen und die Etappe verliert stillschweigend ein Segment.
     """
-    verletzt = []
-    for m in ALLE_MINUTEN:
-        for versaetze in FAMILIEN:
-            werte = fenster_minuten(m, *versaetze)
-            if any(werte[i] >= werte[i + 1] for i in range(len(werte) - 1)):
-                verletzt.append((m, versaetze, werte))
+    def pruefung(m, versaetze, werte):
+        if any(werte[i] >= werte[i + 1] for i in range(len(werte) - 1)):
+            return [(m, versaetze, werte)]
+        return []
+
+    verletzt = _durchlauf(pruefung)
     assert not verletzt, (
         f"{len(verletzt)} Faelle sind nicht streng monoton, z.B. {verletzt[:3]}"
     )
@@ -134,13 +213,14 @@ def test_abstand_bleibt_unter_einem_ganzen_tag():
     nur bei STRIKT fallender Uhrzeit — der Tageswechsel wuerde verschluckt und
     das Segment kollabierte.
     """
-    verletzt = []
-    for m in ALLE_MINUTEN:
-        for versaetze in FAMILIEN:
-            werte = fenster_minuten(m, *versaetze)
-            for i in range(len(werte) - 1):
-                if werte[i + 1] - werte[i] > MINUTEN_PRO_TAG - 1:
-                    verletzt.append((m, versaetze, werte[i], werte[i + 1]))
+    def pruefung(m, versaetze, werte):
+        return [
+            (m, versaetze, werte[i], werte[i + 1])
+            for i in range(len(werte) - 1)
+            if werte[i + 1] - werte[i] > MINUTEN_PRO_TAG - 1
+        ]
+
+    verletzt = _durchlauf(pruefung)
     assert not verletzt, (
         f"{len(verletzt)} Abstaende erreichen oder ueberschreiten einen ganzen "
         f"Tag, z.B. {verletzt[:3]}"
@@ -224,10 +304,44 @@ KIPPKANTEN = [
 ]
 
 
-def _trip_aus_helfer(lat: float, lon: float, versaetze: tuple[int, ...]) -> Trip:
+# Seit #1940 verweigert der Helfer an der Ortszeit-Mitternacht die Auskunft
+# (s. GEWORFEN_JE_FAMILIE). An den Kippkanten unten trifft das 20 der 270
+# Kombinationen aus Kippkante x Ort x Familie — nachgemessen, nicht geschaetzt.
+# Die Tabelle haelt genau diese Faelle fest: sie sind KEIN Segmentfehler,
+# sondern die neue, erwartete Verweigerung. Wer sie nur mit einem stillen
+# ``except ValueError: continue`` uebergeht, prueft an den interessantesten
+# Zeitpunkten unbemerkt nichts mehr.
+NICHT_DARSTELLBAR: dict[tuple[str, str], int] = {
+    ("Island UTC+0", "2026-08-11T00:00:01+00:00"): 2,
+    ("Korsika UTC+2", "2026-08-10T22:00:00+00:00"): 2,
+    ("Korsika UTC+2", "2026-08-10T22:59:59+00:00"): 2,
+    ("Korsika UTC+2", "2026-08-10T23:00:00+00:00"): 2,
+    ("Korsika UTC+2", "2026-08-10T23:30:00+00:00"): 1,
+    ("Korsika UTC+2", "2026-08-10T23:59:59+00:00"): 1,
+    ("London UTC+1", "2026-08-10T23:00:00+00:00"): 2,
+    ("London UTC+1", "2026-08-10T23:30:00+00:00"): 2,
+    ("London UTC+1", "2026-08-10T23:59:59+00:00"): 2,
+    ("London UTC+1", "2026-08-11T00:00:01+00:00"): 2,
+    ("Neuseeland UTC+12", "2026-08-10T12:00:00+00:00"): 2,
+}
+
+
+def _trip_aus_helfer(
+    lat: float,
+    lon: float,
+    versaetze: tuple[int, ...],
+    helfer=active_window_offsets,
+    tagesfenster: dict | None = None,
+) -> Trip:
     """Echter Trip, dessen Ankunftszeiten aus dem Helfer stammen — genau so,
-    wie es die zwoelf umgestellten Fixturen tun."""
-    zeiten = active_window_offsets(lat, lon, *versaetze)
+    wie es die umgestellten Fixturen tun.
+
+    ``helfer`` waehlt zwischen aktivem und vergangenem Fenster; ``tagesfenster``
+    reicht die Vorkehrung durch, die eine Vergangenheits-Fixture seit #1584
+    braucht (s. ``past_window_offsets``-Docstring). Ein zweiter Bauer waere
+    dieselbe Funktion mit einer anderen Zeile gewesen.
+    """
+    zeiten = helfer(lat, lon, *versaetze)
     waypoints = [
         Waypoint(id=f"WP{i}", name=f"WP{i}", lat=lat + i * 0.05,
                  lon=lon + i * 0.05, elevation_m=1000.0, arrival_calculated=z)
@@ -235,7 +349,9 @@ def _trip_aus_helfer(lat: float, lon: float, versaetze: tuple[int, ...]) -> Trip
     ]
     stage = Stage(id="S1", name="Tag 1", date=stage_date(lat, lon), waypoints=waypoints)
     trip = Trip(id="wanduhr-probe", name="Wanduhr-Probe", stages=[stage])
-    trip.report_config = TripReportConfig(trip_id="wanduhr-probe", send_email=False)
+    trip.report_config = TripReportConfig(
+        trip_id="wanduhr-probe", send_email=False, **(tagesfenster or {})
+    )
     return trip
 
 
@@ -255,8 +371,15 @@ def test_segment_liegt_nie_vollstaendig_in_der_vergangenheit(
     """
     with freeze_time(zeitpunkt):
         jetzt = datetime.now(timezone.utc)
+        verweigert = 0
         for versaetze in FAMILIEN:
-            trip = _trip_aus_helfer(lat, lon, versaetze)
+            try:
+                trip = _trip_aus_helfer(lat, lon, versaetze)
+            except ValueError:
+                # #1940: an dieser Ortszeit ist die verlangte Vergangenheit
+                # nicht darstellbar — erwartet, unten stueckgenau gezaehlt.
+                verweigert += 1
+                continue
             segmente = convert_trip_to_segments(trip, stage_date(lat, lon))
             assert segmente, (
                 f"{ortsname} @ {zeitpunkt}, Versaetze {versaetze}: leere "
@@ -271,6 +394,14 @@ def test_segment_liegt_nie_vollstaendig_in_der_vergangenheit(
                 "hier 0 statt 1, genau der Fund aus #1667 S1"
             )
 
+    erwartet = NICHT_DARSTELLBAR.get((ortsname, zeitpunkt), 0)
+    assert verweigert == erwartet, (
+        f"{ortsname} @ {zeitpunkt}: {verweigert} statt {erwartet} Familien "
+        f"verweigert — es wurden {len(FAMILIEN) - verweigert} von "
+        f"{len(FAMILIEN) - erwartet} vorgesehenen Faellen wirklich am Segment "
+        "geprueft"
+    )
+
 
 @pytest.mark.parametrize("zeitpunkt", KIPPKANTEN)
 def test_wegpunktzeiten_ergeben_echt_wachsende_segmentgrenzen(zeitpunkt):
@@ -282,9 +413,14 @@ def test_wegpunktzeiten_ergeben_echt_wachsende_segmentgrenzen(zeitpunkt):
     Segment weniger und laeuft weiter.
     """
     with freeze_time(zeitpunkt):
+        verweigert = 0
         for ortsname, lat, lon in ORTE:
             for versaetze in FAMILIEN:
-                trip = _trip_aus_helfer(lat, lon, versaetze)
+                try:
+                    trip = _trip_aus_helfer(lat, lon, versaetze)
+                except ValueError:
+                    verweigert += 1  # #1940, s. NICHT_DARSTELLBAR
+                    continue
                 segmente = convert_trip_to_segments(trip, stage_date(lat, lon))
                 # Wegpunkte minus 1 Verbindungssegmente, plus das Ziel-Segment.
                 erwartet = len(versaetze)
@@ -298,6 +434,16 @@ def test_wegpunktzeiten_ergeben_echt_wachsende_segmentgrenzen(zeitpunkt):
                         f"{ortsname} @ {zeitpunkt}: Segment {s.segment_id} "
                         "endet nicht nach seinem Anfang"
                     )
+
+    erwartet = sum(
+        NICHT_DARSTELLBAR.get((name, zeitpunkt), 0) for name, _, _ in ORTE
+    )
+    assert verweigert == erwartet, (
+        f"@ {zeitpunkt}: {verweigert} statt {erwartet} Verweigerungen ueber "
+        f"alle Orte — {len(ORTE) * len(FAMILIEN) - verweigert} von "
+        f"{len(ORTE) * len(FAMILIEN) - erwartet} vorgesehenen Faellen wurden "
+        "wirklich am Segmentbau geprueft"
+    )
 
 
 # ══════════ AC-9 (#1697): stage_date() folgt der Ortszeit, nicht dem Serverdatum ══════════
@@ -338,6 +484,284 @@ def test_ac9_stage_date_folgt_der_ortszeit_in_der_randzeit():
     assert korsika_datum != island_datum, (
         "AC-9: Korsika- und Island-Ortsdatum muessen in dieser Randzeit "
         "auseinanderlaufen, sonst ist der Test nicht diskriminierend"
+    )
+
+
+# ══════════ #1940: das Vorzeichen eines Versatzes ist eine Zusicherung ══════════
+
+# Je Offset-Familie der Bereich der Ortsminuten, in dem die
+# Vorwaertsverschiebung (``verschiebung = max(0, -roh[0])``) einen NEGATIV
+# gewuenschten Wegpunkt hinter *jetzt* legt. Nachgemessen ueber alle 1440
+# Ortsminuten, nicht hergeleitet (docs/context/fix-1940-fixture-zeitkippkante.md).
+KAPUTTE_BEREICHE: list[tuple[tuple[int, ...], range]] = [
+    ((-120, -30, 90), range(0, 90)),     # 822 AC-3, Neuseeland -> 12:00-13:30 UTC
+    ((-120, -60, 60), range(0, 60)),     # 822 AC-2, London     -> 23:00-00:00 UTC
+    ((-240, -120, 120), range(0, 120)),  # 822 AC-1, Tirol      -> 22:00-00:00 UTC
+]
+
+# Die Familien der uebrigen 13 Testdateien: sie brauchen nur "ein Segment ist
+# jetzt aktiv" und sind von der Verschiebung nachweislich nicht betroffen.
+HARMLOSE_FAMILIEN: list[tuple[int, ...]] = [(-60, 120), (-60, 180), (-60, 60)]
+
+
+@pytest.mark.parametrize(
+    "versaetze,minute",
+    [
+        (versaetze, minute)
+        for versaetze, bereich in KAPUTTE_BEREICHE
+        for minute in (
+            bereich.start,
+            (bereich.start + bereich.stop) // 2,
+            bereich.stop - 1,
+        )
+    ],
+)
+def test_nicht_darstellbarer_vergangenheits_wegpunkt_scheitert_laut(versaetze, minute):
+    """AC-1 (#1940): ein bewusst in die VERGANGENHEIT gelegter Wegpunkt darf
+    nicht still in der Zukunft landen.
+
+    Nahe der Ortszeit-Mitternacht schiebt ``fenster_minuten`` das ganze Fenster
+    nach vorne. Die Abstaende bleiben dabei erhalten — das Vorzeichen eines
+    Versatzes nicht. Ein Aufrufer, der "zwei Stunden vor jetzt" verlangt hat,
+    bekommt ein Fenster, dessen erstes Segment noch AKTIV ist, und prueft danach
+    eine Konstellation, die er gar nicht hergestellt hat (Issue #1940: CI-Job
+    ``test`` taeglich 12:00-13:30 UTC rot, ohne Bezug zum PR-Inhalt).
+
+    Der Helfer muss das sagen, statt es zu verschweigen — genau so, wie
+    ``past_window_offsets`` es bereits tut (``ValueError``, wenn der Platz auf
+    dem Etappentag nicht reicht). Die Fehlermeldung muss die verletzte
+    Zusicherung benennen; ``match`` prueft deshalb den Begriff, nicht eine
+    zufaellige Formulierung.
+
+    RED heute: ``fenster_minuten`` liefert klaglos ein Fenster.
+    """
+    with pytest.raises(ValueError, match=r"(?i)vergangenheit"):
+        werte = fenster_minuten(minute, *versaetze)
+        verletzt = [(v, w) for v, w in zip(versaetze, werte) if v < 0 and w > minute]
+        raise AssertionError(
+            f"fenster_minuten({minute}, *{versaetze}) lieferte still {werte}; "
+            f"diese negativ gewuenschten Versaetze liegen NACH jetzt={minute}: "
+            f"{verletzt}"
+        )
+
+
+@pytest.mark.parametrize("versaetze,kaputt", KAPUTTE_BEREICHE)
+def test_negative_versaetze_liegen_ausserhalb_der_randzone_in_der_vergangenheit(
+    versaetze, kaputt
+):
+    """AC-2 (#1940), Positivkontrolle — HEUTE SCHON GRUEN, mit Absicht.
+
+    Dieser Test beweist NICHT den Fix; er sichert das Bestandsverhalten ab, das
+    der Fix nicht antasten darf: ausserhalb der Randzone liefert der Helfer
+    tatsaechlich ein Fenster, in dem jeder negativ gewuenschte Wegpunkt bei oder
+    vor *jetzt* liegt. Ohne ihn koennte der neue laute Fehler aus AC-1 beliebig
+    weit greifen (im Grenzfall: immer werfen) und AC-1 bliebe gruen, waehrend
+    die 14 abhaengigen Testdateien reihenweise ausfielen — AC-1 bewachte dann
+    die leere Menge.
+
+    Geprueft wird ueber alle 1440 Ortsminuten eines Tages, nicht an einem
+    Stichzeitpunkt; die Zahl der tatsaechlich geprueften Minuten wird
+    mitgezaehlt, damit ein zu grosszuegiger Ausschluss auffaellt.
+    """
+    geprueft = 0
+    verletzt: list[tuple[int, int, int]] = []
+    for m in range(MINUTEN_PRO_TAG):
+        if m in kaputt:
+            continue
+        geprueft += 1
+        werte = fenster_minuten(m, *versaetze)
+        verletzt += [(m, v, w) for v, w in zip(versaetze, werte) if v < 0 and w > m]
+
+    assert geprueft == MINUTEN_PRO_TAG - len(kaputt), (
+        f"nur {geprueft} von {MINUTEN_PRO_TAG - len(kaputt)} erwarteten "
+        f"Ortsminuten geprueft — der Ausschluss {kaputt} passt nicht zur "
+        "gemessenen Randzone"
+    )
+    assert not verletzt, (
+        f"{len(verletzt)} Faelle ausserhalb der Randzone legen einen negativ "
+        f"gewuenschten Wegpunkt hinter jetzt, z.B. {verletzt[:3]} "
+        "(Format: minuten_jetzt, Versatz, Wegpunkt)"
+    )
+
+
+@pytest.mark.parametrize("versaetze", HARMLOSE_FAMILIEN)
+def test_harmlose_familien_loesen_den_lauten_fehler_nie_aus(versaetze):
+    """AC-5 (#1940): keine Kollateralschaeden.
+
+    Die uebrigen 13 Testdateien verlangen nur "ein Segment ist jetzt aktiv" und
+    duerfen vom neuen lauten Fehler an keiner einzigen Ortsminute getroffen
+    werden — auch nicht ueber die Fan-out-Helfer (``_trip()`` in
+    ``test_briefing_anchor_survives_dispatch_failure.py``: 37 Aufrufe aus 25
+    Testfunktionen). Heute gruen, weil es den Fehler noch nicht gibt; nach dem
+    Fix traegt der Test die Zusicherung, dass er eng gefasst blieb.
+    """
+    ausloesungen: list[tuple[int, str]] = []
+    for m in range(MINUTEN_PRO_TAG):
+        try:
+            fenster_minuten(m, *versaetze)
+        except ValueError as fehler:
+            ausloesungen.append((m, str(fehler)))
+
+    assert not ausloesungen, (
+        f"Versaetze {versaetze} loesen an {len(ausloesungen)} von "
+        f"{MINUTEN_PRO_TAG} Ortsminuten einen Fehler aus, z.B. "
+        f"{ausloesungen[:3]} — der neue Waechter greift zu weit"
+    )
+
+
+# ══════════ #1940 AC-7: past_window_offsets staucht nicht mehr still ══════════
+
+# Beide Aufrufstellen des Vergangenheits-Helfers benutzen dieselbe Familie.
+AC7_VERSAETZE = (-240, -120)
+# Pacific/Auckland, UTC+12 im August: Ortszeit-Mitternacht liegt bei 12:00 UTC.
+AC7_LAT, AC7_LON = -41.29, 174.78
+AC7_MITTERNACHT_UTC = datetime(2026, 8, 18, 12, 0, tzinfo=timezone.utc)
+
+# Ortsminuten des Sweeps: dicht um die gemessene Kante bei 240, grob ueber den
+# Rest des Tages. Der volle 1440-Minuten-Sweep wurde einmal gefahren (Kante
+# scharf bei 240, Spanne durchgehend 120, jeder Wegpunkt vor jetzt) und dauert
+# 4,5 s — jede Ortsminute braucht einen eigenen ``freeze_time``-Kontext, weil
+# ``past_window_offsets`` seine Uhr selbst liest. Diese Auswahl kostet 0,2 s
+# und traegt dieselbe Aussage.
+AC7_PUNKTE = [*range(230, 250), 0, 60, 120, 180, 300, 600, 900, 1200, 1439]
+AC7_VERWEIGERT_ERWARTET = 14   # 230-239 plus 0, 60, 120, 180
+AC7_GELIEFERT_ERWARTET = 15    # 240-249 plus 300, 600, 900, 1200, 1439
+AC7_SPANNE = 120               # -240 -> -120
+
+
+def _minute_aus_hhmm(hhmm: str) -> int:
+    return int(hhmm[:2]) * MINUTEN_PRO_TAG // 24 + int(hhmm[3:])
+
+
+def _ac7_sweep() -> tuple[list, list]:
+    """Ruft ``past_window_offsets`` an jeder Ortsminute aus ``AC7_PUNKTE`` und
+    trennt Verweigerungen von gelieferten Fenstern."""
+    verweigert: list = []
+    geliefert: list = []
+    for m in AC7_PUNKTE:
+        with freeze_time(AC7_MITTERNACHT_UTC + timedelta(minutes=m)):
+            try:
+                erster, letzter = past_window_offsets(
+                    AC7_LAT, AC7_LON, *AC7_VERSAETZE
+                )
+            except ValueError as fehler:
+                verweigert.append((m, str(fehler)))
+                continue
+        geliefert.append((m, _minute_aus_hhmm(erster), _minute_aus_hhmm(letzter)))
+    return verweigert, geliefert
+
+
+def test_past_window_verweigert_wenn_der_ortstag_zu_frueh_ist():
+    """AC-7: der Vergangenheits-Helfer staucht nicht mehr still.
+
+    Bis 2026-08-17 wurde ein Fenster, das nicht mehr auf den vergangenen Teil
+    des Etappentags passte, gleichmaessig auf ``[0, obergrenze]`` gestaucht.
+    Der letzte Wegpunkt landete dann eine Minute vor *jetzt* — und das
+    Ziel-Segment blieb nach dem Randfall-Guard noch eine Stunde offen. Der
+    Trip war damit gerade NICHT "vorbei", also das Gegenteil dessen, wofuer
+    diese Funktion existiert. Sichtbar wurde das als taeglicher CI-Ausfall
+    12:00-16:00 UTC in
+    ``test_issue_818_radar_briefing_integration.py::test_ac5_...``.
+    """
+    verweigert, geliefert = _ac7_sweep()
+
+    assert len(verweigert) == AC7_VERWEIGERT_ERWARTET, (
+        f"{len(verweigert)} statt {AC7_VERWEIGERT_ERWARTET} Verweigerungen an "
+        f"den Ortsminuten {AC7_PUNKTE} — die Kante hat sich verschoben "
+        f"(verweigert wurde bei {[m for m, _ in verweigert]})"
+    )
+    assert len(geliefert) == AC7_GELIEFERT_ERWARTET, (
+        f"{len(geliefert)} statt {AC7_GELIEFERT_ERWARTET} gelieferte Fenster — "
+        "ohne diesen Gegenzaehler waere der Test auch dann gruen, wenn die "
+        "Funktion ueberhaupt nichts mehr liefert"
+    )
+    ohne_hinweis = [
+        (m, meldung) for m, meldung in verweigert
+        if "vergangenes Fenster" not in meldung
+    ]
+    assert not ohne_hinweis, (
+        f"{len(ohne_hinweis)} Meldungen benennen die verletzte Zusicherung "
+        f"nicht, z.B. {ohne_hinweis[:1]}"
+    )
+
+
+def test_past_window_haelt_die_spanne_ausserhalb_der_randzone():
+    """AC-7, Positivkontrolle: die Verweigerung ersetzt die Stauchung, sie
+    ersetzt nicht die Funktion.
+
+    Ohne diesen Test waere ein Waechter, der IMMER wirft, oben trivial gruen —
+    und die beiden Aufrufstellen haetten gar kein Fenster mehr. Geprueft wird
+    deshalb nicht nur, DASS ein Fenster kommt, sondern dass es die verlangte
+    Spanne traegt und vollstaendig vor *jetzt* liegt.
+    """
+    _, geliefert = _ac7_sweep()
+
+    assert len(geliefert) == AC7_GELIEFERT_ERWARTET, (
+        f"nur {len(geliefert)} von {AC7_GELIEFERT_ERWARTET} Ortsminuten "
+        "lieferten ueberhaupt ein Fenster"
+    )
+    gestaucht = [
+        (m, erster, letzter) for m, erster, letzter in geliefert
+        if letzter - erster != AC7_SPANNE
+    ]
+    assert not gestaucht, (
+        f"{len(gestaucht)} Fenster tragen nicht die verlangten {AC7_SPANNE} "
+        f"Minuten Spanne, z.B. {gestaucht[:3]} (Format: Ortsminute, erster, "
+        "letzter Wegpunkt) — genau die stille Stauchung, die AC-7 abschafft"
+    )
+    nicht_vorbei = [
+        (m, letzter) for m, _, letzter in geliefert if letzter >= m
+    ]
+    assert not nicht_vorbei, (
+        f"{len(nicht_vorbei)} Fenster enden nicht vor jetzt, z.B. "
+        f"{nicht_vorbei[:3]} — der Trip waere dort nicht 'vorbei'"
+    )
+
+
+def test_vergangenes_fenster_ist_am_echten_segmentbau_wirklich_vorbei():
+    """AC-7 am WIRKORT — die Luecke aus Adversary-Finding F001.
+
+    Die beiden Tests oben pruefen die Rechnung des Helfers isoliert. Das reicht
+    hier nicht: beide echten Aufrufstellen stellen seit AC-7 ihre Uhr und
+    erreichen die Randzone nie mehr — eine Rueckabwicklung des Prueflings
+    (Stauchung statt Verweigerung) bliebe an ihnen unsichtbar. Ein Waechter,
+    der die Klasse, der er angehoert, nicht sieht, ist genau der Fund, wegen
+    dem es #1940 gibt.
+
+    Geprueft wird deshalb die ZUSICHERUNG der Funktion am echten
+    ``convert_trip_to_segments``: dass das letzte Segment tatsaechlich
+    abgelaufen ist. Dieselbe Vorkehrung wie an der echten Aufrufstelle
+    (Tagesfenster 0-1 Uhr) — ohne sie haelt das Ziel-Segment seit #1584 bis
+    19:00 Ortszeit offen und der Test pruefte etwas anderes, als er behauptet.
+    """
+    fenster = {"day_window_start_hour": 0, "day_window_end_hour": 1}
+    vorbei = verweigert = 0
+    for m in (0, 120, 239, 240, 300, 720, 1439):
+        with freeze_time(AC7_MITTERNACHT_UTC + timedelta(minutes=m)):
+            try:
+                trip = _trip_aus_helfer(
+                    AC7_LAT, AC7_LON, AC7_VERSAETZE,
+                    helfer=past_window_offsets, tagesfenster=fenster,
+                )
+            except ValueError:
+                verweigert += 1
+                continue
+            segmente = convert_trip_to_segments(trip, stage_date(AC7_LAT, AC7_LON))
+            assert segmente, f"Ortsminute {m}: leere Segmentliste"
+            letztes_ende = max(s.end_time for s in segmente)
+            assert letztes_ende < datetime.now(timezone.utc), (
+                f"Ortsminute {m}: das letzte Segment endet erst "
+                f"{letztes_ende.isoformat()} und ist damit NICHT vorbei — "
+                "genau der Zustand, den eine stille Stauchung erzeugt "
+                "(letzter Wegpunkt eine Minute vor jetzt, Ziel-Segment noch "
+                "eine Stunde offen)"
+            )
+            vorbei += 1
+
+    assert (verweigert, vorbei) == (3, 4), (
+        f"{verweigert} Verweigerungen / {vorbei} vorbeigelaufene Trips statt "
+        "3 / 4 — die Kante bei Ortsminute 240 hat sich verschoben, oder der "
+        "Test prueft gar nichts mehr"
     )
 
 


### PR DESCRIPTION
Behebt #1940 (Issue-Close erst nach Prod-Selftest, deshalb kein `Closes`-Schlüsselwort).

## Problem

Die CI-Ampel fiel **täglich mehrere Stunden** aus, unabhängig vom PR-Inhalt. Zwei
Test-Hilfsfunktionen lieferten stillschweigend etwas anderes, als der Aufrufer verlangt hatte:

| Funktion | stilles Verhalten | Folge |
|---|---|---|
| `fenster_minuten` | verschob das Fenster bei früher Ortszeit nach vorne | Abstände blieben, das **Vorzeichen** eines Versatzes nicht — ein bewusst in die Vergangenheit gelegter Wegpunkt landete in der Zukunft |
| `past_window_offsets` | stauchte das Fenster auf den verbliebenen Platz | letzter Wegpunkt eine Minute vor jetzt, Ziel-Segment noch eine Stunde offen — ein „garantiert abgelaufenes" Segment war nicht abgelaufen |

Der Produktivcode war in beiden Fällen korrekt. Nur die Testvorbereitung behauptete eine
Konstellation, die sie nicht herstellte.

## Drei gemessene Ausfallfenster — das Ticket kannte nur das erste

| Fenster (UTC) | Ursache | Herkunft |
|---|---|---|
| 12:00–13:30 | Vorzeichenverlust (Neuseeland) | im Ticket gemeldet |
| 23:00–00:00 | Serverdatum statt Ortstag (nur während britischer Sommerzeit) | in der RED-Phase gemessen → AC-6 |
| 12:00–16:00 | stille Stauchung (Neuseeland) | in der GREEN-Phase gemessen → AC-7 |

AC-6 und AC-7 wurden vom PO ausdrücklich in den Umfang aufgenommen: ohne sie wäre die Ampel
trotz erfülltem Ticketziel weiterhin täglich rot gewesen.

## Lösung

Beide Funktionen verweigern jetzt **laut** mit handlungsleitender Meldung (welche Versätze,
welche Ortsminute, welcher Ausweg), statt still ein Fenster zu liefern, das die Zusicherung
nicht trägt. Diese Haltung existierte im selben Modul bereits für den Totalfall — sie gilt
jetzt durchgängig. Die drei Aufrufstellen mit echtem Vergangenheits-Bedarf stellen ihre Uhr
selbst auf Ortsmittagszeit; eine vierte Stelle nutzt den Ortstag statt des Serverdatums.

Bei `past_window_offsets` sind dabei zwei Bedingungen zu einer geworden — die alte Prüfung
„gar kein Platz mehr" ist in der neuen enthalten.

## Nachweis

- **Wanduhr-Ratsche** (neu): misst zwei Testdateien an je fünf gestellten Uhrzeiten in
  frischen Kindprozessen und vergleicht die Ergebnisse. Vorher wich das Ergebnis je nach
  Uhrzeit ab, jetzt ist die Differenz leer. Eine Positivkontrolle läuft mit — eine leere
  Differenz ist sonst auch das Ergebnis einer kaputten Messung.
- **Schicht-2-Wächter** (Adversary-Finding F001): prüft die Zusicherung am echten
  `convert_trip_to_segments`. Nötig, weil die Aufrufstellen seit dem Fix ihre Uhr stellen und
  die Randzone nie mehr erreichen — eine Rückabwicklung wäre an ihnen unsichtbar geblieben.
  Der Wächter wird unter der zurückgedrehten Fassung an der Fachaussage rot, nicht am Zähler.
- **266 Tests** über alle betroffenen und abhängigen Dateien grün, nach Rebase auf den
  aktuellen `main` erneut geprüft.
- **Adversary: 3 Runden, VERDICT VERIFIED**, F001 geschlossen, keine offenen Findings.
  Zehn Mutationen gefahren; die verankerten Zähler-Literale wurden unabhängig nachgerechnet
  statt übernommen, der Sweep gegen einen vollen 1440-Minuten-Lauf geprüft.

## Bekannte Grenzen

- Eine Änderung des Fehlertextes jenseits des geprüften Begriffs bliebe unbemerkt (bewusst so —
  eine wortgenaue Textprüfung wäre Reibung ohne Schutzwert).
- Prüfling und Zähler-Literale **gemeinsam** zu verschieben käme durch. Das ist die bekannte
  Grenze einer Literal-Ratsche; sie fängt die einseitige Änderung.

## Wechselwirkung mit #1599

Die parallele Lieferung zu #1599 setzt das Ziel-Segment-Ende künftig auf mindestens
`Ankunft + 1 h`. Nachgerechnet: dieser PR bleibt gültig, weil seine Fixtures mit 120 Minuten
Abstand arbeiten (Segmentende damit 60 Minuten vor jetzt). Wer zuletzt merged, lässt die
Testdateien der Gegenseite mitlaufen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
