### PR TITLE
fix(#1720): Ausblick-Spaltenauswahl auf Kompakt-Mail und Telegram ausgeweitet

### DIFF
--- a/docs/adr/0055-trip-ausblick-waehlbare-spalten.md
+++ b/docs/adr/0055-trip-ausblick-waehlbare-spalten.md
@@ -164,6 +164,18 @@ bleibt. Eine Vereinheitlichung muss ihn **hineinziehen**, nicht danebenlegen.
   „Erscheint nur in der E-Mail". Beide haben **keinen** Byte-Wächter
   (`metric_output_matrix.md:237-243`) — Scheibe 2 legt deshalb zuerst einen
   Charakterisierungstest des Ist-Zustands an, bevor sie etwas ändert.
+
+  > **Nachtrag 2026-08-17 (Issue #1720 Scheibe 2, verifiziert, validiert):**
+  > Geliefert wie hier angekündigt. Kompakt-Mail und Telegram sind jetzt
+  > ebenfalls katalog-getrieben — dieselbe, bereits gespeicherte Auswahl
+  > (`display_config.outlook_metrics`) wirkt seither in **allen vier**
+  > Trip-Ausgabeorten mit Ausblick (HTML, Klartext, Kompakt-Mail, Telegram).
+  > Der Hinweistext „Erscheint nur in der E-Mail" ist im Trip-Kontext
+  > entfernt (Compare-Kontext behält ihn, dort gilt die Einschränkung
+  > weiterhin unverändert). Details, Implementierung, ACs:
+  > `docs/specs/modules/feat_1720_s2_ausblick_kompakt_telegram.md`. Diese
+  > historische Ankündigung bleibt oben unverändert stehen — sie war zum
+  > Zeitpunkt von Scheibe 1 richtig.
 - Der stärkste Bestandswächter des Trip-Ausblicks,
   `tests/tdd/test_trip_outlook_parity.py`, ruft die Renderer **isoliert** auf
   und durchläuft die neue Verdrahtung nie — belegt durch eine Mutation, die ihn

--- a/docs/context/feat-1720-s2-ausblick-kompakt-telegram.md
+++ b/docs/context/feat-1720-s2-ausblick-kompakt-telegram.md
@@ -1,0 +1,150 @@
+# Context: feat-1720-s2-ausblick-kompakt-telegram
+
+<!-- Issue #1720 Scheibe 2 — Ausblick-Spaltenauswahl auf Kompakt-Mail und Telegram ausweiten -->
+<!-- Gemessen 2026-08-17 gegen origin/main b66799c6. Alle Zeilenangaben aus dieser Messung. -->
+
+## Request Summary
+
+Scheibe 1 (#1720, PR #1840, live seit `9961b2cd`) hat die 3-Tages-Vorschau
+katalog-getrieben gemacht — aber nur für HTML- und Klartext-Trip-Mail.
+Kompakt-Mail und Telegram zeigen weiterhin ihre alten, fest verdrahteten
+Felder, unabhängig davon, was der Nutzer im Abschnitt „3-Tages-Vorschau"
+auswählt. ADR-0055 kündigt Scheibe 2 ausdrücklich an und schreibt vor:
+**zuerst ein Charakterisierungstest des Ist-Zustands**, weil dort kein
+Byte-Wächter existiert (`metric_output_matrix.md:237-243`).
+
+## Der Ist-Stand, gemessen
+
+### Die Zeilen-Daten liegen für alle vier Ausgabeorte bereits bereit
+
+`trip_report_scheduler.py:2329` baut `multi_day_trend` EINMAL über
+`build_outlook_row(..., trip_display_config=dc, report_type=report_type)`
+und reicht dasselbe Ergebnis an alle vier Renderer weiter
+(`trip_report_scheduler.py:1418,1433,1477`). Ist `outlook_metrics` gesetzt
+(`metrics is not None` in `build_outlook_row()`, `outlook.py:588-652`),
+trägt **jeder Stage-Eintrag bereits** `row["cells"]` (formatierte Zellwerte,
+`outlook.py:635-644`) und `row["cell_bg"]` — Kompakt und Telegram müssten sie
+nur lesen. Es gibt keinen fehlenden Datenabruf, nur eine fehlende
+Darstellung.
+
+### Zwei eigenständige, fest verdrahtete Renderer
+
+| Ausgabeort | Datei | Was heute passiert |
+|---|---|---|
+| Kompakt-Mail | `src/output/renderers/email/compact.py:258-270` — Inline-Loop in `render_compact()` | `format_trend_tokens(stage)` liest die festen Rohfelder (`temp_str`, `precip_str`, `wind_str`) + `_compact_thunder_field()` (`compact.py:84-111`, eigener Gewitter-Helfer). Fünf feste Felder, kein Katalog-Bezug. |
+| Telegram | `src/output/renderers/narrow.py:572-613` — `_outlook_lines(multi_day_trend)`, Aufruf in `render_telegram_bubbles()` bei `narrow.py:833-835` | Ebenfalls über `format_trend_tokens(stage)`, feste Zeile `weekday · temp · precip · wind · thunder`. Kein `metrics`/`dc`-Parameter, obwohl `render_telegram_bubbles()` selbst schon ein `dc:`-Kwarg besitzt (`narrow.py:639`) — nur nicht an `_outlook_lines()` durchgereicht. |
+
+### Die Auflösung existiert bereits — nur zwei Aufrufstellen bekommen sie nicht
+
+`trip_report.py:218-220` löst `outlook_metrics` bereits EINMAL aus dem
+ungekollabierten Stand auf: `resolve_trip_outlook_metrics(_dc_uncollapsed,
+report_type)`. Das Ergebnis geht als `render_email(outlook_metrics=…)`
+(`trip_report.py:201-249`) — aber:
+
+1. **`render_email()`'s `compact`-Zweig verwirft es.** `email/__init__.py:111-132`:
+   der frühe Return bei `email_format == "compact"` ruft `render_compact(...)`
+   auf und übergibt dabei **kein** `outlook_metrics=` — der Parameter fehlt
+   im Aufruf komplett, obwohl `render_compact()` selbst (Signatur
+   `compact.py:130-150`) über `**_ignored` sowieso jeden unbekannten Kwarg
+   schluckt. Selbst wenn `outlook_metrics` gesetzt wäre, käme es nicht an.
+2. **`render_telegram_bubbles()` bekommt gar keinen `outlook_metrics`-Aufruf.**
+   `trip_report.py:290-309` ruft die Funktion mit `dc=_dc_telegram`,
+   `multi_day_trend=effective_trend` — aber ohne `outlook_metrics=`. Die
+   Auflösung passiert für Telegram nirgends; `_outlook_lines()` kennt den
+   Parameter (`narrow.py:572`) gar nicht in ihrer Signatur.
+
+**Das ist der zentrale Befund:** Scheibe 2 ist strukturell keine neue
+Auflösung, sondern (a) zwei fehlende Durchreichungen + (b) zwei Renderer, die
+zwischen Legacy-Feldern und `row["cells"]` umschalten müssen.
+
+## Wiederverwendbare Bausteine (Compare, unverändert)
+
+Dieselben Funktionen, die Scheibe 1 für HTML/Klartext genutzt hat, tragen
+auch hier:
+
+| Funktion | Datei | Zweck |
+|---|---|---|
+| `resolve_trip_outlook_metrics(dc, report_type)` | `compare_outlook_metric_ids.py:78-102` | Bereits vorhandene Auflösung + Schnitt gegen Grundauswahl — **keine neue Funktion nötig**, nur an zwei weiteren Stellen aufrufen |
+| `outlook_columns(metrics)` | `compare_outlook_metric_ids.py:118-142` | Auswahl → geordnete Spalten mit deutschem Label |
+| `format_outlook_value(value, column)` | `compare_outlook_metric_ids.py:145-` | Zellentext (Zahl/Ordinal/Enum) |
+| `row["cells"]` / `row["cell_bg"]` | bereits in `multi_day_trend` enthalten | Liegt für alle vier Kanäle vor, sobald `outlook_metrics` beim Zeilenbau gesetzt war |
+
+## Verhalten bei `[]` und `None` — muss dem HTML/Klartext-Muster folgen
+
+HTML/Klartext lösen das über eine erweiterte Bedingung an der Aufrufstelle
+(ADR-0055 Implementation Details Punkt 2): `if multi_day_trend and
+_outlook_metrics != []:`. Kompakt (`compact.py:258`) und Telegram
+(impliziert durch `narrow.py:833-835`) haben aktuell nur `if multi_day_trend:`
+bzw. äquivalent — dieselbe Erweiterung fehlt dort und muss ergänzt werden,
+sonst zeigt eine bewusst geleerte Auswahl (`outlook_metrics=[]`) dort weiter
+die Legacy-Felder oder eine leere Überschrift ohne Zeilen.
+
+## Hinweistext „Erscheint nur in der E-Mail" — wird für den Trip falsch
+
+`CompareOutlookLayoutControls.svelte:181-183` zeigt den Hinweis
+`outlook-email-hint`, geteilt zwischen Compare- und Trip-Einbindung. Für
+**Compare** bleibt er richtig: `render_compare_telegram()`
+(`comparison.py`) hat nie einen Ausblick-Block, nur `render_compare_email()`
+zeigt ihn — bestätigt, kein Telegram-Ausblick-Renderpfad im
+Compare-Code (`comparison.py`, `compare_html.py` enthalten keinen
+Telegram-Ausblick-Aufruf). Für den **Trip** wird die Aussage mit Scheibe 2
+falsch: die Auswahl wirkt dann auch in Kompakt-Mail und Telegram. Der Hinweis
+muss kontextabhängig werden (Compare: unverändert stehen bleiben; Trip:
+entfällt oder wird umformuliert) — S1 (AC-7) hatte ihn bewusst mit dem
+Vermerk „bis Scheibe 2" für den Trip übernommen.
+
+## Fehlender Wächter (der Befund, der die Testplanung bestimmt)
+
+Es gibt für Kompakt-Mail- und Telegram-Ausblick **keinen** Byte-Golden-Test
+— bestätigt durch Grep: `test_issue_729_render_compact_empty.py`,
+`test_issue_1001_telegram_bubbles.py`, `test_channel_metric_matrix.py`
+decken andere Aspekte ab, keiner den heutigen Ist-Zustand des
+Ausblick-Blocks byte-genau. `test_trip_outlook_parity.py` ruft ausschließlich
+`render_outlook_table()`/`render_outlook_plain()` (den HTML/Klartext-Pfad)
+auf — Kompakt/Telegram nie. **Vor jeder Änderung an `compact.py`/`narrow.py`
+muss deshalb zuerst ein Charakterisierungstest den heutigen Legacy-Zustand
+(`outlook_metrics=None`) festschreiben**, sonst gibt es keinen Beleg, dass
+Scheibe 2 den Altbestand nicht verändert hat.
+
+## Betroffene Dateien (Schätzung)
+
+| Datei | Änderung |
+|---|---|
+| `src/output/renderers/email/__init__.py` | `outlook_metrics=outlook_metrics` in den `render_compact(...)`-Aufruf (Zeile ~112-131) ergänzen |
+| `src/output/renderers/email/compact.py` | `render_compact()`-Signatur um `outlook_metrics` erweitern; `if multi_day_trend:`-Block (Zeile 258-270) auf Katalog-Zweig umstellen, analog `outlook.py`s Spaltenbau |
+| `src/output/renderers/narrow.py` | `_outlook_lines()`-Signatur um `outlook_metrics` erweitern, Katalog-Zweig ergänzen; `render_telegram_bubbles()` reicht `outlook_metrics` durch |
+| `src/output/renderers/trip_report.py` | `outlook_metrics=resolve_trip_outlook_metrics(_dc_uncollapsed, report_type)` an den `render_telegram_bubbles(...)`-Aufruf (Zeile 290-309) ergänzen — für `render_email()` bereits vorhanden, muss dort nur noch bis zum `compact`-Zweig durchdringen |
+| `frontend/src/lib/components/shared/CompareOutlookLayoutControls.svelte` | Hinweistext „Erscheint nur in der E-Mail" für Trip-Kontext entfernen/umformulieren |
+| **neu:** ein Charakterisierungstest für Kompakt+Telegram-Ausblick (Legacy) | Golden/Byte-Vergleich vor jeder Änderung |
+| **neu:** Wirkort-Test analog `test_trip_outlook_dispatch_mail.py` für Kompakt+Telegram | Katalog-Auswahl bis in die zugestellte Kompakt-Mail/Telegram-Bubble verfolgt |
+
+## Offene Fragen für die Spec
+
+1. **Reihenfolge/Format der Kompakt-Zeile bei aktiver Auswahl** — heute feste
+   Feldbreiten (`f"{weekday:<3} {name:<26} ..."`). Mit variabler Spaltenzahl
+   (1 bis N gewählte Größen) muss ein Format ohne feste Breiten pro Spalte
+   entstehen. Vorschlag: Label-Wert-Paare durch Trenner, analog wie
+   `outlook_columns()` es für die Spaltenköpfe liefert — Details in der Spec.
+2. **Telegram-Zeilenformat** analog — heute `weekday  temp  precip  wind
+   thunder` mit `_wrap()` auf Prosa-Breite. Bei Katalog-Auswahl müssen die
+   Spalten-Labels (aus `outlook_columns()`) mit erscheinen (die feste Zeile
+   trägt heute keine Labels, nur Werte — bei freier Auswahl unklar ohne
+   Beschriftung, welche Zahl was ist).
+3. **`[]`-Fall in Kompakt/Telegram**: Soll wie HTML/Klartext die Überschrift
+   „Naechste Etappen" (Kompakt) / „Ausblick" (Telegram) ganz entfallen, wenn
+   `outlook_metrics == []`? (Ja, analog AC-4 aus S1 — zur Bestätigung in der
+   Spec aufnehmen.)
+4. **Hinweistext-Formulierung** für den Trip-Kontext nach Scheibe 2: ganz
+   entfernen oder durch nichts ersetzen (da jetzt alle vier relevanten Kanäle
+   erreicht werden — SMS/Premium-SMS bleiben weiterhin baulich unerreichbar,
+   aber das war nie Teil des Hinweises).
+
+## Nicht betroffen
+
+- SMS/Premium-SMS — bleiben baulich unerreichbar (`sms_trip.py` kennt
+  `multi_day_trend` nicht, unverändert seit ADR-0055).
+- Ortsvergleich — `resolve_outlook_metrics()`, `comparison.py`,
+  `compare_html.py` bleiben unangetastet.
+- `report_config.show_outlook`-Semantik — unverändert, einziger Ein/Aus-Schalter.
+- Persistenzformat `display_config.outlook_metrics` — unverändert, Scheibe 1
+  hat Lesen/Schreiben bereits vollständig verdrahtet.

--- a/docs/reference/metric_output_matrix.md
+++ b/docs/reference/metric_output_matrix.md
@@ -265,6 +265,22 @@ Modul-Docstring sind nachgezogen. Spec:
 > (Pillen, mobile Zeilen, Fließtext-Zusammenfassung, Telegram-Kurzübersicht), nicht
 > dieser separate Trend-Block. Der „→ Scheibe 4"-Verweis ist damit nur teilweise
 > eingelöst; der Trend-/Ausblick-Pfad in Telegram und Kompakt-Mail bleibt unbewacht.
+>
+> 🔴 **ÜBERHOLT seit #1720 S2 (2026-08-17).** Der obige Absatz beschreibt den
+> Stand vor dieser Lieferung: „eigene Implementierungen, die `outlook.py`
+> nicht importieren" und „bleibt unbewacht" gelten so nicht mehr.
+> `narrow.py:_outlook_lines()` und `email/compact.py`s Trend-Block haben seit
+> #1720 S2 einen zweiten, katalog-getriebenen Zweig, der dieselbe
+> `resolve_trip_outlook_metrics()`/`outlook_columns()`-Auflösung wie
+> HTML/Klartext liest, sobald `display_config.outlook_metrics` gesetzt ist —
+> `outlook.py` wird zwar weiterhin nicht importiert (Formatierung bleibt
+> eigenständig, Label-Wert-Muster statt Legende), aber die Auswahl wirkt
+> jetzt auch hier. Der Legacy-Zweig (`outlook_metrics is None`) bleibt
+> unverändert bestehen und weiterhin unbewacht in diesem Sinn. Neue Wächter:
+> Charakterisierungstest für den Legacy-Zustand plus Wirkort-Dispatch-Tests
+> für den Katalog-Zweig (Muster `test_trip_outlook_dispatch_mail.py`,
+> `test_telegram_rate_limit.py:274`). Details:
+> `docs/specs/modules/feat_1720_s2_ausblick_kompakt_telegram.md`.
 
 **Fläche 3 — Nicht-wählbare Register-Metriken.** `metric_catalog.py:695` —
 `get_all_metrics()` gibt `[m for m in _METRICS if m.selectable]` zurück. Jeder

--- a/docs/specs/modules/feat_1720_s2_ausblick_kompakt_telegram.md
+++ b/docs/specs/modules/feat_1720_s2_ausblick_kompakt_telegram.md
@@ -1,0 +1,487 @@
+---
+entity_id: feat_1720_s2_ausblick_kompakt_telegram
+type: feature
+created: 2026-08-17
+updated: 2026-08-17
+status: draft
+version: "1.0"
+workflow: feat-1720-s2-ausblick-kompakt-telegram
+tags: [trip, outlook, ausblick, kompakt-mail, telegram, metrik-katalog, feature, epic-1372, issue-1720]
+---
+
+# 3-Tages-Vorschau des Trip-Briefings: wählbare Spalten für Kompakt-Mail und Telegram (Issue #1720, Scheibe 2)
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Scheibe 1 (#1720, PR #1840) hat die 3-Tages-Vorschau der HTML- und
+Klartext-Trip-Mail katalog-getrieben gemacht. Kompakt-Mail und Telegram
+zeigen weiterhin ihre alten, fest verdrahteten Felder — unabhängig davon,
+was der Nutzer im bereits vorhandenen Abschnitt „3-Tages-Vorschau" auswählt.
+ADR-0055 kündigt diese Scheibe ausdrücklich an. Dieses Modul schließt die
+Lücke: dieselbe, bereits gespeicherte Auswahl (`display_config.outlook_metrics`)
+wirkt danach in **allen vier** Trip-Ausgabeorten mit Ausblick (HTML, Klartext,
+Kompakt-Mail, Telegram) — SMS/Premium-SMS bleiben unverändert baulich
+unerreichbar, Ortsvergleich bleibt unverändert. Es entsteht **keine** neue
+Auflösung, **kein** neues Persistenzfeld — nur zwei fehlende Durchreichungen
+und zwei Renderer, die zwischen Legacy-Feldern und dem bereits vorliegenden
+`row["cells"]` umschalten.
+
+## Source
+
+- **File:** `src/output/renderers/trip_report.py:215-220` (render_email-Aufruf)
+  und `:290-309` (render_telegram_bubbles-Aufruf). Neu: EINE Auflösung vor
+  beiden Aufrufen (`_outlook_metrics = resolve_trip_outlook_metrics(_dc_uncollapsed, report_type)`),
+  wiederverwendet als `outlook_metrics=_outlook_metrics` in **beiden**
+  Aufrufen. `render_telegram_bubbles(...)` bekommt den Kwarg dabei zum
+  ersten Mal — bislang fehlt er komplett. 🔴 Die Quelle MUSS
+  `_dc_uncollapsed` bleiben, NICHT `_dc_telegram` (das kanal-kollabierte
+  Telegram-Layout, Zeile 274/293) — der Ausblick hat laut ADR-0055 Punkt 2
+  keine Kanal-Ebene; Telegram-eigene `per_channel_layouts` dürfen die global
+  gewählte Vorschau-Spalte nicht enger schneiden als die Grundauswahl
+  erlaubt (identische Gefahr zu S1s Adversary-Finding F001/AC-17, jetzt auf
+  den zweiten Konsumenten übertragen).
+- **File:** `src/output/renderers/email/__init__.py:111-132` (`render_email()`,
+  `email_format == "compact"`-Zweig). Neu: `outlook_metrics=outlook_metrics,`
+  in den `render_compact(...)`-Aufruf (Zeile 112-131) einfügen — der Wert ist
+  hier bereits als Funktionsparameter vorhanden (Zeile 51), geht aber vor
+  dieser Änderung verloren, weil er im Aufruf fehlt.
+- **File:** `src/output/renderers/email/compact.py:130-151` (`render_compact()`-
+  Signatur). Neu: `outlook_metrics: Optional[list[dict]] = None,` ergänzen
+  (nach `multi_day_trend`, vor `outlook_state`, analog zur Reihenfolge in
+  `render_email()`). Import `outlook_columns`, `format_outlook_value` aus
+  `output.renderers.compare_outlook_metric_ids`.
+- **File:** `src/output/renderers/email/compact.py:258-270` (`if multi_day_trend:`-
+  Block). Neu: Katalog-Zweig analog `email/outlook.py:333-341`
+  (`render_outlook_plain()`s bereits vorhandenem Muster) — siehe
+  Implementation Details Punkt 1. Bedingung erweitert sich um
+  `outlook_metrics != []` (Implementation Details Punkt 3); dieselbe
+  Erweiterung gilt für den `elif outlook_state ...`-Fallback-Zweig
+  (Zeile 271-278).
+- **File:** `src/output/renderers/narrow.py:572-613` (`_outlook_lines()`).
+  Signatur neu: `def _outlook_lines(multi_day_trend: list[dict], outlook_metrics: Optional[list[dict]] = None) -> list[str]:`.
+  Neu: Katalog-Zweig analog Implementation Details Punkt 2.
+- **File:** `src/output/renderers/narrow.py:635-655`
+  (`render_telegram_bubbles()`-Signatur). Neu:
+  `outlook_metrics: Optional[list[dict]] = None,` ergänzen (nach
+  `multi_day_trend`, analog `render_email()`).
+- **File:** `src/output/renderers/narrow.py:832-839` (Ausblick-Bubble-Block,
+  `if multi_day_trend:` / `elif outlook_state ...`). Neu:
+  `_outlook_lines(multi_day_trend, outlook_metrics)` statt
+  `_outlook_lines(multi_day_trend)`; Bedingung beider Zweige erweitert um
+  `outlook_metrics != []` (identisch zu compact.py, Implementation Details
+  Punkt 3).
+- **File:** `frontend/src/lib/components/shared/CompareOutlookLayoutControls.svelte:37-60`
+  (Props-Interface). Neu: optionale Prop `showEmailOnlyHint?: boolean`
+  (Default `true` — bewahrt das heutige Compare-Verhalten ohne
+  Compare-seitige Änderung). `:176-183` (Hinweistext-Block): die
+  `{#if materializedOutlookKeys.length > 0}`-Bedingung erweitert sich um
+  `&& showEmailOnlyHint`.
+- **File:** `frontend/src/lib/components/shared/WeatherMetricsTab.svelte:1778-1784`
+  (Trip-Einbindung von `CompareOutlookLayoutControls`). Neu:
+  `showEmailOnlyHint={false}` ergänzen — die Compare-Einbindung
+  (`:1398-1405`) bleibt unverändert (Default greift).
+
+> **Schicht-Hinweis:** Python-Core (`src/output/renderers/`) trägt das
+> Rendering; Frontend (`frontend/src/lib/components/shared/`) nur den
+> Hinweistext. Kein Anteil in `cmd/`, `internal/` oder anderen Go-Paketen
+> (`display_config` bleibt `map[string]interface{}`, unverändert seit S1).
+> `compare_outlook_metric_ids.py` wird **nicht** verändert — reine
+> Wiederverwendung.
+
+## Estimated Scope
+
+- **LoC:** ~95-130 Produktiv (`trip_report.py` ~6: eine Variable statt
+  Inline-Aufruf, zweiter Aufrufort ergänzt; `email/__init__.py` ~1;
+  `compact.py` ~30-35: Signatur + Katalog-Zweig + Bedingungserweiterung;
+  `narrow.py` ~35-45: zwei Signaturen + Katalog-Zweig + Bedingungserweiterung
+  + Aufrufstelle; `CompareOutlookLayoutControls.svelte` ~10;
+  `WeatherMetricsTab.svelte` ~1). Bleibt unter dem 250er-Limit; kein Override
+  beantragt.
+- **Files:** 6 Produktionsdateien geändert, 0 neu.
+- **Effort:** medium — kein neuer Resolver, kein neues Persistenzfeld, aber
+  zwei fest verdrahtete Renderer müssen auf den bereits vorhandenen
+  `row["cells"]`-Katalog-Zweig umgestellt werden, und die **einzige**
+  Bestandsschutz-Grundlage (ein Charakterisierungstest) muss für beide
+  Kanäle **neu entstehen**, weil sie heute nicht existiert (s. „Der Befund,
+  der die Testplanung bestimmt").
+- **LoC-Limit Test-Budget:** 450 (getrennt vom 250-Produktiv-Limit,
+  `config_loader.py:264-297`) — zwei neue Referenz-Fixtures
+  (Kompakt-Block, Telegram-Bubble-Text), ein Charakterisierungstest, zwei
+  Wirkort-Dispatch-Tests (Kompakt über `EmailOutput`-Recording analog
+  `test_trip_outlook_dispatch_mail.py`, Telegram über
+  `TelegramOutput`-Recording analog `test_telegram_rate_limit.py:274`).
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|---|---|---|
+| `output.renderers.compare_outlook_metric_ids.resolve_trip_outlook_metrics/outlook_columns/format_outlook_value` | reused, unverändert | Dieselbe Auflösung/Formatierung wie S1 — kein zweites Vokabular, kein neuer Schnitt gegen die Grundauswahl nötig, er gilt bereits |
+| `output.renderers.email.outlook.render_outlook_plain` (Muster, Zeile 333-341) | Vorbild, nicht aufgerufen | Der Katalog-Zweig für `compact.py`s Zeilenformat übernimmt exakt dasselbe Label-Wert-Muster (`f"{c['label']} {cells[i]}"`, `"  "`-Trenner) — keine dritte Formatierungsregel erfinden |
+| `output.channels.email.EmailOutput` / `output.channels.telegram.TelegramOutput` | reused, Wirkort-Test | Recording-Subklassen fangen den echten Versandpfad ab, kein Mock-Framework (Muster `test_trip_outlook_dispatch_mail.py:200-212`, `test_telegram_rate_limit.py:274`) |
+| `renderer_mail_gate.py` (#811) | Gate | Blockiert den Commit auf `compact.py`, bis der Modus-Matrix-Test und ein frischer `briefing_mail_validator.py`-Lauf vorliegen — `compact.py` ist eine Mail-Inhaltsdatei |
+| `pendant_gate.py` (#1481 B) | Gate | Alle geänderten Dateien sind Bestandsdateien, keine Neuanlage — Gate greift nicht |
+| `trip_report_scheduler.py:2329` (`build_outlook_row`) | reused, unverändert | Liefert `row["cells"]`/`row["cell_bg"]` bereits für alle vier Ausgabeorte identisch — diese Scheibe liest sie nur, baut sie nicht neu |
+
+## Implementation Details
+
+1. **Kompakt-Zeilenformat bei aktiver Auswahl.** `compact.py`s Katalog-Zweig
+   übernimmt exakt das Label-Wert-Muster, das `render_outlook_plain()`
+   bereits für den Ortsvergleich-Klartext nutzt (`outlook.py:333-341`) — kein
+   drittes Format erfinden:
+   ```python
+   if outlook_metrics is not None:
+       columns = outlook_columns(outlook_metrics)
+       for stage in multi_day_trend:
+           weekday = stage.get("weekday", "")
+           cells = stage.get("cells") or []
+           values = "  ".join(
+               f"{c['label']} {cells[i] if i < len(cells) else '–'}"
+               for i, c in enumerate(columns)
+           )
+           lines.append(_ascii(f"{weekday:<3} {values}".rstrip()))
+   else:
+       ... bestehende sieben-Feld-Schleife unverändert ...
+   ```
+   Begründung gegen feste Feldbreiten: bei 1..N frei gewählten Spalten gibt
+   es keine sinnvolle feste Breite je Spalte — das Label trägt die
+   Zuordnung, nicht die Spaltenposition. `_ascii()` faltet wie im
+   Legacy-Zweig auf reines ASCII (Kompakt-Mail-Vertrag, Docstring
+   `compact.py:154-156`).
+
+2. **Telegram-Zeilenformat bei aktiver Auswahl — MIT Labels.** Die heutige
+   feste Zeile (`weekday  temp  precip  wind  thunder`) trägt keine Labels,
+   weil die Position selbsterklärend ist (immer dieselben fünf Felder in
+   derselben Reihenfolge). Bei freier Auswahl entfällt diese Garantie —
+   deshalb bekommt jede Zelle ihr Katalog-Label vorangestellt, mit Doppelpunkt
+   (kompakter als das Leerzeichen-Format der Kompakt-Mail, weil Telegram-
+   Bubbles auf `_TG_PROSE_WIDTH` umbrechen und Label+Wert dort optisch enger
+   zusammengehören müssen als in einer Mail-Zeile):
+   ```python
+   if outlook_metrics is not None:
+       columns = outlook_columns(outlook_metrics)
+       for stage in multi_day_trend:
+           weekday = stage.get("weekday", "")
+           cells = stage.get("cells") or []
+           values = "  ".join(
+               f"{c['label']}: {cells[i] if i < len(cells) else '–'}"
+               for i, c in enumerate(columns)
+           )
+           trend_line = f"{weekday}  {values}"
+           lines.extend(_wrap(trend_line, _TG_PROSE_WIDTH))
+           note = stage.get("note")
+           if note:
+               lines.extend(_wrap(f"    ↳ {note}", _TG_PROSE_WIDTH))
+   else:
+       ... bestehende Fünf-Feld-Logik (Zeile 576-612) unverändert ...
+   ```
+   Die Notiz-Zeile (`stage.get("note")`) bleibt in BEIDEN Zweigen identisch
+   — sie ist keine Katalog-Spalte, sondern ein eigenständiges Feld.
+
+3. **`outlook_metrics == []` lässt den GESAMTEN Block entfallen — inklusive
+   des Zustands-Fallbacks.** Anders als HTML/Klartext haben Kompakt-Mail und
+   Telegram einen dritten Zweig: den Zustands-Hinweis
+   (`elif outlook_state is not None and outlook_state != _OutlookState.FOUND:`,
+   `compact.py:271-278`, `narrow.py:836-839`), der bei fehlenden Ausblicksdaten
+   (statt fehlender Auswahl) eine Ersatzmeldung zeigt. Eine bewusst geleerte
+   Auswahl (`outlook_metrics == []`) muss AUCH diesen Fallback unterdrücken —
+   der Nutzer hat den ganzen Abschnitt abgewählt, nicht nur die Spalten. Beide
+   Renderer bekommen deshalb eine gemeinsame äußere Bedingung:
+   ```python
+   if outlook_metrics != []:
+       if multi_day_trend:
+           ...
+       elif outlook_state is not None and outlook_state != _OutlookState.FOUND:
+           ...
+   ```
+   Für `outlook_metrics is None` (Altbestand, Default-Parameter) bleibt das
+   Verhalten unverändert — nur der explizite `[]`-Fall schaltet beide Zweige
+   ab. Identisch zur Bedingungserweiterung aus S1 (`html.py`/`plain.py`,
+   Implementation Details Punkt 2 jener Spec), hier auf den zusätzlichen
+   Fallback-Zweig ausgeweitet, den HTML/Klartext gar nicht besitzen.
+
+4. **EINE Auflösung, jetzt für drei statt zwei Konsumenten.** `trip_report.py`
+   löst `outlook_metrics` bereits einmal aus `_dc_uncollapsed` auf (S1,
+   Implementation Details Punkt 10 jener Spec). Diese Scheibe zieht die
+   Auflösung aus dem Inline-Kwarg-Ausdruck in eine lokale Variable und
+   verdrahtet sie an BEIDE Aufrufstellen:
+   ```python
+   _outlook_metrics = resolve_trip_outlook_metrics(_dc_uncollapsed, report_type)
+   ...
+   email_html, email_plain = render_email(
+       ...,
+       outlook_metrics=_outlook_metrics,
+       ...,
+   )
+   ...
+   telegram_bubbles_result = render_telegram_bubbles(
+       ...,
+       outlook_metrics=_outlook_metrics,
+       ...,
+   )
+   ```
+   Kein zweiter `resolve_trip_outlook_metrics()`-Aufruf für Telegram — sonst
+   könnte (wie bei S1s F001) eine spätere Änderung an einer Stelle die andere
+   unbemerkt zurücklassen. Die Regel aus ADR-0055 Punkt 4 („eine Auflösung,
+   explizit durchgereicht") gilt jetzt für alle drei Renderer-Aufrufstellen
+   im Trip-Pfad (HTML, Klartext, Kompakt teilen sich `render_email()`;
+   Telegram bekommt dieselbe Variable separat).
+
+5. **Hinweistext wird für den Trip-Kontext entfernt, für Compare bleibt er
+   stehen.** `CompareOutlookLayoutControls.svelte` bekommt eine additive,
+   optionale Prop `showEmailOnlyHint` (Default `true`). Die
+   Compare-Einbindung (`WeatherMetricsTab.svelte:1398-1405`) übergibt sie
+   NICHT — der Default hält das Verhalten dort byte-identisch (der Compare-
+   Ausblick erscheint weiterhin ausschließlich in `render_compare_email()`,
+   nie in Telegram; der Hinweis bleibt richtig). Die Trip-Einbindung
+   (`:1778-1784`) übergibt `showEmailOnlyHint={false}` — nach dieser Scheibe
+   wirkt die Auswahl in allen vier Trip-Ausgabeorten, der Hinweis wäre dort
+   falsch. Kein Ersatztext: die Abwesenheit des Hinweises ist selbsterklärend
+   (kein Kanal wird mehr ausgenommen außer den weiterhin baulich
+   unerreichbaren SMS/Premium-SMS, die nie Teil der Aussage waren).
+
+6. **Legenden-Frage: nicht zutreffend.** Weder `compact.py` noch `narrow.py`
+   besitzen eine eigenständige Abkürzungs-Legende wie `html.py:1360-1366`.
+   Die heutigen Kürzel (`R{token}`, `W{token}`, `⚡{token}`) stehen inline in
+   der Wertzelle selbst, nicht in einem separaten Legenden-Block — es gibt
+   nichts, das an die S1-Regel „Legende nur ohne Auswahl" (S1 Implementation
+   Details Punkt 4) gekoppelt werden müsste. Bei aktiver Auswahl tragen die
+   Katalog-Labels bereits die Bedeutung (Punkt 1/2 oben), bei Legacy-Zustand
+   bleiben die bestehenden Inline-Kürzel unverändert.
+
+## Was sich NICHT ändern darf
+
+- **HTML- und Klartext-Trip-Mail bleiben byte-identisch zu S1.** Diese
+  Scheibe rührt `html.py`/`plain.py` nicht an — `test_trip_outlook_parity.py`
+  UND die S1-Wirkort-Tests bleiben grün ohne Anpassung.
+- **Ortsvergleich bleibt unverändert.** `resolve_outlook_metrics()`,
+  `comparison.py`, `compare_html.py`, die Compare-Einbindung von
+  `CompareOutlookLayoutControls.svelte` (Default-Prop greift) — alles
+  unangetastet.
+- **`report_config.show_outlook`-Semantik unverändert.** Weiterhin der
+  einzige Ein/Aus-Schalter für den gesamten Ausblick-Block.
+- **Kompakt-Mail und Telegram OHNE gesetztes `outlook_metrics` bleiben
+  byte-identisch zum heutigen Stand.** Das ist die zentrale Zusicherung
+  dieser Scheibe — geprüft am echten Versandpfad gegen eine vor dieser
+  Lieferung aufgezeichnete Referenz (AC-1).
+- **Persistenzformat `display_config.outlook_metrics` unverändert.** Kein
+  neues Feld, kein neues Vokabular — reine Wiederverwendung des in S1
+  eingeführten Felds.
+- **SMS/Premium-SMS bleiben baulich unerreichbar.** `sms_trip.py` kennt
+  `multi_day_trend` weiterhin nicht — außerhalb des Zuschnitts.
+
+## 🔴 Der Befund, der die Testplanung bestimmt
+
+Für Kompakt-Mail- und Telegram-Ausblick existiert **kein** Byte-Golden-Test.
+`test_issue_729_render_compact_empty.py`, `test_issue_1001_telegram_bubbles.py`
+und `test_channel_metric_matrix.py` decken andere Aspekte ab; keiner
+vergleicht den heutigen Ist-Zustand des Ausblick-Blocks byte-genau gegen eine
+aufgezeichnete Referenz. `test_trip_outlook_parity.py` ruft ausschließlich
+`render_outlook_table()`/`render_outlook_plain()` (den HTML/Klartext-Pfad)
+auf — Kompakt/Telegram nie.
+
+**Deshalb MUSS zuerst ein Charakterisierungstest entstehen**, der den
+heutigen Legacy-Zustand (`outlook_metrics=None`) aus dem echten Aufrufpfad
+(`render_email()` für Kompakt, `render_telegram_bubbles()` für Telegram)
+aufzeichnet, BEVOR `compact.py`/`narrow.py` verändert werden — analog zum
+Vorgehen von S1 (`tests/fixtures/trip_outlook_reference/`, README dort). Die
+Referenz-Fixtures dürfen anschließend NICHT nachgezogen werden, außer für
+eine unabhängig begründete, PO-freigegebene Änderung (Muster: S1s
+Warnstufen-Palette-Ausnahme #1801).
+
+## Acceptance Criteria
+
+- **AC-1:** Given ein Trip, dessen `display_config.outlook_metrics` NICHT
+  gesetzt ist (Altbestand, heutiger Normalfall), When Kompakt-Mail und
+  Telegram-Bubbles über den echten Versandpfad erzeugt werden (nicht der
+  isolierte Renderer-Aufruf), Then sind beide Ausblick-Blöcke byte-identisch
+  zu einer VOR dieser Lieferung aufgezeichneten Referenz.
+  - Test: `render_email(email_format="compact")` bzw.
+    `render_telegram_bubbles()` mit unverändertem `display_config` gegen je
+    eine aufgezeichnete Referenz-Datei (`tests/fixtures/trip_outlook_reference/compact_block.txt`,
+    `telegram_bubble.txt`), NICHT gegen einen zweiten Aufruf desselben Codes
+    im selben Lauf.
+
+- **AC-2:** Gegeben ein Nutzer hat im Abschnitt „3-Tages-Vorschau" eine
+  Teilmenge der Größen gewählt und gespeichert (z. B. „Niederschlag" und
+  „Böen"), wenn die nächste Trip-Mail versendet wird, dann zeigt der
+  Kompakt-Mail-Ausblick ausschließlich diese gewählten Spalten in
+  Auswahlreihenfolge mit lesbaren deutschen Labels — nicht die bisherigen
+  fünf/sieben festen Felder.
+  - Test: echter Trip-Versandpfad (`_send_trip_report_outcome()`,
+    `email_format="compact"`), `EmailOutput(settings).send(...)` über eine
+    Recording-Subklasse abgefangen (Muster
+    `test_trip_outlook_dispatch_mail.py:200-212`), der Kompakt-Textkörper
+    auf genau die gewählten Label-Wert-Paare in Reihenfolge geprüft.
+
+- **AC-3:** Given dieselbe gespeicherte Auswahl wie in AC-2, When die
+  Telegram-Bubbles über den echten Versandpfad erzeugt werden, Then zeigt
+  die Ausblick-Bubble dieselben gewählten Größen in derselben Reihenfolge,
+  jede Zelle MIT ihrem Katalog-Label versehen (nicht nur der Wert).
+  - Test: `TelegramOutput(settings).send(...)` über eine Recording-Subklasse
+    abgefangen (Muster `test_telegram_rate_limit.py:274`), die
+    Ausblick-Bubble auf Label:Wert-Paare in Auswahlreihenfolge geprüft.
+
+- **AC-4:** Given ein Trip mit `display_config.outlook_metrics = []`
+  (bewusst geleerte Auswahl), When Kompakt-Mail und Telegram erzeugt werden,
+  Then entfällt der gesamte Ausblick-Block in BEIDEN Kanälen vollständig —
+  weder die Überschrift „Naechste Etappen" (Kompakt) noch die
+  Ausblick-Bubble (Telegram), UND auch kein Zustands-Fallback-Hinweis
+  (`outlook_state`-Zweig) tritt an ihre Stelle.
+  - Test: gerenderte Kompakt-Mail und Telegram-Bubble-Liste auf vollständige
+    Abwesenheit jedes Ausblick-Bezugs geprüft, inklusive eines Falls mit
+    gesetztem `outlook_state != FOUND` (der Fallback darf trotzdem nicht
+    erscheinen).
+
+- **AC-5:** Given ein Trip führt ein Telegram-eigenes Kanal-Layout
+  (`display_config.per_channel_layouts["telegram"]`), das eine gewählte
+  Ausblick-Größe NICHT enthält, während dieselbe Größe in der Grundauswahl
+  aktiv UND für die Vorschau gewählt ist, When Telegram-Bubbles über den
+  echten Versandpfad erzeugt werden, Then erscheint sie trotzdem als Spalte
+  im Ausblick — ein enges Kanal-Layout darf den kanal-neutralen Ausblick
+  nicht enger schneiden als die Grundauswahl erlaubt (identische Regel zu
+  S1 AC-17, jetzt auf Telegram übertragen; der Ausblick hat laut ADR-0055
+  Punkt 2 keine Kanal-Ebene).
+  - Test: `per_channel_layouts["telegram"]` ohne eine der zwei gewählten
+    Ausblick-Größen gesetzt, echter Versandpfad, die abgefangene
+    Telegram-Bubble enthält beide Spalten mit korrekten Werten (kein
+    Versatz zwischen Label und Zelle).
+
+- **AC-6:** Gegeben der Abschnitt „3-Tages-Vorschau" wird im Trip-Kontext
+  angezeigt, wenn mindestens eine Größe gewählt ist, dann trägt er NICHT
+  mehr den Hinweistext „Erscheint nur in der E-Mail" — die Auswahl wirkt ab
+  dieser Lieferung in allen vier Ausgabeorten. Gegeben derselbe Abschnitt
+  wird im Ortsvergleich-Kontext angezeigt, dann trägt er den Hinweistext
+  weiterhin unverändert (der Compare-Ausblick existiert nach wie vor nur in
+  der E-Mail).
+  - Test: DOM-Test/Component-Test für beide Kontexte getrennt — Trip-Rendering
+    prüft Abwesenheit von `data-testid="compare-layout-outlook-email-only-hint"`,
+    Compare-Rendering prüft dessen Anwesenheit (Regressionsschutz für S1
+    AC-7, das denselben Testid nutzte).
+
+- **AC-7:** Given ein Trip OHNE gesetztes `outlook_metrics`, When die
+  gesamte Trip-Mail (HTML+Klartext+Kompakt) über denselben Versandpfad
+  erzeugt wird, Then bleiben der HTML- und Klartext-Ausblick byte-identisch
+  zur S1-Referenz (`tests/fixtures/trip_outlook_reference/outlook_table.html`,
+  `outlook_legend.html`, `outlook_block.txt`) — diese Scheibe verändert
+  `html.py`/`plain.py` nicht.
+  - Test: `test_trip_outlook_parity.py` und die S1-Wirkort-Tests
+    (`test_trip_outlook_dispatch_mail.py`) laufen unverändert grün, keine
+    Golden-Datei-Anpassung in dieser Lieferung.
+
+## Mutations-Gegenproben
+
+1. `outlook_metrics=_outlook_metrics` wird beim `render_compact(...)`-Aufruf
+   in `email/__init__.py` wieder weggelassen (die Regression, die diese
+   Scheibe überhaupt auslöst) ⇒ **AC-2** muss rot werden — Kompakt-Mail
+   zeigt weiterhin die fünf Legacy-Felder trotz aktiver Auswahl.
+2. `outlook_metrics=_outlook_metrics` wird beim
+   `render_telegram_bubbles(...)`-Aufruf in `trip_report.py` weggelassen ⇒
+   **AC-3** muss rot werden.
+3. Die äußere Bedingung `if outlook_metrics != []:` (Implementation Details
+   Punkt 3) wird in `compact.py`/`narrow.py` weggelassen, nur die innere
+   `if multi_day_trend:` bleibt ⇒ **AC-4** muss rot werden — bei `[]`
+   erscheint der Zustands-Fallback-Hinweis statt eines vollständigen
+   Wegfalls.
+4. `resolve_trip_outlook_metrics(_dc_uncollapsed, report_type)` wird durch
+   `_dc_uncollapsed.outlook_metrics or []` ersetzt (`None` als leer
+   behandelt, keine Nutzung des Resolvers) ⇒ **AC-1** muss rot werden — der
+   Ausblick würde für alle Bestandstrips in Kompakt UND Telegram leer.
+5. Die Telegram-Auflösung wird durch einen ZWEITEN, unabhängigen
+   `resolve_trip_outlook_metrics(_dc_telegram, report_type)`-Aufruf ersetzt
+   (kollabierter statt ungekollabierter Stand, analog S1s F001) ⇒ **AC-5**
+   muss rot werden — ein enges Telegram-Kanal-Layout schneidet dann eine
+   global gewählte Größe fälschlich weg.
+6. Das Telegram-Zeilenformat lässt die Labels weg (nur Werte, Trenner
+   `"  "`, wie im Legacy-Zweig) ⇒ **AC-3** muss rot werden, weil der Test
+   explizit auf `Label: Wert`-Paare prüft, nicht nur auf die Zahlenwerte.
+7. `showEmailOnlyHint={false}` wird bei der Trip-Einbindung in
+   `WeatherMetricsTab.svelte` weggelassen (Default `true` bleibt wirksam)
+   ⇒ **AC-6** muss rot werden — der Hinweis erscheint im Trip-Kontext
+   weiterhin, obwohl die Auswahl dort jetzt in allen vier Kanälen wirkt.
+
+## Prüfhinweis für den Adversary
+
+- Leitfrage (Projektregel „Prüfort muss dem Wirkort entsprechen"): Ist die
+  Zusicherung an der Stelle geprüft, an der sie **wirkt** — an der
+  zugestellten/gerenderten Kompakt-Mail bzw. Telegram-Bubble über den echten
+  Aufrufpfad — oder nur dort, wo der Code steht (isolierter
+  `_outlook_lines()`- bzw. Compact-Loop-Aufruf)?
+- Zweite Pflichtprobe: die Test-Fixtures für AC-2/AC-3 dürfen NICHT
+  dieselbe Auswahl-Reihenfolge wie die AC-1-Referenz verwenden — sonst
+  könnte ein Test grün bleiben, der Reihenfolge und Auswahlmenge verwechselt
+  (analog S1s Drei-Tage-Fixture mit „unterscheidbaren Werten", vgl.
+  `tests/helpers/trip_outlook_selection.py:70-72`).
+- Dritte: prüfen, ob der Charakterisierungstest (AC-1) wirklich VOR jeder
+  Code-Änderung an `compact.py`/`narrow.py` aufgezeichnet wurde (TDD-RED-
+  Reihenfolge) — ein nachträglich aus dem bereits geänderten Code erzeugter
+  „Ist-Stand" wäre keine Referenz, sondern eine Bestätigung der Änderung.
+
+## Out of Scope
+
+- **HTML- und Klartext-Trip-Mail** — unverändert, bleiben bei S1s Stand.
+- **SMS/Premium-SMS** — bleiben baulich unerreichbar
+  (`sms_trip.py` kennt `multi_day_trend` nicht).
+- **Ortsvergleich** — `resolve_outlook_metrics()`, `comparison.py`,
+  `compare_html.py`, die Compare-Einbindung des geteilten Bausteins bleiben
+  unangetastet (Default-Prop hält das Verhalten byte-identisch).
+- **Kanal-Ebene für die Auswahl** — bleibt bewusst global, keine
+  Wiederaufnahme jener bereits in S1/ADR-0055 abgeschlossenen Diskussion.
+- **CI-Ampel-Eintrag für neue Tests dieser Lieferung** — reine
+  Kern-Schicht-Tests (kein Playwright/E2E in dieser Scheibe, da keine neue
+  Bedienfläche entsteht — der Abschnitt existiert bereits seit S1).
+- **Migration bestehender Trips.** Kein Datenmodell-Wechsel, keine
+  Rückwirkung auf gespeicherte `outlook_metrics`-Werte.
+
+## Known Limitations
+
+- Die Telegram-Zeile bricht bei vielen gewählten Spalten auf mehrere Zeilen
+  um (`_wrap(..., _TG_PROSE_WIDTH)`) — identisch zum bestehenden
+  Umbruchverhalten, keine neue Breitensteuerung für diese Scheibe.
+- Kompakt-Mail und Telegram teilen sich weiterhin KEINE gemeinsame
+  Formatierungsfunktion für die Ausblick-Zeile (Label-Wert-Paare mit
+  Leerzeichen-Trenner in Kompakt, mit Doppelpunkt in Telegram) — das ist
+  eine bewusste, in dieser Spec begründete Divergenz (Implementation Details
+  Punkt 1/2), keine übersehene Duplizierung. Eine spätere Vereinheitlichung
+  müsste beide Formate angleichen, was hier nicht verlangt ist.
+- Die Vorschau (`PreviewService`) ist für Kompakt-Mail und Telegram nicht
+  Gegenstand dieser Spec — S1s Vorschau-Parität-Fix (Known Limitations,
+  „falscher Report-Typ") betraf `_build_stage_trend()`, das bereits
+  kanalübergreifend korrekt läuft; eine gesonderte Kompakt-/Telegram-
+  Vorschau-Prüfung ist hier nicht enthalten, weil `PreviewService` beide
+  Formate nicht getrennt rendert (Ist-Stand, ungeändert).
+
+## Definition of Done
+
+- [ ] AC-1 bis AC-7 grün
+- [ ] Adversary-Verdict VERIFIED, alle sieben Pflicht-Mutationen gefangen
+- [ ] `test_trip_outlook_parity.py` und die S1-Wirkort-Tests bleiben grün
+      OHNE Anpassung
+- [ ] Neue Referenz-Fixtures (`compact_block.txt`, `telegram_bubble.txt`)
+      VOR jeder Code-Änderung an `compact.py`/`narrow.py` aufgezeichnet
+      (TDD-RED-Reihenfolge, per Commit-Historie nachvollziehbar)
+- [ ] Issue #1720 Scheiben-Checkbox für Scheibe 2 gesetzt, Issue geschlossen
+      (beide Scheiben ausgeliefert)
+
+## Architektur-Entscheidung (ADR)
+
+Kein neues ADR. ADR-0055 deckt diese Scheibe bereits konzeptionell ab —
+Punkt 1 legt die Drei-Werte-Semantik fest, Punkt 4 die Ein-Auflösung-Regel,
+und der Abschnitt „Folgen" kündigt Scheibe 2 wörtlich an
+(„Kompakt-Mail und Telegram folgen in Scheibe 2 ... Scheibe 2 legt deshalb
+zuerst einen Charakterisierungstest des Ist-Zustands an"). Diese Spec liefert
+genau das an — keine neue Grundsatzentscheidung, keine Abweichung von einer
+dokumentierten Zusicherung, die ein neues ADR mit Status-Fortschreibung
+verlangen würde. Die einzige neue, benannte Design-Entscheidung dieser
+Scheibe (Telegram-Zeilenformat MIT Labels, Kompakt-Zeilenformat OHNE
+Doppelpunkt) ist eine Rendering-Detailfrage innerhalb des bereits durch
+ADR-0055 gesetzten Rahmens, keine Entscheidungsfläche im Sinne von
+CLAUDE.md („Kanäle, Provider, Datenmodell/Persistenz, Auth,
+Editor-Paradigma, Test-/Deploy-Strategie").
+
+## Changelog
+
+- 2026-08-17: Initial spec created

--- a/frontend/e2e/trip-outlook-metric-selection.staging.spec.ts
+++ b/frontend/e2e/trip-outlook-metric-selection.staging.spec.ts
@@ -136,8 +136,15 @@ test.describe('Trip-Vorschau: waehlbare Spalten im Wetter-Metriken-Reiter (#1720
 		expect(fehler, `AC-6: Konsolenfehler waehrend des Klickpfads: ${fehler.join(' | ')}`).toEqual([]);
 	});
 
-	// ── AC-7 ────────────────────────────────────────────────────────────────
-	test('AC-7 (#1720 S1): der Abschnitt traegt den Hinweis "Erscheint nur in der E-Mail"', async ({
+	// ── AC-7 (S1), fortgeschrieben durch AC-6 der Scheibe 2 ─────────────────
+	// Scheibe 1 verlangte hier den Hinweis "Erscheint nur in der E-Mail", weil
+	// die Trip-Auswahl damals wirklich nur die E-Mail erreichte. Mit Scheibe 2
+	// (Spec: docs/specs/modules/feat_1720_s2_ausblick_kompakt_telegram.md,
+	// AC-6) wirkt dieselbe Auswahl in allen vier Ausgabeorten — der Hinweis
+	// waere im Trip jetzt schlicht falsch und ist dort abgeschaltet
+	// (`showEmailOnlyHint={false}`). Im Ortsvergleich bleibt er unveraendert;
+	// das deckt compare-outlook-metric-selection.staging.spec.ts ab.
+	test('AC-6 (#1720 S2): der Trip-Abschnitt traegt KEINEN Hinweis "Erscheint nur in der E-Mail"', async ({
 		page,
 		request
 	}) => {
@@ -146,22 +153,26 @@ test.describe('Trip-Vorschau: waehlbare Spalten im Wetter-Metriken-Reiter (#1720
 		const abschnitt = vorschauAbschnitt(reiter);
 		await expect(abschnitt).toBeVisible({ timeout: 10000 });
 
-		// Mindestens eine Groesse gewaehlt (Bedingung des Hinweises, Muster
-		// CompareOutlookLayoutControls.svelte:159-161).
+		// Mindestens eine Groesse gewaehlt — das ist die Bedingung, unter der
+		// der Hinweis im Ortsvergleich erscheint. Nur so ist die Abwesenheit im
+		// Trip eine Aussage und kein Nebeneffekt einer leeren Auswahl.
 		const niederschlag = abschnitt
 			.getByTestId('compare-layout-outlook-metric-precipitation')
 			.locator('input');
 		if (!(await niederschlag.isChecked())) await niederschlag.check();
+		await expect(niederschlag, 'Vorbedingung: mindestens eine Groesse ist gewaehlt').toBeChecked();
 
-		const hinweis = abschnitt.getByTestId('compare-layout-outlook-email-only-hint');
 		await expect(
-			hinweis,
-			'AC-7: Kompakt-Mail und Telegram folgen erst in Scheibe 2 — bis dahin muss der Abschnitt denselben Hinweis tragen wie beim Ortsvergleich'
-		).toBeVisible();
-		await expect(hinweis).toContainText('Erscheint nur in der E-Mail');
+			abschnitt.getByTestId('compare-layout-outlook-email-only-hint'),
+			'AC-6 (S2): der Trip-Abschnitt zeigt weiterhin den E-Mail-only-Hinweis, obwohl die Auswahl dort jetzt Kompakt-Mail und Telegram mitsteuert'
+		).toHaveCount(0);
+		await expect(
+			abschnitt.getByText('Erscheint nur in der E-Mail', { exact: false }),
+			'AC-6 (S2): der Hinweistext taucht im Trip-Abschnitt noch auf (ggf. ohne Testid gerendert)'
+		).toHaveCount(0);
 
 		await page.screenshot({
-			path: '../docs/artifacts/feat-1720-vorschau-metriken/ac-7-email-hinweis.png'
+			path: '../docs/artifacts/feat-1720-vorschau-metriken/ac-7-kein-email-hinweis.png'
 		});
 	});
 

--- a/frontend/src/lib/components/shared/CompareOutlookLayoutControls.svelte
+++ b/frontend/src/lib/components/shared/CompareOutlookLayoutControls.svelte
@@ -53,10 +53,17 @@
 		 *  waere eine widerspruechliche Bedienflaeche (#1720 S1, AC-13). */
 		enabled?: boolean;
 		onEnabledChange?: (checked: boolean) => void;
+		/** Hinweis „Erscheint nur in der E-Mail" (#1720 S2, AC-6). Vorgabe
+		 *  `true` haelt den Ortsvergleich unveraendert — dort erscheint der
+		 *  Ausblick weiterhin nur in `render_compare_email()`. Der Trip
+		 *  uebergibt `false`: seine Auswahl wirkt seit dieser Scheibe in
+		 *  allen vier Ausgabeorten. */
+		showEmailOnlyHint?: boolean;
 	}
 	let {
 		metricKeys, catalog, onMetricKeys, onOutlookCommit,
-		title = '3-Tages-Ausblick', enabled = true, onEnabledChange
+		title = '3-Tages-Ausblick', enabled = true, onEnabledChange,
+		showEmailOnlyHint = true
 	}: Props = $props();
 
 	// „Nie eingestellt" (`null`) = die heutigen sieben Ausblick-Spalten; eine
@@ -178,9 +185,11 @@
      activeChannel="email": der Ausblick existiert nur in der E-Mail
      (render_compare_email), analog der Begruendung im Stundenverlauf-Block. -->
 {#if materializedOutlookKeys.length > 0}
-	<p class="outlook-email-hint" data-testid="compare-layout-outlook-email-only-hint">
-		Erscheint nur in der E-Mail.
-	</p>
+	{#if showEmailOnlyHint}
+		<p class="outlook-email-hint" data-testid="compare-layout-outlook-email-only-hint">
+			Erscheint nur in der E-Mail.
+		</p>
+	{/if}
 	<Card padding={0} style="margin-top: 6px">
 		<WeatherV2Reihenfolge
 			primaryColumns={materializedOutlookKeys}

--- a/frontend/src/lib/components/shared/WeatherMetricsTab.svelte
+++ b/frontend/src/lib/components/shared/WeatherMetricsTab.svelte
@@ -1780,6 +1780,7 @@
 						catalog={compareCatalog}
 						onMetricKeys={onOutlookMetricKeys}
 						title="3-Tages-Vorschau"
+						showEmailOnlyHint={false}
 					/>
 				</div>
 				{/if}

--- a/frontend/src/lib/components/shared/__tests__/outlook_email_only_hint_per_context.test.ts
+++ b/frontend/src/lib/components/shared/__tests__/outlook_email_only_hint_per_context.test.ts
@@ -1,0 +1,182 @@
+// TDD RED — Issue #1720 Scheibe 2, AC-6.
+//
+// Spec: docs/specs/modules/feat_1720_s2_ausblick_kompakt_telegram.md
+//   § Implementation Details 5, AC-6, Mutations-Gegenprobe 7
+//
+// Der Abschnitt „3-Tages-Vorschau" traegt heute in BEIDEN Kontexten den
+// Hinweis „Erscheint nur in der E-Mail". Nach dieser Scheibe wirkt die Auswahl
+// im TRIP in allen vier Ausgabeorten — der Hinweis waere dort falsch. Im
+// ORTSVERGLEICH bleibt er richtig (der Compare-Ausblick existiert weiterhin
+// nur in `render_compare_email()`).
+//
+// Grund fuer AST statt DOM: dieses Repo hat kein vitest/jsdom
+// (package.json "test": node --test). Geprueft wird mit dem ECHTEN
+// Svelte-5-Compiler am Template-/Instance-AST — kein Dateiinhalt-Vergleich.
+//
+// Ausfuehrung: cd frontend && npm test -- <diese Datei>
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parse } from 'svelte/compiler';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const CONTROLS = join(here, '..', 'CompareOutlookLayoutControls.svelte');
+const TAB = join(here, '..', 'WeatherMetricsTab.svelte');
+
+const HINT_TESTID = 'compare-layout-outlook-email-only-hint';
+const PROP = 'showEmailOnlyHint';
+const TRIP_TITLE = '3-Tages-Vorschau';
+
+function parseComponent(path: string): any {
+	return parse(readFileSync(path, 'utf-8'), { modern: true });
+}
+
+function walk(subtree: unknown, visitor: (n: Record<string, any>) => void): void {
+	if (subtree === null || typeof subtree !== 'object') return;
+	if (Array.isArray(subtree)) {
+		subtree.forEach((child) => walk(child, visitor));
+		return;
+	}
+	const n = subtree as Record<string, any>;
+	visitor(n);
+	for (const key of Object.keys(n)) {
+		if (key === 'parent') continue;
+		walk(n[key], visitor);
+	}
+}
+
+function findComponentsNamed(subtree: unknown, name: string): any[] {
+	const found: any[] = [];
+	walk(subtree, (n) => {
+		if (n.type === 'Component' && n.name === name) found.push(n);
+	});
+	return found;
+}
+
+function findAttr(node: any, name: string): any {
+	return (node?.attributes ?? []).find((a: any) => a.type === 'Attribute' && a.name === name);
+}
+
+/** Statischer Text eines Attributwerts (`title="…"`) oder undefined. */
+function staticAttrText(node: any, name: string): string | undefined {
+	const attr = findAttr(node, name);
+	if (!attr) return undefined;
+	const value = Array.isArray(attr.value) ? attr.value[0] : attr.value;
+	return value?.type === 'Text' ? value.data : undefined;
+}
+
+/** Der `{#if}`-Block, in dessen Rumpf das Element mit `data-testid` steht. */
+function ifBlockRenderingTestid(fragment: unknown, testid: string): any {
+	let treffer: any;
+	walk(fragment, (n) => {
+		if (n.type !== 'IfBlock') return;
+		let enthalten = false;
+		walk(n.consequent, (inner) => {
+			if (inner.type !== 'Attribute' || inner.name !== 'data-testid') return;
+			const value = Array.isArray(inner.value) ? inner.value[0] : inner.value;
+			if (value?.type === 'Text' && value.data === testid) enthalten = true;
+		});
+		// Der INNERSTE passende Block gewinnt: er traegt die eigentliche Bedingung.
+		if (enthalten) treffer = n;
+	});
+	return treffer;
+}
+
+function identifiersIn(node: unknown): string[] {
+	const namen: string[] = [];
+	walk(node, (n) => {
+		if (n.type === 'Identifier' && typeof n.name === 'string') namen.push(n.name);
+	});
+	return namen;
+}
+
+describe('#1720 S2 AC-6 — der E-Mail-only-Hinweis haengt am Kontext', () => {
+	test('Gegeben der geteilte Baustein, dann kennt er die optionale Prop showEmailOnlyHint mit Vorgabe true', () => {
+		const ast = parseComponent(CONTROLS);
+		let vorgabe: unknown;
+		let gefunden = false;
+		walk(ast.instance?.content, (n) => {
+			if (n.type !== 'Property') return;
+			if (n.key?.type !== 'Identifier' || n.key.name !== PROP) return;
+			gefunden = true;
+			if (n.value?.type === 'AssignmentPattern') vorgabe = n.value.right?.value;
+		});
+		assert.ok(
+			gefunden,
+			`AC-6 FAIL: CompareOutlookLayoutControls.svelte kennt die Prop \`${PROP}\` nicht — ` +
+				'ohne sie kann der Trip-Kontext den Hinweis nicht abschalten, ohne den ' +
+				'Ortsvergleich mitzureissen (Spec Implementation Details 5).'
+		);
+		assert.equal(
+			vorgabe,
+			true,
+			`AC-6 FAIL: \`${PROP}\` hat nicht die Vorgabe \`true\` — nur mit ihr bleibt die ` +
+				'Compare-Einbindung ohne eigene Uebergabe unveraendert.'
+		);
+	});
+
+	test('Gegeben der Hinweis-Block, dann steht er unter der Bedingung showEmailOnlyHint', () => {
+		const ast = parseComponent(CONTROLS);
+		const block = ifBlockRenderingTestid(ast.fragment, HINT_TESTID);
+		assert.ok(
+			block,
+			`REGRESSION: kein {#if}-Block rendert data-testid="${HINT_TESTID}" — ` +
+				'der Hinweis ist ganz verschwunden statt kontextabhaengig zu werden.'
+		);
+		assert.ok(
+			identifiersIn(block.test).includes(PROP),
+			`AC-6 FAIL: die Bedingung des Hinweis-Blocks nennt \`${PROP}\` nicht — ` +
+				'der Hinweis erscheint damit in JEDEM Kontext, auch im Trip.'
+		);
+	});
+
+	test('Gegeben die Trip-Einbindung, dann schaltet sie den Hinweis mit showEmailOnlyHint={false} ab', () => {
+		const ast = parseComponent(TAB);
+		const mounts = findComponentsNamed(ast.fragment, 'CompareOutlookLayoutControls');
+		assert.equal(
+			mounts.length,
+			2,
+			`REGRESSION: erwartet genau zwei Einbindungen (Trip + Vergleich), gefunden ${mounts.length}.`
+		);
+		const trip = mounts.find((m) => staticAttrText(m, 'title') === TRIP_TITLE);
+		assert.ok(
+			trip,
+			`REGRESSION: keine Einbindung mit title="${TRIP_TITLE}" — an ihr haengt die ` +
+				'Unterscheidung Trip/Vergleich in dieser Datei.'
+		);
+		const attr = findAttr(trip, PROP);
+		assert.ok(
+			attr,
+			`AC-6 FAIL (Mutation 7): die Trip-Einbindung uebergibt \`${PROP}\` nicht — ` +
+				'die Vorgabe `true` bleibt wirksam und der Hinweis erscheint im Trip, ' +
+				'obwohl die Auswahl dort jetzt in allen vier Kanaelen wirkt.'
+		);
+		const value = Array.isArray(attr.value) ? attr.value[0] : attr.value;
+		assert.equal(
+			value?.expression?.value,
+			false,
+			`AC-6 FAIL: die Trip-Einbindung uebergibt \`${PROP}\` nicht als \`false\`.`
+		);
+	});
+
+	test('Gegeben die Ortsvergleich-Einbindung, dann laesst sie die Vorgabe unangetastet', () => {
+		const ast = parseComponent(TAB);
+		const mounts = findComponentsNamed(ast.fragment, 'CompareOutlookLayoutControls');
+		const vergleich = mounts.filter((m) => staticAttrText(m, 'title') !== TRIP_TITLE);
+		assert.equal(
+			vergleich.length,
+			1,
+			`REGRESSION: erwartet genau eine Vergleichs-Einbindung, gefunden ${vergleich.length}.`
+		);
+		assert.equal(
+			findAttr(vergleich[0], PROP),
+			undefined,
+			`AC-6 FAIL: die Ortsvergleich-Einbindung uebergibt \`${PROP}\` — der Compare-` +
+				'Ausblick erscheint weiterhin ausschliesslich in der E-Mail, der Hinweis ' +
+				'ist dort richtig und muss unveraendert stehen bleiben.'
+		);
+	});
+});

--- a/src/output/renderers/email/__init__.py
+++ b/src/output/renderers/email/__init__.py
@@ -113,6 +113,7 @@ def render_email(
             segments=segments,
             dc=display_config,
             multi_day_trend=multi_day_trend,
+            outlook_metrics=outlook_metrics,
             outlook_state=outlook_state,
             outlook_horizon_days=outlook_horizon_days,
             stability_result=stability_result,

--- a/src/output/renderers/email/compact.py
+++ b/src/output/renderers/email/compact.py
@@ -20,6 +20,7 @@ from utils.timezone import local_fmt
 from output.renderers.day_window import DAY_WINDOW_END_HOUR, DAY_WINDOW_START_HOUR
 from output.renderers.fallback_notice import build_fallback_lines, select_fallback_meta
 from output.renderers.trip_metric_ids import resolve_trip_active_metrics
+from output.renderers.compare_outlook_metric_ids import outlook_columns
 from output.renderers.email.helpers import (
     _AMPEL_STAGE_TONES, _THUNDER_MAP,
     build_confidence_hint, build_metrics_summary_pills, build_origin_footer,
@@ -132,6 +133,10 @@ def render_compact(
     segments: list[SegmentWeatherData],
     dc: UnifiedWeatherDisplayConfig,
     multi_day_trend: Optional[list[dict]],
+    # #1720 S2: fertig aufgeloeste Ausblick-Spalten (trip_report.py, aus dem
+    # UNGEKOLLABIERTEN dc) -- None = Altbestand (feste Felder), [] = bewusst
+    # geleerte Auswahl (ganzer Block entfaellt).
+    outlook_metrics: Optional[list[dict]] = None,
     outlook_state: Optional["OutlookState"] = None,
     outlook_horizon_days: Optional[int] = None,
     stability_result: Optional["StabilityResult"],
@@ -255,27 +260,46 @@ def render_compact(
         lines.append(_ascii(confidence_hint))
         lines.append("")
 
-    if multi_day_trend:
-        lines.append("Naechste Etappen")
-        for stage in multi_day_trend:
-            tok = format_trend_tokens(stage)
-            weekday = stage.get("weekday", "")
-            name = stage.get("name", "")
-            thunder_field = _compact_thunder_field(tok, stage)
-            line = (
-                f"{weekday:<3} {name:<26} {tok['temp_str']:<8} "
-                f"{tok['precip_str']:<5} {tok['wind_str']:<5} {thunder_field}"
-            )
-            lines.append(_ascii(line))
-        lines.append("")
-    elif outlook_state is not None and outlook_state != _OutlookState.FOUND:
-        # Fix #1486: benannter Zustand statt stiller Leerstelle. ascii_safe,
-        # weil der Compact-Body durchgaengig ASCII ist ("!!" statt "⚠️").
-        lines.append("Naechste Etappen")
-        lines.append(_ascii(render_outlook_state_plain(
-            outlook_state, outlook_horizon_days, ascii_safe=True,
-        )))
-        lines.append("")
+    # #1720 S2: eine bewusst geleerte Auswahl ([]) laesst den GESAMTEN
+    # Ausblick entfallen -- auch den Zustands-Fallback. Der Nutzer hat den
+    # Abschnitt abgewaehlt, nicht nur die Spalten. None (Altbestand) faellt
+    # unveraendert in die bisherigen Zweige.
+    if outlook_metrics != []:
+        if multi_day_trend:
+            lines.append("Naechste Etappen")
+            if outlook_metrics is not None:
+                # Label-Wert-Muster wie render_outlook_plain() (outlook.py:333)
+                # -- kein drittes Format. Bei 1..N frei gewaehlten Spalten
+                # traegt das Label die Zuordnung, nicht die Spaltenposition.
+                columns = outlook_columns(outlook_metrics)
+                for stage in multi_day_trend:
+                    weekday = stage.get("weekday", "")
+                    cells = stage.get("cells") or []
+                    values = "  ".join(
+                        f"{c['label']} {cells[i] if i < len(cells) else '–'}"
+                        for i, c in enumerate(columns)
+                    )
+                    lines.append(_ascii(f"{weekday:<3} {values}".rstrip()))
+            else:
+                for stage in multi_day_trend:
+                    tok = format_trend_tokens(stage)
+                    weekday = stage.get("weekday", "")
+                    name = stage.get("name", "")
+                    thunder_field = _compact_thunder_field(tok, stage)
+                    line = (
+                        f"{weekday:<3} {name:<26} {tok['temp_str']:<8} "
+                        f"{tok['precip_str']:<5} {tok['wind_str']:<5} {thunder_field}"
+                    )
+                    lines.append(_ascii(line))
+            lines.append("")
+        elif outlook_state is not None and outlook_state != _OutlookState.FOUND:
+            # Fix #1486: benannter Zustand statt stiller Leerstelle. ascii_safe,
+            # weil der Compact-Body durchgaengig ASCII ist ("!!" statt "⚠️").
+            lines.append("Naechste Etappen")
+            lines.append(_ascii(render_outlook_state_plain(
+                outlook_state, outlook_horizon_days, ascii_safe=True,
+            )))
+            lines.append("")
 
     # Issue #1461 S3b-1: "E-Mail" heisst BEIDE Mail-Formate — das Kurzformat
     # zeigt denselben Abschnitt (AC-9), ascii_safe wie der uebrige Body.

--- a/src/output/renderers/narrow.py
+++ b/src/output/renderers/narrow.py
@@ -34,6 +34,7 @@ from output.renderers.day_window import (
     hiking_field_min_max, night_temp_min_c, night_wind_chill_min_c,
 )
 from output.metric_format import THUNDER_LABEL_DE
+from output.renderers.compare_outlook_metric_ids import outlook_columns
 from output.renderers.email.helpers import _THUNDER_MAP, fmt_val, format_trend_tokens
 from output.renderers.email.thunder_branch import resolve_thunder_day_branch
 from output.renderers.email.unavailable_hint import (
@@ -569,9 +570,32 @@ def _segment_mini_header(seg_data: SegmentWeatherData) -> str:
     return f"{label} · {km_range} · {height_range}"
 
 
-def _outlook_lines(multi_day_trend: list[dict]) -> list[str]:
-    """3-Tage-Trend-Zeilen (Issue #623/#640-Rechenlogik, jetzt Ausblick-Bubble)."""
+def _outlook_lines(
+    multi_day_trend: list[dict],
+    outlook_metrics: Optional[list[dict]] = None,
+) -> list[str]:
+    """3-Tage-Trend-Zeilen (Issue #623/#640-Rechenlogik, jetzt Ausblick-Bubble).
+
+    ``outlook_metrics`` (#1720 S2): gesetzte Auswahl ersetzt die fuenf festen
+    Felder durch die gewaehlten Groessen -- MIT Katalog-Label je Zelle, weil
+    die Positionsgarantie der festen Reihenfolge dann entfaellt. ``None``
+    (Altbestand) laesst die Zeile byte-identisch.
+    """
     lines: list[str] = ["Ausblick"]
+    if outlook_metrics is not None:
+        columns = outlook_columns(outlook_metrics)
+        for stage in multi_day_trend:
+            weekday = stage.get("weekday", "")
+            cells = stage.get("cells") or []
+            values = "  ".join(
+                f"{c['label']}: {cells[i] if i < len(cells) else '–'}"
+                for i, c in enumerate(columns)
+            )
+            lines.extend(_wrap(f"{weekday}  {values}", _TG_PROSE_WIDTH))
+            note = stage.get("note")
+            if note:
+                lines.extend(_wrap(f"    ↳ {note}", _TG_PROSE_WIDTH))
+        return lines
     for stage in multi_day_trend:
         tok = format_trend_tokens(stage)
         weekday = stage.get("weekday", "")
@@ -643,6 +667,9 @@ def render_telegram_bubbles(
     friendly_keys: Optional[set[str]] = None,
     stability_result: Optional[StabilityResult] = None,
     multi_day_trend: Optional[list[dict]] = None,
+    # #1720 S2: fertig aufgeloeste Ausblick-Spalten (trip_report.py, aus dem
+    # UNGEKOLLABIERTEN dc) -- None = Altbestand, [] = bewusst geleerte Auswahl.
+    outlook_metrics: Optional[list[dict]] = None,
     outlook_state: Optional["OutlookState"] = None,
     outlook_horizon_days: Optional[int] = None,
     day_comparison: Optional["DayComparison"] = None,
@@ -830,16 +857,20 @@ def render_telegram_bubbles(
         bubbles.append(TelegramBubble(text="\n".join(text_lines)))
 
     # 5. Ausblick-Bubble (nur wenn multi_day_trend nicht leer).
-    if multi_day_trend:
-        outlook = [_esc(ln) for ln in _outlook_lines(multi_day_trend)]
-        bubbles.append(TelegramBubble(text="\n".join(outlook)))
-    elif outlook_state is not None and outlook_state != _OutlookState.FOUND:
-        # Fix #1486: der vierte, gern vergessene Ausgabeweg — Telegram liess
-        # die Bubble bisher kommentarlos weg. Reiner Text, kein HTML-Kasten.
-        state_line = _esc(render_outlook_state_plain(
-            outlook_state, outlook_horizon_days,
-        ))
-        bubbles.append(TelegramBubble(text="Ausblick\n" + state_line))
+    # #1720 S2: eine bewusst geleerte Auswahl ([]) laesst die Bubble GANZ
+    # entfallen -- auch den Zustands-Fallback (identisch zu compact.py).
+    if outlook_metrics != []:
+        if multi_day_trend:
+            outlook = [_esc(ln) for ln in
+                       _outlook_lines(multi_day_trend, outlook_metrics)]
+            bubbles.append(TelegramBubble(text="\n".join(outlook)))
+        elif outlook_state is not None and outlook_state != _OutlookState.FOUND:
+            # Fix #1486: der vierte, gern vergessene Ausgabeweg — Telegram liess
+            # die Bubble bisher kommentarlos weg. Reiner Text, kein HTML-Kasten.
+            state_line = _esc(render_outlook_state_plain(
+                outlook_state, outlook_horizon_days,
+            ))
+            bubbles.append(TelegramBubble(text="Ausblick\n" + state_line))
 
     # 6. Aktionen-Bubble — einzige Bubble mit reply_markup.
     bubbles.append(TelegramBubble(text="Aktionen", reply_markup=ACTIONS_BUBBLE_BUTTONS))

--- a/src/output/renderers/trip_report.py
+++ b/src/output/renderers/trip_report.py
@@ -198,6 +198,13 @@ class TripReportFormatter:
             day_comparison = None
         # Issue #623 AC-5: Sendezeit für das Kontext-Label im HTML-Trend-Block.
         _sent_at = datetime.now(timezone.utc)
+        # Issue #1720 S1 (F001) / S2: Ausblick-Spalten GENAU EINMAL aufloesen,
+        # aus dem UNGEKOLLABIERTEN Stand (Muster #1575) -- der Ausblick hat
+        # keine Kanal-Ebene. Dieselbe Variable geht an render_email() (HTML,
+        # Klartext, Kompakt) UND an render_telegram_bubbles(); ein zweiter
+        # Aufruf koennte die beiden Konsumenten spaeter auseinanderlaufen
+        # lassen (ADR-0055 Punkt 4).
+        _outlook_metrics = resolve_trip_outlook_metrics(_dc_uncollapsed, report_type)
         email_html, email_plain = render_email(
             token_line,
             segments=segments,
@@ -212,12 +219,7 @@ class TripReportFormatter:
             multi_day_trend=effective_trend,
             outlook_state=outlook_state,
             outlook_horizon_days=outlook_horizon_days,
-            # Issue #1720 S1 (F001): Ausblick-Spalten HIER einmal aufloesen,
-            # aus dem UNGEKOLLABIERTEN Stand (Muster #1575) -- der Ausblick
-            # hat keine Kanal-Ebene. Renderer bekommen nur das Ergebnis.
-            outlook_metrics=resolve_trip_outlook_metrics(
-                _dc_uncollapsed, report_type,
-            ),
+            outlook_metrics=_outlook_metrics,
             changes=changes,
             stage_name=stage_name,
             stage_stats=stage_stats,
@@ -299,6 +301,9 @@ class TripReportFormatter:
             multi_day_trend=effective_trend,
             outlook_state=outlook_state,
             outlook_horizon_days=outlook_horizon_days,
+            # #1720 S2: DIESELBE Aufloesung wie fuer render_email() -- der
+            # Ausblick hat keine Kanal-Ebene, also NICHT aus _dc_telegram.
+            outlook_metrics=_outlook_metrics,
             day_comparison=day_comparison,
             night_weather=night_weather,
             trip=trip,

--- a/tests/fixtures/trip_outlook_reference/compact_block.txt
+++ b/tests/fixtures/trip_outlook_reference/compact_block.txt
@@ -1,0 +1,4 @@
+Naechste Etappen
+XX  Tag 2                      9-21C   2.5mm 25    Tmittel
+XX  Tag 3                      11-19C  -     31    T-
+XX  Tag 4                      6-24C   7.1mm 18    Thoch

--- a/tests/fixtures/trip_outlook_reference/telegram_bubble.txt
+++ b/tests/fixtures/trip_outlook_reference/telegram_bubble.txt
@@ -1,0 +1,6 @@
+Ausblick
+XX  9–21°C  2.5mm  25  ⚡mittel
+    ↳ Gewitter möglich
+XX  11–19°C  R–  31  ⚡–
+XX  6–24°C  7.1mm  18  ⚡hoch
+    ↳ Gewitter möglich · Regen 7 mm

--- a/tests/helpers/trip_outlook_channels.py
+++ b/tests/helpers/trip_outlook_channels.py
@@ -1,0 +1,233 @@
+"""Kompakt-Mail- und Telegram-Ausblick am ECHTEN Versandpfad (#1720 S2).
+
+SPEC: docs/specs/modules/feat_1720_s2_ausblick_kompakt_telegram.md
+
+Warum neben ``trip_outlook_selection`` (S1): jener treibt
+``TripReportFormatter.format_email()`` und liest HTML/Klartext. Kompakt-Mail
+und Telegram-Bubbles entstehen erst im Versand
+(``_send_trip_report_outcome()`` -> ``NotificationService`` ->
+``EmailOutput``/``TelegramOutput``); der Kompakt-Zweig
+(``email/__init__.py:111``) und die Ausblick-Bubble (``narrow.py:832``)
+werden auf dem S1-Weg nie erreicht -- der Befund, der die Testplanung
+bestimmt (Spec).
+
+Kein Mock-Framework: echte Unterklassen + Attribut-Rebind, in ``finally``
+restauriert (Muster ``test_trip_outlook_dispatch_mail.py:200-212``).
+
+Versand-Sicherheit (#1477): alle Transport-Felder ausdruecklich gesetzt,
+Bot-Token/Chat-Id sind Dummy-Zeichenketten UND beide Transporte werden vor
+dem Lauf durch aufzeichnende Unterklassen ersetzt -- es verlaesst nichts den
+Prozess. SMS/Premium-SMS bleiben unkonfiguriert und abgeschaltet.
+"""
+from __future__ import annotations
+
+import re
+import sys
+import uuid
+from datetime import date, timedelta
+from pathlib import Path
+from typing import Optional
+
+# Pfadregel #1409: Pruefling relativ zur eigenen Datei aufloesen.
+REPO_ROOT = Path(__file__).resolve().parents[2]
+for _pfad in (REPO_ROOT, REPO_ROOT / "src"):
+    if str(_pfad) not in sys.path:
+        sys.path.insert(0, str(_pfad))
+
+# Bewusst DIESELBE Fixture-Unterklasse wie S1 statt einer zweiten Kopie: liefen
+# beide auseinander, verglichen Bestandsschutz (S1, HTML/Klartext) und diese
+# Scheibe (Kompakt/Telegram) zwei verschiedene Welten.
+from tests.helpers.trip_outlook_selection import (  # noqa: E402
+    REFERENCE_DIR, mit_outlook_metrics, utc_process_tz,
+)
+from tests.tdd.test_trip_outlook_dispatch_mail import (  # noqa: E402
+    _fixture_scheduler_klasse,
+)
+
+REFERENCE_COMPACT = REFERENCE_DIR / "compact_block.txt"
+REFERENCE_TELEGRAM = REFERENCE_DIR / "telegram_bubble.txt"
+
+LAT, LON = 46.65, 12.85
+COMPACT_OUTLOOK_HEADING = "Naechste Etappen"
+TELEGRAM_OUTLOOK_HEADING = "Ausblick"
+
+NIEDERSCHLAG = {"metric_id": "precipitation", "aggregation": "sum"}
+BOEEN = {"metric_id": "gust", "aggregation": "max"}
+
+_MAIL_FIELDS: dict = {
+    "smtp_host": "dummy.invalid", "smtp_port": 587,
+    "smtp_user": "dummy-1720", "smtp_pass": "dummy-1720",
+    "mail_to": "gregor-test@henemm.com",
+    "telegram_bot_token": "000000:dummy-1720-s2",
+    "telegram_chat_id": "-100000000",
+    "telegram_test_bot_token": "", "telegram_test_chat_id": "",
+    "sms_gateway_url": "", "seven_api_key": "", "sms_to": "",
+    "_env_file": None,
+}
+
+# Der Wochentag ist der einzige kalenderabhaengige Bestandteil des Blocks. Er
+# wird auf BEIDEN Seiten des Referenzvergleichs maskiert (laengengleich: alle
+# deutschen Kuerzel sind zweistellig), alles uebrige bleibt byte-genau.
+_WEEKDAY_RE = re.compile(r"^(Mo|Di|Mi|Do|Fr|Sa|So)\b", re.MULTILINE)
+
+
+def maskiere_wochentage(text: str) -> str:
+    return _WEEKDAY_RE.sub("XX", text)
+
+
+def _settings(user_id: str):
+    from app.config import Settings
+
+    settings = Settings(**_MAIL_FIELDS).with_user_profile(user_id)
+    assert settings.can_send_email() is True, "Vorbedingung: E-Mail sendefaehig."
+    assert settings.can_send_telegram() is True, (
+        "Vorbedingung: Telegram muss sendefaehig sein, sonst entsteht gar "
+        "keine Bubble (der Transport selbst ist ersetzt)."
+    )
+    assert settings.can_send_sms() is False, "Sicherung (#1477): kein SMS."
+    return settings
+
+
+def trip(*, outlook_metrics, enabled_ids=None, telegram_layout_ids=None,
+         stage_count: int = 5, email_format: str = "compact"):
+    """Tour ab heute: der Abendbericht zielt auf MORGEN, der Ausblick zeigt
+    die drei Etappen danach.
+
+    ``stage_count=2`` laesst die Tour mit dem Zieltag enden -- dann liefert
+    ``_build_stage_trend()`` ``rows=None``/``state=NO_STAGES``, also den
+    Zustands-Fallback-Zweig (AC-4, zweiter Fall).
+    ``telegram_layout_ids`` setzt ``per_channel_layouts["telegram"]`` (AC-5).
+    """
+    from app.metric_catalog import build_default_display_config
+    from app.models import TripReportConfig
+    from app.trip import Stage, Trip, Waypoint
+
+    trip_id = f"trip-1720s2-{uuid.uuid4().hex[:8]}"
+    heute = date.today()
+    stages = [
+        Stage(id=f"S{i}", name=f"Tag {i}", date=heute + timedelta(days=i),
+              waypoints=[
+                  Waypoint(id=f"W{i}a", name="Start", lat=LAT, lon=LON,
+                           elevation_m=1400.0, arrival_calculated="08:00"),
+                  Waypoint(id=f"W{i}b", name="Ziel", lat=LAT + 0.05,
+                           lon=LON + 0.1, elevation_m=2100.0,
+                           arrival_calculated="12:00"),
+              ])
+        for i in range(stage_count)
+    ]
+    dc = build_default_display_config()
+    dc.trip_id = trip_id
+    dc.show_night_block = False          # haelt echte Nacht-Abrufe fern
+    if enabled_ids is not None:
+        for mc in dc.metrics:
+            mc.enabled = mc.metric_id in enabled_ids
+    if telegram_layout_ids is not None:
+        dc.per_channel_layouts = {
+            "telegram": [mc for mc in dc.metrics
+                         if mc.metric_id in telegram_layout_ids],
+        }
+    if outlook_metrics is not None:
+        dc = mit_outlook_metrics(dc, outlook_metrics)
+
+    t = Trip(id=trip_id, name="Karnischer Höhenweg", stages=stages,
+             display_config=dc, official_warnings=None)
+    t.report_config = TripReportConfig(
+        trip_id=trip_id, send_email=True, send_telegram=True, send_sms=False,
+        send_premium_sms=False, show_outlook=True,
+        multi_day_trend_reports=["evening"], email_format=email_format,
+    )
+    t.official_alerts_enabled = False
+    t.official_alert_triggers_enabled = False
+    t.alert_cooldown_minutes = 0
+    return t
+
+
+def versendete_teile(t, *, report_type: str = "evening") -> tuple[str, list[str]]:
+    """Treibt den echten Versandlauf und liefert (Kompakt-Mailkoerper,
+    Telegram-Bubble-Texte) genau so, wie die Transporte sie bekommen."""
+    import services.notification_service as ns_mod
+
+    user_id = f"tdd-1720s2-{uuid.uuid4().hex[:8]}"
+    mails: list[dict] = []
+    bubbles: list[str] = []
+    orig_mail, orig_tg = ns_mod.EmailOutput, ns_mod.TelegramOutput
+
+    class _RecordingEmailOutput(orig_mail):     # echte Subklasse, kein Mock
+        def send(self, subject, body, **kwargs):
+            mails.append({"subject": subject, "body": body, **kwargs})
+            return None
+
+    class _RecordingTelegramOutput(orig_tg):    # echte Subklasse, kein Mock
+        def send(self, subject, body, **kwargs):
+            bubbles.append(body)
+            return None
+
+    ns_mod.EmailOutput = _RecordingEmailOutput
+    ns_mod.TelegramOutput = _RecordingTelegramOutput
+    try:
+        with utc_process_tz():
+            scheduler = _fixture_scheduler_klasse()(
+                settings=_settings(user_id), user_id=user_id)
+            ergebnis = scheduler._send_trip_report_outcome(
+                t, report_type, on_demand=True)
+    finally:
+        ns_mod.EmailOutput = orig_mail
+        ns_mod.TelegramOutput = orig_tg
+
+    assert ergebnis == "sent", (
+        f"Der Versandlauf endete mit {ergebnis!r} statt 'sent' -- ohne "
+        "erfolgten Versand prueft dieser Test nichts."
+    )
+    assert mails, "Es wurde keine E-Mail versendet."
+    assert bubbles, "Es wurde keine Telegram-Bubble versendet."
+    return mails[0]["body"], bubbles
+
+
+def compact_outlook_block(body: str) -> Optional[str]:
+    """Ausblick-Block der Kompakt-Mail (Ueberschrift + Zeilen) oder ``None``."""
+    zeilen = body.splitlines()
+    try:
+        start = zeilen.index(COMPACT_OUTLOOK_HEADING)
+    except ValueError:
+        return None
+    block = [zeilen[start]]
+    for zeile in zeilen[start + 1:]:
+        if zeile.strip() == "":
+            break
+        block.append(zeile)
+    return "\n".join(block)
+
+
+def telegram_outlook_bubble(bubbles: list[str]) -> Optional[str]:
+    """Die Ausblick-Bubble (erste Zeile ``Ausblick``) oder ``None``."""
+    for text in bubbles:
+        if text.splitlines()[:1] == [TELEGRAM_OUTLOOK_HEADING]:
+            return text
+    return None
+
+
+def record_reference(force: bool = False) -> list[Path]:
+    """Zeichnet die AC-1-Referenz aus dem AKTUELLEN Code auf. Ohne ``force``
+    wird eine vorhandene Aufzeichnung NICHT ueberschrieben: eine Referenz, die
+    man bei rotem Test neu erzeugen kann, bewacht nichts."""
+    body, bubbles = versendete_teile(trip(outlook_metrics=None))
+    inhalte = {
+        REFERENCE_COMPACT: compact_outlook_block(body),
+        REFERENCE_TELEGRAM: telegram_outlook_bubble(bubbles),
+    }
+    fehlend = [p.name for p, t in inhalte.items() if not t]
+    if fehlend:
+        raise RuntimeError(f"Kein Ausblick gerendert fuer: {fehlend} -- "
+                           "die Aufzeichnung waere leer und wertlos.")
+    geschrieben = []
+    for pfad, text in inhalte.items():
+        if pfad.exists() and not force:
+            continue
+        pfad.write_text(maskiere_wochentage(text), encoding="utf-8")
+        geschrieben.append(pfad)
+    return geschrieben
+
+
+if __name__ == "__main__":  # pragma: no cover - Aufzeichnungs-Werkzeug
+    for pfad in record_reference(force="--force" in sys.argv):
+        print(f"aufgezeichnet: {pfad}")

--- a/tests/tdd/test_trip_outlook_compact_telegram_dispatch.py
+++ b/tests/tdd/test_trip_outlook_compact_telegram_dispatch.py
@@ -1,0 +1,235 @@
+"""TDD RED — #1720 S2: die Ausblick-Auswahl wirkt bis in Kompakt-Mail und
+Telegram-Bubble.
+
+SPEC: docs/specs/modules/feat_1720_s2_ausblick_kompakt_telegram.md (AC-1..AC-5)
+
+🔴 Prueforts-Regel: getrieben wird ``_send_trip_report_outcome()``, abgefangen
+werden die realen ``EmailOutput.send(...)``/``TelegramOutput.send(...)``-Aufrufe
+des ``NotificationService``. Der Kompakt-Zweig (``email/__init__.py:111``) und
+die Ausblick-Bubble (``narrow.py:832``) entstehen NUR auf diesem Weg -- ein
+isolierter ``render_compact()``/``_outlook_lines()``-Aufruf pruefte die
+Durchreichung nicht, die diese Scheibe erst herstellt. Kein Mock-Framework,
+kein Netz: s. ``tests/helpers/trip_outlook_channels.py``.
+
+RED-Erwartung: beide Renderer kennen ``outlook_metrics`` nicht -- die Auswahl
+erreicht sie gar nicht. AC-1 (Charakterisierung des Ist-Zustands) ist GRUEN
+und muss es bleiben.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Pfadregel #1409: Pruefling relativ zur eigenen Testdatei aufloesen.
+REPO_ROOT = Path(__file__).resolve().parents[2]
+for _pfad in (REPO_ROOT, REPO_ROOT / "src"):
+    if str(_pfad) not in sys.path:
+        sys.path.insert(0, str(_pfad))
+
+from tests.helpers.trip_outlook_channels import (  # noqa: E402
+    BOEEN, COMPACT_OUTLOOK_HEADING, NIEDERSCHLAG, REFERENCE_COMPACT,
+    REFERENCE_TELEGRAM, TELEGRAM_OUTLOOK_HEADING, compact_outlook_block,
+    maskiere_wochentage, telegram_outlook_bubble, trip, versendete_teile,
+)
+
+# Auswahlreihenfolge BEWUSST nicht die der Legacy-Felder (dort steht der
+# Niederschlag hinter der Temperatur, die Böen hinter dem Wind) -- sonst
+# koennte ein Test gruen bleiben, der Reihenfolge und Auswahlmenge
+# verwechselt (Spec, Pruefhinweis 2).
+AUSWAHL = [NIEDERSCHLAG, BOEEN]
+
+KOMPAKT_ERWARTET = [
+    "XX  Niederschlag 2.5 mm  Boeen 44 km/h",
+    "XX  Niederschlag 0.0 mm  Boeen 52 km/h",
+    "XX  Niederschlag 7.1 mm  Boeen 33 km/h",
+]
+TELEGRAM_ERWARTET = [
+    "XX  Niederschlag: 2.5 mm  Böen: 44 km/h",
+    "XX  Niederschlag: 0.0 mm  Böen: 52 km/h",
+    "XX  Niederschlag: 7.1 mm  Böen: 33 km/h",
+]
+
+
+def _datenzeilen(block: str) -> list[str]:
+    """Zeilen des Ausblick-Blocks ohne Ueberschrift und ohne Notizzeilen."""
+    return [z for z in maskiere_wochentage(block).splitlines()[1:]
+            if not z.lstrip().startswith("↳")]
+
+
+def _diff(erwartet: list[str], ist: list[str]) -> str:
+    return "\nerwartet:\n" + "\n".join(erwartet) + "\nist:\n" + "\n".join(ist)
+
+
+# ═════════════ AC-1 — Bestandsschutz gegen die aufgezeichnete Referenz ═══════
+
+def test_ac1_kompakt_ausblick_ohne_auswahl_ist_byte_identisch_zur_referenz():
+    """AC-1: Given ein Trip ohne gesetztes ``outlook_metrics`` (Altbestand) /
+    When die Kompakt-Mail ueber den echten Versandpfad zugestellt wird / Then
+    ist ihr Ausblick-Block byte-identisch zur VOR dieser Lieferung
+    aufgezeichneten Referenz.
+
+    Mutation 4 am Wirkort (``_dc_uncollapsed.outlook_metrics or []`` statt des
+    Resolvers): der Ausblick verschwaende fuer 100 % der heutigen Trips.
+    Verglichen wird gegen eine DATEI, nicht gegen einen zweiten Aufruf
+    desselben Codes im selben Lauf.
+    """
+    body, _ = versendete_teile(trip(outlook_metrics=None))
+    block = compact_outlook_block(body)
+
+    assert block is not None, "Kein Ausblick in der Kompakt-Mail (AC-1)."
+    assert maskiere_wochentage(block) == REFERENCE_COMPACT.read_text(encoding="utf-8"), (
+        "Der Kompakt-Ausblick eines Bestandstrips hat sich veraendert. Das ist "
+        f"der Befund -- nicht der Anlass, {REFERENCE_COMPACT.name} neu "
+        f"aufzuzeichnen.\nIst:\n{maskiere_wochentage(block)}"
+    )
+
+
+def test_ac1_telegram_ausblick_ohne_auswahl_ist_byte_identisch_zur_referenz():
+    """AC-1 (zweiter Kanal): dieselbe Zusicherung fuer die Ausblick-Bubble.
+    Kompakt-Mail und Telegram haben getrennte Renderer (``compact.py`` /
+    ``narrow.py``) -- eine Aufzeichnung allein deckt den anderen nicht ab.
+    """
+    _, bubbles = versendete_teile(trip(outlook_metrics=None))
+    bubble = telegram_outlook_bubble(bubbles)
+
+    assert bubble is not None, f"Keine Ausblick-Bubble: {bubbles!r} (AC-1)"
+    assert maskiere_wochentage(bubble) == REFERENCE_TELEGRAM.read_text(encoding="utf-8"), (
+        "Der Telegram-Ausblick eines Bestandstrips hat sich veraendert "
+        f"({REFERENCE_TELEGRAM.name}).\nIst:\n{maskiere_wochentage(bubble)}"
+    )
+
+
+# ═══════════ AC-2 / AC-3 — die Auswahl erreicht beide Kanaele ════════════════
+
+def test_ac2_kompakt_mail_zeigt_genau_die_gewaehlten_spalten_mit_labels():
+    """AC-2: Given der Nutzer hat "Niederschlag" und "Böen" gewaehlt und
+    gespeichert / When die naechste Trip-Mail im Kurzformat versendet wird /
+    Then zeigt der Kompakt-Ausblick ausschliesslich diese beiden Groessen in
+    Auswahlreihenfolge mit deutschen Katalog-Labels -- nicht die bisherigen
+    festen Felder.
+
+    Mutation 1 am Wirkort: fehlt ``outlook_metrics=`` im
+    ``render_compact(...)``-Aufruf (``email/__init__.py:112``), bleibt der
+    Legacy-Zweig stehen -- genau die Regression, die diese Scheibe ausloest.
+    """
+    body, _ = versendete_teile(trip(outlook_metrics=AUSWAHL))
+    block = compact_outlook_block(body)
+
+    assert block is not None, "Kein Kompakt-Ausblick zugestellt (AC-2)."
+    assert _datenzeilen(block) == KOMPAKT_ERWARTET, (
+        "Der Kompakt-Ausblick folgt nicht der gespeicherten Auswahl."
+        + _diff(KOMPAKT_ERWARTET, _datenzeilen(block)) + "\n(AC-2)"
+    )
+
+
+def test_ac3_telegram_bubble_zeigt_die_gewaehlten_spalten_mit_katalog_label():
+    """AC-3: Given dieselbe gespeicherte Auswahl / When die Telegram-Bubbles
+    ueber den echten Versandpfad erzeugt werden / Then zeigt die
+    Ausblick-Bubble dieselben Groessen in derselben Reihenfolge, jede Zelle
+    MIT ihrem Katalog-Label.
+
+    Mutation 2 (kein ``outlook_metrics=`` am
+    ``render_telegram_bubbles(...)``-Aufruf) und Mutation 6 (Labels
+    weggelassen) fallen nur hier auf: ohne Label ist bei freier Auswahl nicht
+    mehr erkennbar, welche Zahl zu welcher Groesse gehoert -- die
+    Positionsgarantie der fuenf festen Felder gibt es dann nicht mehr.
+    """
+    _, bubbles = versendete_teile(trip(outlook_metrics=AUSWAHL))
+    bubble = telegram_outlook_bubble(bubbles)
+
+    assert bubble is not None, f"Keine Ausblick-Bubble: {bubbles!r} (AC-3)"
+    assert _datenzeilen(bubble) == TELEGRAM_ERWARTET, (
+        "Die Ausblick-Bubble folgt nicht der gespeicherten Auswahl bzw. traegt "
+        "keine Katalog-Labels."
+        + _diff(TELEGRAM_ERWARTET, _datenzeilen(bubble)) + "\n(AC-3)"
+    )
+
+
+# ═════════ AC-4 — die bewusst geleerte Auswahl laesst alles entfallen ════════
+
+def test_ac4_leere_auswahl_entfernt_den_ausblick_in_beiden_kanaelen():
+    """AC-4: Given ein Trip mit ``outlook_metrics = []`` (bewusst geleert) /
+    When Kompakt-Mail und Telegram erzeugt werden / Then entfaellt der gesamte
+    Ausblick-Block in BEIDEN Kanaelen -- weder die Ueberschrift "Naechste
+    Etappen" noch die Ausblick-Bubble.
+    """
+    body, bubbles = versendete_teile(trip(outlook_metrics=[]))
+
+    assert COMPACT_OUTLOOK_HEADING not in body, (
+        "Die Kompakt-Mail zeigt weiterhin die Ausblick-Ueberschrift, obwohl "
+        f"der Nutzer den Abschnitt geleert hat (AC-4).\n{body}"
+    )
+    assert not any(TELEGRAM_OUTLOOK_HEADING in b for b in bubbles), (
+        f"Telegram spricht weiterhin vom Ausblick: {bubbles!r} (AC-4)"
+    )
+
+
+def test_ac4_leere_auswahl_unterdrueckt_auch_den_zustands_fallback():
+    """AC-4 (zweiter Zweig): Given eine Tour, die mit dem Zieltag endet -- der
+    Ausblick meldet dann den Zustand ``NO_STAGES`` statt Zeilen -- UND die
+    Auswahl ist bewusst geleert / When beide Kanaele erzeugt werden / Then
+    tritt AUCH der Zustands-Hinweis nicht an die Stelle des Blocks.
+
+    Mutation 3 am Wirkort: bleibt nur die innere ``if multi_day_trend:``
+    -Bedingung erweitert und die aeussere ``if outlook_metrics != []:`` fehlt,
+    erscheint bei geleerter Auswahl der Ersatztext -- der Nutzer hat aber den
+    ganzen Abschnitt abgewaehlt, nicht nur die Spalten.
+
+    Positivkontrolle voran: ohne sie waere die Abwesenheit unten kein Beweis,
+    sondern koennte heissen, dass diese Tourform gar keinen Fallback erzeugt.
+    """
+    body_alt, bubbles_alt = versendete_teile(
+        trip(outlook_metrics=None, stage_count=2))
+    assert COMPACT_OUTLOOK_HEADING in body_alt, (
+        f"Positivkontrolle: kein Zustands-Fallback in der Mail.\n{body_alt}"
+    )
+    assert telegram_outlook_bubble(bubbles_alt) is not None, (
+        f"Positivkontrolle: keine Zustands-Bubble. Bubbles: {bubbles_alt!r}"
+    )
+
+    body, bubbles = versendete_teile(trip(outlook_metrics=[], stage_count=2))
+
+    assert COMPACT_OUTLOOK_HEADING not in body, (
+        f"Kompakt-Mail zeigt bei geleerter Auswahl den Fallback (AC-4).\n{body}"
+    )
+    assert telegram_outlook_bubble(bubbles) is None, (
+        f"Telegram zeigt bei geleerter Auswahl die Zustands-Bubble: "
+        f"{bubbles!r} (AC-4)"
+    )
+
+
+# ═══ AC-5 — der Ausblick hat keine Kanal-Ebene (S1 F001, jetzt Telegram) ═════
+
+def test_ac5_enges_telegram_kanal_layout_schneidet_den_ausblick_nicht():
+    """AC-5: Given ein Trip mit einem Telegram-eigenen Kanal-Layout, das
+    "Böen" NICHT enthaelt, waehrend "Böen" in der Grundauswahl aktiv UND fuer
+    die Vorschau gewaehlt ist / When die Telegram-Bubbles ueber den echten
+    Versandpfad erzeugt werden / Then erscheint "Böen" trotzdem als Spalte im
+    Ausblick, mit ihrem eigenen Wert.
+
+    Mutation 5: wird die Aufloesung ein zweites Mal, diesmal aus dem
+    kanal-kollabierten ``_dc_telegram``, gefahren (S1s F001 auf den zweiten
+    Konsumenten uebertragen), faellt eine global aktive, ausdruecklich
+    gewaehlte Groesse still aus dem Ausblick. Die exakte Zeilenpruefung faengt
+    zusaetzlich den Versatz-Fall: bliebe das Label stehen und nur die Zelle
+    wanderte, stuende das richtige Label vor der falschen Zahl.
+    """
+    t = trip(outlook_metrics=AUSWAHL,
+             enabled_ids={"precipitation", "gust"},
+             telegram_layout_ids={"precipitation"})
+    assert {mc.metric_id for mc in
+            t.display_config.get_metrics_for_channel("telegram", "evening")
+            } == {"precipitation"}, (
+        "Vorbedingung: das Telegram-Kanal-Layout muss enger sein als die "
+        "Grundauswahl, sonst prueft dieser Test die Kanal-Kopplung nicht."
+    )
+
+    _, bubbles = versendete_teile(t)
+    bubble = telegram_outlook_bubble(bubbles)
+
+    assert bubble is not None, f"Keine Ausblick-Bubble: {bubbles!r} (AC-5)"
+    assert _datenzeilen(bubble) == TELEGRAM_ERWARTET, (
+        "Das enge Telegram-Kanal-Layout hat den kanal-neutralen Ausblick "
+        "beschnitten oder die Zellen verschoben."
+        + _diff(TELEGRAM_ERWARTET, _datenzeilen(bubble)) + "\n(AC-5)"
+    )


### PR DESCRIPTION
## Summary
- Scheibe 2 des Epics #1720: die bereits gespeicherte Metrik-Auswahl der 3-Tages-Vorschau (Scheibe 1: HTML/Klartext-Trip-Mail, PR #1840) wirkt jetzt auch in Kompakt-Mail und Telegram-Bubbles — alle vier Trip-Ausgabeorte sind katalog-getrieben.
- Hinweistext "Erscheint nur in der E-Mail" entfällt im Trip-Kontext (Ortsvergleich-Kontext unverändert).
- Kein neuer Resolver, kein neues Persistenzfeld — nur zwei fehlende Durchreichungen + zwei Renderer, die zwischen Legacy-Feldern und dem bereits vorliegenden `row["cells"]` umschalten.

Spec: `docs/specs/modules/feat_1720_s2_ausblick_kompakt_telegram.md`
Adversary-Verdict: **VERIFIED** (7/7 ACs CONFIRMED, alle 7 Pflicht-Mutationen gefangen)

## Test plan
- [x] 7/7 Python-Kern-Tests grün (AC-1..AC-5, echter Versandpfad über Recording-Subklassen)
- [x] 4/4 Frontend-Tests grün (AC-6)
- [x] AC-7-Regressionsschutz: `test_trip_outlook_parity.py` + `test_trip_outlook_dispatch_mail.py` unverändert grün (14 Tests), keine Golden-Datei angepasst
- [x] Gezielter Regressionslauf: 199 zusätzliche Tests rund um Compact/Telegram/Outlook grün
- [x] `renderer_mail_gate.py`: frischer `briefing_mail_validator.py`-Nachweis (Exit 0, echter Testversand über `gr221-mallorca`, Test-Postfach)
- [x] Veralteter Playwright-Test aus Scheibe 1 nachgezogen (`trip-outlook-metric-selection.staging.spec.ts`)

🤖 Generated with Claude Code

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>