### PR TITLE
fix(#1929): SMS-Zeit-Token amtlicher Warnungen wird eindeutig

### DIFF
--- a/docs/specs/modules/fix_1929_warnung_anzeigetext_eindeutig.md
+++ b/docs/specs/modules/fix_1929_warnung_anzeigetext_eindeutig.md
@@ -1,0 +1,234 @@
+---
+entity_id: fix_1929_warnung_anzeigetext_eindeutig
+type: bugfix
+created: 2026-08-17
+updated: 2026-08-17
+status: approved
+version: "1.1"
+tags: [alerts, sms, official-alerts]
+workflow: fix-1929-warnung-anzeigetext-eindeutig
+---
+
+# Warnung: SMS-Kurz-Zeit-Token bekommt eindeutigen Anzeigetext (Scheibe 1)
+
+> **Hinweis zur Fassung (2026-08-17):** Diese Datei ist eine **Rekonstruktion**. Der Worktree mit der
+> Originalfassung wurde durch ein fremdes `git worktree remove --force` gelöscht, bevor der erste
+> Commit erfolgt war (der Branch trug keine Commits und galt deshalb fälschlich als „merged"). Inhalt,
+> ACs und alle Korrekturvermerke sind inhaltlich identisch wiederhergestellt; Formulierungen einzelner
+> Fließtextpassagen können minimal abweichen. Der **Produktivstand** ist dagegen bitgenau
+> wiederhergestellt (MD5-Abgleich gegen die externe Sicherungskopie).
+
+## Approval
+
+- [x] Approved — PO-Freigabe 2026-08-17 („approved"). Freigegeben wurden die 7 ACs, der PO-Entscheid
+  „beide Lücken härten" (Minuten ≠ `:00` **und** Datum im Ganztags-Token) sowie die ausdrückliche
+  Feststellung, dass diese Scheibe den Vorfall vom 2026-08-16 **nicht** behebt.
+- [x] Nachtrags-Entscheid 2026-08-17 (F002): Das Ganztags-Token trägt **Tag und Monat** (`Sa14.02.`).
+  Abgestimmt mit der #1948-Sitzung; die 7 ACs bleiben unverändert, AC-4 wird nur präzisiert.
+
+## Purpose
+
+Zwei amtliche Warnmeldungen mit **verschiedenen** Melde-Zeitfenstern dürfen innerhalb **einer**
+SMS/Premium-SMS/Telegram-Kurzform-Nachricht nicht denselben Anzeigetext tragen. Der Kurz-Zeit-Token
+`_tag_time()` formatierte bisher nur mit `%H` (Stunde) und im Ganztags-Fall nur mit dem
+Wochentagsnamen — beides trug erreichbare Kollisionsquellen. Diese Spec härtet beide, ohne den
+Zeichenpreis der Nachricht unnötig zu erhöhen.
+
+Bezug: Issue **#1929**. Ursprung **#1657** (geschlossen — klammerte den Anzeigetext als „Aspekt (c)"
+aus). Die Ursachenaufklärung des Vorfalls vom 2026-08-16 läuft unter **#1948** (dorthin ist das
+frühere Folge-Issue #1944 als Teilscheibe aufgegangen).
+
+## Was diese Spec NICHT löst
+
+**Diese Scheibe behebt den gemeldeten Vorfall vom 2026-08-16 (Trip `5f534011`, KHW 403) NICHT.** Die
+drei Fenster jenes Vorfalls (`13:00–14:00Z`, `14:00–15:00Z`, `11:00–20:00Z`) rendern bereits heute als
+drei **verschiedene** Tokens. Der berichtete identische Text ist folglich **keine** Token-Kollision.
+Scheibe 1 ist **vorbeugende Härtung**; die Ursachenaufklärung läuft getrennt unter #1948.
+
+## Source
+
+- **File:** `src/output/renderers/alert/official_alerts.py`
+- **Identifier:** `_tag_hour(d)` (neu) und `_tag_time(alert, tz=None)`; Prüfung am Ausgabe-String von
+  `render_official_alert_sms(...)`
+
+## Betroffene Kanäle
+
+Ein Renderer, drei Ausgaben — alle rufen `render_official_alert_sms` auf:
+
+| Kanal | Kollisionsgefahr |
+|---|---|
+| SMS | ja |
+| Premium-SMS (Garmin inReach, Satellit, kostenpflichtig) | ja |
+| Telegram (Stil `kurzform`) | ja |
+
+**Budget: 140 Zeichen** (`render_official_alert_sms(..., limit: int = 140)`), kein produktiver Aufrufer
+übergibt einen abweichenden Wert.
+
+**Nicht betroffen:** E-Mail (HTML + Plain) und Telegram-Standard nutzen `_format_validity` mit `%H:%M`
+— dort sind Minuten bereits enthalten, keine Kollisionsgefahr, **nicht angefasst**.
+
+## Implementation Details
+
+**Regel 1 — Minuten nur wenn ≠ `:00`, in beiden Stundenzweigen:**
+
+Zwei stundengleiche Fenster rendern nur dann identisch, wenn beide Grenzen auf volle Stunden fallen —
+dann sind es aber dieselben Uhrzeiten, also dieselbe Warnung. Die Regel ist damit kontextfrei und pro
+Token für sich entscheidbar (kein Vergleich mit anderen Tokens der Nachricht, kein Zustand über die
+Token-Schleife). `15:00–21:00` bleibt `Sa15-21`; `15:20–21:40` wird `Sa15:20-21:40`. Gilt für **beide
+Grenzen** in **beiden** Zweigen (gleicher Tag, Tagesübergang) — umgesetzt über die Hilfsfunktion
+`_tag_hour`.
+
+Verworfene Alternativen: Minuten unbedingt anhängen (bricht alle Stundenzweig-Pins ohne Zusatznutzen);
+Minuten nur bei erkannter Kollision (braucht Zustand über die Token-Schleife, reihenfolgeabhängig ab
+drei Tokens).
+
+**Regel 2 — Ganztags-Token trägt Tag und Monat:**
+
+Bei `(vf.hour, vf.minute, vt.hour, vt.minute) == (0, 0, 23, 59)` gab `_tag_time` bisher **nur** den
+Wochentagsnamen zurück. Das Token trägt jetzt Tag **und** Monat: `Sa14.02.` statt `Sa` (+3 Zeichen
+gegenüber der Tag-only-Variante, nur im Ganztags-Fall).
+
+**Begründung — korrigiert nach dem Adversary-Finding F002:** Die ursprüngliche Fassung rechtfertigte
+eine Tag-only-Angabe mit dem 15-Tage-Horizont von Open-Meteo. Das trägt **nicht**:
+
+1. `valid_from`/`valid_to` amtlicher Warnungen stammen aus vier unabhängigen Quellen (Vigilance,
+   MeteoAlarm, GeoSphere, DPC), nicht aus Open-Meteo. Der Alarm-Pfad prüft zudem die gesamte
+   Restroute ohne Tagesdeckel (`trip_alert.py:1531-1538`, Fenstergrenze über
+   `window_end_utc_exclusive()` in `src/app/day_window.py`).
+2. Die Token-Kollision ist trotzdem kaum erreichbar, aber aus einem **anderen** Grund als gedacht:
+   Zwei Ganztags-Tokens kollidieren nur bei gleichem Wochentag **und** gleichem Tag im Monat, also bei
+   einem Abstand als Vielfaches von 7 Tagen — frühestens **28 Tage** (Februar→März; der Februar hat
+   selbst 28 Tage und ist damit automatisch ein Vielfaches von 7).
+
+**Folge:** Der Monat verhindert praktisch **keine** Kollision zweier Tokens in derselben Nachricht —
+er macht das **einzelne** Token für den Leser eindeutig („welcher Samstag?"). Das war die
+Entscheidungsgrundlage, abgestimmt mit #1948 („Eindeutigkeit schlägt Zeichenersparnis in vertretbarem
+Rahmen"). Für die Referenztouren (KHW, GR20, bis ~15 Tage) ist die Kollision unerreichbar; für
+mehrwöchige Touren bleibt sie selten, aber nicht strukturell ausgeschlossen.
+
+**Nicht Teil dieser Spec:** Die #1948-Regel „Wochentag nur wenn Gültigkeit nicht heute" gilt laut
+PO-Entscheid auch für amtliche Warnungen, wird hier aber **bewusst nicht** umgesetzt — sie kommt mit
+der #1948-Scheibe und setzt auf dem hier gehärteten `_tag_time` auf.
+
+**Wo die Zusicherung geprüft wird:**
+
+Nicht an `_tag_time` isoliert — das liefert den Rohstring **vor** jeder Kürzung. Geprüft wird am
+**fertigen Ausgabe-String** von `render_official_alert_sms`, weil danach die Kürzungskette greift
+(`_sms_pack_with_fallback` mit vier Rückfallstufen; `_sms_pack` droppt ganze Tail-Tokens, sichtbar am
+`+N`-Marker). Zu prüfende Eigenschaft: *für alle Zeit-Tokens, die im finalen SMS-String tatsächlich
+erscheinen, ist kein Zeitabschnitt für zwei verschiedene Fenster identisch.* Per `+N` weggefallene
+Tokens zählen ausdrücklich **nicht** als Verletzung.
+
+## Out of Scope
+
+- **Fall B — zwei getrennte, aufeinanderfolgende Nachrichten mit gleichem Text.** Nicht lösbar ohne
+  Gedächtnis über den zuletzt gesendeten Text (`ThrottleStore.last_sent()` liefert nur ein `datetime`).
+  Läuft unter #1948.
+- **Sekunden:** `_tag_time` bezieht Sekunden nicht ein — folgenlos für dieses Token. Gebucht in #1199.
+- **`None`-Fenster:** fehlendes `valid_from`/`valid_to` liefert `""` (vorbestehendes, gewolltes
+  F003-Verhalten). Unverändert.
+- **E-Mail und Telegram-Standard:** nutzen `_format_validity`, bereits minutengenau — nicht anfassen.
+
+## Test Plan
+
+Datei `tests/tdd/test_official_alert_time_token_uniqueness.py`, **12 Testfunktionen**:
+
+1. **AC-1 Grundfall gleicher Tag** — `15:00–21:00` vs. `15:20–21:40`, Prüfung am finalen SMS-String.
+   *Korrektur aus der RED-Messung:* Das ursprünglich vorgesehene Paar `15:20–20:50` taugt **nicht** —
+   es rendert als `Sa15-20` gegen `Sa15-21` und kollidiert gar nicht. Die Kollision entsteht nur, wenn
+   die **Stundenpaarung gleich bleibt**; „unterscheidet sich nur in den Minuten" ist notwendig, aber
+   nicht hinreichend.
+2. **AC-1 Einzelgrenzen** (2 Tests) — `vf` konstant/nur `vt` variiert und umgekehrt.
+3. **AC-2 Tagesübergang** — `Fr22:15–Sa03:10` vs. `Fr22:30–Sa03:45`.
+4. **AC-2 Einzelgrenzen** (2 Tests) — je eine Grenze konstant.
+5. **AC-3 Nicht-Regression** — `15:00–21:00` bleibt bit-identisch `Sa15-21`.
+6. **AC-4 Ganztags** — zwei Ganztags-Fenster am selben Wochentag verschiedener Wochen.
+7. **F002 Monatsfall** — gleicher Tag im Monat in **verschiedenen** Monaten: `Sa 14.02.` gegen
+   `Sa 14.03.2026` (beide Samstag). Vor der Änderung ergaben beide bit-identisch `Sa14.`.
+8. **AC-5 Budgetdruck** — *Korrektur aus der RED-Messung:* mit nur **zwei** Warnungen ist AC-5
+   strukturell nicht verletzbar, weil `_sms_pack` ein Token nur vollständig behält; bei Overflow
+   bliebe höchstens eines übrig. Der stille Kollisions-Rest ist erst **ab drei** Warnungen erreichbar
+   — das ist die Gefahrenzone.
+9. **AC-6 Zeichengrenze** — kein Szenario über 140 Zeichen.
+10. **AC-7 Bestandsverhalten** — `None`-Fenster liefert `""`, Sekunden weiterhin ignoriert.
+
+**Einzelgrenzen-Tests sind Pflicht (Adversary-Finding F001):** Ein Test, der `vf` und `vt`
+gleichzeitig variiert, verdeckt eine halbseitig kaputte Grenze vollständig — eine solche Mutation
+blieb im Bestand über 223 Tests unsichtbar.
+
+**Parser-Anforderung:** Die Token-Extraktion im Test muss altes **und** neues Format erfassen und eine
+Positivkontrolle über die erwartete Tokenzahl führen — „nichts gefunden" muss ein Testfehler sein,
+nie stilles Bestehen.
+
+## Acceptance Criteria
+
+- **AC-1:** Given zwei amtliche Warnungen mit identischem Hazard/Level/Label und Fenstern am gleichen
+  Kalendertag, die sich nur in den Minuten unterscheiden (bei gleicher Stundenpaarung) / When
+  `render_official_alert_sms` beide gemeinsam rendert / Then tragen die beiden Zeit-Tokens im finalen
+  SMS-String unterscheidbare Minutenangaben.
+- **AC-2:** Given zwei amtliche Warnungen mit Tagesübergangs-Fenstern (`vf.date() != vt.date()`), die
+  sich nur in den Minuten unterscheiden / When gerendert wird / Then sind beide Zeit-Tokens im finalen
+  String verschieden, nicht nur `_tag_time` isoliert betrachtet — und zwar auch dann, wenn sich **nur
+  eine** der beiden Grenzen unterscheidet.
+- **AC-3:** Given zwei volle-Stunden-Fenster ohne Minutenanteil (`:00` bei from und to) / When
+  gerendert wird / Then bleibt der Kurz-Token unverändert im Format `<Tag><Std>-<Std>` ohne
+  Minutenanhang, bit-identisch zum Bestand.
+- **AC-4:** Given zwei Ganztags-Warnungen am selben Wochentag in unterschiedlichen Kalenderwochen /
+  When gemeinsam gerendert wird / Then tragen beide Ganztags-Tokens im finalen String eine Tag-**und
+  Monat**-Angabe (`Sa14.02.`) und sind textlich unterscheidbar.
+- **AC-5:** Given eine Kollisionslage aus AC-1 mit **drei** Warnungen und einem überlangen Ortsnamen,
+  der die Kürzungskette zum Droppen zwingt / When gerendert wird / Then ist im finalen Rückgabewert
+  jedes verbliebene Zeit-Token eindeutig oder ein kollidierendes Token per `+N`-Marker vollständig
+  entfernt, nie als kollidierender Rest sichtbar.
+- **AC-6:** Given jedes der Szenarien aus AC-1, AC-2, AC-4 und AC-5 / When mit dem produktiven
+  Default-Limit gerendert wird / Then überschreitet der zurückgegebene String niemals 140 Zeichen.
+- **AC-7:** Given ein Fenster ohne `valid_from`/`valid_to` (DPC-Fall) oder mit Sekundenanteil ≠ 0 /
+  When `_tag_time` aufgerufen wird / Then bleibt das bestehende Verhalten unverändert (leerer String
+  bzw. Sekunden werden weiterhin ignoriert).
+
+## Known Limitations
+
+- Fall B (zwei getrennte Nachrichten, gleicher Text) bleibt ungelöst — #1948.
+- Die Ganztags-Eindeutigkeit ist keine vom Code erzwungene Garantie: Zwei Ganztags-Fenster mit exakt
+  einem Vielfachen von 28 Tagen Abstand *und* gleichem Tag im Monat kollidierten weiterhin. Für die
+  Referenztouren unerreichbar, für mehrwöchige Touren selten, aber nicht ausgeschlossen.
+- Sekunden-Ungenauigkeit (#1199) und der `None`-Fenster-Fall (F003) bleiben wie vorbestehend.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Keine dokumentierte Entscheidung legt das Weglassen von Minuten oder Datum im
+  SMS-Kurz-Token fest; die archivierten Ursprungs-Specs definieren nur das Grobformat `<Tag>[<zeit>]`.
+  Diese Änderung ist damit keine Abweichung von einer begründeten Architektur-Entscheidung und braucht
+  kein Ablöse-ADR. Der Zeichenpreis wird hier erstmals explizit gemacht (AC-6).
+
+## Bekannte Test-Auswirkung
+
+Die Stundenzweig-Pins bleiben **unverändert grün**: alle Bestandsfixtures liegen auf `:00`-Minuten.
+
+Die Datums-Regel verlängert jedes Ganztags-Token. **Real betroffen ist genau eine Stelle** —
+`tests/tdd/test_official_alert_subject_label_fidelity.py` (`test_ac6_sms_unchanged`):
+`"… HT ORANGE Fr ges.Route …"` → `"… HT ORANGE Fr10.07. ges.Route …"`. Die Assertion bleibt exakte
+Volltext-Gleichheit; angepasst wurde nur der erwartete Text, kein Wächter aufgeweicht.
+
+**Nicht betroffen** (entgegen der ursprünglichen Schätzung, die aus einem Zeilen-Grep statt einer
+Messung stammte): `test_official_alert_channel_scope.py` (enthält **keine** Ganztags-Fixture,
+`grep -c '23, 59'` → 0), `test_official_alert_template_render.py` (die genannten Zeilen gehören zum
+Stundenzweig), `test_sms_official_alert_tokens.py` (prüft Gefahren-Kürzel, nicht den Zeit-Token).
+
+## Abgrenzung zu #1948
+
+`official_alerts.py` — `_tag_time` und der Zeit-Token-Pfad von `render_official_alert_sms` — gilt für
+das #1948-Konzept als **durch diese Spec entschieden** und wird dort nicht neu aufgerollt. Das hier
+festgelegte Format wird als „WANN"-Baustein amtlicher Warnungen **übernommen**; #1948 baut die
+Struktur drumherum um (Kopf ohne Trip-Name, Behörden-Stufe auf die Briefing-Stufenleiter
+`-`/`L`/`M`/`H`, Ortskopf vorne — Leitsatz „Format folgt Phänomen, nicht Quelle"). Abgestimmt mit der
+#1948-Sitzung am 2026-08-17.
+
+## Changelog
+
+- 2026-08-17: Initial spec created
+- 2026-08-17: Testplan-Korrekturen aus der RED-Messung (AC-1-Vergleichswert; AC-5 braucht drei Notices)
+- 2026-08-17: F002-Entscheid — Ganztags-Token trägt Tag **und** Monat; Begründung korrigiert (28-Tage-
+  Kalendermathematik statt Provider-Horizont); Einzelgrenzen-Tests aus F001 ergänzt
+- 2026-08-17: Rekonstruktion nach Worktree-Verlust (siehe Hinweis am Dateikopf)

--- a/src/output/renderers/alert/official_alerts.py
+++ b/src/output/renderers/alert/official_alerts.py
@@ -1893,10 +1893,29 @@ def render_official_alert_telegram(
     return "\n".join(lines)
 
 
+def _tag_hour(d: "datetime") -> str:
+    """Stundenteil eines Zeit-Tokens (#1929): Minuten nur, wenn sie nicht auf
+    ':00' liegen -- '15' bzw. '15:20'. Zwei stundengleiche Fenster kollidieren
+    nur, wenn beide Grenzen voll sind; dann sind es dieselben Uhrzeiten. Die
+    Regel ist damit pro Token fuer sich entscheidbar (kein Vergleich mit
+    anderen Tokens der Nachricht) und kostet nur dort Zeichen, wo sie traegt."""
+    return d.strftime("%H:%M") if d.minute else d.strftime("%H")
+
+
 def _tag_time(alert: "OfficialAlert", tz: "ZoneInfo | None" = None) -> str:
-    """Kompakte SMS-Zeitangabe: 'Fr' (ganztaegig) bzw. 'Sa15-21'. Tagesuebergang
-    (F006): zweites Wochentagskuerzel statt nur der zweiten Stunde, z.B.
-    'Fr22-Sa03' statt des irrefuehrenden 'Fr22-03'.
+    """Kompakte SMS-Zeitangabe: 'Fr10.07.' (ganztaegig, mit Tag UND Monat) bzw.
+    'Sa15-21' -- mit Minuten, wo diese nicht ':00' sind ('Sa15:20-21:40').
+    Tagesuebergang (F006): zweites Wochentagskuerzel statt nur der zweiten
+    Stunde, z.B. 'Fr22-Sa03' statt des irrefuehrenden 'Fr22-03'.
+
+    Issue #1929: beide Kollisionsquellen gehaertet -- ohne Minuten trugen
+    15:00-21:00 und 15:20-21:40 denselben Text, ohne Datum zwei Ganztags-
+    Warnungen am selben Wochentag verschiedener Wochen.
+
+    Issue #1929 F002: das Ganztags-Token traegt zusaetzlich den Monat. Der Tag
+    im Monat allein bleibt mehrdeutig, sobald derselbe Wochentag mit demselben
+    Datum in verschiedenen Monaten auftritt (Sa 14.02. und Sa 14.03. ergaben
+    beide 'Sa14.'); das kostet drei Zeichen nur im Ganztags-Fall.
 
     `tz` (Issue #1216 F001, optional): lokalisiert wie `_format_validity`.
 
@@ -1912,10 +1931,10 @@ def _tag_time(alert: "OfficialAlert", tz: "ZoneInfo | None" = None) -> str:
     vt = alert.valid_to.astimezone(tz) if tz else alert.valid_to
     tag = _de_weekday_short(vf)
     if vf.date() != vt.date():
-        return f"{tag}{vf.strftime('%H')}-{_de_weekday_short(vt)}{vt.strftime('%H')}"
+        return f"{tag}{_tag_hour(vf)}-{_de_weekday_short(vt)}{_tag_hour(vt)}"
     if (vf.hour, vf.minute, vt.hour, vt.minute) == (0, 0, 23, 59):
-        return tag
-    return f"{tag}{vf.strftime('%H')}-{vt.strftime('%H')}"
+        return f"{tag}{vf.strftime('%d.%m')}."
+    return f"{tag}{_tag_hour(vf)}-{_tag_hour(vt)}"
 
 
 def _sms_pack(head: str, tokens: list[str], limit: int, suffix: str = "") -> tuple[str, int]:

--- a/tests/tdd/test_official_alert_subject_label_fidelity.py
+++ b/tests/tdd/test_official_alert_subject_label_fidelity.py
@@ -235,7 +235,10 @@ def test_ac6_sms_unchanged():
     from output.renderers.alert.official_alerts import render_official_alert_sms
     _ab, _vig, n_ab, n_vig = _ab_and_vigilance_notices()
     sms = render_official_alert_sms([n_ab, n_vig], sms_prefix="KHW403")
-    assert sms == "KHW403 AMT: HT ORANGE Fr ges.Route + CL GELB Sa15-21 ges.Route", (
+    # #1929: Ganztags-Token traegt jetzt Tag UND Monat ('Fr10.07.' statt 'Fr';
+    # F002 ergaenzte den Monat) -- bewusst geaendertes Ausgabeformat, kein
+    # aufgeweichter Wachhund: der Pin bleibt eine exakte Volltext-Gleichheit.
+    assert sms == "KHW403 AMT: HT ORANGE Fr10.07. ges.Route + CL GELB Sa15-21 ges.Route", (
         f"SMS hat sich veraendert: {sms!r}"
     )
 

--- a/tests/tdd/test_official_alert_time_token_uniqueness.py
+++ b/tests/tdd/test_official_alert_time_token_uniqueness.py
@@ -1,0 +1,302 @@
+"""Eindeutigkeit des SMS-Kurz-Zeit-Tokens amtlicher Warnungen (#1929, Scheibe 1).
+
+SPEC: docs/specs/modules/fix_1929_warnung_anzeigetext_eindeutig.md — AC-1..AC-7
+
+TDD RED. Geprueft wird am FINALEN Rueckgabe-String von
+`render_official_alert_sms`, nicht an `_tag_time` isoliert: die Kuerzungskette
+(`_sms_pack_with_fallback`, vier Rueckfallstufen) greift danach und kann Tokens
+ganz entfernen. Nur AC-3 und AC-7 rufen `_tag_time` direkt auf — dort IST die
+isolierte Funktion die Zusicherung. Keine Mocks: echte `OfficialAlert`/
+`OfficialAlertNotice`, echter Renderer-Aufruf, netzfrei.
+"""
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+
+from output.renderers.alert.official_alerts import (
+    OfficialAlertNotice, _tag_time, render_official_alert_sms,
+)
+from services.official_alerts.models import OfficialAlert
+
+UTC = timezone.utc
+SMS_LIMIT = 140  # produktiver Default von `render_official_alert_sms`
+# 2026-07-10 = Freitag, 2026-07-11 = Samstag, 2026-07-18 = Samstag (Folgewoche).
+_FR, _SA, _SA2 = 10, 11, 18
+
+# Erkennt Zeit-Tokens in BEIDEN Formaten: Bestand ('Sa', 'Sa15-21',
+# 'Fr22-Sa03') UND kuenftig ('Sa11.07.', 'Sa15:20-21:40', 'Fr22:15-Sa03:10').
+# Ein Parser, der nach der Implementierung nichts mehr findet, meldet trivial
+# "keine Kollision" — deshalb ist "nicht gefunden" in `_time_tokens` ein
+# Testfehler (Positivkontrolle), kein stilles Bestehen. Die Monatsgruppe
+# `(?:\.\d{1,2})?` ist fuer F002 noetig: ohne sie endet der Match von
+# 'Sa14.02.' schon nach 'Sa14.', und zwei Tokens verschiedener Monate saehen
+# fuer den Parser weiterhin gleich aus — der Test wuerde dann die Kollision
+# melden, die die Implementierung gerade behoben hat.
+_WD = "(?:Mo|Di|Mi|Do|Fr|Sa|So)"
+_TIME_TOKEN_RE = re.compile(
+    rf"(?<![A-Za-z0-9]){_WD}(?:\d{{1,2}}(?::\d{{2}})?(?:\.\d{{1,2}})?\.?)?"
+    rf"(?:-{_WD}?\d{{1,2}}(?::\d{{2}})?)?(?![A-Za-z])"
+)
+
+
+def _dt(day: int, hour: int, minute: int, second: int = 0, *,
+        month: int = 7) -> datetime:
+    return datetime(2026, month, day, hour, minute, second, tzinfo=UTC)
+
+
+def _alert(vf, vt, *, hazard: str = "thunderstorm", label: str = "Gewitter") -> OfficialAlert:
+    return OfficialAlert(source="vigilance", hazard=hazard, level=3, label=label,
+                         valid_from=vf, valid_to=vt, region_label="Var")
+
+
+def _notice(alert: OfficialAlert, scope: str, scope_id: str) -> OfficialAlertNotice:
+    return OfficialAlertNotice(alert=alert, scope_label=scope, sms_scope=scope,
+                               affected_chips=[scope], free_chips=[],
+                               scope_ids=(scope_id,))
+
+
+def _sms(notices: list[OfficialAlertNotice]) -> str:
+    return render_official_alert_sms(notices, sms_prefix="GZ", limit=SMS_LIMIT, tz=UTC)
+
+
+def _time_tokens(sms: str, *, expected: int) -> list[str]:
+    """Zeit-Tokens des finalen SMS-Strings; Positivkontrolle inklusive."""
+    found = _TIME_TOKEN_RE.findall(sms)
+    assert len(found) == expected, (
+        f"Positivkontrolle: {expected} Zeit-Tokens erwartet, {len(found)} "
+        f"gefunden ({found!r}) in {sms!r}"
+    )
+    return found
+
+
+def test_ac1_gleicher_tag_minuten_machen_tokens_unterscheidbar():
+    """AC-1: Given zwei Warnungen am selben Kalendertag, deren Fenster sich nur
+    in den Minuten unterscheiden und dieselbe Stundenpaarung ergeben
+    (15:00-21:00 vs. 15:20-21:40) / When `render_official_alert_sms` beide
+    gemeinsam rendert / Then sind die Zeit-Tokens im finalen SMS-String
+    unterscheidbar.
+
+    Abweichung vom Spec-Wortlaut, gemessen: das dort genannte Paar
+    15:00-21:00 vs. 15:20-20:50 kollidiert im Bestand GAR NICHT ('Sa15-21' vs.
+    'Sa15-20') und wuerde die Zusicherung nicht pruefen."""
+    sms = _sms([
+        _notice(_alert(_dt(_SA, 15, 0), _dt(_SA, 21, 0)), "Var interieur", "z1"),
+        _notice(_alert(_dt(_SA, 15, 20), _dt(_SA, 21, 40)), "Var cotier", "z2"),
+    ])
+    first, second = _time_tokens(sms, expected=2)
+    assert first != second, (
+        f"Zwei verschiedene Zeitfenster tragen denselben Text {first!r}: {sms!r}"
+    )
+
+
+def test_ac1_gleicher_tag_nur_die_bis_grenze_variiert():
+    """AC-1 (Einzelgrenze `vt`): Given zwei Warnungen am selben Kalendertag mit
+    IDENTISCHER Von-Grenze (15:00), die sich allein in den Minuten der
+    Bis-Grenze unterscheiden (21:00 vs. 21:40) / When gemeinsam gerendert wird
+    / Then sind die Zeit-Tokens verschieden.
+
+    Deckt die Luecke, die `test_ac1_gleicher_tag_...unterscheidbar` offenlaesst:
+    dort variieren beide Grenzen, sodass allein die Von-Differenz die Tokens
+    schon trennt und eine kaputte Bis-Grenze unbemerkt bleibt."""
+    sms = _sms([
+        _notice(_alert(_dt(_SA, 15, 0), _dt(_SA, 21, 0)), "Var interieur", "z1"),
+        _notice(_alert(_dt(_SA, 15, 0), _dt(_SA, 21, 40)), "Var cotier", "z2"),
+    ])
+    first, second = _time_tokens(sms, expected=2)
+    assert first != second, (
+        f"Nur die Bis-Grenze unterscheidet sich, beide Tokens lauten {first!r}: "
+        f"{sms!r}"
+    )
+
+
+def test_ac1_gleicher_tag_nur_die_von_grenze_variiert():
+    """AC-1 (Einzelgrenze `vf`): Given zwei Warnungen am selben Kalendertag mit
+    IDENTISCHER Bis-Grenze (21:00), die sich allein in den Minuten der
+    Von-Grenze unterscheiden (15:00 vs. 15:20) / When gemeinsam gerendert wird
+    / Then sind die Zeit-Tokens verschieden."""
+    sms = _sms([
+        _notice(_alert(_dt(_SA, 15, 0), _dt(_SA, 21, 0)), "Var interieur", "z1"),
+        _notice(_alert(_dt(_SA, 15, 20), _dt(_SA, 21, 0)), "Var cotier", "z2"),
+    ])
+    first, second = _time_tokens(sms, expected=2)
+    assert first != second, (
+        f"Nur die Von-Grenze unterscheidet sich, beide Tokens lauten {first!r}: "
+        f"{sms!r}"
+    )
+
+
+def test_ac2_tagesuebergang_minuten_machen_tokens_unterscheidbar():
+    """AC-2: Given zwei Warnungen mit Tagesuebergangs-Fenstern
+    (Fr22:15-Sa03:10 vs. Fr22:30-Sa03:45), die sich nur in den Minuten
+    unterscheiden / When gerendert wird / Then sind beide Zeit-Tokens im
+    finalen String verschieden."""
+    sms = _sms([
+        _notice(_alert(_dt(_FR, 22, 15), _dt(_SA, 3, 10)), "Var interieur", "z1"),
+        _notice(_alert(_dt(_FR, 22, 30), _dt(_SA, 3, 45)), "Var cotier", "z2"),
+    ])
+    first, second = _time_tokens(sms, expected=2)
+    assert first != second, (
+        f"Zwei Tagesuebergangs-Fenster tragen denselben Text {first!r}: {sms!r}"
+    )
+
+
+def test_ac2_tagesuebergang_nur_die_bis_grenze_variiert():
+    """AC-2 (Einzelgrenze `vt`): Given zwei Tagesuebergangs-Warnungen mit
+    IDENTISCHER Von-Grenze (Fr22:00), die sich allein in den Minuten der
+    Bis-Grenze unterscheiden (Sa03:10 vs. Sa03:45) / When gemeinsam gerendert
+    wird / Then sind die Zeit-Tokens verschieden.
+
+    Nur erfuellbar, wenn die Bis-Grenze des Tagesuebergangs-Zweigs die Minuten
+    traegt; im Bestandstest variieren beide Grenzen zugleich und die
+    Von-Differenz verdeckt eine kaputte Bis-Grenze vollstaendig."""
+    sms = _sms([
+        _notice(_alert(_dt(_FR, 22, 0), _dt(_SA, 3, 10)), "Var interieur", "z1"),
+        _notice(_alert(_dt(_FR, 22, 0), _dt(_SA, 3, 45)), "Var cotier", "z2"),
+    ])
+    first, second = _time_tokens(sms, expected=2)
+    assert first != second, (
+        f"Nur die Bis-Grenze unterscheidet sich, beide Tokens lauten {first!r}: "
+        f"{sms!r}"
+    )
+
+
+def test_ac2_tagesuebergang_nur_die_von_grenze_variiert():
+    """AC-2 (Einzelgrenze `vf`): Given zwei Tagesuebergangs-Warnungen mit
+    IDENTISCHER Bis-Grenze (Sa03:00), die sich allein in den Minuten der
+    Von-Grenze unterscheiden (Fr22:15 vs. Fr22:30) / When gemeinsam gerendert
+    wird / Then sind die Zeit-Tokens verschieden."""
+    sms = _sms([
+        _notice(_alert(_dt(_FR, 22, 15), _dt(_SA, 3, 0)), "Var interieur", "z1"),
+        _notice(_alert(_dt(_FR, 22, 30), _dt(_SA, 3, 0)), "Var cotier", "z2"),
+    ])
+    first, second = _time_tokens(sms, expected=2)
+    assert first != second, (
+        f"Nur die Von-Grenze unterscheidet sich, beide Tokens lauten {first!r}: "
+        f"{sms!r}"
+    )
+
+
+def test_ac3_volle_stunden_bleiben_ohne_minutenanhang():
+    """AC-3 (Nicht-Regression, bewusst schon gruen): Given ein Fenster ohne
+    Minutenanteil (15:00-21:00) / When `_tag_time` bzw.
+    `render_official_alert_sms` rendert / Then bleibt der Kurz-Token
+    bit-identisch 'Sa15-21' — ohne Minutenanhang, ohne Datum."""
+    alert = _alert(_dt(_SA, 15, 0), _dt(_SA, 21, 0))
+    assert _tag_time(alert, UTC) == "Sa15-21", (
+        f"Voll-Stunden-Token veraendert: {_tag_time(alert, UTC)!r}"
+    )
+    sms = _sms([_notice(alert, "Var interieur", "z1")])
+    assert _time_tokens(sms, expected=1) == ["Sa15-21"], f"in der SMS: {sms!r}"
+
+
+def test_ac4_ganztags_tokens_verschiedener_wochen_sind_unterscheidbar():
+    """AC-4: Given zwei Ganztags-Warnungen am selben Wochentag verschiedener
+    Kalenderwochen (Sa 11.07. und Sa 18.07., beide im 15-Tage-Horizont) / When
+    gemeinsam gerendert wird / Then tragen beide Tokens eine Tag-im-Monat-
+    Angabe und sind textlich verschieden."""
+    sms = _sms([
+        _notice(_alert(_dt(_SA, 0, 0), _dt(_SA, 23, 59)), "Var interieur", "z1"),
+        _notice(_alert(_dt(_SA2, 0, 0), _dt(_SA2, 23, 59)), "Var cotier", "z2"),
+    ])
+    first, second = _time_tokens(sms, expected=2)
+    assert first != second, (
+        f"Zwei Ganztags-Warnungen eine Woche auseinander tragen denselben Text "
+        f"{first!r}: {sms!r}"
+    )
+    assert all(any(c.isdigit() for c in t) for t in (first, second)), (
+        f"Ganztags-Tokens ohne Datumsangabe: {first!r}/{second!r} in {sms!r}"
+    )
+
+
+def test_f002_ganztags_tokens_verschiedener_monate_sind_unterscheidbar():
+    """AC-4 (F002, Monat im Ganztags-Token): Given zwei Ganztags-Warnungen mit
+    demselben Tag-im-Monat auf demselben Wochentag in VERSCHIEDENEN Monaten
+    (Sa 14.02. und Sa 14.03.2026) / When gemeinsam gerendert wird / Then sind
+    die Zeit-Tokens verschieden und tragen die Form 'Sa14.02.'/'Sa14.03.'.
+
+    Gemessen vor der Aenderung: beide ergaben bit-identisch 'Sa14.' — die
+    schaerfste Kollisionslage des Ganztags-Tokens. Der Bestandstest AC-4
+    (11.07. vs. 18.07.) faengt sie nicht, weil dort beide Termine im SELBEN
+    Monat liegen und schon der Tag-im-Monat trennt.
+
+    Das Datumspaar ist bewusst gewaehlt und nicht frei austauschbar: gleicher
+    Wochentag UND gleicher Tag-im-Monat erzwingen einen Abstand als Vielfaches
+    von 7 Tagen, den nur Februar->Maerz (28 Tage) knapp liefert. Ein Paar wie
+    10.07./10.08. waere Fr gegen Mo und damit schon ueber das Wochentags-
+    kuerzel unterscheidbar — der Test wuerde die Zusicherung nicht pruefen.
+
+    Der zweite Assert nagelt die Reihenfolge Tag-vor-Monat fest; ohne ihn
+    bliebe eine Vertauschung ('Sa02.14.') unbemerkt, da auch vertauschte
+    Tokens noch verschieden sind."""
+    sms = _sms([
+        _notice(_alert(_dt(14, 0, 0, month=2), _dt(14, 23, 59, month=2)),
+                "Var interieur", "z1"),
+        _notice(_alert(_dt(14, 0, 0, month=3), _dt(14, 23, 59, month=3)),
+                "Var cotier", "z2"),
+    ])
+    first, second = _time_tokens(sms, expected=2)
+    assert first != second, (
+        f"Gleicher Wochentag, gleicher Tag-im-Monat, verschiedene Monate tragen "
+        f"denselben Text {first!r}: {sms!r}"
+    )
+    assert (first, second) == ("Sa14.02.", "Sa14.03."), (
+        f"Ganztags-Token nicht in der Form 'Tag.Monat.': {first!r}/{second!r} "
+        f"in {sms!r}"
+    )
+
+
+def test_ac5_kein_kollidierender_rest_unter_budgetdruck():
+    """AC-5: Given die Kollisionslage aus AC-1 plus eine dritte Warnung und
+    lange Ortsnamen, die die Kuerzungskette zum Droppen zwingen (gemessen: das
+    dritte Token faellt per '+1' weg, die beiden kollidierenden bleiben) / When
+    gerendert wird / Then ist jedes verbliebene Zeit-Token eindeutig — ein
+    kollidierender Rest ist die Verletzung."""
+    scope = "Vallee du Verdon Haute Rive Est"
+    sms = _sms([
+        _notice(_alert(_dt(_SA, 15, 0), _dt(_SA, 21, 0)), scope, "z1"),
+        _notice(_alert(_dt(_SA, 15, 20), _dt(_SA, 21, 40), hazard="wind_gust",
+                       label="Sturm"), scope + " Sued", "z2"),
+        _notice(_alert(_dt(_SA, 17, 0), _dt(_SA, 19, 0), hazard="snow",
+                       label="Schneefall"), scope + " Nord", "z3"),
+    ])
+    assert " +" in sms, (
+        f"Szenario greift nicht: kein Auslassungsmarker, kein Budgetdruck: {sms!r}"
+    )
+    visible = _time_tokens(sms, expected=2)
+    assert len(set(visible)) == len(visible), (
+        f"Kollidierender Rest nach der Kuerzung sichtbar: {visible!r} in {sms!r}"
+    )
+
+
+def test_ac6_alle_szenarien_bleiben_unter_140_zeichen():
+    """AC-6: Given die Szenarien aus AC-1, AC-2, AC-4 und AC-5 / When mit dem
+    produktiven Default-Limit gerendert wird / Then ueberschreitet der
+    zurueckgegebene String nie 140 Zeichen."""
+    lang = "Vallee du Verdon Haute Rive Est"
+    szenarien = {
+        "ac1": ("Var", [((_SA, 15, 0), (_SA, 21, 0)), ((_SA, 15, 20), (_SA, 21, 40))]),
+        "ac2": ("Var", [((_FR, 22, 15), (_SA, 3, 10)), ((_FR, 22, 30), (_SA, 3, 45))]),
+        "ac4": ("Var", [((_SA, 0, 0), (_SA, 23, 59)), ((_SA2, 0, 0), (_SA2, 23, 59))]),
+        "ac5": (lang, [((_SA, 15, 0), (_SA, 21, 0)), ((_SA, 15, 20), (_SA, 21, 40)),
+                       ((_SA, 17, 0), (_SA, 19, 0))]),
+    }
+    for name, (scope, fenster) in szenarien.items():
+        sms = _sms([_notice(_alert(_dt(*vf), _dt(*vt)), f"{scope} {i}", f"z{i}")
+                    for i, (vf, vt) in enumerate(fenster)])
+        assert len(sms) <= SMS_LIMIT, (
+            f"Szenario {name}: {len(sms)} Zeichen > {SMS_LIMIT}: {sms!r}"
+        )
+
+
+def test_ac7_none_fenster_und_sekunden_bleiben_unveraendert():
+    """AC-7 (Bestandsverhalten, bewusst schon gruen): Given ein Fenster ohne
+    `valid_from`/`valid_to` (DPC-Fall) sowie eines mit Sekundenanteil != 0 /
+    When `_tag_time` aufgerufen wird / Then bleibt das Ergebnis wie
+    vorbestehend: leerer String bzw. Sekunden weiterhin ignoriert."""
+    assert _tag_time(_alert(None, None), UTC) == "", (
+        "Fehlender Gueltigkeitszeitraum liefert nicht mehr '' (F003-Verhalten)"
+    )
+    mit = _tag_time(_alert(_dt(_SA, 9, 55, 57), _dt(_SA, 20, 0, 30)), UTC)
+    ohne = _tag_time(_alert(_dt(_SA, 9, 55), _dt(_SA, 20, 0)), UTC)
+    assert mit == ohne, f"Sekundenanteil wirkt neuerdings: {mit!r} vs. {ohne!r}"


### PR DESCRIPTION
Zwei amtliche Warnungen mit **verschiedenen** Melde-Zeitfenstern trugen in derselben SMS / Premium-SMS / Telegram-Kurzform denselben Anzeigetext. Beide Kollisionsquellen sind gehärtet.

## Was sich ändert

| Fall | vorher | nachher |
|---|---|---|
| volle Stunden | `Sa15-21` | `Sa15-21` (**bit-identisch**) |
| mit Minuten | `Sa15-21` | `Sa15:20-21:40` |
| Tagesübergang | `Fr22-Sa03` | `Fr22:15-Sa03:10` |
| ganztägig | `Sa` | `Sa14.02.` |

Minuten werden **nur** angehängt, wenn sie nicht auf `:00` liegen — die Regel ist pro Token für sich entscheidbar und kostet nur dort Zeichen, wo sie trägt.

## Zur Monatsangabe

Der Monat verhindert praktisch **keine** Token-Kollision: Dafür bräuchte es gleichen Wochentag *und* gleichen Tag im Monat, also mindestens **28 Tage** Abstand (Februar→März; der Februar ist selbst ein Vielfaches von 7). Er macht das **einzelne** Token für den Leser eindeutig — „welcher Samstag?".

Die ursprüngliche Spec-Begründung über den 15-Tage-Horizont von Open-Meteo trägt **nicht**: Amtliche Warnungen stammen aus vier anderen Quellen (Vigilance, MeteoAlarm, GeoSphere, DPC), und der Alarm-Pfad prüft die gesamte Restroute ohne Tagesdeckel. Der Adversary hat das aufgedeckt, die Spec ist korrigiert.

## Zeichenbudget

+3 Zeichen nur im Ganztags-Fall, 0 für jedes `:00`-Fenster. Das 140er-Budget kippt nicht — die engste gemessene Lage (118/140) enthält gar kein Ganztags-Token. Es kann strukturell auch nicht kippen: `_sms_pack` droppt bei Überlauf ganze Tokens mit `+N`-Marker, statt Text abzuschneiden.

## Nachweis

**12 Tests**, die jede Fenstergrenze **einzeln** absichern. Der ursprüngliche Nachweis hatte eine Lücke, die der Adversary fand: Tests, die Anfang *und* Ende gleichzeitig variieren, verdecken eine halbseitig kaputte Grenze — eine solche Mutation blieb über 223 Tests unsichtbar. Alle vier Einzelgrenzen-Mutationen werden jetzt von je einem eigenen Test gefangen.

Ebenfalls gefangen: Monat entfernen, Tag/Monat vertauschen (nur durch einen expliziten Form-Assert — die reine Verschiedenheits-Prüfung greift dort nicht), Tag entfernen.

- **228 Tests grün** über alle 12 Dateien, die `_tag_time` / `render_official_alert_sms` berühren
- Adversary: **VERIFIED**, 7/7 Mutationen gefangen
- Official-Alert-Mail-Validator gegen echt zugestellte Mail: Exit 0
- Angepasst wurde genau **ein** Bestands-Pin (Ganztags-Text), Assertion bleibt exakte Volltext-Gleichheit

## Abgrenzung

`_tag_time` gilt für **#1948** als entschieden und wird dort als „WANN"-Baustein übernommen, nicht ersetzt. Die #1948-Regel „Wochentag nur wenn nicht heute" ist hier **bewusst nicht** umgesetzt.

## Hinweis

Der Arbeits-Worktree wurde vor dem ersten Commit durch ein fremdes `git worktree remove --force` gelöscht (der Branch trug keine Commits und galt dadurch als „merged"). Der Produktivstand ist **bitgenau** aus einer externen Sicherungskopie wiederhergestellt (MD5-Abgleich), Testdatei und Spec sind rekonstruiert. Der Adversary hat den wiederhergestellten Stand **frisch nachgeprüft** statt das gerettete Protokoll zu übernehmen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014hBrWK1KFXSL5Hyk71uqwL