### PR TITLE
fix 1945 alarm countdown unklar

### DIFF
--- a/docs/context/fix-1945-alarm-countdown-unklar.md
+++ b/docs/context/fix-1945-alarm-countdown-unklar.md
@@ -1,0 +1,39 @@
+# Context: fix-1945-alarm-countdown-unklar (#1945 „Alarm unklar")
+
+## Request Summary
+Nutzer erhielt zwei Radar-Nowcast-Alarme (15:52 und 17:07, 75 Min auseinander) mit demselben
+Countdown-Wert "8". Root Cause: `_NOWCAST_HORIZON_MIN` in `src/services/radar_service.py` deckelt
+den Suchhorizont künstlich auf 60 Minuten, obwohl die GeoSphere-INCA-API (Endpunkt
+`nowcast-v1-15min-1km`) live bis zu 180 Minuten Vorschau im 15-Min-Raster liefert. Der Scheduler
+prüft alle 15 Min, immer ~8 Min vor dem nächsten Rasterpunkt — der Alarm feuert fast immer erst
+beim NÄCHSTEN Rasterpunkt, daher praktisch immer ≈8 Minuten Countdown.
+
+## Related Files
+| File | Relevance |
+|------|-----------|
+| `src/services/radar_service.py:62` | `_NOWCAST_HORIZON_MIN = 60` → wird zu `180` |
+| `src/services/radar_service.py:514-536` (`_derive_result`) | Sucht ersten nassen Frame im Horizont-Fenster |
+| `tests/tdd/test_radar_alert_follows_ortstag.py:412-436` | Hartcodierte Annahme Horizont==60, Fern-Fall 90 Min |
+| `tests/tdd/test_starkregen_kurzfristhinweis.py:338-346` | Hartcodierte Annahme Horizont==60, Fern-Fall 90 Min |
+
+## Existing Patterns
+Zwei-Cooldown-Architektur (Trip-Scope + segment-lokaler Guard) funktioniert bereits korrekt und
+ist NICHT Teil dieses Fixes. Segment-Auswahl (`resolve_current_segment()`) und ETA-Modell
+(Naismith-Pace) sind bereits korrekt verdrahtet, keine Änderung nötig.
+
+## Dependencies
+- Upstream: GeoSphere-INCA-Provider (`src/providers/geosphere.py`), Scheduler-Cron
+  (`internal/scheduler/scheduler.go`, Takt `7,22,37,52 * * * *`).
+- Downstream: `trip_alert.py` (Horizont-Guard nutzt denselben Alias `NOWCAST_HORIZON_MIN`).
+
+## Existing Specs
+- `docs/specs/modules/fix_1945_nowcast_horizon.md` (diese Spec)
+- `docs/specs/modules/rework_1467_s4b_entdopplung.md` — Ereignis-Identität (nicht betroffen)
+
+## Risks & Considerations
+- Reine Konstanten-Änderung, aber zwei Bestandstests brechen ohne Anpassung ihres Fern-Fall-Offsets
+  (90 → >180 Min), da eine reine Zahlenänderung im Assert die Testsemantik kippen würde.
+- Scope bewusst klein gehalten — Format/Rendering (#1948), Frühwarnung (#1493) und amtliche
+  Warnungen (#1929) sind explizit ausgeschlossen und gehören anderen, bereits vergebenen Tickets.
+- Ursprünglicher Worktree wurde durch fremden Cleanup-Lauf gelöscht; dieses Dokument ist eine
+  inhaltsgleiche Rekonstruktion im neuen Worktree `replicated-cuddling-sphinx`.

--- a/docs/features/architecture.md
+++ b/docs/features/architecture.md
@@ -445,7 +445,7 @@ check_radar_alerts(user_id)  [Issue #822 + #919, tagesübergreifend seit #1667 S
 _send_briefing_report() [trip_report_scheduler.py]
   ↓ WeatherSnapshotService.save(snapshot)
   ↓ AlertStateService.reset(trip_id)
-  ↓ _build_starkregen_hint() → Nähe-Guard (60 Min) + Budget-Gate ("nowcast") → get_nowcast() [Issue #1439]
+  ↓ _build_starkregen_hint() → Nähe-Guard (180 Min, #1945) + Budget-Gate ("nowcast") → get_nowcast() [Issue #1439]
   ↓ bei Treffer: Hinweiszeile in E-Mail/Telegram + ThrottleStore("radar").record(trip_id) (s. Punkt 5 oben)
 
 check_all_compare_presets(user_id)  [CompareAlertService, Issue #1169]

--- a/docs/specs/data_sources.md
+++ b/docs/specs/data_sources.md
@@ -234,7 +234,8 @@ zusaetzlich eine laengere Rueckschau (5,8 Tage statt 23 h) und deutschsprachige 
 
 **Zusammenfassung:** `minutely_15` (Open-Meteo, Parameter `precipitation`/`weather_code`) ist der
 globale Fallback des bereits produktiven `RadarNowcastService` (Issue #656, `src/services/radar_service.py`)
-fuer den 60-Minuten-Regen-/Gewitter-Nowcast — ausserhalb der RADOLAN/INCA/DPC/AROME-Bounding-Boxen sowie
+fuer den Regen-/Gewitter-Nowcast (Horizont `NOWCAST_HORIZON_MIN`, 180 Min seit #1945, zuvor 60 Min) —
+ausserhalb der RADOLAN/INCA/DPC/AROME-Bounding-Boxen sowie
 als Sidecar-Quelle fuer den Konvektions-Check. War in dieser Spec bisher nicht eingetragen; kein neuer
 Parameter, reiner Nachtrag.
 

--- a/docs/specs/modules/feat_1439_starkregen_kurzfristhinweis.md
+++ b/docs/specs/modules/feat_1439_starkregen_kurzfristhinweis.md
@@ -22,14 +22,17 @@ tags: [radar-nowcast, trip-briefing, email, telegram, alerts]
 Das planmäßige Trip-Briefing (Morgen-/Abend-Mail + Telegram) bekommt eine
 kurze Hinweiszeile, wenn der bereits produktiv laufende `RadarNowcastService`
 (Issue #656) für den Startpunkt des aktiven/nächsten Segments **Starkregen
-innerhalb der nächsten 60 Minuten** erkennt. Das ist eine **Änderung**, kein
-Neubau: die Nowcast-Infrastruktur existiert bereits (u.a. im 15-Minuten-
-Alarm-Poll, `trip_alert.py`); es fehlt nur die Einbindung in den
-**planmäßigen** Briefing-Versandpfad.
+innerhalb der nächsten `NOWCAST_HORIZON_MIN` Minuten** erkennt (Wert bei
+Erstellung dieser Spec: 60 — seit Issue #1945 auf **180** angehoben, s.
+Changelog). Das ist eine **Änderung**, kein Neubau: die Nowcast-
+Infrastruktur existiert bereits (u.a. im 15-Minuten-Alarm-Poll,
+`trip_alert.py`); es fehlt nur die Einbindung in den **planmäßigen**
+Briefing-Versandpfad.
 
 **Wichtige Grenze (durch die Nowcast-Technologie selbst gesetzt, keine
 Implementierungslücke):** `RadarNowcastService` erkennt Regen ausschließlich
-innerhalb eines 60-Minuten-Fensters ab Abrufzeitpunkt. Der Hinweis kann daher
+innerhalb eines `NOWCAST_HORIZON_MIN`-Fensters (180 Min, s. Changelog) ab
+Abrufzeitpunkt. Der Hinweis kann daher
 **keine** Tage- oder Stunden-vorher-Vorhersage für morgen leisten — bei einer
 Abend-Mail (die die Etappe des Folgetags beschreibt) erscheint er nur, wenn
 die Etappe zufällig kurz nach Versandzeit beginnt. Der reguläre
@@ -55,9 +58,10 @@ weiterhin die maßgebliche Vorschau für spätere Stunden/Tage.
   einbauen (`render_telegram_bubbles`, analog dem bestehenden
   „Amtliche Warnungen nicht abrufbar"-Block)
 - **File:** `src/services/radar_service.py` (MODIFY, minimal) — bestehende
-  private `_NOWCAST_HORIZON_MIN = 60` bekommt einen öffentlichen Alias
-  `NOWCAST_HORIZON_MIN`, damit der Zeitfenster-Guard im Scheduler dieselbe
-  Zahl referenziert statt eine zweite Kopie zu pflegen
+  private `_NOWCAST_HORIZON_MIN` (Wert bei Erstellung dieser Spec: 60, seit
+  #1945: 180) bekommt einen öffentlichen Alias `NOWCAST_HORIZON_MIN`, damit
+  der Zeitfenster-Guard im Scheduler dieselbe Zahl referenziert statt eine
+  zweite Kopie zu pflegen
 - **File:** `docs/specs/data_sources.md` (MODIFY, Governance-Nachtrag) —
   Eintrag für `minutely_15` als bereits seit #656 produktiv genutzte Quelle
 
@@ -95,7 +99,7 @@ def _build_starkregen_hint(self, trip, segments, tz, now_utc) -> Optional[str]:
     # 1. Aktives/naechstes Segment waehlen — dieselbe Auswahl wie
     #    TripAlertService.check_radar_alerts() (trip_alert.py:730-745)
     # 2. Naehe-Guard: Segment muss aktiv sein ODER innerhalb
-    #    NOWCAST_HORIZON_MIN (60 Min) starten, sonst -> None
+    #    NOWCAST_HORIZON_MIN (180 Min, #1945) starten, sonst -> None
     # 3. Budget-Gate: alert_daily_limit.is_allowed(user_id, now_utc,
     #    reason="nowcast") -- False -> None, KEIN Fetch
     # 4. get_nowcast(lat, lon, priority="polling") -- Exception -> None
@@ -159,7 +163,8 @@ ab; der Eintrag bleibt bewusst auf eine Zeile beschränkt.
 ## Expected Behavior
 
 - **Input:** Trip mit aktivem/nächstem Segment, dessen Startpunkt-Koordinate
-  Starkregen (mm/h >= 4.0) innerhalb der nächsten 60 Minuten zeigt
+  Starkregen (mm/h >= 4.0) innerhalb der nächsten `NOWCAST_HORIZON_MIN`
+  Minuten (180, #1945) zeigt
 - **Output:** Hinweiszeile „Starker Regen ab ca. HH:MM (in ~N Min)." in
   E-Mail (HTML + Plain) und Telegram-Bubble des planmäßigen Briefings;
   ohne Treffer/außerhalb des Fensters/ohne Budget entfällt die Zeile
@@ -181,16 +186,19 @@ ab; der Eintrag bleibt bewusst auf eine Zeile beschränkt.
     aufgerufen wurde.
 
 - **AC-2:** Given die aktive/nächste Etappe eines Trips beginnt erst in
-  mehr als `NOWCAST_HORIZON_MIN` (60) Minuten / When das planmäßige
-  Briefing gerendert wird / Then erscheint kein Starkregen-Kurzfristhinweis
-  und `RadarNowcastService.get_nowcast()` wird für diesen Trip nicht
-  aufgerufen, selbst wenn ein injizierter Nowcast Starkregen melden würde.
-  - Test: Segment-Startzeit auf „in 90 Minuten" setzen, Fetch-Spy prüft
-    Nicht-Aufruf; Segment-Startzeit auf „in 30 Minuten" setzen, Fetch wird
-    aufgerufen (Gegenprobe im selben Test).
+  mehr als `NOWCAST_HORIZON_MIN` (180, #1945) Minuten / When das
+  planmäßige Briefing gerendert wird / Then erscheint kein
+  Starkregen-Kurzfristhinweis und `RadarNowcastService.get_nowcast()` wird
+  für diesen Trip nicht aufgerufen, selbst wenn ein injizierter Nowcast
+  Starkregen melden würde.
+  - Test: Segment-Startzeit auf „in 200 Minuten" (> 180) setzen, Fetch-Spy
+    prüft Nicht-Aufruf; Segment-Startzeit auf „in 30 Minuten" (<= 180)
+    setzen, Fetch wird aufgerufen (Gegenprobe im selben Test,
+    `tests/tdd/test_starkregen_kurzfristhinweis.py::test_ac2_zeitfenster_guard_kein_fetch_ausserhalb_horizon`).
 
 - **AC-3:** Given ein Trip, dessen aktive/nächste Etappe innerhalb der
-  nächsten 60 Minuten beginnt UND `get_nowcast()` für den
+  nächsten `NOWCAST_HORIZON_MIN` Minuten (180, #1945) beginnt UND
+  `get_nowcast()` für den
   Etappen-Startpunkt `INTENSITY_HEAVY` mit gesetztem `onset_minutes`
   liefert / When das planmäßige Briefing versendet wird / Then enthalten
   sowohl die E-Mail (HTML und Plain) als auch die Telegram-Nachricht eine
@@ -252,12 +260,13 @@ ab; der Eintrag bleibt bewusst auf eine Zeile beschränkt.
 
 ## Known Limitations
 
-- **Kein Tage-vorher-Hinweis:** Durch das 60-Minuten-Nowcast-Fenster von
-  `RadarNowcastService` greift der Kurzfristhinweis bei Abend-Mails
-  (Etappe = Folgetag) praktisch nur, wenn die Etappe zufällig kurz nach
-  Versandzeit beginnt. Das ist eine bewusste, technisch bedingte Grenze,
-  keine Implementierungslücke — für eine echte Vorabend-Vorhersage bleibt
-  die reguläre Stundentabelle maßgeblich.
+- **Kein Tage-vorher-Hinweis:** Durch das `NOWCAST_HORIZON_MIN`-Fenster von
+  `RadarNowcastService` (180 Min seit #1945, vorher 60 Min) greift der
+  Kurzfristhinweis bei Abend-Mails (Etappe = Folgetag) weiterhin praktisch
+  nur, wenn die Etappe zufällig innerhalb weniger Stunden nach Versandzeit
+  beginnt. Das ist eine bewusste, technisch bedingte Grenze, keine
+  Implementierungslücke — für eine echte Vorabend-Vorhersage bleibt die
+  reguläre Stundentabelle maßgeblich.
 - **SMS nicht im Scope:** Token-Format-Aufwand für SMS wird als eigenes
   Folge-Issue vorgemerkt (PO-Entscheidung, Deadline-getrieben).
 - **Konsistenz-Mechanismus ist ein Cooldown, keine Wortlaut-Korrektur:**
@@ -282,3 +291,12 @@ ab; der Eintrag bleibt bewusst auf eine Zeile beschränkt.
 ## Changelog
 
 - 2026-08-07: Initial spec erstellt — Issue #1439
+- 2026-08-18: `NOWCAST_HORIZON_MIN` von 60 auf 180 Minuten angehoben —
+  Issue #1945. Grund: Der Countdown-Alarm zeigte strukturell fast immer
+  denselben Wert (~8 Min), weil die GeoSphere-INCA-Daten auf einem
+  15-Min-Raster liegen, der Scheduler alle 15 Min prüft und der alte
+  60-Min-Deckel den Alarm fast nur beim unmittelbar nächsten Rasterpunkt
+  auslösen ließ. Reine Konstanten-Änderung in `radar_service.py`, kein
+  neues Architektur-Muster; alle numerischen Erwähnungen des alten
+  60-Min-Werts oben sind entsprechend aktualisiert. Details:
+  `docs/specs/modules/fix_1945_nowcast_horizon.md`.

--- a/docs/specs/modules/fix_1945_nowcast_horizon.md
+++ b/docs/specs/modules/fix_1945_nowcast_horizon.md
@@ -1,0 +1,124 @@
+---
+entity_id: fix_1945_nowcast_horizon
+type: bugfix
+created: 2026-08-17
+updated: 2026-08-17
+status: approved
+---
+
+## Approval
+
+- [x] Approved
+
+## Purpose
+
+Issue #1945 ("Alarm unklar"): Der Radar-Nowcast-Alarm zeigte bei zwei unabhängigen Alarmen für
+denselben Trip (KHW 403, 15:52 und 17:07 Uhr, 75 Min auseinander) beide Male denselben
+Countdown-Wert. Root Cause: `_NOWCAST_HORIZON_MIN` in `src/services/radar_service.py` deckelt den
+Suchhorizont künstlich auf 60 Minuten, obwohl die GeoSphere-INCA-API selbst live nachgewiesen bis
+zu 180 Minuten (3 Stunden) Vorschau im 15-Minuten-Raster liefert (Endpunkt
+`nowcast-v1-15min-1km`). Weil der Alarm nur den ERSTEN nassen Frame innerhalb des 60-Min-Fensters
+sucht, löst er praktisch immer erst aus, wenn der NÄCHSTE 15-Minuten-Rasterpunkt nass wird — der
+Scheduler prüft alle 15 Minuten (`7,22,37,52 * * * *`), das ist strukturell immer ~8 Minuten vor
+dem nächsten Rasterpunkt. Ergebnis: `onset_minutes` ist fast immer ≈8, unabhängig vom realen
+Wettergeschehen, und der Nutzer bekommt praktisch nie mehr als 8-23 Minuten Vorlauf, obwohl die
+Datenquelle mehr hergäbe.
+
+## Source
+
+Issue #1945, PO-Bericht mit zwei realen Produktions-Alarmen (bestätigt über
+`/var/lib/gregor/users/henning/alert_log.json`, `sent_at` 2026-08-17T13:52:02Z und
+15:07:02Z UTC, exakt 75 Min = 5×15-Min-Raster auseinander). Root Cause live gegen den echten
+GeoSphere-INCA-Endpunkt verifiziert (`curl` gegen `dataset.api.hub.geosphere.at`, Antwort liefert
+12 Zeitstempel im 15-Min-Raster über 3 Stunden voraus).
+
+## Dependencies
+
+| Was | Wovon abhängig |
+|-----|-----------------|
+| `_derive_result()` (radar_service.py) | `_NOWCAST_HORIZON_MIN`-Konstante |
+| `check_radar_alerts()` (trip_alert.py) | Horizont-Guard nutzt denselben Wert über den Alias `NOWCAST_HORIZON_MIN` |
+| Zwei Bestandstests | Harte `assert NOWCAST_HORIZON_MIN == 60`-Prüfung, muss mit angepasst werden |
+
+## Scope
+
+### Affected Files
+
+| File | Change Type | Description |
+|------|-------------|--------------|
+| `src/services/radar_service.py` | MODIFY | `_NOWCAST_HORIZON_MIN` von 60 auf 180 |
+| `tests/tdd/test_nowcast_horizon_180min.py` | CREATE | Neuer Regressionstest (AC-1/2/3) |
+| `tests/tdd/test_radar_alert_follows_ortstag.py` | MODIFY | Assert + Fern-Fall-Offset an neuen Horizont anpassen |
+| `tests/tdd/test_starkregen_kurzfristhinweis.py` | MODIFY | Assert + Fern-Fall-Offset an neuen Horizont anpassen |
+
+### Estimated Changes
+
+~1 Zeile Produktivcode, ~3 Testdateien (1 neu, 2 angepasst) — weit unter dem 250-LoC-Standardbudget.
+
+### Explizit AUSGESCHLOSSEN (gehört zu anderen, bereits vergebenen Tickets)
+
+- **Rendering/Format der Onset-Nachricht** (SMS-Token `TH!8`/`R!8`, Umstieg auf absolute Uhrzeit,
+  Segment-Kopf, Einheit) — gehört zu **#1948** (PO-Entscheid: einheitliches Alarm-Format über alle
+  drei Zweige). `src/output/renderers/alert/render.py` NICHT anfassen.
+- **Frühwarnung aus der Stundenvorhersage** (weiter im Voraus, gröber) — eigenes Ticket **#1493**.
+- **Amtliche Warnungen** (`official_alerts.py`) — **#1929**, andere Session, NICHT anfassen.
+
+## Implementation Details
+
+`src/services/radar_service.py`, Zeile ~62: `_NOWCAST_HORIZON_MIN = 60` → `= 180`. Der öffentliche
+Alias `NOWCAST_HORIZON_MIN` (Zeile ~65) übernimmt den Wert automatisch. Einzige funktionale
+Verwendung: `_derive_result()`, Zeile ~522, `horizon = now + timedelta(minutes=_NOWCAST_HORIZON_MIN)`.
+
+Zwei Bestandstests haben `assert NOWCAST_HORIZON_MIN == 60` als Testvoraussetzung UND nutzen einen
+"Fern"-Fall mit 90 Minuten Abstand (bei altem Horizont=60 außerhalb, bei neuem Horizont=180
+plötzlich innerhalb) — reine Zahlenänderung im Assert würde die Testsemantik kippen. Der Fern-Fall
+muss auf einen Offset > 180 Min angehoben werden (z.B. 200 Min), damit "außerhalb Horizont"
+weiterhin geprüft wird:
+- `tests/tdd/test_radar_alert_follows_ortstag.py::test_ac4_horizont_guard_fern_kein_abruf_nah_ein_abruf`
+- `tests/tdd/test_starkregen_kurzfristhinweis.py::test_ac2_zeitfenster_guard_kein_fetch_ausserhalb_horizon`
+
+## Expected Behavior
+
+Ein Nowcast-Alarm kann ab sofort auch dann auslösen, wenn der erste nasse Rasterpunkt bis zu 180
+Minuten (statt bisher 60) in der Zukunft liegt — dadurch verteilen sich die gezeigten
+Countdown-Werte über mehr Rasterpunkte (23/38/53/68/83/98/113/128/143/158/173 Min), und Nutzer
+bekommen im typischen Fall deutlich mehr Vorlauf vor einem Wetterereignis.
+
+## Acceptance Criteria
+
+- **AC-1:** Given `_NOWCAST_HORIZON_MIN` in `src/services/radar_service.py` / When das Modul
+  importiert wird / Then ist der Wert `180`, nicht mehr `60`.
+  - Test: `assert radar_service.NOWCAST_HORIZON_MIN == 180` direkt gegen das importierte Modul.
+
+- **AC-2:** Given eine Frame-Liste mit einem nassen Frame bei `now + 90 Minuten` (precip_mm_h=2.0)
+  und ausschließlich trockenen Frames davor / When `RadarNowcastService()._derive_result(frames,
+  "test-source", now=now)` aufgerufen wird / Then ist `result.onset_minutes == 90` statt `None`.
+  - Test: `tests/tdd/test_nowcast_horizon_180min.py`, echte `RadarFrame`-Objekte (kein Mock),
+    reproduziert das Nutzersymptom (Alarm bleibt aus, obwohl Regen in 90 Minuten kommt) — MUSS vor
+    der Konstanten-Änderung rot sein (`onset_minutes is None`) und danach grün.
+
+- **AC-3:** Given dieselbe Frame-Liste wie in AC-2, zusätzlich ein nasser Frame bei
+  `now + 200 Minuten` / When `_derive_result()` aufgerufen wird / Then bleibt der 200-Minuten-Frame
+  außerhalb des Fensters unberücksichtigt und `onset_minutes` referenziert weiterhin den
+  90-Minuten-Frame — der Horizont ist auf 180 begrenzt, nicht unbegrenzt geöffnet.
+  - Test: Assert im selben Testfall wie AC-2, prüft `onset_minutes == 90` und NICHT `200`.
+
+## Known Limitations
+
+- Die absolute Genauigkeit bleibt weiterhin auf das 15-Minuten-Datenraster begrenzt (physikalische
+  Grenze der Quelle, kein Implementierungsfehler) — mit größerem Horizont verteilen sich die Werte
+  nur über mehr Rasterpunkte, werden aber nicht "krummer".
+- Zwei Bestandstests (`test_radar_alert_follows_ortstag.py`,
+  `test_starkregen_kurzfristhinweis.py`) müssen mit angepasst werden, sonst werden sie durch diese
+  Änderung selbst rot (siehe Implementation Details).
+
+## Architektur-Entscheidung (ADR)
+
+Keine — reine Konstanten-Anpassung innerhalb bestehender Architektur, kein neues
+Architektur-Muster, keine Breaking Changes an Datenmodell/Persistenz/Kanälen.
+
+## Changelog
+
+- 2026-08-17: Spec erstellt und PO-freigegeben (AC-1/2/3). Nach Verlust des ursprünglichen
+  Worktrees (fremder Cleanup-Lauf) inhaltsgleich rekonstruiert im neuen Worktree
+  `replicated-cuddling-sphinx`.

--- a/src/services/radar_service.py
+++ b/src/services/radar_service.py
@@ -58,8 +58,11 @@ _ICON_D2_LAT_MAX = 58.0
 _ICON_D2_LON_MIN = 2.0
 _ICON_D2_LON_MAX = 19.0
 
-# Onset threshold: frames within 60 min from now considered "nowcast"
-_NOWCAST_HORIZON_MIN = 60
+# Onset threshold: frames within 180 min from now considered "nowcast"
+# Issue #1945: 180 statt 60 — die GeoSphere-INCA-Quelle liefert live 3 Stunden
+# im 15-Min-Raster; der alte 60-Min-Deckel liess den Alarm praktisch immer erst
+# beim naechsten Rasterpunkt (~8 Min Vorlauf) ausloesen.
+_NOWCAST_HORIZON_MIN = 180
 # Issue #1439: oeffentlicher Alias, damit der Scheduler-Zeitfenster-Guard
 # dieselbe Zahl referenziert statt eine zweite Kopie zu pflegen.
 NOWCAST_HORIZON_MIN = _NOWCAST_HORIZON_MIN

--- a/tests/tdd/test_alert_gate.py
+++ b/tests/tdd/test_alert_gate.py
@@ -885,17 +885,17 @@ def test_ac8_zweite_meldung_vollstaendig_innerhalb_des_abgedeckten_fensters():
 def test_ac9_valid_to_reicht_wesentlich_ueber_das_abgedeckte_ende_hinaus():
     """AC-9 (V1-Ausnahme) + Mutations-Gegenprobe (PFLICHT laut Spec).
 
-    GIVEN ein registrierter Nowcast-Eintrag (abgedeckt bis Onset+60 Min)
+    GIVEN ein registrierter Nowcast-Eintrag (abgedeckt bis Onset+180 Min)
     WHEN  eine amtliche Warnung derselben Klasse/desselben Orts eintrifft,
-          deren ``valid_to`` MEHR ALS 60 Min ueber das abgedeckte Ende
+          deren ``valid_to`` MEHR ALS 180 Min ueber das abgedeckte Ende
           hinausreicht — OHNE hoehere Dringlichkeit
     THEN  wird sie zugestellt (neue Information).
 
     Mutations-Gegenprobe: wird ``NOWCAST_HORIZON_MIN`` durch eine deutlich
     groessere Zahl (z. B. 600) ersetzt, deckt das verfaelschte Fenster
     ``covered_until + 600min`` das hier verwendete ``valid_to`` (nur +90 Min
-    ueber ``covered_until``) weiterhin ab — die V1-Ausnahme greift dann
-    NICHT mehr, ``allowed`` wird ``False`` statt ``True``, und dieser Test
+    ueber ``covered_until + Horizont``) weiterhin ab — die V1-Ausnahme greift
+    dann NICHT mehr, ``allowed`` wird ``False`` statt ``True``, und dieser Test
     wird rot."""
     from services.alert_gate import check_event_identity_gate, record_event_identity
 
@@ -907,12 +907,12 @@ def test_ac9_valid_to_reicht_wesentlich_ueber_das_abgedeckte_ende_hinaus():
             user_id=uid, entity_id="trip-ac9", hazard_class="wet",
             segment_ids=["4"], severity="MODERATE", point_at=onset, now=onset,
         )
-        # covered_until = onset + NOWCAST_HORIZON_MIN (60 Min)
+        # covered_until = onset + NOWCAST_HORIZON_MIN (180 Min, #1945)
         ergebnis = check_event_identity_gate(
             user_id=uid, entity_id="trip-ac9", hazard_class="wet",
             segment_ids=["4"], severity="MODERATE",  # keine hoehere Dringlichkeit
             window_start=onset,
-            window_end=onset + timedelta(minutes=150),  # 90 Min ueber covered_until
+            window_end=onset + timedelta(minutes=450),  # 90 Min ueber covered_until+180
             now=onset + timedelta(minutes=5),
         )
         assert ergebnis.allowed is True, (

--- a/tests/tdd/test_nowcast_horizon_180min.py
+++ b/tests/tdd/test_nowcast_horizon_180min.py
@@ -1,0 +1,64 @@
+"""TDD RED — Issue #1945: Nowcast-Horizont auf 180 Minuten anheben.
+
+Spec: docs/specs/modules/fix_1945_nowcast_horizon.md
+
+KEINE MOCKS: echte `RadarFrame`-Objekte gegen den echten
+`RadarNowcastService._derive_result()` mit injiziertem `now`.
+
+In der RED-Phase schlagen die Tests fehl, weil `_NOWCAST_HORIZON_MIN` noch 60
+ist: ein nasser Frame in 90 Minuten liegt ausserhalb des Fensters, der Alarm
+bleibt aus (`onset_minutes is None`) — genau das Nutzersymptom aus #1945.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+
+def _frames(now: datetime, wet_offsets: tuple[int, ...]):
+    """Trockene 15-Min-Raster-Frames ueber 4 Stunden, nass nur bei wet_offsets."""
+    from providers.brightsky import RadarFrame  # noqa: PLC0415
+
+    return [
+        RadarFrame(
+            timestamp=now + timedelta(minutes=offset),
+            precip_mm_h=(2.0 if offset in wet_offsets else 0.0),
+            is_convective=False,
+        )
+        for offset in range(0, 241, 5)
+    ]
+
+
+def test_ac1_nowcast_horizon_is_180_minutes():
+    """AC-1: Der oeffentliche Horizont-Wert ist 180, nicht mehr 60."""
+    from services import radar_service
+
+    assert radar_service.NOWCAST_HORIZON_MIN == 180
+
+
+def test_ac2_onset_at_90_minutes_is_detected():
+    """AC-2: Nasser Frame in 90 Minuten -> onset_minutes == 90 statt None."""
+    from services.radar_service import RadarNowcastService
+
+    now = datetime(2026, 8, 17, 12, 0, tzinfo=timezone.utc)
+    result = RadarNowcastService()._derive_result(
+        _frames(now, wet_offsets=(90,)), "test-source", now=now
+    )
+
+    assert result.onset_minutes == 90
+
+
+def test_ac3_frame_beyond_180_minutes_stays_outside_window():
+    """AC-3: Frame bei 200 Min bleibt draussen, onset bleibt der 90-Min-Frame."""
+    from services.radar_service import RadarNowcastService
+
+    now = datetime(2026, 8, 17, 12, 0, tzinfo=timezone.utc)
+    result = RadarNowcastService()._derive_result(
+        _frames(now, wet_offsets=(90, 200)), "test-source", now=now
+    )
+
+    assert result.onset_minutes == 90
+
+    only_far = RadarNowcastService()._derive_result(
+        _frames(now, wet_offsets=(200,)), "test-source", now=now
+    )
+    assert only_far.onset_minutes is None

--- a/tests/tdd/test_radar_alert_follows_ortstag.py
+++ b/tests/tdd/test_radar_alert_follows_ortstag.py
@@ -401,7 +401,7 @@ def test_ac3_das_ehrliche_fenster_waehlt_die_folgetags_etappe(caplog):
 
 
 def test_ac4_horizont_guard_fern_kein_abruf_nah_ein_abruf():
-    """AC-4: Segment > ``NOWCAST_HORIZON_MIN`` (60 min) entfernt -> KEIN
+    """AC-4: Segment > ``NOWCAST_HORIZON_MIN`` (180 min) entfernt -> KEIN
     Nowcast-Abruf; Segment innerhalb -> genau EIN Abruf (Gegenprobe im
     selben Test — der Nah-Fall allein waere nicht diskriminierend, weil
     er auch ohne jeden Guard schon einen Abruf ausloest).
@@ -411,21 +411,21 @@ def test_ac4_horizont_guard_fern_kein_abruf_nah_ein_abruf():
     """
     from services.radar_service import NOWCAST_HORIZON_MIN
 
-    assert NOWCAST_HORIZON_MIN == 60, (
-        f"Testvoraussetzung: NOWCAST_HORIZON_MIN muss 60 sein, war {NOWCAST_HORIZON_MIN!r}"
+    assert NOWCAST_HORIZON_MIN == 180, (
+        f"Testvoraussetzung: NOWCAST_HORIZON_MIN muss 180 sein, war {NOWCAST_HORIZON_MIN!r}"
     )
 
     with freeze_time("2026-08-10T10:00:00+00:00"):
         heute = date_type.today()
 
-        # Fern: Segment beginnt in 90 Minuten (> 60) -> kein Abruf.
+        # Fern: Segment beginnt in 200 Minuten (> 180) -> kein Abruf.
         reset_radar_cache()
         frame_source_fern = CountingFrameSource(onset_minutes=10)
         uid_fern = fresh_uid("ac4-fern")
         trip_fern_id = f"trip-ac4-fern-{uuid.uuid4().hex[:8]}"
         trip_fern = make_trip(
             trip_fern_id, stage_date=heute, lat=REYKJAVIK_LAT, lon=REYKJAVIK_LON,
-            arrival_start="11:30", arrival_end="15:00",
+            arrival_start="13:20", arrival_end="15:00",
         )
         save_trip(trip_fern, uid_fern)
         TripAlertService(
@@ -434,7 +434,7 @@ def test_ac4_horizont_guard_fern_kein_abruf_nah_ein_abruf():
         ).check_radar_alerts()
 
         assert frame_source_fern.calls == [], (
-            "AC-4: Segment beginnt erst in 90 Minuten (> NOWCAST_HORIZON_MIN=60) "
+            "AC-4: Segment beginnt erst in 200 Minuten (> NOWCAST_HORIZON_MIN=180) "
             f"— get_nowcast() darf NICHT aufgerufen werden, war "
             f"{frame_source_fern.calls!r}. RED: check_radar_alerts() hat noch "
             "keinen Horizont-Guard."

--- a/tests/tdd/test_starkregen_kurzfristhinweis.py
+++ b/tests/tdd/test_starkregen_kurzfristhinweis.py
@@ -38,6 +38,7 @@ from datetime import date as date_type, datetime, time, timedelta, timezone
 from pathlib import Path
 
 import pytest
+from freezegun import freeze_time
 
 from app.config import Settings
 from app.models import TripReportConfig
@@ -337,28 +338,35 @@ def test_ac2_zeitfenster_guard_kein_fetch_ausserhalb_horizon(monkeypatch):
     Segment innerhalb -> Fetch UND Hinweis (Gegenprobe im selben Test)."""
     from services.radar_service import NOWCAST_HORIZON_MIN
 
-    assert NOWCAST_HORIZON_MIN == 60, (
-        f"Testvoraussetzung: NOWCAST_HORIZON_MIN muss 60 sein, war {NOWCAST_HORIZON_MIN!r}."
+    assert NOWCAST_HORIZON_MIN == 180, (
+        f"Testvoraussetzung: NOWCAST_HORIZON_MIN muss 180 sein, war {NOWCAST_HORIZON_MIN!r}."
     )
 
-    # Fern: Segment beginnt in 90 Minuten (> 60) -> kein Fetch, kein Hinweis.
-    uid_fern = _uid("ac2-fern")
-    trip_fern = _trip_with_segment_offset(f"trip-ac2-fern-{uuid.uuid4().hex[:6]}", start_in_min=90)
-    calls_fern: list = []
-    _install_fake_nowcast(monkeypatch, calls_fern, onset_minutes=10, intensity_label=INTENSITY_HEAVY)
-    rec_fern = _ReportRecorder()
-    rec_fern.install(monkeypatch)
-    _outcome_fern, report_fern = _run_briefing(rec_fern, uid_fern, trip_fern)
+    # Fern: Segment beginnt in 200 Minuten (> 180) -> kein Fetch, kein Hinweis.
+    # Feste Uhr (#1945): mit 200 Min Offset wuerde der Mitternachts-Guard in
+    # `_trip_with_segment_offset` den Fall ab ~20:20 UTC wegskippen statt beweisen.
+    with freeze_time("2026-08-17T10:00:00+00:00"):
+        uid_fern = _uid("ac2-fern")
+        trip_fern = _trip_with_segment_offset(
+            f"trip-ac2-fern-{uuid.uuid4().hex[:6]}", start_in_min=200
+        )
+        calls_fern: list = []
+        _install_fake_nowcast(
+            monkeypatch, calls_fern, onset_minutes=10, intensity_label=INTENSITY_HEAVY
+        )
+        rec_fern = _ReportRecorder()
+        rec_fern.install(monkeypatch)
+        _outcome_fern, report_fern = _run_briefing(rec_fern, uid_fern, trip_fern)
 
-    assert calls_fern == [], (
-        "AC-2: Segment beginnt erst in 90 Minuten (> NOWCAST_HORIZON_MIN=60) -> "
-        f"get_nowcast() darf NICHT aufgerufen werden, war {calls_fern!r}."
-    )
-    assert _HINT_MARKER not in report_fern.email_plain, (
-        f"AC-2: kein Hinweis erwartet ausserhalb des Horizonts.\n{report_fern.email_plain}"
-    )
+        assert calls_fern == [], (
+            "AC-2: Segment beginnt erst in 200 Minuten (> NOWCAST_HORIZON_MIN=180) -> "
+            f"get_nowcast() darf NICHT aufgerufen werden, war {calls_fern!r}."
+        )
+        assert _HINT_MARKER not in report_fern.email_plain, (
+            f"AC-2: kein Hinweis erwartet ausserhalb des Horizonts.\n{report_fern.email_plain}"
+        )
 
-    # Nah: Segment beginnt in 30 Minuten (<= 60) -> Fetch UND Hinweis.
+    # Nah: Segment beginnt in 30 Minuten (<= 180) -> Fetch UND Hinweis.
     uid_nah = _uid("ac2-nah")
     trip_nah = _trip_with_segment_offset(f"trip-ac2-nah-{uuid.uuid4().hex[:6]}", start_in_min=30)
     calls_nah: list = []


### PR DESCRIPTION
- **fix(#1945): Nowcast-Horizont 60->180 Min, Countdown zeigte strukturell immer ~8 Min**
- **fix(#1945): Bestandstests an neuen Nowcast-Horizont (180 Min) anpassen**
- **docs(#1945): 60-Min-Nowcast-Horizont-Referenzen auf 180 Min aktualisiert**
