### PR TITLE
docs(#1458): Messlatte des Alerts-Epics durch messbare Kennzahlen ersetzen

### DIFF
--- a/docs/context/epic-1458-messlatte.md
+++ b/docs/context/epic-1458-messlatte.md
@@ -1,0 +1,335 @@
+# Context: epic-1458-messlatte
+
+## Request Summary
+
+Das Epic #1458 („Alerts neu ordnen") hat alle fünf Scheiben geliefert. Offen ist genau ein
+Punkt seiner eigenen Erledigt-Liste: der **Messlatte-Nachweis** — *„Juni 76 · Juli 31 ·
+August (bis 02.) 3 Meldungen. Ziel ist weniger Wiederholung, nicht weniger echte Warnung —
+mit den Daten aus #1459 belegen."* Diese Arbeit soll den Nachweis erbringen und daraus
+ableiten, ob das Epic schließt oder Folgetickets bekommt.
+
+## Umfang gegen `origin/main` gemessen (nicht gegen die Beschreibung vom Anlegetag)
+
+| Scheibe | Issue | Stand |
+|---|---|---|
+| Protokoll | #1459 | geschlossen, live **2026-08-02** (`161db8bb`) |
+| Relevanzfilter T1 | #1460 | geschlossen, live **2026-08-03** (`8f2053f9`) |
+| Ablaufsteuerungen zusammenlegen | #1467 | geschlossen — S2 AG5 **08-04**, S3 **08-08**, S4a/S4b-1 **08-16** |
+| Schwelle je Kanal | #1461 | geschlossen |
+| Bedienung / Ortsvergleich | #1462 / #1463 | geschlossen 08-06 (beide beim Aufschlagen bereits erfüllt) |
+| Vorgänger | #1444 | geschlossen 08-03 |
+| E6 Beobachtbarkeit | → **#1948** | läuft in **anderer Sitzung** — hier nicht anfassen |
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `src/services/alert_log.py` | **Einzige** Schreibfunktion des Protokolls; definiert das gesamte Vokabular und den Aufbau |
+| `src/services/alert_log.py:239` | Weiche `entries` vs. `not_delivered` — Kern der Messfalle M1 |
+| `src/services/alert_log.py:242-254` | `_append()` — Read-Modify-Write der ganzen Datei, **keine Rotation, keine Kappung** |
+| `src/services/alert_log.py:337-341` | Vermerk: ein Alarm-Lauf erzeugt **bis zu drei** Einträge; `DEDUP_WINDOW = 2 min` — Kern der Messfalle M2 |
+| `src/services/alert_log.py:45-61` | Vollständiges Grund-Vokabular (unten ausgeschrieben) |
+| `internal/store/log.go` | Lesepfad Go: `AlertCountByEntity()` zählt **Einträge**, nicht Kanäle; `not_delivered` wird **nie** gelesen (D4) |
+| `docs/specs/modules/feat_1459_alert_protokoll.md` | Spec der Protokoll-Scheibe, inkl. der offenen Lücke O3 |
+| `docs/context/konzept-1458-alerts-zweck.md` | Technische Landkarte des Epics vom 2026-08-02 |
+
+## Datenlage
+
+| Ort | Befund |
+|---|---|
+| `/var/lib/gregor/users/henning/alert_log.json` | 76 627 Bytes, zuletzt 2026-08-17 18:52 — **die einzige belastbare Quelle** |
+| `…/users/steffi/alert_log.json` | endet 2026-07-02 — kein August, für den Vorher/Nachher-Vergleich unbrauchbar |
+| `…/users/default/alert_log.json` | endet 2026-07-12 — dito |
+| `/home/hem/gregor_zwanzig/data/users/` | enthält **kein** `alert_log.json`; Prod liest aus `GZ_DATA_DIR=/var/lib/gregor` (systemd `gregor-api`) |
+
+**Der Nachweis ist damit eine Ein-Nutzer-Messung** (`henning`). Das ist keine Schwäche der
+Arbeit, sondern die Datenlage — muss aber im Ergebnis stehen.
+
+Rohauszählung (Stand 2026-08-17 20:35):
+
+| Liste | Juni | Juli | August (bis 17.) | Summe |
+|---|---|---|---|---|
+| `entries` | 76 | 31 | 50 | 157 |
+| `not_delivered` | 0 | 0 | 68 | 68 |
+
+## Existing Patterns
+
+- **Ein Schreibmodul, zwei Schreibpfade.** `append_entry()` (nach Zustellversuch) und
+  `append_suppressed_entry()` (vor dem Versand abgewiesen, #1467 S3). Letzterer schreibt
+  ausschließlich nach `not_delivered` und **nur aus den beiden Nowcast-Pfaden** — Vorhersage-
+  Änderung und amtliche Warnung protokollieren ihre Unterdrückungen bis heute **nicht**
+  (offene Lücke O3 in `feat_1459_alert_protokoll.md`).
+- **Zusammenfassen beim Lesen, nie im Protokoll** (`alert_log.py:337-341`). Das Protokoll ist
+  bewusst roh; jede Auswertung muss selbst zusammenfassen.
+- **Vokabular ist bewusst ein freier String, kein Enum** (`:40-44`), damit neue Gründe additiv
+  dazukommen. Folge: die Grundmenge hat über die Epic-Laufzeit **gewachsen**.
+
+**Auslöser einer Meldung** (`reason` des Eintrags): `forecast_change` · `nowcast` ·
+`official_alert`
+
+**Gründe einer Nicht-Zustellung** (`channels_not_sent[].reason`): `channel_disabled` ·
+`delivery_failed` · `quiet_hours` · `daily_limit` · `cooldown` · `below_channel_threshold`
+(#1461) · `event_duplicate` (#1467 S4b-1)
+
+## Risks & Considerations
+
+**M1 — `entries` und `not_delivered` sind nicht dieselbe Größe, und die zweite Liste gibt es
+erst seit August.** Juni/Juli haben 0 Einträge in `not_delivered`, weil die Liste damals nicht
+existierte — nicht, weil nichts unterdrückt wurde. Ein Vergleich „76 → 118" behauptet eine
+Verdopplung, die reine Buchführung ist; ein Vergleich „76 → 50" behauptet eine Halbierung, die
+ebenso wenig belegt ist.
+
+**M2 — Ein Eintrag ist keine Nachricht.** Ein Alarm-Lauf erzeugt bis zu drei Einträge
+(Vorhersage, Radar, amtlich sind drei getrennte `append_entry()`-Aufrufe, Millisekunden
+auseinander). Im Juni war faktisch ein Melder aktiv, im August drei. Die Eintragszahl steigt
+also allein durch die Quellenzahl, ohne dass der Nutzer eine Nachricht mehr bekäme. Die
+Auswertung **muss** über `DEDUP_WINDOW` (2 min) auf Vorfälle zusammenfassen, bevor sie zählt.
+
+**M3 — Die Wirkung des Epics ist erst seit 2026-08-16 vollständig live.** Die letzte Scheibe
+(#1467 S4b-1, quellenübergreifende Entdopplung) ging gestern in Betrieb. Ein „August"-Zeitraum
+ist damit kein einheitlicher Zustand, sondern eine Treppe. Sinnvolle Schnitte: **vor 08-02**
+(Altzustand), **08-04 bis 08-15** (Relevanzfilter + Kanal-Schwelle live), **ab 08-16**
+(vollständig).
+
+**M4 — Ungleiche Vergleichsbasis.** Juni umfasst laut Epic-Text drei Touren; August ist
+KHW-Vorbereitung mit intensiver Test- und Staging-Aktivität. Wetterlage, Tourenzahl und
+Testverkehr unterscheiden sich. Eine Zahl allein trägt die Aussage nicht — die Auswertung
+braucht eine Größe, die gegen diese Störgrößen robust ist (Kandidat: Anteil wiederholter
+Meldungen an allen Meldungen, statt absolute Meldungszahl).
+
+**M5 — Das Ziel ist zweiseitig.** „Weniger Wiederholung, **nicht** weniger echte Warnung."
+Ein Rückgang der Gesamtzahl allein ist deshalb **kein** Erfolgsnachweis — er könnte genauso
+die Fehlerlage sein, vor der #638 warnt. Beide Seiten brauchen je einen eigenen Beleg.
+
+**M6 — Keine Rotation.** `_append()` schreibt die volle Datei ohne Kappung. Ältere Monate sind
+also **nicht** abgeschnitten; der Vergleich ist insoweit vollständig.
+
+## Abgrenzung zu anderen Sitzungen
+
+- **#1948** (Sitzung `1948`) besitzt Format und Beobachtbarkeit der Alarm-Nachrichten (E6).
+- **#1945**, **#1493** sind eigene laufende Alarm-Stränge.
+- Diese Sitzung fasst **keine** Alarm-Laufzeitdateien an (`trip_alert.py`, `compare_alert.py`,
+  `alert_log.py`, Alarme-Reiter). Der Nachweis ist eine Auswertung, kein Umbau.
+
+---
+
+# Analysis
+
+## Type
+
+**Feature** — Nachweis- und Auswertungsarbeit. Kein Bug, kein Produktivcode zu erwarten.
+
+## Korrekturen an der Kontext-Phase (alle belegt, alle zu meinen Ungunsten)
+
+**M2 ist entkräftet.** Ich hatte vermutet, die Eintragszahl steige allein durch die Quellenzahl.
+Zwei unabhängige Belege sagen das Gegenteil:
+- Die Faltung auf Nutzer-Vorfälle ergibt **1,01 / 1,00 / 1,00** Zeilen pro Vorfall — die drei
+  Quellen feuern in der Praxis praktisch nie gleichzeitig.
+- Schon im Altstand schrieben **alle drei** Quellen ins Protokoll: `trip_alert.py:323`
+  (Vorhersage-Änderung), `:978` (Radar), `:1210` (amtliche Warnung), Stand `161db8bb~1`.
+
+**M1 ist kleiner als gedacht.** `alert_log.json` existiert seit `31d7a366` (2026-05-27, #393),
+nicht erst seit #1459. Es gab **nie** eine Datei-Migration, nur sieben additive Feld-
+Erweiterungen. Die Juni-Zahlen sind unverfälschte Rohdaten. Neu ist allein die Liste
+`not_delivered` — der Mengenvergleich der `entries` ist damit zulässig.
+
+**Zeilen mit Vorfällen verwechselt (nachgetragen 2026-08-18).** Ich hatte `event_duplicate`
+mit **4** gezählt und daraus abgeleitet, die quellenübergreifende Entdopplung wirke. Die 4 sind
+Protokoll**zeilen**: je Vorfall werden zwei Kanäle gesperrt (E-Mail + Telegram). Es sind
+**2 Vorfälle**. Gefunden hat das nicht mein eigener Durchgang, sondern eine **externe
+Methodik-Prüfung** — mein Zählskript summierte `channels_not_sent`-Einträge, die restliche
+Auswertung zählte durchweg Vorfälle. Derselbe Fehler wäre bei jedem Sperrgrund möglich, denn
+**jeder** Grund erzeugt pro Vorfall so viele Zeilen, wie Kanäle betroffen sind. **Lehre: bei
+jeder Zahl aus dem Protokoll ausdrücklich mitschreiben, ob sie Zeilen oder Vorfälle zählt.**
+
+## Messergebnis
+
+### Mengenvergleich (zulässig, aber störanfällig)
+
+| Monat | Zeilen | Alarmtage | Alarme je Alarmtag |
+|---|---|---|---|
+| Juni | 76 | 12 | 6,3 |
+| Juli | 31 | 14 | 2,2 |
+| August (bis 17.) | 50 | 16 | 3,1 |
+
+**Kein Trend.** Die Schwankung folgt Wetter- und Tourenlage, nicht der Liefer-Treppe des
+Epics — der stärkste Rückgang (Juni→Juli) liegt einen ganzen Monat **vor** der ersten Scheibe.
+
+### Zeitstruktur-Kennzahl (auch im Altformat verfügbar)
+
+Abstand zum vorigen Alarm desselben Empfängers:
+
+| Phase | N | Median (min) | ≤20 min | ≤60 min |
+|---|---|---|---|---|
+| A bis 08-01 | 106 | 150 | 10,4 % | 27,4 % |
+| C 08-04..08-15 | 33 | 179 | 6,1 % | 24,2 % |
+| D ab 08-16 | 9 | 75 | 11,1 % | 22,2 % |
+
+*Nenner ist die Zahl der **Paare** (Alarme mit Vorgänger derselben Entität innerhalb der
+Phase), nicht die Zeilenzahl; jede Phase wird eigenständig gerechnet. Nur `entries`,
+`not_delivered` ausgeschlossen.*
+
+Deutet auf Besserung in Phase C, **trägt aber keinen Nachweis**: Phase D hat n = 9.
+
+**Nachtrag 2026-08-18 — die ≤60-Minuten-Spalte ist als Kennzahl K1' brauchbar.** Sie braucht
+den fehlenden Wert **nicht** und reicht bis Juni zurück: **27,4 % (vor 08-02) → 24,2 %
+(08-04..08-15) → 22,2 % (ab 08-16)** — monoton fallend. Schwaches Signal (5 Prozentpunkte
+Spanne, n = 9 in Phase D, Störgrößen aus Wetter- und Tourenlage ungefiltert), aber **gerichtet
+und nicht bloß Rauschen**: die ≤20-Minuten-Spalte derselben Messung läuft **nicht** monoton
+(10,4 % → 6,1 % → 11,1 %).
+
+**Messfalle M7 — `not_delivered` niemals ungefiltert mitzählen.** `quiet_hours` und `cooldown`
+schreiben bei **jedem** Poll-Zyklus (15 min) eine Zeile, ohne dass der Nutzer je etwas sieht —
+sichtbar am 17.08. zwischen 18:07 und 18:52 mit vier `quiet_hours`-Zeilen in Folge. Dieselbe
+Rechnung naiv über **beide** Listen ergibt für 08-04..08-17 **69,4 %** statt 24,2 %/22,2 %:
+Das misst die Prüftaktung des Schedulers, nicht das Nutzererlebnis. **Wertlos.**
+
+### Was die Bremsen belegbar tun
+
+Gebuchte Sperrgründe — jede Unterdrückung ist einzeln protokolliert:
+
+| Grund | Phase C (08-04..08-15) | Phase D (ab 08-16) | Herkunft |
+|---|---|---|---|
+| | Vorfälle *(Zeilen)* | Vorfälle *(Zeilen)* | |
+| `quiet_hours` | **48** *(96)* | **4** *(8)* | Bestand |
+| `channel_disabled` | **31** *(48)* | **10** *(20)* | Bestand |
+| `cooldown` | **8** *(18)* | **6** *(12)* | Bestand |
+| `below_channel_threshold` | **7** *(7)* | **0** *(0)* | **#1461** |
+| `event_duplicate` | **0** *(0)* | **2** *(4)* | **#1467 S4b-1** |
+
+> **Fußnote zur Einheit (korrigiert 2026-08-18).** Die ursprüngliche Tabelle zählte
+> **Protokollzeilen**, nicht Vorfälle — ein Vorfall erzeugt so viele Zeilen, wie Kanäle
+> gesperrt wurden (typisch zwei: E-Mail + Telegram). Bei `event_duplicate` wurde daraus
+> fälschlich „4×"; richtig sind **2 Vorfälle × 2 gesperrte Kanäle = 4 Zeilen**. Der Fehler war
+> **nicht** auf `event_duplicate` beschränkt: er betraf jede Zeile der Tabelle außer
+> `below_channel_threshold` (dort ist die Sperre einkanalig, Zeilen = Vorfälle). Die Tabelle
+> führt jetzt beide Einheiten, fett die Vorfälle.
+
+Komplett unterdrückte Vorfälle (`not_delivered`, 68 gesamt): 52× `quiet_hours`, 14× `cooldown`,
+2× `event_duplicate`. **Vor #1459 waren diese 68 Vorgänge spurlos.**
+
+**Die Entdopplung hat die Wiederholung nicht verhindert (Korrektur 2026-08-18).** Die beiden
+`event_duplicate`-Vorfälle liegen am 2026-08-17 um 14:52 und 15:52 UTC, Empfänger `5f534011`,
+beide `reason=nowcast`. Sie tragen die Aussage „die Entdopplung wirkt" auch inhaltlich nicht.
+Tagesverlauf 17.08. (UTC): 13:52 **zugestellt** (Nowcast, `thunder,max`) → 14:07/14:22 `cooldown` → 14:52
+`event_duplicate` → 15:07 **erneut zugestellt** (Nowcast, `thunder,max`) → 15:22/15:37
+`cooldown` → 15:52 `event_duplicate`. **Die Wiederholung kam durch.** Den Takt bestimmt der
+Cooldown, nicht die Entdopplung.
+
+Dazu: beide Treffer sind **Nowcast gegen Nowcast**. Der Mechanismus ist laut
+`alert_log.py:53-56` für den **quellenübergreifenden** Fall gedacht (Nowcast ↔ amtlich); am
+17.08. gibt es im Protokoll gar keinen `official_alert`-Eintrag. Das dokumentierte Muster ist
+damit **nicht bestätigt** — aber auch nicht widerlegt: zwei Treffer sind zu wenig. **Offener
+Punkt.**
+
+**Keine Quelle ist verstummt:** Phase C `forecast_change` 20 / `official_alert` 10 /
+`nowcast` 5; Phase D 4 / 3 / 3.
+
+### Der entscheidende Befund
+
+Wiederholungsquote im Neuzustand — Anteil zugestellter Vorfälle, die binnen 24 h dieselbe
+fachliche Aussage (`reason` + `metrics` + `hazards`) am selben Empfänger wiederholen:
+
+| Phase | Vorfälle | Wiederholungen | Quote |
+|---|---|---|---|
+| C 08-04..08-15 | 35 | 24 | 68,6 % |
+| D ab 08-16 | 10 | 5 | 50,0 % |
+| **C+D ab 08-04** | **45** | **30** | **66,7 %** |
+
+Aufschlüsselung der 30 Wiederholungen: Median-Abstand **328 min (5,5 h)**, keine unter 20 min,
+nur 3 unter 60 min, 13 über 6 h. Inhaltlich: **17× `forecast_change` / `thunder,max`**,
+8× `official_alert` / `thunderstorm`, Rest einzeln.
+
+**Das ist kein Dauerfeuer** — die Bremsen gegen Bursts greifen. Es sind über den Tag verteilte
+Meldungen zu derselben Größe (fast immer Gewitter).
+
+**Ob das echte Wiederholung ist, kann das Protokoll nicht beantworten.** `metrics` hält
+`metric_id` + `aggregation` fest (`alert_log.py:226-229`) — also *welche Größe*, aber **nicht
+welchen Wert**. Ob 17× Gewitter siebzehn echte Stufenwechsel waren oder siebzehnmal dieselbe
+Aussage, ist aus dem Protokoll **nicht auflösbar**.
+
+## Schlussfolgerung
+
+**Die Messlatte ist in ihrer Formulierung nicht *präzise* beantwortbar — und zwar aus einem
+einzigen, präzise benennbaren Grund:** das Protokoll führt bis heute nicht den **Wert** der
+gemeldeten Größe.
+
+> **Korrektur 2026-08-18.** Die ursprüngliche Formulierung „strukturell nicht beantwortbar"
+> war zu stark. Sie gilt für die Wiederholungsfrage in der Form, die die alte Messlatte
+> verlangt — dort fehlt der Wert und daran ändert sich nichts. Sie gilt **nicht** für die
+> Frage insgesamt: die Kennzahl K1' (≤60-Minuten-Abstand, `not_delivered` ausgeschlossen)
+> beantwortet sie grob, ohne Protokoll-Erweiterung und bis Juni zurück. Richtig ist:
+> **„nicht ohne Protokoll-Erweiterung *präzise* messbar."** #1459 hat Befund B3 („nicht nachvollziehbar, worüber gemeldet wurde") nur zur Hälfte
+geschlossen: die Größe kam dazu, der Wert nicht. Genau der Wert entscheidet aber, ob eine
+zweite Meldung Wiederholung oder neue Information ist.
+
+Drei weitere Gründe stützen dasselbe Ergebnis:
+1. Vor dem 02.08. fehlt zusätzlich die Größe — eine Rückrechnung auf Juni ist ausgeschlossen.
+   Die naive Kontrollprobe liefert dort 85 %, aber das ist ein **Artefakt**: im Altformat
+   fallen alle Signaturen auf `(None, (), ())` zusammen, also zählt fast alles als
+   Wiederholung. **Diese Zahl darf nicht als Vergleich verwendet werden.**
+2. Der akute Schmerz B1 war nur vom 01.08. bis 03.08. live (#1444 S1 → #1460). Die „84
+   Nachrichten über sechs Wochen" waren eine Hochrechnung, kein gemessener Bestand — es gibt
+   kein „Vorher".
+3. Der Vollzustand läuft seit 2026-08-16: 1,5 Tage, 10 zugestellte Alarme.
+
+**Was das Epic dennoch belegbar erreicht hat:** vier eigenständige Bremsen, jede mit gebuchtem
+Grund, 68 vormals spurlose Vorgänge jetzt sichtbar, keine verstummte Quelle. Der Nachweis
+gelingt über die gebuchten Sperrgründe — nicht über einen Mengenvergleich.
+
+## Technical Approach (Empfehlung)
+
+Die Messlatte **ersetzen**, nicht erzwingen:
+
+- **Kennzahl 1' (weniger Wiederholung, sofort messbar):** Anteil zugestellter Alarme mit
+  ≤60 min Abstand zum vorigen zugestellten Alarm derselben Entität, `not_delivered`
+  **ausgeschlossen**. Basislinie **27,4 % vor dem Epic → 22,2 % danach**. Keine Abhängigkeit
+  von der Protokoll-Erweiterung. Ergänzt K1, ersetzt sie nicht — sie überbrückt die Zeit bis
+  #1954. *(ergänzt 2026-08-18)*
+- **Kennzahl 1 (weniger Wiederholung, präzise):** Wiederholungsquote wie oben, mit dem Wert in
+  der Signatur. Basislinie **66,7 %** ab 08-04 festhalten. Voraussetzung: das Protokoll muss
+  den Wert mitschreiben — kleine additive Erweiterung von `alert_log.py`, kein Schemabruch.
+- **Kennzahl 2 (nicht weniger echte Warnung):** je Auslöser mindestens ein zugestellter Alarm
+  je Kalenderwoche mit Alarmlage. Heute schon erfüllt und ohne Änderung messbar.
+
+Umfang, wenn nur dokumentiert und gebucht wird: **0 LoC Produktivcode**, Doku + Issue-Kommentar.
+Umfang mit der Protokoll-Erweiterung: ~20–40 LoC in `alert_log.py` plus Aufrufer — das wäre
+aber eine **eigene Scheibe**, nicht Teil dieses Nachweises.
+
+## Scope Assessment
+
+- Files: 1 (dieses Dokument) + Issue-Kommentar
+- Estimated LoC: +0 Produktivcode
+- Risk Level: **LOW**
+
+## PO-Entscheidungen 2026-08-17
+
+| Frage | Entscheid |
+|---|---|
+| **F1** Messlatte | **Ersetzen + Epic schließen.** Zwei prospektiv messbare Kennzahlen, Basislinie 66,7 % festhalten, Befund als Kommentar ans Epic. |
+| **F2** Wert ins Protokoll | **Ja — eigenes Issue anlegen.** Additive Erweiterung, ~20–40 LoC. Nicht Teil dieses Nachweises. |
+| **F3** Ruhezeit vs. akute Gefahr | **Eigenes Issue, `priority:high`.** Vor dem KHW-Abmarsch. |
+
+## Open Questions (beantwortet, Historie)
+
+- [x] **F1 — Ersatz-Messlatte annehmen?** Die Erledigt-Liste des Epics enthält ein Kriterium,
+      das strukturell nicht erfüllbar ist. Ersetzen und Epic schließen, oder Epic offen halten,
+      bis das Protokoll den Wert führt?
+- [ ] **F2 — Wert ins Protokoll?** Eigene Scheibe, klein und additiv. Ohne sie bleibt die
+      Wiederholungsfrage dauerhaft unbeantwortbar.
+- [ ] **F3 — Nebenbefund Ruhezeit vs. akute Gefahr.** `check_nowcast_gate`
+      (`src/services/alert_gate.py:143`) prüft die Ruhezeit zuerst und **ohne Gewitter-
+      Ausnahme**; beide Nowcast-Pfade laufen dadurch (`trip_alert.py:1120`,
+      `compare_radar_alert.py:145`). Gemessen: 52 Vorfälle komplett unterdrückt, 48 davon
+      nachts 02–06 Uhr Ortszeit. #1310 hat den Akut-Override nur für die **Briefing**-Sperre
+      gebaut. PO-Vorgabe 4 lautet „akute Gefahr muss durchkommen". **Nicht verifiziert**, ob
+      unter den 52 konvektive Lagen waren — unterdrückte Einträge tragen `metrics: []`
+      (Lücke O3). Eigenes Issue?
+
+## Existing Specs
+
+- `docs/specs/modules/feat_1459_alert_protokoll.md` — Protokoll-Schema, Lücke O3
+- `docs/specs/modules/rework_1467_s1_alarm_kennung.md` — `entity_id`/`entity_type`
+- `docs/specs/modules/feat_1461_s3a_alarm_dringlichkeit.md` — Dringlichkeits-Ableitung
+- `docs/specs/modules/trip_alert.md` — Status „Approved", beschreibt laut #1464 einen
+  überholten Stand

--- a/docs/context/epic-1458-messlatte.md
+++ b/docs/context/epic-1458-messlatte.md
@@ -146,11 +146,15 @@ jeder Zahl aus dem Protokoll ausdrücklich mitschreiben, ob sie Zeilen oder Vorf
 
 ### Mengenvergleich (zulässig, aber störanfällig)
 
-| Monat | Zeilen | Alarmtage | Alarme je Alarmtag |
-|---|---|---|---|
-| Juni | 76 | 12 | 6,3 |
-| Juli | 31 | 14 | 2,2 |
-| August (bis 17.) | 50 | 16 | 3,1 |
+| Monat | Zeilen | Vorfälle | Alarmtage | Vorfälle je Alarmtag |
+|---|---|---|---|---|
+| Juni | 76 | 75 | 12 | **6,2** |
+| Juli | 31 | 31 | 14 | 2,2 |
+| August (bis 17.) | 50 | 50 | 16 | 3,1 |
+
+*Gezählt wird in **Vorfällen**, nicht in Zeilen (Messfalle M2). Nur im Juni fallen zwei Zeilen
+desselben Empfängers ins gleiche 2-Minuten-Fenster; in Juli und August sind Zeilen und Vorfälle
+deckungsgleich.*
 
 **Kein Trend.** Die Schwankung folgt Wetter- und Tourenlage, nicht der Liefer-Treppe des
 Epics — der stärkste Rückgang (Juni→Juli) liegt einen ganzen Monat **vor** der ersten Scheibe.

--- a/docs/specs/modules/fix_1458_messlatte_ersatz.md
+++ b/docs/specs/modules/fix_1458_messlatte_ersatz.md
@@ -1,0 +1,215 @@
+---
+entity_id: fix_1458_messlatte_ersatz
+type: refactor
+created: 2026-08-18
+updated: 2026-08-18
+status: approved
+version: "1.0"
+tags: [alerts, epic-1458, doku, issue-triage]
+---
+
+# Messlatte des Epics #1458 ersetzen und Epic schließen
+
+## Approval
+
+- [x] Approved — PO (Henning), 2026-08-18
+
+## Purpose
+
+Epic #1458 („Alerts neu ordnen") hat alle fünf Scheiben geliefert. Sein einziges noch
+offenes Erledigt-Kriterium — *„Juni 76 · Juli 31 · August 3 Meldungen. Ziel ist weniger
+Wiederholung, nicht weniger echte Warnung — mit den Daten aus #1459 belegen."* — ist
+strukturell nicht erfüllbar: Das Alarm-Protokoll (`src/services/alert_log.py:226-229`)
+führt nur `metric_id` + `aggregation`, nicht den **Wert** der gemeldeten Größe. Ob 17×
+„Gewitter" siebzehn echte Stufenwechsel waren oder siebzehnmal dieselbe Aussage, ist aus
+dem Protokoll nicht auflösbar. Diese Arbeit ersetzt die unerfüllbare Messlatte durch zwei
+prospektiv messbare Kennzahlen, dokumentiert den Befund als Kommentar an Epic #1458,
+schließt das Epic und legt zwei Folge-Issues für die offenen Nebenbefunde an.
+
+## Source
+
+- **File:** `docs/context/epic-1458-messlatte.md` (Analyse, bereits vollständig, wird nur
+  committet)
+- **Identifier:** GitHub Issue #1458 (Kommentar + Close), zwei neue GitHub Issues
+
+> **Schicht-Hinweis:** Diese Arbeit berührt keine Schicht des Produktivsystems (Frontend,
+> Go-API, Python-Core). Sie ist reine Doku- und Issue-Pflege. Kein Datei-Edit in `src/`,
+> `api/`, `internal/`, `frontend/`, `cmd/`.
+
+## Estimated Scope
+
+- **LoC:** 0 (Produktivcode)
+- **Files:** 1 (`docs/context/epic-1458-messlatte.md`, bereits vorhanden — nur Commit)
+- **Effort:** low
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| #1458 | GitHub Issue (Epic) | Träger der alten Messlatte; bekommt Befund-Kommentar und wird geschlossen |
+| #1459 | GitHub Issue (geschlossen) | Lieferte das Alarm-Protokoll, das als Datenquelle dieser Auswertung dient |
+| `src/services/alert_log.py:226-229` | Code-Fundstelle | Beleg dafür, dass `metrics` nur `metric_id`+`aggregation` führt, keinen Wert |
+| `src/services/alert_gate.py:143` | Code-Fundstelle | Beleg für Nebenbefund F3 (Ruhezeit-Sperre ohne Gewitter-Ausnahme) |
+
+## Implementation Details
+
+Vier Arbeitsschritte, keiner davon Produktivcode:
+
+1. **Analyse-Dokument committen.** `docs/context/epic-1458-messlatte.md` existiert bereits
+   fertig im Worktree und wird unverändert übernommen. Es enthält die vollständige
+   Messmethodik, die Rohzahlen und die Schlussfolgerung, auf die der Issue-Kommentar
+   verweist.
+
+2. **Kommentar an Epic #1458.** Der Kommentar muss enthalten:
+   - **Begründung**, warum die alte Messlatte (Juni 76 · Juli 31 · August 3) nicht
+     erfüllbar ist: das Protokoll führt den Wert der gemeldeten Größe nicht
+     (`alert_log.py:226-229`), daher ist eine Wiederholung fachlich nicht von einer neuen
+     Information unterscheidbar.
+   - Die **zwei Ersatzkennzahlen** K1 und K2 (siehe unten) inklusive Basislinie für K1:
+     **66,7 %** (30 von 45 zugestellten Vorfällen, Zeitraum 2026-08-04 bis 2026-08-17,
+     Nutzer `henning`).
+   - Den **ausdrücklichen Hinweis auf die Artefakt-Falle**: die naive Kontrollprobe auf
+     Juni/Juli liefert 85 %, ist aber kein Vergleichswert — im Altformat vor dem 02.08.
+     fallen alle Signaturen auf `(None, (), ())` zusammen, wodurch fast jede zweite Meldung
+     rechnerisch als „Wiederholung" erscheint, ohne es fachlich zu sein.
+   - **Beleg, was das Epic erreicht hat:** vier eigenständige Bremsen mit gebuchtem Grund
+     (`quiet_hours`, `channel_disabled`, `cooldown`, `below_channel_threshold` aus #1461,
+     `event_duplicate` aus #1467 S4b-1), 68 vormals spurlose Unterdrückungen jetzt sichtbar
+     in `not_delivered`, keine der drei Quellen (`forecast_change`/`nowcast`/
+     `official_alert`) verstummt.
+
+3. **Epic #1458 schließen**, erst nach dem Kommentar aus Schritt 2.
+
+4. **Zwei neue Issues anlegen:**
+   - **„Alarm-Protokoll hält den WERT der gemeldeten Größe fest"** — Labels `enhancement`,
+     `area:alerts`, `session:alarm`. Setzt Befund B3 aus #1459 zu Ende (die Scheibe brachte
+     *welche Größe*, nicht *welcher Wert*). Additive Erweiterung in
+     `src/services/alert_log.py`, geschätzt ~20–40 LoC, kein Schemabruch. Ohne dieses Issue
+     bleibt Kennzahl K1 dauerhaft nur teilweise messbar (Signatur ohne Wert).
+   - **„Ruhezeit-Sperre kennt keine Ausnahme für akute Gefahr"** — Labels `bug`,
+     `priority:high`, `area:alerts`, `session:alarm`. `check_nowcast_gate`
+     (`src/services/alert_gate.py:143`) prüft die Ruhezeit zuerst und ohne
+     Gewitter-Ausnahme; beide Nowcast-Pfade sind betroffen (`trip_alert.py:1120`,
+     `compare_radar_alert.py:145`). Gemessen: 52 Vorfälle komplett unterdrückt, davon 48
+     nachts zwischen 02 und 06 Uhr Ortszeit. #1310 hat den Akut-Override nur für die
+     **Briefing**-Sperre gebaut, nicht für die Nowcast-Sperre. PO-Vorgabe 4 des Epics lautet
+     „akute Gefahr muss durchkommen". **Wörtlich in die Issue-Beschreibung aufnehmen:**
+     nicht verifiziert, ob unter den 52 unterdrückten Vorfällen konvektive Lagen waren —
+     die unterdrückten Einträge tragen `metrics: []` (Lücke O3 aus
+     `feat_1459_alert_protokoll.md`). Der Befund ist ein **belegter Verdacht**, keine
+     bewiesene Fehlfunktion.
+
+## Die zwei Ersatzkennzahlen (verbindlicher Wortlaut)
+
+- **K1 „weniger Wiederholung":** Anteil der zugestellten Alarm-Vorfälle, die binnen 24 h
+  dieselbe fachliche Aussage (`reason` + `metrics` + `hazards` + **Wert**) am selben
+  Empfänger wiederholen. Basislinie **66,7 %** (30 von 45 Vorfällen, 2026-08-04 bis
+  2026-08-17, Nutzer `henning`). Voll messbar erst nach der Protokoll-Erweiterung aus
+  Issue 4a — bis dahin ist die Signatur unvollständig (Größe ohne Wert).
+- **K2 „nicht weniger echte Warnung":** In jeder Kalenderwoche mit Alarmlage geht je
+  Auslöser (`forecast_change`, `nowcast`, `official_alert`) mindestens ein Alarm
+  zugestellt raus. Heute erfüllt und ohne weitere Änderung sofort messbar.
+
+## Expected Behavior
+
+- **Input:** die bereits abgeschlossene Analyse in `docs/context/epic-1458-messlatte.md`
+  (Rohzahlen, Messmethodik, Schlussfolgerung).
+- **Output:** committetes Analyse-Dokument · ein Kommentar an Issue #1458 mit den drei
+  Pflichtinhalten (Begründung, Ersatzkennzahlen inkl. Basislinie, Beleg der Epic-Wirkung) ·
+  Issue #1458 geschlossen · zwei neue GitHub Issues mit den oben spezifizierten Labels und
+  Fundstellen.
+- **Side effects:** keine. Kein Produktivcode wird verändert, keine Laufzeitdatei des
+  Alarm-Systems wird angefasst, keine Konfiguration ändert sich.
+
+## Was sich NICHT ändert
+
+- **Kein Produktivcode.** Weder `src/services/alert_log.py` noch
+  `src/services/alert_gate.py` werden in dieser Arbeit editiert — sie werden nur als
+  Fundstellen zitiert. Die Änderung an `alert_log.py` ist Gegenstand des neuen Issues 4a,
+  nicht dieser Spec.
+- **Keine Alarm-Laufzeitdatei wird angefasst:** `trip_alert.py`, `compare_alert.py`,
+  `compare_radar_alert.py`, `alert_log.py`, `alert_gate.py`, der Alarme-Reiter im Frontend.
+- **Keine Migration, keine Schema-Änderung** am bestehenden `alert_log.json`.
+- **Kein Verhalten des Alarm-Systems ändert sich** — weder Zustellung noch Unterdrückung
+  noch Format einer Meldung.
+
+## Acceptance Criteria
+
+- **AC-1:** Given `docs/context/epic-1458-messlatte.md` liegt fertig im Worktree vor / When
+  diese Arbeit abgeschlossen ist / Then ist die Datei im Repository committet und enthält
+  unverändert die Basislinie 66,7 % sowie den Hinweis auf die Artefakt-Falle (85 %).
+  - Test: `git log -- docs/context/epic-1458-messlatte.md` zeigt einen Commit; die Datei
+    ist am Zielcommit vorhanden und lesbar.
+
+- **AC-2:** Given die alte Messlatte („Juni 76 · Juli 31 · August 3") ist strukturell nicht
+  erfüllbar / When der Nachweis abgeschlossen ist / Then trägt Issue #1458 einen Kommentar,
+  der begründet, dass das Alarm-Protokoll (`alert_log.py:226-229`) den Wert der gemeldeten
+  Größe nicht führt und deshalb Wiederholung nicht von neuer Information unterscheidbar ist.
+  - Test: Kommentar-Text auf Issue #1458 nennt die Fundstelle `alert_log.py:226-229` und
+    die Begründung "Wert nicht geführt".
+
+- **AC-3:** Given die zwei Ersatzkennzahlen K1 und K2 / When der Kommentar verfasst wird /
+  Then nennt der Kommentar beide Kennzahlen im oben festgelegten Wortlaut sowie die
+  Basislinie 66,7 % mit Zeitraum (2026-08-04 bis 2026-08-17) und Nutzer (`henning`).
+  - Test: Kommentar-Text enthält "66,7 %", "2026-08-04", "2026-08-17" und "henning" sowie
+    beide Kennzahlnamen K1/K2.
+
+- **AC-4:** Given die naive Kontrollprobe auf Juni/Juli liefert 85 % / When der Kommentar
+  diese Zahl erwähnt / Then steht explizit dabei, dass diese Zahl ein Artefakt der
+  zusammenfallenden Alt-Signaturen `(None, (), ())` ist und nicht als Vergleichswert
+  verwendet werden darf.
+  - Test: Kommentar-Text enthält den Begriff "Artefakt" im selben Absatz wie "85 %" und
+    einen Hinweis, dass der Wert nicht zum Vergleich taugt.
+
+- **AC-5:** Given der Kommentar aus AC-2 bis AC-4 ist auf Issue #1458 gepostet / When alle
+  Pflichtinhalte vorhanden sind / Then ist Issue #1458 geschlossen.
+  - Test: `gh issue view 1458 --json state` liefert `"CLOSED"`.
+
+- **AC-6:** Given Befund B3 aus #1459 ist nur zur Hälfte geschlossen (Größe ja, Wert nein) /
+  When die Analyse abgeschlossen ist / Then existiert ein neues GitHub Issue mit den Labels
+  `enhancement`, `area:alerts`, `session:alarm`, das `alert_log.py:226-229` als Fundstelle
+  und die unvollständige K1-Messbarkeit als Motivation nennt.
+  - Test: `gh issue list --search "Wert" --label enhancement` zeigt ein Issue mit
+    Fundstelle `alert_log.py:226-229` im Body.
+
+- **AC-7:** Given der Ruhezeit-Befund F3 (52 unterdrückte Vorfälle, 48 davon nachts 02–06
+  Uhr) / When die Analyse abgeschlossen ist / Then existiert der Befund als GitHub Issue mit
+  den Labels `bug`, `priority:high`, `area:alerts`, `session:alarm`, das `alert_gate.py:143`
+  als Fundstelle nennt und ausdrücklich vermerkt, dass nicht verifiziert ist, ob unter den
+  52 unterdrückten Vorfällen konvektive Lagen waren — **und** der PO-Entscheid zu diesem
+  Befund ist am Issue nachlesbar begründet, unabhängig davon, ob das Issue offen oder
+  geschlossen ist.
+  - Test: Ein Issue (beliebiger Zustand) mit diesen Labels enthält `alert_gate.py:143`, die
+    Zahlen "52" und "48" sowie die Phrase "nicht verifiziert" im Body; zusätzlich ist in Body
+    oder einem Kommentar ein begründeter PO-Entscheid nachlesbar.
+  - Begründung für die Zustands-Unabhängigkeit: Ob das Issue offen bleibt oder geschlossen
+    wird, entscheidet der PO — nicht diese Lieferung. Ein Kriterium, das „offen" verlangt,
+    prüft damit einen Zustand außerhalb des Liefergegenstands. Prüfbar ist, was diese Arbeit
+    zusichert: dass der Befund vollständig gebucht und der Umgang damit begründet ist.
+
+## Known Limitations
+
+- Die Kennzahl K1 ist bis zur Umsetzung des Folge-Issues 4a nur eingeschränkt aussagekräftig
+  (Signatur ohne Wert), das ist bewusst akzeptiert und in Issue 4a dokumentiert.
+- Der Nachweis ist eine Ein-Nutzer-Messung (`henning`) — die einzige Prod-Datenquelle mit
+  durchgängiger August-Abdeckung. Das steht bereits im Analyse-Dokument und wird nicht
+  erneut gemessen.
+- Der Ruhezeit-Befund F3 ist ein belegter Verdacht, keine bewiesene Fehlfunktion — die
+  Klärung, ob konvektive Lagen betroffen waren, ist Aufgabe des neuen Issues, nicht dieser
+  Arbeit.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Diese Arbeit ändert keine Entscheidungsfläche (Kanäle, Provider,
+  Datenmodell, Auth, Editor-Paradigma, Test-/Deploy-Strategie) — sie ersetzt ein
+  unerfüllbares Erledigt-Kriterium eines Epics durch zwei messbare Kennzahlen und dokumentiert
+  den Befund. Kein ADR nötig.
+
+## Changelog
+
+- 2026-08-18: Initial spec created
+- 2026-08-18: AC-7 nach PO-Entscheid angepasst — geprüft wird nicht mehr ein **offenes**
+  Issue, sondern dass der Befund als Issue existiert und der PO-Entscheid dort begründet
+  nachlesbar ist. Grund: das ursprüngliche Kriterium prüfte einen Zustand, über den der PO
+  entscheidet und nicht die Lieferung (#1955 wurde bewusst geschlossen, F3 revidiert).

--- a/tests/test_alert_epic_nachweis_dokumentiert.py
+++ b/tests/test_alert_epic_nachweis_dokumentiert.py
@@ -1,0 +1,333 @@
+"""Nachweis-Schicht: ist der Messlatte-Ersatz am Epic #1458 nachlesbar? (Epic #1458)
+
+Die Zusicherungen dieser Arbeit liegen NICHT im Code, sondern auf GitHub: ein
+Befund-Kommentar am Epic, der geschlossene Epic-Zustand und zwei Folge-Issues.
+Geprueft wird deshalb aus Nutzersicht -- "kann ich am Epic nachlesen, warum die
+alte Messlatte ersetzt wurde, und sind die Folgebefunde gebucht?" -- gegen die
+echte GitHub-API via ``gh``. Kein Mock: ein gemockter ``gh``-Aufruf wuerde nur
+die eigene Annahme zurueckspiegeln und nichts ueber den Zustand auf GitHub
+aussagen.
+
+Weil dafuer Netz noetig ist, traegt das Modul den Marker ``live`` -- der
+deterministische Kern-Testlauf sammelt diese Tests nicht ein.
+"""
+import json
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.live
+
+# Repo-Wurzel relativ zur eigenen Testdatei aufloesen -- nie ueber einen festen
+# Hauptrepo-Pfad, sonst prueft ein Worktree-Lauf das falsche Repository.
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+EPIC_NUMBER = 1458
+GH_TIMEOUT_S = 60
+
+# Wortgrenzen sind hier tragend: ohne sie prueft das Muster nicht "genau diese
+# Zeile". ``\b`` allein genuegt NICHT -- der Unterstrich in "alert_log" ist ein
+# Wortzeichen, "nicht_alert_log.py:226-229" haette also keine Grenze davor.
+# Darum ``(?<!\w)`` vorn, und ``(?!\d)`` hinten, damit ":1430"/":2290" nicht
+# als Treffer durchgehen.
+FUNDSTELLE_LOG = r"(?<!\w)alert_log\.py\s*:\s*226\s*[-–]\s*229(?!\d)"
+FUNDSTELLE_GATE = r"(?<!\w)alert_gate\.py\s*:\s*143(?!\d)"
+
+
+def _gh_json(args: list[str]) -> object:
+    """Ruft ``gh`` im Repo der Testdatei auf und gibt die JSON-Antwort zurueck.
+
+    Scheitert der Aufruf (fehlendes ``gh``, fehlende Authentifizierung,
+    API-Fehler), bricht der Test mit der Original-Fehlermeldung ab -- das ist
+    dann ausdruecklich KEIN inhaltlicher Befund, sondern ein Werkzeugproblem,
+    und muss als solches erkennbar sein. Kein Skip: ein stiller Skip wuerde
+    die Zusicherung unbemerkt abschalten.
+    """
+    try:
+        proc = subprocess.run(
+            ["gh", *args],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=GH_TIMEOUT_S,
+        )
+    except FileNotFoundError:  # pragma: no cover - Werkzeugproblem
+        pytest.fail("WERKZEUG: 'gh' ist nicht installiert -- kein inhaltlicher Befund.")
+    if proc.returncode != 0:  # pragma: no cover - Werkzeugproblem
+        pytest.fail(
+            "WERKZEUG: 'gh "
+            + " ".join(args)
+            + f"' scheiterte (exit {proc.returncode}) -- kein inhaltlicher Befund.\n"
+            + proc.stderr.strip()
+        )
+    return json.loads(proc.stdout)
+
+
+def _normalize(text: str) -> str:
+    """Whitespace vereinheitlichen, damit Zeilenumbrueche und Einrueckungen im
+    Kommentartext die Suche nicht scheitern lassen. Zeichen werden NICHT
+    entfernt -- fehlt eine Zahl, bleibt der Test rot."""
+    return re.sub(r"\s+", " ", text)
+
+
+@pytest.fixture(scope="module")
+def epic_comments() -> list[str]:
+    """Alle Kommentar-Texte von Issue #1458, normalisiert."""
+    data = _gh_json(["issue", "view", str(EPIC_NUMBER), "--json", "comments"])
+    return [c.get("body", "") for c in data["comments"]]
+
+
+@pytest.fixture(scope="module")
+def epic_comments_normalized(epic_comments: list[str]) -> list[str]:
+    return [_normalize(body) for body in epic_comments]
+
+
+def _issues_with_labels(*labels: str, state: str = "open") -> list[dict]:
+    args = ["issue", "list", "--state", state, "--limit", "100"]
+    for label in labels:
+        args += ["--label", label]
+    args += ["--json", "number,title,body,labels"]
+    return _gh_json(args)
+
+
+def _open_issues_with_labels(*labels: str) -> list[dict]:
+    return _issues_with_labels(*labels, state="open")
+
+
+def _issue_texts(number: int) -> list[str]:
+    """Body und alle Kommentar-Texte eines Issues, normalisiert.
+
+    Der PO-Entscheid kann an beiden Stellen stehen -- beim Anlegen im Body, bei
+    einer spaeteren Revision als Kommentar. Beide Orte zaehlen, aber jeder
+    Textblock wird EINZELN geprueft: sonst wuerde ein "PO-Entscheid" aus dem
+    Body zusammen mit einer "Begruendung" aus einem beliebigen anderen
+    Kommentar als Treffer durchgehen.
+    """
+    data = _gh_json(["issue", "view", str(number), "--json", "body,comments"])
+    return [_normalize(data.get("body") or "")] + [
+        _normalize(c.get("body", "")) for c in data.get("comments", [])
+    ]
+
+
+def _titles(issues: list[dict]) -> str:
+    if not issues:
+        return "(keine)"
+    return ", ".join(f"#{i['number']} {i['title']!r}" for i in issues)
+
+
+# --- AC-2: Begruendung mit Fundstelle -----------------------------------------
+def test_ac2_kommentar_begruendet_unerfuellbare_messlatte(epic_comments_normalized):
+    """GIVEN die alte Messlatte des Epics ist strukturell nicht erfuellbar
+    WHEN ein Leser die Kommentare von Issue #1458 durchgeht
+    THEN findet er einen Kommentar, der die Fundstelle alert_log.py:226-229
+         nennt und begruendet, dass der Wert der gemeldeten Groesse dort nicht
+         gefuehrt wird."""
+    mit_fundstelle = [
+        body for body in epic_comments_normalized if re.search(FUNDSTELLE_LOG, body)
+    ]
+    assert mit_fundstelle, (
+        f"Kein Kommentar an #{EPIC_NUMBER} nennt die Fundstelle "
+        "'alert_log.py:226-229' -- die Begruendung, warum die alte Messlatte "
+        f"nicht erfuellbar ist, ist am Epic nicht nachlesbar "
+        f"({len(epic_comments_normalized)} Kommentare geprueft)."
+    )
+    mit_begruendung = [
+        body
+        for body in mit_fundstelle
+        if re.search(r"Wert[^.]{0,160}nicht|nicht[^.]{0,160}Wert", body)
+    ]
+    assert mit_begruendung, (
+        f"Der Kommentar an #{EPIC_NUMBER} nennt zwar 'alert_log.py:226-229', "
+        "begruendet aber nicht, dass der WERT der gemeldeten Groesse dort nicht "
+        "gefuehrt wird -- ohne diese Begruendung bleibt offen, warum "
+        "Wiederholung nicht von neuer Information unterscheidbar ist."
+    )
+
+
+# --- AC-3: Basislinie mit Zeitraum und Nutzer ---------------------------------
+def test_ac3_kommentar_nennt_basislinie_mit_zeitraum_und_nutzer(
+    epic_comments_normalized,
+):
+    """GIVEN die Ersatzkennzahl K1 hat die Basislinie 66,7 %
+    WHEN ein Leser die Kommentare von Issue #1458 durchgeht
+    THEN findet er einen Kommentar, der 66,7 % zusammen mit dem Messzeitraum
+         2026-08-04 bis 2026-08-17 und dem Nutzer henning nennt."""
+    # ``(?<!\d)`` statt ``\b``: zwischen "1" und "6" in "166,7 %" gibt es keine
+    # Wortgrenze, die falsche Nachbarzahl wuerde sonst mitzaehlen.
+    kandidaten = [
+        body for body in epic_comments_normalized if re.search(r"(?<!\d)66,7\s*%", body)
+    ]
+    assert kandidaten, (
+        f"Kein Kommentar an #{EPIC_NUMBER} nennt die Basislinie '66,7 %' -- "
+        "ohne Basislinie ist Kennzahl K1 nicht nachpruefbar."
+    )
+    fehlend_pro_kandidat = []
+    for body in kandidaten:
+        fehlt = [
+            teil
+            for teil, muster in (
+                ("2026-08-04", r"2026-08-04"),
+                ("2026-08-17", r"2026-08-17"),
+                ("henning", r"henning"),
+            )
+            if not re.search(muster, body)
+        ]
+        if not fehlt:
+            return
+        fehlend_pro_kandidat.append(fehlt)
+    pytest.fail(
+        f"Der Kommentar an #{EPIC_NUMBER} nennt '66,7 %', aber ohne "
+        f"vollstaendige Einordnung -- fehlend: {fehlend_pro_kandidat}. "
+        "Eine Basislinie ohne Zeitraum und Nutzer ist nicht reproduzierbar."
+    )
+
+
+# --- AC-3: beide Ersatzkennzahlen ---------------------------------------------
+def test_ac3_kommentar_nennt_beide_ersatzkennzahlen(epic_comments_normalized):
+    """GIVEN die alte Messlatte wird durch zwei Kennzahlen K1 und K2 ersetzt
+    WHEN ein Leser die Kommentare von Issue #1458 durchgeht
+    THEN findet er einen Kommentar, der beide Kennzahlen K1 und K2 benennt."""
+    for body in epic_comments_normalized:
+        if re.search(r"\bK1\b", body) and re.search(r"\bK2\b", body):
+            return
+    nur_k1 = sum(
+        1
+        for body in epic_comments_normalized
+        if re.search(r"\bK1\b", body) and not re.search(r"\bK2\b", body)
+    )
+    nur_k2 = sum(
+        1
+        for body in epic_comments_normalized
+        if re.search(r"\bK2\b", body) and not re.search(r"\bK1\b", body)
+    )
+    pytest.fail(
+        f"Kein Kommentar an #{EPIC_NUMBER} nennt beide Ersatzkennzahlen K1 UND "
+        f"K2 (nur K1: {nur_k1}, nur K2: {nur_k2}). Die Messlatte gilt erst als "
+        "ersetzt, wenn beide Seiten -- weniger Wiederholung UND nicht weniger "
+        "echte Warnung -- am Epic stehen."
+    )
+
+
+# --- AC-4: 85 % ist ein Artefakt ----------------------------------------------
+def test_ac4_kommentar_markiert_85_prozent_als_artefakt(epic_comments):
+    """GIVEN die naive Kontrollprobe auf Juni/Juli liefert 85 %
+    WHEN ein Leser den Kommentar an Issue #1458 liest
+    THEN steht die Zahl 85 % im selben Absatz mit dem Wort 'Artefakt' und dem
+         Hinweis, dass sie nicht zum Vergleich taugt."""
+    absaetze = [
+        _normalize(absatz)
+        for body in epic_comments
+        for absatz in re.split(r"\n\s*\n", body)
+    ]
+    mit_85 = [a for a in absaetze if re.search(r"\b85\s*%", a)]
+    assert mit_85, (
+        f"Kein Kommentar an #{EPIC_NUMBER} erwaehnt die Kontrollprobe '85 %' -- "
+        "die Artefakt-Falle ist damit nicht dokumentiert und ein spaeterer "
+        "Leser koennte die Zahl fuer einen Vergleichswert halten."
+    )
+    ohne_artefakt = [a for a in mit_85 if not re.search(r"Artefakt", a, re.I)]
+    assert not ohne_artefakt, (
+        f"Ein Absatz im Kommentar an #{EPIC_NUMBER} nennt '85 %' ohne das Wort "
+        f"'Artefakt' im selben Absatz: {ohne_artefakt[0][:200]!r}"
+    )
+    if not any(re.search(r"Vergleich", a, re.I) for a in mit_85):
+        pytest.fail(
+            f"Der Absatz mit '85 %' an #{EPIC_NUMBER} sagt nicht, dass die Zahl "
+            "nicht als Vergleichswert taugt -- 'Artefakt' allein sagt einem "
+            "Leser noch nicht, dass er damit nicht rechnen darf."
+        )
+
+
+# --- AC-5: Epic geschlossen ---------------------------------------------------
+def test_ac5_epic_1458_ist_geschlossen():
+    """GIVEN der Befund-Kommentar ist an Issue #1458 gepostet
+    WHEN der Nachweis abgeschlossen ist
+    THEN ist Issue #1458 geschlossen."""
+    data = _gh_json(["issue", "view", str(EPIC_NUMBER), "--json", "state"])
+    assert data["state"] == "CLOSED", (
+        f"Issue #{EPIC_NUMBER} ist '{data['state']}', nicht 'CLOSED' -- das Epic "
+        "gilt erst als erledigt, wenn die ersetzte Messlatte dokumentiert und "
+        "das Epic geschlossen ist."
+    )
+
+
+# --- AC-6: Folge-Issue "Protokoll fuehrt den Wert" ------------------------------
+def test_ac6_folge_issue_protokoll_wert_ist_gebucht():
+    """GIVEN Befund B3 aus #1459 ist nur zur Haelfte geschlossen (Groesse ja,
+         Wert nein)
+    WHEN der Nachweis abgeschlossen ist
+    THEN existiert ein offenes Issue mit den Labels 'enhancement' und
+         'area:alerts', dessen Beschreibung alert_log.py:226-229 als Fundstelle
+         nennt."""
+    issues = _open_issues_with_labels("enhancement", "area:alerts")
+    treffer = [i for i in issues if re.search(FUNDSTELLE_LOG, _normalize(i["body"] or ""))]
+    assert treffer, (
+        "Kein offenes Issue mit den Labels 'enhancement' + 'area:alerts' nennt "
+        "'alert_log.py:226-229' im Body -- der Nebenbefund B3 (Protokoll fuehrt "
+        "die Groesse, nicht den Wert) ist nicht gebucht, obwohl Kennzahl K1 ohne "
+        f"ihn dauerhaft nur teilweise messbar bleibt. Geprueft: {_titles(issues)}"
+    )
+
+
+# --- AC-7: Folge-Issue "Ruhezeit-Sperre" ---------------------------------------
+def test_ac7_folge_issue_ruhezeit_sperre_ist_gebucht():
+    """GIVEN Befund F3: 52 Vorfaelle durch die Ruhezeit-Sperre unterdrueckt,
+         48 davon nachts zwischen 02 und 06 Uhr
+    WHEN der Nachweis abgeschlossen ist
+    THEN existiert -- unabhaengig von offen/geschlossen -- ein Issue mit den
+         Labels 'priority:high' und 'area:alerts', dessen Beschreibung
+         alert_gate.py:143, die Zahlen 52 und 48 sowie die Phrase 'nicht
+         verifiziert' enthaelt, und an dem der PO-Entscheid begruendet
+         nachlesbar ist.
+
+    Bewusst NICHT auf ``--state open`` eingeschraenkt: ob das Issue offen
+    bleibt oder geschlossen wird, entscheidet der PO (#1955 wurde am
+    2026-08-18 nach Revision von F3 geschlossen) -- das ist kein Zustand, den
+    diese Lieferung zusichern kann. Zugesichert ist, dass der Befund
+    vollstaendig gebucht und der Umgang damit begruendet ist.
+    """
+    issues = _issues_with_labels("priority:high", "area:alerts", state="all")
+    kandidaten = [
+        i for i in issues if re.search(FUNDSTELLE_GATE, _normalize(i["body"] or ""))
+    ]
+    assert kandidaten, (
+        "Kein Issue mit den Labels 'priority:high' + 'area:alerts' nennt "
+        "'alert_gate.py:143' im Body -- der Ruhezeit-Befund F3 (akute Gefahr "
+        "kommt nachts nicht durch) ist nicht gebucht. "
+        f"Geprueft: {_titles(issues)}"
+    )
+    fehlend_pro_kandidat = []
+    for issue in kandidaten:
+        body = _normalize(issue["body"] or "")
+        fehlt = [
+            teil
+            for teil, muster in (
+                ("52", r"\b52\b"),
+                ("48", r"\b48\b"),
+                ("nicht verifiziert", r"nicht verifiziert"),
+            )
+            if not re.search(muster, body, re.I)
+        ]
+        # Der PO-Entscheid muss begruendet sein -- ein blosser Vermerk
+        # "PO-Entscheid: eigenes Issue" sagt einem spaeteren Leser nicht,
+        # WARUM so entschieden wurde. Marker und Begruendung muessen im
+        # SELBEN Textblock stehen.
+        if not any(
+            re.search(r"PO-Entscheid", text, re.I)
+            and re.search(r"Begr(ü|ue)ndung|\bweil\b|\bdenn\b", text, re.I)
+            for text in _issue_texts(issue["number"])
+        ):
+            fehlt.append("begruendeter PO-Entscheid (Body oder Kommentar)")
+        if not fehlt:
+            return
+        fehlend_pro_kandidat.append((issue["number"], fehlt))
+    pytest.fail(
+        "Das Folge-Issue zur Ruhezeit-Sperre nennt 'alert_gate.py:143', aber "
+        f"nicht alles Noetige -- fehlend je Kandidat: {fehlend_pro_kandidat}. "
+        "Ohne die Zahlen 52/48 fehlt das Ausmass, ohne 'nicht verifiziert' liest "
+        "sich ein belegter Verdacht wie eine bewiesene Fehlfunktion, und ohne "
+        "begruendeten PO-Entscheid ist nicht nachlesbar, warum mit dem Befund so "
+        "umgegangen wurde."
+    )


### PR DESCRIPTION
Das Epic #1458 trug ein Erledigt-Kriterium, das strukturell nicht praezise
erfuellbar ist: das Alarm-Protokoll fuehrt nur `metric_id` + `aggregation`
(`alert_log.py:226-229`), nicht den WERT der gemeldeten Groesse. Ob 17x
"Gewitter" siebzehn echte Stufenwechsel waren oder siebzehnmal dieselbe
Aussage, ist daraus nicht aufloesbar. Befund B3 aus #1459 ist damit nur zur
Haelfte geschlossen.

Ersetzt durch prospektiv messbare Kennzahlen:
- K1' (sofort messbar, ohne Protokoll-Erweiterung): Anteil zugestellter
  Alarme mit <=60 min Abstand zum vorigen derselben Entitaet.
  27,4 % -> 24,2 % -> 22,2 %, monoton fallend.
- K1 (praeziser, erst nach #1954): Signatur inkl. Wert. Basislinie 66,7 %.
- K2: je Ausloeser mindestens ein zugestellter Alarm je Alarmwoche.

Zwei Messfallen dokumentiert, in beide selbst hineingetappt und korrigiert:
- Zeilen sind keine Vorfaelle. Die Sperrgrund-Tabelle stand durchgehend in
  Zeilen; `event_duplicate` sind 2 Vorfaelle, nicht 4. Die Entdopplung hat
  die Wiederholung ausserdem nicht verhindert (17.08.: 13:52 zugestellt,
  14:52 geblockt, 15:07 erneut zugestellt) - den Takt gibt der Cooldown vor.
- Die 85-%-Kontrollprobe auf Juni/Juli ist ein Artefakt: im Altformat fallen
  alle Signaturen auf (None,(),()) zusammen. Kein Vergleichswert.

Abgeleitet: #1954 (Wert ins Protokoll), #1955 (Ruhezeit vs. akute Gefahr,
vom PO nach Pruefung revidiert und geschlossen).

Kein Produktivcode. Der neue Test traegt den `live`-Marker und wird im
deterministischen Kernlauf deselektiert.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SXizFJM4NV6AswyzFrnNE3
