### PR TITLE
feat(#1948): Alarm-Eingangsprotokoll S1 — roher Eingangs-Mitschnitt aller drei Alarm-Zweige

### DIFF
--- a/docs/analysis/alarm-format-konzept-2026-08.md
+++ b/docs/analysis/alarm-format-konzept-2026-08.md
@@ -1,0 +1,358 @@
+# Alarm-Format-Konzept v3 — FREIGEGEBEN (#1948)
+
+> Status: **Alle Entscheidungsfragen vom PO beantwortet (PO-Runde 4,
+> 2026-08-17).** Ersetzt inhaltlich die pausierte Spec
+> `docs/specs/modules/fix_1948_1939_alarm_sms_referenzzeitpunkt.md` (jetzt
+> obsolet markiert, s. Abschnitt 8). Grundlage: Ist-Vokabular-Inventur
+> (Kommentare in #1948), PO-Runde 3+4 (2026-08-17). Ortsvergleich bleibt in
+> diesem Dokument durchgehend zurückgestellt (PO-Entscheid).
+>
+> **Aufgabenteilung zu Epic #1458** (Ergänzung #1493-Sitzung): #1458 (E1–E5 —
+> Zweck, Dringlichkeit, Auslöser-Zahl, Bedienort, Ortsvergleich-Parität; die
+> „Messlatte", WANN überhaupt alarmiert wird) ist an eine eigene Sitzung
+> vergeben und NICHT Teil dieses Dokuments. #1948 behält E6 (Debug-Protokoll,
+> Abschnitt 8 S1) und die Format-Frage (WIE eine ausgelöste Meldung aussieht).
+
+## 0. Leitsatz (PO-Kern)
+
+> **Format folgt dem Phänomen, nicht der Quelle.**
+
+Der Empfänger einer Alarm-SMS interessiert sich nicht dafür, welcher
+Programmteil ein Gewitter zuerst bemerkt hat — Δ-Vergleich zum letzten
+Briefing, Regenradar-Nowcast oder amtliche Wetterwarnung. Er erwartet EIN
+Standardformat, in der Sprache, die er aus dem täglichen Trip-Briefing bereits
+kennt. Konkret: ein Gewitter heißt in ALLEN drei Alarm-Zweigen `TH:` mit
+derselben Stufenleiter, die das Briefing bereits verwendet
+(`LEVELS = {0: "-", 1: "L", 2: "M", 3: "H"}`, `src/output/tokens/metrics.py:14`).
+Das amtliche Sonderformat — Trip-Präfix (`KHW403`), `AMT`-Kopf, numerische
+Warnstufen-Notation (`GELB1/3`), ein von der Zeitfenster-Notation dominiertes
+Erscheinungsbild — verschwindet aus Nutzersicht vollständig. Die zugrunde
+liegende Datenherkunft (amtlicher Dienst vs. eigene Modellauswertung) bleibt
+intern unterschiedlich; nur die Darstellung wird eins.
+
+## 1. Zielbild je Phänomen (NUR Ist-Vokabular, mit Fundstellen)
+
+**Die Trip-Briefing-SMS ist die lebende Referenz-Implementierung dieses
+Zielbilds** (Ergänzung #1493-Sitzung) — kein reines Bauteil-Lager, sondern der
+bereits produktiv laufende Beweis, dass `TH:M@14(H@18)` als Notation
+funktioniert (`render_threshold_peak_value()`, `tokens/builder.py:392`,
+`FORECAST_TH` + `LEVELS`). Das Alarm-System zieht auf genau dieses,
+bereits bewährte Format nach — es entsteht nichts fachlich Neues.
+
+Am Beispiel Gewitter, Ziel-Segment, PO-finalisierte Beispiele
+(**PO-Entscheidung Runde 4: Trennzeichen `->`, KEIN Vorzeichen-Präfix** —
+Begründung Abschnitt 3):
+
+| Zweig | Zielbild-SMS | Bausteine (alle Ist-Vokabular, Fundstelle) |
+|---|---|---|
+| **a — Δ-Alarm** | `Ziel: TH:M->H@16` | Kopf `Ziel:` = `format_alert_location`/`_km_str` (`render.py:787`, bereits Ist-Zustand für Zweig a); Code `TH:` = Wetter-Register (`get_sms_code`, `metric_catalog.py`, genutzt von `render.py:93` UND `output/tokens/builder.py`); Stufen-Buchstaben `M`/`H` = `LEVELS`-Map (`output/tokens/metrics.py:14`, **heute nur vom Trip-Briefing-Builder genutzt, NICHT von `_sms_token()`** — Bauteil existiert, ist aber nicht verdrahtet, s. Abschnitt 9); `->`-Notation OHNE Vorzeichen-Präfix = finale PO-Entscheidung (Abschnitt 3); `@16` = `occurred_at`-Suffix (`_sms_token`, `render.py:712-713`, bereits Ist-Zustand) — Regel 5 (Abschnitt 2) legt fest: `@` markiert immer den BEGINN-Zeitpunkt |
+| **c — Nowcast** | `Ziel: TH@15:40` | Kopf `Ziel:` = **fehlt heute** — `_render_sms_onset` baut eigenständig `km{a}-{b}:` (`render.py:346-349`), nutzt NICHT `format_alert_location`/`_km_str` wie Zweig a (Bauteil fehlt, s. Abschnitt 9); Code `TH` = Wetter-Register (bereits genutzt, `render.py:343`, aktuell als `TH!{n}`); Uhrzeit `15:40` = `OnsetEvent.onset_time` (Feld **existiert bereits**, wird in E-Mail/Telegram genutzt, `render.py:227,282,330`, aber NICHT in `_render_sms_onset` — PO-bestätigter Uhrzeit-statt-Countdown-Entscheid ist damit ohne neuen Datenpunkt umsetzbar, s. Ist-Vokabular-Inventur „Machbarkeit 1") — `@15:40` (mit Minuten) statt `@14` (nur Stunde), da Radar-Nowcast-Auflösung feiner ist als Stundenvorhersage (Regel 5) |
+| **b — amtlich** | `Ziel: TH:H 13-22` | Kopf `Ziel:` = **fehlt heute** — `render_official_alert_sms` baut `{prefix} AMT {Stufenwort}{Pos}/3:` (`official_alerts.py:2070`), kennt `format_alert_location` nicht (Bauteil fehlt); Code `TH:` = Wetter-Register-Form (heute nutzt Zweig b das GETRENNTE Gefahren-Register `HAZARD_SMS_SYMBOLS`, `thunderstorm→TH` OHNE Doppelpunkt, `hazard_symbols.py:15` — Angleichung an `TH:` ist Teil der Kollisions-Bereinigung, Abschnitt 5); Stufenbuchstabe `H` = **PO-Entscheidung Option 1** (Abschnitt 4): GRÜN→`-`, GELB→`L`, ORANGE→`M`, ROT→`H`, für ALLE Gefahrenarten; Zeitfenster `13-22` = vereinfachte Form von `_tag_time` (`official_alerts.py:1896-1918`, heute `Fr06-20` mit Wochentag) — Wochentag entfällt hier, weil Gültigkeit laut Regel 2 (Abschnitt 2) heute beginnt |
+
+**Vergleichszeitpunkt (`reference_at`) entfällt aus der SMS vollständig** —
+keines der finalen Zielbilder trägt ein `@HH:MM`-Präfix im Kopf. Der
+Von-Bis-Token selbst (`VS1400->280`) zeigt den Ausschlag bereits vollständig;
+ein zusätzlicher Hinweis „verglichen mit HH:MM" wäre in der Kurzform
+redundant. Das löst den ursprünglichen #1948-Auslöser-Bug durch **Entfernen**
+statt durch Umformulieren (Details Abschnitt 8, Scheibe S3) — und macht
+#1939 (Vergleichszeitpunkt schleicht sich in den kopflosen Compare-Pfad)
+strukturell unmöglich, weil es in der SMS gar keinen Vergleichszeitpunkt mehr
+gibt, der sich einschleichen könnte.
+
+**Was NICHT im Zielbild vorkommt, weil es heute schon fehlt und hier nicht neu
+erfunden wird:** ein Wiederholungs-Signal (PO-Entscheid: gestrichen, s.
+Abschnitt 7).
+
+## 2. Regeln (aus dem Leitsatz abgeleitet)
+
+1. **Kein Trip-Name in Alarm-SMS.** Ausweitung von `fix_1935_1779_...md` AC-5
+   (bereits für Zweig a Trip-Δ, teilweise Zweig c) auf Zweig b — der
+   `KHW403`-Präfix in `render_official_alert_sms` entfällt.
+2. **Wochentag nur, wenn die Gültigkeit NICHT heute beginnt.** Eine Regel für
+   alle Zweige mit Zeitbezug (heute betrifft praktisch nur Zweig b, da Zweig a
+   keine Wochentage zeigt und Zweig c auf eine Uhrzeit ohne Datum umgestellt
+   wird). Baut auf `_tag_time` auf, ergänzt eine Bedingung, ersetzt die
+   Funktion nicht.
+3. **Etappen-/Segment-Kopf vorne, wie im Δ-Pfad.** Alle drei Zweige nutzen
+   künftig `format_alert_location`/`_km_str` als EINZIGE Kopf-Quelle. Heute:
+   Zweig a hat das bereits, Zweig c baut einen eigenen `km{a}-{b}:`-Kopf,
+   Zweig b einen eigenen `AMT`-Kopf.
+4. **Behörden-Warnstufe wird auf die `TH:`-/Gefahren-Stufenleiter abgebildet**
+   — **PO-Entscheidung: Option 1** (Abschnitt 4), GRÜN→`-`, GELB→`L`,
+   ORANGE→`M`, ROT→`H`, für alle Gefahrenarten.
+5. **`@` markiert immer den BEGINN-Zeitpunkt eines Ereignisses; die Auflösung
+   (Stunde vs. Stunde:Minute) folgt der Datenquelle, nicht dem Zweig**
+   (Ergänzung #1493-Sitzung). Stundenvorhersage → `@14` (ohne führende Null,
+   wie im Briefing, `sms_format.md:52`); Radar-Nowcast → `@15:40` (Minuten,
+   da die Quelle minutengenau misst). Dieselbe Notation gilt identisch in
+   Briefing-SMS UND Alarm-SMS — keine zweite `@`-Bedeutung entsteht.
+
+## 3. Notations-Studie: `>` vs. Alternativen
+
+**Ausgangslage:** `1400>280` (heutige #1935-Notation) liest sich als „größer
+als" — PO-Kritik, zur Neuentscheidung gestellt. Sechs Kandidaten (Trennzeichen-
+Varianten des bestehenden Von-Bis-Prinzips, keine neuen Codes), gegen sechs
+Extremfälle geprüft. Zeichenkosten ohne Vorzeichen-Präfix/Code gezählt, wo
+nicht anders vermerkt.
+
+**Kandidaten:**
+
+| # | Kandidat | GSM-7-Kosten |
+|---|---|---|
+| A | `von>bis` (Ist-Zustand, #1935) | Basis, 1 Septet je Zeichen |
+| B | `von/bis` | Basis, 1 Septet je Zeichen |
+| C | `von-bis` | Basis, 1 Septet je Zeichen |
+| D | `von(bis)` | Basis — `(`/`)` sind GSM-7-BASIS-Zeichen, nicht Extension (verifiziert an `render.py:822-833`: die Extension-Ersetzungstabelle wandelt `[`/`{` GERADE IN `(` um, um die 2-Septet-Kosten der eckigen/geschweiften Klammern zu vermeiden) |
+| E | `von zu bis` | Basis, aber mit Leerzeichen teurer |
+| F | `von→bis` | **NICHT GSM-7** — jedes Vorkommen zwingt die GESAMTE SMS in UCS-2-Kodierung |
+
+**Extremfälle × Kandidaten** (Format: gerenderter Token · Zeichen · Befund):
+
+**1) Sicht 1.400→280 m (VS, fallend, großer Zahlenbereich)**
+- A: `-VS1400>280` (11) — liest sich als „größer als" (Ausgangs-Kritik)
+- B: `-VS1400/280` (11) — „/" evoziert eher Bruch/Oder, unüblich für Zeitreihen
+- C: `-VS1400-280` (11) — 🔴 kollidiert mit der bestehenden km-Spannen-Notation (`km{a}-{b}`) — dieselbe Zeichenfolge bedeutet an anderer Stelle im System etwas anderes
+- D: `-VS1400(280)` (12, +1) — Klammer trennt optisch klar, kein Kollisionsrisiko
+- E: `-VS1400zu280` (12, +1, ohne Leerzeichen) / `-VS 1400 zu 280` (16, +5, mit Leerzeichen)
+- F: `-VS1400→280` (11 Zeichen, aber UCS-2-Trigger für die GANZE SMS)
+
+**2) Böen 30→80 km/h (G, steigend)**
+- A: `+G30>80` (7) · B: `+G30/80` (7) · C: `+G30-80` (7, 🔴 dieselbe km-Kollision) · D: `+G30(80)` (8) · E: `+G30zu80` (8) · F: `+G30→80` (7, UCS-2-Trigger)
+
+**3) Temperatur 5→−3 °C (Minus-Kollision, der schärfste Testfall)**
+- A: `-D5>-3` (6) — 🔴🔴 der Alarm-Vorzeichen-Präfix „-" und der negative Zielwert „-3" stehen unmittelbar nach dem „>" — liest sich wie „5 größer als minus 3" oder verschmilzt zu „5>−3" ohne erkennbare Grenze zwischen Vorzeichen und Wert
+- B: `-D5/-3` (6) — dieselbe Doppel-Minus-Unschärfe, unabhängig vom Trennzeichen
+- C: `-D5--3` (6) — 🔴🔴🔴 ZWEI Minuszeichen direkt hintereinander, praktisch unlesbar
+- D: `-D5(-3)` (7, +1) — Klammer trennt das negative Vorzeichen des Zielwerts optisch klar vom Alarm-Vorzeichen-Präfix — geringstes Verwechslungsrisiko aller Kandidaten bei diesem Testfall, trotz identischer Zeichen
+- E: `-D5zu-3` (7, +1) — „zu" trennt ebenfalls eindeutig, kein Minus-Zusammenstoß
+- F: `-D5→-3` (6, UCS-2-Trigger) — Pfeil trennt visuell klar, löst aber das Kodierungsproblem aus
+
+**4) Gewitterstufe M→H (nicht-numerisch, `LEVELS`-Buchstaben)**
+- A: `+TH:M>H` (7) · B: `+TH:M/H` (7) · C: `+TH:M-H` (7) · D: `+TH:M(H)` (8) · E: `+TH:Mzu H`? — Buchstabe+Wort ohne Trennzeichen kaum scannbar, mit Leerzeichen `+TH:M zu H` (10) · F: `+TH:M→H` (7, UCS-2-Trigger)
+- Befund: bei Buchstaben-Stufen ist die „>"-Ambiguität („größer als") deutlich SCHWÄCHER als bei Zahlen — ein Leser liest „M größer als H" seltener fehl als „1400 größer als 280", weil Buchstaben keine Zahlenordnung suggerieren, die mit realen Messwerten verwechselt werden könnte
+
+**5) Regen 0,2→14,5 mm (Dezimalstellen)**
+- A: `+R0.2>14.5` (10) · B: `+R0.2/14.5` (10) · C: `+R0.2-14.5` (10, 🔴 km-Kollisionsrisiko geringer da Dezimalpunkt unüblich in km-Spannen, aber strukturell dasselbe Zeichen) · D: `+R0.2(14.5)` (11) · E: `+R0.2zu14.5` (11) · F: `+R0.2→14.5` (10, UCS-2-Trigger)
+
+**6) Mehrfach-Ereignis in einer SMS** (`Segment 2-3, Ziel: {Token1} {Token2}`, Beispiel Böen + Sicht)
+- A: `+G30>80@15 -VS1400>280@14` (25) — zwei „>"-Zeichen nebeneinander im Fließtext erschweren das Scannen, technisch aber je Token eindeutig zuordenbar (Code-Präfix trennt)
+- B: `+G30/80@15 -VS1400/280@14` (25) — dieselbe Scan-Schwierigkeit
+- C: entfällt strukturell (km-Kollision UND Doppel-Minus-Risiko gelten pro Token, addieren sich)
+- D: `+G30(80)@15 -VS1400(280)@14` (28, +3) — Klammern grenzen jedes Token optisch klarer ab, auch im Mehrfach-Fall
+- E: `+G30zu80@15 -VS1400zu280@14` (28, +3)
+- F: `+G30→80@15 -VS1400→280@14` (25 Zeichen, aber die GESAMTE SMS inkl. Kopf UND aller anderen Tokens wechselt zu UCS-2 — bei Mehrfach-Ereignis trifft die Kodierungs-Verteuerung ALLE Tokens der Nachricht, nicht nur das eine mit dem Pfeil)
+
+**Zusatzbefund für Zweig b (amtlich), Quelle: Messung der #1929-Sitzung:**
+Das 140-Zeichen-Budget kippt im amtlichen Pfad nie sichtbar als abgeschnittener
+Text — `_sms_pack` droppt bei Überlauf GANZE Tokens mit `+N`-Marker
+(`official_alerts.py:1933-1945`), statt einzelne Tokens zu kürzen. Zeichenkosten
+eines längeren Kopfes (z. B. `Ziel:`/`Segment N:` statt des heutigen
+`AMT`-Kopfes) zahlen sich dort also nicht in abgeschnittenem Text aus, sondern
+in UNSICHTBAR wegfallenden Warnungen — eine Warnung verschwindet ganz, statt
+gekürzt zu erscheinen. Gemessener engster Fall aktuell: 118 von 140 Zeichen.
+**Konsequenz für die Notations-Wahl in Zweig b:** die Zeichenkosten der
+Kandidaten A-F (oben) sind für den amtlichen Zweig nicht nur gegen Lesbarkeit,
+sondern gegen diese Dropp-Schwelle zu rechnen — ein teurerer Kandidat (z. B. D
+mit +1 bis +3 Zeichen je Token) kann bei mehreren gleichzeitigen Warnungen
+dazu führen, dass eine zusätzliche Warnung komplett aus der SMS fällt, die mit
+Kandidat A noch hineingepasst hätte. Diese Abwägung gilt zusätzlich zur
+Notations-Wahl selbst und ist Teil der PO-Entscheidung in Abschnitt 3, nicht
+gesondert zu entscheiden.
+
+**Zusammenfassender Befund (Fakten, keine Vorschlags-Bindung):**
+- Kandidat **C** (`-`) scheidet strukturell aus zwei unabhängigen Gründen aus:
+  Kollision mit der bestehenden km-Spannen-Notation UND Doppel-Minus bei
+  fallenden negativen Werten (Fall 3).
+- Kandidat **F** (`→`) löst die Lesbarkeits-Ambiguität am klarsten, hat aber
+  eine **Kostenfolge außerhalb der reinen Zeichenzählung**: jedes Vorkommen
+  erzwingt UCS-2 für die komplette Nachricht — bei Premium-SMS (Garmin
+  inReach, kostenpflichtig je Segment, ADR-0049) eine direkte Mehrkosten-Frage,
+  nicht nur eine Geschmacksfrage.
+- Kandidat **D** (`alt(neu)`) ist über alle sechs Fälle hinweg konsistent
+  GSM-7-günstig (+1 bis +3 Zeichen ggü. A) und zeigt beim schärfsten Testfall
+  (Minus-Kollision, Fall 3) das geringste Verwechslungsrisiko aller
+  GSM-7-Basis-Kandidaten.
+- Kandidat **E** (`zu`) ist bei Buchstaben-Stufen (Fall 4) ohne Leerzeichen
+  schwer scannbar, bei Zahlen mit Leerzeichen am teuersten.
+
+### PO-Entscheidung Runde 4: `->` (ASCII-Pfeil), OHNE Vorzeichen-Präfix
+
+**Gewählt: `->`** — zwei GSM-7-Basis-Zeichen (`-` gefolgt von `>`), keiner der
+sechs oben studierten Kandidaten wörtlich, aber eine Synthese aus F
+(Pfeil-Richtung, Lesbarkeit) und A/B (GSM-7-Sicherheit, kein UCS-2-Trigger).
+**Zusätzlich entfällt der Vorzeichen-Präfix `+`/`-` vollständig** — PO-
+Begründung: der Präfix trug nur die ZAHLENRICHTUNG, die im Pfeil bereits
+steckt, führte aber bei „gut/schlecht" in die Irre (`-TH:H->M` sähe wie eine
+Verschärfung aus, ist aber eine Entwarnung; `-SL2200->1400` [Schneehöhe]
+sähe entwarnend aus, ist aber eine Verschärfung — das Vorzeichen spiegelte
+nie die Handlungsrelevanz, nur die Arithmetik).
+
+**Zielnotation an den sechs Extremfällen:**
+
+| Fall | Neue Notation | Vergleich zu Kandidat A (Ist, mit Präfix) |
+|---|---|---|
+| Sicht 1.400→280 | `VS1400->280` (11) | **gleiche Länge** wie `-VS1400>280` (11) — Präfix-Wegfall UND Pfeil-Verlängerung heben sich auf |
+| Böen 30→80 | `G30->80` (7) | gleiche Länge wie `+G30>80` (7) |
+| Temperatur 5→−3 | `D5->-3` (6) | gleiche Länge wie `-D5>-3` (6), **aber nur noch EIN Minuszeichen** vor der 3 statt der Doppel-Minus-Unschärfe aus Fall 3 — der Präfix-Wegfall löst genau das schärfste Problem der Studie |
+| Gewitterstufe M→H | `TH:M->H` (7) | gleiche Länge wie `+TH:M>H` (7) |
+| Regen 0,2→14,5 | `R0.2->14.5` (10) | gleiche Länge wie `+R0.2>14.5` (10) |
+| Mehrfach-Ereignis | `G30->80@15 VS1400->280@14` (24) | 1 Zeichen KÜRZER als `+G30>80@15 -VS1400>280@14` (25) — zwei eingesparte Präfixe, zwei verlängerte Pfeile, Netto-Ersparnis 1 Zeichen |
+
+Diese Notation gilt für Zweig a (Δ-Alarm) direkt. Für Zweig b (amtlich) gilt
+zusätzlich der Zusatzbefund oben (Dropp-Schwelle statt Kürzung) — die
+Zeichenkosten von `->` (gleich bis günstiger als der Ist-Zustand) wirken sich
+dort tendenziell POSITIV aus, nicht negativ.
+
+## 4. Warnstufen-Mapping — PO-Entscheidung: Option 1
+
+Heute: Behörden-Warnstufe ist vierstufig (GRÜN/GELB/ORANGE/ROT,
+`_LEVEL_WORDS`, `official_alerts.py:44-48`), die `TH:`-Stufenleiter aus dem
+Briefing ist ebenfalls vierstufig (`LEVELS = {0:"-", 1:"L", 2:"M", 3:"H"}`,
+`output/tokens/metrics.py:14`). Zahlenmäßig passt 4-zu-4 — die Frage ist,
+WELCHE Behördenstufe auf WELCHEN Buchstaben abgebildet wird, und ob dabei
+Information verloren geht.
+
+| Option | Mapping | Informationsverlust |
+|---|---|---|
+| **1 — direkte Übersetzung** | GRÜN→`-`, GELB→`L`, ORANGE→`M`, ROT→`H` | keiner, 1:1 |
+| **2 — verschobene Übersetzung** | GRÜN→`-`, GELB→`-`(keine Meldung wert), ORANGE→`M`, ROT→`H` (GELB wird nicht separat gezeigt, da GELB-Warnungen laut heutigem Sicherheits-Filter `MIN_SMS_LEVEL=3` = ORANGE ohnehin nicht per SMS verschickt werden, `hazard_symbols.py:37`) | GELB als eigene Stufe geht in der SMS-Darstellung verloren — deckt sich aber mit dem bereits bestehenden Versand-Filter (GELB wird heute SCHON nicht per SMS verschickt) |
+| **3 — Positions-Zahl bleibt zusätzlich sichtbar** | Buchstabe UND Positions-Ziffer, z.B. `M/3` statt nur `M` (analog zur heutigen `GELB1/3`-Notation, nur mit Buchstabe statt Wort) | keiner, aber widerspricht dem Leitsatz „ein Standardformat" teilweise — Zweig b behielte ein eigenes Zusatzelement |
+
+**PO-Entscheidung Runde 4: Option 1 — direkte Übersetzung**, für ALLE
+Gefahrenarten (nicht nur Gewitter): GRÜN→`-`, GELB→`L`, ORANGE→`M`, ROT→`H`.
+Damit trägt jede Gefahrenart dieselbe vierstufige Leiter wie `TH:` im
+Briefing (Regel 4, Abschnitt 2) — GELB bleibt als eigene Stufe `L` sichtbar,
+auch wenn der heutige Sicherheits-Filter `MIN_SMS_LEVEL=3` GELB-Warnungen
+weiterhin nicht per SMS verschickt (dieser Filter ist unverändert, nur die
+DARSTELLUNG einer tatsächlich verschickten Warnung ändert sich).
+
+## 5. Kollisions-Bereinigung
+
+Zwei im Ist-Vokabular gefundene Symbol-Kollisionen (Details: Ist-Vokabular-
+Inventur, Kommentare in #1948):
+
+**Kollision 1 — `TH`/`FL`/`W`/`CL` doppelt belegt in zwei getrennten
+Registern** (Wetter-Register `metric_catalog.py` vs. Gefahren-Register
+`hazard_symbols.py`), mit unterschiedlicher Bedeutung je Register (z. B.
+Wetter-`FL` = gefühlte Tiefsttemperatur vs. Warn-`FL` = Hochwasser).
+
+| Option | Beschreibung |
+|---|---|
+| **1 — Gefahren-Register auf Wetter-Register-Kürzel umstellen, wo eine Entsprechung existiert** | `thunderstorm` trägt bereits `TH` in beiden Registern (keine Änderung nötig für Gewitter, das Zielbild-Beispiel); für `flood`/`wind_gust`/`access_ban` müsste ein NEUES, kollisionsfreies Kürzel gefunden werden — das widerspricht „keine neuen Codes" teilweise, wäre aber auf die drei Kollisionsfälle begrenzt |
+| **2 — Kollision bewusst stehen lassen, weil beide Register nie in derselben Token-Position auftreten** | Wetter-Kürzel stehen immer im Δ-/Briefing-Kontext, Gefahren-Kürzel immer nach dem `!`-Präfix (Briefing) bzw. im AMT-Block (heute) — Kontext macht die Bedeutung eindeutig, auch wenn das Zeichen gleich ist |
+| **3 — Nur die im Zielbild TATSÄCHLICH zusammentreffenden Kürzel bereinigen** (aktuell nur `TH`, das aber schon identisch ist) | kleinster Eingriff, verschiebt die Bereinigung der übrigen Kollisionen auf einen Zeitpunkt, an dem sie tatsächlich im selben Format zusammentreffen |
+
+**Kollision 2 — Symbol `!` positionsabhängig zweideutig**: Zweig a
+Corridor-Token `!{code}{wert}` (`!` VOR dem Code, z. B. `!G55`) vs. Zweig c
+Onset-Token `{code}!{minuten}` (`!` NACH dem Code, z. B. `TH!8`).
+
+| Option | Beschreibung |
+|---|---|
+| **1 — löst sich durch das Zielbild selbst auf** | Zweig c wechselt laut Zielbild (Abschnitt 1) von `TH!{minuten}` auf `TH@{Uhrzeit}` — das `!`-Symbol verschwindet aus Zweig c vollständig, die Kollision entfällt ohne eigene Entscheidung |
+| **2 — zusätzlich Corridor-Token (Zweig a) umbenennen** | falls der PO das verbleibende `!` in `!G55` (reiner Grenzwert-Alarm, kein Δ-Vergleich) ebenfalls für missverständlich hält — bislang keine PO-Beschwerde dazu vorliegend |
+
+**Empfehlung des Planers (keine Bindung):** Kollision 2 löst sich durch das
+ohnehin beschlossene Nowcast-Zielbild von selbst — keine gesonderte
+Entscheidung nötig. Kollision 1 ist am Zielbild-Beispiel (nur `TH` betroffen)
+bereits kollisionsfrei; Option 3 vermeidet, ungefragt neue Kürzel für Fälle
+einzuführen, die noch nicht zusammentreffen.
+
+## 6. Verhältnis zu #1929 — PO-Entscheidung: mitlaufen lassen (Option 1)
+
+#1929 (läuft aktuell separat, ändert `official_alerts.py:1896-2104`,
+`_tag_time`/`render_official_alert_sms`, Spec freigegeben, TDD-RED-Stand laut
+letztem Stand) baut eine Korrektur INNERHALB des heutigen amtlichen
+Sonderformats (Minuten-Suffix, Kalendertag im Ganztags-Token). Dieses Konzept
+ersetzt das gesamte amtliche SMS-Format perspektivisch (Abschnitt 1, Zweig b).
+
+| Option | Beschreibung | Konsequenz |
+|---|---|---|
+| **1 — #1929 zuerst ausliefern, danach umbauen** | #1929 liefert seinen kleinen, bereits spezifizierten Fix aus; Scheibe „Zweig b Zielbild" (Abschnitt 8) baut danach auf dem #1929-korrigierten `_tag_time` auf, soweit dessen Grundlogik (Zeitfenster-Berechnung, nicht die Darstellung) weiterverwendet wird | kein verlorener Aufwand — #1929 behebt einen Datenkorrektheits-Bug (Melde-Zeitraum ≠ Anzeige-Zeitraum), unabhängig vom Anzeigeformat |
+| **2 — PO stoppt #1929, Zweig-b-Zielbild-Scheibe übernimmt beides** | vermeidet, `official_alerts.py` zweimal kurz hintereinander anzufassen | die #1929-Sitzung hat bereits Spec + TDD-RED-Vorarbeit investiert, die verfallen würde; #1929 behebt zusätzlich einen Bug, der unabhängig vom Format besteht (falsche Zeitraum-Zuordnung bleibt bestehen, wenn nur gewartet wird) |
+
+**PO-Entscheidung Runde 4 (formal bestätigt): Option 1 — #1929 läuft
+mit.** #1929 liefert seinen Fix an der Zeitraum-BERECHNUNG aus, bevor Zweig-b-
+Zielbild-Scheibe (Abschnitt 8, S5) die DARSTELLUNG umbaut — kein verlorener
+Aufwand, kein Doppel-Zugriff auf dieselben Zeilen zur gleichen Zeit.
+
+## 7. Wiederholungs-Signal — gestrichen (PO-Entscheid, zur Dokumentation)
+
+Frühere Konzept-Fassungen sahen ein sichtbares „neu/wiederholt"-Signal in der
+Nachricht vor (frühere Kommentare in #1948, Scheibe S4). PO-Entscheid Runde 3:
+**gestrichen.** Begründung: reine Wiederholungen werden bereits heute nie
+gesendet (Entprellung/Dedup existiert in allen drei Zweigen, s.
+Ist-Vokabular-Inventur). Jede tatsächlich gesendete Nachricht IST per
+Definition eine Änderung und zeigt das bereits über ihren Inhalt (z. B.
+`M>H` — der Stufensprung selbst ist der Beweis der Neuigkeit). Eine doppelte,
+inhaltlich identische Zustellung wäre ein Bug, kein normaler Fall — dessen
+Nachweis führt das Debug-Protokoll aus Scheibe S1 (Abschnitt 8), nicht ein
+zusätzliches Nachrichten-Element. Damit: **kein neu erfundenes Element** in
+diesem Konzept, wie vom PO gefordert.
+
+## 8. Scheiben-Reihenfolge — PO-Entscheidung Runde 4: Debug zuerst
+
+> **PO-Vorgabe, wörtlich:** „Debug ist der erste Schritt, um schon mal Daten
+> zu sammeln." Die Reihenfolge ist damit NICHT mehr „schnellster sichtbarer
+> Fix zuerst", sondern **Beobachtbarkeit vor Korrektur**.
+
+**Leitprinzip (als Satz ins Dokument, gilt für S3 und alle Folgescheiben):**
+Jede Format-Scheibe ab S3 wird mit ECHTEN, in S1 aufgezeichneten Meldungen
+verifiziert, die über S2 (Testmeldungs-Einspeisung) reproduzierbar in die
+Renderer eingespeist werden — nicht nur mit von Hand konstruierten Fixtures.
+S1 liefert die Rohdaten, S2 den Einspeisungsweg, S3+ nutzen beides als
+Verifikations-Grundlage zusätzlich zu den üblichen Unit-Tests.
+
+| # | Inhalt | Umfang | Status |
+|---|---|---|---|
+| **S1 — Debug-Eingangs-Protokoll** | Rollierendes Protokoll des rohen Eingangszustands aller drei Alarm-Zweige. Einhängepunkte: Zweig b (amtlich) **direkt am API-Eingang** `warn_egress.cached_fetch` (`geosphere_warn.py:99`, deckt GeoSphere+MeteoAlarm+DPC); Zweig a (Δ) nach der Delta-Berechnung, vor `_send_alert` (`trip_alert.py`, ~Zeile 352); Zweig c (Nowcast) vor `_derive_result` (`radar_service.py`, ~Zeile 167-210). Retention-Vorlage `WeatherSnapshotService._prune_dated_snapshots` (`weather_snapshot.py:165`). Antwort auf #1458 E6/B3. Details: neue Spec, Abschnitt „Nächster Schritt" unten. | 3-4 Dateien | **spec-bereit, nächster Schritt** |
+| **S2 — Testmeldungs-Einspeisung** | `/api/trips/{trip_id}/alert-preview` um dritten Payload-Typ (amtliche Warnung) erweitern, analog `OnsetPayload`/`ChangePayload`. Nutzt S1-Aufzeichnungen als Eingabequelle für reproduzierbare Testläufe. | 2-3 Dateien | folgt S1 |
+| **S3 — SMS-Sofortfix** | Δ-Alarm-SMS (Zweig a): Vergleichszeitpunkt-Präfix (`@HH:MM`) komplett aus dem Kopf entfernen (löst #1948-Auslöser-Bug UND #1939 strukturell, s. Abschnitt 1); `->`-Notation ohne Vorzeichen-Präfix einführen (Abschnitt 3); `LEVELS`-Stufenbuchstaben in `_sms_token()` verdrahten. **Ersetzt die alte, jetzt obsolete Spec `fix_1948_1939_alarm_sms_referenzzeitpunkt.md` vollständig** — deren Notations-ACs (`@HH:MM`-Umformulierung) sind durch „entfernen statt umformulieren" überholt. Verifiziert an ECHTEN S1-Aufzeichnungen sobald verfügbar (Leitprinzip oben), sonst an Fixtures. | 1 Datei + Tests | folgt S1/S2 |
+| **S4 — Zweig-c-Zielbild (Nowcast)** | `_render_sms_onset` auf `format_alert_location`/`_km_str`-Kopf umstellen, Token von `TH!{min}` auf `TH@{onset_time}` (Feld existiert bereits, Regel 5). Löst Kollision 2 (Abschnitt 5) nebenbei auf. **Leitplanke (aus #1599, Prod `ba1bec92`):** `src/app/day_window.py` trennt bewusst Alarm-Fenster (Alarm-Randstunde 19-20 Uhr wird bewertet) von Anzeige-Fenster (`display_end_time()` nimmt die Alarm-Zusatzstunde für Stundentabelle/Kopfzeilen/Kurzformen zurück, bewacht durch `tests/unit/test_ziel_segment_anzeige_invarianz.py` AC-10–18). Ein Umbau der Kurzform-Ausgabe darf die Alarm-Randstunde NICHT in die Anzeige ziehen — `display_end_time()` ist die Trennstelle. | 1 Datei + Tests | folgt S3 |
+| **S5 — Zweig-b-Zielbild (amtlich)** | `render_official_alert_sms` auf gemeinsamen Kopf umstellen, Warnstufen-Mapping Option 1 (Abschnitt 4) verdrahten, Wochentag-Regel (Regel 2) ergänzen, kein Trip-Präfix mehr (Regel 1). Startet NACH #1929 (Abschnitt 6, PO-Entscheid: mitlaufen lassen). | 1-2 Dateien + Tests | folgt #1929-Auslieferung |
+| **S6 — Telegram-Parität** | Prüfen, ob Telegram nach Wegfall des SMS-Vergleichszeitpunkts (S3) noch einen eigenen Angleich braucht — offene Detailfrage, s. u. | klein | folgt S3 |
+| **S7 — E-Mail-Struktur (#1737)** | Δ-Alarm-E-Mail auf Briefing-Stundenzeile/Stufen-Darstellung umstellen. Eigene, größere Initiative, NICHT Teil dieses Dokuments im Detail — nur als Folge-Scheibe vorgemerkt. | größer, eigene Spec | eigenständig |
+
+**Offene Detailfrage für S6 (nicht vom PO entschieden, da erst durch S3
+entstanden):** Bisher war „Telegram zeigt `reference_at` gar nicht, E-Mail
+zeigt ihn als vollständigen Satz" eine Paritäts-Lücke. Da S3 den
+Vergleichszeitpunkt jetzt auch aus der SMS entfernt (Abschnitt 1), ist offen,
+ob Telegram (a) dem NEUEN SMS-Verhalten folgt (auch keinen
+Vergleichszeitpunkt mehr zeigt) oder (b) beim E-Mail-Verhalten bleibt
+(voller Satz, da Telegram kein Zeichenlimit hat). Wird in der S6-Spec als
+Entscheidungsfrage vorgelegt, nicht hier vorentschieden.
+
+**Entfallen aus dem vorherigen Konzept-Stand:** die separate „Frage 1 /
+Wiederholungs-Signal"-Scheibe (jetzt Abschnitt 7, gestrichen).
+
+## 9. Bauteile-Inventur — was existiert, was fehlt (Zusammenfassung)
+
+| Baustein | Existiert? | Fundstelle |
+|---|---|---|
+| `LEVELS`-Stufenbuchstaben (`-`/`L`/`M`/`H`) | ✅ existiert, ungenutzt in `_sms_token()` | `output/tokens/metrics.py:14` |
+| `format_alert_location`/`_km_str`-Kopf | ✅ existiert für Zweig a, fehlt für b/c | `render.py:787` |
+| `OnsetEvent.onset_time` (konkrete Uhrzeit) | ✅ existiert, ungenutzt in `_render_sms_onset` | `model.py:41`, genutzt in `render.py:227,282,330` |
+| Segment-Projektion amtlicher Warnungen | ✅ existiert für Trip, fehlt für Compare (zurückgestellt) | `trip_alert.py:1570-1596`, `official_alerts.py:2120-2179` |
+| Wetter-Register (`TH:` etc.) | ✅ existiert, EIN Quell-Ort | `metric_catalog.py` |
+| Gefahren-Register (`TH` ohne Doppelpunkt) | ✅ existiert, GETRENNTER Quell-Ort | `hazard_symbols.py` |
+| Warnstufen→Buchstaben-Mapping | ❌ existiert nicht, PO-Entscheidung Option 1 liegt vor | — (Abschnitt 4) |
+| Notation für Von-Bis-Änderung | ✅ entschieden: `->` ohne Vorzeichen-Präfix | Abschnitt 3 |
+| Debug-Eingangs-Protokoll (alle 3 Zweige) | ❌ existiert nicht, Mount-Points identifiziert | Abschnitt 8, S1 |
+
+## Konzept-Historie
+
+- 2026-08-17: v1/v2 (Kommentare in #1948) — Wurzelbefund, Issue-Landkarte,
+  Positionierung zu #1458.
+- 2026-08-17: S1-Spec `fix_1948_1939_alarm_sms_referenzzeitpunkt.md`
+  geschrieben, danach vom PO pausiert (Grundsatzrunde gefordert).
+- 2026-08-17: Ist-Vokabular-Inventur (Kommentare in #1948).
+- 2026-08-17: v3 (dieses Dokument) — Leitsatz „Format folgt dem Phänomen",
+  Notations-Studie, Warnstufen-Mapping und Kollisions-Bereinigung als
+  Entscheidungsfragen, Wiederholungs-Signal gestrichen.
+- 2026-08-17: PO-Runde 4 — alle Entscheidungsfragen beantwortet: Notation
+  `->` ohne Vorzeichen-Präfix, Warnstufen-Mapping Option 1, #1929 läuft mit,
+  Vergleichszeitpunkt entfällt aus der SMS vollständig, Scheiben-Reihenfolge
+  auf „Debug zuerst" umgestellt (S1 Debug-Protokoll, S2 Testmeldungs-
+  Einspeisung, S3 SMS-Sofortfix, S4+ Format-Konsolidierung je Zweig).
+  Ergänzungen #1493-Sitzung: `@`-Regel (Regel 5), Briefing-SMS als lebende
+  Referenz-Implementierung, Aufgabenteilung zu #1458 dokumentiert. Dokument
+  gilt als freigegeben; alte S1-Spec obsolet markiert.

--- a/docs/context/feat-1948-eingangsprotokoll.md
+++ b/docs/context/feat-1948-eingangsprotokoll.md
@@ -1,0 +1,53 @@
+# Context: feat-1948-eingangsprotokoll (Scheibe 1 aus #1948)
+
+**Issue:** #1948 · **Scheibe:** S1 Debug-Eingangs-Protokoll (PO-Reihenfolge: „Daten sammeln ist der erste Schritt")
+**Konzept (PO-freigegeben, alle Entscheidungen gefallen):** `docs/analysis/alarm-format-konzept-2026-08.md`
+
+## Was gebaut wird
+
+Rollierendes Protokoll des ROHEN Eingangszustands jeder verarbeiteten Alarm-Meldung, für alle
+drei Alarm-Zweige — damit nachvollziehbar wird, aus welchen Eingangsdaten welche Nachricht
+wurde (PO-Befund: der API-Eingang wird heute nirgends geloggt), und damit Scheibe 2
+(Testmeldungs-Einspeisung) echte aufgezeichnete Meldungen wiedereinspielen kann.
+
+## Einhängepunkte je Zweig (aus der Ist-Inventur, verifiziert)
+
+| Zweig | Einhängepunkt | Fundstelle |
+|---|---|---|
+| (a) Δ-Alarm | nach Delta-Berechnung, vor `_send_alert` | `src/services/trip_alert.py` (~Z. 352) |
+| (b) amtliche Warnung | HTTP-Layer `warn_egress.cached_fetch` — deckt GeoSphere+MeteoAlarm+DPC | `src/services/official_alerts/geosphere_warn.py:99`; letzter Roh-Payload `:167` |
+| (c) Nowcast | vor `_derive_result` | `src/services/radar_service.py` (~Z. 167–210) |
+
+## Bestehende Bausteine (erweitern, NICHT neu bauen)
+
+- `src/services/alert_log.py` (#1459): geteiltes ENTSCHEIDUNGS-Protokoll aller drei Zweige
+  (`reason` ∈ forecast_change/nowcast/official_alert). Lücke: kein Eingangszustand.
+  → Eingangs-Protokoll als Begleit-Log, verknüpfbar mit dem `alert_log`-Eintrag (Kern des
+  PO-Wunsches: Eingang ↔ Ausgang zuordenbar).
+- Retention-Vorlage: `WeatherSnapshotService._prune_dated_snapshots`
+  (`src/services/weather_snapshot.py:154/165` — behält 7, sortiert `st_mtime`).
+
+## Constraints (PFLICHT)
+
+- Multi-User: Ablage unter `data/users/<user_id>/…`, niemals `"default"`-Fallback.
+- Keine Secrets/Tokens im Mitschnitt.
+- Observability: neuer Schreiber braucht `last_run`-Sichtbarkeit (CLAUDE.md-Regel).
+- #1944 geht in dieser Scheibe auf (Kommentar dort existiert). #1929 läuft parallel
+  (`official_alerts.py:1896-2104` nicht anfassen — hier ohnehin nicht nötig).
+- Ortsvergleich zurückgestellt — Compare-Zweige nur mitschneiden, wenn es über dieselben
+  geteilten Dienste ohne Zusatzaufwand mitfällt; kein Compare-spezifischer Bau.
+
+## Affected Files (erwartet)
+
+- NEU: `src/services/alert_input_capture.py` (o. ä. — Name folgt Verhalten)
+- `src/services/trip_alert.py` (Einhängung a)
+- `src/services/official_alerts/geosphere_warn.py` (Einhängung b, `warn_egress`-Naht)
+- `src/services/radar_service.py` (Einhängung c)
+- Tests (neu, deterministischer Kern)
+
+## Analyse-Kurzfassung (Phase 2)
+
+Wurzelbefund und Gesamtbild stehen im Konzept-Dokument (§1–§9): drei unabhängig gewachsene
+Zweige ohne gemeinsame Beobachtbarkeit; `alert_log` protokolliert Entscheidungen, niemand
+protokolliert Eingänge; Einspeisung (S2) braucht die Aufzeichnungen aus dieser Scheibe.
+Historie der PO-Entscheidungen: Issue #1948, Kommentare vom 2026-08-17.

--- a/docs/features/architecture.md
+++ b/docs/features/architecture.md
@@ -425,6 +425,27 @@ Scheibe 3 (#1170). Scheduler: `POST /api/scheduler/compare-alert-checks`, Go-Cro
      `src/output/renderers/email/compare_html.py`, Slice 7) — darf nur einmal implementiert sein.
      Diese Anzeige-Markierung ist von der oben beschriebenen Alarm-Abschaltung unberührt.
 
+8. **Alarm-Eingangsprotokoll (Issue #1948 Scheibe S1)**
+   - Rollierendes Begleit-Log des ROHEN Eingangszustands jeder Alarm-Meldung
+     (`src/services/alert_input_capture.py`), zusätzlich zum bestehenden
+     Entscheidungs-Log `alert_log.py` (#1459) — reines Beobachtungs-Feature, kein
+     Versand-/Format-Verhalten geändert.
+   - Drei Mount-Punkte: Zweig a (Δ-Alarm, vor `_send_alert` in `trip_alert.py`,
+     nutzerskopiert) · Zweig b (amtliche Warnung, `official_alerts/warn_egress.py::cached_fetch`,
+     System-Ablage) · Zweig c (Radar-Nowcast, vor `_derive_result` in
+     `radar_service.py::get_nowcast`, System-Ablage).
+   - Persistenz: `data/users/<user_id>/alert_input/` (Zweig a) bzw.
+     `data/debug/alert_input/<branch>/` (Zweig b/c, bewusst außerhalb `data/users/` —
+     an diesem Mount-Punkt koordinaten-, nicht nutzerskopiert). Retention 50 Dateien
+     je Ablage-Verzeichnis (Vorlage `WeatherSnapshotService._prune_dated_snapshots`),
+     fail-open (Schreibfehler loggt nur eine Warnung, blockiert nie den Alarmversand).
+   - Korrelation zum Entscheidungs-Eintrag über ein neues, additives, optionales
+     `capture_id`-Feld in `alert_log.append_entry`/`append_suppressed_entry`: Zweig a
+     reicht die `capture_id` direkt durch, Zweig c löst sie per Zeitfenster-Lookup
+     (`latest_capture_id()`) auf; für Zweig b ist die Korrelation in S1 zurückgestellt
+     (an der Aufrufstelle liegt kein provider-spezifischer Cache-Schlüssel vor).
+   - Spec: `docs/specs/modules/alarm_eingangsprotokoll.md`.
+
 **Datenfluss:**
 ```
 check_and_send_alerts(trip, cached_weather)
@@ -461,7 +482,7 @@ send_one_compare_preset() [scheduler_dispatch_service.py, nach Report-Versand]
 
 **Mandantentrennung:** `AlertStateService(user_id=...)`, `TripAlertService(user_id=...)` laden/speichern strikt unter `data/users/{user_id}/alert_state/` resp. `data/users/{user_id}/radar_alert_throttle.json`.
 
-Siehe: `docs/features/issue-816-alert-deviation-core.md`, `docs/specs/_archive/modules/issue_816_alert_deviation_core.md`, `docs/specs/_archive/modules/issue_822_radar_nowcast_segment.md`, `docs/specs/_archive/modules/issue_883_acute_danger_override.md`
+Siehe: `docs/features/issue-816-alert-deviation-core.md`, `docs/specs/_archive/modules/issue_816_alert_deviation_core.md`, `docs/specs/_archive/modules/issue_822_radar_nowcast_segment.md`, `docs/specs/_archive/modules/issue_883_acute_danger_override.md`, `docs/specs/modules/alarm_eingangsprotokoll.md`
 
 ---
 

--- a/docs/specs/modules/alarm_eingangsprotokoll.md
+++ b/docs/specs/modules/alarm_eingangsprotokoll.md
@@ -1,0 +1,236 @@
+---
+entity_id: alarm_eingangsprotokoll
+type: feature
+created: 2026-08-17
+updated: 2026-08-17
+status: draft
+workflow: feat-1948-eingangsprotokoll
+version: "1.0"
+tags: [alarm, observability, debug]
+---
+
+# Alarm-Eingangsprotokoll (Scheibe S1, Issue #1948)
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Rollierendes Protokoll des ROHEN Eingangszustands jeder verarbeiteten Alarm-Meldung, für alle
+drei Alarm-Zweige (a = Δ-Alarm, b = amtliche Warnung, c = Radar-Nowcast). Heute protokolliert
+`alert_log.py` (#1459) nur die ENTSCHEIDUNG/den Versand — der Eingang, aus dem diese Entscheidung
+entstand, wird nirgends festgehalten (PO-Befund: "der Eingangskanal wird schlicht nirgends
+geloggt"). Diese Scheibe schließt genau diese Lücke als Begleit-Log und liefert damit erstens die
+Beweisgrundlage, um künftige Format-Beschwerden nachzuvollziehen (Antwort auf Epic #1458 E6/B3),
+und zweitens die Rohdaten-Quelle für Scheibe S2 (Testmeldungs-Einspeisung über `alert-preview`).
+
+## Source
+
+- **File:** `src/services/alert_input_capture.py` (NEU)
+- **Identifier:** `def capture_user_scoped(...)`, `def capture_system(...)`, `def latest_capture_id(...)`
+
+> Schicht: Python-Core (`src/services/`) — kein Go-/Frontend-Anteil in dieser Scheibe.
+
+## Estimated Scope
+
+- **LoC:** ~200-235 (produktiv; eng am 250-LoC-Ziel der Scheibe, Tests separat)
+- **Files:** 5 Code-Dateien (1 neu, 4 geändert) + 6-8 Testdateien
+- **Effort:** medium
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `src/services/alert_log.py` (#1459) | module | Bekommt einen additiven, optionalen `capture_id`-Parameter in `append_entry`/`append_suppressed_entry` — Korrelations-Anker vom Entscheidungs-Eintrag zum Eingangs-Datensatz |
+| `src/services/weather_snapshot.py::WeatherSnapshotService._prune_dated_snapshots` | module | Retention-Vorlage: Datei-je-Ereignis, `glob`-Muster, sortiert nach `st_mtime`, älteste zuerst gelöscht |
+| `src/services/trip_alert.py` | module | Mount-Punkt Zweig a; Korrelations-Lookup für Zweig b/c an den bestehenden `alert_log`-Aufrufstellen |
+| `src/services/official_alerts/warn_egress.py::cached_fetch` | module | Mount-Punkt Zweig b — geteilter HTTP-Layer aller amtlichen Warnquellen |
+| `src/services/radar_service.py::RadarService.get_nowcast` | module | Mount-Punkt Zweig c |
+| `app.loader.get_data_dir`/`VALID_USER_ID_RE` | module | Nutzerskopierte Ablage für Zweig a, gleiche `user_id`-Validierung wie bei `weather_snapshots` |
+
+## Implementation Details
+
+### Drei Mount-Punkte (verifiziert am Code, Stand 2026-08-17)
+
+| Zweig | Mount-Punkt | Fundstelle | Skopiert? |
+|---|---|---|---|
+| **a — Δ-Alarm** | nach Aufbau der Änderungsliste `to_report` (nicht leer), vor `self._send_alert(...)` | `src/services/trip_alert.py`, ~Z. 333-352 | trip-/nutzerskopiert (`self._user_id`, `trip.id` liegen bereits vor) |
+| **b — amtliche Warnung** | innerhalb `cached_fetch()`, an der bestehenden Ausführungsstelle des optionalen `on_response`-Hooks (nach dem echten, nicht gecachten HTTP-Response, vor `parse_fn`) | `src/services/official_alerts/warn_egress.py`, ~Z. 296-360 | **nicht** skopiert — `cached_fetch` ist ein geteilter, koordinaten-scoped Cache über 8 Provider (GeoSphere, MeteoAlarm, DPC, …), kein `user_id`/`trip_id` im Kontext |
+| **c — Nowcast** | vor beiden Aufrufen von `self._derive_result(...)` in `get_nowcast()` (Cache-Hit-Zweig UND Cache-Miss-Zweig) | `src/services/radar_service.py`, Z. 199 und Z. 212 | **nicht** skopiert — `RadarService` cached nach `(lat, lon, region)`, kein `user_id`/`trip_id` im Kontext |
+
+**Abweichung von der ursprünglichen Datei-Angabe (bewusst, mit Team-Lead abgestimmt):** Der Auftrag
+nannte `geosphere_warn.py:99` als Mount-Punkt b. Die tatsächliche Naht liegt eine Ebene tiefer, in
+`warn_egress.cached_fetch()` selbst — dort laufen GeoSphere, MeteoAlarm UND DPC bereits durch
+dieselbe Funktion zusammen (`service`/`host`-Parameter je Aufrufer). Eine Mount-Stelle in
+`cached_fetch()` deckt alle drei Quellen mit EINER Code-Änderung ab; eine Mount-Stelle in
+`geosphere_warn.py` würde nur GeoSphere erfassen und müsste in `meteoalarm.py`/`dpc.py`/weiteren
+Providern dupliziert werden — das widerspricht der "deckt GeoSphere+MeteoAlarm+DPC"-Vorgabe aus
+dem Konzept (§8, S1-Zeile) und würde den Datei-/LoC-Rahmen sprengen. `official_alerts.py:1896-2104`
+(#1929-Sperrzone) wird durch diese Wahl nicht berührt — die neue Stelle liegt strukturell VOR
+diesem Code, im HTTP-Layer.
+
+### Speicherorte (Nutzer- vs. System-Ablage)
+
+- **Zweig a (nutzerskopiert):** `data/users/<user_id>/alert_input/forecast_change_<entity_type>_<entity_id>_<timestamp>.json`
+  — `user_id` kommt IMMER aus `self._user_id` des aufrufenden `TripAlertService`, nie ein
+  Default-Fallback (gleiche `VALID_USER_ID_RE`-Prüfung wie `get_data_dir`).
+- **Zweig b/c (System-Ablage, außerhalb `data/users/`):** `data/debug/alert_input/official_alert/…json`
+  bzw. `data/debug/alert_input/nowcast/…json`. **Begründung, warum das KEIN Verstoß gegen die
+  Mandantentrennungs-Regel ist:** (1) der PO will explizit den API-Eingang selbst protokolliert
+  haben — das ist die HTTP-/Cache-Naht, und die ist strukturell koordinaten-, nicht
+  nutzerskopiert; (2) die Rohdaten an dieser Stelle (amtlicher Warndienst-Response, Radar-Rohframes)
+  sind zu diesem Zeitpunkt KEINE Nutzerdaten — noch keinem Trip/User zugeordnet, keine
+  Empfängerinformation, keine Trip-Namen enthalten; (3) ein Verschieben des Mount-Punkts auf die
+  nutzerskopierte Ebene (z. B. erst nach der Trip-Zuordnung) würde genau den rohen Eingangszustand
+  verlieren, den die Scheibe einfangen soll — die Cache-Wiederverwendung über mehrere Trips hinweg
+  ginge dabei verloren oder würde dupliziert protokolliert.
+
+### Korrelierbarkeit (Pflicht-AC-2, Tech-Lead-Entscheid)
+
+- `alert_input_capture.py` generiert bei jedem Schreibvorgang eine `capture_id` (`uuid.uuid4().hex`,
+  gleiches Muster wie `alert_preset.py`) und schreibt sie in den Datensatz.
+- `alert_log.append_entry()`/`append_suppressed_entry()` bekommen einen neuen, additiven,
+  optionalen Parameter `capture_id: Optional[str] = None` (Bestandsschutz: alte Aufrufer und alte
+  Einträge bleiben unverändert, gleiche Additiv-Konvention wie `blocked_reason_codes`).
+- **Zweig a:** direktes Durchreichen — `capture_id` entsteht und wird verbraucht in derselben
+  Methode (`check_weather_alerts` in `trip_alert.py`), keine Zwischenschicht.
+- **Zweig b/c:** kein Durchreichen durch mehrere Funktionsebenen (würde `official_alerts.py`
+  und die Nowcast-Kette invasiv anfassen, teils in der #1929-Sperrzone). Stattdessen liefert
+  `alert_input_capture.py` eine Lesefunktion `latest_capture_id(branch, source_key, *, max_age)`,
+  die an der bestehenden `alert_log`-Aufrufstelle (Zweig b: `_send_official_alert_only`,
+  `trip_alert.py` ~Z. 1735; Zweig c: analoge Nowcast-Aufrufstelle mit `reason=REASON_NOWCAST`)
+  aus den dort bereits vorliegenden Koordinaten den passenden, jüngsten Eingangs-Datensatz
+  nachschlägt (Zeitfenster = Cache-TTL des jeweiligen Zweigs). Bei Cache-Wiederverwendung durch
+  mehrere Trips gleichzeitig können mehrere `alert_log`-Einträge korrekt auf dieselbe `capture_id`
+  verweisen — das ist beabsichtigt, kein Fehler.
+
+### Retention
+
+Vorlage `WeatherSnapshotService._prune_dated_snapshots` (`weather_snapshot.py:165`): pro
+Ablage-Verzeichnis (je Nutzer bei Zweig a, je Branch bei Zweig b/c) werden nach jedem Schreiben
+alle `*.json`-Dateien nach `st_mtime` sortiert; alles über die neuesten **50** hinaus wird gelöscht.
+50 statt der 7 aus der Vorlage, weil dieser Mitschnitt zweigübergreifend über mehrere Tage hinweg
+zur Fehleranalyse dienen soll (PO-Vorgabe "schon mal Daten sammeln"), nicht wie der Wetter-Snapshot
+nur den letzten Tagesvergleich sichert. Die Zahl ist eine begründete Anfangsschätzung, kein
+PO-fixierter Wert.
+
+### Fail-open
+
+Jeder Mount-Punkt umschließt den Schreibaufruf mit `try/except Exception`, loggt einen
+`logger.warning(...)` bei Fehlschlag und lässt den umgebenden Alarm-Fluss unverändert weiterlaufen
+— gleiches Muster wie `alert_log._append()` (kaputte Datei killt keinen Alarm) und
+`weather_snapshot.save_dated()` (Exception wird gefangen, Funktion kehrt früh zurück).
+
+### Keine Secrets
+
+Der Capture-Schreiber für Zweig b nimmt AUSSCHLIESSLICH den geparsten Response-Body plus
+`service`/`host`/Status entgegen — Request-Objekt, Header und Auth-Parameter werden an der
+Schreibstelle strukturell gar nicht erst übergeben (kein nachträglicher Filter nötig). Die
+amtlichen Warndienste (GeoSphere/MeteoAlarm/DPC) übertragen laut bestehendem Code ohnehin keine
+Zugangsdaten im Response-Body — die Ausschluss-Grenze liegt trotzdem an der Schnittstelle, nicht
+als Vertrauen in die Quelle.
+
+## Expected Behavior
+
+- **Input:** interne Aufrufe aus den drei bestehenden Alarm-Zweigen (kein neuer externer Endpoint).
+- **Output:** JSON-Dateien unter `data/users/<user_id>/alert_input/` (Zweig a) bzw.
+  `data/debug/alert_input/<branch>/` (Zweig b/c); optionales `capture_id`-Feld in neuen
+  `alert_log`-Einträgen.
+- **Side effects:** Dateisystem-Schreibzugriffe (fail-open), Log-Zeilen bei Erfolg (`debug`) und
+  Fehlschlag (`warning`). Kein Versandverhalten ändert sich — reines Beobachtungs-Feature.
+
+## Test Plan
+
+Deterministischer Kern, keine Mock-Theater (echte Fixture-Läufe, `tmp_path`, bestehende
+Test-Seams wie `_frame_source`/`request_fn`-Injection statt `Mock()`/`patch()`). Testdateien nach
+Verhalten benannt, nicht nach Issue-Nummer.
+
+### Automated Tests (TDD RED)
+
+- [ ] `tests/unit/test_trip_alert_forecast_change_capture.py` — Zweig-a-Mount schreibt vor
+  `_send_alert` einen Eingangs-Datensatz mit den rohen Change-Werten. → AC-1
+- [ ] `tests/unit/test_warn_egress_capture.py` — `cached_fetch` schreibt bei echter (nicht
+  gecachter) Antwort einen System-Level-Datensatz mit rohem Body + Service/Host/Cache-Key. → AC-2
+- [ ] `tests/unit/test_radar_service_capture.py` — `get_nowcast` schreibt vor `_derive_result`
+  (Cache-Hit UND Cache-Miss) einen Datensatz mit den rohen Frames. → AC-3
+- [ ] `tests/unit/test_alert_log_capture_correlation.py` — `alert_log.append_entry`/
+  `append_suppressed_entry` mit `capture_id` schreiben das Feld; Alt-Einträge ohne das Feld
+  bleiben unverändert lesbar (Bestandsschutz). → AC-4
+- [ ] `tests/unit/test_alert_input_capture_retention.py` — bei >50 Dateien in einem
+  Ablage-Verzeichnis werden die ältesten bis auf 50 gelöscht (sortiert nach `st_mtime`). → AC-5
+- [ ] `tests/unit/test_alert_input_capture_tenancy.py` — zwei verschiedene `user_id`-Werte
+  erzeugen getrennte Verzeichnisse; kein `"default"`-Fallback in der Signatur möglich. → AC-6
+- [ ] `tests/unit/test_warn_egress_capture_no_secrets.py` — Header/Auth-Parameter werden der
+  Capture-Funktion strukturell nicht übergeben, landen daher nie in der Datei. → AC-7
+- [ ] `tests/unit/test_alert_input_capture_failopen.py` — ein fehlschlagender Schreibvorgang
+  (z. B. unschreibbares `tmp_path`-Verzeichnis) verhindert den Alarmversand NICHT, erzeugt nur
+  eine Log-Warnung, keine Exception nach oben. → AC-8
+- [ ] `tests/unit/test_alert_input_capture_payload_schema.py` — Feldnamen/-typen des
+  Zweig-a-Datensatzes gegen `ChangePayload`/`SegmentTimePayload` (`api/routers/validator.py`)
+  abgeglichen (Schema-/Attributvergleich, kein Dateiinhalt-Stringcheck). → AC-9
+
+## Acceptance Criteria
+
+- **AC-1:** Given ein Trip löst einen Δ-Alarm mit mindestens einer berichtenswerten Änderung aus, When `check_weather_alerts` die Änderungsliste gebildet hat und bevor `_send_alert` aufgerufen wird, Then liegt unter `data/users/<user_id>/alert_input/` ein Eingangs-Datensatz mit den rohen Änderungswerten (Metrik, alter/neuer Wert, Delta, Schwelle je Änderung).
+  - Test: echter Trip-Fixture-Lauf mit injiziertem `DeviationAlertEngine`-Ergebnis, Prüfung des tatsächlich geschriebenen Datei-Inhalts (kein Mock der Schreibfunktion selbst).
+
+- **AC-2:** Given ein amtlicher Warndienst wird über `warn_egress.cached_fetch` mit einer echten, nicht gecachten Antwort abgefragt, When die Antwort erfolgreich geparst wird, Then liegt ein System-Level-Eingangs-Datensatz mit dem rohen Response-Body sowie Service/Host/Cache-Key unter `data/debug/alert_input/official_alert/` — unabhängig davon, ob daraus später eine Warnung für irgendeinen Trip entsteht.
+  - Test: `cached_fetch` mit injiziertem `request_fn` (bestehendes Test-Seam) gegen eine reale Fixture-Antwort aufrufen, Datei-Inhalt gegen die Fixture prüfen.
+
+- **AC-3:** Given `RadarService.get_nowcast` liefert Frames aus einem Cache-Hit oder einem frischen Abruf, When die Methode `_derive_result` aufruft, Then existiert vorher ein System-Level-Eingangs-Datensatz mit denselben rohen Frames und der Quelle unter `data/debug/alert_input/nowcast/`.
+  - Test: `get_nowcast` mit injizierter `_frame_source` (bestehendes DI-Seam) für Cache-Hit UND Cache-Miss aufrufen, je einen Datensatz nachweisen.
+
+- **AC-4:** Given ein Eingangs-Datensatz wurde für eine später tatsächlich verschickte Alarm-Meldung erzeugt, When der zugehörige `alert_log`-Eintrag geschrieben wird, Then trägt dieser Eintrag ein `capture_id`-Feld, das auf genau diesen Eingangs-Datensatz verweist (Zweig a: direkt durchgereicht; Zweig b/c: über `latest_capture_id`-Lookup nach Branch, Quell-Schlüssel und Zeitfenster).
+  - Test: End-to-End innerhalb eines Zweigs (kein Cross-Branch) — geschriebener `alert_log`-Eintrag und der zuvor erzeugte Eingangs-Datensatz teilen dieselbe `capture_id`.
+
+- **AC-5:** Given mehr als 50 Eingangs-Datensätze liegen bereits in einem Ablage-Verzeichnis, When ein weiterer Datensatz in diesem Verzeichnis geschrieben wird, Then werden die ältesten Datensätze über die Grenze von 50 hinaus gelöscht (sortiert nach Änderungszeit, gleiche Mechanik wie `_prune_dated_snapshots`).
+  - Test: 55 reale Dateien in einem `tmp_path`-Verzeichnis vorbereiten, einen Schreibvorgang auslösen, genau 50 verbleibende, jüngste Dateien nachweisen.
+
+- **AC-6:** Given zwei verschiedene Nutzer A und B lösen unabhängig voneinander je einen Δ-Alarm für ihren eigenen Trip aus, When beide Eingangs-Datensätze geschrieben werden, Then liegt der Datensatz von A ausschließlich unter `data/users/<user_id_A>/alert_input/` und der von B ausschließlich unter `data/users/<user_id_B>/alert_input/`, und an keiner Aufrufstelle wird `"default"` als `user_id` verwendet.
+  - Test: zwei vollständig unterschiedliche `user_id`-Werte durch denselben Code-Pfad schicken, Verzeichnistrennung UND Signatur (Pflichtparameter ohne Default) nachweisen.
+
+- **AC-7:** Given ein Eingangs-Datensatz für Zweig b wird geschrieben, When der Datensatz anschließend gelesen wird, Then enthält er ausschließlich den geparsten Response-Body sowie Service/Host/Status — keine Request-Header, keine Auth-Parameter, kein API-Schlüssel, weil diese der Schreibfunktion strukturell gar nicht übergeben werden.
+  - Test: Signatur-/Verhaltenstest — Aufruf der Capture-Funktion mit einem Response-Objekt, das (testweise) einen Header trägt; Nachweis, dass der Header nicht in der geschriebenen Datei landet, weil die Funktion ihn nicht entgegennimmt.
+
+- **AC-8:** Given das Schreiben eines Eingangs-Datensatzes schlägt fehl (z. B. nicht beschreibbares Zielverzeichnis), When der jeweilige Alarm-Zweig weiterläuft, Then wird der Alarm trotzdem wie gewohnt verarbeitet und verschickt, und der Fehlschlag wird ausschließlich als Warnung geloggt, nie als Exception nach oben gereicht.
+  - Test: Zielverzeichnis für den Schreibvorgang absichtlich unschreibbar machen (`tmp_path`-Verzeichnis mit entzogenen Schreibrechten oder injizierter Fehlerquelle), Alarmversand-Erfolg UND Log-Warnung gemeinsam nachweisen.
+
+- **AC-9:** Given ein Eingangs-Datensatz für Zweig a, When seine Felder mit `ChangePayload`/`SegmentTimePayload` (`api/routers/validator.py`) verglichen werden, Then decken sie deren Pflichtfelder verlustfrei ab, sodass Scheibe S2 ihn ohne Transformation in `alert-preview` einspeisen kann; für Zweig c liegt am Mount-Punkt vor `_derive_result` nur der rohe Frame-Zustand vor (Feldabdeckung gegen `OnsetPayload` ist dokumentierte Limitation für S2, kein direktes 1:1-Mapping).
+  - Test: Feldnamen/-typen des Zweig-a-Datensatzes gegen die Pydantic-Modelldefinition abgleichen (kein Dateiinhalt-Stringcheck, sondern Schema-/Attributvergleich).
+
+## Known Limitations
+
+- Zweig b und Zweig c sind an ihrem vorgegebenen Mount-Punkt strukturell NICHT trip-/
+  nutzerskopiert (globaler Koordinaten-Cache) — Ablage bewusst außerhalb `data/users/`
+  (Tech-Lead-Entscheid, Begründung siehe Implementation Details). AC-6 gilt daher nur für Zweig a.
+- Korrelation für Zweig b/c ist ein Zeitfenster-/Schlüssel-Lookup, kein durch alle Zwischenschichten
+  durchgereichtes Argument — bei gleichzeitiger Cache-Nutzung durch mehrere Trips können mehrere
+  `alert_log`-Einträge korrekt auf dieselbe `capture_id` verweisen.
+- **Zweig-b-Korrelation ist in S1 zurückgestellt (PO-gebilligt, GREEN-Freigabe 2026-08-18):** Der
+  Mitschnitt für Zweig b funktioniert vollständig, aber der `alert_log`-Eintrag amtlicher Warnungen
+  trägt KEINE `capture_id` — an der Aufrufstelle `_send_official_alert_only` liegt keiner der fünf
+  provider-spezifischen Cache-Schlüssel vor (`OfficialAlert`-Objekte tragen weder Rohkoordinaten
+  noch `cache_key`), eine rekonstruierte Zuordnung würde meist ins Leere zeigen oder falsch
+  verlinken. AC-4 gilt daher für Zweig a (direkt) und Zweig c (Lookup); Zweig b folgt als
+  Folge-Ticket (z. B. `service`-Name als zweiter Lookup-Schlüssel in `capture_system`).
+- Ortsvergleich (Compare) wird in dieser Scheibe NICHT eigens mitgeschnitten — nur was über
+  dieselben geteilten Dienste (`warn_egress`, `RadarService`) ohnehin mitfällt. Ein
+  Compare-eigener Δ-Alarm-Mount-Punkt (analog Zweig a) ist NICHT Teil dieser Scheibe — bewusster
+  PO-Entscheid (Konzept, durchgehend zurückgestellt), kein Pendant-Verstoß und kein Versehen.
+- Retention-Grenze (50 Dateien) ist eine begründete Anfangsschätzung, kein PO-fixierter Wert.
+- `official_alerts.py:1896-2104` (#1929-Sperrzone) bleibt unangetastet.
+- Diese Scheibe ändert KEIN sichtbares Alarm-Format (SMS/E-Mail/Telegram bleiben bit-identisch) —
+  reines Beobachtungs-Feature für S1; die Format-Konsolidierung folgt in S3+.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Erweitert zwei bereits etablierte, dokumentierte Muster additiv (JSON-Read-Modify-
+  Write wie `alert_log.py`, Datei-Retention wie `weather_snapshot.py`) — keine neue
+  Persistenztechnologie, keine neue externe Abhängigkeit, keine Rücknahme einer bestehenden
+  Architekturentscheidung. Kein ADR-würdiger Grundsatzentscheid.
+
+## Changelog
+
+- 2026-08-17: Initial spec created (Scheibe S1 aus #1948, PO-Entscheidung Runde 4: "Debug zuerst").

--- a/src/services/alert_input_capture.py
+++ b/src/services/alert_input_capture.py
@@ -1,0 +1,162 @@
+"""Alarm-Eingangsprotokoll -- rollierender Mitschnitt des ROHEN
+Eingangszustands jeder verarbeiteten Alarm-Meldung (Issue #1948, Scheibe S1).
+
+Zweig a (Delta-Alarm): nutzerskopiert unter
+``data/users/<user_id>/alert_input/`` (``capture_user_scoped()``). Zweig b
+(amtliche Warnung)/c (Nowcast): System-Ablage unter
+``data/debug/alert_input/<branch>/`` (``capture_system()``), Korrelation
+mit ``alert_log`` ueber ``latest_capture_id()``.
+
+SPEC: docs/specs/modules/alarm_eingangsprotokoll.md (AC-1..AC-9)
+
+Fail-open (wie ``alert_log._append()``/``weather_snapshot.save_dated()``):
+jeder Schreibvorgang faengt ALLE Exceptions, loggt eine Warnung, gibt
+``None`` zurueck. Retention (Vorlage ``_prune_dated_snapshots``): pro
+Verzeichnis bleiben nach jedem Schreiben nur die 50 juengsten Dateien.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import re
+import time
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from app.loader import VALID_USER_ID_RE, get_data_dir, get_data_root
+
+logger = logging.getLogger("alert_input_capture")
+
+_MAX_FILES_PER_DIR = 50
+_UNSAFE_KEY_CHARS = re.compile(r"[^A-Za-z0-9_.-]+")
+
+
+def _safe_key(value: str) -> str:
+    """Macht einen beliebigen Quell-Schluessel dateinamen-tauglich."""
+    return _UNSAFE_KEY_CHARS.sub("_", str(value))[:80] or "key"
+
+
+def _prune(dir_path: Path) -> None:
+    """Behaelt nur die ``_MAX_FILES_PER_DIR`` juengsten ``*.json``-Dateien."""
+    files = sorted(dir_path.glob("*.json"), key=lambda p: (p.stat().st_mtime, p.name))
+    for old_file in files[:-_MAX_FILES_PER_DIR]:
+        try:
+            old_file.unlink()
+        except OSError as e:
+            logger.warning("alert_input_capture: Bereinigung fehlgeschlagen (%s): %s", old_file, e)
+
+
+def capture_user_scoped(
+    user_id: str,
+    *,
+    entity_type: str,
+    entity_id: str,
+    payload: dict,
+) -> Optional[str]:
+    """Zweig a. Datei: data/users/<user_id>/alert_input/forecast_change_
+    <entity_type>_<entity_id>_<timestamp>.json. ``user_id`` PFLICHT ohne
+    Vorgabewert (kein stiller "default"-Fallback, Pruefung wie
+    ``get_data_dir``). Rueckgabe: capture_id oder None (fail-open)."""
+    try:
+        if not VALID_USER_ID_RE.match(user_id):
+            raise ValueError(f"invalid user_id: {user_id!r}")
+        capture_id = uuid.uuid4().hex
+        now = datetime.now(timezone.utc)
+        record = {
+            "capture_id": capture_id,
+            "captured_at": now.isoformat(),
+            "entity_type": entity_type,
+            "entity_id": entity_id,
+            "payload": payload,
+        }
+        dir_path = get_data_dir(user_id) / "alert_input"
+        filename = (
+            f"forecast_change_{_safe_key(entity_type)}_{_safe_key(entity_id)}_"
+            f"{now.strftime('%Y%m%dT%H%M%S%f')}.json"
+        )
+        dir_path.mkdir(parents=True, exist_ok=True)
+        (dir_path / filename).write_text(json.dumps(record, indent=2))
+        _prune(dir_path)
+        return capture_id
+    except Exception as e:
+        logger.warning(
+            "alert_input_capture.capture_user_scoped fehlgeschlagen fuer "
+            "%s/%s (%s): %s", entity_type, entity_id, user_id, e,
+        )
+        return None
+
+
+def capture_system(
+    *,
+    branch: str,
+    source_key: str,
+    payload: dict,
+) -> Optional[str]:
+    """Zweig b/c. Datei: data/debug/alert_input/<branch>/<source_key>_
+    <timestamp>.json. Strukturell KEIN Header-/Request-/Auth-Parameter
+    (AC-7) -- der Aufrufer kann keine Zugangsdaten uebergeben, die diese
+    Funktion nicht entgegen nimmt. Rueckgabe: capture_id oder None
+    (fail-open)."""
+    try:
+        capture_id = uuid.uuid4().hex
+        now = datetime.now(timezone.utc)
+        record = {
+            "capture_id": capture_id,
+            "captured_at": now.isoformat(),
+            "branch": branch,
+            "source_key": source_key,
+            "payload": payload,
+        }
+        dir_path = get_data_root() / "debug" / "alert_input" / branch
+        filename = f"{_safe_key(source_key)}_{now.strftime('%Y%m%dT%H%M%S%f')}.json"
+        dir_path.mkdir(parents=True, exist_ok=True)
+        (dir_path / filename).write_text(json.dumps(record, indent=2))
+        _prune(dir_path)
+        return capture_id
+    except Exception as e:
+        logger.warning(
+            "alert_input_capture.capture_system fehlgeschlagen fuer %s/%s: %s",
+            branch, source_key, e,
+        )
+        return None
+
+
+def latest_capture_id(branch: str, source_key: str, *, max_age: float) -> Optional[str]:
+    """Juengste capture_id fuer (branch, source_key), nicht aelter als
+    max_age Sekunden -- Korrelations-Lookup fuer Zweig b/c (Zeitfenster =
+    Cache-TTL des jeweiligen Zweigs). None, wenn nichts passt (fail-open)."""
+    try:
+        dir_path = get_data_root() / "debug" / "alert_input" / branch
+        if not dir_path.exists():
+            return None
+        now = time.time()
+        best: tuple[float, str] | None = None
+        for f in dir_path.glob("*.json"):
+            try:
+                record = json.loads(f.read_text())
+            except (OSError, ValueError):
+                continue
+            if record.get("source_key") != source_key:
+                continue
+            captured_at = record.get("captured_at")
+            capture_id = record.get("capture_id")
+            if not captured_at or not capture_id:
+                continue
+            try:
+                captured_ts = datetime.fromisoformat(captured_at).timestamp()
+            except ValueError:
+                continue
+            age = now - captured_ts
+            if age < 0 or age > max_age:
+                continue
+            if best is None or captured_ts > best[0]:
+                best = (captured_ts, capture_id)
+        return best[1] if best else None
+    except Exception as e:
+        logger.warning(
+            "alert_input_capture.latest_capture_id fehlgeschlagen fuer %s/%s: %s",
+            branch, source_key, e,
+        )
+        return None

--- a/src/services/alert_log.py
+++ b/src/services/alert_log.py
@@ -156,6 +156,7 @@ def append_entry(
     reachable_channels: Optional[Iterable[str]] = None,
     below_threshold_channels: Optional[Iterable[str]] = None,
     blocked_reason_codes: Optional[dict[str, str]] = None,
+    capture_id: Optional[str] = None,
 ) -> None:
     """Haengt GENAU EINEN Eintrag an das Alarm-Protokoll des Nutzers an.
 
@@ -235,6 +236,8 @@ def append_entry(
             blocked_reason_codes,
         ),
     }
+    if capture_id is not None:  # additiv (#1948), Alt-Eintraege unveraendert
+        entry["capture_id"] = capture_id
 
     _append(user_id, "entries" if reachable else "not_delivered", entry)
 
@@ -262,6 +265,7 @@ def append_suppressed_entry(
     reason: str,
     gate_reason: str,
     effective_channels: Iterable[str],
+    capture_id: Optional[str] = None,
 ) -> None:
     """Haengt GENAU EINEN Eintrag fuer eine VOR dem Versand abgewiesene
     Meldung an (#1467 S3, Aenderung (d)).
@@ -310,7 +314,7 @@ def append_suppressed_entry(
     effective = set(effective_channels or ())
     if not effective:
         return
-    _append(user_id, "not_delivered", {
+    entry = {
         "entity_id": entity_id,
         "entity_type": entity_type,
         "sent_at": datetime.now(tz=timezone.utc).isoformat(),
@@ -327,7 +331,10 @@ def append_suppressed_entry(
             {"channel": channel, "reason": gate_reason}
             for channel in _ALL_CHANNELS if channel in effective
         ],
-    })
+    }
+    if capture_id is not None:  # additiv (#1948), siehe append_entry()
+        entry["capture_id"] = capture_id
+    _append(user_id, "not_delivered", entry)
 
 
 # ---------------------------------------------------------------------------

--- a/src/services/official_alerts/warn_egress.py
+++ b/src/services/official_alerts/warn_egress.py
@@ -33,6 +33,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Iterator, Optional
 
+from services import alert_input_capture
+
 logger = logging.getLogger("warn_egress")
 
 WARN_SUCCESS_TTL = 1800.0  # Sekunden — Erfolgs-Fenster (30 min, warngerecht)
@@ -383,6 +385,20 @@ def cached_fetch(
                 on_response(resp)
             except Exception:
                 pass  # Beobachtungshaken darf den Abruf NIE beeintraechtigen
+
+        # Issue #1948 (S1, AC-2/AC-7): roher Eingangs-Datensatz der ECHTEN
+        # Antwort -- nur geparster Body plus Service/Host/Cache-Key/Status,
+        # KEINE Header/Auth (strukturell nicht uebergeben).
+        try:
+            alert_input_capture.capture_system(
+                branch="official_alert", source_key=service,
+                payload={
+                    "body": resp.json(), "service": service, "host": host,
+                    "cache_key": cache_key, "status": resp.status_code,
+                },
+            )
+        except Exception as e:
+            log.warning("%s: Eingangs-Mitschnitt fehlgeschlagen (%s)", service, e)
 
         status = resp.status_code
         # S1c-Nachbesserung (Tageskontingent-Fund): ein Tageskontingent

--- a/src/services/radar_service.py
+++ b/src/services/radar_service.py
@@ -24,6 +24,8 @@ from pathlib import Path
 from typing import Callable, Optional
 from zoneinfo import ZoneInfo
 
+from services import alert_input_capture
+
 logger = logging.getLogger("radar_service")
 
 # RADOLAN bounding box (DE)
@@ -199,6 +201,7 @@ class RadarNowcastService:
         cached = self._cache.get(lat, lon, region, now=now)
         if cached is not None:
             self._budget_gate.record_cache_hit()
+            _capture_nowcast_frames(lat, lon, cached.frames, cached.source)
             return self._derive_result(cached.frames, cached.source, now=now)
 
         self._budget_gate.record_cache_miss()
@@ -212,6 +215,7 @@ class RadarNowcastService:
         if frames:
             self._cache.put(lat, lon, region, frames, source, now=now)
 
+        _capture_nowcast_frames(lat, lon, frames, source)
         return self._derive_result(frames, source, now=now)
 
     # Human-readable source labels (single source of truth — used by
@@ -643,3 +647,28 @@ def _region_bucket(lat: float, lon: float) -> str:
     if _within_icon_d2(lat, lon):
         return "icon_d2"
     return "global"
+
+
+def _nowcast_source_key(lat: float, lon: float) -> str:
+    """Korrelations-Schluessel fuer Zweig c (#1948, AC-4) -- dieselbe
+    Koordinaten+Region-Formel wie `RadarNowcastCacheService._key`, EINMAL
+    hier definiert fuer Schreib- (`get_nowcast`) und Lesepfad
+    (`trip_alert.py`-Lookup)."""
+    return f"{round(lat, 4)}_{round(lon, 4)}_{_region_bucket(lat, lon)}"
+
+
+def _capture_nowcast_frames(lat: float, lon: float, frames: list, source: str) -> None:
+    """Roher Eingangs-Datensatz VOR `_derive_result` (#1948, AC-3)."""
+    try:
+        alert_input_capture.capture_system(
+            branch="nowcast", source_key=_nowcast_source_key(lat, lon),
+            payload={
+                "source": source,
+                "frames": [
+                    {"timestamp": f.timestamp.isoformat(), "precip_mm_h": f.precip_mm_h}
+                    for f in frames
+                ],
+            },
+        )
+    except Exception as e:
+        logger.warning("radar_service: Eingangs-Mitschnitt fehlgeschlagen: %s", e)

--- a/src/services/trip_alert.py
+++ b/src/services/trip_alert.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING, List, Optional
 
 from app.config import Settings
 from app.models import SegmentWeatherData, WeatherChange
-from services import alert_channel_threshold, alert_daily_limit, alert_log
+from services import alert_channel_threshold, alert_daily_limit, alert_input_capture, alert_log
 from services.alert_briefing_anchor import record_alert_anchor_rejected
 import services.alert_urgency as alert_urgency
 from services.alert_gate import (
@@ -93,6 +93,20 @@ def _as_aware_utc(value: Optional[datetime]) -> Optional[datetime]:
     if value is not None and value.tzinfo is None:
         return value.replace(tzinfo=timezone.utc)
     return value
+
+
+def _change_to_capture_dict(change: WeatherChange) -> dict:
+    """Rohe Aenderungswerte im ChangePayload-Schema (#1948, AC-1/AC-9)."""
+    return {
+        "metric": change.metric,
+        "old_value": change.old_value,
+        "new_value": change.new_value,
+        "delta": change.delta,
+        "threshold": change.threshold,
+        "severity": change.severity.value,
+        "direction": change.direction,
+        "segment_id": change.segment_id,
+    }
 
 
 @dataclass(frozen=True)
@@ -335,6 +349,13 @@ class TripAlertService:
             f"Detected {len(to_report)} significant changes for trip {trip.id}"
         )
 
+        # Issue #1948 (S1, AC-1): roher Eingangs-Datensatz VOR dem Versand
+        # -- capture_user_scoped() ist selbst fail-open.
+        capture_id = alert_input_capture.capture_user_scoped(
+            self._user_id, entity_type="trip", entity_id=trip.id,
+            payload={"changes": [_change_to_capture_dict(c) for c in to_report]},
+        )
+
         # Issue #1916 (AC-1..AC-4): Referenz-Zeitpunkt der TATSAECHLICH
         # verglichenen Vergleichsbasis (nicht der aktuelle Abrufzeitpunkt) —
         # sichtbar im Alarm-Footer statt des generischen Texts.
@@ -377,6 +398,7 @@ class TripAlertService:
             reachable_channels=notif_result.sent_channels,
             below_threshold_channels=self._last_below_threshold_channels,
             blocked_reason_codes=notif_result.blocked_reason_codes,
+            capture_id=capture_id,
         )
         delivered = notif_result.sent
         if not delivered:
@@ -1328,6 +1350,13 @@ class TripAlertService:
             # `append_entry()` selbst (D4). `result` traegt hier bereits die
             # NotificationResult — die Nowcast-Auswertung steckt im Request.
             # `effective_channels` bleibt ROH (rote Linie #638).
+            # Issue #1948 (S1, AC-4): Korrelation ueber denselben
+            # Koordinaten-Schluessel wie get_nowcast() (Zeitfenster =
+            # Radar-Cache-TTL, 300s Default).
+            from services.radar_service import _nowcast_source_key
+            _nowcast_capture_id = alert_input_capture.latest_capture_id(
+                "nowcast", _nowcast_source_key(lat, lon), max_age=300.0,
+            )
             alert_log.append_entry(
                 self._user_id, entity_id=trip.id, entity_type="trip",
                 changes_count=1,
@@ -1341,6 +1370,7 @@ class TripAlertService:
                 reachable_channels=result.sent_channels,
                 below_threshold_channels=_radar_suppressed,
                 blocked_reason_codes=result.blocked_reason_codes,
+                capture_id=_nowcast_capture_id,
             )
             delivered = result.sent
             if not delivered:

--- a/tests/unit/test_alert_input_capture_failopen.py
+++ b/tests/unit/test_alert_input_capture_failopen.py
@@ -1,0 +1,92 @@
+"""TDD RED — Issue #1948 (Scheibe S1): ein fehlschlagender Capture-
+Schreibvorgang verhindert den Alarmversand NICHT (fail-open, gleiches
+Muster wie ``alert_log._append()``/``weather_snapshot.save_dated()``).
+
+SPEC: docs/specs/modules/alarm_eingangsprotokoll.md (AC-8)
+
+RED-Grund: ``services.alert_input_capture`` existiert nicht; der
+Delta-Alarm-Mount-Punkt in ``trip_alert.py`` ruft noch keinen
+Capture-Aufruf auf, kann also auch keinen Fehlschlag abfangen.
+
+Der Schreibfehler wird ueber einen echten Dateisystem-Konflikt erzwungen
+(eine reguläre Datei liegt dort, wo das Ablageverzeichnis entstehen
+muesste) -- kein Mock, kein Rechte-Trickser (portabel).
+"""
+from __future__ import annotations
+
+import logging
+
+from tests.helpers.alert_log_fixtures import (
+    fresh_user, gust_alert_trip, settings_email_only, weather,
+)
+
+
+def _service(user_id: str, sink: list):
+    from services.trip_alert import TripAlertService
+
+    return TripAlertService(
+        settings=settings_email_only(), user_id=user_id, throttle_hours=0,
+        mail_sink=lambda subject, body: sink.append((subject, body)),
+    )
+
+
+def test_ac8_kaputtes_capture_verzeichnis_verhindert_alarmversand_nicht(caplog):
+    """AC-8: GIVEN das Ablageverzeichnis fuer den Eingangs-Datensatz ist
+    strukturell blockiert (eine Datei liegt dort, wo ein Verzeichnis
+    entstehen muesste), WHEN der Delta-Alarm-Zweig weiterlaeuft, THEN wird
+    der Alarm trotzdem verschickt, und der Fehlschlag erscheint
+    ausschliesslich als Log-Warnung, nie als Exception nach oben."""
+    from app.loader import get_data_dir
+
+    uid = fresh_user("ac8-failopen")
+    data_dir = get_data_dir(uid)
+    data_dir.mkdir(parents=True, exist_ok=True)
+    # Blockiert: "alert_input" existiert bereits als DATEI, nicht als
+    # Verzeichnis -- ein echter, deterministischer Fehlschlag.
+    (data_dir / "alert_input").write_text("blockiert absichtlich (AC-8)")
+
+    trip = gust_alert_trip("trip-ac8-failopen")
+    mails: list = []
+
+    with caplog.at_level(logging.WARNING):
+        sent = _service(uid, mails).check_and_send_alerts(
+            trip, [weather(1, gust_max_kmh=20.0)],
+            fresh_weather=[weather(1, gust_max_kmh=60.0)],
+        )
+
+    assert sent is True and mails, (
+        "Der Alarm haette trotz kaputtem Capture-Verzeichnis versendet "
+        "werden muessen (fail-open) -- stattdessen wurde der Versand "
+        "verhindert."
+    )
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert warnings, (
+        "Der fehlgeschlagene Capture-Schreibvorgang haette als Log-Warnung "
+        "erscheinen muessen."
+    )
+
+
+def test_ac8_capture_user_scoped_selbst_wirft_bei_schreibfehler_nicht(caplog):
+    """AC-8 (direkter Unit-Nachweis): ``capture_user_scoped()`` selbst
+    faengt einen Schreibfehler ab, gibt ``None`` zurueck (statt zu werfen)
+    und loggt eine Warnung."""
+    from app.loader import get_data_dir
+    from services import alert_input_capture
+
+    uid = fresh_user("ac8-direct")
+    data_dir = get_data_dir(uid)
+    data_dir.mkdir(parents=True, exist_ok=True)
+    (data_dir / "alert_input").write_text("blockiert absichtlich (AC-8, direkt)")
+
+    with caplog.at_level(logging.WARNING):
+        result = alert_input_capture.capture_user_scoped(
+            uid, entity_type="trip", entity_id="direct-failopen",
+            payload={"changes": []},
+        )
+
+    assert result is None, (
+        f"Bei einem Schreibfehler muss None zurueckkommen (fail-open), "
+        f"erhalten: {result!r}"
+    )
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert warnings, "Kein Log-Warning bei fehlgeschlagenem Schreibvorgang."

--- a/tests/unit/test_alert_input_capture_payload_schema.py
+++ b/tests/unit/test_alert_input_capture_payload_schema.py
@@ -1,0 +1,71 @@
+"""TDD RED — Issue #1948 (Scheibe S1): Feldnamen/-typen des Zweig-a-
+Datensatzes decken ``ChangePayload`` (``api/routers/validator.py``)
+verlustfrei ab -- Schema-/Attributvergleich, kein Dateiinhalt-Stringcheck.
+
+SPEC: docs/specs/modules/alarm_eingangsprotokoll.md (AC-9)
+
+RED-Grund: ``services.alert_input_capture`` existiert nicht -- kein
+Eingangs-Datensatz zum Vergleichen.
+
+Der Typ-Nachweis laeuft ueber eine ECHTE Pydantic-Konstruktion von
+``ChangePayload`` aus den geschriebenen Feldern (kein reiner
+Namensabgleich) -- genau das, was Scheibe S2 ("ohne Transformation
+einspeisen") tatsaechlich braucht.
+"""
+from __future__ import annotations
+
+import json
+
+from api.routers.validator import ChangePayload
+
+from tests.helpers.alert_log_fixtures import (
+    fresh_user, gust_alert_trip, settings_email_only, weather,
+)
+
+
+def _service(user_id: str, sink: list):
+    from services.trip_alert import TripAlertService
+
+    return TripAlertService(
+        settings=settings_email_only(), user_id=user_id, throttle_hours=0,
+        mail_sink=lambda subject, body: sink.append((subject, body)),
+    )
+
+
+def test_ac9_zweig_a_change_felder_decken_changepayload_verlustfrei_ab():
+    """AC-9: GIVEN ein Eingangs-Datensatz fuer Zweig a wurde geschrieben,
+    WHEN seine ``changes``-Eintraege mit ``ChangePayload`` verglichen
+    werden, THEN deckt jeder Eintrag ALLE Pflichtfelder von
+    ``ChangePayload`` ab, mit kompatiblem Typ -- Scheibe S2 kann ihn ohne
+    Transformation in ``alert-preview`` einspeisen."""
+    from app.loader import get_data_dir
+
+    uid = fresh_user("ac9-schema")
+    trip = gust_alert_trip("trip-ac9-schema")
+    mails: list = []
+
+    sent = _service(uid, mails).check_and_send_alerts(
+        trip, [weather(1, gust_max_kmh=20.0)],
+        fresh_weather=[weather(1, gust_max_kmh=60.0)],
+    )
+    assert sent is True and mails
+
+    files = sorted((get_data_dir(uid) / "alert_input").glob("*.json"))
+    assert files, (
+        "Kein Eingangs-Datensatz geschrieben -- Voraussetzung fuer den "
+        "Schema-Vergleich fehlt."
+    )
+    record = json.loads(files[-1].read_text())
+    changes = record.get("payload", {}).get("changes")
+    assert changes, f"Der Datensatz enthaelt keine 'changes': {record!r}"
+
+    required_fields = set(ChangePayload.model_fields)
+    for change in changes:
+        missing = required_fields - set(change)
+        assert not missing, (
+            f"Aenderungs-Eintrag deckt ChangePayload nicht verlustfrei ab "
+            f"-- fehlende Felder: {missing!r}, Eintrag: {change!r}"
+        )
+        # Echte Pydantic-Validierung statt reinem Namensabgleich: beweist
+        # Typ-Kompatibilitaet, nicht nur gleiche Schluesselnamen.
+        ChangePayload(**{k: change[k] for k in required_fields})

--- a/tests/unit/test_alert_input_capture_retention.py
+++ b/tests/unit/test_alert_input_capture_retention.py
@@ -1,0 +1,71 @@
+"""TDD RED — Issue #1948 (Scheibe S1): Retention haelt je Ablage-
+Verzeichnis maximal 50 Eingangs-Datensaetze (Vorlage
+``WeatherSnapshotService._prune_dated_snapshots``, weather_snapshot.py:165).
+
+SPEC: docs/specs/modules/alarm_eingangsprotokoll.md (AC-5)
+
+RED-Grund: ``services.alert_input_capture`` existiert nicht.
+
+Mock-frei: 55 echte JSON-Dateien mit real gesetzten ``st_mtime``-Werten
+(``os.utime``) im pytest-isolierten Datenverzeichnis (#1133); ein echter
+Schreibvorgang loest die Bereinigung aus.
+"""
+from __future__ import annotations
+
+import json
+import os
+import time
+import uuid
+
+
+def _uid(prefix: str) -> str:
+    return f"tdd-1948-retention-{prefix}-{uuid.uuid4().hex[:6]}"
+
+
+def test_ac5_ueber_50_dateien_werden_die_aeltesten_geloescht():
+    """AC-5: GIVEN mehr als 50 Eingangs-Datensaetze liegen bereits in einem
+    Ablage-Verzeichnis, WHEN ein weiterer Datensatz geschrieben wird, THEN
+    werden die aeltesten Datensaetze ueber die Grenze von 50 hinaus
+    geloescht (sortiert nach ``st_mtime``, aelteste zuerst)."""
+    from app.loader import get_data_dir
+    from services import alert_input_capture
+
+    uid = _uid("prune")
+    target_dir = get_data_dir(uid) / "alert_input"
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    base = time.time() - 10_000
+    for i in range(55):
+        f = target_dir / f"forecast_change_trip_altbestand-{i:03d}_0.json"
+        f.write_text(json.dumps({"idx": i}))
+        os.utime(f, (base + i, base + i))  # streng steigende st_mtime
+
+    alert_input_capture.capture_user_scoped(
+        uid, entity_type="trip", entity_id="frisch",
+        payload={"changes": [{
+            "metric": "gust", "old_value": 1.0, "new_value": 2.0,
+            "delta": 1.0, "threshold": 0.5, "severity": "minor",
+            "direction": "increase", "segment_id": "1",
+        }]},
+    )
+
+    remaining = sorted(target_dir.glob("*.json"), key=lambda p: p.stat().st_mtime)
+    assert len(remaining) == 50, (
+        f"Erwartet genau 50 verbleibende Dateien nach Retention, gefunden "
+        f"{len(remaining)}: {[p.name for p in remaining]!r}"
+    )
+    remaining_names = {p.name for p in remaining}
+    # 55 Alt-Dateien (idx 000-054) + 1 frischer Schreibvorgang = 56 Dateien
+    # insgesamt -> die 6 aeltesten (idx 000-005) muessen weg sein.
+    for i in range(6):
+        name = f"forecast_change_trip_altbestand-{i:03d}_0.json"
+        assert name not in remaining_names, (
+            f"Alt-Datei idx={i} haette geloescht werden muessen (aelteste "
+            f"zuerst): verbleibende Dateien {sorted(remaining_names)!r}"
+        )
+    for i in range(6, 55):
+        name = f"forecast_change_trip_altbestand-{i:03d}_0.json"
+        assert name in remaining_names, (
+            f"Juengere Alt-Datei idx={i} wurde faelschlich geloescht: "
+            f"verbleibende Dateien {sorted(remaining_names)!r}"
+        )

--- a/tests/unit/test_alert_input_capture_tenancy.py
+++ b/tests/unit/test_alert_input_capture_tenancy.py
@@ -1,0 +1,76 @@
+"""TDD RED — Issue #1948 (Scheibe S1): zwei Nutzer bekommen getrennte
+Ablageverzeichnisse; ``user_id`` ist Pflichtparameter OHNE Default (kein
+stiller ``"default"``-Fallback).
+
+SPEC: docs/specs/modules/alarm_eingangsprotokoll.md (AC-6)
+
+RED-Grund: ``services.alert_input_capture`` existiert nicht.
+"""
+from __future__ import annotations
+
+import inspect
+import json
+import uuid
+
+
+def _uid(prefix: str) -> str:
+    return f"tdd-1948-tenancy-{prefix}-{uuid.uuid4().hex[:6]}"
+
+
+def _payload() -> dict:
+    return {"changes": [{
+        "metric": "gust", "old_value": 1.0, "new_value": 2.0, "delta": 1.0,
+        "threshold": 0.5, "severity": "minor", "direction": "increase",
+        "segment_id": "1",
+    }]}
+
+
+def test_ac6_zwei_nutzer_erzeugen_getrennte_verzeichnisse():
+    """AC-6: GIVEN zwei verschiedene Nutzer A und B loesen unabhaengig je
+    einen Delta-Alarm aus, WHEN beide Eingangs-Datensaetze geschrieben
+    werden, THEN liegt der Datensatz von A ausschliesslich unter
+    ``data/users/<uid_A>/alert_input/`` und der von B ausschliesslich
+    unter ``data/users/<uid_B>/alert_input/``."""
+    from app.loader import get_data_dir
+    from services import alert_input_capture
+
+    uid_a, uid_b = _uid("a"), _uid("b")
+
+    alert_input_capture.capture_user_scoped(
+        uid_a, entity_type="trip", entity_id="trip-a", payload=_payload(),
+    )
+    alert_input_capture.capture_user_scoped(
+        uid_b, entity_type="trip", entity_id="trip-b", payload=_payload(),
+    )
+
+    files_a = list((get_data_dir(uid_a) / "alert_input").glob("*.json"))
+    files_b = list((get_data_dir(uid_b) / "alert_input").glob("*.json"))
+    assert files_a and files_b, "Beide Nutzer muessen je einen Datensatz bekommen."
+
+    entities_a = {json.loads(f.read_text()).get("entity_id") for f in files_a}
+    entities_b = {json.loads(f.read_text()).get("entity_id") for f in files_b}
+    assert "trip-b" not in entities_a, (
+        f"Nutzer A hat Daten von Nutzer B in seinem Verzeichnis: {entities_a!r}"
+    )
+    assert "trip-a" not in entities_b, (
+        f"Nutzer B hat Daten von Nutzer A in seinem Verzeichnis: {entities_b!r}"
+    )
+
+
+def test_ac6_user_id_ist_pflichtparameter_ohne_default():
+    """AC-6: ``capture_user_scoped`` darf ``user_id`` KEINEN Default-Wert
+    geben -- eine vergessene ``user_id`` an der Aufrufstelle soll knallen
+    statt still auf ``"default"`` zurueckzufallen (Mandantentrennungs-
+    Regel, CLAUDE.md)."""
+    from services import alert_input_capture
+
+    sig = inspect.signature(alert_input_capture.capture_user_scoped)
+    user_id_param = sig.parameters.get("user_id")
+    assert user_id_param is not None, (
+        "capture_user_scoped hat keinen user_id-Parameter."
+    )
+    assert user_id_param.default is inspect.Parameter.empty, (
+        f"user_id hat einen Default-Wert ({user_id_param.default!r}) -- das "
+        "ermoeglicht einen stillen 'default'-Fallback und verstoesst gegen "
+        "die Mandantentrennungs-Regel."
+    )

--- a/tests/unit/test_alert_log_capture_correlation.py
+++ b/tests/unit/test_alert_log_capture_correlation.py
@@ -210,7 +210,6 @@ def test_ac4_e2e_zweig_c_alert_log_capture_id_matches_written_input_record():
     sie DIESELBE ``capture_id``. Faengt die Mutation
     ``capture_id=_nowcast_capture_id`` -> ``capture_id=None`` in
     ``trip_alert.py`` (Zeile ~1373)."""
-    from datetime import date as date_type
     from datetime import datetime, timedelta, timezone
     from datetime import time as time_type
 
@@ -222,20 +221,19 @@ def test_ac4_e2e_zweig_c_alert_log_capture_id_matches_written_input_record():
     from services.radar_cache import RadarNowcastCacheService
     from services.radar_service import RadarNowcastService, _nowcast_source_key
     from services.trip_alert import TripAlertService
-    from utils.timezone import tz_for_coords
 
     from tests.helpers.alert_log_fixtures import fresh_user
+    from tests.helpers.arrival_window_fixtures import active_window_offsets, stage_date
 
     uid = fresh_user("ac4-e2e-c")
     trip_id = "trip-ac4-e2e-c"
     lat, lon = 42.20, 9.10
 
-    # Aktives Segment JETZT (Vorbild _trip_with_active_segment,
-    # tests/tdd/test_952_onset_alert_fidelity.py).
-    tz = tz_for_coords(lat, lon)
-    now_local = datetime.now(tz)
-    start_str = (now_local - timedelta(hours=1)).strftime("%H:%M")
-    end_str = (now_local + timedelta(hours=3)).strftime("%H:%M")
+    # Wanduhr-robustes aktives Segment (#1940/#1667 S1): rohe
+    # (now +/- timedelta).strftime()-Arithmetik wird von
+    # tests/tdd/test_fixture_wallclock_ratchet.py verboten -- sie wird
+    # zwischen ~22:00 und 00:00 UTC reproduzierbar rot (Bezugstag-Bruch).
+    start_str, end_str = active_window_offsets(lat, lon, -60, 180)
     wp0 = Waypoint(
         id="G1", name="Start", lat=lat, lon=lon, elevation_m=1000.0,
         time_window=TimeWindow(start=time_type(0, 0), end=time_type(23, 57)),
@@ -246,10 +244,7 @@ def test_ac4_e2e_zweig_c_alert_log_capture_id_matches_written_input_record():
         time_window=TimeWindow(start=time_type(23, 58), end=time_type(23, 59)),
         arrival_override=end_str,
     )
-    stage = Stage(
-        id="T1", name="Tag 1", date=date_type.today(),
-        start_time=time_type(now_local.hour, now_local.minute), waypoints=[wp0, wp1],
-    )
+    stage = Stage(id="T1", name="Tag 1", date=stage_date(lat, lon), waypoints=[wp0, wp1])
     trip = Trip(id=trip_id, name="AC4-E2E-C", stages=[stage])
     trip.report_config = TripReportConfig(
         trip_id=trip_id, send_email=True, send_telegram=False, send_sms=False,

--- a/tests/unit/test_alert_log_capture_correlation.py
+++ b/tests/unit/test_alert_log_capture_correlation.py
@@ -1,0 +1,299 @@
+"""TDD RED — Issue #1948 (Scheibe S1): ``alert_log.append_entry``/
+``append_suppressed_entry`` bekommen ein optionales ``capture_id``-Feld;
+Alt-Eintraege ohne das Feld bleiben unveraendert lesbar; Zweig-b/c-
+Korrelation ueber ``alert_input_capture.latest_capture_id()``.
+
+SPEC: docs/specs/modules/alarm_eingangsprotokoll.md (AC-4)
+
+RED-Grund: ``append_entry()``/``append_suppressed_entry()`` kennen den
+Parameter ``capture_id`` noch nicht -- ein Aufruf mit diesem Keyword
+scheitert heute mit ``TypeError: unexpected keyword argument``.
+``services.alert_input_capture`` existiert nicht.
+
+Mock-frei: ``append_entry``/``append_suppressed_entry`` sind bereits die
+geteilten, direkt aufgerufenen Bausteine (Vorbild
+``tests/unit/test_alert_log_premium_sms_channel.py``); ``alert_log.json``
+wird danach als echte Datei gelesen.
+
+Nachtrag (Adversary-Findings F001/F002, Runde nach GREEN): die vier
+Tests oben pruefen ``append_entry``/``append_suppressed_entry`` bzw. den
+Capture-Lookup je fuer sich -- keiner davon laeuft ueber die tatsaechliche
+Verdrahtungsstelle in ``trip_alert.py`` (Zweig a: Z. ~401, Zweig c:
+Z. ~1373). Eine Mutation ``capture_id=capture_id`` -> ``capture_id=None``
+an diesen Stellen blieb dadurch ungefangen. Die beiden End-to-End-Tests am
+Dateiende schliessen genau diese Luecke: echter ``check_and_send_alerts()``-
+bzw. ``check_radar_alerts()``-Lauf, danach Gleichheit zwischen dem
+geschriebenen ``alert_log``-Eintrag und dem zuvor geschriebenen
+Eingangs-Datensatz geprueft (nicht nur "Feld vorhanden").
+"""
+from __future__ import annotations
+
+import json
+import uuid
+
+from services import alert_log
+
+
+def _uid(prefix: str) -> str:
+    return f"tdd-1948-log-{prefix}-{uuid.uuid4().hex[:6]}"
+
+
+def _read_log(user_id: str) -> dict:
+    from app.loader import get_data_dir
+
+    path = get_data_dir(user_id) / "alert_log.json"
+    data = json.loads(path.read_text())
+    data.setdefault("entries", [])
+    data.setdefault("not_delivered", [])
+    return data
+
+
+def test_ac4_append_entry_schreibt_capture_id_feld():
+    """AC-4: GIVEN ein Eingangs-Datensatz mit einer bestimmten
+    ``capture_id`` wurde erzeugt, WHEN ``alert_log.append_entry()`` mit
+    diesem ``capture_id``-Argument aufgerufen wird, THEN traegt der
+    geschriebene Eintrag ein ``capture_id``-Feld mit genau diesem Wert."""
+    uid = _uid("entry")
+    alert_log.append_entry(
+        uid, entity_id="trip-cap-1", entity_type="trip", changes_count=1,
+        severity="moderate", reason=alert_log.REASON_FORECAST_CHANGE,
+        effective_channels=["email"], sent_channels=["email"],
+        capture_id="cap-abcdef123456",
+    )
+    entry = _read_log(uid)["entries"][-1]
+    assert entry.get("capture_id") == "cap-abcdef123456", (
+        f"capture_id fehlt oder falsch im Eintrag: {entry!r}"
+    )
+
+
+def test_ac4_append_suppressed_entry_schreibt_capture_id_feld():
+    """AC-4: dieselbe Zusicherung fuer den Unterdrueckungs-Pfad
+    ``append_suppressed_entry()``."""
+    uid = _uid("suppressed")
+    alert_log.append_suppressed_entry(
+        uid, entity_id="trip-cap-2", entity_type="trip",
+        reason=alert_log.REASON_NOWCAST, gate_reason="quiet_hours",
+        effective_channels=["email"], capture_id="cap-fedcba654321",
+    )
+    entry = _read_log(uid)["not_delivered"][-1]
+    assert entry.get("capture_id") == "cap-fedcba654321", (
+        f"capture_id fehlt oder falsch im Unterdrueckungs-Eintrag: {entry!r}"
+    )
+
+
+def test_ac4_alt_eintraege_ohne_capture_id_bleiben_unveraendert_lesbar():
+    """AC-4 (Bestandsschutz): GIVEN ein alter Eintrag ohne ``capture_id``-
+    Feld liegt bereits in ``alert_log.json``, WHEN ein neuer Eintrag MIT
+    ``capture_id`` dazukommt, THEN bleibt der alte Eintrag strukturell
+    unveraendert (kein ``capture_id``-Schluessel wird nachtraeglich
+    eingefuegt)."""
+    from app.loader import get_data_dir
+
+    uid = _uid("legacy")
+    path = get_data_dir(uid) / "alert_log.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    legacy_entry = {
+        "entity_id": "trip-legacy", "entity_type": "trip",
+        "sent_at": "2026-01-01T00:00:00+00:00", "changes_count": 1,
+        "severity": "minor", "metrics": [], "hazards": [],
+        "reason": "forecast_change", "channels_sent": ["email"],
+        "channels_not_sent": [],
+    }
+    path.write_text(json.dumps({"entries": [legacy_entry], "not_delivered": []}))
+
+    alert_log.append_entry(
+        uid, entity_id="trip-new", entity_type="trip", changes_count=1,
+        severity="moderate", reason=alert_log.REASON_FORECAST_CHANGE,
+        effective_channels=["email"], sent_channels=["email"],
+        capture_id="cap-neu",
+    )
+
+    entries = _read_log(uid)["entries"]
+    assert entries[0] == legacy_entry, f"Alt-Eintrag wurde veraendert: {entries[0]!r}"
+    assert entries[1].get("capture_id") == "cap-neu", (
+        f"Neuer Eintrag traegt keine capture_id: {entries[1]!r}"
+    )
+
+
+def test_ac4_latest_capture_id_lookup_liefert_korrelierbare_id():
+    """AC-4 (Zweig b/c-Korrelation): GIVEN ein Eingangs-Datensatz wurde fuer
+    einen bestimmten (branch, source_key) geschrieben, WHEN der zugehoerige
+    alert_log-Eintrag ueber ``latest_capture_id()`` nach demselben Branch/
+    Quell-Schluessel und einem ausreichenden Zeitfenster sucht, THEN
+    liefert der Lookup dieselbe ``capture_id`` wie der Eingangs-Datensatz,
+    und der damit geschriebene alert_log-Eintrag traegt sie."""
+    from services import alert_input_capture
+
+    uid = _uid("lookup")
+    written_id = alert_input_capture.capture_system(
+        branch="official_alert", source_key="AT-lookup-1948",
+        payload={
+            "body": {"features": []}, "service": "meteoalarm", "host": "x",
+            "cache_key": "AT-lookup-1948",
+        },
+    )
+    assert written_id, "capture_system() lieferte keine capture_id."
+
+    found_id = alert_input_capture.latest_capture_id(
+        "official_alert", "AT-lookup-1948", max_age=60.0,
+    )
+    assert found_id == written_id, (
+        f"latest_capture_id() fand nicht dieselbe capture_id: "
+        f"{found_id!r} != {written_id!r}"
+    )
+
+    alert_log.append_entry(
+        uid, entity_id="trip-lookup", entity_type="trip", changes_count=1,
+        severity="moderate", reason=alert_log.REASON_OFFICIAL_ALERT,
+        effective_channels=["email"], sent_channels=["email"],
+        capture_id=found_id,
+    )
+    entry = _read_log(uid)["entries"][-1]
+    assert entry.get("capture_id") == written_id, (
+        f"alert_log-Eintrag traegt nicht dieselbe capture_id: {entry!r}"
+    )
+
+
+# ══════════════ End-to-End (Adversary F001/F002-Gegenprobe) ═══════════════
+
+
+def test_ac4_e2e_zweig_a_alert_log_capture_id_matches_written_input_record():
+    """AC-4 (E2E, F001): GIVEN ein echter Delta-Alarm-Lauf
+    (``check_and_send_alerts``) schreibt sowohl einen Eingangs-Datensatz
+    (Zweig a) als auch einen ``alert_log``-Eintrag, WHEN beide gelesen
+    werden, THEN tragen sie DIESELBE ``capture_id`` -- nicht nur je fuer
+    sich ein gefuelltes Feld. Faengt die Mutation ``capture_id=capture_id``
+    -> ``capture_id=None`` in ``trip_alert.py`` (Zeile ~401), die von den
+    isolierten Tests oben ungefangen blieb."""
+    from app.loader import get_data_dir
+    from services.trip_alert import TripAlertService
+
+    from tests.helpers.alert_log_fixtures import (
+        fresh_user, gust_alert_trip, settings_email_only, weather,
+    )
+
+    uid = fresh_user("ac4-e2e-a")
+    trip = gust_alert_trip("trip-ac4-e2e-a")
+    mails: list = []
+    svc = TripAlertService(
+        settings=settings_email_only(), user_id=uid, throttle_hours=0,
+        mail_sink=lambda subject, body: mails.append((subject, body)),
+    )
+
+    sent = svc.check_and_send_alerts(
+        trip, [weather(1, gust_max_kmh=20.0)],
+        fresh_weather=[weather(1, gust_max_kmh=60.0)],
+    )
+    assert sent is True and mails, "Voraussetzung: der Alarm muss verschickt werden."
+
+    capture_files = sorted((get_data_dir(uid) / "alert_input").glob("*.json"))
+    assert capture_files, "Kein Eingangs-Datensatz unter alert_input/ gefunden."
+    written_capture_id = json.loads(capture_files[-1].read_text())["capture_id"]
+    assert written_capture_id, "Eingangs-Datensatz traegt keine capture_id."
+
+    log_entry = _read_log(uid)["entries"][-1]
+    assert log_entry.get("capture_id") == written_capture_id, (
+        f"alert_log-Eintrag traegt eine ANDERE capture_id als der "
+        f"Eingangs-Datensatz: log={log_entry.get('capture_id')!r} != "
+        f"input={written_capture_id!r}"
+    )
+
+
+def test_ac4_e2e_zweig_c_alert_log_capture_id_matches_written_input_record():
+    """AC-4 (E2E, F002): GIVEN ein echter Nowcast-Alarm-Lauf
+    (``check_radar_alerts``, echter ``RadarNowcastService`` ueber die
+    ``frame_source``-DI-Naht -- KEIN Subklassen-Override von
+    ``get_nowcast()``, sonst liefe der Capture-Mount-Punkt gar nicht mit)
+    schreibt sowohl einen Eingangs-Datensatz (Zweig c, unter
+    ``data/debug/alert_input/nowcast/``) als auch einen ``alert_log``-
+    Eintrag (``REASON_NOWCAST``), WHEN beide gelesen werden, THEN tragen
+    sie DIESELBE ``capture_id``. Faengt die Mutation
+    ``capture_id=_nowcast_capture_id`` -> ``capture_id=None`` in
+    ``trip_alert.py`` (Zeile ~1373)."""
+    from datetime import date as date_type
+    from datetime import datetime, timedelta, timezone
+    from datetime import time as time_type
+
+    from app.config import Settings
+    from app.loader import get_data_root, save_trip
+    from app.models import TripReportConfig
+    from app.trip import Stage, TimeWindow, Trip, Waypoint
+    from providers.brightsky import RadarFrame
+    from services.radar_cache import RadarNowcastCacheService
+    from services.radar_service import RadarNowcastService, _nowcast_source_key
+    from services.trip_alert import TripAlertService
+    from utils.timezone import tz_for_coords
+
+    from tests.helpers.alert_log_fixtures import fresh_user
+
+    uid = fresh_user("ac4-e2e-c")
+    trip_id = "trip-ac4-e2e-c"
+    lat, lon = 42.20, 9.10
+
+    # Aktives Segment JETZT (Vorbild _trip_with_active_segment,
+    # tests/tdd/test_952_onset_alert_fidelity.py).
+    tz = tz_for_coords(lat, lon)
+    now_local = datetime.now(tz)
+    start_str = (now_local - timedelta(hours=1)).strftime("%H:%M")
+    end_str = (now_local + timedelta(hours=3)).strftime("%H:%M")
+    wp0 = Waypoint(
+        id="G1", name="Start", lat=lat, lon=lon, elevation_m=1000.0,
+        time_window=TimeWindow(start=time_type(0, 0), end=time_type(23, 57)),
+        arrival_override=start_str,
+    )
+    wp1 = Waypoint(
+        id="G2", name="Ziel", lat=lat + 0.05, lon=lon + 0.05, elevation_m=1200.0,
+        time_window=TimeWindow(start=time_type(23, 58), end=time_type(23, 59)),
+        arrival_override=end_str,
+    )
+    stage = Stage(
+        id="T1", name="Tag 1", date=date_type.today(),
+        start_time=time_type(now_local.hour, now_local.minute), waypoints=[wp0, wp1],
+    )
+    trip = Trip(id=trip_id, name="AC4-E2E-C", stages=[stage])
+    trip.report_config = TripReportConfig(
+        trip_id=trip_id, send_email=True, send_telegram=False, send_sms=False,
+        alert_on_changes=True,
+    )
+    save_trip(trip, user_id=uid)
+
+    now_utc = datetime.now(timezone.utc)
+    frames = [
+        RadarFrame(timestamp=now_utc + timedelta(minutes=i), precip_mm_h=(2.5 if i >= 5 else 0.0))
+        for i in range(0, 60, 5)
+    ]
+    radar_svc = RadarNowcastService(
+        frame_source=lambda _lat, _lon: frames, cache=RadarNowcastCacheService(),
+    )
+    mails: list = []
+    settings = Settings().model_copy(update={
+        "smtp_host": "smtp.test.invalid", "smtp_user": "alert@test.invalid",
+        "smtp_pass": "secret", "mail_to": "gregor-test@henemm.com",
+        "smtp_port": 587, "is_test_mode": False,
+        "telegram_bot_token": "", "telegram_chat_id": "",
+    })
+    svc = TripAlertService(
+        settings=settings, throttle_hours=0, user_id=uid,
+        radar_service=radar_svc,
+        mail_sink=lambda subject, body: mails.append((subject, body)),
+    )
+
+    result = svc.check_radar_alerts()
+    assert result == 1 and mails, (
+        f"check_radar_alerts() sollte 1 Alert liefern und eine Mail senden, "
+        f"war result={result!r}, mails={mails!r}"
+    )
+
+    capture_dir = get_data_root() / "debug" / "alert_input" / "nowcast"
+    capture_files = sorted(capture_dir.glob(f"{_nowcast_source_key(lat, lon)}_*.json"))
+    assert capture_files, "Kein Eingangs-Datensatz unter data/debug/alert_input/nowcast/ gefunden."
+    written_capture_id = json.loads(capture_files[-1].read_text())["capture_id"]
+    assert written_capture_id, "Eingangs-Datensatz traegt keine capture_id."
+
+    log_entry = _read_log(uid)["entries"][-1]
+    assert log_entry.get("reason") == alert_log.REASON_NOWCAST
+    assert log_entry.get("capture_id") == written_capture_id, (
+        f"alert_log-Eintrag (Zweig c) traegt eine ANDERE capture_id als der "
+        f"Eingangs-Datensatz: log={log_entry.get('capture_id')!r} != "
+        f"input={written_capture_id!r}"
+    )

--- a/tests/unit/test_radar_service_capture.py
+++ b/tests/unit/test_radar_service_capture.py
@@ -1,0 +1,102 @@
+"""TDD RED — Issue #1948 (Scheibe S1): Zweig-c-Mount in
+``RadarNowcastService.get_nowcast`` schreibt vor ``_derive_result``
+(Cache-Hit UND Cache-Miss) einen System-Level-Eingangs-Datensatz mit den
+rohen Frames.
+
+SPEC: docs/specs/modules/alarm_eingangsprotokoll.md (AC-3)
+
+RED-Grund: ``alert_input_capture.py`` existiert nicht; ``get_nowcast()``
+ruft an ihren beiden Mount-Punkten (radar_service.py Z. 199 und Z. 212)
+noch keinen Capture-Aufruf auf.
+
+Mock-frei: echte ``RadarFrame``-Objekte, ``_frame_source``-DI-Seam fuer den
+Cache-Miss-Zweig (Vorbild ``tests/tdd/test_feature_656_radar_nowcast.py``),
+eine echte ``RadarNowcastCacheService``-Instanz fuer den vorbefuellten
+Cache-Hit-Zweig (kein Mock/patch).
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+
+
+def _capture_dir():
+    from app.loader import get_data_root
+
+    return get_data_root() / "debug" / "alert_input" / "nowcast"
+
+
+def _frames(rate_mm_h: float = 1.5):
+    from providers.brightsky import RadarFrame
+
+    now = datetime.now(timezone.utc)
+    return [
+        RadarFrame(timestamp=now + timedelta(minutes=i), precip_mm_h=rate_mm_h)
+        for i in range(0, 30, 5)
+    ]
+
+
+def test_ac3_cache_miss_schreibt_rohe_frames_vor_derive_result():
+    """AC-3 (Cache-Miss): GIVEN ``get_nowcast`` ruft ueber die injizierte
+    ``_frame_source`` frische Frames ab, WHEN ``_derive_result`` aufgerufen
+    wird, THEN existiert vorher ein Eingangs-Datensatz mit denselben rohen
+    Frames unter ``data/debug/alert_input/nowcast/``."""
+    from services.radar_cache import RadarNowcastCacheService
+    from services.radar_service import RadarNowcastService
+
+    frames = _frames(rate_mm_h=2.5)
+    svc = RadarNowcastService(
+        frame_source=lambda lat, lon: frames,
+        cache=RadarNowcastCacheService(),  # leer -> garantierter Cache-Miss
+    )
+    lat, lon = 47.7, 12.3
+    result = svc.get_nowcast(lat, lon)
+    assert result is not None  # Bestandsverhalten unveraendert
+
+    files = sorted(_capture_dir().glob("*.json"))
+    assert files, (
+        "Kein Eingangs-Datensatz unter data/debug/alert_input/nowcast/ "
+        "gefunden -- get_nowcast() ruft alert_input_capture.capture_system()"
+        " am Cache-Miss-Mount-Punkt nicht auf."
+    )
+    record = json.loads(files[-1].read_text())
+    assert record.get("capture_id"), "capture_id fehlt im Eingangs-Datensatz."
+    payload = record.get("payload", {})
+    assert payload.get("source") == "radar", f"Falsche/fehlende Quelle: {payload!r}"
+    raw_frames = payload.get("frames")
+    assert raw_frames and len(raw_frames) == len(frames), (
+        f"Rohe Frame-Anzahl weicht ab: erwartet {len(frames)}, "
+        f"erhalten {raw_frames!r}"
+    )
+
+
+def test_ac3_cache_hit_schreibt_ebenfalls_einen_eingangsdatensatz():
+    """AC-3 (Cache-Hit): GIVEN ``get_nowcast`` liefert Frames aus einem
+    vorbefuellten Cache-Treffer, WHEN ``_derive_result`` aufgerufen wird,
+    THEN existiert AUCH in diesem Zweig vorher ein Eingangs-Datensatz --
+    nicht nur beim Cache-Miss."""
+    from services.radar_cache import RadarNowcastCacheService
+    from services.radar_service import RadarNowcastService, _region_bucket
+
+    cache = RadarNowcastCacheService()
+    lat, lon = 47.7, 12.3
+    now = datetime.now(timezone.utc)
+    frames = _frames(rate_mm_h=4.0)
+    cache.put(lat, lon, _region_bucket(lat, lon), frames, "INCA", now=now)
+
+    def _sentinel(_lat, _lon):
+        raise AssertionError("_frame_source wurde bei einem Cache-Hit aufgerufen")
+
+    svc = RadarNowcastService(frame_source=_sentinel, cache=cache)
+    result = svc.get_nowcast(lat, lon)
+    assert result is not None
+
+    files = sorted(_capture_dir().glob("*.json"))
+    hit_records = [json.loads(f.read_text()) for f in files]
+    matching = [r for r in hit_records if r.get("payload", {}).get("source") == "INCA"]
+    assert matching, (
+        "Kein Eingangs-Datensatz fuer den Cache-Hit-Zweig gefunden -- "
+        "get_nowcast() ruft alert_input_capture.capture_system() am "
+        "Cache-Hit-Mount-Punkt (vor dem ersten _derive_result-Aufruf) nicht "
+        "auf."
+    )

--- a/tests/unit/test_trip_alert_forecast_change_capture.py
+++ b/tests/unit/test_trip_alert_forecast_change_capture.py
@@ -1,0 +1,93 @@
+"""TDD RED — Issue #1948 (Scheibe S1): Zweig-a-Mount schreibt vor dem
+Alarmversand einen rohen Eingangs-Datensatz.
+
+SPEC: docs/specs/modules/alarm_eingangsprotokoll.md (AC-1)
+Kontext: docs/context/feat-1948-eingangsprotokoll.md
+
+RED-Grund: ``src/services/alert_input_capture.py`` existiert noch nicht --
+``check_and_send_alerts()`` in ``trip_alert.py`` ruft an ihrem Delta-Alarm-
+Mount-Punkt (vor ``_send_alert``, trip_alert.py ~Z. 333-352) noch keinen
+Capture-Aufruf auf. Der Import innerhalb der Testfunktion (nicht auf
+Modulebene) schlaegt daher mit ``ModuleNotFoundError`` fehl -- Collection
+der Datei bleibt trotzdem intakt.
+
+Mock-frei: echter ``TripAlertService``-Lauf (Vorbild
+``tests/tdd/test_alert_log_metrics.py``), echte Persistenz ueber die
+pytest-isolierte ``get_data_dir()``-Basis (#1133), Transport ueber den
+bestehenden ``mail_sink``-DI-Seam.
+"""
+from __future__ import annotations
+
+import json
+
+from tests.helpers.alert_log_fixtures import (
+    fresh_user, gust_alert_trip, settings_email_only, weather,
+)
+
+
+def _service(user_id: str, sink: list):
+    from services.trip_alert import TripAlertService
+
+    return TripAlertService(
+        settings=settings_email_only(), user_id=user_id, throttle_hours=0,
+        mail_sink=lambda subject, body: sink.append((subject, body)),
+    )
+
+
+def _capture_files(user_id: str) -> list:
+    from app.loader import get_data_dir
+
+    d = get_data_dir(user_id) / "alert_input"
+    if not d.exists():
+        return []
+    return sorted(d.glob("forecast_change_*.json"))
+
+
+def test_ac1_delta_alarm_schreibt_rohen_eingangsdatensatz_vor_versand():
+    """AC-1: GIVEN ein Trip loest einen Boeen-Delta-Alarm (20 -> 60 km/h)
+    aus, WHEN ``check_and_send_alerts`` die Aenderungsliste gebildet hat und
+    den Alarm verschickt, THEN liegt unter
+    ``data/users/<uid>/alert_input/`` ein Eingangs-Datensatz mit den rohen
+    Aenderungswerten (Metrik, alter/neuer Wert, Delta, Schwelle)."""
+    uid = fresh_user("ac1-capture")
+    trip = gust_alert_trip("trip-ac1-capture")
+    mails: list = []
+
+    sent = _service(uid, mails).check_and_send_alerts(
+        trip, [weather(1, gust_max_kmh=20.0)],
+        fresh_weather=[weather(1, gust_max_kmh=60.0)],
+    )
+
+    assert sent is True and mails, (
+        "Voraussetzung: der Alarm muss tatsaechlich verschickt werden."
+    )
+    files = _capture_files(uid)
+    assert files, (
+        f"Kein Eingangs-Datensatz unter data/users/{uid}/alert_input/ "
+        "gefunden -- alert_input_capture.capture_user_scoped() wurde am "
+        "Delta-Alarm-Mount-Punkt (trip_alert.py) nicht aufgerufen."
+    )
+    record = json.loads(files[-1].read_text())
+    assert record.get("entity_type") == "trip", (
+        f"Falscher/fehlender entity_type: {record.get('entity_type')!r}"
+    )
+    assert record.get("entity_id") == "trip-ac1-capture", (
+        f"Falsche/fehlende entity_id: {record.get('entity_id')!r}"
+    )
+    assert record.get("capture_id"), "capture_id fehlt im Eingangs-Datensatz."
+
+    changes = record.get("payload", {}).get("changes")
+    assert changes, f"Der Datensatz enthaelt keine rohen Aenderungswerte: {record!r}"
+    # Rohes WeatherChange.metric-Feld (Rohdaten-Vokabular, z.B.
+    # "gust_max_kmh"), NICHT das Register-Paar ("gust","max") aus
+    # alert_log.register_pairs_from_changes() -- das ist eine spaetere
+    # Projektion, kein roher Eingangswert (AC-1 verlangt genau die rohen
+    # Aenderungswerte).
+    gust = next((c for c in changes if c.get("metric") == "gust_max_kmh"), None)
+    assert gust is not None, f"Erwartete Metrik 'gust_max_kmh' fehlt: {changes!r}"
+    assert gust["old_value"] == 20.0
+    assert gust["new_value"] == 60.0
+    assert gust["delta"] == 40.0
+    assert "threshold" in gust and "severity" in gust and "direction" in gust, (
+        f"Aenderungs-Eintrag ist unvollstaendig: {gust!r}"
+    )

--- a/tests/unit/test_warn_egress_capture.py
+++ b/tests/unit/test_warn_egress_capture.py
@@ -1,0 +1,90 @@
+"""TDD RED — Issue #1948 (Scheibe S1): Zweig-b-Mount in
+``warn_egress.cached_fetch`` schreibt bei echter (nicht gecachter) Antwort
+einen System-Level-Eingangs-Datensatz.
+
+SPEC: docs/specs/modules/alarm_eingangsprotokoll.md (AC-2)
+
+RED-Grund: ``alert_input_capture.py`` existiert nicht; ``cached_fetch()``
+ruft an ihrer bestehenden ``on_response``-Ausfuehrungsstelle
+(warn_egress.py ~Z. 296-360) noch keinen Capture-Aufruf auf -- die
+Verzeichnis-Existenzpruefung findet daher nichts.
+
+Mock-frei: echtes ``request_fn`` liefert ein reales ``httpx.Response``-
+Objekt (Vorbild ``tests/tdd/test_warn_service_egress.py``), kein Netz.
+``WARN_CALLS_PATH_OVERRIDE`` wird wie im Vorbild auf ``tmp_path``
+umgelenkt. Die pytest-isolierte Datenwurzel (#1133, autouse) sorgt dafuer,
+dass ``get_data_root()`` in einem Test-tmp-Baum landet.
+"""
+from __future__ import annotations
+
+import json
+
+import httpx
+
+
+def _fixed_clock(value: float):
+    return lambda: value
+
+
+def _capture_dir():
+    from app.loader import get_data_root
+
+    return get_data_root() / "debug" / "alert_input" / "official_alert"
+
+
+def test_ac2_echte_antwort_schreibt_datensatz_cache_hit_schreibt_keinen_weiteren(monkeypatch, tmp_path):
+    """AC-2: GIVEN ein amtlicher Warndienst wird ueber ``cached_fetch`` mit
+    einer echten, nicht gecachten Antwort abgefragt, WHEN die Antwort
+    erfolgreich geparst wird, THEN liegt ein System-Level-Eingangs-
+    Datensatz mit dem rohen Response-Body sowie Service/Host/Cache-Key
+    unter ``data/debug/alert_input/official_alert/``. Ein anschliessender
+    Cache-Treffer fuer denselben Schluessel erzeugt KEINEN weiteren
+    Datensatz (nur echte, nicht gecachte Antworten werden mitgeschnitten)."""
+    from services.official_alerts import warn_egress
+
+    monkeypatch.setattr(
+        warn_egress, "WARN_CALLS_PATH_OVERRIDE", tmp_path / "warn_service_calls.jsonl"
+    )
+    fixture_body = {"features": [{"id": "warn-1948", "properties": {"event": "Sturm"}}]}
+    cache: dict = {}
+
+    result = warn_egress.cached_fetch(
+        cache=cache, cache_key="AT-1948-capture", service="meteoalarm",
+        host="api.meteoalarm.org",
+        request_fn=lambda: httpx.Response(200, json=fixture_body),
+        parse_fn=lambda r: r.json(),
+        clock=_fixed_clock(2000.0),
+    )
+    assert result == fixture_body  # Bestandsverhalten unveraendert (BIT-identisch)
+
+    files = sorted(_capture_dir().glob("*.json"))
+    assert files, (
+        "Kein System-Level-Eingangs-Datensatz unter "
+        "data/debug/alert_input/official_alert/ gefunden -- cached_fetch() "
+        "ruft alert_input_capture.capture_system() an der on_response-"
+        "Stelle nicht auf."
+    )
+    record = json.loads(files[-1].read_text())
+    assert record.get("capture_id"), "capture_id fehlt im Eingangs-Datensatz."
+    payload = record.get("payload", {})
+    assert payload.get("body") == fixture_body, f"Roher Response-Body weicht ab: {payload!r}"
+    assert payload.get("service") == "meteoalarm"
+    assert payload.get("host") == "api.meteoalarm.org"
+    assert payload.get("cache_key") == "AT-1948-capture"
+
+    # Kehrseite: derselbe cache_key ist jetzt gueltig (WARN_SUCCESS_TTL,
+    # clock unveraendert) -- ein weiterer cached_fetch()-Aufruf ist ein
+    # Cache-Hit und darf keinen zusaetzlichen Datensatz erzeugen.
+    def _net_sentinel():
+        raise AssertionError("request_fn wurde bei einem Cache-Hit aufgerufen")
+
+    warn_egress.cached_fetch(
+        cache=cache, cache_key="AT-1948-capture", service="meteoalarm",
+        host="api.meteoalarm.org", request_fn=_net_sentinel,
+        parse_fn=lambda r: r.json(), clock=_fixed_clock(2000.0),
+    )
+    files_after_hit = sorted(_capture_dir().glob("*.json"))
+    assert len(files_after_hit) == len(files), (
+        f"Ein Cache-Hit hat einen zusaetzlichen Eingangs-Datensatz "
+        f"geschrieben: vorher {len(files)}, nachher {len(files_after_hit)}."
+    )

--- a/tests/unit/test_warn_egress_capture_no_secrets.py
+++ b/tests/unit/test_warn_egress_capture_no_secrets.py
@@ -1,0 +1,82 @@
+"""TDD RED — Issue #1948 (Scheibe S1): der Zweig-b-Eingangs-Datensatz
+enthaelt keine Request-Header/Auth-Parameter, weil sie der Capture-Funktion
+strukturell nicht uebergeben werden.
+
+SPEC: docs/specs/modules/alarm_eingangsprotokoll.md (AC-7)
+
+RED-Grund: ``alert_input_capture.py`` existiert nicht; ``cached_fetch()``
+schreibt an ihrer ``on_response``-Stelle noch keinen Eingangs-Datensatz.
+"""
+from __future__ import annotations
+
+import inspect
+import json
+
+import httpx
+
+
+def _capture_dir():
+    from app.loader import get_data_root
+
+    return get_data_root() / "debug" / "alert_input" / "official_alert"
+
+
+def _fixed_clock(value: float):
+    return lambda: value
+
+
+def test_ac7_response_header_landet_nicht_in_der_capture_datei(monkeypatch, tmp_path):
+    """AC-7: GIVEN eine echte Response traegt einen Header mit einem
+    (testweise eingebauten) Geheimnis, WHEN ``cached_fetch`` sie an der
+    ``on_response``-Stelle mitschneidet, THEN taucht das Geheimnis in
+    KEINER geschriebenen Datei auf -- die Schreibstelle nimmt nur den
+    geparsten Body plus Service/Host/Status entgegen."""
+    from services.official_alerts import warn_egress
+
+    monkeypatch.setattr(
+        warn_egress, "WARN_CALLS_PATH_OVERRIDE", tmp_path / "warn_service_calls.jsonl"
+    )
+    secret = "tdd-1948-geheimes-token-9f8e7d"
+
+    warn_egress.cached_fetch(
+        cache={}, cache_key="AT-1948-no-secret", service="meteoalarm",
+        host="api.meteoalarm.org",
+        request_fn=lambda: httpx.Response(
+            200, json={"features": []},
+            headers={"Authorization": f"Bearer {secret}", "X-Api-Key": secret},
+        ),
+        parse_fn=lambda r: r.json(),
+        clock=_fixed_clock(3000.0),
+    )
+
+    files = list(_capture_dir().glob("*.json"))
+    assert files, (
+        "Kein Eingangs-Datensatz geschrieben -- Voraussetzung fuer die "
+        "Geheimnis-Pruefung fehlt."
+    )
+    for f in files:
+        raw_text = f.read_text()
+        assert secret not in raw_text, (
+            f"Geheimnis aus dem Response-Header wurde mitgeschrieben: {f}"
+        )
+        record = json.loads(raw_text)
+        assert "headers" not in record.get("payload", {}), (
+            f"Die Capture-Datei enthaelt ein 'headers'-Feld: {record!r}"
+        )
+
+
+def test_ac7_capture_system_nimmt_keine_header_oder_request_parameter_entgegen():
+    """AC-7 (Signatur-Zusicherung): ``capture_system()`` besitzt
+    strukturell KEINEN Parameter fuer Header/Request/Auth -- ein Geheimnis
+    kann also gar nicht erst hereingereicht werden, unabhaengig vom
+    Aufrufer-Verhalten (kein nachtraeglicher Filter noetig)."""
+    from services import alert_input_capture
+
+    sig = inspect.signature(alert_input_capture.capture_system)
+    forbidden = {"headers", "request", "auth", "response", "resp"}
+    leaked = forbidden & set(sig.parameters)
+    assert not leaked, (
+        f"capture_system() nimmt einen Header-/Request-nahen Parameter "
+        f"entgegen: {leaked!r} -- Geheimnisse koennten so hereingereicht "
+        "werden."
+    )


### PR DESCRIPTION
## Zusammenfassung

Scheibe S1 aus Epic #1948 (Teilarbeit — Epic bleibt offen): Rollierendes Begleit-Log des ROHEN Eingangszustands jeder verarbeiteten Alarm-Meldung, für alle drei Alarm-Zweige.

- **Zweig a (Δ-Alarm):** nutzerskopiert unter `data/users/<uid>/alert_input/`, Mount vor `_send_alert` in `trip_alert.py`
- **Zweig b (amtliche Warnung):** System-Ablage `data/debug/alert_input/official_alert/`, Mount in `warn_egress.cached_fetch` (deckt GeoSphere+MeteoAlarm+DPC mit einer Stelle); strukturell keine Header/Auth-Parameter an der Schreibstelle
- **Zweig c (Radar-Nowcast):** System-Ablage `data/debug/alert_input/nowcast/`, Mounts vor beiden `_derive_result`-Aufrufen in `get_nowcast`
- **Korrelation:** optionales, additives `capture_id`-Feld in `alert_log`-Einträgen (Zweig a direkt durchgereicht, Zweig c per `latest_capture_id`-Lookup; Zweig b in S1 zurückgestellt — PO-gebilligt, Known Limitations der Spec)
- **Retention:** 50 Dateien je Verzeichnis nach `st_mtime` · **fail-open** an allen Mount-Punkten · kein sichtbares Alarm-Format geändert, keine neuen Endpoints

## Qualitätsnachweis

- Spec: `docs/specs/modules/alarm_eingangsprotokoll.md` (9 ACs, PO-freigegeben)
- TDD: 16 RED-Tests → GREEN; Fix-Loop ergänzte 2 E2E-Korrelationstests nach Adversary-Findings F001/F002 (Mutations-rot-Nachweis an trip_alert.py:401/:1373)
- Adversary-Verdict: **VERIFIED** (3 Runden, 9 Mutationen), QA-Gate grün
- 18 Feature-Tests + 196 Regressionstests der angefassten Module grün; `official_alerts.py`-Sperrzone (#1929) unberührt
- Produktiv-LoC: 244/250

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017pkrpMq7ud9h42pABCHcFr