### PR TITLE
feat(#1948): S2 Testmeldungs-Einspeisung — alert-preview mit official/nowcast_frames + Zweig-a-Replay

### DIFF
--- a/api/routers/validator.py
+++ b/api/routers/validator.py
@@ -234,10 +234,42 @@ class OnsetPayload(BaseModel):
     cooldown_display: str | None = None
 
 
+class OfficialAlertPayload(BaseModel):
+    """Issue #1948 Scheibe S2 (Zweig b): strukturierte Testmeldung fuer eine
+    amtliche Warnung — Feldspiegel von ``OfficialAlert``
+    (services/official_alerts/models.py:15) plus die betroffenen Segmente."""
+    source: str
+    hazard: str
+    level: int
+    label: str
+    valid_from: str | None = None
+    valid_to: str | None = None
+    url: str | None = None
+    region_label: str | None = None
+    dedup_id: str | None = None
+    segment_ids: list[str] = Field(default_factory=list)
+
+
+class NowcastFramePayload(BaseModel):
+    timestamp: str
+    precip_mm_h: float
+    is_convective: bool = False
+
+
+class NowcastFramesPayload(BaseModel):
+    """Issue #1948 Scheibe S2 (Zweig c): Replay eines S1-Nowcast-Mitschnitts."""
+    source: str
+    frames: list[NowcastFramePayload]
+    km_from: float = 0.0
+    km_to: float = 0.0
+
+
 class AlertPreviewBody(BaseModel):
     changes: list[ChangePayload] = Field(default_factory=list)
     segment_times: list[SegmentTimePayload] = Field(default_factory=list)
     onset: OnsetPayload | None = None
+    official: list[OfficialAlertPayload] | None = None
+    nowcast_frames: NowcastFramesPayload | None = None
 
 
 @router.post("/api/trips/{trip_id}/alert-preview")
@@ -253,15 +285,55 @@ def alert_preview(
             detail=f"Trip {trip_id} nicht gefunden für User {user_id}",
         )
 
-    has_onset = body.onset is not None
-    has_deviation = bool(body.changes and body.segment_times)
-    if has_onset == has_deviation:
+    # Issue #1948 Scheibe S2 (AC-1): Vier-Wege-Exklusivitaet statt binaerem
+    # Alt-Gate (onset XOR changes+segment_times). segment_times ist bei
+    # changes seit S2 optional (Zweig-a-Synthese aus dem Trip, s.u.).
+    provided = [
+        bool(body.onset), bool(body.changes), bool(body.official),
+        bool(body.nowcast_frames),
+    ]
+    if sum(provided) != 1:
         raise HTTPException(
             status_code=422,
-            detail="Body muss genau einen von 'onset' ODER 'changes'+'segment_times' enthalten",
+            detail=(
+                "Body muss genau einen von 'onset', 'changes', 'official' "
+                "oder 'nowcast_frames' enthalten"
+            ),
         )
 
+    if body.changes and not body.segment_times:
+        body.segment_times = _synthesize_segment_times(trip_obj, body.changes)
+
     return render_alert_preview(trip_obj, body)
+
+
+def _synthesize_segment_times(
+    trip_obj: Trip, changes: "list[ChangePayload]",
+) -> "list[SegmentTimePayload]":
+    """Issue #1948 Scheibe S2 (AC-2/AC-3): Segment-Zeiten der in ``changes``
+    genannten ``segment_id``s aus dem bereits geladenen Trip synthetisieren
+    — dieselbe Produktions-Segmentierung wie der Versandpfad."""
+    from services.trip_day import trip_local_today
+    from services.trip_segments import convert_trip_to_segments
+
+    today = trip_local_today(trip_obj, datetime.now(timezone.utc))
+    real_segments = {
+        str(s.segment_id): s for s in convert_trip_to_segments(trip_obj, today)
+    }
+    synthesized: list[SegmentTimePayload] = []
+    for c in changes:
+        seg = real_segments.get(c.segment_id)
+        if seg is None:
+            raise HTTPException(
+                status_code=422,
+                detail=f"Unbekannte segment_id '{c.segment_id}' im Trip",
+            )
+        synthesized.append(SegmentTimePayload(
+            segment_id=c.segment_id,
+            start=seg.start_time.strftime("%H:%M"),
+            end=seg.end_time.strftime("%H:%M"),
+        ))
+    return synthesized
 
 
 # ---------------------------------------------------------------------------

--- a/docs/context/feat-1948-s2-testeinspeisung.md
+++ b/docs/context/feat-1948-s2-testeinspeisung.md
@@ -1,0 +1,75 @@
+# Context: feat-1948-s2-testeinspeisung
+
+## Request Summary
+
+Issue #1948, Scheibe S2 (PO-Konzept 2026-08-17): Testmeldungs-Einspeisung — dem System
+aufgezeichnete Meldungen (S1-Rohmitschnitte) oder frei formulierte Testmeldungen übergeben,
+um zu sehen, wie sie über alle Kanäle gerendert würden. Konkret: der zustandslose Endpoint
+`POST /api/trips/{trip_id}/alert-preview` bekommt den fehlenden Zweig b (amtliche Warnung)
+und die drei S1-Aufzeichnungsformate werden einspeisbar. Format-Scheiben S3+ werden damit
+gegen echte Eingangsdaten verifiziert.
+
+## Related Files
+
+| File | Relevance |
+|------|-----------|
+| `api/routers/validator.py:237-264` | `AlertPreviewBody` (changes+segment_times ODER onset), 422-Guard, Endpoint |
+| `src/services/validator_render_service.py:89` | `render_alert_preview()` — Render-Sequenz aller Kanäle, `_stub_segment()` (Z. 57) |
+| `src/services/alert_input_capture.py` | S1-Mitschnitt: `capture_user_scoped` (Z. 51), `capture_system` (Z. 91), Hüllen-Felder |
+| `src/services/trip_alert.py:98-109,354-357` | Zweig-a-Capture: `_change_to_capture_dict` spiegelt `ChangePayload` 1:1; KEINE `segment_times` |
+| `src/services/official_alerts/warn_egress.py:390-400` | Zweig-b-Capture: `{"body": resp.json(), service, host, cache_key, status}` — nur JSON-Provider |
+| `src/services/radar_service.py:653-676,521` | Zweig-c-Capture (`source`+Frames `timestamp`/`precip_mm_h`) · `_derive_result(frames,…)` |
+| `src/output/renderers/alert/official_alerts.py` | Zweig-b-Renderer: Subject (883), HTML (1446), Plain (1522), Telegram (1834), SMS (2038), DTO-Builder `build_official_alert_notices` (2139) |
+| `src/services/notification_service.py:829-882` | `send_official_alert` — Render-Sequenz-Vorlage (Versand, für Preview spiegeln, nicht aufrufen) |
+| `src/services/official_alerts/models.py:15` | `OfficialAlert`: source, hazard, level:int, label, valid_from, valid_to, url, region_label, dedup_id |
+| `internal/router/router.go:167` · `internal/handler/proxy.go:297-335` | Go-Proxy: `AlertPreviewProxyHandler` mit user_id-Injektion; kein Catch-all — neue Routen brauchen Registrierung |
+
+## Existing Patterns
+
+- **Mehrkanal-Preview in EINEM Abruf** (ADR-0011): alert-preview liefert `subject/email_html/email_plain/telegram/sms` — neuer Zweig b MUSS dieselbe Antwortform liefern.
+- **Zustandsloser Validator-Endpoint ohne Seiteneffekte:** kein SMTP, kein Throttle-Write (Tests `test_issue_221_validator_endpoints.py:246-320`, `test_issue_918_alert_preview_4ch.py`).
+- **Exklusiv-Guard im Body:** heute `onset` XOR `changes+segment_times` (422 sonst) — wird auf drei Typen erweitert.
+- **Payload-Schema-Nahtstelle S1↔S2 per Test bewiesen:** `test_alert_input_capture_payload_schema.py` konstruiert `ChangePayload(**capture_felder)` echt.
+
+## Befund: Abstand S1-Mitschnitt → heutiger Preview-Body
+
+| Zweig | Deckung | Lücke |
+|---|---|---|
+| a (Δ) | `changes` 1:1 deckungsgleich | Capture enthält KEINE `segment_times` → 422-Guard schlägt heute fehl |
+| b (amtlich) | — | Payload-Typ fehlt komplett; Capture ist ROHER Provider-Body (nur JSON-Provider: geosphere_warn, vigilance, meteo_forets, meteoalarm_feed:*; DPC/CAP-XML werfen bei `resp.json()` und werden fail-open verschluckt) |
+| c (Nowcast) | Frames vorhanden | `_derive_result` liefert onset_minutes/intensity_label; FEHLEND im Mitschnitt: `is_convective` je Frame, `km_from`/`km_to` (Trip-Geometrie), `source_label` (Mapping `_SOURCE_LABELS` radar_service.py:223), `cooldown_display` |
+
+## Dependencies
+
+- Upstream: `build_official_alert_notices`, Renderer in `official_alerts.py`, `_derive_result`, `_alert_tz_for_trip`, `_stub_segment`
+- Downstream: S3+ (SMS-Sofortfix, Formatscheiben) verifizieren Formatänderungen über diesen Einspeiseweg; Frontend nutzt den Endpoint heute nicht direkt (Validator-Fläche)
+
+## Existing Specs
+
+- `docs/specs/modules/alarm_eingangsprotokoll.md` — S1 (AC-9 dokumentiert die Zweig-c-Limitation bewusst)
+- `docs/specs/modules/issue_221_validator_observability_endpoints.md` — Ursprungs-Spec alert-preview + Proxy
+- `docs/specs/modules/fix_923_sms_fidelity_backend.md` — Muster zustandsloser Preview ohne user_id
+- Zweig-b-Format: `warnmail_official_alert_display.md`, `sms_official_alert_tokens.md`, `fix_1796_official_alert_gsm7_extension.md`
+
+## Risks & Considerations
+
+- **#1929-Sperrzone `official_alerts.py:1896-2104`:** Der SMS-Renderpfad (`_tag_hour`…`render_official_alert_sms`) liegt KOMPLETT darin. S2 darf ihn AUFRUFEN, aber keine Zeile darin ändern.
+- **Roh-Body-Replay Zweig b hieße 4 Provider-Parser anbinden** (`geosphere_warn._extract_alerts`, `meteo_forets._extract_alert`, `meteoalarm._extract_alerts_from_cap`, `dpc._alerts_for_zone`) — sprengt die Scheibe. Alternative: strukturierte `OfficialAlert`-Felder als Payload (Testmeldungen frei formulierbar; Roh-Replay ggf. Folgescheibe).
+- **Mandantentrennung:** bestehender Endpoint erzwingt user_id-Query + 404 bei Fremd-Trip — bleibt für alle neuen Typen unverändert (Test mit 2 Nutzern PFLICHT).
+- **Kein Versand:** neuer Zweig darf keinerlei Throttle-/Log-/Versand-Seiteneffekt haben.
+- **`resp.json()`-Lücke Zweig b (DPC/CAP)** ist ein S1-Nebenbefund, nicht S2-Blocker.
+
+## Analyse: Design-Optionen (Tech-Lead-Empfehlung ➜ in Spec ausformulieren)
+
+1. **Zweig b als dritter exklusiver Payload-Typ `official`** am bestehenden Endpoint (Liste von
+   `OfficialAlertPayload` ≙ `OfficialAlert`-Felder + betroffene `segment_ids`), Render-Sequenz aus
+   `notification_service.py:846-882` in `validator_render_service.py` gespiegelt. ➜ EMPFOHLEN.
+2. **Zweig-a-Replay:** `segment_times` optional machen und aus dem bereits geladenen Trip
+   (Segment-Zeiten der in `changes` genannten `segment_id`s) synthetisieren — S1-Format bleibt
+   unverändert, Capture-Datei ist 1:1 einspeisbar. ➜ EMPFOHLEN.
+3. **Zweig-c-Replay:** neuer exklusiver Payload-Typ `nowcast_frames` (`source` + Frames wie im
+   Mitschnitt), serverseitig `_derive_result` → OnsetEvent; `km_from/km_to` aus Trip oder Body,
+   `source_label` über `_SOURCE_LABELS`. S1 additiv um `is_convective` je Frame erweitern.
+   ➜ Umfang prüfen — ggf. als S2b abtrennen, wenn LoC-Rahmen kippt.
+4. **Einspeise-Mechanik:** Capture-JSON wird clientseitig (curl/jq-Rezept, dokumentiert) an den
+   Endpoint gegeben — KEIN serverseitiges Datei-Lesen per Pfad (Path-Traversal-/Tenancy-Risiko).

--- a/docs/reference/api_contract.md
+++ b/docs/reference/api_contract.md
@@ -3279,6 +3279,70 @@ export interface AlertRule {
 
 ---
 
+## 22.5) Alert Preview Endpoint (Issue #918, ADR-0011; Testmeldungs-Einspeisung Issue #1948 S2)
+
+Zustandsloser, nicht versionsstabiler Validator-/Vorschau-Endpoint (Python-Core,
+`api/routers/validator.py`). Rendert eine Alarm-Meldung über alle Kanäle (Subject, E-Mail
+HTML/Plain, Telegram, SMS) aus **testweise eingespeisten** Rohdaten — kein Wetterdaten-Fetch,
+kein Versand, keine Nutzerdaten-Persistenz. Ursprünglich nur für Δ-Alarm und Onset-Nowcast
+(Issue #918); seit Issue #1948 Scheibe S2 um die zwei amtlichen/Nowcast-Zweige b/c erweitert,
+sodass alle drei Alarm-Zweige (a/b/c) testweise durchspielbar sind, gespeist aus dem
+S1-Eingangsprotokoll (`src/services/alert_input_capture.py`, siehe
+`docs/specs/modules/alarm_eingangsprotokoll.md`).
+
+**Handler:** `api/routers/validator.py::alert_preview` → `src/services/validator_render_service.py::render_alert_preview`
+
+### POST /api/trips/{trip_id}/alert-preview
+
+**Query Parameters:**
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| user_id | string | yes | Session-User; wie bei allen Validator-Endpoints zustandslos verwendet (kein Trip-/Nutzerdaten-Fetch außer Name/Config des geladenen Trips) |
+
+**Request Body (`AlertPreviewBody`) — genau EINER von vier Payload-Typen (sonst HTTP 422):**
+
+| Feld | Typ | Beschreibung |
+|------|-----|------|
+| changes | `ChangePayload[]` | Zweig a (Δ-Alarm): rohe Änderungswerte je Etappe (`metric`, `old_value`, `new_value`, `delta`, `threshold`, `severity`, `direction`, `segment_id`) |
+| segment_times | `SegmentTimePayload[]` | Optional bei `changes` — fehlt es, synthetisiert der Endpoint die Etappen-Zeitfenster aus dem geladenen Trip über dieselbe Produktions-Segmentierung wie der Versandpfad (`convert_trip_to_segments`) |
+| onset | `OnsetPayload` \| null | Radar-Onset (Zweig c, Alt-Form vor S2): `onset_minutes`, `onset_time`, `km_from`, `km_to`, `is_convective`, `intensity_label`, `source_label`, `cooldown_display?` |
+| official | `OfficialAlertPayload[]` \| null | **NEU (#1948 S2), Zweig b:** amtliche Warnung(en), Feldspiegel von `OfficialAlert` — `source`, `hazard`, `level: int`, `label`, `valid_from?`, `valid_to?`, `url?`, `region_label?`, `dedup_id?`, `segment_ids: string[]` |
+| nowcast_frames | `NowcastFramesPayload` \| null | **NEU (#1948 S2), Zweig c:** Replay eines S1-Nowcast-Mitschnitts — `source`, `frames: [{timestamp, precip_mm_h, is_convective}]`, `km_from`, `km_to` |
+
+**Response 200 (`changes`/`onset`/`official`):**
+
+```json
+{
+  "subject": "...",
+  "email_html": "...",
+  "email_plain": "...",
+  "telegram": "...",
+  "sms": "..."
+}
+```
+
+**Response 200 (`nowcast_frames`, additiv):** wie oben, plus `"onset_detected": bool`. Leitet
+der eingespeiste Frame-Mitschnitt über dieselbe `_derive_result`-Ableitung wie der Live-Radar-
+Pfad **keinen** Onset innerhalb des Fensters ab, ist `onset_detected: false` und alle
+Render-Felder (`subject`/`email_html`/`email_plain`/`telegram`/`sms`) sind `null` — expliziter
+Leerbefund statt Exception/HTTP 500.
+
+**Error Responses:**
+- `404` — Trip nicht gefunden für `user_id`
+- `422` — Body enthält nicht genau einen der vier Payload-Typen, oder eine `segment_id` in
+  `changes` existiert nicht im Trip
+
+**Notes:**
+- Zustandslos wie `compare-email-preview`/`sms-fidelity-preview` — kein Wetterdaten-Fetch, kein
+  Versand, keine Persistenz.
+- `official` ruft `services/official_alerts/*` ausschließlich auf (Render-Sequenz gespiegelt aus
+  `notification_service.send_official_alert`), ändert keine Zeile in der #1929-Sperrzone
+  (`official_alerts.py:1896-2104`).
+- Spec S2 (`official`/`nowcast_frames`, `segment_times`-Synthese): `docs/specs/modules/alarm_testeinspeisung.md`.
+
+---
+
 ## 23) Stage-Weather Internal Endpoint (Issue #1212, Slice R1)
 
 Interner, nicht versionsstabiler Endpoint (Python FastAPI, Port 8000, **kein** Go-Proxy in
@@ -3476,6 +3540,15 @@ function corridorInside(value, min, max) {
 
 ## Changelog
 
+- 2026-08-18: Issue #1948 Scheibe S2 — `POST /api/trips/{trip_id}/alert-preview` (Section 22.5,
+  neu dokumentiert) bekommt zwei additive, exklusive Payload-Typen neben `changes`/`onset`:
+  `official` (Zweig b, amtliche Warnung(en) als `OfficialAlertPayload[]`) und `nowcast_frames`
+  (Zweig c, Replay eines S1-Nowcast-Mitschnitts, Antwort zusätzlich `onset_detected: bool`).
+  `segment_times` ist bei `changes` jetzt optional — fehlt es, synthetisiert der Endpoint die
+  Etappen-Zeitfenster aus dem geladenen Trip. Vier-Wege-Exklusivität (`HTTP 422` bei ≠1 gesetztem
+  Payload-Typ) ersetzt das alte binäre `onset` XOR `changes`-Gate. Der S1-Nowcast-Mitschnitt
+  (`src/services/alert_input_capture.py`) trägt seither zusätzlich `is_convective` je Frame.
+  Spec: `docs/specs/modules/alarm_testeinspeisung.md`.
 - 2026-08-16: Issue #1678 — `EU_REST` (ICON-EU, `lpi_con_max`) bekommt eine eigene, belegte
   LPI-Schwellenleiter **(7,14 / 23,81 / 86,16 J/kg)** und löst damit den Interim-Wert 5/20/50
   ab, den #1679 dort bewusst stehen ließ. Quelle aller drei Sprossen: Schröder/Göcke/Köhler

--- a/docs/specs/modules/alarm_eingangsprotokoll.md
+++ b/docs/specs/modules/alarm_eingangsprotokoll.md
@@ -222,6 +222,9 @@ Verhalten benannt, nicht nach Issue-Nummer.
 - `official_alerts.py:1896-2104` (#1929-Sperrzone) bleibt unangetastet.
 - Diese Scheibe ändert KEIN sichtbares Alarm-Format (SMS/E-Mail/Telegram bleiben bit-identisch) —
   reines Beobachtungs-Feature für S1; die Format-Konsolidierung folgt in S3+.
+- **Seit Scheibe S2 (#1948, `alarm_testeinspeisung.md`):** der Zweig-c-Mitschnitt trägt je Frame
+  zusätzlich `is_convective` — Voraussetzung für den `nowcast_frames`-Replay über `alert-preview`
+  (dort AC-8).
 
 ## Architektur-Entscheidung (ADR)
 

--- a/docs/specs/modules/alarm_testeinspeisung.md
+++ b/docs/specs/modules/alarm_testeinspeisung.md
@@ -1,0 +1,357 @@
+---
+entity_id: alarm_testeinspeisung
+type: feature
+created: 2026-08-18
+updated: 2026-08-18
+status: draft
+workflow: feat-1948-s2-testeinspeisung
+version: "1.0"
+tags: [alarm, testing, validator]
+---
+
+# Alarm-Testmeldungs-Einspeisung (Scheibe S2, Issue #1948)
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Der zustandslose Preview-Endpoint `POST /api/trips/{trip_id}/alert-preview` rendert heute nur
+zwei der drei Alarm-Zweige (Δ-Abweichung, Radar-Onset). Scheibe S1 (#1948) hat den rohen
+Eingangs-Mitschnitt aller drei Zweige geschaffen (`src/services/alert_input_capture.py`) — diese
+Scheibe schließt die Ausgabe-Seite: der fehlende dritte Payload-Typ (amtliche Warnung) wird
+ergänzt, und alle drei S1-Mitschnittformate werden ohne Transformation direkt in den Endpoint
+einspeisbar. Damit lässt sich für jede real aufgezeichnete oder frei formulierte Testmeldung
+sehen, wie sie über alle vier Kanäle (E-Mail/HTML+Plain, Telegram, SMS, Betreff) gerendert würde
+— die Beweisgrundlage, gegen die künftige Format-Scheiben (S3+) verifiziert werden.
+
+## Source
+
+- **File:** `api/routers/validator.py` (`AlertPreviewBody`, `alert_preview`), `src/services/validator_render_service.py` (`render_alert_preview`), `src/services/radar_service.py` (`_capture_nowcast_frames`)
+- **Identifier:** `AlertPreviewBody`, `render_alert_preview()`
+
+> Schicht: Python-Core (`api/`, `src/services/`) — kein Go-/Frontend-Anteil in dieser Scheibe.
+> Keine neue Route, daher keine Proxy-Änderung in `internal/`.
+
+## Estimated Scope
+
+- **LoC:** ~200-250 (produktiv; Tests separat)
+- **Files:** 3 Code-Dateien geändert (`api/routers/validator.py`, `src/services/validator_render_service.py`, `src/services/radar_service.py`) + 5-7 Testdateien
+- **Effort:** medium
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `src/services/official_alerts/official_alerts.py::build_official_alert_notices` | function | Baut aus `(OfficialAlert, segment_ids)`-Paaren die `OfficialAlertNotice`-DTOs — identische Eingangsform wie die neue `OfficialAlertPayload`-Liste |
+| `src/output/renderers/alert/official_alerts.py` | module | Vier Vorlagen-Renderer (Subject/HTML+Plain/Telegram/SMS) — NUR aufgerufen, `official_alerts.py:1896-2104` (#1929-Sperrzone) bleibt unangetastet |
+| `src/services/notification_service.py::send_official_alert` (Z. 829-882) | method | Render-Sequenz-Vorlage — wird in `validator_render_service.py` gespiegelt, nicht importiert (Preview braucht keinen Versandpfad) |
+| `src/services/trip_segments.py::convert_trip_to_segments` | function | Liefert reale Segment-Zeiten des Trips für die Zweig-a-Synthese ohne `segment_times` |
+| `src/services/trip_day.py::trip_local_today` | function | Bestimmt den `target_date` für `convert_trip_to_segments` (gleiches Muster wie `trip_alert.py:344`) |
+| `src/services/radar_service.py::RadarService._derive_result`, `_SOURCE_LABELS` | method/attribute | Leitet aus rohen Frames ein `NowcastResult` ab; liefert die menschenlesbaren Quellen-Label |
+| `src/services/alert_input_capture.py` (S1) | module | Liefert das Mitschnitt-Dateiformat, das 1:1 (Zweig a) bzw. mit minimaler `jq`-Extraktion (Zweig b/c) eingespeist wird |
+
+## Implementation Details
+
+### Vier exklusive Payload-Typen an EINEM Endpoint
+
+`AlertPreviewBody` (`api/routers/validator.py:237-240`) bekommt zwei neue optionale Felder,
+`segment_times` wird optional (Default bleibt leere Liste):
+
+```python
+class OfficialAlertPayload(BaseModel):
+    source: str
+    hazard: str
+    level: int
+    label: str
+    valid_from: str | None = None
+    valid_to: str | None = None
+    url: str | None = None
+    region_label: str | None = None
+    dedup_id: str | None = None
+    segment_ids: list[str] = Field(default_factory=list)
+
+
+class NowcastFramePayload(BaseModel):
+    timestamp: str
+    precip_mm_h: float
+    is_convective: bool = False
+
+
+class NowcastFramesPayload(BaseModel):
+    source: str
+    frames: list[NowcastFramePayload]
+    km_from: float = 0.0
+    km_to: float = 0.0
+
+
+class AlertPreviewBody(BaseModel):
+    changes: list[ChangePayload] = Field(default_factory=list)
+    segment_times: list[SegmentTimePayload] = Field(default_factory=list)
+    onset: OnsetPayload | None = None
+    official: list[OfficialAlertPayload] | None = None
+    nowcast_frames: NowcastFramesPayload | None = None
+```
+
+Der 422-Guard (`api/routers/validator.py:256-262`) wird von einem binären XOR auf eine
+Vier-Wege-Exklusivität erweitert:
+
+```python
+provided = [bool(body.onset), bool(body.changes), bool(body.official), bool(body.nowcast_frames)]
+if sum(provided) != 1:
+    raise HTTPException(422, "Body muss genau einen von 'onset', 'changes', 'official' oder "
+                              "'nowcast_frames' enthalten")
+```
+
+**Invariante:** Keine neue Route — `internal/router/router.go:167` und
+`internal/handler/proxy.go:297-335` (Go-Proxy-Registrierung inkl. `user_id`-Injektion) bleiben
+unverändert, da derselbe bestehende Endpoint erweitert wird.
+
+### Zweig-a-Replay: `segment_times` optional
+
+Fehlt `segment_times`, werden die Segment-Zeiten der in `changes` genannten `segment_id`s aus
+dem bereits geladenen Trip synthetisiert:
+
+```python
+if not body.segment_times and body.changes:
+    today = trip_local_today(trip_obj, datetime.now(timezone.utc))
+    real_segments = {str(s.segment_id): s for s in convert_trip_to_segments(trip_obj, today)}
+    synthesized = []
+    for c in body.changes:
+        seg = real_segments.get(c.segment_id)
+        if seg is None:
+            raise HTTPException(422, f"Unbekannte segment_id '{c.segment_id}' im Trip")
+        synthesized.append(SegmentTimePayload(
+            segment_id=c.segment_id,
+            start=seg.start_time.strftime("%H:%M"),
+            end=seg.end_time.strftime("%H:%M"),
+        ))
+    body.segment_times = synthesized
+```
+
+Damit ist der `payload.changes`-Teil einer S1-Mitschnittdatei
+`data/users/<uid>/alert_input/forecast_change_*.json` (Hülle: `{capture_id, captured_at,
+entity_type, entity_id, payload: {"changes": [...]}}`, `alert_input_capture.py:67-73`) ohne
+Transformation als `{"changes": <payload.changes>}` einspeisbar.
+
+### Zweig b (NEU): `official`
+
+Render-Sequenz aus `notification_service.py:846-882` in `validator_render_service.py` gespiegelt
+(nicht importiert — die Preview braucht weder Versandkanäle noch Trip-Notification-Historie):
+
+```python
+def _render_official_preview(trip_obj: Trip, payloads: list) -> dict:
+    from services.official_alerts.models import OfficialAlert
+    from output.renderers.alert.official_alerts import (
+        build_official_alert_notices, render_official_alert_mail_plain,
+        render_official_alert_sms, render_official_alert_subject,
+        render_official_alert_telegram, render_warn_block,
+    )
+    # _official_source_label_for/_official_source_url_for stehen in
+    # notification_service.py:240/292, nicht in official_alerts.py -- Import
+    # von dort (oder Extraktion in ein geteiltes Modul, falls der zyklische
+    # Import services.notification_service <-> services.validator_render_service
+    # sich als problematisch erweist).
+    alert_tz = _alert_tz_for_trip(trip_obj)
+    tagged = [
+        (OfficialAlert(source=p.source, hazard=p.hazard, level=p.level, label=p.label,
+                        valid_from=_parse_dt(p.valid_from), valid_to=_parse_dt(p.valid_to),
+                        url=p.url, region_label=p.region_label, dedup_id=p.dedup_id),
+         p.segment_ids)
+        for p in payloads
+    ]
+    dto_notices = build_official_alert_notices(trip_obj, tagged)
+    source_label = _official_source_label_for(dto_notices)
+    stand_at = local_fmt(datetime.now(timezone.utc), alert_tz)
+    subject = render_official_alert_subject(dto_notices, prefix=trip_obj.name, tz=alert_tz)
+    html = render_warn_block(dto_notices, variant="standalone", source_label=source_label,
+                              source_url=_official_source_url_for(dto_notices),
+                              stand_at=stand_at, tz=alert_tz, context_label=trip_obj.name)
+    plain = render_official_alert_mail_plain(dto_notices, source_label=source_label,
+                                              stand_at=stand_at, tz=alert_tz,
+                                              context_label=trip_obj.name)
+    telegram = render_official_alert_telegram(dto_notices, prefix=trip_obj.name,
+                                               source_label=source_label, tz=alert_tz)
+    sms = render_official_alert_sms(dto_notices, prefix=trip_obj.name, source_label=source_label)
+    return {"subject": subject, "email_html": html, "email_plain": plain,
+            "telegram": telegram, "sms": sms}
+```
+
+**Invariante:** `official_alerts.py:1896-2104` (#1929-Sperrzone, SMS-Renderpfad `_tag_hour`…
+`render_official_alert_sms`) wird ausschließlich AUFGERUFEN — keine Zeile darin ändert sich.
+Antwortform bleibt `subject/email_html/email_plain/telegram/sms` (ADR-0011), identisch zu den
+bestehenden Zweigen a/c.
+
+**Beispiel-Payload (Ist-Vokabular, analog Test-Fixtures `tests/tdd/test_meteoalarm_feed_italien.py`
+und Spec `fix_1744_alarm_format_angleichen.md`):**
+
+```json
+{
+  "official": [
+    {"source": "geosphere_warn", "hazard": "thunderstorm", "level": 3,
+     "label": "Gewitter", "segment_ids": ["1", "2"]}
+  ]
+}
+```
+
+Erwartete SMS-Form (bestehender Renderer, unverändert): `KHW403 AMT GELB1/3: TH …`.
+
+### Zweig c (NEU): Replay `nowcast_frames`
+
+Serverseitig via `RadarService._derive_result`-Logik (`radar_service.py:521`):
+
+```python
+def _render_nowcast_replay(trip_obj: Trip, body_nf) -> dict:
+    from services.radar_service import RadarService, RadarFrame
+    frames = [
+        RadarFrame(timestamp=datetime.fromisoformat(f.timestamp),
+                   precip_mm_h=f.precip_mm_h, is_convective=f.is_convective)
+        for f in body_nf.frames
+    ]
+    svc = RadarService()
+    result = svc._derive_result(frames, body_nf.source, now=datetime.now(timezone.utc))
+    if result.onset_minutes is None:
+        return {"onset_detected": False, "subject": None, "email_html": None,
+                "email_plain": None, "telegram": None, "sms": None}
+    alert_tz = _alert_tz_for_trip(trip_obj)
+    onset_time = datetime.now(timezone.utc) + timedelta(minutes=result.onset_minutes)
+    onset_payload = OnsetPayload(
+        onset_minutes=result.onset_minutes,
+        onset_time=local_fmt(onset_time, alert_tz)[-5:],  # "HH:MM"-Anteil
+        km_from=body_nf.km_from, km_to=body_nf.km_to,
+        is_convective=result.is_convective,
+        intensity_label=result.intensity_label,
+        source_label=RadarService._SOURCE_LABELS.get(result.source, result.source),
+    )
+    body_for_render = AlertPreviewBody(onset=onset_payload)
+    out = render_alert_preview(trip_obj, body_for_render)
+    out["onset_detected"] = True
+    return out
+```
+
+`source_label` über das Mapping `RadarService._SOURCE_LABELS` (`radar_service.py:223`);
+`km_from`/`km_to` default `0.0`, wenn im Body nicht übergeben. Kein Nowcast-Ergebnis in den
+Frames (kein `onset_minutes`) ⇒ Antwort mit explizitem Leerbefund (`onset_detected: false`,
+alle Render-Felder `null`) statt HTTP 500.
+
+### S1-Erweiterung (einzige Änderung an S1-Code): `is_convective` je Frame im Mitschnitt
+
+`radar_service.py:660-676` (`_capture_nowcast_frames`) schreibt das `is_convective`-Feld additiv
+in jeden Frame-Eintrag mit — es liegt an dieser Stelle bereits auf `RadarFrame.is_convective` vor
+(gesetzt in `_load_fixture`/`_fetch_frames_with_fallback`), wird heute im Mitschnitt nur nicht
+mitgeschrieben:
+
+```python
+"frames": [
+    {"timestamp": f.timestamp.isoformat(), "precip_mm_h": f.precip_mm_h,
+     "is_convective": f.is_convective}
+    for f in frames
+],
+```
+
+Damit deckt eine Zweig-c-S1-Mitschnittdatei (`data/debug/alert_input/nowcast/*.json`) ab sofort
+alle Pflichtfelder von `NowcastFramesPayload` ab und ist per `jq '.payload'` direkt einspeisbar.
+
+### Einspeise-Mechanik (clientseitig, dokumentiert)
+
+Kein serverseitiges Datei-Lesen per Pfadparameter (Path-Traversal-/Mandanten-Risiko) — die
+Capture-JSON wird clientseitig extrahiert und im Request-Body übergeben:
+
+```bash
+# Zweig a: S1-Mitschnitt 1:1 einspeisen
+CAPTURE=data/users/<uid>/alert_input/forecast_change_trip_<trip_id>_<ts>.json
+jq -c '{changes: .payload.changes}' "$CAPTURE" | \
+  curl -s -X POST "https://staging.gregor20.henemm.com/api/trips/<trip_id>/alert-preview?user_id=<uid>" \
+    -H 'Content-Type: application/json' -d @-
+
+# Zweig c: S1-Mitschnitt 1:1 einspeisen (nach der additiven is_convective-Erweiterung)
+CAPTURE=data/debug/alert_input/nowcast/<key>_<ts>.json
+jq -nc --argjson nf "$(jq -c '.payload' "$CAPTURE")" '{nowcast_frames: $nf}' | \
+  curl -s -X POST "https://staging.gregor20.henemm.com/api/trips/<trip_id>/alert-preview?user_id=<uid>" \
+    -H 'Content-Type: application/json' -d @-
+```
+
+## Expected Behavior
+
+- **Input:** `POST /api/trips/{trip_id}/alert-preview?user_id=<uid>` mit Body, der GENAU EINEN
+  von `changes` (+optional `segment_times`), `onset`, `official`, `nowcast_frames` enthält.
+- **Output:** bestehende Vier-Kanal-Form `{subject, email_html, email_plain, telegram, sms}`
+  (ADR-0011); Zweig c ergänzt `onset_detected: bool`.
+- **Side effects:** keine — kein Versand, kein Throttle-/`alert_log`-Write, keine Persistenz.
+  Bestandsverhalten der zwei existierenden Typen (`onset`, `changes`+`segment_times`) bleibt
+  bit-identisch.
+
+## Acceptance Criteria
+
+- **AC-1:** Given ein Preview-Request enthält mehr als einen oder keinen der vier Payload-Typen (`changes`, `onset`, `official`, `nowcast_frames`), When der Endpoint aufgerufen wird, Then antwortet er mit HTTP 422 und einer Meldung, die alle vier zulässigen Typen benennt.
+  - Test: vier Kombinationen (leer, zwei gleichzeitig, drei gleichzeitig, alle vier) real gegen den Endpoint schicken, 422 in jedem Fall nachweisen.
+
+- **AC-2:** Given ein Preview-Request mit `changes`, aber ohne `segment_times`, für einen real geladenen Trip mit bekannten `segment_id`s, When der Endpoint gerendert wird, Then werden die Segment-Zeiten aus dem Trip synthetisiert und das Rendering liefert dieselbe Ausgabe wie ein äquivalenter Request mit explizit mitgelieferten `segment_times`.
+  - Test: einmal mit synthetisierten, einmal mit explizit gleichwertigen `segment_times` denselben Trip anfragen, Antworten byte-identisch vergleichen.
+
+- **AC-3:** Given ein Preview-Request mit `changes`, dessen `segment_id` im geladenen Trip nicht existiert, When der Endpoint gerendert wird, Then antwortet er mit HTTP 422 und einer Meldung, die die unbekannte `segment_id` benennt.
+  - Test: `changes` mit einer erfundenen `segment_id` gegen einen realen Trip-Fixture schicken, 422 mit der ID im Fehlertext nachweisen.
+
+- **AC-4:** Given ein Preview-Request mit `official` (Liste von `OfficialAlertPayload`), When der Endpoint gerendert wird, Then enthält die Antwort für alle fünf Felder (`subject`, `email_html`, `email_plain`, `telegram`, `sms`) nicht-leeren Text, der die übergebenen `hazard`/`level`/`label`-Werte widerspiegelt.
+  - Test: eine `official`-Payload mit `source="geosphere_warn"`, `hazard="thunderstorm"`, `level=3`, `label="Gewitter"` senden, alle fünf Antwortfelder auf Inhalt prüfen (kein reiner String-Contains, sondern Struktur-/Wertevergleich gegen die erwartete Renderer-Ausgabe).
+
+- **AC-5:** Given dieselbe `OfficialAlert`-Eingabe wird einmal über den Preview-Endpoint (`official`) und einmal direkt über `send_official_alert`s Renderer-Aufrufe (`build_official_alert_notices` → `render_official_alert_sms`/`render_official_alert_telegram`/`render_warn_block`) gerendert, When beide Ergebnisse verglichen werden, Then sind SMS-, Telegram- und HTML-Ausgabe byte-identisch (Fidelity, keine Zeile in der #1929-Sperrzone wird umgangen).
+  - Test: gleiche `OfficialAlert`+`segment_ids` durch beide Pfade schicken, Textvergleich der drei Ausgaben.
+
+- **AC-6:** Given ein Preview-Request mit `nowcast_frames`, dessen Frames einen Regen-Onset innerhalb des Nowcast-Horizonts enthalten, When der Endpoint gerendert wird, Then leitet er `onset_minutes`/`intensity_label`/`is_convective` über dieselbe `_derive_result`-Logik ab wie der Live-Radar-Pfad und rendert daraus ein vollständiges Preview mit `onset_detected: true`.
+  - Test: Frames-Fixture mit bekanntem Onset (z. B. `precip_mm_h` über der Trockenschwelle in Frame 3) senden, `onset_minutes` und `sms`-Inhalt gegen die erwartete Ableitung prüfen.
+
+- **AC-7:** Given ein Preview-Request mit `nowcast_frames`, dessen Frames keinen Regen-Onset im Nowcast-Horizont enthalten, When der Endpoint gerendert wird, Then antwortet er mit HTTP 200 und `onset_detected: false` sowie `null`-Renderfeldern, statt eine Exception zu werfen oder HTTP 500 zu liefern.
+  - Test: Frames-Fixture ausschließlich mit `precip_mm_h` unter der Trockenschwelle senden, 200 + `onset_detected: false` nachweisen.
+
+- **AC-8:** Given `RadarService.get_nowcast` schreibt (nach der S1-Erweiterung) einen Zweig-c-Mitschnitt, When die Datei gelesen wird, Then trägt jeder Frame-Eintrag zusätzlich zu `timestamp`/`precip_mm_h` das Feld `is_convective`, das dem tatsächlichen `RadarFrame.is_convective`-Wert entspricht.
+  - Test: `get_nowcast` mit injizierten Frames aufrufen, von denen mindestens einer `is_convective=True` trägt, geschriebene Mitschnittdatei auf das Feld prüfen.
+
+- **AC-9:** Given ein Preview-Request beliebigen Typs (inkl. `official` und `nowcast_frames`) wird verarbeitet, When der Response zurückkommt, Then wurde weder eine E-Mail/SMS/Telegram-Nachricht tatsächlich verschickt noch ein Eintrag in `alert_log` oder eine Throttle-Markierung geschrieben.
+  - Test: vor und nach dem Request den Zustand von `alert_log`, Throttle-Store und (injiziertem) Mail-/SMS-Sink vergleichen — unverändert.
+
+- **AC-10:** Given zwei verschiedene Nutzer A und B mit je eigenen Trips, When Nutzer A versucht, `alert-preview` für einen Trip von Nutzer B aufzurufen, Then antwortet der Endpoint mit HTTP 404, und ein Request mit dem jeweils eigenen Trip liefert für beide Nutzer unabhängig voneinander ein korrektes Rendering.
+  - Test: zwei reale `user_id`-Werte mit je eigenem Trip-Fixture, Cross-User-Zugriff UND Self-Access für beide Nutzer prüfen.
+
+- **AC-11:** Given ein Preview-Request im bestehenden Format (`onset` oder `changes`+explizit mitgelieferten `segment_times`), When der Endpoint nach dieser Erweiterung aufgerufen wird, Then ist die Antwort byte-identisch zum Verhalten vor dieser Scheibe (Bestandsschutz, bestehende Tests `test_issue_221_validator_endpoints.py`/`test_issue_918_alert_preview_4ch.py` bleiben grün ohne Anpassung).
+  - Test: bestehende Testsuite unverändert laufen lassen; zusätzlich ein Request mit explizitem `segment_times` gegen den Endpoint vor und nach dem Merge vergleichen (Snapshot).
+
+## Known Limitations
+
+- **Zweig-b-Roh-Body-Replay ist NICHT Teil von S2.** Testmeldungen für Zweig b werden strukturiert
+  als `OfficialAlertPayload` formuliert, nicht als roher Provider-Response. Die vier
+  Provider-Parser (`geosphere_warn._extract_alerts`, `meteo_forets._extract_alert`,
+  `meteoalarm._extract_alerts_from_cap`, `dpc._alerts_for_zone`) anzubinden würde die Scheibe
+  sprengen — bleibt Folgearbeit, sollte der PO Roh-Replay für Zweig b priorisieren.
+- DPC/CAP-XML-Provider werden von S1 gar nicht mitgeschnitten (`resp.json()`-Lücke bei
+  XML-Antworten) — ein S1-Nebenbefund, kein S2-Blocker, da S2 ohnehin nur strukturierte
+  `official`-Payloads entgegennimmt.
+- `cooldown_display` bleibt bei Zweig-c-Replay immer `None` — ein echter Cooldown-Zustand
+  existiert im zustandslosen Preview-Endpoint nicht und lässt sich aus reinen Frames nicht
+  rekonstruieren.
+- Kein serverseitiges Datei-Lesen per Pfadparameter — Testende müssen die S1-Mitschnittdatei
+  selbst per `jq` extrahieren und im Request-Body übergeben (dokumentiertes Rezept oben).
+- `official_alerts.py:1896-2104` (#1929-Sperrzone) bleibt unangetastet — nur aufgerufen.
+- Keine neue Route ⇒ Go-Proxy (`internal/router/router.go:167`, `internal/handler/proxy.go:297-335`)
+  bleibt unverändert.
+
+## Open Questions
+
+1. Bleibt der Zweig-c-Replay (`nowcast_frames`, Radar-Onset-Ableitung) Teil dieser Scheibe S2,
+   oder wird er als eigene Scheibe S2b abgetrennt? **Empfehlung (Tech-Lead):** drinlassen —
+   Mehrumfang gegenüber Zweig a+b allein liegt bei ~40-60 LoC, die `_derive_result`-Logik ist
+   bereits vollständig entkoppelt aufrufbar, und eine Abtrennung würde die Verifikations-Kette
+   für Format-Scheibe S3+ (die alle drei Zweige braucht) künstlich in zwei PRs zerreißen.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Erweitert einen bereits etablierten, dokumentierten Endpoint (`alert-preview`,
+  ADR-0011 Mehrkanal-Preview) additiv um zwei neue exklusive Payload-Typen — keine neue Route,
+  keine neue Persistenztechnologie, keine Rücknahme einer bestehenden Architekturentscheidung.
+  Kein ADR-würdiger Grundsatzentscheid.
+
+## Changelog
+
+- 2026-08-18: Initial spec created (Scheibe S2 aus #1948, Tech-Lead-Design-Entscheide 2026-08-18).

--- a/src/services/radar_service.py
+++ b/src/services/radar_service.py
@@ -665,7 +665,8 @@ def _capture_nowcast_frames(lat: float, lon: float, frames: list, source: str) -
             payload={
                 "source": source,
                 "frames": [
-                    {"timestamp": f.timestamp.isoformat(), "precip_mm_h": f.precip_mm_h}
+                    {"timestamp": f.timestamp.isoformat(), "precip_mm_h": f.precip_mm_h,
+                     "is_convective": f.is_convective}
                     for f in frames
                 ],
             },

--- a/src/services/validator_render_service.py
+++ b/src/services/validator_render_service.py
@@ -7,7 +7,7 @@ directly.
 from __future__ import annotations
 
 from datetime import date as date_type
-from datetime import datetime, time, timezone
+from datetime import datetime, time, timedelta, timezone
 from typing import Any
 
 from app.models import (
@@ -93,7 +93,15 @@ def render_alert_preview(
     """Render alert preview across all channels.
 
     Returns a dict with subject, email_html, email_plain, telegram, sms.
+    Issue #1948 Scheibe S2: ``official`` (Zweig b) und ``nowcast_frames``
+    (Zweig c) sind zwei weitere exklusive Payload-Typen neben ``onset``
+    und ``changes`` — der Router garantiert bereits Vier-Wege-Exklusivitaet.
     """
+    if getattr(body, "official", None):
+        return _render_official_preview(trip_obj, body.official)
+    if getattr(body, "nowcast_frames", None) is not None:
+        return _render_nowcast_replay(trip_obj, body.nowcast_frames)
+
     alert_tz = _alert_tz_for_trip(trip_obj)
     stand_at = local_fmt(datetime.now(timezone.utc), alert_tz)
     has_onset = body.onset is not None
@@ -146,6 +154,109 @@ def render_alert_preview(
         "telegram": telegram,
         "sms": sms,
     }
+
+
+def _parse_official_dt(value: "str | None") -> "datetime | None":
+    return None if value is None else datetime.fromisoformat(value)
+
+
+def _render_official_preview(trip_obj: Trip, payloads: list) -> dict:
+    """Issue #1948 Scheibe S2 (Zweig b): Render-Sequenz aus
+    ``notification_service.send_official_alert`` (Z. 846-882) gespiegelt --
+    der zustandslose Preview braucht weder Versandkanaele noch
+    Trip-Notification-Historie. #1929-Sperrzone (``official_alerts.py``:
+    1896-2104) wird ausschliesslich AUFGERUFEN, keine Zeile darin geaendert.
+    """
+    from services.official_alerts.models import OfficialAlert
+    from output.renderers.alert.official_alerts import (
+        build_official_alert_notices, render_official_alert_mail_plain,
+        render_official_alert_sms, render_official_alert_subject,
+        render_official_alert_telegram, render_warn_block,
+    )
+    from services.notification_service import (
+        _official_source_label_for, _official_source_url_for,
+    )
+
+    alert_tz = _alert_tz_for_trip(trip_obj)
+    tagged = [
+        (
+            OfficialAlert(
+                source=p.source, hazard=p.hazard, level=p.level, label=p.label,
+                valid_from=_parse_official_dt(p.valid_from),
+                valid_to=_parse_official_dt(p.valid_to),
+                url=p.url, region_label=p.region_label, dedup_id=p.dedup_id,
+            ),
+            p.segment_ids,
+        )
+        for p in payloads
+    ]
+    dto_notices = build_official_alert_notices(trip_obj, tagged)
+    source_label = _official_source_label_for(dto_notices)
+    source_url = _official_source_url_for(dto_notices)
+    stand_at = local_fmt(datetime.now(timezone.utc), alert_tz)
+    subject = render_official_alert_subject(dto_notices, prefix=trip_obj.name, tz=alert_tz)
+    html = render_warn_block(
+        dto_notices, variant="standalone", source_label=source_label,
+        source_url=source_url, stand_at=stand_at, tz=alert_tz,
+        context_label=trip_obj.name,
+    )
+    plain = render_official_alert_mail_plain(
+        dto_notices, source_label=source_label, stand_at=stand_at,
+        tz=alert_tz, context_label=trip_obj.name,
+    )
+    telegram = render_official_alert_telegram(
+        dto_notices, prefix=trip_obj.name, source_label=source_label, tz=alert_tz,
+    )
+    sms = render_official_alert_sms(dto_notices, sms_prefix=trip_obj.name, tz=alert_tz)
+    return {
+        "subject": subject, "email_html": html, "email_plain": plain,
+        "telegram": telegram, "sms": sms,
+    }
+
+
+def _render_nowcast_replay(trip_obj: Trip, body_nf: Any) -> dict:
+    """Issue #1948 Scheibe S2 (Zweig c): Replay eines Frame-Mitschnitts ueber
+    dieselbe ``_derive_result``-Ableitung wie der Live-Radar-Pfad. Kein
+    Onset im Fenster -> expliziter Leerbefund statt Exception/HTTP 500."""
+    from types import SimpleNamespace
+
+    from providers.brightsky import RadarFrame
+    from services.radar_service import RadarNowcastService
+
+    frames = [
+        RadarFrame(
+            timestamp=datetime.fromisoformat(f.timestamp),
+            precip_mm_h=f.precip_mm_h, is_convective=f.is_convective,
+        )
+        for f in body_nf.frames
+    ]
+    svc = RadarNowcastService()
+    now = datetime.now(timezone.utc)
+    result = svc._derive_result(frames, body_nf.source, now=now)
+    if result.onset_minutes is None:
+        return {
+            "onset_detected": False, "subject": None, "email_html": None,
+            "email_plain": None, "telegram": None, "sms": None,
+        }
+
+    alert_tz = _alert_tz_for_trip(trip_obj)
+    onset_time = now + timedelta(minutes=result.onset_minutes)
+    onset_ns = SimpleNamespace(
+        onset_minutes=result.onset_minutes,
+        onset_time=local_fmt(onset_time, alert_tz)[-5:],  # "HH:MM"-Anteil
+        km_from=body_nf.km_from, km_to=body_nf.km_to,
+        is_convective=result.is_convective,
+        intensity_label=result.intensity_label,
+        source_label=RadarNowcastService._SOURCE_LABELS.get(
+            result.source, result.source,
+        ),
+        cooldown_display=None,
+    )
+    out = render_alert_preview(
+        trip_obj, SimpleNamespace(onset=onset_ns, official=None, nowcast_frames=None),
+    )
+    out["onset_detected"] = True
+    return out
 
 
 def render_compare_email_preview(body: Any) -> str:

--- a/tests/tdd/test_alert_preview_no_side_effects.py
+++ b/tests/tdd/test_alert_preview_no_side_effects.py
@@ -1,0 +1,161 @@
+"""TDD-RED: Issue #1948 Scheibe S2 — AC-9 Seiteneffektfreiheit und AC-10
+Mandantentrennung fuer die NEUEN Payload-Typen (``official``,
+``nowcast_frames``) am Preview-Endpoint.
+
+SPEC: docs/specs/modules/alarm_testeinspeisung.md
+
+AC-9: kein Versand, kein ``alert_log``-Eintrag, keine Throttle-Markierung --
+fuer ``official`` UND ``nowcast_frames`` genauso wie fuer die Alt-Typen.
+AC-10: fremder User -> 404; jeder eigene User bekommt fuer BEIDE neuen Typen
+ein korrektes Rendering.
+
+RED-Grund: beide neuen Typen liefern heute 422 (unbekanntes Feld, leere
+Alt-Felder) statt 200 -- die Seiteneffekt-Pruefung waere ohne den
+vorgeschalteten Status-200-Nachweis trivial erfuellt (auf einer 422-Antwort
+passiert nie etwas). Jede Testfunktion assertet deshalb ZUERST 200, bevor
+sie Abwesenheit von Seiteneffekten behauptet.
+
+Kein Mock — echter FastAPI-TestClient, echte Trip-Fixtures, echte
+Dateisystem-Pruefung von ``alert_log.json``/``alert_throttle.json``.
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.loader import get_data_dir
+
+pytestmark = pytest.mark.real_data_root
+
+OFFICIAL_PAYLOAD = {
+    "source": "geosphere_warn", "hazard": "thunderstorm", "level": 3,
+    "label": "Gewitter", "segment_ids": ["1"],
+}
+
+
+@pytest.fixture
+def client():
+    from api.routers import validator
+    app = FastAPI()
+    app.include_router(validator.router)
+    return TestClient(app)
+
+
+def _write_stub_trip(user_id: str, trip_id: str, name: str) -> None:
+    trip_dir = Path("data/users") / user_id / "briefings"
+    trip_dir.mkdir(parents=True, exist_ok=True)
+    (trip_dir / f"{trip_id}.json").write_text(json.dumps({
+        "id": trip_id, "name": name, "stages": [],
+    }))
+
+
+def _nowcast_body() -> dict:
+    now = datetime.now(timezone.utc)
+    return {"nowcast_frames": {
+        "source": "radar",
+        "frames": [
+            {"timestamp": (now + timedelta(minutes=15)).isoformat(),
+             "precip_mm_h": 2.0, "is_convective": False},
+        ],
+    }}
+
+
+@pytest.fixture
+def two_users():
+    uid_a = f"test_1948s2ac9a_{uuid.uuid4().hex[:8]}"
+    uid_b = f"test_1948s2ac9b_{uuid.uuid4().hex[:8]}"
+    trip_a, trip_b = "trip-a", "trip-b"
+    _write_stub_trip(uid_a, trip_a, "Trip A")
+    _write_stub_trip(uid_b, trip_b, "Trip B")
+    yield (uid_a, trip_a), (uid_b, trip_b)
+    shutil.rmtree(Path("data/users") / uid_a, ignore_errors=True)
+    shutil.rmtree(Path("data/users") / uid_b, ignore_errors=True)
+
+
+class TestAC9_NoSideEffects:
+    @pytest.mark.parametrize(
+        "body_factory,label",
+        [
+            (lambda: {"official": [OFFICIAL_PAYLOAD]}, "official"),
+            (_nowcast_body, "nowcast_frames"),
+        ],
+        ids=["official", "nowcast_frames"],
+    )
+    def test_no_alert_log_or_throttle_write_for_new_payload_types(
+        self, client, two_users, body_factory, label,
+    ):
+        (uid_a, trip_a), _ = two_users
+        alert_log = get_data_dir(uid_a) / "alert_log.json"
+        throttle = get_data_dir(uid_a) / "alert_throttle.json"
+        assert not alert_log.exists(), "Fixtur-Schutz: kein Alt-Log vorhanden"
+        assert not throttle.exists(), "Fixtur-Schutz: keine Alt-Throttle-Datei vorhanden"
+
+        resp = client.post(
+            f"/api/trips/{trip_a}/alert-preview",
+            params={"user_id": uid_a}, json=body_factory(),
+        )
+        assert resp.status_code == 200, (
+            f"AC-9 ({label}): Request muss 200 liefern, sonst prueft der "
+            f"Seiteneffekt-Nachweis nichts (leere Menge waere trivial wahr). "
+            f"War {resp.status_code}: {resp.text[:300]}"
+        )
+        assert not alert_log.exists(), (
+            f"AC-9 ({label}): alert_log.json wurde geschrieben -- "
+            "verbotener Seiteneffekt eines zustandslosen Preview-Requests."
+        )
+        assert not throttle.exists(), (
+            f"AC-9 ({label}): alert_throttle.json wurde geschrieben -- "
+            "verbotener Seiteneffekt eines zustandslosen Preview-Requests."
+        )
+
+
+class TestAC10_MandantentrennungFuerNeueTypen:
+    def test_cross_user_denied_and_each_user_self_access_renders_correctly(
+        self, client, two_users,
+    ):
+        (uid_a, trip_a), (uid_b, trip_b) = two_users
+
+        cross_resp = client.post(
+            f"/api/trips/{trip_b}/alert-preview",
+            params={"user_id": uid_a}, json={"official": [OFFICIAL_PAYLOAD]},
+        )
+        assert cross_resp.status_code == 404, (
+            f"AC-10: Nutzer A darf den Trip von Nutzer B nicht sehen, bekam "
+            f"{cross_resp.status_code}: {cross_resp.text[:200]}"
+        )
+
+        for uid, trip_id, name in ((uid_a, trip_a, "Trip A"), (uid_b, trip_b, "Trip B")):
+            resp_official = client.post(
+                f"/api/trips/{trip_id}/alert-preview",
+                params={"user_id": uid}, json={"official": [OFFICIAL_PAYLOAD]},
+            )
+            assert resp_official.status_code == 200, (
+                f"AC-10: Self-Access 'official' fuer {uid} muss 200 "
+                f"liefern, war {resp_official.status_code}: "
+                f"{resp_official.text[:300]}"
+            )
+            assert f"[{name}]" in resp_official.json()["subject"], (
+                f"AC-10: Betreff muss den EIGENEN Trip-Namen '{name}' "
+                f"tragen: {resp_official.json()['subject']!r}"
+            )
+
+            resp_nowcast = client.post(
+                f"/api/trips/{trip_id}/alert-preview",
+                params={"user_id": uid}, json=_nowcast_body(),
+            )
+            assert resp_nowcast.status_code == 200, (
+                f"AC-10: Self-Access 'nowcast_frames' fuer {uid} muss 200 "
+                f"liefern, war {resp_nowcast.status_code}: "
+                f"{resp_nowcast.text[:300]}"
+            )
+            assert resp_nowcast.json().get("onset_detected") is True, (
+                f"AC-10: Onset muss fuer {uid}s eigenen Trip erkannt "
+                f"werden: {resp_nowcast.json()!r}"
+            )

--- a/tests/tdd/test_alert_preview_nowcast_replay.py
+++ b/tests/tdd/test_alert_preview_nowcast_replay.py
@@ -1,0 +1,151 @@
+"""TDD-RED: Issue #1948 Scheibe S2 — AC-6/AC-7 Zweig-c-Replay
+(``nowcast_frames``) am Preview-Endpoint.
+
+SPEC: docs/specs/modules/alarm_testeinspeisung.md
+
+AC-6: Frames mit Regen-Onset im Nowcast-Horizont -> dieselbe
+``_derive_result``-Ableitung wie der Live-Radar-Pfad, volles Preview mit
+``onset_detected: true``.
+AC-7: Frames ohne Onset -> HTTP 200, ``onset_detected: false``, alle
+Render-Felder ``null`` -- statt Exception/HTTP 500.
+
+RED-Grund: ``AlertPreviewBody`` kennt heute kein ``nowcast_frames``-Feld
+(Pydantic ignoriert es); mit leerem ``changes``/``onset`` liefert der
+Endpunkt 422 statt 200.
+
+Wanduhr-Ratsche (#1940): alle Frame-Zeitstempel sind relativ zu einem
+``request_now``, der UNMITTELBAR vor dem Request erfasst wird -- keine
+festen Uhrzeiten, kein Hour-Tipping.
+
+Kein Mock — echter FastAPI-TestClient, echte Trip-Fixture.
+"""
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.real_data_root
+
+
+@pytest.fixture
+def client():
+    from api.routers import validator
+    app = FastAPI()
+    app.include_router(validator.router)
+    return TestClient(app)
+
+
+@pytest.fixture
+def stub_trip():
+    user_id = f"test_1948s2ac6_{uuid.uuid4().hex[:8]}"
+    trip_id = "trip-ac6"
+    trip_dir = Path("data/users") / user_id / "briefings"
+    trip_dir.mkdir(parents=True, exist_ok=True)
+    (trip_dir / f"{trip_id}.json").write_text(json.dumps({
+        "id": trip_id, "name": "AC-6 Trip", "stages": [],
+    }))
+    yield user_id, trip_id
+    shutil.rmtree(Path("data/users") / user_id, ignore_errors=True)
+
+
+def _wet_frames(now: datetime) -> list[dict]:
+    """Erster nasser Frame nach 20 Minuten, 2.5 mm/h (>= "Maessiger Regen",
+    < 4.0 mm/h Schwelle "Starker Regen")."""
+    return [
+        {"timestamp": (now + timedelta(minutes=5)).isoformat(),
+         "precip_mm_h": 0.0, "is_convective": False},
+        {"timestamp": (now + timedelta(minutes=20)).isoformat(),
+         "precip_mm_h": 2.5, "is_convective": False},
+        {"timestamp": (now + timedelta(minutes=40)).isoformat(),
+         "precip_mm_h": 3.0, "is_convective": False},
+    ]
+
+
+def _dry_frames(now: datetime) -> list[dict]:
+    """Alle Raten unter der Trockenschwelle (0.1 mm/h) -- kein Onset."""
+    return [
+        {"timestamp": (now + timedelta(minutes=m)).isoformat(),
+         "precip_mm_h": 0.0, "is_convective": False}
+        for m in (10, 30, 60)
+    ]
+
+
+class TestAC6_OnsetReplayDetectsOnset:
+    def test_wet_frames_yield_onset_detected_true_with_derived_minutes(
+        self, client, stub_trip,
+    ):
+        user_id, trip_id = stub_trip
+        request_now = datetime.now(timezone.utc)
+        body = {"nowcast_frames": {
+            "source": "radar", "frames": _wet_frames(request_now),
+            "km_from": 2.0, "km_to": 6.0,
+        }}
+        resp = client.post(
+            f"/api/trips/{trip_id}/alert-preview",
+            params={"user_id": user_id}, json=body,
+        )
+        assert resp.status_code == 200, f"Body: {resp.text[:300]}"
+        data = resp.json()
+        assert data.get("onset_detected") is True, (
+            f"AC-6: onset_detected muss True sein: {data!r}"
+        )
+        for field in ("subject", "email_html", "email_plain", "telegram", "sms"):
+            assert data.get(field), (
+                f"AC-6: '{field}' darf bei erkanntem Onset nicht leer sein: {data!r}"
+            )
+
+        match = re.search(r"R!(\d+)", data["sms"])
+        assert match, (
+            f"AC-6: SMS muss ein nicht-konvektives 'R!<Minuten>'-Token "
+            f"tragen: {data['sms']!r}"
+        )
+        actual_minutes = int(match.group(1))
+        assert abs(actual_minutes - 20) <= 1, (
+            f"AC-6: onset_minutes muss aus derselben _derive_result-"
+            f"Ableitung stammen wie der Live-Radar-Pfad (erster nasser "
+            f"Frame bei ~20 Min), bekam R!{actual_minutes}"
+        )
+        assert (
+            "Mäßiger Regen" in data["email_plain"]
+            or "Mäßiger Regen" in data["telegram"]
+        ), (
+            f"AC-6: Intensitaets-Label 'Mäßiger Regen' (2.5 mm/h) muss "
+            f"reflektiert werden.\nplain={data['email_plain']!r}\n"
+            f"telegram={data['telegram']!r}"
+        )
+
+
+class TestAC7_NoOnsetReturns200WithNullFields:
+    def test_dry_frames_yield_200_onset_false_and_null_render_fields(
+        self, client, stub_trip,
+    ):
+        user_id, trip_id = stub_trip
+        request_now = datetime.now(timezone.utc)
+        body = {"nowcast_frames": {
+            "source": "radar", "frames": _dry_frames(request_now),
+        }}
+        resp = client.post(
+            f"/api/trips/{trip_id}/alert-preview",
+            params={"user_id": user_id}, json=body,
+        )
+        assert resp.status_code == 200, (
+            f"AC-7: trockene Frames muessen 200 liefern, keine Exception "
+            f"oder HTTP 500. War {resp.status_code}: {resp.text[:300]}"
+        )
+        data = resp.json()
+        assert data.get("onset_detected") is False, (
+            f"AC-7: onset_detected muss False sein: {data!r}"
+        )
+        for field in ("subject", "email_html", "email_plain", "telegram", "sms"):
+            assert data.get(field) is None, (
+                f"AC-7: '{field}' muss null sein, wenn kein Onset erkannt "
+                f"wurde: {data!r}"
+            )

--- a/tests/tdd/test_alert_preview_official_render.py
+++ b/tests/tdd/test_alert_preview_official_render.py
@@ -1,0 +1,199 @@
+"""TDD-RED: Issue #1948 Scheibe S2 — AC-4/AC-5 Zweig b (amtliche Warnung)
+am Preview-Endpoint.
+
+SPEC: docs/specs/modules/alarm_testeinspeisung.md
+
+AC-4: ``official``-Payload liefert alle fuenf Kanal-Felder nicht-leer, mit
+Inhalten die hazard/level/label widerspiegeln (Struktur-/Wertevergleich
+gegen bekannte Renderer-Vokabeln, kein geratener String-Contains).
+
+AC-5 (Fidelity): dieselbe ``OfficialAlert``-Eingabe ueber den Preview-
+Endpoint UND direkt ueber ``build_official_alert_notices`` + die vier
+Vorlagen-Renderer (#1929-Sperrzone bleibt unangetastet, wird nur
+AUFGERUFEN) muessen byte-identische SMS-/Telegram-/HTML-/Plain-Ausgaben
+liefern.
+
+RED-Grund: ``AlertPreviewBody`` kennt heute kein ``official``-Feld (Pydantic
+ignoriert es); mit leerem ``changes``/``onset`` liefert der Endpunkt 422
+statt 200.
+
+Kein Mock — echter FastAPI-TestClient, echte Renderer-Aufrufe, echte
+Trip-Fixture.
+"""
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.real_data_root
+
+OFFICIAL_PAYLOAD = {
+    "source": "geosphere_warn", "hazard": "thunderstorm", "level": 3,
+    "label": "Gewitter", "segment_ids": ["1"],
+}
+
+
+@pytest.fixture
+def client():
+    from api.routers import validator
+    app = FastAPI()
+    app.include_router(validator.router)
+    return TestClient(app)
+
+
+@pytest.fixture
+def stub_trip():
+    user_id = f"test_1948s2ac4_{uuid.uuid4().hex[:8]}"
+    trip_id = "trip-ac4"
+    trip_dir = Path("data/users") / user_id / "briefings"
+    trip_dir.mkdir(parents=True, exist_ok=True)
+    (trip_dir / f"{trip_id}.json").write_text(json.dumps({
+        "id": trip_id, "name": "AC-4 Trip", "stages": [],
+    }))
+    yield user_id, trip_id
+    shutil.rmtree(Path("data/users") / user_id, ignore_errors=True)
+
+
+class TestAC4_OfficialRenderAllFiveFields:
+    def test_official_payload_renders_all_five_fields_reflecting_hazard_level_label(
+        self, client, stub_trip,
+    ):
+        from output.tokens.hazard_symbols import HAZARD_SMS_SYMBOLS
+        from output.renderers.alert.official_alerts import _LEVEL_WORDS
+
+        user_id, trip_id = stub_trip
+        resp = client.post(
+            f"/api/trips/{trip_id}/alert-preview",
+            params={"user_id": user_id},
+            json={"official": [OFFICIAL_PAYLOAD]},
+        )
+        assert resp.status_code == 200, f"Body: {resp.text[:300]}"
+        data = resp.json()
+        for field in ("subject", "email_html", "email_plain", "telegram", "sms"):
+            assert field in data, f"Feld '{field}' fehlt in der Antwort: {list(data)}"
+            assert isinstance(data[field], str) and data[field], (
+                f"AC-4: '{field}' darf nicht leer sein: {data[field]!r}"
+            )
+
+        level_word = _LEVEL_WORDS[OFFICIAL_PAYLOAD["level"]][1]  # "ORANGE" fuer Stufe 3
+        sms_symbol = HAZARD_SMS_SYMBOLS[OFFICIAL_PAYLOAD["hazard"]]  # "TH" fuer thunderstorm
+
+        assert data["subject"].startswith("["), (
+            f"Betreff muss mit '[<Trip>]' beginnen: {data['subject']!r}"
+        )
+        assert level_word in data["subject"], (
+            f"AC-4: Betreff muss die Warnstufe '{level_word}' (Stufe "
+            f"{OFFICIAL_PAYLOAD['level']}) nennen: {data['subject']!r}"
+        )
+        assert OFFICIAL_PAYLOAD["label"] in data["telegram"], (
+            f"AC-4: Telegram muss das Label '{OFFICIAL_PAYLOAD['label']}' "
+            f"nennen: {data['telegram']!r}"
+        )
+        assert OFFICIAL_PAYLOAD["label"] in data["email_plain"], (
+            f"AC-4: email_plain muss das Label '{OFFICIAL_PAYLOAD['label']}' "
+            f"nennen: {data['email_plain']!r}"
+        )
+        assert re.search(rf"\b{sms_symbol}\b|{sms_symbol}!", data["sms"]), (
+            f"AC-4: SMS muss das Hazard-Kuerzel '{sms_symbol}' "
+            f"(thunderstorm) tragen: {data['sms']!r}"
+        )
+
+
+class TestAC5_FidelityWithDirectRenderPath:
+    def test_official_preview_matches_direct_renderer_calls_byte_identical(
+        self, client, stub_trip,
+    ):
+        user_id, trip_id = stub_trip
+        resp = client.post(
+            f"/api/trips/{trip_id}/alert-preview",
+            params={"user_id": user_id},
+            json={"official": [OFFICIAL_PAYLOAD]},
+        )
+        assert resp.status_code == 200, f"Body: {resp.text[:300]}"
+        data = resp.json()
+
+        from api.routers.validator import _load_trip_for_validator
+        from output.renderers.alert.official_alerts import (
+            build_official_alert_notices, render_official_alert_mail_plain,
+            render_official_alert_sms, render_official_alert_subject,
+            render_official_alert_telegram, render_warn_block,
+        )
+        from services.notification_service import (
+            _official_source_label_for, _official_source_url_for,
+        )
+        from services.official_alerts.models import OfficialAlert
+        from services.validator_render_service import _alert_tz_for_trip
+        from utils.timezone import local_fmt
+
+        trip_obj = _load_trip_for_validator(user_id, trip_id)
+        assert trip_obj is not None, "Fixtur-Schutz: Trip muss ladbar sein"
+
+        alert = OfficialAlert(
+            source=OFFICIAL_PAYLOAD["source"], hazard=OFFICIAL_PAYLOAD["hazard"],
+            level=OFFICIAL_PAYLOAD["level"], label=OFFICIAL_PAYLOAD["label"],
+        )
+        dto_notices = build_official_alert_notices(
+            trip_obj, [(alert, OFFICIAL_PAYLOAD["segment_ids"])],
+        )
+        source_label = _official_source_label_for(dto_notices)
+        source_url = _official_source_url_for(dto_notices)
+        alert_tz = _alert_tz_for_trip(trip_obj)
+        stand_at = local_fmt(datetime.now(timezone.utc), alert_tz)
+
+        expected_subject = render_official_alert_subject(
+            dto_notices, prefix=trip_obj.name, tz=alert_tz,
+        )
+        expected_html = render_warn_block(
+            dto_notices, variant="standalone", source_label=source_label,
+            source_url=source_url, stand_at=stand_at, tz=alert_tz,
+            context_label=trip_obj.name,
+        )
+        expected_plain = render_official_alert_mail_plain(
+            dto_notices, source_label=source_label, stand_at=stand_at,
+            tz=alert_tz, context_label=trip_obj.name,
+        )
+        expected_telegram = render_official_alert_telegram(
+            dto_notices, prefix=trip_obj.name, source_label=source_label, tz=alert_tz,
+        )
+        expected_sms = render_official_alert_sms(
+            dto_notices, sms_prefix=trip_obj.name, tz=alert_tz,
+        )
+
+        def _strip_stand(text: str) -> str:
+            """Neutralisiert 'Stand: heute HH:MM' -- Wanduhr-Ratsche: die
+            direkt gerechnete Erwartung und der Endpoint-Aufruf koennen
+            theoretisch ueber eine Minutengrenze hinweg auseinanderfallen;
+            der Rest der Ausgabe bleibt strikt byte-identisch."""
+            return re.sub(r"Stand:\s*heute\s*\d{2}:\d{2}", "Stand: heute <ZEIT>", text)
+
+        assert data["subject"] == expected_subject, (
+            f"AC-5: Betreff weicht vom direkten Renderer-Aufruf ab.\n"
+            f"Endpoint: {data['subject']!r}\nDirekt:   {expected_subject!r}"
+        )
+        assert data["sms"] == expected_sms, (
+            f"AC-5: SMS weicht vom direkten Renderer-Aufruf ab.\n"
+            f"Endpoint: {data['sms']!r}\nDirekt:   {expected_sms!r}"
+        )
+        assert data["telegram"] == expected_telegram, (
+            f"AC-5: Telegram weicht vom direkten Renderer-Aufruf ab.\n"
+            f"Endpoint: {data['telegram']!r}\nDirekt:   {expected_telegram!r}"
+        )
+        assert _strip_stand(data["email_html"]) == _strip_stand(expected_html), (
+            f"AC-5: HTML weicht vom direkten Renderer-Aufruf ab (Stand-"
+            f"Zeitstempel neutralisiert).\nEndpoint: {data['email_html'][:400]!r}\n"
+            f"Direkt:   {expected_html[:400]!r}"
+        )
+        assert _strip_stand(data["email_plain"]) == _strip_stand(expected_plain), (
+            f"AC-5: email_plain weicht vom direkten Renderer-Aufruf ab "
+            f"(Stand-Zeitstempel neutralisiert).\n"
+            f"Endpoint: {data['email_plain'][:400]!r}\n"
+            f"Direkt:   {expected_plain[:400]!r}"
+        )

--- a/tests/tdd/test_alert_preview_payload_exclusivity.py
+++ b/tests/tdd/test_alert_preview_payload_exclusivity.py
@@ -1,0 +1,201 @@
+"""TDD-RED: Issue #1948 Scheibe S2 — AC-1/AC-3 Payload-Exklusivitaet am
+Preview-Endpoint ``POST /api/trips/{trip_id}/alert-preview``.
+
+SPEC: docs/specs/modules/alarm_testeinspeisung.md
+
+Der 422-Guard wird von einer binaeren (onset XOR changes+segment_times) auf
+eine Vier-Wege-Exklusivitaet erweitert (``onset`` | ``changes`` | ``official``
+| ``nowcast_frames``). AC-1 verlangt eine 422-Meldung, die ALLE VIER Typen
+nennt; AC-3 verlangt bei unbekannter ``segment_id`` eine 422-Meldung, die die
+ID selbst nennt.
+
+RED-Grund: ``AlertPreviewBody`` kennt heute weder ``official`` noch
+``nowcast_frames`` (Pydantic ignoriert unbekannte Felder), und die
+422-Meldung nennt nur 'onset'/'changes'. Manche Kombinationen unten liefern
+deshalb HEUTE bereits zufaellig 422 (weil das binaere Alt-Gate zwei bekannte
+Felder gleichzeitig sieht), andere HEUTE 200 (weil ``official``/
+``nowcast_frames`` unbeachtet verpuffen und nur das Alt-Feld ``changes``
+uebrig bleibt) -- in JEDEM Fall schlaegt mindestens eine der beiden
+Zusicherungen (Status ODER Meldungstext) heute fehl.
+
+Kein Mock — echter FastAPI-TestClient gegen den echten Router, echte
+Trip-Fixtures unter data/users/<uid>/briefings/.
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import uuid
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.real_data_root
+
+REQUIRED_TYPE_NAMES = ("onset", "changes", "official", "nowcast_frames")
+
+CHANGE_PAYLOAD = {
+    "metric": "gust_max_kmh", "old_value": 25.0, "new_value": 72.0,
+    "delta": 47.0, "threshold": 60.0, "severity": "major", "direction": "increase",
+    "segment_id": "1",
+}
+SEGMENT_TIME_PAYLOAD = {"segment_id": "1", "start": "08:00", "end": "10:00"}
+ONSET_PAYLOAD = {
+    "onset_minutes": 12, "onset_time": "14:35", "km_from": 0.0, "km_to": 5.0,
+    "is_convective": False, "intensity_label": "leichter Regen",
+    "source_label": "Radar (DWD)",
+}
+OFFICIAL_PAYLOAD = {
+    "source": "geosphere_warn", "hazard": "thunderstorm", "level": 3,
+    "label": "Gewitter", "segment_ids": ["1"],
+}
+
+
+def _nowcast_frames_payload() -> dict:
+    now = datetime.now(timezone.utc)
+    return {
+        "source": "radar",
+        "frames": [
+            {"timestamp": (now + timedelta(minutes=20)).isoformat(),
+             "precip_mm_h": 2.5, "is_convective": False},
+        ],
+        "km_from": 0.0, "km_to": 5.0,
+    }
+
+
+@pytest.fixture
+def client():
+    from api.routers import validator
+    app = FastAPI()
+    app.include_router(validator.router)
+    return TestClient(app)
+
+
+@pytest.fixture
+def stub_trip():
+    user_id = f"test_1948s2ac1_{uuid.uuid4().hex[:8]}"
+    trip_id = "trip-stub"
+    trip_dir = Path("data/users") / user_id / "briefings"
+    trip_dir.mkdir(parents=True, exist_ok=True)
+    (trip_dir / f"{trip_id}.json").write_text(json.dumps({
+        "id": trip_id, "name": "Exklusivitaets-Trip", "stages": [],
+    }))
+    yield user_id, trip_id
+    shutil.rmtree(Path("data/users") / user_id, ignore_errors=True)
+
+
+def _write_real_trip(user_id: str, trip_id: str) -> None:
+    """Trip mit EINEM echten Segment ('1') fuer den AC-3-Unbekannt-Test."""
+    trip_dir = Path("data/users") / user_id / "briefings"
+    trip_dir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "id": trip_id, "name": "AC-3 Trip",
+        "stages": [{
+            "id": "T1", "name": "Tag 1", "date": date.today().isoformat(),
+            "waypoints": [
+                {"id": "G1", "name": "Start", "lat": 47.0, "lon": 11.0,
+                 "elevation_m": 1000, "arrival_override": "08:00"},
+                {"id": "G2", "name": "Ziel", "lat": 47.05, "lon": 11.05,
+                 "elevation_m": 1200, "arrival_override": "10:00"},
+            ],
+        }],
+    }
+    (trip_dir / f"{trip_id}.json").write_text(json.dumps(payload))
+
+
+def _assert_422_names_all_four(resp) -> None:
+    assert resp.status_code == 422, (
+        f"Erwartet 422, bekam {resp.status_code}: {resp.text[:300]}"
+    )
+    detail = resp.json().get("detail", "")
+    for name in REQUIRED_TYPE_NAMES:
+        assert name in detail, (
+            f"AC-1: 422-Meldung muss alle vier Typnamen nennen, "
+            f"'{name}' fehlt. Meldung: {detail!r}"
+        )
+
+
+class TestAC1_PayloadExclusivity:
+    """AC-1: genau EINER von onset/changes/official/nowcast_frames -- sonst
+    422 mit einer Meldung, die alle vier Typen benennt."""
+
+    def test_empty_body_returns_422_naming_all_four_types(self, client, stub_trip):
+        user_id, trip_id = stub_trip
+        resp = client.post(
+            f"/api/trips/{trip_id}/alert-preview",
+            params={"user_id": user_id}, json={},
+        )
+        _assert_422_names_all_four(resp)
+
+    def test_two_types_simultaneously_returns_422_naming_all_four_types(
+        self, client, stub_trip,
+    ):
+        user_id, trip_id = stub_trip
+        body = {
+            "changes": [CHANGE_PAYLOAD], "segment_times": [SEGMENT_TIME_PAYLOAD],
+            "official": [OFFICIAL_PAYLOAD],
+        }
+        resp = client.post(
+            f"/api/trips/{trip_id}/alert-preview",
+            params={"user_id": user_id}, json=body,
+        )
+        _assert_422_names_all_four(resp)
+
+    def test_three_types_simultaneously_returns_422_naming_all_four_types(
+        self, client, stub_trip,
+    ):
+        user_id, trip_id = stub_trip
+        body = {
+            "changes": [CHANGE_PAYLOAD], "segment_times": [SEGMENT_TIME_PAYLOAD],
+            "official": [OFFICIAL_PAYLOAD],
+            "nowcast_frames": _nowcast_frames_payload(),
+        }
+        resp = client.post(
+            f"/api/trips/{trip_id}/alert-preview",
+            params={"user_id": user_id}, json=body,
+        )
+        _assert_422_names_all_four(resp)
+
+    def test_all_four_types_simultaneously_returns_422_naming_all_four_types(
+        self, client, stub_trip,
+    ):
+        user_id, trip_id = stub_trip
+        body = {
+            "onset": ONSET_PAYLOAD,
+            "changes": [CHANGE_PAYLOAD], "segment_times": [SEGMENT_TIME_PAYLOAD],
+            "official": [OFFICIAL_PAYLOAD],
+            "nowcast_frames": _nowcast_frames_payload(),
+        }
+        resp = client.post(
+            f"/api/trips/{trip_id}/alert-preview",
+            params={"user_id": user_id}, json=body,
+        )
+        _assert_422_names_all_four(resp)
+
+
+class TestAC3_UnknownSegmentId:
+    """AC-3: ``changes`` ohne ``segment_times`` mit einer im Trip nicht
+    existenten ``segment_id`` -> 422, Meldung nennt die unbekannte ID."""
+
+    def test_unknown_segment_id_returns_422_naming_the_id(self, client):
+        user_id = f"test_1948s2ac3_{uuid.uuid4().hex[:8]}"
+        trip_id = "trip-ac3"
+        try:
+            _write_real_trip(user_id, trip_id)
+            bogus_id = "does-not-exist-9876"
+            body = {"changes": [{**CHANGE_PAYLOAD, "segment_id": bogus_id}]}
+            resp = client.post(
+                f"/api/trips/{trip_id}/alert-preview",
+                params={"user_id": user_id}, json=body,
+            )
+            assert resp.status_code == 422, f"Body: {resp.text[:300]}"
+            detail = resp.json().get("detail", "")
+            assert bogus_id in detail, (
+                f"AC-3: 422-Meldung muss die unbekannte segment_id "
+                f"{bogus_id!r} nennen. Meldung: {detail!r}"
+            )
+        finally:
+            shutil.rmtree(Path("data/users") / user_id, ignore_errors=True)

--- a/tests/tdd/test_alert_preview_segment_synthesis.py
+++ b/tests/tdd/test_alert_preview_segment_synthesis.py
@@ -1,0 +1,130 @@
+"""TDD-RED: Issue #1948 Scheibe S2 — AC-2 Zweig-a-Replay ohne ``segment_times``.
+
+SPEC: docs/specs/modules/alarm_testeinspeisung.md
+
+Fehlt ``segment_times``, werden die Segment-Zeiten der in ``changes``
+genannten ``segment_id``s aus dem bereits geladenen Trip synthetisiert
+(``trip_local_today`` + ``convert_trip_to_segments``). Damit ist eine S1-
+Mitschnittdatei (die nie ``segment_times`` enthaelt) ohne Transformation
+einspeisbar.
+
+RED-Grund: ``AlertPreviewBody.segment_times`` ist heute PFLICHT (der
+422-Guard verlangt ``changes`` UND ``segment_times``) -- ein Request nur mit
+``changes`` liefert heute 422 statt 200.
+
+Kein Mock — echter FastAPI-TestClient, echte Trip-Fixture, die erwarteten
+expliziten ``segment_times`` werden ueber DIESELBE Produktions-Segmentierung
+(``convert_trip_to_segments``) gewonnen, nicht handgerechnet (vermeidet
+Zeitzonen-Fehlrechnung und Wanduhr-Kippkanten).
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import uuid
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.real_data_root
+
+CHANGE_TEMPLATE = {
+    "metric": "gust_max_kmh", "old_value": 25.0, "new_value": 72.0,
+    "delta": 47.0, "threshold": 60.0, "severity": "major", "direction": "increase",
+}
+
+
+@pytest.fixture
+def client():
+    from api.routers import validator
+    app = FastAPI()
+    app.include_router(validator.router)
+    return TestClient(app)
+
+
+@pytest.fixture
+def real_trip():
+    """Trip mit drei Wegpunkten (= zwei echten Segmenten '1'/'2') fuer HEUTE
+    (``date.today()``), feste ``arrival_override``-Zeiten -- deterministisch,
+    unabhaengig von Naismith-Berechnung."""
+    user_id = f"test_1948s2ac2_{uuid.uuid4().hex[:8]}"
+    trip_id = "trip-ac2"
+    trip_dir = Path("data/users") / user_id / "briefings"
+    trip_dir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "id": trip_id, "name": "AC-2 Trip",
+        "stages": [{
+            "id": "T1", "name": "Tag 1", "date": date.today().isoformat(),
+            "waypoints": [
+                {"id": "G1", "name": "Start", "lat": 47.0, "lon": 11.0,
+                 "elevation_m": 1000, "arrival_override": "08:00"},
+                {"id": "G2", "name": "Mitte", "lat": 47.05, "lon": 11.05,
+                 "elevation_m": 1200, "arrival_override": "10:00"},
+                {"id": "G3", "name": "Ziel", "lat": 47.1, "lon": 11.1,
+                 "elevation_m": 900, "arrival_override": "12:00"},
+            ],
+        }],
+    }
+    (trip_dir / f"{trip_id}.json").write_text(json.dumps(payload))
+    yield user_id, trip_id
+    shutil.rmtree(Path("data/users") / user_id, ignore_errors=True)
+
+
+def _real_segment_times(user_id: str, trip_id: str) -> list[dict]:
+    """Baut die 'richtigen' expliziten segment_times ueber denselben
+    Produktions-Segmentierungsweg, den die Synthese im GREEN-Stand nutzen
+    MUSS -- kein Handrechnen von Zeitzonen-Offsets."""
+    from api.routers.validator import _load_trip_for_validator
+    from services.trip_day import trip_local_today
+    from services.trip_segments import convert_trip_to_segments
+
+    trip_obj = _load_trip_for_validator(user_id, trip_id)
+    today = trip_local_today(trip_obj, datetime.now(timezone.utc))
+    segments = convert_trip_to_segments(trip_obj, today)
+    return [
+        {"segment_id": str(s.segment_id),
+         "start": s.start_time.strftime("%H:%M"),
+         "end": s.end_time.strftime("%H:%M")}
+        for s in segments
+    ]
+
+
+class TestAC2_SegmentTimesSynthesizedFromTrip:
+    def test_synthesized_segment_times_match_explicit_equivalent_byte_identical(
+        self, client, real_trip,
+    ):
+        user_id, trip_id = real_trip
+        real_times = _real_segment_times(user_id, trip_id)
+        assert real_times, (
+            "Fixtur-Schutz: der Trip muss reale Segmente fuer heute liefern, "
+            f"sonst testet AC-2 nichts. Bekam: {real_times!r}"
+        )
+        used_ids = [seg["segment_id"] for seg in real_times[:2]]
+        changes = [{**CHANGE_TEMPLATE, "segment_id": sid} for sid in used_ids]
+        explicit_times = [seg for seg in real_times if seg["segment_id"] in used_ids]
+
+        resp_synth = client.post(
+            f"/api/trips/{trip_id}/alert-preview",
+            params={"user_id": user_id},
+            json={"changes": changes},
+        )
+        resp_explicit = client.post(
+            f"/api/trips/{trip_id}/alert-preview",
+            params={"user_id": user_id},
+            json={"changes": changes, "segment_times": explicit_times},
+        )
+
+        assert resp_synth.status_code == 200, (
+            f"AC-2: Request ohne segment_times muss 200 liefern (Segment-"
+            f"Zeiten werden aus dem Trip synthetisiert), war "
+            f"{resp_synth.status_code}: {resp_synth.text[:300]}"
+        )
+        assert resp_explicit.status_code == 200, f"Body: {resp_explicit.text[:300]}"
+        assert resp_synth.json() == resp_explicit.json(), (
+            "AC-2: synthetisierte und explizit gleichwertige segment_times "
+            "muessen byte-identische Antworten liefern.\n"
+            f"Synth: {resp_synth.text[:500]}\nExplizit: {resp_explicit.text[:500]}"
+        )

--- a/tests/tdd/test_alert_preview_segment_synthesis.py
+++ b/tests/tdd/test_alert_preview_segment_synthesis.py
@@ -128,3 +128,63 @@ class TestAC2_SegmentTimesSynthesizedFromTrip:
             "muessen byte-identische Antworten liefern.\n"
             f"Synth: {resp_synth.text[:500]}\nExplizit: {resp_explicit.text[:500]}"
         )
+
+
+class TestGuard_SynthesizeSegmentTimesMatchesConvertTripToSegments:
+    """Waechter-Test (Fix-Loop, Adversary-Fund F001 HIGH): der AC-2-Byte-
+    Vergleich ueber den Endpoint prueft nur, dass BEIDE Requests gleich
+    rendern -- nicht, dass ``_synthesize_segment_times()`` die RICHTIGEN
+    start/end-Werte liefert (der Renderpfad konsumiert start/end aktuell gar
+    nicht: ``_stub_segment`` setzt km 0-0, ``to_alert_message`` liest nur
+    start_point/end_point/occurred_at). Eine vertauschte start/end-Zuordnung
+    waere durch den bisherigen Test NICHT gefangen worden. Dieser Test prueft
+    ``_synthesize_segment_times()`` DIREKT gegen ``convert_trip_to_segments()``
+    -- ohne HTTP-Umweg, an der Stelle, an der die Zusicherung wirkt."""
+
+    def test_synthesized_start_end_match_convert_trip_to_segments_exactly(
+        self, real_trip,
+    ):
+        from api.routers.validator import (
+            ChangePayload, _load_trip_for_validator, _synthesize_segment_times,
+        )
+        from services.trip_day import trip_local_today
+        from services.trip_segments import convert_trip_to_segments
+
+        user_id, trip_id = real_trip
+        trip_obj = _load_trip_for_validator(user_id, trip_id)
+        today = trip_local_today(trip_obj, datetime.now(timezone.utc))
+        real_segments = {
+            str(s.segment_id): s for s in convert_trip_to_segments(trip_obj, today)
+        }
+        assert real_segments, (
+            "Fixtur-Schutz: der Trip muss reale Segmente fuer heute liefern, "
+            f"sonst prueft dieser Test nichts. Bekam: {real_segments!r}"
+        )
+
+        changes = [
+            ChangePayload(**{**CHANGE_TEMPLATE, "segment_id": sid})
+            for sid in real_segments
+        ]
+        synthesized = _synthesize_segment_times(trip_obj, changes)
+        by_id = {st.segment_id: st for st in synthesized}
+        assert set(by_id) == set(real_segments), (
+            f"Synthetisierte segment_ids weichen ab: {sorted(by_id)} != "
+            f"{sorted(real_segments)}"
+        )
+
+        for sid, seg in real_segments.items():
+            expected_start = seg.start_time.strftime("%H:%M")
+            expected_end = seg.end_time.strftime("%H:%M")
+            assert by_id[sid].start == expected_start, (
+                f"Segment {sid}: start weicht von convert_trip_to_segments() "
+                f"ab: {by_id[sid].start!r} != {expected_start!r}"
+            )
+            assert by_id[sid].end == expected_end, (
+                f"Segment {sid}: end weicht von convert_trip_to_segments() "
+                f"ab: {by_id[sid].end!r} != {expected_end!r}"
+            )
+            assert by_id[sid].start < by_id[sid].end, (
+                f"Segment {sid}: start muss vor end liegen (start/end nicht "
+                f"vertauscht), bekam start={by_id[sid].start!r} "
+                f"end={by_id[sid].end!r}"
+            )

--- a/tests/tdd/test_radar_capture_is_convective.py
+++ b/tests/tdd/test_radar_capture_is_convective.py
@@ -1,0 +1,70 @@
+"""TDD-RED: Issue #1948 Scheibe S2 — AC-8 ``is_convective`` je Frame im
+Zweig-c-Mitschnitt (S1-Erweiterung, einzige Aenderung an S1-Code).
+
+SPEC: docs/specs/modules/alarm_testeinspeisung.md
+
+``RadarNowcastService._capture_nowcast_frames`` (radar_service.py:660-676)
+schreibt heute je Frame nur ``timestamp``/``precip_mm_h`` -- ``is_convective``
+liegt auf ``RadarFrame.is_convective`` bereits vor, wird aber nicht mit
+weggeschrieben. Ohne das Feld deckt eine Zweig-c-Mitschnittdatei nicht alle
+Pflichtfelder von ``NowcastFramesPayload`` ab (Scheibe S2).
+
+RED-Grund: ``is_convective`` fehlt im geschriebenen Datensatz.
+
+Mock-frei: echte ``RadarFrame``-Objekte (DI-Seam ``frame_source``), echte
+``RadarNowcastCacheService``-Instanz (leer -> garantierter Cache-Miss),
+echte Dateilese-Pruefung. Kein ``real_data_root``-Marker: die autouse-
+Isolation (``_isolate_data_root``) leitet ``get_data_root()`` in einen
+tmp-Pfad um, wie im Vorbild ``tests/unit/test_radar_service_capture.py``.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+
+
+def _capture_dir():
+    from app.loader import get_data_root
+
+    return get_data_root() / "debug" / "alert_input" / "nowcast"
+
+
+def test_ac8_capture_records_is_convective_per_frame_matching_raw_value():
+    from providers.brightsky import RadarFrame
+    from services.radar_cache import RadarNowcastCacheService
+    from services.radar_service import RadarNowcastService, _nowcast_source_key
+
+    lat, lon = 47.601234, 12.897654
+    now = datetime.now(timezone.utc)
+    frames = [
+        RadarFrame(timestamp=now + timedelta(minutes=5), precip_mm_h=3.0, is_convective=True),
+        RadarFrame(timestamp=now + timedelta(minutes=10), precip_mm_h=1.0, is_convective=False),
+    ]
+    svc = RadarNowcastService(
+        frame_source=lambda la, lo: frames,
+        cache=RadarNowcastCacheService(),  # leer -> garantierter Cache-Miss
+    )
+    result = svc.get_nowcast(lat, lon)
+    assert result is not None  # Bestandsverhalten unveraendert
+
+    key = _nowcast_source_key(lat, lon)
+    matches = sorted(_capture_dir().glob(f"{key}_*.json"))
+    assert matches, (
+        f"Kein Eingangs-Datensatz fuer source_key {key!r} unter "
+        f"{_capture_dir()} gefunden -- get_nowcast() ruft "
+        f"alert_input_capture.capture_system() nicht am Cache-Miss-Mount-"
+        f"Punkt auf."
+    )
+    record = json.loads(matches[-1].read_text())
+    raw_frames = record.get("payload", {}).get("frames")
+    assert raw_frames and len(raw_frames) == 2, (
+        f"Unerwartete Frame-Anzahl im Mitschnitt: {raw_frames!r}"
+    )
+    assert raw_frames[0].get("is_convective") is True, (
+        f"AC-8: Frame 0 (RadarFrame.is_convective=True) fehlt/falsch im "
+        f"Mitschnitt: {raw_frames[0]!r}"
+    )
+    assert raw_frames[1].get("is_convective") is False, (
+        f"AC-8: Frame 1 (RadarFrame.is_convective=False) fehlt/falsch im "
+        f"Mitschnitt: {raw_frames[1]!r}"
+    )


### PR DESCRIPTION
Teil von #1948 (Scheibe S2, Epic bleibt offen — kein Auto-Close).

## Was
- `POST /api/trips/{trip_id}/alert-preview` akzeptiert vier exklusive Payload-Typen: `changes` (+optional `segment_times`, sonst Trip-Synthese), `onset`, NEU `official` (OfficialAlertPayload-Liste), NEU `nowcast_frames` (S1-Frame-Replay, `onset_detected`-Feld, Leerbefund statt 500)
- S1-Nowcast-Mitschnitt trägt additiv `is_convective` je Frame
- #1929-Sperrzone `official_alerts.py:1896-2104` nur aufgerufen, Diff leer
- Spec: `docs/specs/modules/alarm_testeinspeisung.md` (11 ACs, PO-approved) · api_contract 22.5 ergänzt

## Nachweise
- TDD: 14 RED-Tests → GREEN + Wächter-Test Segment-Synthese (Fix-Loop F001)
- Adversary VERIFIED (3 Runden, 5/5 Mutationen gefangen), QA-Gate Exit 0
- Scope +184 produktive LoC, 3 Code-Dateien; Bestands-Tests unverändert grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017pkrpMq7ud9h42pABCHcFr