### PR TITLE
fix(#1948): alert-preview Eingabevalidierung 422 + robuste Segment-Referenz

### DIFF
--- a/api/routers/validator.py
+++ b/api/routers/validator.py
@@ -301,10 +301,77 @@ def alert_preview(
             ),
         )
 
-    if body.changes and not body.segment_times:
-        body.segment_times = _synthesize_segment_times(trip_obj, body.changes)
+    if body.official:
+        _validate_official_segment_ids(trip_obj, body.official)
+    if body.changes:
+        _validate_change_metrics(body.changes)
+        _validate_change_segment_ids(trip_obj, body.changes)
+        if not body.segment_times:
+            body.segment_times = _synthesize_segment_times(trip_obj, body.changes)
 
     return render_alert_preview(trip_obj, body)
+
+
+def _real_segment_ids_for_today(trip_obj: Trip) -> set[str]:
+    """Echte Segment-IDs des Trips fuer HEUTE (dieselbe Quelle wie AC-3:
+    ``convert_trip_to_segments``). Leer, wenn der Trip fuer heute keine
+    echten Segmente hat (Stub-/Test-Trip) -- die Aufrufer behandeln das
+    dann als No-Op (fix-1948-s2-preview-eingaben: sonst brechen die
+    bestehenden S2-Tests, die durchgaengig ``stages: []``-Trips nutzen)."""
+    from services.trip_day import trip_local_today
+    from services.trip_segments import convert_trip_to_segments
+
+    today = trip_local_today(trip_obj, datetime.now(timezone.utc))
+    return {str(s.segment_id) for s in convert_trip_to_segments(trip_obj, today)}
+
+
+def _reject_unknown_segment_id(real_ids: set[str], segment_id: str) -> None:
+    if real_ids and segment_id not in real_ids:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Unbekannte segment_id '{segment_id}' im Trip",
+        )
+
+
+def _validate_official_segment_ids(
+    trip_obj: Trip, payloads: "list[OfficialAlertPayload]",
+) -> None:
+    """fix-1948-s2-preview-eingaben (Bug B Teil 1): ``official[].segment_ids``
+    gegen die echten Trip-Segmente pruefen -- unbekannte ID (bei einem Trip
+    MIT echten Segmenten) -> 422 mit der ID. Leere Liste bleibt erlaubt."""
+    real_ids = _real_segment_ids_for_today(trip_obj)
+    for p in payloads:
+        for sid in p.segment_ids:
+            _reject_unknown_segment_id(real_ids, sid)
+
+
+def _validate_change_metrics(changes: "list[ChangePayload]") -> None:
+    """fix-1948-s2-preview-eingaben (Bug A): ``changes[].metric`` gegen den
+    Metrik-Katalog pruefen (gleiche Quelle wie ``project.py:_resolve_metric_id``)
+    -- unbekannte Metrik -> 422 mit dem Namen, statt spaeter als KeyError zu
+    crashen."""
+    from app.metric_catalog import _METRICS
+
+    known = {f for m in _METRICS for f in m.summary_fields.values()}
+    for c in changes:
+        if c.metric not in known:
+            raise HTTPException(
+                status_code=422,
+                detail=f"Unbekannte Metrik '{c.metric}' in changes",
+            )
+
+
+def _validate_change_segment_ids(
+    trip_obj: Trip, changes: "list[ChangePayload]",
+) -> None:
+    """fix-1948-s2-preview-eingaben: dieselbe Pruefung wie bei ``official``,
+    aber fuer ``changes[].segment_id`` -- schliesst die Luecke, dass bei
+    EXPLIZIT mitgeliefertem ``segment_times`` (kein Aufruf von
+    ``_synthesize_segment_times``, dessen AC-3-Pruefung sonst greift) eine
+    unbekannte ``segment_id`` bislang ungeprueft blieb."""
+    real_ids = _real_segment_ids_for_today(trip_obj)
+    for c in changes:
+        _reject_unknown_segment_id(real_ids, c.segment_id)
 
 
 def _synthesize_segment_times(

--- a/docs/specs/fast/fix-1948-s2-preview-eingaben.md
+++ b/docs/specs/fast/fix-1948-s2-preview-eingaben.md
@@ -1,0 +1,49 @@
+# Mini-Spec: fix-1948-s2-preview-eingaben
+
+Nachbesserung zu #1948 S2 (Staging-E2E BROKEN 2026-08-18) — behebt zugleich #1965.
+
+## Was ändert sich
+
+- **Bug A (`changes` → 500):** `api/routers/validator.py` prüft vor dem Rendern jeden
+  `changes[].metric`-Wert gegen den Metrik-Katalog (gleiche Quelle wie
+  `project.py:_resolve_metric_id`, `summary_fields` aus `app.metric_catalog._METRICS`).
+  Unbekannte Metrik ⇒ HTTP 422 mit dem Metrik-Namen im Fehlertext (Parallel-Muster zur
+  bestehenden `segment_id`-Prüfung AC-3). Kein 500 mehr.
+- **Bug B Teil 1 (`official.segment_ids` unvalidiert):** `official[].segment_ids` werden gegen
+  die Segment-IDs des geladenen Trips geprüft (dieselbe Quelle wie die AC-3-Prüfung);
+  unbekannte ID ⇒ HTTP 422 mit der ID im Fehlertext. Leere Liste bleibt erlaubt
+  (Bestandsverhalten „gesamte Route").
+- **Bug B Teil 2 / #1965 (Renderer-Crash bei String-IDs):** `format_segment_reference()`
+  (`src/output/renderers/alert/segments.py:42`) verkraftet nicht-numerische Segment-IDs:
+  numerische IDs weiterhin sortiert/als Range, nicht-numerische IDs (außer „Ziel") werden
+  unverändert in Original-Reihenfolge aufgezählt („Segment stage1, stage2"); „Ziel" und die
+  „>4 ⇒ N Segmente"-Verdichtung bleiben unverändert. Damit ist auch der PRODUKTIV-Versandpfad
+  (`trip_alert.py:1614` übergibt `str(segment_id)`) crashfrei ⇒ schließt #1965.
+
+## Was darf sich nicht ändern
+
+- `src/output/renderers/alert/official_alerts.py` — KEINE Zeile (inkl. #1929-Sperrzone 1896–2104).
+- Verhalten für rein numerische Segment-IDs in `format_segment_reference` (byte-identische
+  Ausgabe; bestehende Renderer-/Mail-Tests bleiben unverändert grün).
+- Alle 15 S2-Tests + Bestands-Tests (`test_issue_221`, `test_issue_918`, `test_952`) unverändert grün.
+- Keine neue Route, kein Go-/Frontend-Anteil, Endpoint bleibt seiteneffektfrei.
+
+## Manuelle Test-Schritte (Staging, nach Deploy)
+
+1. `alert-preview` mit `changes` und `metric="temperature"` ⇒ 422, Fehlertext nennt „temperature".
+2. `changes` mit gültigem Katalog-Feld (z. B. `temp_max_c`) und echter Stage-ID ⇒ 200, fünf Felder.
+3. `official` mit `segment_ids=["<echte stage-id>"]` ⇒ 200; SMS/Telegram zeigen Segment-Bezug.
+4. `official` mit `segment_ids=["gibt-es-nicht"]` ⇒ 422 mit der ID.
+5. Staging-E2E-Wiederholung (e2e-verify) ⇒ VERIFIED, erst dann Prod-Deploy.
+
+## Inline-Tests (rot vor Fix, grün nach Fix)
+
+- [ ] `changes` mit unbekannter Metrik ⇒ 422 + Name (heute: 500) — Endpoint-Test
+- [ ] `official` mit unbekannter segment_id ⇒ 422 + ID (heute: 500) — Endpoint-Test
+- [ ] `official` mit gültiger String-Segment-ID („stage1"-artiger Trip) ⇒ 200, fünf Felder (heute: 500)
+- [ ] `format_segment_reference(["stage1","Ziel"])` ⇒ crashfrei, „Ziel" separat; numerischer
+      Bestandsfall byte-identisch (Wächter direkt an der Funktion)
+
+## Scope
+
+~40–60 LoC produktiv in 2 Dateien (`api/routers/validator.py`, `src/output/renderers/alert/segments.py`) + Tests. Schließt #1965 mit (gleicher Wirkort); Issue-Close erst nach Prod-Selftest Exit 0.

--- a/docs/specs/fast/fix-1948-s2-preview-eingaben.md
+++ b/docs/specs/fast/fix-1948-s2-preview-eingaben.md
@@ -44,6 +44,14 @@ Nachbesserung zu #1948 S2 (Staging-E2E BROKEN 2026-08-18) — behebt zugleich #1
 - [ ] `format_segment_reference(["stage1","Ziel"])` ⇒ crashfrei, „Ziel" separat; numerischer
       Bestandsfall byte-identisch (Wächter direkt an der Funktion)
 
+## Acceptance Criteria
+
+- **AC-1:** Given ein alert-preview-Request mit `changes`, dessen `metric` kein Katalog-`summary_field` ist, When der Endpoint aufgerufen wird (mit ODER ohne explizite `segment_times`), Then antwortet er mit HTTP 422 und der Fehlertext nennt die unbekannte Metrik.
+- **AC-2:** Given ein `changes`-Request mit EXPLIZIT mitgelieferten `segment_times` und einer `segment_id`, die im Trip (mit echten Segmenten) nicht existiert, When der Endpoint aufgerufen wird, Then antwortet er mit HTTP 422 mit der ID im Text — die Prüfung läuft also auch außerhalb des Synthese-Falls (Lückenschluss zu Staging-Finding #1).
+- **AC-3:** Given ein `official`-Request mit `segment_ids`, die nicht zu den echten Trip-Segment-IDs gehören (Trip MIT echten Segmenten), When der Endpoint aufgerufen wird, Then 422 mit der ID; Given eine leere `segment_ids`-Liste ODER ein Trip ohne echte Segmente (Stub), Then bleibt das Bestandsverhalten unverändert (200, „gesamte Route"-Semantik).
+- **AC-4:** Given `format_segment_reference` erhält nicht-numerische Segment-IDs (außer „Ziel"), When formatiert wird, Then kein Crash: nicht-numerische IDs werden in Original-Reihenfolge aufgezählt, „Ziel" bleibt separates Element, die „>4 ⇒ N Segmente"-Verdichtung zählt alle; für rein numerische Eingaben ist die Ausgabe byte-identisch zum Ist-Stand.
+- **AC-5:** Given der Fix ist implementiert, When die 15 S2-Tests, `tests/tdd/test_alert_segment_reference.py` und die Bestands-Tests (`test_issue_221`, `test_issue_918`) unverändert laufen, Then sind alle grün und `src/output/renderers/alert/official_alerts.py` ist laut `git diff` unberührt.
+
 ## Scope
 
 ~40–60 LoC produktiv in 2 Dateien (`api/routers/validator.py`, `src/output/renderers/alert/segments.py`) + Tests. Schließt #1965 mit (gleicher Wirkort); Issue-Close erst nach Prod-Selftest Exit 0.

--- a/src/output/renderers/alert/segments.py
+++ b/src/output/renderers/alert/segments.py
@@ -36,27 +36,42 @@ def format_segment_reference(segment_ids: list[str]) -> str:
     wird NIE in die numerische Range/Aufzaehlung gemischt, sondern immer als
     eigenes Element '🏁 Ziel' angehaengt. Mehr als 4 betroffene Segmente
     insgesamt -> Verdichtung 'N Segmente' (Begriff bewusst 'Segmente', nicht
-    'Etappen')."""
-    has_ziel = "Ziel" in segment_ids
-    numeric = sorted({int(s) for s in segment_ids if s != "Ziel"})
+    'Etappen').
 
-    total = len(numeric) + (1 if has_ziel else 0)
+    Issue #1965: reale Trips koennen nicht-numerische Segment-IDs tragen
+    (z.B. "stage1") -- `int()` auf jeder Nicht-"Ziel"-ID crashte den
+    Versandpfad. Nicht-numerische IDs werden jetzt crashfrei in Original-
+    Reihenfolge angehaengt statt geworfen; rein numerische Faelle bleiben
+    byte-identisch zum Bestandsverhalten."""
+    has_ziel = "Ziel" in segment_ids
+    numeric = sorted({int(s) for s in segment_ids if s != "Ziel" and s.isdigit()})
+    other: list[str] = []
+    for s in segment_ids:
+        if s == "Ziel" or s.isdigit():
+            continue
+        if s not in other:
+            other.append(s)
+
+    total = len(numeric) + len(other) + (1 if has_ziel else 0)
     if total > 4:
         return f"{total} Segmente"
 
-    numeric_part = ""
+    parts: list[str] = []
     if numeric:
         is_consecutive = numeric == list(range(numeric[0], numeric[-1] + 1))
         if is_consecutive and len(numeric) > 1:
-            numeric_part = f"Segment {numeric[0]}–{numeric[-1]}"
+            parts.append(f"{numeric[0]}–{numeric[-1]}")
         else:
-            numeric_part = "Segment " + ", ".join(str(n) for n in numeric)
+            parts.extend(str(n) for n in numeric)
+    parts.extend(other)
 
-    if numeric_part and has_ziel:
-        return f"{numeric_part}, 🏁 Ziel"
+    main_part = "Segment " + ", ".join(parts) if parts else ""
+
+    if main_part and has_ziel:
+        return f"{main_part}, 🏁 Ziel"
     if has_ziel:
         return "🏁 Ziel"
-    return numeric_part
+    return main_part
 
 
 def _renderable_segment_ids(segment_ids) -> list[str]:

--- a/tests/tdd/test_alert_preview_input_validation.py
+++ b/tests/tdd/test_alert_preview_input_validation.py
@@ -1,0 +1,203 @@
+"""TDD: fix-1948-s2-preview-eingaben — Eingabevalidierung des Preview-
+Endpoints ``POST /api/trips/{trip_id}/alert-preview`` (Nachbesserung zu
+#1948 S2, schliesst zugleich #1965 mit).
+
+SPEC: docs/specs/fast/fix-1948-s2-preview-eingaben.md
+
+Bug A: ``changes[].metric`` wird nicht gegen den Metrik-Katalog geprueft --
+eine unbekannte Metrik crasht (KeyError in ``_resolve_metric_id``) als 500
+statt als 422 mit der Metrik im Fehlertext.
+
+Bug B Teil 1: ``official[].segment_ids`` werden nicht gegen die echten
+Trip-Segmente geprueft. Hat der Trip fuer heute ECHTE Segmente, muss eine
+unbekannte ID 422 liefern. Hat der Trip KEINE echten Segmente (Stub-/
+Test-Trip, wie in allen bestehenden S2-Official-Tests), bleibt die Pruefung
+ein No-Op -- deckt sich mit der bestehenden "gesamte Route"-Semantik in
+``official_alerts.py`` (Trip ohne echte Zwischen-Segmente akzeptiert jede
+uebergebene ID).
+
+Bug B Teil 2 / #1965: ``format_segment_reference()`` crasht bei
+nicht-numerischen, nicht-"Ziel"-Segment-IDs (``int()``-ValueError) --
+betrifft auch den Produktiv-Versandpfad (``trip_alert.py:1614`` uebergibt
+``str(segment_id)``).
+
+Kein Mock — echter FastAPI-TestClient, echte Trip-Fixtures unter
+data/users/<uid>/briefings/.
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import uuid
+from datetime import date
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.real_data_root
+
+CHANGE_TEMPLATE = {
+    "old_value": 25.0, "new_value": 72.0, "delta": 47.0, "threshold": 60.0,
+    "severity": "major", "direction": "increase", "segment_id": "1",
+}
+
+
+@pytest.fixture
+def client():
+    from api.routers import validator
+    app = FastAPI()
+    app.include_router(validator.router)
+    return TestClient(app)
+
+
+@pytest.fixture
+def stub_trip():
+    """Trip OHNE echte Segmente (leere stages) -- Muster aus den bestehenden
+    S2-Official-Tests (test_alert_preview_official_render.py etc.)."""
+    user_id = f"test_fix1948s2_{uuid.uuid4().hex[:8]}"
+    trip_id = "trip-stub"
+    trip_dir = Path("data/users") / user_id / "briefings"
+    trip_dir.mkdir(parents=True, exist_ok=True)
+    (trip_dir / f"{trip_id}.json").write_text(json.dumps({
+        "id": trip_id, "name": "Eingabevalidierungs-Trip", "stages": [],
+    }))
+    yield user_id, trip_id
+    shutil.rmtree(Path("data/users") / user_id, ignore_errors=True)
+
+
+@pytest.fixture
+def real_trip():
+    """Trip mit EINEM echten Segment ('1') fuer heute (Muster aus
+    test_alert_preview_payload_exclusivity.py::_write_real_trip)."""
+    user_id = f"test_fix1948s2real_{uuid.uuid4().hex[:8]}"
+    trip_id = "trip-real"
+    trip_dir = Path("data/users") / user_id / "briefings"
+    trip_dir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "id": trip_id, "name": "Echtsegment-Trip",
+        "stages": [{
+            "id": "T1", "name": "Tag 1", "date": date.today().isoformat(),
+            "waypoints": [
+                {"id": "G1", "name": "Start", "lat": 47.0, "lon": 11.0,
+                 "elevation_m": 1000, "arrival_override": "08:00"},
+                {"id": "G2", "name": "Ziel", "lat": 47.05, "lon": 11.05,
+                 "elevation_m": 1200, "arrival_override": "10:00"},
+            ],
+        }],
+    }
+    (trip_dir / f"{trip_id}.json").write_text(json.dumps(payload))
+    yield user_id, trip_id
+    shutil.rmtree(Path("data/users") / user_id, ignore_errors=True)
+
+
+class TestBugA_UnknownMetricRejected:
+    def test_unknown_metric_in_changes_returns_422_naming_the_metric(
+        self, client, stub_trip,
+    ):
+        user_id, trip_id = stub_trip
+        resp = client.post(
+            f"/api/trips/{trip_id}/alert-preview",
+            params={"user_id": user_id},
+            json={"changes": [{**CHANGE_TEMPLATE, "metric": "temperature"}]},
+        )
+        assert resp.status_code == 422, (
+            f"Unbekannte Metrik 'temperature' (kein Katalog-summary_field) "
+            f"muss 422 liefern, nicht {resp.status_code}: {resp.text[:300]}"
+        )
+        assert "temperature" in resp.json().get("detail", ""), (
+            f"422-Meldung muss die Metrik nennen: {resp.text[:300]}"
+        )
+
+
+class TestAC2_UnknownChangesSegmentIdRejectedWithExplicitSegmentTimes:
+    """AC-2 (Staging-Finding #1): die AC-3-Pruefung sitzt heute nur in
+    ``_synthesize_segment_times`` und laeuft NUR, wenn ``segment_times``
+    NICHT mitgeliefert wird (``validator.py:304-305`` vor dem Fix). Bei
+    explizit mitgeliefertem ``segment_times`` blieb eine unbekannte
+    ``segment_id`` bislang komplett ungeprueft (Lueckenschluss)."""
+
+    def test_unknown_segment_id_with_explicit_segment_times_returns_422(
+        self, client, real_trip,
+    ):
+        user_id, trip_id = real_trip
+        bogus = {**CHANGE_TEMPLATE, "metric": "gust_max_kmh",
+                 "segment_id": "gibt-es-nicht"}
+        resp = client.post(
+            f"/api/trips/{trip_id}/alert-preview",
+            params={"user_id": user_id},
+            json={
+                "changes": [bogus],
+                "segment_times": [
+                    {"segment_id": "gibt-es-nicht", "start": "08:00", "end": "10:00"},
+                ],
+            },
+        )
+        assert resp.status_code == 422, (
+            f"Unbekannte segment_id MUSS auch bei explizitem segment_times "
+            f"422 liefern, nicht {resp.status_code}: {resp.text[:300]}"
+        )
+        assert "gibt-es-nicht" in resp.json().get("detail", ""), (
+            f"422-Meldung muss die ID nennen: {resp.text[:300]}"
+        )
+
+
+class TestBugB1_UnknownOfficialSegmentIdRejected:
+    def test_unknown_segment_id_on_real_trip_returns_422_naming_the_id(
+        self, client, real_trip,
+    ):
+        user_id, trip_id = real_trip
+        resp = client.post(
+            f"/api/trips/{trip_id}/alert-preview",
+            params={"user_id": user_id},
+            json={"official": [{
+                "source": "geosphere_warn", "hazard": "thunderstorm",
+                "level": 3, "label": "Gewitter",
+                "segment_ids": ["gibt-es-nicht"],
+            }]},
+        )
+        assert resp.status_code == 422, (
+            f"Unbekannte segment_id auf einem Trip mit echten Segmenten "
+            f"muss 422 liefern, nicht {resp.status_code}: {resp.text[:300]}"
+        )
+        assert "gibt-es-nicht" in resp.json().get("detail", ""), (
+            f"422-Meldung muss die ID nennen: {resp.text[:300]}"
+        )
+
+
+class TestBugB2_FormatSegmentReferenceHandlesStringIds:
+    """Direkt-Test an der Funktion (#1965) -- am Wirkort, ohne HTTP-Umweg.
+
+    Deviation von der Mini-Spec-Formulierung ("official mit gueltiger
+    String-Segment-ID ueber den Endpoint"): eine Endpoint-Reproduktion ist
+    nicht konstruierbar, ohne Bug B Teil 1 (422 bei unbekannter ID) zu
+    widersprechen -- ``convert_trip_to_segments`` liefert fuer JEDEN echten
+    Trip ausschliesslich `i+1` (int) oder "Ziel" (`trip_segments.py:223/305`,
+    `app/models.py:399` dokumentiert dasselbe). Ein Trip, dessen ECHTES
+    Segment "stage1" heisst, existiert damit nicht -- Bug B Teil 1 wuerde
+    "stage1" also stets als unbekannt ablehnen (422), nie 200 liefern; ein
+    Trip OHNE echte Segmente wiederum laesst ``official_alerts.py``s
+    ``is_full``-Kollaps (Trip <=1 echtes Segment -> immer "gesamte Route")
+    ``format_segment_reference()`` gar nicht erst erreichen -- ein Endpoint-
+    Test mit Stub-Trip ist schon HEUTE gruen (kein Rot-Beweis moeglich,
+    verifiziert vor dem Fix). Issue #1965 selbst trennt die beiden Bugs
+    explizit ("Abgrenzung": 422-Validierung = Preview-Endpoint-Eingabe,
+    Renderer-Robustheit = Versandpfad) -- dieser Test deckt exakt den
+    Versandpfad-Teil an der Stelle ab, an der die Zusicherung wirkt."""
+
+    def test_non_numeric_id_appended_ziel_stays_separate(self):
+        from output.renderers.alert.segments import format_segment_reference
+
+        result = format_segment_reference(["stage1", "Ziel"])
+        assert result == "Segment stage1, 🏁 Ziel", (
+            f"Nicht-numerische ID muss crashfrei aufgezaehlt werden, "
+            f"'Ziel' bleibt separat am Ende: {result!r}"
+        )
+
+    def test_numeric_case_stays_byte_identical(self):
+        """Gegenprobe: der Bestandsfall (rein numerisch, zusammenhaengend)
+        darf durch die Erweiterung nicht veraendert werden."""
+        from output.renderers.alert.segments import format_segment_reference
+
+        assert format_segment_reference(["3", "4", "5"]) == "Segment 3–5"


### PR DESCRIPTION
Nachbesserung zu #1948 S2 (Staging-E2E BROKEN 2026-08-18); behebt den Wirkort von #1965 (Close nach Prod-Selftest, nicht per Auto-Close).

## Was
- `changes[].metric` gegen Katalog-`summary_fields` ⇒ unbekannt 422 mit Name (vorher 500 via KeyError `project.py:29`)
- `changes`-segment_id-Prüfung läuft jetzt AUCH bei explizit mitgeliefertem `segment_times` (Staging-Lücke: Prüfung saß nur im Synthese-Zweig)
- `official[].segment_ids` zweistufig validiert: strikt bei echten Segmenten (422 + ID), No-Op bei Stub-Trips (Bestandssemantik „gesamte Route")
- `format_segment_reference` verkraftet nicht-numerische IDs (Aufzählung, „Ziel" separat); rein numerische Ausgaben byte-identisch (10 Bestands-Tests unverändert)
- `official_alerts.py` unberührt (#1929-Sperrzone)

## Nachweise
- Mini-Spec `docs/specs/fast/fix-1948-s2-preview-eingaben.md` (AC-1..AC-5, PO-approved)
- Inline-Tests rot vor Fix (Artefakt), 50/50 grün nach Fix
- Adversary VERIFIED (2 Runden, 10 Edge-Probes, 5/5 Mutationen gefangen), QA-Gate Exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017pkrpMq7ud9h42pABCHcFr
