### PR TITLE
feat(#1468): Alarm, wenn sich der Beginn von Gewitter oder Starkregen deutlich verschiebt

### DIFF
--- a/docs/context/feat-1468-onset-verschiebung.md
+++ b/docs/context/feat-1468-onset-verschiebung.md
@@ -18,6 +18,8 @@ bei deutlicher Verschiebung alarmieren.
 |---|---|
 | Für welche Größen? | **Gewitter UND Starkregen zusammen** (nicht nur Gewitter) |
 | Wie wird der Beginn vergleichbar? | **Neues Feld im Datenmodell**, mitgespeichert — nicht zur Laufzeit aus der Stundenreihe abgeleitet |
+| Ab wann gilt Regen als „Starkregen"? | **≥ 4,0 mm/h — dieselbe Grenze wie im Radar** (`INTENSITY_HEAVY`, `radar_service.py:77`). Bewusst kein neues Vokabular: „Starker Regen" bedeutet auf beiden Wegen dasselbe. Basis ist die stündliche Intensität `precip_rate_mmph`, nicht die Menge. |
+| Richtung der Verschiebung | **Asymmetrisch — früher ist gefährlicher.** Ein früherer Beginn meldet bei kleinerer Verschiebung als ein späterer. Begründung: Wer um 15 statt 17 Uhr ins Gewitter läuft, ist bereits im Gelände. Erfordert Neu-Mechanik (Risiko 3). |
 
 ## Kernbefund: Die Vorarbeit liefert weniger als angenommen
 

--- a/docs/context/feat-1468-onset-verschiebung.md
+++ b/docs/context/feat-1468-onset-verschiebung.md
@@ -192,6 +192,161 @@ im alten Stand an" liegen vor — sie werden von `detect_changes()` nur nicht ge
 - **#1948 S2** — keine Überschneidung. Fasst `api/routers/validator.py`,
   `src/services/validator_render_service.py`, `src/services/radar_service.py` an.
   Sperrzone `official_alerts.py:1896-2104` (#1929, fremde Session) notiert.
-- **#1954** — keine Dateikollision (nur `src/services/alert_log.py`), aber Kopplung über die
-  `WeatherChange`-Feldform, siehe Risiko 4. Branch `fix-1954-alarm-wert-protokollieren`,
-  Adversary VERIFIED, noch nicht gepusht.
+- **#1954** — **auf `main` seit 2026-08-18** (Merge `e677aee2`, PR #1963, Prod-Selftest PASS).
+  Keine Dateikollision (nur `src/services/alert_log.py`), aber Kopplung über die
+  `WeatherChange`-Feldform, siehe Risiko 4 und Analyse-Abschnitt „Register-Paar".
+
+---
+
+# Analysis (Phase 2, 2026-08-18)
+
+## Type
+
+**Feature** — neue Alarm-Größe, kein Fehlverhalten bestehenden Codes.
+
+## Die drei Entwurfs-Entscheidungen
+
+### E1 — Der Beginn wird ein eigenes Summary-Feld je Größe
+
+Zwei neue Felder in `SegmentWeatherSummary`, befüllt in
+`WeatherMetricsService.compute_basis_metrics()` (`src/services/weather_metrics.py:397-470`)
+nach dem Muster der bestehenden `_compute_*`-Methoden:
+
+| Feld | Bedeutung | Schwelle |
+|---|---|---|
+| `thunder_onset_utc` | erste Stunde mit `thunder_level >= LOW` | `ThunderLevel.LOW` (wie `render_threshold_peak_value("TH", …, threshold=1.0)`) |
+| `precip_heavy_onset_utc` | erste Stunde mit `precip_rate_mmph >= 4.0` | **4,0 mm/h** — PO-Entscheid, identisch mit `INTENSITY_HEAVY` (`radar_service.py:77`) |
+
+Typ: `Optional[datetime]` (UTC, naiv — Hausnorm `src/utils/timezone.py:107-109`).
+**Nicht** eine nackte Stundenzahl: Die Verschiebung 23:00 → 01:00 ist 2 Stunden, nicht 22
+(Risiko 8). Nur ein echter Zeitstempel rechnet das richtig.
+
+**Warum ein eigenes Feld je Größe und nicht ein gemeinsames:** Das Alarm-Protokoll bildet
+sein Register-Paar über `metric_and_aggregation_for_field(c.metric)`
+(`src/app/metric_catalog.py:1166-1196`) — Schlüssel ist der **Summary-Feldname**. Ein eigenes
+Feld ergibt automatisch ein eigenes Paar `("thunder", "onset")` und damit die von #1954
+geforderte Trennung von der Stufen-Änderung `("thunder", "max")`. Ohne eigenen
+Katalog-Eintrag liefert der Reverse-Lookup `None` und die Beginn-Änderung fällt **still**
+aus dem Protokoll (`alert_log.py:132-134`) — Fehlerfall ohne Fehlermeldung, gehört bewacht.
+
+**Compare erbt automatisch:** `summarize_points()` (`weather_metrics.py:1108-1160`) ist ein
+dünner Wrapper um `compute_basis_metrics()`. Trip und Ortsvergleich teilen den Code, die
+Teilungs-Invariante ist ohne Zusatzarbeit erfüllt.
+
+**Bestandsdaten:** `_deserialize_summary()` (`weather_snapshot.py:357-373`) filtert über
+`dataclasses.fields()`. Alte Anker ohne die Felder laden weiter, das Feld ist dann `None`.
+
+### E2 — Der Beginn ist eine LOKALE, tagesfenster-gefilterte Größe
+
+**🔴 Die Falle:** Die Aggregation ist heute **zeitzonen- und fensterblind**
+(`weather_metrics.py:397-470` kennt weder `tz` noch `day_window_*`). Das Tagesfenster
+(Default 4–19 Uhr, `src/app/day_window.py:20-21`) wird erst in der Render-Schicht angewendet
+(`helpers.py:1005-1007`). Ein naiv in der Aggregation berechnetes Onset wäre die erste
+Überschreitung **im gesamten Zeitraum inklusive Nachtstunden**.
+
+Das ergäbe zwei verschiedene Zahlen, die beide „Gewitterbeginn" heißen: Das Briefing zeigt
+„Gewitter mittel ab 14:00" (gefiltert), der Alarm meldete „03:00 → 01:00" (ungefiltert). Der
+Wanderer bekäme einen Alarm über eine Verschiebung, die in seinem Briefing nie stand.
+
+**Entscheidung:** Der Alarm vergleicht **dieselbe Zahl, die im Briefing steht.** Der Zweck
+des Tickets ist wörtlich *„das Briefing hat 17 Uhr geschrieben und der Forecast ändert sich
+auf 15 Uhr"* — eine andere Bezugsgröße macht den Alarm unbrauchbar. Zeitzone und
+Tagesfenster müssen die Onset-Berechnung also erreichen.
+
+**Absicherung als AC (Muster von #1493 AC-9):** Aus **derselben Fixture** muss die
+Onset-Stunde im gerenderten Briefing und der Wert im Summary-Feld **gleich** sein — geprüft
+als Gleichheit beider Größen, nicht als zwei getrennte Textprüfungen. Driften Anzeige und
+Alarm auseinander, wird der Test rot.
+
+**Wichtig:** Ein global berechnetes Onset lässt sich **nicht** nachträglich in ein
+fenster-gefiltertes umrechnen — die erste Überschreitung nachts und die erste im Tagesfenster
+sind verschiedene Stunden. Nachrüsten geht also nicht; das muss von Anfang an stimmen.
+
+### E3 — Asymmetrie über eine dritte Weiche, kein neuer Regeltyp
+
+`detect_changes()` hat bei `weather_change_detection.py:692-696` bereits genau die Weiche,
+die gebraucht wird:
+
+```python
+level = self._ordinal_levels.get(metric)
+if level is not None:
+    triggered = self._ordinal_change_triggers(old_value, new_value, level)
+else:
+    triggered = abs(delta) > threshold
+```
+
+Der Beginn-Vergleich fügt sich als dritter Zweig nach demselben Muster ein (eigenes
+`_onset_levels`-Dict, eigenes Prädikat), Severity analog bei `:705-708`. **Kein neuer
+`AlertRuleKind`** nötig — das spart die Verzweigungsstellen bei `:513/517/535` und
+`loader.py:376`.
+
+Die Asymmetrie selbst ist echtes Neuland (das Muster „zwei Schwellen je nach Vorzeichen"
+existiert nirgends). Sie sitzt in der Preset-Tabelle, die pro Stufe **zwei** Werte trägt:
+
+| Stufe | früher (vorgezogen) | später (verschoben) |
+|---|---|---|
+| entspannt | ab 2 h | ab 4 h |
+| standard | ab 1 h | ab 3 h |
+| sensibel | ab 1 h | ab 2 h |
+
+*(Vorschlag — die Zahlen gehören in die Spec-Freigabe. Ausgangspunkt ist der Issue-Text
+„entspannt ab 3 h, standard ab 2 h, sensibel ab 1 h", nach vorn verschärft und nach hinten
+gelockert.)*
+
+## Affected Files
+
+| Datei | Änderung | Beschreibung |
+|---|---|---|
+| `src/app/models.py` | MODIFY | 2 Summary-Felder, 2 `AlertMetric`-Werte |
+| `src/services/weather_metrics.py` | MODIFY | 2 `_compute_*_onset()`, Aufruf in `compute_basis_metrics`, Regel in `aggregate_stage` |
+| `src/app/metric_catalog.py` | MODIFY | `summary_fields`/`alert_metrics` um `"onset"` erweitern (`thunder`, `precipitation`), `alert_label`, `sms_code` |
+| `src/services/weather_change_detection.py` | MODIFY | `_ALERT_METRIC_TO_SUMMARY_FIELD`, `_ALERT_METRIC_TO_CATALOG_ID`, `_ALERTABLE_METRIC_VALUES`, Onset-Weiche + Prädikat + Severity |
+| `src/services/alert_preset.py` | MODIFY | `_PRESET_TABLE` (zwei Schwellen je Stufe), `ONSET_METRICS`-Set, `_make_rule` |
+| `src/output/renderers/alert/project.py` | MODIFY | Zeitpunkt-Wert nach Vorbild `_fmt_occurred_at()` (`:56-63`) |
+| `src/output/renderers/alert/render.py` | MODIFY | eigener Formatierpfad — `_val()` würde „15 h" statt „15:00" liefern |
+| `internal/model/trip.go` | MODIFY | Go-Spiegel: `AlertMetric`-Konstanten, `AlertableMetrics`, `DefaultDeltaThreshold` |
+| `frontend/src/lib/generated/alertPresetThresholds.generated.json` | REGENERATE | `scripts/generate_alert_preset_table.py` |
+| `scripts/generate_alert_metric_mapping.py`-Ausgaben | REGENERATE | sonst reißt `tests/tdd/test_alert_metric_mapping_parity.py` |
+| `frontend/…/alerts-tab/alertMetricTable.ts` | MODIFY | `METRIC_DEFAULTS`, `ALL_ALERT_METRICS`, `ALERTABLE_METRICS`, `_METRIC_UNITS`, `CATALOG_TO_ALERT_METRICS` |
+| `frontend/src/lib/utils/alertMetricLabels.ts` | MODIFY | Label + Reverse-Mapping (nicht generiert, separat gepflegt) |
+| `tests/…` | CREATE | Verhaltenstests, siehe unten |
+
+## Scope Assessment
+
+- **Dateien:** ~12 produktiv + 2 generierte + Tests
+- **LoC produktiv:** geschätzt **+200 bis +250** — das **LoC-Limit von 250 wird voraussichtlich
+  gerissen**, `loc_limit_override 500` ist einzuplanen
+- **Risiko: HIGH** — Alarm-Pfad, Persistenz-Schema, Go/Python-Parität, 4 Kanäle, 18+
+  Registrierungsstellen
+
+## Offene Punkte für die Spec
+
+1. **Doppelmeldung** (Risiko 5): Gewitter kommt früher **und** wird stärker ⇒ zwei
+   `WeatherChange`. Vorschlag: beide melden, aber im Text zusammenfassen — die PO-Linie aus
+   `feat_1493` verbietet doppelte Textform für dieselbe Information.
+2. **Erscheinen/Verschwinden** (Risiko 7): `None → 15:00` ist kein Beginn-Alarm, sondern
+   von der Stufen-Änderung abgedeckt. Vorschlag: Onset-Vergleich feuert **nur**, wenn beide
+   Seiten gesetzt sind.
+3. **Melde-Gedächtnis** (`deviation_alert_engine.py:242`): filtert über
+   `abs(new_value - last)`. Bei Uhrzeiten läuft das über die Tagesgrenze falsch — zweite
+   Stelle mit demselben Fehler wie der Vergleich selbst.
+4. **Aktivierungs-Kopplung:** Der Alarme-Tab zeigt nur Metriken, deren Katalog-Größe im
+   Wetter-Tab aktiv ist (`activeAlertMetricsFromCatalog.ts:22-29`,
+   `weather_change_detection.is_alert_metric_active()`). Da der Beginn an den bestehenden
+   Katalog-IDs `thunder`/`precipitation` hängt, erbt er deren Gate — gewollt: wer Gewitter
+   nicht beobachtet, will auch keinen Gewitterbeginn-Alarm.
+5. **Konkrete Stundenwerte** der Preset-Tabelle (siehe E3).
+
+## Test-Strategie (Kern, deterministisch)
+
+- **Verschiebung meldet:** Anker 17:00, neuer Stand 15:00, Stufe standard ⇒ genau ein Alarm.
+- **Gegenprobe Richtung:** dieselbe Verschiebung nach hinten (17:00 → 19:00) ⇒ **kein**
+  Alarm bei standard (2 h < 3 h Schwelle für später). Bewacht die Asymmetrie.
+- **Tagesgrenze:** 23:00 → 01:00 ⇒ 2 h Verschiebung, nicht 22 h.
+- **Anzeige-Gleichheit (E2):** dieselbe Fixture ⇒ Onset im Briefing-Text == Summary-Feld.
+- **Bestandsanker:** Anker ohne das Feld ⇒ kein Alarm, keine Ausnahme.
+- **Erscheinen:** `None → 15:00` ⇒ kein Beginn-Alarm.
+- **Protokoll-Trennung:** Stufen- und Beginn-Änderung derselben Größe erzeugen **zwei**
+  getrennte Protokoll-Einträge (Register-Paare `("thunder","max")` vs. `("thunder","onset")`).
+- **Textform:** „15:00", nicht „15 h"; „2 h früher", nicht „−2 h".
+- **Vier Kanäle:** Beginn-Alarm erscheint in E-Mail, Telegram, SMS und Premium-SMS.

--- a/docs/context/feat-1468-onset-verschiebung.md
+++ b/docs/context/feat-1468-onset-verschiebung.md
@@ -1,0 +1,195 @@
+# Context: feat-1468-onset-verschiebung
+
+**Issue:** #1468 — Alarm, wenn sich der Beginn eines Ereignisses deutlich verschiebt
+(Gewitter 17 Uhr → 15 Uhr)
+**Track:** Full Process (Intake-Score 6/6) · **Erstellt:** 2026-08-18
+
+## Request Summary
+
+Der Änderungs-Wächter vergleicht heute ausschließlich **Aggregate je Segment**
+(`thunder_level_max`, `precip_sum_mm`, …). Verschiebt sich ein Gewitter von 17 auf 15 Uhr,
+bleibt jedes Aggregat unverändert ⇒ Delta 0 ⇒ **kein Alarm**. Der Wanderer plant weiter mit
+17 Uhr. #1468 soll den **Beginn** eines Ereignisses zu einer vergleichbaren Größe machen und
+bei deutlicher Verschiebung alarmieren.
+
+## PO-Entscheide (2026-08-18, Intake)
+
+| Frage | Entscheid |
+|---|---|
+| Für welche Größen? | **Gewitter UND Starkregen zusammen** (nicht nur Gewitter) |
+| Wie wird der Beginn vergleichbar? | **Neues Feld im Datenmodell**, mitgespeichert — nicht zur Laufzeit aus der Stundenreihe abgeleitet |
+
+## Kernbefund: Die Vorarbeit liefert weniger als angenommen
+
+Das Issue nimmt an, #1419 S7 / #1493 liefere „genau die fehlende Größe". **Tut es nicht.**
+Die Onset-Stunde ist eine reine **Render-Ableitung**: `render_threshold_peak_value()`
+(`src/output/tokens/metrics.py:29-67`) sucht bei jedem Rendern die erste Stunde über einer
+Schwelle und baut daraus ein transientes String-Token (`"mittel@14"`). Danach existiert die
+Information nirgends mehr.
+
+- `SegmentWeatherSummary` (`src/app/models.py:414-500`) führt 31 Felder — **kein Zeitfeld**.
+  Für Gewitter nur `thunder_level_max` (:425) und `thunder_level_max_signals` (:430).
+- Weder `weather_change_detection.py` noch `deviation_alert_engine.py` kennen den Begriff
+  `onset` (grep: keine Treffer im Forecast-Pfad).
+
+**Aber:** Der rollierende Alarm-Anker speichert die **volle Stundenreihe** bereits mit.
+`_serialize_segment()` (`src/services/weather_snapshot.py:376-409`) schreibt neben
+`aggregated` auch `hourly` und iteriert generisch über `vars(p)` — es landet also **jedes**
+nicht-leere Feld von `ForecastDataPoint` im Anker, inklusive `thunder_level` (als `.name`,
+z.B. `"MED"`), `precip_1h_mm`, `precip_rate_mmph`, `pop_pct`. Die Rohdaten für „wann fing es
+im alten Stand an" liegen vor — sie werden von `detect_changes()` nur nicht gelesen
+(dort wird ausschließlich `aggregated` ausgewertet).
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `src/app/models.py:414-500` | `SegmentWeatherSummary` — hier entsteht das neue Onset-Feld |
+| `src/app/models.py:99-126` | `ForecastDataPoint` — Stundenreihe, Quelle der Onset-Berechnung |
+| `src/app/models.py:556ff` | `WeatherChange` DTO — `old_value`/`new_value`/`delta`/`threshold`/`severity`/`direction`, alle `float` |
+| `src/app/models.py:1118-1138` | `AlertMetric`-Enum — braucht neue Werte |
+| `src/app/models.py:1142-1166` | `AlertRule` — `kind`/`metric`/`threshold`/`unit`/`sensitivity_level` |
+| `src/app/models.py:805` | `metric_alert_levels` — Nutzer-Empfindlichkeit je Metrik |
+| `src/app/metric_catalog.py:28-85` | `MetricDefinition` — Katalog-Eintrag je Metrik |
+| `src/app/metric_catalog.py:365-373` | Katalogeintrag `precipitation` (nur Summe, keine Intensität) |
+| `src/app/metric_catalog.py:1258-1288` | `format_metric_value()` — Zahl→Text, kennt keine Uhrzeit |
+| `src/services/weather_change_detection.py:38-62` | Feldlisten `_ALERT_METRIC_TO_SUMMARY_FIELD`, `_ALERT_DELTA_METRIC_TO_FIELDS` |
+| `src/services/weather_change_detection.py:581-735` | `detect_changes()` — Kernvergleich `abs(delta) > threshold` |
+| `src/services/weather_change_detection.py:761-786` | `_ordinal_change_triggers()` — Vorbild für einen zweiten Vergleichstyp |
+| `src/services/weather_change_detection.py:268-340` | `_peak_occurred_at()` — einziger vorhandener Zeitstempel-Bezug |
+| `src/services/alert_preset.py:43-56` | `_PRESET_TABLE` — die Stufen-Tabelle, Andockpunkt der Stunden-Schwelle |
+| `src/services/alert_preset.py:96-107` | `ORDINAL_LEVEL_BOUNDS`, `ORDINAL_LEVEL_METRICS` |
+| `src/services/alert_preset.py:145ff` | `expand_per_metric_levels()` — (Metrik, Stufe) → `AlertRule` |
+| `src/services/weather_snapshot.py:179-252` | `save_alarm_anchor()`/`load_alarm_anchor()` — der Vergleichsanker |
+| `src/services/weather_snapshot.py:340-409` | Serialisierung Summary + Stundenreihe |
+| `src/services/deviation_alert_engine.py` | Auswertungskern: Filter, Severity, Ruhezeiten, Cooldown |
+| `src/services/alert_state.py` | Melde-Gedächtnis `{"<metric>:<segment_id>": {...}}` |
+| `src/output/renderers/alert/project.py:66-104` | `to_alert_message()` — `WeatherChange` → `AlertEvent` |
+| `src/output/renderers/alert/project.py:56-63` | `_fmt_occurred_at()` — **Vorbild** für Zeitpunkt-Formatierung |
+| `src/output/renderers/alert/render.py:40-74` | `_val()`/`_num()` — würden bei Uhrzeiten Unfug liefern |
+| `src/output/renderers/alert/render.py:731-820` | `render_sms()` — Zeichenbudget, Token-Kürzung |
+| `src/output/tokens/metrics.py:29-67` | `render_threshold_peak_value()` — bestehende Onset-Berechnung (Anzeige) |
+| `src/output/renderers/email/helpers.py:978, 1011-1018` | Aufrufstellen Regen (`"R"`, 0,5 mm) und Gewitter (`"TH"`, Tag/Nacht) |
+| `src/services/radar_service.py:147-164` | `intensity_to_text()` — **einzige** Starkregen-Definition im System (≥ 4,0 mm/h) |
+| `src/services/alert_log.py` | #1954: liest `old_value`/`new_value`/`delta`/`segment_id`, entscheidet über `abs(delta)` |
+
+## Existing Patterns
+
+- **Stufen → Schwelle ist eine Tabelle, kein Rechenwerk.** `_PRESET_TABLE`
+  (`alert_preset.py:43-56`) ist eine Liste von Tupeln
+  `(AlertMetric, AlertRuleKind, entspannt, standard, sensibel)` mit hart kodierten Zahlen,
+  z.B. `(WIND_GUST, DELTA, 35, 20, 12)` in km/h. `expand_per_metric_levels()` macht nur
+  Spalten-Lookup. Eine Zeile `(…_ONSET, DELTA, 3, 2, 1)` in Stunden fügt sich ohne neues
+  Steuerkonzept ein — genau wie das Issue es verlangt.
+- **Zweiter Vergleichstyp existiert bereits.** `thunder_level_max` läuft nicht über
+  `abs(delta) > threshold`, sondern über Niveau-Grenzen (`ORDINAL_LEVEL_BOUNDS`,
+  `_ordinal_change_triggers()`). Der Weg dorthin: `AlertRule.sensitivity_level` →
+  `_ordinal_levels` im Konstruktor (`weather_change_detection.py:386-402`) →
+  eigenes Prädikat. **Strukturelles Vorbild** für einen Zeitpunkt-Vergleich.
+- **Einheiten kommen aus dem Katalog**, nicht aus dem Renderer (`render.py:49`, `:101`
+  lesen `get_metric(...).unit`).
+- **Zeitpunkte werden separat formatiert**, wenn es sie gibt: `_fmt_occurred_at()`
+  (`project.py:56-63`) geht über `local_fmt(value, tz)` → `"HH:MM"`, nicht über
+  `format_metric_value()`.
+- **Snapshot ist feld-generisch:** `_deserialize_summary()`
+  (`weather_snapshot.py:357-373`) filtert über `dataclasses.fields(SegmentWeatherSummary)`.
+  Ein neues Feld ist damit automatisch anker-tauglich, alte Dateien ohne das Feld bleiben
+  lesbar (Read-Modify-Write-Vorgabe erfüllt).
+
+## Dependencies
+
+**Upstream** (was wir brauchen)
+- Stundenreihe `SegmentWeatherData.timeseries` mit `thunder_level` bzw. Regenfeldern je Stunde
+- Schwellen-Logik aus `render_threshold_peak_value()` (erste Stunde über Schwelle)
+- Metrik-Katalog für Einheit, Label, Aggregation
+- Tagesfenster-Filter (Gewitter-Token wird bereits Tag/Nacht-getrennt gebaut, `helpers.py:1011-1018`)
+
+**Downstream** (was auf uns aufsetzt)
+- `weather_change_detection.detect_changes()` → `deviation_alert_engine` → `trip_alert` /
+  Compare-Pfad → alle **vier** Kanäle (E-Mail, Telegram, SMS, Premium-SMS)
+- **`src/services/alert_log.py` (#1954, noch nicht auf main):** liest `new_value`,
+  `old_value`, `delta`, `segment_id` aus jeder `WeatherChange` und protokolliert sie.
+  `_ist_extremer()`/`_norm_pairs()` gruppieren nach `(metric_id, aggregation)` und
+  entscheiden **innerhalb** einer Gruppe über `abs(delta)`.
+- `alert_state` Melde-Gedächtnis (Schlüssel `<metric>:<segment_id>`)
+- Alerts-Tab im Frontend (`AlarmeTab.svelte`, `AlertCard.svelte`) — zeigt nur Metriken aus
+  `ALERTABLE_METRICS`
+
+## Existing Specs
+
+| Spec | Bindung für #1468 |
+|---|---|
+| `docs/specs/modules/weather_change_detection.md` (v2.2, approved) | Zentral. `WeatherChange`-DTO-Form, Algorithmus rein über `{summary_field: threshold}`. **Kein Sonderpfad für Zeitpunkte vorgesehen.** |
+| `docs/specs/modules/rework_1467_s2_aenderungsalarm.md` (v1.2, approved) | Steuerungsschicht: Kanäle, Ruhezeiten, Cooldown, Tageslimit, Gedächtnis-Reset. Ein neuer Metrik-Typ läuft **automatisch** mit, wenn er über den Katalog eingehängt wird. Invariante: *„Der gefährlichste Fehler ist der ausbleibende Alarm."* AC-7/7b: Compare-SMS trägt Ortsnummern, keine Namen. |
+| `docs/specs/modules/feat_1493_gewitter_onset_sichtbar.md` (approved 2026-08-18) | AC-9: Trip und Ortsvergleich müssen dieselbe Onset-Stunde in derselben Schreibweise zeigen (Teilungs-Invariante). SSoT für Stufenwörter ist `THUNDER_LABEL_DE` (`src/output/metric_format.py:246-251`). PO-Linie: **keine doppelte Textform für dieselbe Information.** |
+| `docs/specs/modules/feat_864_859_alert_presets.md` (draft, nicht approved) | AC-1/2: Alerts-Tab zeigt Metriken aus `ALERTABLE_METRICS` mit 4-Stufen-Regler. AC-3: Schwellwert-Anzeige ist fest `"Δ ≥ {wert} {einheit}"` — eine Stunden-Schwelle passt strukturell, `einheit` müsste `"h"` liefern. |
+| `docs/specs/modules/weather_config.md` (v2.0) | SSoT-Spec für den Metrik-Katalog — neuer Katalog-Eintrag gehört dort dokumentiert. |
+
+## Risks & Considerations
+
+1. **🔴 „Starkregen" ist im Vorhersage-Pfad nicht definiert.** Der PO-Entscheid verlangt
+   Gewitter **und** Starkregen. Für Gewitter gibt es eine Stufenleiter (`ThunderLevel`), für
+   Regen **nicht**. Die bestehende Regen-Onset-Ableitung (`helpers.py:978`) nutzt
+   `_DEFAULT_PRECIP_THR = 0.5` mm — das ist „irgendein messbarer Regen", **keine**
+   Starkregen-Schwelle. Die einzige Starkregen-Definition im System ist die
+   Radar-Nowcast-Klassifikation `INTENSITY_HEAVY` ab **≥ 4,0 mm/h**
+   (`radar_service.py:77, 147-164`). Zusätzlich: `precip_rate_mmph` existiert **nur
+   stündlich**, es gibt kein aggregiertes Intensitäts-Feld und keine `AlertMetric` dafür.
+   ⇒ **Offener PO-Entscheid, gehört in die Spec.**
+
+2. **Uhrzeit durch den Zahlen-Formatierer = Unfug.** `_val()` (`render.py:40-54`) rundet und
+   hängt die Katalog-Einheit an; `_HANDLED_UNITS` kennt weder `"h"` noch `"Uhr"`. Ergebnis
+   wäre `"15 h"` statt `"15:00"`, und ein negatives Delta würde als `"−2 h"` erscheinen statt
+   „2 Stunden früher". Braucht einen eigenen Formatierpfad nach dem Vorbild
+   `_fmt_occurred_at()`.
+
+3. **Richtungs-Asymmetrie ist nicht modellierbar ohne Neubau.** Früher = gefährlicher als
+   später. `AlertRule` hat **kein** Richtungsfeld; `AlertRuleKind` kennt nur `ABSOLUTE`,
+   `DELTA` (meldet beide Richtungen über `abs(delta)`), `THRESHOLD_CROSSING`. Eine
+   asymmetrische Schwelle (z.B. 1 h früher meldet, 3 h später meldet) braucht entweder einen
+   neuen `AlertRuleKind` oder zwei Regeln.
+
+4. **Kollision mit dem Alarm-Protokoll (#1954).** `_ist_extremer()` vergleicht `abs(delta)`
+   **innerhalb** eines Register-Paars `(metric_id, aggregation)`. Löst der Onset-Change auf
+   dasselbe Paar auf wie die Wert-Änderung derselben Größe, konkurrieren „2 Stunden
+   Verschiebung" und „30 Prozentpunkte" um denselben Protokolleintrag — der größere nackte
+   Betrag gewänne. **Vorgabe: eigenes Register-Paar für den Onset-Change.** (Abgestimmt mit
+   Session #1954, 2026-08-18.)
+
+5. **Doppelmeldung.** Ändert sich Beginn *und* Stufe gleichzeitig (Gewitter kommt früher und
+   wird stärker), entstehen zwei Änderungen für dieselbe Größe. Zu klären: zwei Alarme, ein
+   zusammengefasster Alarm, oder Vorrang einer Seite. Berührt die PO-Linie „keine doppelte
+   Textform für dieselbe Information" aus `feat_1493`.
+
+6. **Erster Lauf hat nichts zu vergleichen.** Bestandsanker ohne Onset-Feld dürfen keinen
+   Fehlalarm erzeugen (`None` → kein Alarm, nicht „von 0 auf 15"). Bestandsdaten müssen
+   lesbar bleiben (Read-Modify-Write mit Merge, CLAUDE.md-Pflicht).
+
+7. **Ereignis verschwindet / erscheint.** Beginn alt = 17:00, neu = gar kein Gewitter (oder
+   umgekehrt). Das ist keine Verschiebung, sondern ein Auftauchen/Verschwinden — bereits von
+   der Stufen-Änderung abgedeckt. Der Onset-Vergleich darf hier **nicht** zusätzlich feuern.
+
+8. **Tagesgrenze.** Beginn 23:00 → 01:00 ist eine Verschiebung um 2 Stunden über die
+   Kalendergrenze, nicht um 22 Stunden zurück. Der Vergleich braucht echte Zeitpunkte, keine
+   nackten Stundenzahlen.
+
+9. **Zeichenbudget SMS.** `render_sms()` schneidet notfalls hart auf `limit` (`render.py:813`).
+   Ein Onset-Token muss kurz sein und darf bestehende Tokens nicht verdrängen.
+
+10. **Vier Kanäle sind gleichrangig** (CLAUDE.md). Der neue Alarm muss E-Mail, Telegram, SMS
+    **und** Premium-SMS erreichen — und in beiden Flächen (Trip **und** Ortsvergleich).
+
+## Abgrenzung (aus dem Issue)
+
+- Die **Darstellung** der Anfangszeit im Briefing ist #1493 — hier nicht.
+- Der **Nowcast**-Weg (Radar, „in ~20 Minuten") bleibt unverändert.
+- Steuerung/Bedienoberfläche → #1462.
+
+## Session-Koordination (2026-08-18)
+
+- **#1948 S2** — keine Überschneidung. Fasst `api/routers/validator.py`,
+  `src/services/validator_render_service.py`, `src/services/radar_service.py` an.
+  Sperrzone `official_alerts.py:1896-2104` (#1929, fremde Session) notiert.
+- **#1954** — keine Dateikollision (nur `src/services/alert_log.py`), aber Kopplung über die
+  `WeatherChange`-Feldform, siehe Risiko 4. Branch `fix-1954-alarm-wert-protokollieren`,
+  Adversary VERIFIED, noch nicht gepusht.

--- a/docs/specs/modules/feat_1468_onset_verschiebung_alarm.md
+++ b/docs/specs/modules/feat_1468_onset_verschiebung_alarm.md
@@ -1,0 +1,403 @@
+---
+entity_id: feat_1468_onset_verschiebung_alarm
+type: feature
+created: 2026-08-18
+updated: 2026-08-18
+status: approved
+version: "1.0"
+tags: [thunder, precipitation, alert, onset, issue-1468, issue-1493, issue-1954]
+---
+
+<!-- Issue #1468 ("Alarm, wenn sich der Beginn eines Ereignisses deutlich
+     verschiebt"). Grundlage: PFLICHTLEKTUERE
+     docs/context/feat-1468-onset-verschiebung.md — Abschnitt "PO-Entscheide
+     (2026-08-18, Intake)" und die drei Entwurfs-Entscheidungen E1/E2/E3 sind
+     BINDEND und werden hier nicht neu verhandelt. Abgrenzung zu #1493
+     (Anzeige der Onset-Stunde im Briefing, bereits approved/geliefert) und
+     #1954 (Alarm-Protokoll, auf main). -->
+
+# Onset-Verschiebungs-Alarm: Gewitter- und Starkregen-Beginn als Alarmgröße (#1468)
+
+## Approval
+
+- [x] Approved — PO (Henning), 2026-08-18. Freigegeben inklusive der drei
+  Entscheidungspunkte: Preset-Schwellen wie tabelliert · Beginn- und
+  Stufenänderung beide melden, im Text zusammengefasst · Starkregen-Onset mit
+  `precip_1h_mm`-Fallback gegen dieselbe 4,0-mm/h-Schwelle.
+
+## Purpose
+
+Der Änderungs-Wächter vergleicht heute ausschließlich **Aggregate je
+Segment** (`thunder_level_max`, `precip_sum_mm`, …). Verschiebt sich ein
+Gewitter von 17 auf 15 Uhr, bleibt jedes Aggregat unverändert ⇒ Delta 0 ⇒
+**kein Alarm**, obwohl der Wanderer mit einer inzwischen falschen Uhrzeit
+weiterplant. Diese Spec macht den **Beginn** von Gewitter und Starkregen zu
+einer eigenen, vergleichbaren Alarmgröße: Verschiebt sich der Beginn deutlich
+gegenüber dem letzten Stand, entsteht ein Alarm — asymmetrisch, weil ein
+**vorgezogener** Beginn gefährlicher ist als ein hinausgezögerter (wer um 15
+statt 17 Uhr ins Gewitter läuft, ist bereits im Gelände).
+
+## Source
+
+> **Schicht-Hinweis:** Kern liegt im **Python-Core**
+> (`src/app/`, `src/services/`, `src/output/renderers/alert/`). Zusätzlich
+> betroffen: **Go-Spiegel** (`internal/model/trip.go` — `AlertMetric`-
+> Konstanten müssen mit dem Python-Katalog übereinstimmen, sonst schlägt
+> `tests/test_alert_metric_mapping_parity.py`/das Go-Pendant fehl) und
+> **Frontend** (`frontend/src/lib/generated/alertPresetThresholds.generated.json`
+> — generiert, nicht von Hand pflegen — sowie `alertMetricTable.ts`/
+> `alertMetricLabels.ts` im Alarme-Tab).
+
+- **File:** `src/app/models.py`
+  - **Identifier:** `SegmentWeatherSummary` (neue Felder `thunder_onset_utc`,
+    `precip_heavy_onset_utc`), `AlertMetric`-Enum (zwei neue Werte)
+- **File:** `src/services/weather_metrics.py`
+  - **Identifier:** `WeatherMetricsService.compute_basis_metrics()` — zwei
+    neue `_compute_*_onset()`-Methoden nach dem Muster der bestehenden
+    `_compute_*`-Methoden
+- **File:** `src/services/weather_change_detection.py`
+  - **Identifier:** `detect_changes()` — dritte Weiche neben
+    `_ordinal_change_triggers()`, `_ALERT_METRIC_TO_SUMMARY_FIELD`,
+    `_ALERT_DELTA_METRIC_TO_FIELDS`
+- **File:** `src/services/alert_preset.py`
+  - **Identifier:** `_PRESET_TABLE`, `ORDINAL_LEVEL_METRICS`-Pendant für
+    Onset (`ONSET_METRICS`), `expand_preset()`
+- **File:** `src/app/metric_catalog.py`
+  - **Identifier:** `MetricDefinition` für `thunder`/`precipitation` —
+    `summary_fields["onset"]`, `alert_metrics["onset"]`, `alert_label`,
+    `sms_code`
+- **File:** `src/output/renderers/alert/project.py`
+  - **Identifier:** `to_alert_message()`, `_fmt_occurred_at()` (Vorbild für
+    den neuen Zeitpunkt-Formatierpfad der Onset-Werte selbst)
+- **File:** `src/output/renderers/alert/render.py`
+  - **Identifier:** `_val()`/`_num()` (dürfen Onset-Werte NICHT durchlaufen),
+    `render_sms()` (Zeichenbudget)
+
+## Estimated Scope
+
+- **LoC:** ~+200 bis +250 produktiv (siehe Affected Files) — **voraussichtlich
+  über dem Workflow-Limit von 250**, `loc_limit_override` ist einzuplanen.
+- **Files:** ~12 Produktivdateien + 2 generierte Dateien + neue Testdateien
+  (siehe Test Plan)
+- **Effort:** high — Alarm-Pfad, Persistenz-Schema, Go/Python-Parität, vier
+  Kanäle, zwei Flächen (Trip + Ortsvergleich), 18+ Registrierungsstellen.
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `radar_service.INTENSITY_HEAVY`/`radar_service.py:77` | Konstante (SSoT) | Definiert „Starker Regen" ≥ 4,0 mm/h — dieselbe Zahl, dieselbe Bedeutung wie im Nowcast, PO-Entscheid bewusst kein neues Vokabular |
+| `_ordinal_change_triggers()` / `ORDINAL_LEVEL_BOUNDS` (`weather_change_detection.py:692-696`, `alert_preset.py:102-111`) | Funktion + Tabelle | Strukturelles Vorbild für die dritte Weiche (E3) — Niveau-Vergleich statt `abs(delta) > threshold` |
+| `_fmt_occurred_at()` (`project.py:56-63`) | Funktion | Vorbild für den eigenen Onset-Formatierpfad — `local_fmt()`, UTC-naive-Guard, NICHT über `format_metric_value()` |
+| `metric_and_aggregation_for_field()` (`metric_catalog.py:1166-1196`) | Funktion | Reverse-Lookup Summary-Feld → Register-Paar — Grundlage für die vom #1954-Protokoll geforderte Trennung `("thunder","onset")` vs. `("thunder","max")` |
+| `_ist_extremer()`/`_norm_pairs()` (`src/services/alert_log.py`) | Funktion | Gruppiert Protokoll-Einträge nach `(metric_id, aggregation)` — der Grund, warum Onset ein **eigenes** `summary_fields`-Paar braucht, nicht ein geteiltes |
+| `_deserialize_summary()` (`weather_snapshot.py:357-373`) | Funktion | Feld-generischer Anker-Loader über `dataclasses.fields()` — macht die neuen Felder automatisch bestandssicher (`None` bei alten Ankern) ohne Zusatzcode |
+| `summarize_points()` (`weather_metrics.py:1108-1160`) | Funktion | Dünner Wrapper um `compute_basis_metrics()` — Ortsvergleich erbt die Onset-Berechnung ohne Zusatzarbeit (Teilungs-Invariante) |
+| `day_window.py:20-21` / Tagesfenster-Filterung (`helpers.py:1005-1007`) | Modul | Muss die Onset-Berechnung erreichen (E2) — heute nur in der Render-Schicht angewendet, nicht in der Aggregation |
+
+## Implementation Details
+
+### E1 — Zwei eigene Summary-Felder (BINDEND)
+
+`SegmentWeatherSummary` bekommt zwei neue Felder, Typ `Optional[datetime]`
+(UTC, naiv — Hausnorm `src/utils/timezone.py:107-109`), **kein** Feld für
+beide Größen gemeinsam:
+
+| Feld | Bedeutung | Schwelle |
+|---|---|---|
+| `thunder_onset_utc` | erste Stunde im Tagesfenster mit `thunder_level >= LOW` | `ThunderLevel.LOW` |
+| `precip_heavy_onset_utc` | erste Stunde im Tagesfenster mit Regenintensität ≥ 4,0 mm/h | identisch mit `INTENSITY_HEAVY` |
+
+Grund für getrennte Felder: Das Alarm-Protokoll (#1954) bildet sein
+Register-Paar über den Summary-Feldnamen
+(`metric_and_aggregation_for_field()`). Ein eigenes Feld je Größe ergibt
+automatisch das Paar `("thunder", "onset")` bzw.
+`("precipitation", "onset")` — getrennt von `("thunder", "max")`. Ohne
+eigenen Katalog-Eintrag (`summary_fields["onset"] = "..."`) fiele die
+Beginn-Änderung **still** aus dem Protokoll.
+
+Zwei neue `AlertMetric`-Werte (Namensvorschlag, kein PO-Bezug nötig — folgt
+bestehender Konvention wie `FRESH_SNOW`/`WIND_CHANGE`):
+`AlertMetric.THUNDER_ONSET = "thunder_onset"`,
+`AlertMetric.PRECIPITATION_HEAVY_ONSET = "precipitation_heavy_onset"`.
+
+### E2 — Lokale, tagesfenster-gefilterte Berechnung (BINDEND)
+
+Die Onset-Berechnung muss **dieselbe Zahl** liefern, die im Briefing steht
+(Tagesfenster Default 4–19 Uhr, `day_window.py:20-21`, Ortszeit). Eine im
+gesamten Zeitraum inklusive Nachtstunden berechnete Onset-Zeit wäre eine
+**andere** Zahl als die im Briefing gezeigte — der Alarm würde über eine
+Verschiebung informieren, die im Briefing nie stand. Zeitzone und
+Tagesfenster müssen deshalb bereits in `compute_basis_metrics()` ankommen,
+nicht erst in der Render-Schicht. **Nicht nachrüstbar:** ein global
+berechnetes Onset lässt sich nicht nachträglich auf ein fenstergefiltertes
+umrechnen (die erste Überschreitung nachts und die erste im Tagesfenster
+sind verschiedene Stunden) — muss von Anfang an korrekt sein.
+
+### E3 — Asymmetrische dritte Weiche, kein neuer `AlertRuleKind` (BINDEND)
+
+`detect_changes()` bekommt neben der bestehenden Niveau-Weiche
+(`_ordinal_levels`) eine dritte, analoge Weiche (eigenes `_onset_levels`-
+Dict, eigenes Prädikat), kein neuer `AlertRuleKind`. Die Richtungs-Asymmetrie
+lebt in der Preset-Tabelle, die für Onset-Metriken **zwei** Schwellen je
+Stufe führt (`früher`/`später` statt einer symmetrischen `abs(delta)`-
+Schwelle):
+
+| Stufe | früher (vorgezogen) | später (verschoben) |
+|---|---|---|
+| entspannt | ab 2 h | ab 4 h |
+| standard | ab 1 h | ab 3 h |
+| sensibel | ab 1 h | ab 2 h |
+
+> ✅ **PO-freigegeben 2026-08-18.** Die Tabelle gilt wie oben. Ausgangspunkt
+> war der Issue-Text („entspannt ab 3 h, standard ab 2 h, sensibel ab 1 h"),
+> nach vorn verschärft und nach hinten gelockert, weil ein vorgezogener
+> Beginn gefährlicher ist als ein verzögerter. Die ACs sind so geschrieben,
+> dass sie mit dieser Tabelle stehen und fallen, nicht mit konkreten Zahlen
+> im Fließtext.
+
+**Vergleichsbasis muss echte Zeitpunkte nutzen, nicht nackte Stundenzahlen**
+(Risiko 8): Die Verschiebung 23:00 → 01:00 ist eine Verschiebung um 2 Stunden
+über die Kalendergrenze, nicht um 22 Stunden zurück. `WeatherChange.old_value`/
+`new_value`/`delta` sind heute `float`-typisiert (`models.py:556ff`) — die
+Onset-Weiche muss die Differenz **vor** der Umwandlung in dieses DTO als
+echte Zeitspanne (z. B. Sekunden zwischen den beiden `datetime`-Werten)
+berechnen, nicht als Differenz zweier Stundenzahlen. Dasselbe gilt für das
+Melde-Gedächtnis (`deviation_alert_engine.py:242`, filtert über
+`abs(new_value - last)`) — zweite Stelle mit demselben Fehlerrisiko.
+
+**Nur wenn beide Seiten gesetzt sind** (Risiko 7, PO-Entscheid): Die
+bestehende Schleife in `detect_changes()` überspringt Metriken bereits heute,
+wenn altes oder neues Feld `None` ist („Skip if either value is None",
+`weather_change_detection.py:606`) — dieses bestehende Verhalten deckt
+`None → 15:00` automatisch ab, wenn die Onset-Felder über denselben
+Mechanismus eingehängt werden. Kein Sonderfall-Code nötig, aber ein
+Wächter-Test ist Pflicht (AC-6).
+
+### Formatierung
+
+Onset-Werte dürfen `_val()`/`_num()` (`render.py:40-74`) **nicht**
+durchlaufen — `_HANDLED_UNITS` kennt weder `"h"` noch `"Uhr"`, das Ergebnis
+wäre „15 h" statt „15:00" und ein negatives Delta erschiene als „−2 h" statt
+„2 h früher". Ein eigener Formatierpfad nach Vorbild `_fmt_occurred_at()`
+(`project.py:56-63`) liefert Uhrzeiten als `"HH:MM"` in Ortszeit und die
+Verschiebung als Text „N h früher"/„N h später" (kein Vorzeichen im Text).
+
+### Doppelmeldung bei gleichzeitiger Beginn- und Stufenänderung
+
+Ändert sich Beginn **und** Stufe eines Ereignisses gleichzeitig (Gewitter
+kommt früher **und** wird stärker), entstehen zwei `WeatherChange`-Objekte
+für dieselbe Größe.
+
+> ✅ **PO-freigegeben 2026-08-18.** **Beide melden**, aber im
+> zusammengesetzten Alarmtext derselben Nachricht zusammenfassen (nicht zwei
+> getrennte Nachrichten) — folgt der PO-Linie aus `feat_1493`, dass dieselbe
+> Information nicht doppelt in zwei Textformen erscheinen darf. Im
+> Alarm-Protokoll bleiben es dagegen zwei getrennte Einträge (AC-7), damit
+> der größere nackte Betrag den kleineren nicht verdeckt.
+
+### ⚠️ Ergänzender Befund (Spec-Phase, 2026-08-18): Starkregen-Onset ist beim Primärprovider nicht berechenbar
+
+Die Analyse setzt `precip_heavy_onset_utc` auf die stündliche Intensität
+`precip_rate_mmph` (≥ 4,0 mm/h). Verifiziert: **`precip_rate_mmph` wird
+ausschließlich vom Geosphere-Provider befüllt**
+(`src/providers/geosphere.py:571`). Der **Open-Meteo-Provider** — laut
+CLAUDE.md der primäre Provider — setzt das Feld hart auf `None`
+(`src/providers/openmeteo.py:885`, Kommentar: „Not available (Open-Meteo
+provides hourly totals, not rates)"). Für alle Open-Meteo-basierten
+Segmente (die Mehrheit) wäre `precip_heavy_onset_utc` damit strukturell
+immer `None` — kein Fehlalarm, aber auch **nie ein Alarm**, obwohl die Daten
+zur Beurteilung vorlägen: Open-Meteos stündlicher Niederschlagswert
+(`precip_1h_mm`) ist bei 1-Stunden-Auflösung numerisch dieselbe Größe wie
+eine mm/h-Rate.
+
+> ✅ **PO-freigegeben 2026-08-18.** Die Schwelle **bleibt 4,0 mm/h**, nur die
+> Datenquelle wird ergänzt: `_compute_*_onset()` nutzt `precip_rate_mmph`,
+> wenn gesetzt (Geosphere), sonst `precip_1h_mm` als Fallback (Open-Meteo) —
+> beide gegen dieselbe 4,0-mm/h-Schwelle. Rechnerisch identisch: Geosphere
+> setzt `precip_rate_mmph` selbst auf den Stundenwert `precip_1h`
+> (`src/providers/geosphere.py:571`), bei 1-Stunden-Auflösung ist mm/h
+> dieselbe Zahl wie mm je Stunde. Ohne diese Ergänzung wäre die
+> Starkregen-Hälfte des Tickets bei Open-Meteo-Segmenten strukturell
+> wirkungslos.
+
+## Expected Behavior
+
+- **Input:** Zwei aufeinanderfolgende Wetter-Läufe (Anker vs. frischer Stand)
+  für dieselbe Etappe/denselben Ort, mit unterschiedlicher Onset-Stunde für
+  Gewitter und/oder Starkregen im Tagesfenster.
+- **Output:** Verschiebt sich der Beginn um mindestens die für die
+  Empfindlichkeitsstufe und Richtung geltende Schwelle, entsteht ein Alarm
+  auf allen vier konfigurierten Kanälen (E-Mail, Telegram, SMS,
+  Premium-SMS), sowohl im Trip- als auch im Ortsvergleichs-Pfad. Der
+  Alarmtext nennt alte und neue Uhrzeit sowie „N h früher"/„N h später" in
+  lesbarer Form.
+- **Side effects:** Neues Katalog-/Register-Paar erscheint im Alarm-Protokoll
+  (#1954), getrennt vom bestehenden Stufen-Alarm derselben Größe. Alte
+  Wetter-Anker ohne die neuen Felder laden unverändert weiter (`None`, kein
+  Fehlalarm beim ersten Vergleich nach dem Rollout).
+
+## Test Plan
+
+### Automated Tests (TDD RED)
+
+- [ ] Test 1: GIVEN ein Anker mit Gewitterbeginn 17:00 und ein frischer Stand
+      mit Beginn 15:00 (Empfindlichkeit „standard") WHEN `detect_changes()`
+      läuft THEN entsteht genau eine `WeatherChange` mit Metrik
+      Gewitter-Beginn.
+- [ ] Test 2: GIVEN dieselbe Verschiebung in die Gegenrichtung (17:00 →
+      19:00, „standard") WHEN `detect_changes()` läuft THEN entsteht **keine**
+      `WeatherChange` (2 h < 3 h Schwelle für „später").
+- [ ] Test 3: GIVEN Anker 23:00 und frischer Stand 01:00 (Kalendergrenze)
+      WHEN der Alarm gerendert wird THEN nennt der Text „2 h später", nicht
+      „22 h früher".
+- [ ] Test 4: GIVEN eine Etappe mit Gewitterbeginn 14:00 im Tagesfenster
+      WHEN dieselbe Fixture sowohl das Briefing als auch
+      `compute_basis_metrics()` durchläuft THEN sind Briefing-Onset-Stunde
+      und `thunder_onset_utc` gleich (Ortszeit, tagesfenstergefiltert).
+- [ ] Test 5: GIVEN ein persistierter Anker aus der Zeit vor #1468 (ohne
+      `thunder_onset_utc`/`precip_heavy_onset_utc`) WHEN er geladen und mit
+      einem frischen Stand verglichen wird THEN entsteht kein Beginn-Alarm
+      und keine Ausnahme.
+- [ ] Test 6: GIVEN Anker-Onset `None`, frischer Stand 15:00 WHEN
+      `detect_changes()` läuft THEN entsteht kein Beginn-Alarm (Erscheinen
+      eines Ereignisses ist Sache der Stufen-Änderung, nicht der Onset-Weiche).
+- [ ] Test 7: GIVEN Gewitter verschiebt sich UND die Stufe ändert sich
+      gleichzeitig WHEN das Alarm-Protokoll (#1954) den Lauf auswertet THEN
+      liegen zwei getrennte Einträge vor, Register-Paare `("thunder","max")`
+      und `("thunder","onset")`.
+- [ ] Test 8: GIVEN eine Verschiebung ohne Kalendergrenze (z. B. 12:00 →
+      10:00) WHEN der Alarmtext gerendert wird THEN steht „10:00"/„12:00" und
+      „2 h früher" im Text — nicht „10 h", nicht „−2 h".
+- [ ] Test 9: GIVEN ein Beginn-Alarm für eine Trip-Etappe WHEN E-Mail-,
+      Telegram-, SMS- und Premium-SMS-Ausgabe für denselben Lauf gerendert
+      werden THEN enthält jeder der vier Kanäle den Beginn-Alarm; derselbe
+      Nachweis wird für den Ortsvergleichs-Pfad erbracht.
+
+## Acceptance Criteria
+
+- **AC-1:** Given ein Trip-Segment mit Gewitterbeginn 17:00 im letzten
+  Wetter-Anker und einem frischen Wetterstand mit Gewitterbeginn 15:00 bei
+  Empfindlichkeit „standard" / When der Änderungs-Wächter den Lauf auswertet
+  / Then erhält der Nutzer genau einen Beginn-Alarm für dieses Segment — die
+  Verschiebung um 2 Stunden nach vorn überschreitet die Schwelle „ab 1 h
+  früher". Analog gilt derselbe Mechanismus für einen Starkregen-Beginn
+  (`precip_heavy_onset_utc`) mit eigener Fixture.
+  - Test: Test 1 aus dem Test Plan — Alarm-Auslösung aus Nutzersicht
+    (entstandene `WeatherChange`/`AlertEvent`), kein Dateiinhalt-Check.
+
+- **AC-2:** Given dieselbe Ausgangslage wie AC-1, aber die Verschiebung geht
+  in die Gegenrichtung (Beginn 17:00 → 19:00, „standard") / When der
+  Änderungs-Wächter denselben Lauf auswertet / Then erhält der Nutzer
+  **keinen** Alarm — 2 Stunden Verzögerung liegen unter der für „später"
+  geltenden Schwelle von 3 Stunden. Bewacht die vom PO verlangte Asymmetrie
+  (früher ist gefährlicher als später).
+  - Test: Test 2 aus dem Test Plan — Gegenprobe zu AC-1 auf denselben
+    Rohdaten, nur die Richtung ändert sich.
+
+- **AC-3:** Given ein Gewitterbeginn, der sich über Mitternacht verschiebt
+  (23:00 im Anker, 01:00 im frischen Stand) / When der Nutzer den
+  resultierenden Alarmtext liest / Then liest er „2 h später" — nicht eine
+  aus nackten Stundenzahlen fehlberechnete „22 h früher". Bewacht, dass die
+  Verschiebung über echte Zeitpunkte, nicht über Stundenzahlen, berechnet
+  wird.
+  - Test: Test 3 aus dem Test Plan — Alarmtext einer Kalendergrenz-Fixture
+    auf Richtung und Betrag prüfen.
+
+- **AC-4:** Given eine Etappe mit Gewitterbeginn 14:00 innerhalb des
+  Tagesfensters / When derselbe Datenstand sowohl das Trip-Briefing rendert
+  als auch die Alarm-Vergleichsbasis berechnet / Then zeigen beide dieselbe
+  Onset-Stunde 14:00 — der Alarm bezieht sich auf exakt die Zahl, die der
+  Nutzer im Briefing liest, nicht auf eine ungefilterte, evtl. nächtliche
+  Ersterkennung.
+  - Test: Test 4 aus dem Test Plan — Gleichheitsprüfung beider Größen aus
+    derselben Fixture (Muster #1493 AC-9), keine zwei getrennten
+    Textprüfungen.
+
+- **AC-5:** Given einen Wetter-Anker, der vor Einführung dieses Features
+  gespeichert wurde und die neuen Onset-Felder nicht enthält / When dieser
+  Anker geladen und gegen einen frischen Stand verglichen wird / Then bricht
+  die Auswertung nicht ab und es entsteht kein fälschlicher Beginn-Alarm —
+  Bestandsdaten bleiben nutzbar (Read-Modify-Write, kein Datenverlust).
+  - Test: Test 5 aus dem Test Plan — Anker-Fixture ohne die neuen Felder,
+    Vergleichslauf schlägt weder mit Ausnahme noch mit Fehlalarm fehl.
+
+- **AC-6:** Given ein Ereignis, das im alten Stand noch gar nicht existierte
+  (Onset `None`) und im frischen Stand erstmals auftritt (Onset 15:00) / When
+  der Änderungs-Wächter den Lauf auswertet / Then entsteht **kein**
+  Beginn-Verschiebungs-Alarm für dieses Auftauchen — das Erscheinen eines
+  Ereignisses ist bereits Sache des bestehenden Stufen-Alarms, nicht der
+  neuen Onset-Weiche, sonst würde derselbe Vorgang doppelt gemeldet.
+  - Test: Test 6 aus dem Test Plan — `None → Wert` erzeugt keine
+    `WeatherChange` über die Onset-Weiche.
+
+- **AC-7:** Given ein Lauf, in dem sich Beginn **und** Stufe eines Gewitters
+  gleichzeitig ändern / When der Nutzer das Alarm-Protokoll (#1954) für
+  diesen Lauf einsieht / Then findet er zwei getrennt ausgewiesene Einträge
+  für Gewitter — einen für den Stufenwechsel, einen für den
+  Beginn-Wechsel — statt eines Eintrags, in dem der größere nackte Betrag den
+  anderen verdeckt.
+  - Test: Test 7 aus dem Test Plan — Protokoll-Register-Paare
+    `("thunder","max")` und `("thunder","onset")` beide vorhanden und
+    inhaltlich unterschieden.
+
+- **AC-8:** Given einen Beginn-Alarm ohne Kalendergrenze (z. B. Verschiebung
+  12:00 → 10:00) / When der Nutzer den Alarmtext auf einem beliebigen der
+  vier Kanäle liest / Then liest er Uhrzeiten im Format „10:00"/„12:00" und
+  die Verschiebung als „2 h früher" — nicht als gerundete Zahl mit
+  Einheit „h" (die für Uhrzeiten Unfug wäre) und nicht mit Minuszeichen
+  statt Richtungswort.
+  - Test: Test 8 aus dem Test Plan — Textform-Prüfung auf dem gerenderten
+    Alarmtext, kein Dateiinhalt-Grep auf Formatierfunktionen.
+
+- **AC-9:** Given einen ausgelösten Beginn-Alarm für ein Trip-Segment und
+  denselben Alarm-Typ im Ortsvergleichs-Pfad für einen verglichenen Ort /
+  When die Nachrichten für E-Mail, Telegram, SMS und Premium-SMS erzeugt
+  werden / Then enthält jeder der vier Kanäle in **beiden** Flächen (Trip und
+  Ortsvergleich) den Beginn-Alarm — kein Kanal und keine Fläche wird
+  ausgelassen (CLAUDE.md: alle vier Kanäle sind gleichrangig relevant).
+  - Test: Test 9 aus dem Test Plan — vier Kanal-Renderer plus
+    Ortsvergleichs-Pfad aus demselben Alarm-Lauf, Beginn-Alarm-Inhalt in
+    jedem einzeln nachgewiesen.
+
+## Known Limitations
+
+- **Alle drei PO-Freigabe-Punkte sind entschieden (2026-08-18):**
+  Preset-Schwellen wie tabelliert · Beginn- und Stufenänderung werden beide
+  gemeldet, im Alarmtext zusammengefasst und im Protokoll getrennt ·
+  Starkregen-Onset nutzt `precip_1h_mm` als Fallback gegen dieselbe
+  4,0-mm/h-Schwelle. Siehe die ✅-Markierungen in „Implementation Details".
+- **Aktivierungs-Kopplung (gewollt):** Der Alarme-Tab zeigt nur Metriken,
+  deren Katalog-Größe im Wetter-Tab aktiv ist. Da der Beginn-Alarm an den
+  bestehenden Katalog-IDs `thunder`/`precipitation` hängt, erbt er deren
+  Sichtbarkeits-Gate automatisch — wer Gewitter nicht beobachtet, sieht auch
+  keinen Gewitterbeginn-Alarm. Kein Zusatzcode nötig.
+- **Kein Bezug zu #1493:** Die Darstellung der Onset-Stunde im Briefing
+  selbst ist bereits geliefert (#1493) und wird hier nicht verändert — diese
+  Spec fügt ausschließlich die Alarm-Auswertung hinzu und liest dieselbe
+  Zahl mit, die #1493 sichtbar macht.
+- **Kein Nowcast-Bezug:** Der Radar-Nowcast-Weg („in ~20 Minuten") bleibt
+  unverändert; dieser Alarm läuft ausschließlich über den Forecast-
+  Vergleichspfad.
+- **Go/Frontend-Parität:** Nach jeder Änderung an `_PRESET_TABLE` bzw. am
+  `AlertMetric`-Katalog müssen `scripts/generate_alert_preset_table.py` und
+  `scripts/generate_alert_metric_mapping.py` laufen, sonst schlagen die
+  Frische-Ratschen (`test_alert_preset_table_parity.py`,
+  `test_alert_metric_mapping_parity.py`) fehl.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Erweitert ausschließlich bestehende, bereits etablierte
+  Mechanismen (Summary-Feld → Alarm-Metrik → Preset-Tabelle → Renderer,
+  vollständig analog zur bestehenden Niveau-Weiche für `thunder_level_max`).
+  Kein neuer Kanal, kein neuer Provider, kein neues Auth-/Persistenz-Modell,
+  kein neues Editor-Paradigma — keine der in CLAUDE.md genannten
+  Entscheidungsflächen ist strukturell betroffen. Die Asymmetrie (zwei
+  Schwellen statt einer) ist neu in ihrer Konkretisierung, folgt aber
+  demselben Preset-Tabellen-Muster, das die bestehende Architektur bereits
+  für die Niveau-Weiche etabliert hat.
+
+## Changelog
+
+- 2026-08-18: Initial spec created

--- a/docs/specs/modules/feat_1468_onset_verschiebung_alarm.md
+++ b/docs/specs/modules/feat_1468_onset_verschiebung_alarm.md
@@ -360,6 +360,34 @@ eine mm/h-Rate.
     Ortsvergleichs-Pfad aus demselben Alarm-Lauf, Beginn-Alarm-Inhalt in
     jedem einzeln nachgewiesen.
 
+- **AC-10:** Given eine Tour, für die ein vom Standard abweichendes Tagesfenster
+  konfiguriert ist (weiter, enger oder über Mitternacht) / When der Nutzer den
+  Beginn-Alarm für diese Tour erhält / Then bezieht sich der Alarm auf dieselbe
+  Beginn-Uhrzeit, die im Briefing dieser Tour steht — und nicht auf eine mit dem
+  Standardfenster 4–19 gerechnete andere Stunde. Fehlt die Konfiguration
+  (Alt-Tour), gilt weiterhin der Standard, und Briefing wie Alarm bleiben
+  unverändert.
+  - Test: `tests/tdd/test_onset_respects_configured_day_window.py` —
+    Gleichheitsprüfung Briefing-Onset == Vergleichsbasis aus derselben Fixture,
+    für ein weiteres (3–21) und ein engeres (8–16) Fenster, plus Mitternachtsfall
+    (21–4) und drei Bestandsverhalten-Fälle.
+
+> ✅ **PO-freigegeben 2026-08-18 (Nachtrag).** Ursprünglich sah die Umsetzung nur
+> das Standard-Tagesfenster vor; die Analyse hatte offengelassen, ob die
+> Tour-Konfiguration bis zur Aggregation durchgereicht wird. Belegt wurde: das
+> Fenster ist pro Tour einstellbar (`DayWindowCard.svelte`, Go-Handler
+> `trip.go:316`, `loader.py:99` `_clamped_day_window`), die Vorschnitt-Logik fängt
+> die Abweichung NICHT ab, und bei abweichendem Fenster driften Briefing-Anzeige
+> und Alarm-Bezug in beide Richtungen auseinander — also genau der Bruch der
+> Zusicherung E2/AC-4, nur außerhalb des Default-Falls. PO-Entscheid: **jetzt
+> schließen, nicht vertagen.** Briefing-/Anker-Pfad und Alarm-Pfad werden
+> GEMEINSAM umgestellt (ein einseitiger Umbau erzeugte einen Scheinalarm beim
+> ersten Lauf nach dem Deploy, weil Anker und frischer Stand sich allein durch die
+> Fensterwahl unterschieden); der Ortsvergleich wird mitgezogen (gleiche
+> Fehlerklasse, Teilungs-Invariante); Nacht-Segmente bleiben bewusst beim Standard,
+> weil ein Tagesfenster dort genau die Stunden entfernen würde, für die sie geholt
+> werden.
+
 ## Known Limitations
 
 - **Alle drei PO-Freigabe-Punkte sind entschieden (2026-08-18):**

--- a/frontend/src/lib/components/alerts-tab/alertMetricTable.test.ts
+++ b/frontend/src/lib/components/alerts-tab/alertMetricTable.test.ts
@@ -23,12 +23,13 @@ import {
 import type { AlertRule, AlertMetric } from '../../types.ts';
 
 // =============================================================================
-// METRIC_DEFAULTS — 14 Eintraege mit korrekten Standardwerten (Spec §Implementation)
-// (Issue #946: freezing_level ergänzt → 14 statt 13.)
+// METRIC_DEFAULTS — 16 Eintraege mit korrekten Standardwerten (Spec §Implementation)
+// (Issue #946: freezing_level ergänzt → 14 statt 13.
+//  Issue #1468: thunder_onset + precipitation_heavy_onset → 16 statt 14.)
 // =============================================================================
 
-test('METRIC_DEFAULTS > hat genau 14 Eintraege', () => {
-	assert.equal(Object.keys(METRIC_DEFAULTS).length, 14);
+test('METRIC_DEFAULTS > hat genau 16 Eintraege', () => {
+	assert.equal(Object.keys(METRIC_DEFAULTS).length, 16);
 });
 
 test('METRIC_DEFAULTS > wind_gust default ist 50', () => {

--- a/frontend/src/lib/components/alerts-tab/alertMetricTable.ts
+++ b/frontend/src/lib/components/alerts-tab/alertMetricTable.ts
@@ -36,6 +36,9 @@ export const METRIC_DEFAULTS: Record<AlertMetric, number> = {
 	humidity: 15,
 	// Issue #946: Nullgradgrenze (freezing_level).
 	freezing_level: 200,
+	// Issue #1468: Beginn-Verschiebung in Stunden (Fallback-Defaults).
+	thunder_onset: 1,
+	precipitation_heavy_onset: 1,
 };
 
 // Issue #846 / Fix #1435 Etappe E4: Preset-Schwellwert-Tabelle wird aus der
@@ -196,6 +199,9 @@ export const ALERTABLE_METRICS: readonly AlertMetric[] = [
 	'visibility',
 	'humidity',
 	'freezing_level',
+	// Issue #1468: Beginn-Verschiebung von Gewitter und Starkregen.
+	'thunder_onset',
+	'precipitation_heavy_onset',
 ];
 
 /** Metriken die THRESHOLD_CROSSING verwenden (absoluter Schwellwert, nicht Delta).
@@ -222,6 +228,9 @@ const _METRIC_UNITS: Record<AlertMetric, string> = {
 	visibility: 'm',
 	humidity: '%',
 	freezing_level: 'm',
+	// Issue #1468: die Schwelle ist eine Verschiebung, gemessen in Stunden.
+	thunder_onset: 'h',
+	precipitation_heavy_onset: 'h',
 };
 
 /**
@@ -307,8 +316,9 @@ const CATALOG_TO_ALERT_METRICS: Record<string, readonly AlertMetric[]> = {
 	// Kurz-IDs aus dem Catalog
 	gust:          ['wind_gust'],
 	wind:          ['wind_change'],
-	precipitation: ['precipitation_sum', 'precipitation_change'],
-	thunder:       ['thunder_level'],
+	// Issue #1468: der Beginn erbt die Sichtbarkeit seiner Register-Groesse.
+	precipitation: ['precipitation_sum', 'precipitation_change', 'precipitation_heavy_onset'],
+	thunder:       ['thunder_level', 'thunder_onset'],
 	// Issue #959: snow_line/snowfall_limit aktivieren die konsolidierte Metrik freezing_level.
 	snowfall_limit: ['freezing_level'],
 	temperature:   ['temperature_min', 'temperature_max', 'temperature_change'],

--- a/frontend/src/lib/components/alerts-tab/alertPreviewHelpers.test.ts
+++ b/frontend/src/lib/components/alerts-tab/alertPreviewHelpers.test.ts
@@ -24,9 +24,11 @@ import type { AlertRule, Stage } from '../../types.ts';
 // =============================================================================
 
 // #846: 4 neue Metriken (fresh_snow, cape, visibility, humidity) + #946: freezing_level
-// -> METRIC_MAP ist seither auf 14 Eintraege gewachsen (9 Basis + 4 aus #846 + 1 aus #946).
-test('METRIC_MAP > hat genau 14 Eintraege', () => {
-	assert.equal(Object.keys(METRIC_MAP).length, 14);
+// + #1468: die beiden Beginn-Groessen
+// -> METRIC_MAP ist seither auf 16 Eintraege gewachsen
+//    (9 Basis + 4 aus #846 + 1 aus #946 + 2 aus #1468).
+test('METRIC_MAP > hat genau 16 Eintraege', () => {
+	assert.equal(Object.keys(METRIC_MAP).length, 16);
 });
 
 test('METRIC_MAP > wind_gust mappt auf gust_max_kmh / above (Spec §Data Model)', () => {

--- a/frontend/src/lib/components/alerts-tab/alertPreviewHelpers.ts
+++ b/frontend/src/lib/components/alerts-tab/alertPreviewHelpers.ts
@@ -23,6 +23,11 @@ export const METRIC_MAP: Record<AlertMetric, { metric: string; direction: string
 	humidity:             { metric: 'humidity_avg_pct',  direction: 'above' },
 	// Issue #946: Nullgradgrenze (freezing_level).
 	freezing_level:       { metric: 'freezing_level_m',  direction: 'below' },
+	// Issue #1468: Beginn-Verschiebung. `direction` ist hier nur der
+	// Vorschau-Vorgabewert; die echte Richtung entscheidet der Wert-Vergleich
+	// im Backend (frueher = decrease, spaeter = increase).
+	thunder_onset:             { metric: 'thunder_onset_utc',      direction: 'decrease' },
+	precipitation_heavy_onset: { metric: 'precip_heavy_onset_utc', direction: 'decrease' },
 };
 
 export const SEVERITY_MAP: Record<string, string> = {

--- a/frontend/src/lib/generated/alertPresetThresholds.generated.json
+++ b/frontend/src/lib/generated/alertPresetThresholds.generated.json
@@ -23,6 +23,12 @@
     "sensibel": 3,
     "standard": 7
   },
+  "precipitation_heavy_onset": {
+    "entspannt": 2,
+    "kind": "delta",
+    "sensibel": 1,
+    "standard": 1
+  },
   "precipitation_sum": {
     "entspannt": 20,
     "kind": "delta",
@@ -49,6 +55,12 @@
   },
   "thunder_level": {
     "entspannt": 1,
+    "kind": "delta",
+    "sensibel": 1,
+    "standard": 1
+  },
+  "thunder_onset": {
+    "entspannt": 2,
     "kind": "delta",
     "sensibel": 1,
     "standard": 1

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -85,7 +85,10 @@ export type AlertMetric =
 	| 'visibility'
 	| 'humidity'
 	// Issue #946: Nullgradgrenze
-	| 'freezing_level';
+	| 'freezing_level'
+	// Issue #1468: Beginn-Verschiebung von Gewitter und Starkregen
+	| 'thunder_onset'
+	| 'precipitation_heavy_onset';
 
 export interface AlertRule {
 	id: string;

--- a/frontend/src/lib/utils/alertMetricCatalogIds.test.ts
+++ b/frontend/src/lib/utils/alertMetricCatalogIds.test.ts
@@ -2,7 +2,7 @@
 // Zuordnung AlertMetric → Metrik-Register-ID.
 // Spec: docs/specs/modules/fix_1401b_register_stundenverlauf_alarme.md
 //
-// Zweck: jede der 14 Alarm-Groessen ist genau einmal eingeordnet — entweder sie
+// Zweck: jede der 16 Alarm-Groessen ist genau einmal eingeordnet — entweder sie
 // hat eine Register-Entsprechung (Crosswalk) oder sie ist bewusst als
 // registerlos vermerkt (Aenderungs-Metriken). Damit kann kein neuer Eintrag
 // still ohne Entscheidung dazukommen.
@@ -33,8 +33,8 @@ const CATALOG_IDS = new Set([
 const ALL_ALERT_METRICS = Object.keys(ALERT_METRIC_LABELS);
 
 describe('#1401b AC-5: jede Alarm-Groesse ist genau einmal eingeordnet', () => {
-	test('Es gibt 14 Alarm-Groessen (Vakuum-Schutz)', () => {
-		assert.equal(ALL_ALERT_METRICS.length, 14);
+	test('Es gibt 16 Alarm-Groessen (Vakuum-Schutz)', () => {
+		assert.equal(ALL_ALERT_METRICS.length, 16);
 	});
 
 	test('Genau drei Groessen sind als registerlos vermerkt', () => {
@@ -57,7 +57,7 @@ describe('#1401b AC-5: jede Alarm-Groesse ist genau einmal eingeordnet', () => {
 		}
 	});
 
-	test('Registerlose Menge und Crosswalk ergeben zusammen exakt alle 14 — ohne Ueberschneidung', () => {
+	test('Registerlose Menge und Crosswalk ergeben zusammen exakt alle 16 — ohne Ueberschneidung', () => {
 		const crosswalkKeys = Object.keys(ALERT_METRIC_TO_CATALOG_ID);
 		const overlap = crosswalkKeys.filter((k) => NON_CATALOG_ALERT_METRICS.has(k as never));
 		assert.deepEqual(overlap, [], 'Groesse ist gleichzeitig registerlos und zugeordnet');

--- a/frontend/src/lib/utils/alertMetricCatalogIds.ts
+++ b/frontend/src/lib/utils/alertMetricCatalogIds.ts
@@ -21,7 +21,11 @@ export const ALERT_METRIC_TO_CATALOG_ID: Partial<Record<AlertMetric, string>> = 
 	// Zwei Auswertungen derselben Register-Groesse — die Unterscheidung traegt
 	// der label_de-Text ("Temperatur (Minimum)"/"(Maximum)"), nicht die ID.
 	temperature_min: 'temperature',
-	temperature_max: 'temperature'
+	temperature_max: 'temperature',
+	// Issue #1468: der Beginn haengt an derselben Register-Groesse wie die
+	// Stufe bzw. die Summe — unterschieden wird ueber den label_de-Text.
+	thunder_onset: 'thunder',
+	precipitation_heavy_onset: 'precipitation'
 };
 
 /**

--- a/frontend/src/lib/utils/alertMetricLabels.ts
+++ b/frontend/src/lib/utils/alertMetricLabels.ts
@@ -37,6 +37,14 @@ export const ALERT_METRIC_LABELS: Record<
 	humidity: { label_de: 'Luftfeuchtigkeit', unit: '%', comparison: '>' },
 	// Issue #946: Nullgradgrenze
 	freezing_level: { label_de: 'Nullgradgrenze', unit: 'm', comparison: '<' },
+	// Issue #1468: die Schwelle ist eine Verschiebung in Stunden, nicht ein
+	// Absolutwert — Vergleichssymbol darum '≥' wie bei Gewitter.
+	thunder_onset: { label_de: 'Gewitter (Beginn)', unit: 'h', comparison: '≥' },
+	precipitation_heavy_onset: {
+		label_de: 'Starkregen (Beginn)',
+		unit: 'h',
+		comparison: '≥'
+	},
 };
 
 export const ALERT_SEVERITY_TONE: Record<AlertSeverity, 'info' | 'warning' | 'danger'> = {

--- a/src/app/metric_catalog.py
+++ b/src/app/metric_catalog.py
@@ -94,6 +94,13 @@ class MetricDefinition:
         return bool(self.friendly_label)
 
 
+# Issue #1468: Auswertung "Beginn des Ereignisses". Bewusst KEIN Eintrag in
+# `_AGGREGATION_ORDER` -- der Beginn ist keine vom Nutzer waehlbare
+# Zusammenfassung einer Stundenreihe, sondern ein Zeitpunkt. Er traegt
+# trotzdem einen `summary_fields`-Schluessel, weil das Alarm-Protokoll (#1954)
+# seine Register-Paare ueber genau diese Zuordnung bildet.
+ONSET_AGGREGATION: str = "onset"
+
 # --- Metric Registry ---
 
 _METRICS: list[MetricDefinition] = [
@@ -367,9 +374,11 @@ _METRICS: list[MetricDefinition] = [
         default_aggregations=("sum",),
         compact_label="R", col_key="precip", col_label="Rain",
         providers={"openmeteo": True, "geosphere": True},
-        summary_fields={"sum": "precip_sum_mm"},
+        summary_fields={"sum": "precip_sum_mm",
+                        ONSET_AGGREGATION: "precip_heavy_onset_utc"},  # #1468
         default_change_threshold=10.0,
-        alert_metrics={"sum": "precipitation_sum"},  # #1435 E1a
+        alert_metrics={"sum": "precipitation_sum",
+                       ONSET_AGGREGATION: "precipitation_heavy_onset"},  # #1435 E1a, #1468
         change_alert_metric="precipitation_change",
         display_thresholds={"yellow": 1.0, "orange": 5.0, "red": 10.0},
         risk_thresholds={"medium": 20.0},
@@ -416,9 +425,11 @@ _METRICS: list[MetricDefinition] = [
         default_aggregations=("max",),
         compact_label="⚡", col_key="thunder", col_label="Thdr",
         providers={"openmeteo": True, "geosphere": False},
-        summary_fields={"max": "thunder_level_max"},
+        summary_fields={"max": "thunder_level_max",
+                        ONSET_AGGREGATION: "thunder_onset_utc"},  # #1468
         default_change_threshold=1.0,
-        alert_metrics={"max": "thunder_level"},  # #1435 E1a
+        alert_metrics={"max": "thunder_level",
+                       ONSET_AGGREGATION: "thunder_onset"},  # #1435 E1a, #1468
         friendly_label="⚡",
         # Issue #814 AC-6: "raw" in format_modes erlaubt explizites format_mode="raw"
         # im Renderer (matrix test setzt mc.format_mode="raw"). Der #435-Fallback-Test
@@ -1122,7 +1133,13 @@ def get_change_detection_map() -> dict[str, float]:
         # Schwelle stehen, obwohl die Größe nirgends mehr wählbar ist.
         if not m.selectable:
             continue
-        for summary_field in m.summary_fields.values():
+        for aggregation, summary_field in m.summary_fields.items():
+            # Issue #1468: Beginn-Felder tragen einen ZEITPUNKT, keinen
+            # Messwert -- `abs(delta) > threshold` waere dort ein Vergleich
+            # von timedelta mit float (TypeError). Der Beginn-Alarm laeuft
+            # ueber seine eigene Weiche in `detect_changes()`.
+            if aggregation == ONSET_AGGREGATION:
+                continue
             result[summary_field] = m.default_change_threshold
     return result
 

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -418,6 +418,16 @@ class TripSegment:
     # Optional fields for Story 1 (Feature 1.5)
     adjusted_to_waypoint: bool = False
     waypoint: Optional["DetectedWaypoint"] = None
+    # Issue #1468 (E2): Tagesfenster in ORTSZEIT, unter dem die Aggregation
+    # dieses Segments ausgewertet wird. Das Segment traegt es, NICHT die
+    # Aufrufkette: Briefing-/Anker-Pfad und Alarm-Pfad benutzen dieselben
+    # Segmente, damit ist die Symmetrie beider Vergleichsseiten strukturell
+    # gesichert statt an vier Aufrufstellen per Disziplin. `None` = keine
+    # Angabe -> Default 4-19 ueber `day_window.resolve_configured_window()`;
+    # das ist zugleich das Verhalten fuer Bestandsdaten und fuer jedes
+    # Segment, das ohne Trip-Bezug entsteht.
+    day_window_start_hour: Optional[int] = None
+    day_window_end_hour: Optional[int] = None
 
 
 @dataclass

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -494,6 +494,19 @@ class SegmentWeatherSummary:
     # filtert Unbekanntes bereits ueber `dataclasses.fields()`).
     cape_model_id: Optional[str] = None
 
+    # Issue #1468 (E1): BEGINN der beiden Ereignisse als eigene, vergleichbare
+    # Groesse -- erste Stunde IM TAGESFENSTER mit Gewitterstufe >= LOW bzw.
+    # Regenintensitaet >= 4,0 mm/h. Typ `datetime` (naive UTC, Hausnorm
+    # src/utils/timezone.py) und NICHT eine nackte Stundenzahl: 23:00 -> 01:00
+    # ist eine Verschiebung um 2 Stunden, nicht um 22 zurueck. Je Groesse ein
+    # EIGENES Feld, damit das Alarm-Protokoll (#1954) ueber
+    # `metric_and_aggregation_for_field()` die Paare ("thunder","onset") bzw.
+    # ("precipitation","onset") getrennt von ("thunder","max") bildet.
+    # Additiv, Default None -- alte Anker laden unveraendert weiter
+    # (`weather_snapshot._deserialize_summary` filtert ueber `dataclasses.fields()`).
+    thunder_onset_utc: Optional[datetime] = None
+    precip_heavy_onset_utc: Optional[datetime] = None
+
     # Metadata
     aggregation_config: dict[str, str] = field(default_factory=dict)
 
@@ -1171,6 +1184,11 @@ class AlertMetric(str, Enum):
     # Der Enum-Wert bleibt bewusst als toter Eintrag erhalten, damit alt-persistierte
     # AlertRules mit metric="humidity" ohne Lade-Crash deserialisieren (Backward-Compat).
     HUMIDITY = "humidity"
+    # Issue #1468: Beginn-Verschiebung als eigene Alarm-Groesse (E1). Haengt an
+    # denselben Katalog-IDs wie die Stufen-/Summen-Alarme (thunder /
+    # precipitation) und erbt damit deren Wetter-Tab-Sichtbarkeits-Gate.
+    THUNDER_ONSET = "thunder_onset"
+    PRECIPITATION_HEAVY_ONSET = "precipitation_heavy_onset"
 
 
 @dataclass

--- a/src/output/renderers/alert/model.py
+++ b/src/output/renderers/alert/model.py
@@ -57,6 +57,29 @@ class OnsetEvent:
 
 
 @dataclass(frozen=True)
+class OnsetShiftEvent:
+    """Eine Beginn-Verschiebung (Issue #1468) -- eigener Render-Vertrag nach
+    dem Vorbild von `CorridorEvent` (ADR-0013).
+
+    Bewusst KEIN `AlertEvent`: dessen Werte laufen durch den Zahlen-
+    Formatierer (`render._val`/`_num`, Katalog-Einheit angehaengt, Vorzeichen
+    statt Richtungswort). Eine Uhrzeit erschiene dort als "15 h" und eine
+    Verschiebung als "-2 h" -- beides Unfug. Die Uhrzeiten sind hier bereits
+    ORTSZEIT-formatiert ("HH:MM"), die Verschiebung ist bereits Text
+    ("2 h frueher"/"2 h spaeter"): die Umrechnung passiert in der
+    Projektionsschicht, wo die Koordinaten bekannt sind.
+    """
+    metric_id: str            # catalog metric_id (NICHT summary_field)
+    from_time: str            # "HH:MM" Ortszeit -- Beginn im letzten Stand
+    to_time: str              # "HH:MM" Ortszeit -- Beginn im frischen Stand
+    shift_text: str           # "2 h früher" | "2 h später"
+    km_from: float
+    km_to: float
+    segment_id: str | None = None
+    location_label: str | None = None
+
+
+@dataclass(frozen=True)
 class CorridorEvent:
     """Ein Schwellen-Treffer (Issue #1444 S1) -- eigener Render-Vertrag
     (ADR-0013): KEIN `WeatherChange`-Missbrauch mit erfundenem
@@ -90,6 +113,11 @@ class AlertMessage:
     # gebuendelt (Muster #1088). Bestehende Aufrufer setzen dieses Feld nie
     # (Default leer, Regressions-Invariante).
     corridor_events: tuple[CorridorEvent, ...] = ()
+    # Issue #1468: additiv, optional. Beginn-Verschiebungen desselben Laufs --
+    # in DERSELBE Nachricht wie die Stufen-/Wert-Aenderungen (PO-Entscheid:
+    # beide melden, im Text zusammenfassen, nicht zwei getrennte Nachrichten).
+    # Bestehende Aufrufer setzen dieses Feld nie (Regressions-Invariante).
+    onset_shift_events: tuple[OnsetShiftEvent, ...] = ()
     # Issue #1916 (AC-1..AC-4): additiv, optional. Referenz-Zeitpunkt der
     # tatsaechlich verglichenen Vergleichsbasis (Ortszeit, ggf. mit Tagesbezug
     # wie "gestern 18:03 Uhr"), NICHT der aktuelle Abrufzeitpunkt (`stand_at`).

--- a/src/output/renderers/alert/project.py
+++ b/src/output/renderers/alert/project.py
@@ -9,9 +9,13 @@ from __future__ import annotations
 import logging
 from datetime import datetime, timedelta, timezone
 
-from app.metric_catalog import _METRICS, get_cmp
+from app.metric_catalog import (
+    _METRICS, ONSET_AGGREGATION, get_cmp, metric_and_aggregation_for_field,
+)
 from utils.timezone import local_fmt, resolve_location_tz
-from .model import AlertEvent, AlertMessage, CorridorEvent, OnsetEvent
+from .model import (
+    AlertEvent, AlertMessage, CorridorEvent, OnsetEvent, OnsetShiftEvent,
+)
 from .segments import normalize_segment_id
 
 logger = logging.getLogger("alert_project")
@@ -63,6 +67,53 @@ def _fmt_occurred_at(value, tz) -> str | None:
     return local_fmt(value, tz)
 
 
+# --- Issue #1468: Beginn-Verschiebung (eigener Formatierpfad) ---------------
+
+def _is_onset_change(ch) -> bool:
+    """Traegt diese `WeatherChange` eine Beginn-Verschiebung?
+
+    Entschieden ueber den KATALOG (Auswertung des Summary-Felds), nicht ueber
+    eine zweite Feldliste im Renderer -- sonst waere eine dritte Beginn-Groesse
+    genau die Danebenpflege, die #1435 abgeschafft hat.
+    """
+    paar = metric_and_aggregation_for_field(ch.metric)
+    return bool(paar) and paar[1] == ONSET_AGGREGATION
+
+
+def _fmt_onset_at(epoch_seconds: float, tz) -> str:
+    """Beginn-Zeitpunkt (Epochensekunden, s. `_onset_change()`) -> "HH:MM" in
+    ORTSZEIT. Vorbild `_fmt_occurred_at()` -- bewusst NICHT ueber
+    `format_metric_value()`, das aus einer Uhrzeit "15 h" machte."""
+    return local_fmt(datetime.fromtimestamp(epoch_seconds, timezone.utc), tz)
+
+
+def _onset_shift_text(delta_seconds: float) -> str:
+    """Verschiebung als WORT, nicht als Vorzeichen: "2 h früher"/"2 h später".
+
+    Positives Delta heisst spaeter (der Beginn wandert nach hinten). Der
+    Betrag steht ohne Vorzeichen -- die Richtung traegt das Wort.
+    """
+    stunden = abs(delta_seconds) / 3600.0
+    betrag = (f"{stunden:.0f}" if abs(stunden - round(stunden)) < 0.05
+              else f"{stunden:.1f}".replace(".", ","))
+    return f"{betrag} h {'später' if delta_seconds > 0 else 'früher'}"
+
+
+def _to_onset_shift_event(
+    ch, *, tz, km_from: float, km_to: float,
+    segment_id: str | None = None, location_label: str | None = None,
+) -> OnsetShiftEvent:
+    metric_id, _aggregation = metric_and_aggregation_for_field(ch.metric)
+    return OnsetShiftEvent(
+        metric_id=metric_id,
+        from_time=_fmt_onset_at(ch.old_value, tz),
+        to_time=_fmt_onset_at(ch.new_value, tz),
+        shift_text=_onset_shift_text(ch.delta),
+        km_from=km_from, km_to=km_to,
+        segment_id=segment_id, location_label=location_label,
+    )
+
+
 def to_alert_message(
     changes, segments, trip_name, *, tz, stand_at, corridor_hits=None,
     reference_at=None,
@@ -78,14 +129,24 @@ def to_alert_message(
     `changes` kann dabei leer sein (Korridor als einzige Alarmquelle, AC-5).
     """
     events: list[AlertEvent] = []
+    onset_events: list[OnsetShiftEvent] = []
     for ch in changes:
+        match = _find_segment(segments, ch.segment_id)
+        km_from = match.segment.start_point.distance_from_start_km
+        km_to = match.segment.end_point.distance_from_start_km
+        # Issue #1468: Beginn-Verschiebungen tragen einen ZEITPUNKT und gehen
+        # deshalb NICHT durch den Zahlen-Formatierer (s. `OnsetShiftEvent`).
+        if _is_onset_change(ch):
+            onset_events.append(_to_onset_shift_event(
+                ch, tz=_tz_for_location(match.segment.start_point, tz),
+                km_from=km_from, km_to=km_to,
+                segment_id=normalize_segment_id(match.segment.segment_id),
+            ))
+            continue
         metric_id = _resolve_metric_id(ch.metric, ch.direction)
         cmp = get_cmp(metric_id)
         if not cmp:
             raise ValueError(f"Leeres cmp für metric_id={metric_id!r}")
-        match = _find_segment(segments, ch.segment_id)
-        km_from = match.segment.start_point.distance_from_start_km
-        km_to = match.segment.end_point.distance_from_start_km
         events.append(AlertEvent(
             metric_id=metric_id, value_from=ch.old_value, value_to=ch.new_value,
             threshold=ch.threshold, cmp=cmp,
@@ -104,7 +165,8 @@ def to_alert_message(
     )
     return AlertMessage(
         trip_short=trip_name, stand_at=stand_at, events=tuple(events), source=None,
-        corridor_events=corridor_events, reference_at=reference_at,
+        corridor_events=corridor_events,
+        onset_shift_events=tuple(onset_events), reference_at=reference_at,
     )
 
 
@@ -206,10 +268,19 @@ def to_multi_point_alert_message(groups, *, tz, stand_at, reference_at=None) -> 
     redundanten Orts-Präfix vor JEDER Metrik-Zeile (Issue #1170 Finding F007).
     """
     events: list[AlertEvent] = []
+    onset_events: list[OnsetShiftEvent] = []
     multi = len(groups) > 1
     for location_name, changes, point in groups:
         point_tz = _tz_for_location(point, tz)
         for ch in changes:
+            # Issue #1468: derselbe eigene Formatierpfad wie im Trip-Zweig --
+            # der Ortsvergleich erbt den Beginn-Alarm ohne Zweitlogik.
+            if _is_onset_change(ch):
+                onset_events.append(_to_onset_shift_event(
+                    ch, tz=point_tz, km_from=0.0, km_to=0.0,
+                    location_label=location_name if multi else None,
+                ))
+                continue
             metric_id = _resolve_metric_id(ch.metric, ch.direction)
             cmp = get_cmp(metric_id)
             if not cmp:
@@ -224,7 +295,8 @@ def to_multi_point_alert_message(groups, *, tz, stand_at, reference_at=None) -> 
     collective_label = ", ".join(name for name, _changes, _point in groups)
     return AlertMessage(
         trip_short=collective_label, stand_at=stand_at, events=tuple(events), source=None,
-        location_label=collective_label, reference_at=reference_at,
+        location_label=collective_label,
+        onset_shift_events=tuple(onset_events), reference_at=reference_at,
     )
 
 

--- a/src/output/renderers/alert/render.py
+++ b/src/output/renderers/alert/render.py
@@ -18,8 +18,8 @@ from output.renderers.email.design_tokens import (
 from utils.ascii_fold import fold_ascii
 
 from .model import (
-    AlertEvent, AlertMessage, CorridorEvent, OnsetEvent, arrow, delta_pct,
-    km_span, over_thr, severity, side_label,
+    AlertEvent, AlertMessage, CorridorEvent, OnsetEvent, OnsetShiftEvent,
+    arrow, delta_pct, km_span, over_thr, severity, side_label,
 )
 from .segments import _renderable_segment_ids, format_alert_location
 
@@ -188,6 +188,84 @@ def _sms_corridor_token(ce: CorridorEvent) -> str:
     return tok + f"@{ce.occurred_at[:2]}" if ce.occurred_at else tok
 
 
+# --- Beginn-Verschiebung (Issue #1468, ADR-0013: eigener Render-Vertrag --
+# NIE durch _val()/_num(), sonst stuende "15 h" statt "15:00" im Text) -------
+
+def _onset_shift_where(oe: OnsetShiftEvent) -> str:
+    return format_alert_location(
+        oe.location_label, [oe.segment_id], oe.km_from, oe.km_to,
+    )
+
+
+def _onset_shift_line(oe: OnsetShiftEvent) -> str:
+    """Eine Zeile Klartext: Groesse, alte und neue Uhrzeit, Richtungswort."""
+    return (
+        f"{_label(oe)}-Beginn: {oe.from_time} → {oe.to_time} "
+        f"({oe.shift_text} · {_onset_shift_where(oe)})"
+    )
+
+
+def _onset_shift_location(msg: AlertMessage) -> str:
+    """Ortsangabe der Beginn-Ereignisse -- dieselbe Aufloesung wie ueberall
+    sonst (`segments.format_alert_location`), damit eine Mail nicht zwei
+    Ortssprachen spricht (Issue #1744 AC-6)."""
+    evs = msg.onset_shift_events
+    return format_alert_location(
+        msg.location_label, [oe.segment_id for oe in evs],
+        min(oe.km_from for oe in evs), max(oe.km_to for oe in evs),
+    )
+
+
+def _onset_shift_h1(msg: AlertMessage) -> str:
+    n = len(msg.onset_shift_events)
+    if n == 1:
+        return f"{_label(msg.onset_shift_events[0])}-Beginn verschiebt sich"
+    return f"{n} Beginn-Zeiten verschieben sich"
+
+
+def _sms_onset_shift_token(oe: OnsetShiftEvent) -> str:
+    """Kurznachricht-Token: Kuerzel + neue Uhrzeit + Verschiebung im Klartext.
+
+    Die Richtung MUSS als Wort mit -- ein Vorzeichen an einer Uhrzeit ist auf
+    einer Kurznachricht nicht entzifferbar, und die Verschiebung ist genau die
+    Aussage, um derentwillen die Meldung verschickt wird.
+    """
+    return f"{_code(oe)}{oe.to_time} {oe.shift_text}"
+
+
+def _render_email_onset_shift_only(msg: AlertMessage) -> tuple[str, str]:
+    """Reine Beginn-Verschiebung ohne Wert-Aenderungs-Anteil -- Bauform 1:1
+    wie `_render_email_corridor_only` (Issue #1444 S1)."""
+    h1 = _onset_shift_h1(msg)
+    footer = f"Stand: heute {msg.stand_at}"
+    plain = "\n".join(
+        [h1, "", *[_onset_shift_line(oe) for oe in msg.onset_shift_events], "", footer]
+    )
+    rows = [
+        _datarow_html(
+            f"{_label(oe)}-Beginn · {_onset_shift_where(oe)}",
+            f"{oe.from_time} → {oe.to_time} ({oe.shift_text})", G_DANGER, i == 0,
+        )
+        for i, oe in enumerate(msg.onset_shift_events)
+    ]
+    html = (
+        "<html><body style=\"font-family:" + FONT_UI + ";color:" + G_INK + ";\">"
+        f"<h1 style=\"margin:0 0 12px;font-family:{FONT_UI};color:{G_INK};\">{_esc(h1)}</h1>"
+        f"<div style=\"border-bottom:1px solid #d8d5c9;\">{''.join(rows)}</div>"
+        f"<p style=\"color:{G_INK_MUTED};margin-top:16px;font-family:{FONT_UI};\">{_esc(footer)}</p>"
+        "</body></html>"
+    )
+    return _with_origin(html, plain, "deviation-alert", "Open-Meteo")
+
+
+def _render_sms_onset_shift_only(msg: AlertMessage, limit: int) -> str:
+    head = f"{_ascii_alert_location(_onset_shift_location(msg))}: "
+    body = head + " ".join(
+        _sms_onset_shift_token(oe) for oe in msg.onset_shift_events
+    )
+    return body if len(body) <= limit else body[:limit]
+
+
 def _render_subject_onset(msg: AlertMessage) -> str:
     # Issue #1041 Slice 1a: Sammel-Betreff nur bei MEHR ALS EINEM Event
     # (Bündel-Alarm); Ein-Ort-Fall bleibt byte-identisch (AC-2/AC-5).
@@ -353,6 +431,15 @@ def _render_sms_onset(msg: AlertMessage, limit: int = 140) -> str:
 def render_subject(msg: AlertMessage) -> str:
     if msg.source is not None:
         return _render_subject_onset(msg)
+    if not msg.events and not msg.corridor_events and msg.onset_shift_events:
+        # Issue #1468: reine Beginn-Verschiebung ohne Wert-Aenderungs-Anteil.
+        oe = msg.onset_shift_events[0]
+        mehr = (f" +{len(msg.onset_shift_events) - 1}"
+                if len(msg.onset_shift_events) > 1 else "")
+        return (
+            f"[{msg.trip_short}] {_onset_shift_where(oe)} · {_label(oe)}-Beginn "
+            f"{oe.to_time} ({oe.shift_text}){mehr}"
+        )
     if not msg.events and msg.corridor_events:
         # Issue #1444 S1 (AC-1/2/5): reiner Schwellen-Alarm ohne Aenderungs-Anteil.
         n = len(msg.corridor_events)
@@ -527,6 +614,8 @@ def render_email(msg: AlertMessage) -> tuple[str, str]:
         # AC-5 (Befund 4a): reale Quelle des ersten (fuehrenden) Onset-Events.
         onset_source = getattr(msg.events[0], "source_label", None) or "Open-Meteo"
         return _with_origin(html, plain, "radar-alert", onset_source)
+    if not msg.events and not msg.corridor_events and msg.onset_shift_events:
+        return _render_email_onset_shift_only(msg)
     if not msg.events and msg.corridor_events:
         return _render_email_corridor_only(msg)
     evs = _sorted(msg)
@@ -610,7 +699,12 @@ def render_email(msg: AlertMessage) -> tuple[str, str]:
     # Issue #1444 S1 (AC-6): Schwellen-Treffer desselben Laufs in dieselbe
     # Nachricht buendeln -- eigener Wortlaut, kein erfundenes "vorher".
     corridor_lines = [_corridor_line(ce) for ce in msg.corridor_events]
+    # Issue #1468 (PO-Entscheid): Beginn- UND Stufenaenderung werden beide
+    # gemeldet, aber im Text DERSELBEN Nachricht zusammengefasst.
+    onset_lines = [_onset_shift_line(oe) for oe in msg.onset_shift_events]
     plain_parts = [h1, "", verdict_text, ""] + plain_data
+    if onset_lines:
+        plain_parts += ["", *onset_lines]
     if corridor_lines:
         plain_parts += ["", *corridor_lines]
     plain_parts += ["", footer]
@@ -626,6 +720,11 @@ def render_email(msg: AlertMessage) -> tuple[str, str]:
         for e, (label, value) in zip(evs, data_rows):
             value_color = G_DANGER if over_thr(e) else G_INK_MUTED
             rows.append(_datarow_html(label, value, value_color, not rows))
+    for oe in msg.onset_shift_events:
+        rows.append(_datarow_html(
+            f"{_label(oe)}-Beginn · {_onset_shift_where(oe)}",
+            f"{oe.from_time} → {oe.to_time} ({oe.shift_text})", G_DANGER, not rows,
+        ))
     for ce in msg.corridor_events:
         rows.append(_datarow_html(_label(ce), _corridor_value_str(ce), G_DANGER, not rows))
 
@@ -647,6 +746,11 @@ def render_email(msg: AlertMessage) -> tuple[str, str]:
 def render_telegram(msg: AlertMessage) -> str:
     if msg.source is not None:
         return _render_telegram_onset(msg)
+    if not msg.events and not msg.corridor_events and msg.onset_shift_events:
+        # Issue #1468: reine Beginn-Verschiebung.
+        lines = [f"<b>{_esc(f'{msg.trip_short} · {_onset_shift_h1(msg)}')}</b>"]
+        lines += [_onset_shift_line(oe) for oe in msg.onset_shift_events]
+        return "\n".join(lines)
     if not msg.events and msg.corridor_events:
         # Issue #1444 S1 (AC-1/2/5): reiner Schwellen-Alarm.
         lines = [f"<b>{_esc(msg.trip_short)}</b>"]
@@ -680,7 +784,9 @@ def render_telegram(msg: AlertMessage) -> str:
             for e in evs
         )
         lines = [f"<b>{_esc(verdict)}</b>", metric_line]
-    # Issue #1444 S1 (AC-6): Schwellen-Treffer desselben Laufs anhaengen.
+    # Issue #1468 / #1444 S1 (AC-6): Beginn-Verschiebungen und Schwellen-
+    # Treffer desselben Laufs anhaengen -- eine Nachricht, nicht drei.
+    lines += [_onset_shift_line(oe) for oe in msg.onset_shift_events]
     lines += [_corridor_line(ce) for ce in msg.corridor_events]
     return "\n".join(lines)
 
@@ -762,6 +868,8 @@ def render_sms(
     """
     if msg.source is not None:
         return _render_sms_onset(msg, limit)
+    if not msg.events and not msg.corridor_events and msg.onset_shift_events:
+        return _render_sms_onset_shift_only(msg, limit)
     if not msg.events and msg.corridor_events:
         return _render_sms_corridor_only(msg, limit)
     evs = _sorted(msg)
@@ -793,9 +901,11 @@ def render_sms(
     if msg.reference_at:
         head += f"@{msg.reference_at} "
     # Issue #1444 S1 (AC-6): Schwellen-Treffer-Tokens desselben Laufs mit.
-    tokens = [_sms_token(e, location_positions) for e in evs] + [
-        _sms_corridor_token(ce) for ce in msg.corridor_events
-    ]
+    tokens = (
+        [_sms_token(e, location_positions) for e in evs]
+        + [_sms_onset_shift_token(oe) for oe in msg.onset_shift_events]
+        + [_sms_corridor_token(ce) for ce in msg.corridor_events]
+    )
 
     kept: list[str] = []
     for tok in tokens:

--- a/src/services/alert_preset.py
+++ b/src/services/alert_preset.py
@@ -22,6 +22,12 @@ Schwellwert-Tabelle:
     fresh_snow              delta ↑              20          8         2
     cape                    delta ↑            1200        600       200
     visibility   threshold_crossing ↓           500       1000      3000
+    thunder_onset           delta (h)             2/4       1/3       1/2
+    precipitation_heavy_onset delta (h)           2/4       1/3       1/2
+
+Die beiden Beginn-Zeilen tragen ZWEI Schwellen je Stufe (frueher/spaeter,
+Issue #1468) — die Tabelle fuehrt die schaerfere („frueher"), das Paar steht
+in ONSET_SHIFT_BOUNDS.
 """
 from __future__ import annotations
 
@@ -61,6 +67,12 @@ _PRESET_TABLE: Final[list[tuple]] = [
     (AlertMetric.FRESH_SNOW,           AlertRuleKind.DELTA,              20,     8,     2),
     (AlertMetric.CAPE,                 AlertRuleKind.DELTA,            1200,   600,   200),
     (AlertMetric.VISIBILITY,           AlertRuleKind.THRESHOLD_CROSSING, 500,  1000,  3000),
+    # Issue #1468: Beginn-Verschiebung in STUNDEN. Die Spalte traegt die
+    # Schwelle fuer den VORGEZOGENEN Beginn (die schaerfere Richtung, siehe
+    # ONSET_SHIFT_BOUNDS) -- sie ist die Zahl, die der Alarme-Reiter als
+    # "Δ ≥ N h" anzeigt.
+    (AlertMetric.THUNDER_ONSET,        AlertRuleKind.DELTA,               2,     1,     1),
+    (AlertMetric.PRECIPITATION_HEAVY_ONSET, AlertRuleKind.DELTA,          2,     1,     1),
     # Issue #889 / ADR-0010: HUMIDITY ist Vorboten-Metrik — kein Preset-Alert mehr.
 ]
 
@@ -108,6 +120,29 @@ ORDINAL_LEVEL_BOUNDS: Final[dict[str, tuple[ThunderLevel, ThunderLevel]]] = {
 # Metriken, fuer die die Stufe als Niveau statt als Sprunggroesse gilt.
 ORDINAL_LEVEL_METRICS: Final[frozenset[str]] = frozenset({
     AlertMetric.THUNDER_LEVEL.value,
+})
+
+# ───────────── Issue #1468: Beginn-Verschiebung, ASYMMETRISCH ───────────────
+#
+# Je Empfindlichkeitsstufe: (frueher_h, spaeter_h) — gemeldet wird, sobald
+# sich der Beginn um mindestens so viele Stunden verschiebt. Zwei Zahlen statt
+# einer, weil ein VORGEZOGENER Beginn gefaehrlicher ist als ein
+# hinausgezoegerter: wer um 15 statt 17 Uhr ins Gewitter laeuft, ist bereits
+# im Gelaende. PO-freigegeben 2026-08-18 (Spec feat_1468).
+#
+#   entspannt: ab 2 h frueher / ab 4 h spaeter
+#   standard:  ab 1 h frueher / ab 3 h spaeter
+#   sensibel:  ab 1 h frueher / ab 2 h spaeter
+ONSET_SHIFT_BOUNDS: Final[dict[str, tuple[int, int]]] = {
+    "entspannt": (2, 4),
+    "standard":  (1, 3),
+    "sensibel":  (1, 2),
+}
+
+# Metriken, deren Stufe als Verschiebungs-Schwellenpaar gilt (Beginn-Alarm).
+ONSET_METRICS: Final[frozenset[str]] = frozenset({
+    AlertMetric.THUNDER_ONSET.value,
+    AlertMetric.PRECIPITATION_HEAVY_ONSET.value,
 })
 
 
@@ -220,7 +255,9 @@ def expand_per_metric_levels(
         )
         # Issue #1460 (P1b): Gefahrenstufen-Groessen tragen die gewaehlte Stufe
         # mit — der Detektor wertet sie als Niveau, nicht als Sprunggroesse.
-        if metric_str in ORDINAL_LEVEL_METRICS:
+        # Issue #1468: Beginn-Groessen ebenso -- dort loest die Stufe das
+        # Schwellenpaar (frueher/spaeter) aus ONSET_SHIFT_BOUNDS auf.
+        if metric_str in ORDINAL_LEVEL_METRICS or metric_str in ONSET_METRICS:
             rule.sensitivity_level = level
         return rule
 

--- a/src/services/compare_location_weather_source.py
+++ b/src/services/compare_location_weather_source.py
@@ -158,6 +158,16 @@ class CompareLocationWeatherSource:
             distance_km=0.0,
             ascent_m=0,
             descent_m=0,
+            # Issue #1468 (E2): dasselbe Fenster, das oben schon `window_start`/
+            # `window_end` bestimmt hat -- hier bereits ueber
+            # `resolve_configured_window()` aufgeloest, also kein zweiter
+            # Aufloeser, nur die Weitergabe. Ohne diese Angabe filterte die
+            # Beginn-Berechnung zusaetzlich gegen den Default 4-19 und schnitte
+            # bei einem WEITEREN Vergleichs-Fenster Stunden weg, die der
+            # Ortsvergleich sehr wohl zeigt. Trip und Ortsvergleich verhalten
+            # sich damit gleich (Teilungs-Invariante).
+            day_window_start_hour=start_hour,
+            day_window_end_hour=end_hour,
         )
         segment_weather = service.fetch_segment_weather(
             segment,

--- a/src/services/segment_weather.py
+++ b/src/services/segment_weather.py
@@ -278,7 +278,13 @@ class SegmentWeatherService:
         from services.weather_metrics import WeatherMetricsService
 
         metrics_service = WeatherMetricsService(debug=self._debug)
-        basis_summary = metrics_service.compute_basis_metrics(filtered_ts)
+        # Issue #1468 (E2): die Beginn-Felder sind ORTSZEIT-Groessen -- die
+        # Zone kommt aus den Segment-Koordinaten ueber denselben einen
+        # Aufloeser wie ueberall sonst (`resolve_location_tz`, #1378 E3).
+        from utils.timezone import location_tz
+        basis_summary = metrics_service.compute_basis_metrics(
+            filtered_ts, tz=location_tz(segment.start_point),
+        )
         extended_summary = metrics_service.compute_extended_metrics(filtered_ts, basis_summary)
 
         return SegmentWeatherData(

--- a/src/services/segment_weather.py
+++ b/src/services/segment_weather.py
@@ -21,7 +21,7 @@ from app.models import SegmentWeatherData, SegmentWeatherSummary, TripSegment
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
-    from app.models import NormalizedTimeseries, TripReportConfig
+    from app.models import NormalizedTimeseries
     from providers.base import WeatherProvider
     from services.weather_cache import WeatherCacheService
 
@@ -80,7 +80,6 @@ class SegmentWeatherService:
         enrich_ensemble: bool = True,
         enrich_snow: bool = True,
         priority: str = "user_briefing",
-        report_config: "TripReportConfig | None" = None,
     ) -> SegmentWeatherData:
         """
         Fetch weather forecast for a trip segment.
@@ -223,16 +222,13 @@ class SegmentWeatherService:
         self._cache.put(segment, timeseries, enrich_ensemble, enrich_snow, model_id)
 
         # Step 6+7: Aggregate over THIS segment's own window and wrap
-        return self._aggregate_for_segment(
-            segment, timeseries, fetched_at=fetched_at, report_config=report_config,
-        )
+        return self._aggregate_for_segment(segment, timeseries, fetched_at=fetched_at)
 
     def _aggregate_for_segment(
         self,
         segment: TripSegment,
         timeseries: "NormalizedTimeseries",
         fetched_at: datetime,
-        report_config: "TripReportConfig | None" = None,
     ) -> SegmentWeatherData:
         """Filtert eine (moeglicherweise breitere, gecachte) Zeitreihe auf
         GENAU dieses Segment-Fenster und aggregiert NUR darueber (Issue
@@ -286,17 +282,26 @@ class SegmentWeatherService:
         # TAGESFENSTER DIESES TRIPS -- sonst nennt der Alarm eine andere
         # Stunde als das Briefing. Die Zone kommt aus den Segment-Koordinaten
         # ueber denselben einen Aufloeser wie ueberall sonst
-        # (`resolve_location_tz`, #1378 E3), die Fenstergrenzen ueber die EINE
-        # Aufloesungsstelle `resolve_configured_window()` (ADR-0035): fehlende
-        # oder ungueltige Werte fallen dort auf den Default 4-19 zurueck,
-        # `start > end` bleibt ein gueltiges Fenster ueber Mitternacht
-        # (#1361/#1372 S1b). Der Segment-Vorschnitt oben ersetzt das NICHT --
-        # die Etappengrenzen folgen den Gehzeiten, nicht dem Fenster.
+        # (`resolve_location_tz`, #1378 E3), die Fenstergrenzen VOM SEGMENT
+        # (`trip_segments.convert_trip_to_segments()` setzt sie aus
+        # `trip.report_config`) ueber die EINE Aufloesungsstelle
+        # `resolve_configured_window()` (ADR-0035): fehlende oder ungueltige
+        # Werte fallen dort auf den Default 4-19 zurueck, `start > end` bleibt
+        # ein gueltiges Fenster ueber Mitternacht (#1361/#1372 S1b).
+        #
+        # Warum am SEGMENT und nicht als Parameter dieser Methode: Briefing-/
+        # Anker-Pfad und Alarm-Pfad benutzen dieselben Segmente. Traegt das
+        # Segment das Fenster, koennen die beiden Vergleichsseiten gar nicht
+        # mit verschiedenen Fenstern rechnen -- ein Alarm, der allein aus der
+        # Fensterwahl entsteht, ist damit strukturell ausgeschlossen statt an
+        # jeder Aufrufstelle per Disziplin.
+        #
+        # Der Segment-Vorschnitt oben ersetzt den Fensterschnitt NICHT -- die
+        # Etappengrenzen folgen den Gehzeiten, nicht dem Fenster.
         from app.day_window import resolve_configured_window
         from utils.timezone import location_tz
         window_start, window_end = resolve_configured_window(
-            getattr(report_config, "day_window_start_hour", None),
-            getattr(report_config, "day_window_end_hour", None),
+            segment.day_window_start_hour, segment.day_window_end_hour,
         )
         basis_summary = metrics_service.compute_basis_metrics(
             filtered_ts, tz=location_tz(segment.start_point),

--- a/src/services/segment_weather.py
+++ b/src/services/segment_weather.py
@@ -21,7 +21,7 @@ from app.models import SegmentWeatherData, SegmentWeatherSummary, TripSegment
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
-    from app.models import NormalizedTimeseries
+    from app.models import NormalizedTimeseries, TripReportConfig
     from providers.base import WeatherProvider
     from services.weather_cache import WeatherCacheService
 
@@ -80,6 +80,7 @@ class SegmentWeatherService:
         enrich_ensemble: bool = True,
         enrich_snow: bool = True,
         priority: str = "user_briefing",
+        report_config: "TripReportConfig | None" = None,
     ) -> SegmentWeatherData:
         """
         Fetch weather forecast for a trip segment.
@@ -222,13 +223,16 @@ class SegmentWeatherService:
         self._cache.put(segment, timeseries, enrich_ensemble, enrich_snow, model_id)
 
         # Step 6+7: Aggregate over THIS segment's own window and wrap
-        return self._aggregate_for_segment(segment, timeseries, fetched_at=fetched_at)
+        return self._aggregate_for_segment(
+            segment, timeseries, fetched_at=fetched_at, report_config=report_config,
+        )
 
     def _aggregate_for_segment(
         self,
         segment: TripSegment,
         timeseries: "NormalizedTimeseries",
         fetched_at: datetime,
+        report_config: "TripReportConfig | None" = None,
     ) -> SegmentWeatherData:
         """Filtert eine (moeglicherweise breitere, gecachte) Zeitreihe auf
         GENAU dieses Segment-Fenster und aggregiert NUR darueber (Issue
@@ -278,12 +282,25 @@ class SegmentWeatherService:
         from services.weather_metrics import WeatherMetricsService
 
         metrics_service = WeatherMetricsService(debug=self._debug)
-        # Issue #1468 (E2): die Beginn-Felder sind ORTSZEIT-Groessen -- die
-        # Zone kommt aus den Segment-Koordinaten ueber denselben einen
-        # Aufloeser wie ueberall sonst (`resolve_location_tz`, #1378 E3).
+        # Issue #1468 (E2): die Beginn-Felder sind ORTSZEIT-Groessen im
+        # TAGESFENSTER DIESES TRIPS -- sonst nennt der Alarm eine andere
+        # Stunde als das Briefing. Die Zone kommt aus den Segment-Koordinaten
+        # ueber denselben einen Aufloeser wie ueberall sonst
+        # (`resolve_location_tz`, #1378 E3), die Fenstergrenzen ueber die EINE
+        # Aufloesungsstelle `resolve_configured_window()` (ADR-0035): fehlende
+        # oder ungueltige Werte fallen dort auf den Default 4-19 zurueck,
+        # `start > end` bleibt ein gueltiges Fenster ueber Mitternacht
+        # (#1361/#1372 S1b). Der Segment-Vorschnitt oben ersetzt das NICHT --
+        # die Etappengrenzen folgen den Gehzeiten, nicht dem Fenster.
+        from app.day_window import resolve_configured_window
         from utils.timezone import location_tz
+        window_start, window_end = resolve_configured_window(
+            getattr(report_config, "day_window_start_hour", None),
+            getattr(report_config, "day_window_end_hour", None),
+        )
         basis_summary = metrics_service.compute_basis_metrics(
             filtered_ts, tz=location_tz(segment.start_point),
+            day_window_start_hour=window_start, day_window_end_hour=window_end,
         )
         extended_summary = metrics_service.compute_extended_metrics(filtered_ts, basis_summary)
 

--- a/src/services/trip_segments.py
+++ b/src/services/trip_segments.py
@@ -129,6 +129,13 @@ def convert_trip_to_segments(trip: "Trip", target_date: date) -> List[TripSegmen
         stage = compute_stage_arrivals(stage, trip.activity)
 
     segments: List[TripSegment] = []
+    # Issue #1468 (E2): die eingestellten Fenstergrenzen der Tour, unveraendert
+    # weitergereicht. Die AUFLOESUNG (Default 4-19, Gueltigkeitsregeln) wohnt
+    # am Auswertungsort (`segment_weather._aggregate_for_segment`) -- eine
+    # zweite Aufloesung hier waere genau die Doppelung, die ADR-0035 vermeidet.
+    _trip_rc = getattr(trip, "report_config", None)
+    _win_start = getattr(_trip_rc, "day_window_start_hour", None)
+    _win_end = getattr(_trip_rc, "day_window_end_hour", None)
     waypoints = stage.waypoints
     default_start = stage.start_time if stage.start_time else time(8, 0)
 
@@ -219,6 +226,8 @@ def convert_trip_to_segments(trip: "Trip", target_date: date) -> List[TripSegmen
         elev_diff = elev2 - elev1
         dist_km = haversine_km(wp1.lat, wp1.lon, wp2.lat, wp2.lon)
 
+        # Issue #1468 (E2): das Auswertungsfenster der Tour reist mit dem
+        # Segment -- jeder spaetere Aggregations-Aufrufer erbt es dadurch.
         segment = TripSegment(
             segment_id=i + 1,
             start_point=GPXPoint(
@@ -239,6 +248,8 @@ def convert_trip_to_segments(trip: "Trip", target_date: date) -> List[TripSegmen
             distance_km=round(dist_km, 1),
             ascent_m=float(max(0, elev_diff)),
             descent_m=float(max(0, -elev_diff)),
+            day_window_start_hour=_win_start,
+            day_window_end_hour=_win_end,
         )
         cumulative_dist_km += round(dist_km, 1)
         segments.append(segment)
@@ -321,6 +332,12 @@ def convert_trip_to_segments(trip: "Trip", target_date: date) -> List[TripSegmen
             distance_km=0.0,
             ascent_m=0.0,
             descent_m=0.0,
+            # Dasselbe Fenster wie die uebrigen Segmente. Das ZEIT-Ende oben
+            # (`window_end`) folgt bereits dem Fenster (#1584) -- die
+            # Auswertungsgrenzen gehoeren trotzdem mit, weil die Aggregation
+            # in ORTSZEIT filtert und nicht am Segment-Ende haengt.
+            day_window_start_hour=_win_start,
+            day_window_end_hour=_win_end,
         )
         segments.append(destination_segment)
 

--- a/src/services/weather_change_detection.py
+++ b/src/services/weather_change_detection.py
@@ -9,7 +9,7 @@ SPEC: docs/specs/modules/weather_change_detection.md v2.0
 from __future__ import annotations
 
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from typing import TYPE_CHECKING, Optional
 
@@ -52,7 +52,21 @@ _ALERT_METRIC_TO_SUMMARY_FIELD: dict[AlertMetric, str] = {
     AlertMetric.VISIBILITY: "visibility_min_m",
     # Issue #889 / ADR-0010: HUMIDITY ist Vorboten-Metrik — kein Field-Mapping mehr,
     # damit auch alt-persistierte humidity-AlertRules keinen Change-Eintrag erzeugen.
+    # Issue #1468: Beginn-Verschiebung (Zeitpunkt-Felder, eigene Weiche unten).
+    AlertMetric.THUNDER_ONSET: "thunder_onset_utc",
+    AlertMetric.PRECIPITATION_HEAVY_ONSET: "precip_heavy_onset_utc",
 }
+
+# Issue #1468: Summary-Felder, die einen ZEITPUNKT tragen statt eines
+# Messwerts. Sie duerfen NIE in den `abs(delta) > threshold`-Zweig geraten
+# (dort verglichen sich timedelta und float, TypeError) -- `detect_changes()`
+# zweigt sie vor der Delta-Rechnung in die Beginn-Weiche ab. Abgeleitet aus
+# dem Mapping darueber, damit eine dritte Beginn-Groesse nicht danebengepflegt
+# werden muss.
+_ONSET_SUMMARY_FIELDS: frozenset[str] = frozenset({
+    _ALERT_METRIC_TO_SUMMARY_FIELD[AlertMetric.THUNDER_ONSET],
+    _ALERT_METRIC_TO_SUMMARY_FIELD[AlertMetric.PRECIPITATION_HEAVY_ONSET],
+})
 
 # Delta-Rule metrics → tuple of summary fields (metric-aggregating)
 _ALERT_DELTA_METRIC_TO_FIELDS: dict[AlertMetric, tuple[str, ...]] = {
@@ -96,6 +110,11 @@ _ALERT_METRIC_TO_CATALOG_ID: dict[AlertMetric, tuple[str, ...]] = {
     AlertMetric.WIND_CHANGE: ("wind",),
     AlertMetric.PRECIPITATION_CHANGE: ("precipitation",),
     AlertMetric.VISIBILITY: ("visibility",),
+    # Issue #1468: haengt an denselben Katalog-Groessen wie der Stufen-/
+    # Summen-Alarm -- wer Gewitter nicht beobachtet, will auch keinen
+    # Gewitterbeginn-Alarm (Aktivierungs-Kopplung, Spec Known Limitations).
+    AlertMetric.THUNDER_ONSET: ("thunder",),
+    AlertMetric.PRECIPITATION_HEAVY_ONSET: ("precipitation",),
 }
 
 # Issue #961: VISIBILITY nutzt Threshold-Crossing (cmp="unter"), soll aber NICHT im
@@ -248,6 +267,20 @@ _RULE_SEVERITY_TO_CHANGE_SEVERITY: dict[AlertSeverity, ChangeSeverity] = {
 }
 
 
+def _epoch_seconds(value) -> "float | None":
+    """Issue #1468: `datetime` -> Epochensekunden (float), naiv = UTC.
+
+    Hausnorm ist naive UTC (`ForecastDataPoint.__post_init__`, #1345); ein
+    aware Zeitstempel wird korrekt umgerechnet statt umgedeutet. Nicht-
+    `datetime`-Werte liefern `None` (fail-soft im Alarm-Lauf).
+    """
+    if not isinstance(value, datetime):
+        return None
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.timestamp()
+
+
 def _as_utc(ts: "datetime | None") -> "datetime | None":
     """Naiven Zeitstempel als UTC deuten (Issue #1386).
 
@@ -369,6 +402,7 @@ class WeatherChangeDetectionService:
         absolute_seeded_fields: Optional[set[str]] = None,
         threshold_crossing_rules: Optional[list["AlertRule"]] = None,
         ordinal_levels: Optional[dict[str, str]] = None,
+        onset_levels: Optional[dict[str, str]] = None,
     ):
         """
         Initialize with thresholds.
@@ -400,6 +434,9 @@ class WeatherChangeDetectionService:
         self._threshold_crossing_rules: list["AlertRule"] = list(threshold_crossing_rules) if threshold_crossing_rules else []
         # Issue #1460 (P1b): Felder mit Niveau- statt Delta-Semantik
         self._ordinal_levels: dict[str, str] = dict(ordinal_levels) if ordinal_levels else {}
+        # Issue #1468: Felder mit Beginn-Semantik (Zeitpunkt-Verschiebung,
+        # zwei richtungsabhaengige Schwellen aus `alert_preset.ONSET_SHIFT_BOUNDS`)
+        self._onset_levels: dict[str, str] = dict(onset_levels) if onset_levels else {}
 
     @classmethod
     def from_trip_config(cls, config: "TripReportConfig") -> "WeatherChangeDetectionService":
@@ -451,7 +488,7 @@ class WeatherChangeDetectionService:
         Returns:
             WeatherChangeDetectionService with filtered thresholds
         """
-        from app.metric_catalog import get_metric
+        from app.metric_catalog import ONSET_AGGREGATION, get_metric
         thresholds: dict[str, float] = {}
         for mc in display_config.metrics:
             if not mc.enabled:
@@ -467,7 +504,11 @@ class WeatherChangeDetectionService:
             if metric_def.is_precursor:
                 continue
             threshold = mc.alert_threshold if mc.alert_threshold is not None else metric_def.default_change_threshold
-            for field in metric_def.summary_fields.values():
+            for aggregation, field in metric_def.summary_fields.items():
+                # Issue #1468: Beginn-Felder tragen einen Zeitpunkt und haben
+                # keine Delta-Schwelle (s. get_change_detection_map()).
+                if aggregation == ONSET_AGGREGATION:
+                    continue
                 thresholds[field] = threshold
         return cls(thresholds=thresholds)
 
@@ -499,6 +540,8 @@ class WeatherChangeDetectionService:
         threshold_crossing_rules: list["AlertRule"] = []
         # Issue #1460 (P1b): {summary-field → Empfindlichkeitsstufe} für ordinale Größen
         ordinal_levels: dict[str, str] = {}
+        # Issue #1468: {summary-field → Empfindlichkeitsstufe} für Beginn-Größen
+        onset_levels: dict[str, str] = {}
 
         for rule in rules:
             if not rule.enabled:
@@ -565,7 +608,13 @@ class WeatherChangeDetectionService:
                     # entscheidet das Niveau, nicht die Sprunggroesse.
                     level = getattr(rule, "sensitivity_level", None)
                     if level:
-                        ordinal_levels[field_name] = level
+                        # Issue #1468: Beginn-Felder in ihr eigenes Register --
+                        # dort entscheidet ein RICHTUNGSABHAENGIGES
+                        # Schwellenpaar, nicht eine Niveau-Grenze.
+                        if field_name in _ONSET_SUMMARY_FIELDS:
+                            onset_levels[field_name] = level
+                        else:
+                            ordinal_levels[field_name] = level
                     # Issue #821: Explizite DELTA-Regel überschreibt Seed — das Feld
                     # ist nicht mehr rein-geseedet, darf nicht unterdrückt werden.
                     absolute_seeded.discard(field_name)
@@ -574,6 +623,7 @@ class WeatherChangeDetectionService:
             thresholds=thresholds,
             absolute_rules=absolute_rules,
             ordinal_levels=ordinal_levels,
+            onset_levels=onset_levels,
             absolute_seeded_fields=absolute_seeded,
             threshold_crossing_rules=threshold_crossing_rules,
         )
@@ -627,6 +677,19 @@ class WeatherChangeDetectionService:
 
             # Skip if either is None
             if old_value is None or new_value is None:
+                continue
+
+            # Issue #1468 (E3): DRITTE Weiche -- der BEGINN eines Ereignisses
+            # ist ein Zeitpunkt, kein Messwert. Er wird ueber echte
+            # Zeitspannen verglichen (23:00 -> 01:00 sind 2 h, nicht 22 h
+            # zurueck) und gegen ein RICHTUNGSABHAENGIGES Schwellenpaar
+            # gehalten. Der None-Guard eine Zeile hoeher deckt zugleich den
+            # Fall "Ereignis taucht erstmals auf" ab (AC-6): das meldet die
+            # Stufen-Aenderung, nicht diese Weiche.
+            if metric in _ONSET_SUMMARY_FIELDS:
+                onset_change = self._onset_change(metric, old_value, new_value, new_data)
+                if onset_change is not None:
+                    changes.append(onset_change)
                 continue
 
             # Issue #1592 Scheibe C3: CAPE-Aenderungsalarme rechnen die
@@ -733,6 +796,54 @@ class WeatherChangeDetectionService:
         changes.extend(self._detect_threshold_crossing_changes(old_summary, new_summary, new_data))
 
         return changes
+
+    def _onset_change(
+        self, metric: str, old_value, new_value,
+        new_data: "SegmentWeatherData",
+    ) -> "WeatherChange | None":
+        """Issue #1468: Beginn-Verschiebung -> `WeatherChange` oder None.
+
+        Werte und Schwelle wandern als SEKUNDEN in das `float`-typisierte DTO
+        (`WeatherChange.old_value`/`new_value`/`threshold`). Das ist kein
+        Kunstgriff, sondern die Bedingung dafuer, dass die Rechnung ueberall
+        stimmt: die Differenz zweier Epochensekunden IST die echte Zeitspanne,
+        auch ueber die Kalendergrenze -- und das Melde-Gedaechtnis
+        (`deviation_alert_engine._filter_against_alert_state`) rechnet mit
+        `abs(new_value - last) >= threshold` genau denselben Vergleich, ohne
+        dass es dafuer einen Sonderfall braucht. Die Uhrzeiten selbst baut
+        erst die Projektionsschicht daraus (`project._fmt_onset_at`), weil nur
+        dort die Ortszeit bekannt ist.
+
+        `None`, wenn keine Empfindlichkeitsstufe hinterlegt ist oder die
+        Verschiebung die fuer IHRE RICHTUNG geltende Schwelle nicht erreicht.
+        """
+        from services.alert_preset import ONSET_SHIFT_BOUNDS
+
+        bounds = ONSET_SHIFT_BOUNDS.get(self._onset_levels.get(metric) or "")
+        if bounds is None:
+            return None
+        old_ts, new_ts = _epoch_seconds(old_value), _epoch_seconds(new_value)
+        if old_ts is None or new_ts is None:
+            return None
+        delta = new_ts - old_ts
+        if delta == 0:
+            return None
+        earlier_h, later_h = bounds
+        threshold = float(later_h if delta > 0 else earlier_h) * 3600.0
+        if abs(delta) < threshold:
+            return None
+        return WeatherChange(
+            metric=metric,
+            old_value=old_ts,
+            new_value=new_ts,
+            delta=delta,
+            threshold=threshold,
+            severity=self._classify_severity(abs(delta), threshold),
+            direction="increase" if delta > 0 else "decrease",
+            segment_id=str(new_data.segment.segment_id),
+            # Kein Spitzenwert-Zeitpunkt: der Wert IST bereits ein Zeitpunkt.
+            occurred_at=None,
+        )
 
     @staticmethod
     def _ordinal_severity(old_value, new_value) -> ChangeSeverity:

--- a/src/services/weather_metrics.py
+++ b/src/services/weather_metrics.py
@@ -9,7 +9,7 @@ SPEC: docs/specs/modules/weather_emoji_dni.md v1.0 (DNI-based emoji)
 """
 from __future__ import annotations
 
-from datetime import datetime, timezone, tzinfo
+from datetime import datetime, tzinfo
 from typing import List, Optional
 
 import math

--- a/src/services/weather_metrics.py
+++ b/src/services/weather_metrics.py
@@ -916,6 +916,14 @@ class WeatherMetricsService:
             humidity_avg_pct=basis_summary.humidity_avg_pct,
             thunder_level_max=basis_summary.thunder_level_max,
             visibility_min_m=basis_summary.visibility_min_m,
+            # Issue #1468: die beiden Beginn-Zeitpunkte MUESSEN mitkopiert
+            # werden -- diese Funktion baut ein NEUES Summary, und ihr
+            # Ergebnis ist das, was der Trip-Pfad als `aggregated` weitergibt
+            # (segment_weather.py:282). Ohne die Uebernahme waere der
+            # Beginn-Alarm im Trip-Pfad strukturell tot (dieselbe Naht wie
+            # #1391/#1392, s. hail_flag).
+            thunder_onset_utc=basis_summary.thunder_onset_utc,
+            precip_heavy_onset_utc=basis_summary.precip_heavy_onset_utc,
             # Felder aus compute_basis_metrics() die bisher fehlten (Issue #226)
             dominant_wmo_code=basis_summary.dominant_wmo_code,
             dni_avg_wm2=basis_summary.dni_avg_wm2,

--- a/src/services/weather_metrics.py
+++ b/src/services/weather_metrics.py
@@ -9,6 +9,7 @@ SPEC: docs/specs/modules/weather_emoji_dni.md v1.0 (DNI-based emoji)
 """
 from __future__ import annotations
 
+from datetime import datetime, timezone, tzinfo
 from typing import List, Optional
 
 import math
@@ -398,6 +399,10 @@ class WeatherMetricsService:
     def compute_basis_metrics(
         self,
         timeseries: NormalizedTimeseries,
+        *,
+        tz: Optional[tzinfo] = None,
+        day_window_start_hour: Optional[int] = None,
+        day_window_end_hour: Optional[int] = None,
     ) -> SegmentWeatherSummary:
         """
         Compute 8 basic hiking metrics from timeseries.
@@ -414,6 +419,12 @@ class WeatherMetricsService:
 
         Args:
             timeseries: Weather timeseries from provider
+            tz: Ortszeit-Zone fuer die Beginn-Felder (Issue #1468, E2). Ohne
+                Angabe gilt UTC.
+            day_window_start_hour / day_window_end_hour: Tagesfenster in
+                Ortszeit fuer die Beginn-Felder (Issue #1468, E2). Ohne
+                Angabe gilt der Default 4-19 Uhr
+                (``day_window.resolve_configured_window``).
 
         Returns:
             SegmentWeatherSummary with 8 basis metrics populated
@@ -440,6 +451,11 @@ class WeatherMetricsService:
         )
         hail_flag = self._compute_hail_flag(timeseries)
         visibility_min = self._compute_visibility(timeseries)
+        # Issue #1468 (E1/E2): Beginn der beiden Ereignisse, ORTSZEIT-gefiltert
+        # auf das Tagesfenster -- dieselbe Stunde, die das Briefing zeigt.
+        window = (tz, day_window_start_hour, day_window_end_hour)
+        thunder_onset = self._compute_thunder_onset(timeseries, *window)
+        precip_heavy_onset = self._compute_precip_heavy_onset(timeseries, *window)
 
         # DNI-based emoji aggregation (SPEC: weather_emoji_dni.md)
         dominant_wmo = compute_dominant_wmo(timeseries.data)
@@ -460,6 +476,8 @@ class WeatherMetricsService:
             humidity_avg_pct=humidity_avg,
             thunder_level_max=thunder_max,
             thunder_level_max_signals=thunder_max_signals,
+            thunder_onset_utc=thunder_onset,
+            precip_heavy_onset_utc=precip_heavy_onset,
             hail_flag=hail_flag,
             visibility_min_m=visibility_min,
             dominant_wmo_code=dominant_wmo,
@@ -476,6 +494,8 @@ class WeatherMetricsService:
                 "humidity_avg_pct": "avg",
                 "thunder_level_max": "max",
                 "thunder_level_max_signals": "union_of_max_carriers",
+                "thunder_onset_utc": "onset",
+                "precip_heavy_onset_utc": "onset",
                 "hail_flag": "hail_priority",
                 "visibility_min_m": "min",
                 "dominant_wmo_code": "max_wmo_severity",
@@ -591,6 +611,82 @@ class WeatherMetricsService:
             return None
 
         return round(sum(humidity_vals) / len(humidity_vals))
+
+    # --- Issue #1468: Beginn der beiden Ereignisse (E1/E2) ------------------
+
+    # Starkregen-Schwelle. Dieselbe Zahl und dieselbe Bedeutung wie im
+    # Radar-Nowcast (`radar_service.INTENSITY_HEAVY`) -- "Starker Regen" heisst
+    # auf beiden Wegen dasselbe (PO-Entscheid 2026-08-18, bewusst kein neues
+    # Vokabular).
+    _PRECIP_HEAVY_MMPH = 4.0
+
+    def _onset_of(
+        self, timeseries: NormalizedTimeseries, erreicht,
+        tz: Optional[tzinfo], start_hour: Optional[int], end_hour: Optional[int],
+    ) -> Optional[datetime]:
+        """Erste Stunde IM TAGESFENSTER, fuer die ``erreicht(dp)`` wahr ist.
+
+        Der Fensterschnitt geschieht in ORTSZEIT (``tz``), das Ergebnis bleibt
+        naive UTC (Hausnorm). Ohne diesen Schnitt waere der Beginn eine ANDERE
+        Zahl als die im Briefing (E2: eine nachts erstmals ueberschrittene
+        Schwelle ist nicht der Beginn, ueber den das Briefing schreibt) -- und
+        die Verschiebung, die der Alarm meldete, haette dort nie gestanden.
+        """
+        from app.day_window import hour_in_window, resolve_configured_window
+
+        zone = tz or timezone.utc
+        von, bis = resolve_configured_window(start_hour, end_hour)
+        treffer = [
+            dp.ts for dp in timeseries.data
+            if erreicht(dp) and hour_in_window(
+                (dp.ts if dp.ts.tzinfo else dp.ts.replace(tzinfo=timezone.utc))
+                .astimezone(zone).hour,
+                von, bis,
+            )
+        ]
+        return min(treffer) if treffer else None
+
+    def _compute_thunder_onset(
+        self, timeseries: NormalizedTimeseries, tz: Optional[tzinfo] = None,
+        start_hour: Optional[int] = None, end_hour: Optional[int] = None,
+    ) -> Optional[datetime]:
+        """Beginn des Gewitters: erste Tagesfenster-Stunde mit Stufe >= LOW.
+
+        Schwelle ueber die kanonische Ordnung (``thunder_ordinal``), nicht ueber
+        eine im Code getippte Zahl -- die Ordinale haben sich mit #1474 bereits
+        einmal verschoben.
+        """
+        from output.metric_format import thunder_ordinal
+
+        low = thunder_ordinal(ThunderLevel.LOW)
+        return self._onset_of(
+            timeseries,
+            lambda dp: (dp.thunder_level is not None
+                        and thunder_ordinal(dp.thunder_level) >= low),
+            tz, start_hour, end_hour,
+        )
+
+    def _compute_precip_heavy_onset(
+        self, timeseries: NormalizedTimeseries, tz: Optional[tzinfo] = None,
+        start_hour: Optional[int] = None, end_hour: Optional[int] = None,
+    ) -> Optional[datetime]:
+        """Beginn des Starkregens: erste Tagesfenster-Stunde >= 4,0 mm/h.
+
+        Quelle ist ``precip_rate_mmph``, wo der Provider sie liefert
+        (GeoSphere), sonst ``precip_1h_mm`` (Open-Meteo setzt die Rate hart auf
+        ``None``, ``openmeteo.py:885``). Bei Stundenaufloesung ist mm je Stunde
+        dieselbe Zahl wie mm/h -- GeoSphere setzt die Rate selbst auf den
+        Stundenwert (``geosphere.py:571``). Ohne diesen Rueckfall waere die
+        Starkregen-Haelfte beim Primaerprovider strukturell wirkungslos
+        (PO-Entscheid 2026-08-18).
+        """
+        def erreicht(dp) -> bool:
+            wert = dp.precip_rate_mmph
+            if wert is None:
+                wert = dp.precip_1h_mm
+            return wert is not None and wert >= self._PRECIP_HEAVY_MMPH
+
+        return self._onset_of(timeseries, erreicht, tz, start_hour, end_hour)
 
     def _compute_thunder_level(
         self,

--- a/src/services/weather_metrics.py
+++ b/src/services/weather_metrics.py
@@ -400,7 +400,7 @@ class WeatherMetricsService:
         self,
         timeseries: NormalizedTimeseries,
         *,
-        tz: Optional[tzinfo] = None,
+        tz: Optional[tzinfo],
         day_window_start_hour: Optional[int] = None,
         day_window_end_hour: Optional[int] = None,
     ) -> SegmentWeatherSummary:
@@ -419,8 +419,14 @@ class WeatherMetricsService:
 
         Args:
             timeseries: Weather timeseries from provider
-            tz: Ortszeit-Zone fuer die Beginn-Felder (Issue #1468, E2). Ohne
-                Angabe gilt UTC.
+            tz: Ortszeit-Zone fuer die Beginn-Felder (Issue #1468, E2).
+                PFLICHT (keyword-only, KEIN Default): der Aufrufer muss sich
+                entscheiden. `None` heisst ausdruecklich "dieser Aufrufer hat
+                keinen Ortsbezug" und laesst die Beginn-Felder leer (Abstain)
+                -- es wird KEINE Zone angenommen. Ein stiller UTC-Rueckfall
+                waere genau die Bugklasse, die `tests/
+                test_output_timezone_guard.py` seit #1402 verankert: eine
+                Ortszeit-Groesse, die in Wahrheit Serverzeit zeigt.
             day_window_start_hour / day_window_end_hour: Tagesfenster in
                 Ortszeit fuer die Beginn-Felder (Issue #1468, E2). Ohne
                 Angabe gilt der Default 4-19 Uhr
@@ -626,28 +632,33 @@ class WeatherMetricsService:
     ) -> Optional[datetime]:
         """Erste Stunde IM TAGESFENSTER, fuer die ``erreicht(dp)`` wahr ist.
 
-        Der Fensterschnitt geschieht in ORTSZEIT (``tz``), das Ergebnis bleibt
-        naive UTC (Hausnorm). Ohne diesen Schnitt waere der Beginn eine ANDERE
-        Zahl als die im Briefing (E2: eine nachts erstmals ueberschrittene
-        Schwelle ist nicht der Beginn, ueber den das Briefing schreibt) -- und
-        die Verschiebung, die der Alarm meldete, haette dort nie gestanden.
+        Der Fensterschnitt geschieht in ORTSZEIT, das Ergebnis bleibt naive
+        UTC (Hausnorm). Ohne diesen Schnitt waere der Beginn eine ANDERE Zahl
+        als die im Briefing (E2: eine nachts erstmals ueberschrittene Schwelle
+        ist nicht der Beginn, ueber den das Briefing schreibt) -- und die
+        Verschiebung, die der Alarm meldete, haette dort nie gestanden.
+
+        ``tz is None`` heisst "kein Ortsbezug" und liefert ``None``: ohne Zone
+        gibt es keine Ortszeit-Stunde, und eine angenommene waere Serverzeit
+        im Gewand einer Ortszeit -- die Bugklasse aus #1402. Die Umrechnung
+        laeuft ueber ``utils.timezone.local_hour()``, die EINE Stelle, die
+        naiv/aware korrekt deutet; ein rohes ``.astimezone()`` hier waere eine
+        zweite Auslegung derselben Frage.
         """
         from app.day_window import hour_in_window, resolve_configured_window
+        from utils.timezone import local_hour
 
-        zone = tz or timezone.utc
+        if tz is None:
+            return None
         von, bis = resolve_configured_window(start_hour, end_hour)
         treffer = [
             dp.ts for dp in timeseries.data
-            if erreicht(dp) and hour_in_window(
-                (dp.ts if dp.ts.tzinfo else dp.ts.replace(tzinfo=timezone.utc))
-                .astimezone(zone).hour,
-                von, bis,
-            )
+            if erreicht(dp) and hour_in_window(local_hour(dp.ts, tz), von, bis)
         ]
         return min(treffer) if treffer else None
 
     def _compute_thunder_onset(
-        self, timeseries: NormalizedTimeseries, tz: Optional[tzinfo] = None,
+        self, timeseries: NormalizedTimeseries, tz: Optional[tzinfo],
         start_hour: Optional[int] = None, end_hour: Optional[int] = None,
     ) -> Optional[datetime]:
         """Beginn des Gewitters: erste Tagesfenster-Stunde mit Stufe >= LOW.
@@ -667,7 +678,7 @@ class WeatherMetricsService:
         )
 
     def _compute_precip_heavy_onset(
-        self, timeseries: NormalizedTimeseries, tz: Optional[tzinfo] = None,
+        self, timeseries: NormalizedTimeseries, tz: Optional[tzinfo],
         start_hour: Optional[int] = None, end_hour: Optional[int] = None,
     ) -> Optional[datetime]:
         """Beginn des Starkregens: erste Tagesfenster-Stunde >= 4,0 mm/h.
@@ -1234,7 +1245,13 @@ def summarize_points(points: list) -> Optional[SegmentWeatherSummary]:
         meta=ForecastMeta(provider=Provider.OPENMETEO, model="aggregate", grid_res_km=0.0),
         data=list(points),
     )
-    summary = svc.compute_basis_metrics(ts)
+    # Issue #1468: `tz=None` ist hier eine AUSDRUECKLICHE Entscheidung, keine
+    # Auslassung -- dieser Compare-ANZEIGE-Helfer bekommt nur Stundenpunkte,
+    # keinen Ort. Ohne Ortsbezug gibt es keine Ortszeit und damit keine
+    # Beginn-Aussage (Abstain). Der Compare-ALARM-Pfad laeuft NICHT hier
+    # durch, sondern ueber `SegmentWeatherService._aggregate_for_segment()`,
+    # wo die Zone aus den Segment-Koordinaten kommt.
+    summary = svc.compute_basis_metrics(ts, tz=None)
     summary.pop_max_pct = svc._compute_pop(ts)
     summary.uv_index_max = svc._compute_uv_index(ts)
     summary.cape_max_jkg = svc._compute_cape(ts)

--- a/src/services/weather_snapshot.py
+++ b/src/services/weather_snapshot.py
@@ -409,6 +409,17 @@ def _serialize_segment(seg: SegmentWeatherData) -> dict:
         "ascent_m": seg.segment.ascent_m,
         "descent_m": seg.segment.descent_m,
         "duration_hours": seg.segment.duration_hours,
+        # Issue #1468 (E2): das Auswertungsfenster gehoert MIT in den Anker.
+        # Wird aus einem geladenen Anker-Segment je neu aggregiert, muss
+        # dasselbe Fenster gelten wie beim Schreiben -- sonst faellt es still
+        # auf den Default zurueck und die Vergleichsbasis waere wieder schief.
+        # `None` bleibt weg (Absenz heisst "keine Angabe", nicht "0 Uhr").
+        **{
+            k: v for k, v in (
+                ("day_window_start_hour", seg.segment.day_window_start_hour),
+                ("day_window_end_hour", seg.segment.day_window_end_hour),
+            ) if v is not None
+        },
         "aggregated": _serialize_summary(seg.aggregated),
     }
     if seg.timeseries is not None:
@@ -477,4 +488,8 @@ def _reconstruct_segment(seg_data: dict) -> TripSegment:
         distance_km=seg_data.get("distance_km", 0.0),
         ascent_m=seg_data.get("ascent_m", 0.0),
         descent_m=seg_data.get("descent_m", 0.0),
+        # Issue #1468 (E2): fehlender Schluessel -> None -> Default 4-19.
+        # Alt-Anker ohne die Felder laden dadurch unveraendert.
+        day_window_start_hour=seg_data.get("day_window_start_hour"),
+        day_window_end_hour=seg_data.get("day_window_end_hour"),
     )

--- a/src/services/weather_snapshot.py
+++ b/src/services/weather_snapshot.py
@@ -40,6 +40,17 @@ _ENUM_FIELDS: dict[str, type] = {
     "precip_type_dominant": PrecipType,
 }
 
+# Issue #1468: Felder des Tages-Aggregats, die einen ZEITPUNKT tragen. Sie
+# gehen als ISO-Zeichenkette in den Anker und kommen als naives `datetime`
+# (UTC, Hausnorm) zurueck. Ohne diese Behandlung schluckt `save_alarm_anchor`
+# den Serialisierungsfehler still (`weather_snapshot.py:208`) -- der Anker
+# waere dann GAR NICHT geschrieben und jeder Folgelauf haette nichts zu
+# vergleichen.
+_DATETIME_FIELDS: frozenset[str] = frozenset({
+    "thunder_onset_utc",
+    "precip_heavy_onset_utc",
+})
+
 # Fields that hold Enum values in ForecastDataPoint
 _HOURLY_ENUM_FIELDS: dict[str, type] = {
     "thunder_level": ThunderLevel,
@@ -349,6 +360,8 @@ def _serialize_summary(summary: SegmentWeatherSummary) -> dict:
             continue
         if isinstance(value, Enum):
             result[field_name] = value.name
+        elif isinstance(value, datetime):
+            result[field_name] = value.isoformat()
         else:
             result[field_name] = value
     return result
@@ -368,6 +381,11 @@ def _deserialize_summary(data: dict) -> SegmentWeatherSummary:
             continue
         if key in _ENUM_FIELDS and isinstance(value, str):
             kwargs[key] = _ENUM_FIELDS[key](value)
+        elif key in _DATETIME_FIELDS and isinstance(value, str):
+            try:
+                kwargs[key] = datetime.fromisoformat(value)
+            except ValueError:
+                continue  # unlesbarer Zeitpunkt -> Feld bleibt None
         else:
             kwargs[key] = value
     return SegmentWeatherSummary(**kwargs)

--- a/tests/tdd/test_cape_model_id_aggregate_field.py
+++ b/tests/tdd/test_cape_model_id_aggregate_field.py
@@ -54,7 +54,7 @@ def test_ac2_trip_aggregat_traegt_normalisierten_modell_schluessel():
     ts = NormalizedTimeseries(meta=meta, data=[_minimal_point(cape_jkg=840.0)])
 
     svc = WeatherMetricsService()
-    basis = svc.compute_basis_metrics(ts)
+    basis = svc.compute_basis_metrics(ts, tz=None)
     result = svc.compute_extended_metrics(ts, basis)
 
     assert result.cape_model_id == "meteofrance_arome", (
@@ -77,7 +77,7 @@ def test_ac2_gegenprobe_rohwert_wird_normalisiert_nicht_unveraendert_durchgereic
     ts = NormalizedTimeseries(meta=meta, data=[_minimal_point(cape_jkg=840.0)])
 
     svc = WeatherMetricsService()
-    basis = svc.compute_basis_metrics(ts)
+    basis = svc.compute_basis_metrics(ts, tz=None)
     result = svc.compute_extended_metrics(ts, basis)
 
     assert result.cape_model_id == "meteofrance_arome", (

--- a/tests/tdd/test_cape_model_id_stage_aggregation.py
+++ b/tests/tdd/test_cape_model_id_stage_aggregation.py
@@ -59,7 +59,7 @@ def _segment_mit_herkunft(model: str, start_hour: int, cape_jkg: float) -> Segme
         )],
     )
     svc = WeatherMetricsService()
-    basis = svc.compute_basis_metrics(ts)
+    basis = svc.compute_basis_metrics(ts, tz=None)
     aggregiert = svc.compute_extended_metrics(ts, basis)
     return SegmentWeatherData(
         segment=seg, timeseries=ts, aggregated=aggregiert,

--- a/tests/tdd/test_channel_metric_matrix.py
+++ b/tests/tdd/test_channel_metric_matrix.py
@@ -2707,7 +2707,7 @@ def test_ac_s2_5_beide_tagesaggregationen_fuellen_dieselben_felder():
         data=list(punkte),
     )
     trip = _s2_aggregat_felder(
-        dienst.compute_extended_metrics(reihe, dienst.compute_basis_metrics(reihe))
+        dienst.compute_extended_metrics(reihe, dienst.compute_basis_metrics(reihe, tz=None))
     )
     vergleich = _s2_aggregat_felder(summarize_points(punkte))
 
@@ -3478,7 +3478,7 @@ def _s5_location(hourly: list[ForecastDataPoint]):
     den Engine-Vorrang."""
     from app.user import LocationResult, SavedLocation
 
-    basis = WeatherMetricsService().compute_basis_metrics(_s5_timeseries(hourly))
+    basis = WeatherMetricsService().compute_basis_metrics(_s5_timeseries(hourly), tz=None)
     return LocationResult(
         location=SavedLocation(
             id="s5-ort", name="S5-Ort", lat=47.0, lon=11.0, elevation_m=500,
@@ -3522,7 +3522,7 @@ def _s5_erwartete_werte(hourly: list[ForecastDataPoint]) -> dict[str, float]:
     Fehler in deren ``_compute_*``-Regeln die Renderer-Ausgabe gegen sich
     selbst, und eine vertauschte Zuweisung bliebe unsichtbar (Lehre
     AC-S2-8/F001)."""
-    basis = WeatherMetricsService().compute_basis_metrics(_s5_timeseries(hourly))
+    basis = WeatherMetricsService().compute_basis_metrics(_s5_timeseries(hourly), tz=None)
     return {
         "temp_max": basis.temp_max_c,
         "wind_max": basis.wind_max_kmh,

--- a/tests/tdd/test_compare_katalog_schwellen.py
+++ b/tests/tdd/test_compare_katalog_schwellen.py
@@ -83,7 +83,7 @@ def _timeseries(hourly: list[ForecastDataPoint]) -> NormalizedTimeseries:
 
 def _location(name: str, **overrides) -> LocationResult:
     hourly = _hourly(**overrides)
-    s = WeatherMetricsService().compute_basis_metrics(_timeseries(hourly))
+    s = WeatherMetricsService().compute_basis_metrics(_timeseries(hourly), tz=None)
     return LocationResult(
         location=SavedLocation(id=name.lower(), name=name, lat=39.76, lon=2.71, elevation_m=200),
         score=50,

--- a/tests/tdd/test_hail_flag_aggregation.py
+++ b/tests/tdd/test_hail_flag_aggregation.py
@@ -94,7 +94,7 @@ def _timeseries_eine_hagelstunde_drei_unbekannt() -> NormalizedTimeseries:
 
 def test_ac4_compute_basis_metrics_traegt_true_trotz_umgebender_unbekannt():
     ts = _timeseries_eine_hagelstunde_drei_unbekannt()
-    summary = WeatherMetricsService().compute_basis_metrics(ts)
+    summary = WeatherMetricsService().compute_basis_metrics(ts, tz=None)
 
     assert summary.hail_flag is True, (
         f"Eine einzelne bestaetigte Hagelstunde (True) darf nicht von drei "

--- a/tests/tdd/test_hail_flag_wmo_signal.py
+++ b/tests/tdd/test_hail_flag_wmo_signal.py
@@ -133,7 +133,7 @@ def test_ac1_gerenderter_text_zeigt_hagel_hinweis_fuer_true_stunde(
     from services.weather_metrics import WeatherMetricsService
 
     reihe = om.OpenMeteoProvider().fetch_forecast(_ORT, enrich_ensemble=False)
-    summary = WeatherMetricsService().compute_basis_metrics(reihe)
+    summary = WeatherMetricsService().compute_basis_metrics(reihe, tz=None)
 
     assert summary.hail_flag is True, (
         "Die Tagesaggregation traegt kein hail_flag=True, obwohl eine "

--- a/tests/tdd/test_issue_846_alert_preset.py
+++ b/tests/tdd/test_issue_846_alert_preset.py
@@ -195,24 +195,46 @@ def test_ac4_visibility_already_below_threshold_no_realert():
 
 
 # ═════════════════════════════ AC-6 ═════════════════════════════════════════
-# Preset "entspannt" → exakt 12 Regeln inkl. der neuen Metriken.
+# Preset "entspannt" → exakt 14 Regeln inkl. der neuen Metriken.
 # Issue #889 / ADR-0010: HUMIDITY als Vorboten-Metrik aus dem Preset entfernt
 # (war zuvor 13 Regeln inkl. humidity).
 
 
-def test_ac6_entspannt_has_exactly_12_rules():
-    """AC-6: `expand_preset("entspannt")` liefert exakt 12 Regeln.
+def test_ac6_entspannt_has_exactly_14_rules():
+    """AC-6: `expand_preset("entspannt")` liefert exakt 14 Regeln.
 
     Issue #889: humidity entfernt → 12.
     Issue #946: freezing_level ergänzt → 13.
     Issue #959: snow_line + freezing_level zu EINER Nullgradgrenze-Zeile
     konsolidiert (snow_line-Zeile entfernt) → 12.
+    Issue #1468: die beiden Beginn-Größen (thunder_onset,
+    precipitation_heavy_onset) ergänzt → 14. Sie tragen je Stufe ZWEI
+    Schwellen (entspannt 2 h früher / 4 h später); die Preset-Tabelle führt
+    die schärfere, das Paar steht in `alert_preset.ONSET_SHIFT_BOUNDS`.
+
+    Die Zahl allein wäre blind dafür, WELCHE Regeln es sind — deshalb prüft
+    der Test zusätzlich die Metrik-Menge. Ohne das hätte eine versehentlich
+    verlorene Bestandsregel neben einer neu hinzugekommenen dieselbe Summe
+    ergeben.
     """
+    from app.models import AlertMetric
     from services.alert_preset import expand_preset
 
     rules = expand_preset("entspannt")
-    assert len(rules) == 12, (
-        f"Preset 'entspannt' muss exakt 12 Regeln liefern, erhielt: {len(rules)}"
+    assert len(rules) == 14, (
+        f"Preset 'entspannt' muss exakt 14 Regeln liefern, erhielt: {len(rules)}"
+    )
+    assert {r.metric for r in rules} == {
+        AlertMetric.WIND_GUST, AlertMetric.PRECIPITATION_SUM,
+        AlertMetric.THUNDER_LEVEL, AlertMetric.FREEZING_LEVEL,
+        AlertMetric.TEMPERATURE_MIN, AlertMetric.TEMPERATURE_MAX,
+        AlertMetric.TEMPERATURE_CHANGE, AlertMetric.WIND_CHANGE,
+        AlertMetric.PRECIPITATION_CHANGE, AlertMetric.FRESH_SNOW,
+        AlertMetric.CAPE, AlertMetric.VISIBILITY,
+        AlertMetric.THUNDER_ONSET, AlertMetric.PRECIPITATION_HEAVY_ONSET,
+    }, (
+        "Die Metrik-Menge des Presets weicht ab: "
+        f"{sorted(str(r.metric) for r in rules)}"
     )
 
 

--- a/tests/tdd/test_kompaktmail_ausblick_tagesfenster.py
+++ b/tests/tdd/test_kompaktmail_ausblick_tagesfenster.py
@@ -137,7 +137,7 @@ def _heutige_etappe() -> SegmentWeatherData:
     )
     return SegmentWeatherData(
         segment=seg, timeseries=reihe,
-        aggregated=WeatherMetricsService().compute_basis_metrics(reihe),
+        aggregated=WeatherMetricsService().compute_basis_metrics(reihe, tz=None),
         fetched_at=datetime.now(timezone.utc), provider="openmeteo",
     )
 

--- a/tests/tdd/test_onset_alert_armed_from_weather_tab.py
+++ b/tests/tdd/test_onset_alert_armed_from_weather_tab.py
@@ -1,0 +1,213 @@
+"""Issue #1468 — Wird der Beginn-Alarm in der REALISTISCHEN Ausgangslage
+ueberhaupt scharf?
+
+SPEC: docs/specs/modules/feat_1468_onset_verschiebung_alarm.md
+KONTEXT: docs/context/feat-1468-onset-verschiebung.md
+
+WARUM DIESE DATEI ZUSAETZLICH ZU `test_onset_shift_alert.py` EXISTIERT:
+
+Dort setzt JEDER Test die Empfindlichkeitsstufe der Beginn-Groesse selbst
+(`expand_per_metric_levels({"thunder_onset": "standard"})`). In Produktion
+tut das niemand: `metric_alert_levels` eines Trips enthaelt genau die
+Groessen, die der Nutzer im Alarme-Reiter angefasst hat -- eine gerade erst
+eingefuehrte Groesse steht dort NIE. Scharf wird sie ausschliesslich ueber
+die Nachfuell-Regel in `expand_per_metric_levels()` (Issue #961,
+"Aktivieren-Luecke"): die Schleife ueber `_ALERT_METRIC_TO_CATALOG_ID`, die
+jede Wetter-Tab-aktive Groesse ohne eigenen Eintrag implizit auf "standard"
+setzt.
+
+Damit haengt die gesamte Wirksamkeit des Tickets an einem Pfad, den die
+neun AC-Tests nicht beruehren. Bleibt er stumm -- weil `_fields_for()` fuer
+die Beginn-Groessen nichts liefert und der Zweig
+`if metric_fields and not remaining: continue` die Regel unterdrueckt, oder
+weil `is_alert_metric_active()` sie nicht als aktiv fuehrt --, sind alle
+zehn Tests dort gruen UND der Alarm in Produktion trotzdem tot. Genau das
+verbietet die Invariante aus `rework_1467_s2_aenderungsalarm.md`: *"Der
+gefaehrlichste Fehler ist der ausbleibende Alarm."*
+
+PRUEFORT = WIRKORT. Der Test faehrt die echte Kette
+`expand_per_metric_levels(levels, display_config)` ->
+`WeatherChangeDetectionService.from_alert_rules()` -> `detect_changes()`.
+Keine handgesetzte Regel-Liste, kein Mock (CLAUDE.md, Kern-Schicht).
+
+Pfadregel #1409: der Prueling wird RELATIV ZU DIESER DATEI aufgeloest.
+"""
+from __future__ import annotations
+
+import sys
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from app.models import (  # noqa: E402
+    ForecastMeta, GPXPoint, MetricConfig, NormalizedTimeseries, Provider,
+    SegmentWeatherData, SegmentWeatherSummary, TripSegment,
+    UnifiedWeatherDisplayConfig,
+)
+from services.alert_preset import expand_per_metric_levels  # noqa: E402
+from services.weather_change_detection import (  # noqa: E402
+    WeatherChangeDetectionService,
+)
+
+TH_ONSET_FELD = "thunder_onset_utc"
+RAIN_ONSET_FELD = "precip_heavy_onset_utc"
+TH_ONSET_METRIK = "thunder_onset"
+RAIN_ONSET_METRIK = "precipitation_heavy_onset"
+
+TAG = date(2026, 8, 20)
+
+
+def _utc(stunde: int) -> datetime:
+    return datetime(TAG.year, TAG.month, TAG.day, stunde, 0)
+
+
+def _wetter_reiter(**aktiv: bool) -> UnifiedWeatherDisplayConfig:
+    """Ein ECHT konfigurierter Wetter-Reiter.
+
+    Bewusst mit MEHREREN Eintraegen: ein leeres `metrics[]` gilt in
+    `is_alert_metric_active()` als "nie konfiguriert" und damit konservativ
+    als aktiv (Finding F002) -- der Test wuerde dann gruen, ohne dass die
+    Aktivierung je geprueft waere. Erst ein gefuelltes `metrics[]` zwingt zur
+    echten Einzelpruefung.
+    """
+    return UnifiedWeatherDisplayConfig(
+        trip_id="onset-scharf",
+        metrics=[
+            MetricConfig(metric_id="temperature", enabled=True),
+            MetricConfig(metric_id="wind", enabled=True),
+            *[MetricConfig(metric_id=mid, enabled=an) for mid, an in aktiv.items()],
+        ],
+    )
+
+
+def _segment(segment_id: int = 1) -> TripSegment:
+    return TripSegment(
+        segment_id=segment_id,
+        start_point=GPXPoint(lat=47.0, lon=12.0, elevation_m=1000.0,
+                             distance_from_start_km=0.0),
+        end_point=GPXPoint(lat=47.1, lon=12.1, elevation_m=1200.0,
+                           distance_from_start_km=8.0),
+        start_time=_utc(6).replace(tzinfo=timezone.utc),
+        end_time=_utc(18).replace(tzinfo=timezone.utc),
+        duration_hours=12.0, distance_km=8.0, ascent_m=500.0, descent_m=200.0,
+    )
+
+
+def _data(**summary) -> SegmentWeatherData:
+    return SegmentWeatherData(
+        segment=_segment(),
+        timeseries=NormalizedTimeseries(
+            meta=ForecastMeta(provider=Provider.OPENMETEO, model="test",
+                              grid_res_km=1.0),
+            data=[],
+        ),
+        aggregated=SegmentWeatherSummary(**summary),
+        fetched_at=datetime.now(timezone.utc), provider="openmeteo",
+    )
+
+
+def _regel(regeln, metrik: str):
+    return next((r for r in regeln if str(r.metric) == metrik), None)
+
+
+# --------------------------------------------------------------------------
+# Der Nachfuell-Pfad stellt die Beginn-Groessen scharf
+# --------------------------------------------------------------------------
+
+def test_aktiver_wetter_reiter_stellt_beide_beginn_groessen_ohne_eintrag_scharf():
+    """Gewitter UND Niederschlag sind im Wetter-Reiter aktiv,
+    `metric_alert_levels` enthaelt KEINEN Eintrag fuer die Beginn-Groessen.
+
+    Erwartet: der Nachfuell-Pfad erzeugt fuer BEIDE eine Regel auf
+    "standard" -- genau das, was in Produktion passiert, wenn ein Nutzer den
+    Alarme-Reiter nach dem Rollout nie wieder anfasst.
+    """
+    dc = _wetter_reiter(thunder=True, precipitation=True)
+    # Die Stufen-Groesse hat der Nutzer angefasst, die Beginn-Groesse nicht.
+    regeln = expand_per_metric_levels({"thunder_level": "standard"}, dc)
+
+    th = _regel(regeln, TH_ONSET_METRIK)
+    rain = _regel(regeln, RAIN_ONSET_METRIK)
+    assert th is not None, (
+        "Der Gewitterbeginn wird nie scharf: der Nachfuell-Pfad "
+        "(expand_per_metric_levels, Aktivieren-Luecke #961) erzeugt keine "
+        f"Regel. Erzeugt wurden: {sorted(str(r.metric) for r in regeln)!r}"
+    )
+    assert rain is not None, (
+        "Der Starkregenbeginn wird nie scharf. Erzeugt wurden: "
+        f"{sorted(str(r.metric) for r in regeln)!r}"
+    )
+    for name, regel in ((TH_ONSET_METRIK, th), (RAIN_ONSET_METRIK, rain)):
+        assert regel.enabled, f"{name}: Regel entsteht, ist aber nicht scharf."
+        assert getattr(regel, "sensitivity_level", None) == "standard", (
+            f"{name}: die nachgefuellte Regel traegt die Stufe nicht mit "
+            f"({getattr(regel, 'sensitivity_level', '<fehlt>')!r}) -- ohne sie "
+            "findet der Detektor kein Schwellenpaar und meldet nie."
+        )
+
+
+def test_nachgefuellte_regel_meldet_eine_echte_verschiebung():
+    """Dieselbe Ausgangslage, aber bis zum Alarm durchgefahren.
+
+    Eine Regel, die entsteht und trotzdem nichts ausloest, waere derselbe
+    stille Ausfall -- die Existenzpruefung oben allein genuegt nicht.
+    Verschiebung 17:00 -> 15:00 (2 h vorgezogen) liegt bei "standard" ueber
+    der Schwelle "ab 1 h frueher".
+    """
+    dc = _wetter_reiter(thunder=True, precipitation=True)
+    regeln = expand_per_metric_levels({"thunder_level": "standard"}, dc)
+    detektor = WeatherChangeDetectionService.from_alert_rules(regeln)
+
+    changes = detektor.detect_changes(
+        _data(**{TH_ONSET_FELD: _utc(17), RAIN_ONSET_FELD: _utc(17)}),
+        _data(**{TH_ONSET_FELD: _utc(15), RAIN_ONSET_FELD: _utc(15)}),
+        include_absolute=False,
+    )
+    gemeldet = {c.metric for c in changes}
+    assert TH_ONSET_FELD in gemeldet, (
+        "Der Gewitterbeginn verschiebt sich um 2 h nach vorn und es entsteht "
+        f"kein Alarm. Gemeldet wurde: {sorted(gemeldet)!r}"
+    )
+    assert RAIN_ONSET_FELD in gemeldet, (
+        "Der Starkregenbeginn verschiebt sich um 2 h nach vorn und es "
+        f"entsteht kein Alarm. Gemeldet wurde: {sorted(gemeldet)!r}"
+    )
+
+
+# --------------------------------------------------------------------------
+# Gegenprobe: ohne aktive Register-Groesse bleibt der Beginn stumm
+# --------------------------------------------------------------------------
+
+def test_ohne_gewitter_im_wetter_reiter_entsteht_keine_beginn_regel():
+    """Gewitter ist im Wetter-Reiter ABGEWAEHLT, Niederschlag bleibt aktiv.
+
+    Erwartet: keine Gewitterbeginn-Regel und kein Gewitterbeginn-Alarm (die
+    Aktivierungs-Kopplung aus den Known Limitations der Spec: wer Gewitter
+    nicht beobachtet, will auch keinen Gewitterbeginn-Alarm). Der
+    Starkregenbeginn bleibt als Positivkontrolle scharf -- ohne sie waere der
+    Test auch dann gruen, wenn der Nachfuell-Pfad gar nichts mehr erzeugt.
+    """
+    dc = _wetter_reiter(thunder=False, precipitation=True)
+    regeln = expand_per_metric_levels({}, dc)
+
+    assert _regel(regeln, RAIN_ONSET_METRIK) is not None, (
+        "Positivkontrolle: der Starkregenbeginn muss bei aktivem Niederschlag "
+        f"scharf sein. Erzeugt wurden: {sorted(str(r.metric) for r in regeln)!r}"
+    )
+    assert _regel(regeln, TH_ONSET_METRIK) is None, (
+        "Gewitter ist abgewaehlt, trotzdem entsteht eine Gewitterbeginn-Regel "
+        f"-- die Aktivierungs-Kopplung greift nicht: "
+        f"{sorted(str(r.metric) for r in regeln)!r}"
+    )
+
+    detektor = WeatherChangeDetectionService.from_alert_rules(regeln)
+    changes = detektor.detect_changes(
+        _data(**{TH_ONSET_FELD: _utc(17)}),
+        _data(**{TH_ONSET_FELD: _utc(15)}),
+        include_absolute=False,
+    )
+    assert not [c for c in changes if c.metric == TH_ONSET_FELD], (
+        "Gewitter ist im Wetter-Reiter abgewaehlt, es entsteht trotzdem ein "
+        f"Gewitterbeginn-Alarm: {changes!r}"
+    )

--- a/tests/tdd/test_onset_anchor_fresh_window_symmetry.py
+++ b/tests/tdd/test_onset_anchor_fresh_window_symmetry.py
@@ -1,0 +1,322 @@
+"""Issue #1468 — Anker und frischer Stand rechnen mit DEMSELBEN Tagesfenster.
+
+SPEC: docs/specs/modules/feat_1468_onset_verschiebung_alarm.md (E2, AC-10)
+
+WAS HIER BEWACHT WIRD, und warum es eine eigene Datei verdient:
+
+Der Beginn-Alarm vergleicht zwei Staende derselben Tour — den Anker (vom
+Briefing-/Versandpfad geschrieben, `trip_report_scheduler._fetch_weather`)
+gegen den frischen Stand (vom Alarm-Pfad geholt,
+`trip_alert._fetch_fresh_weather`). Beide Seiten muessen ihre Onset-Stunde
+unter DEMSELBEN Tagesfenster berechnen. Tun sie das nicht, unterscheiden sich
+die beiden Zahlen allein durch die Fensterwahl — und der Nutzer bekommt einen
+Alarm, obwohl sich am Wetter nichts geaendert hat. Bei einem Fenster 10-16
+gegen den Default 4-19 waeren das in der Fixture unten 2 Stunden
+"Verschiebung" aus dem Nichts.
+
+WARUM DIE STRUKTUR DAS LOEST: das Fenster haengt am SEGMENT
+(`TripSegment.day_window_start_hour`/`_end_hour`, gesetzt in
+`trip_segments.convert_trip_to_segments()` aus `trip.report_config`), nicht an
+der Aufrufkette. Beide Pfade holen ihre Segmente aus derselben Quelle, also
+koennen sie gar nicht mit verschiedenen Fenstern rechnen.
+
+Der erste Test unten ist nach dieser Umstellung leicht gruen — deshalb steht
+die POSITIVKONTROLLE daneben: sie stellt genau die Asymmetrie her, die eine
+Uebergabe per Parameter erlaubt haette (ein Aufrufer reicht das Fenster
+weiter, der andere vergisst es), und zeigt, dass daraus tatsaechlich ein
+Alarm entsteht. Ohne sie bewiese der erste Test nichts — er waere auch dann
+gruen, wenn ueberhaupt nie ein Beginn-Alarm entstuende.
+
+Kein Mock (CLAUDE.md, Kern-Schicht): Gewitterstufen aus der ECHTEN Fusion,
+Segmente aus dem ECHTEN `convert_trip_to_segments()`, Vergleich ueber den
+ECHTEN Detektor. Pfadregel #1409: Prueling relativ zu DIESER Datei.
+"""
+from __future__ import annotations
+
+import sys
+from dataclasses import replace
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from app.model_registry import (  # noqa: E402
+    cape_ladder_thresholds_jkg, lpi_thresholds_jkg,
+)
+from app.models import (  # noqa: E402
+    ForecastDataPoint, ForecastMeta, NormalizedTimeseries, Provider,
+    TripReportConfig,
+)
+from app.trip import Stage, Trip, Waypoint  # noqa: E402
+from providers.thunder_enrichment import _fuse_thunder_levels  # noqa: E402
+from providers.thunder_routing import thunder_region_for  # noqa: E402
+from services.alert_preset import expand_per_metric_levels  # noqa: E402
+from services.segment_weather import SegmentWeatherService  # noqa: E402
+from services.trip_segments import convert_trip_to_segments  # noqa: E402
+from services.weather_change_detection import (  # noqa: E402
+    WeatherChangeDetectionService,
+)
+from services.weather_snapshot import WeatherSnapshotService  # noqa: E402
+
+TH_ONSET_FELD = "thunder_onset_utc"
+# Die TOUR liegt auf Island (ganzjaehrig UTC+0, keine Sommerzeit): damit ist
+# die UTC-Stunde der Fixture zugleich die Ortszeit-Stunde, nach der die
+# Aggregation filtert -- der Test haengt weder an der Systemzone noch an der
+# Sommerzeit. Die Gewitter-FUSION nutzt weiterhin die geeichte Alpen-Leiter
+# (sie kennt die Koordinaten nicht, sie bekommt die Schwellen uebergeben) --
+# dasselbe Vorgehen wie in test_onset_shift_alert.py.
+ISLAND_LAT, ISLAND_LON = 64.13, -21.90
+ALPEN_LAT, ALPEN_LON, MODELL = 47.0, 12.0, "icon_d2"
+
+# Das erste Etappen-Segment laeuft von 08:00 bis 11:42 Ortszeit (GEHZEIT,
+# nicht Tagesfenster -- genau darum wirkt der Fensterschnitt zusaetzlich).
+# Der Vorschnitt in `_aggregate_for_segment` ist am Ende EXKLUSIV und
+# floort auf die Stunde (Bug #806), es bleiben also die Stunden 08, 09, 10.
+# Ein Fenster 10-16 schneidet darin nochmals:
+#   Fenster 10-16 sieht als erste die 10:00
+#   Default 4-19  sieht als erste die 08:00
+# -> 2 Stunden Unterschied allein aus der Fensterwahl. Das reicht bei
+#    Empfindlichkeit "sensibel" (ab 2 h spaeter) fuer einen Alarm.
+ENG = (10, 16)
+GEWITTERSTUNDEN = {8: 400.0, 10: 800.0}
+
+
+def _tag() -> date:
+    return date.today() + timedelta(days=1)
+
+
+def _dp(stunde: int, cape: float) -> ForecastDataPoint:
+    t = _tag()
+    return ForecastDataPoint(
+        ts=datetime(t.year, t.month, t.day, stunde, 0, tzinfo=timezone.utc),
+        t2m_c=16.0, wind10m_kmh=10.0, gust_kmh=20.0, precip_1h_mm=0.2,
+        cloud_total_pct=40, humidity_pct=50, pop_pct=30,
+        cape_jkg=cape, convective_inhibition_jkg=5.0,
+    )
+
+
+def _reihe() -> NormalizedTimeseries:
+    punkte = [_dp(h, GEWITTERSTUNDEN.get(h, 100.0)) for h in range(24)]
+    region = thunder_region_for(ALPEN_LAT, ALPEN_LON)
+    _fuse_thunder_levels(punkte, cape_ladder_thresholds_jkg(MODELL, region),
+                         lpi_thresholds_jkg(region))
+    return NormalizedTimeseries(
+        meta=ForecastMeta(provider=Provider.OPENMETEO, model="test",
+                          grid_res_km=1.0),
+        data=punkte,
+    )
+
+
+def _trip(start: int | None, ende: int | None) -> Trip:
+    t = Trip(
+        id="symmetrie-trip", name="Symmetrie-Trip",
+        stages=[Stage(
+            id="S1", name="Etappe", date=_tag(),
+            waypoints=[
+                Waypoint(id="W1", name="Start", lat=ISLAND_LAT, lon=ISLAND_LON,
+                         elevation_m=1000),
+                Waypoint(id="W2", name="Ziel", lat=ISLAND_LAT + 0.1,
+                         lon=ISLAND_LON + 0.1, elevation_m=1200),
+            ],
+        )],
+    )
+    t.report_config = TripReportConfig(
+        trip_id=t.id, day_window_start_hour=start, day_window_end_hour=ende,
+    )
+    return t
+
+
+def _segmente(start: int | None, ende: int | None):
+    segmente = convert_trip_to_segments(_trip(start, ende), _tag())
+    assert segmente, "Vorbedingung: die Tour muss Segmente ergeben"
+    return segmente
+
+
+def _aggregiert(segment):
+    """Ein Etappen-Aggregat ueber den PRODUKTIVEN Weg -- die Onset-Stunde
+    entsteht hier wirklich, sie wird nicht gesetzt."""
+    from providers.base import get_provider
+
+    return SegmentWeatherService(get_provider("openmeteo"))._aggregate_for_segment(
+        segment, _reihe(), fetched_at=datetime.now(timezone.utc),
+    )
+
+
+def _pruefe_fixture_passt_zum_segment(segment) -> None:
+    """Vakuum-Schutz: beide Gewitterstunden muessen INNERHALB der Gehzeit
+    dieses Segments liegen. Sonst misst der Test den Segment-Vorschnitt statt
+    den Fensterschnitt -- und wuerde bei jeder Aenderung der Etappenzeiten
+    stillschweigend blind."""
+    von = segment.start_time.astimezone(timezone.utc).hour
+    bis = segment.end_time.astimezone(timezone.utc).hour
+    for stunde in GEWITTERSTUNDEN:
+        # Obergrenze EXKLUSIV: der Vorschnitt floort das Segmentende auf die
+        # Stunde und filtert `< end_floor` (Bug #806). Ein `<=` hier waere zu
+        # lax und liesse eine Fixture durchgehen, deren letzte Gewitterstunde
+        # der Vorschnitt bereits wegschneidet.
+        assert von <= stunde < bis, (
+            f"Fixture passt nicht zum Segment: Gewitterstunde {stunde:02d}:00 "
+            f"liegt ausserhalb der Gehzeit {von:02d}-{bis:02d} (Ende exklusiv) "
+            "-- der Test misst dann den Vorschnitt, nicht das Tagesfenster."
+        )
+
+
+def _onset_aenderungen(alt, neu) -> list:
+    regeln = expand_per_metric_levels({"thunder_onset": "sensibel"})
+    detektor = WeatherChangeDetectionService.from_alert_rules(regeln)
+    return [
+        c for c in detektor.detect_changes(alt, neu, include_absolute=False)
+        if c.metric == TH_ONSET_FELD
+    ]
+
+
+# ==========================================================================
+# Die Strukturaussage: das Fenster haengt am Segment
+# ==========================================================================
+
+def test_jedes_segment_der_tour_traegt_das_eingestellte_fenster():
+    """Auch das ZIEL-Segment — es entsteht in `convert_trip_to_segments()` an
+    einer eigenen Stelle und wurde dort frueher vergessen (#1584 setzte dort
+    nur das Zeit-Ende aus dem Fenster, nicht die Auswertungsgrenzen)."""
+    segmente = _segmente(*ENG)
+    kennungen = [str(s.segment_id) for s in segmente]
+    assert "Ziel" in kennungen, (
+        f"Vorbedingung: die Tour muss ein Ziel-Segment haben: {kennungen!r}"
+    )
+    for s in segmente:
+        assert (s.day_window_start_hour, s.day_window_end_hour) == ENG, (
+            f"Segment {s.segment_id!r} traegt das Fenster nicht: "
+            f"({s.day_window_start_hour}, {s.day_window_end_hour}) statt {ENG}"
+        )
+
+
+def test_ohne_eingestelltes_fenster_bleiben_die_segmente_leer():
+    """Bestandsverhalten: keine Angabe heisst `None` am Segment — die
+    Aufloesung auf den Default 4-19 gehoert an den Auswertungsort, nicht
+    hierher. Zwei Aufloesungen an zwei Orten waeren die Doppelung, die
+    ADR-0035 vermeidet."""
+    for s in _segmente(None, None):
+        assert s.day_window_start_hour is None and s.day_window_end_hour is None, (
+            f"Segment {s.segment_id!r} erfindet ein Fenster: "
+            f"({s.day_window_start_hour}, {s.day_window_end_hour})"
+        )
+
+
+# ==========================================================================
+# Die Wirkung: kein Alarm aus der Fensterwahl
+# ==========================================================================
+
+def test_anker_und_frischer_stand_derselben_tour_erzeugen_keinen_alarm():
+    """Beide Vergleichsseiten stammen aus derselben Tour mit Fenster 8-16 und
+    DERSELBEN Stundenreihe — es hat sich am Wetter nichts geaendert, also darf
+    kein Beginn-Alarm entstehen."""
+    segment = _segmente(*ENG)[0]
+    _pruefe_fixture_passt_zum_segment(segment)
+    anker = _aggregiert(segment)
+    frisch = _aggregiert(segment)
+
+    assert anker.aggregated.thunder_onset_utc is not None, (
+        "Vorbedingung: beide Staende muessen ueberhaupt einen Beginn fuehren, "
+        "sonst ist die Gleichheit unten trivial."
+    )
+    assert _onset_aenderungen(anker, frisch) == [], (
+        "Unveraendertes Wetter erzeugt einen Beginn-Alarm: "
+        f"Anker {anker.aggregated.thunder_onset_utc}, "
+        f"frisch {frisch.aggregated.thunder_onset_utc}"
+    )
+
+
+def test_asymmetrische_fensterwahl_erzeugt_genau_den_scheinalarm():
+    """POSITIVKONTROLLE — ohne sie bewacht der Test darueber nichts.
+
+    Hier bekommt EINE Seite kein Fenster (sie faellt damit auf den Default
+    4-19 zurueck), die andere behaelt 8-16. Genau diese Asymmetrie waere
+    moeglich gewesen, wenn das Fenster als Parameter durch die Aufrufkette
+    liefe und ein Aufrufer ihn nicht weiterreicht. Ergebnis: ein Alarm ueber
+    eine Verschiebung, die es gar nicht gab -- beide Seiten sehen dieselbe
+    Stundenreihe.
+    """
+    mit_fenster = _segmente(*ENG)[0]
+    _pruefe_fixture_passt_zum_segment(mit_fenster)
+    ohne_fenster = replace(
+        mit_fenster, day_window_start_hour=None, day_window_end_hour=None,
+    )
+    anker = _aggregiert(ohne_fenster)
+    frisch = _aggregiert(mit_fenster)
+
+    a, f = anker.aggregated.thunder_onset_utc, frisch.aggregated.thunder_onset_utc
+    assert a is not None and f is not None, "Vorbedingung: beide Staende brauchen einen Beginn"
+    assert a.hour != f.hour, (
+        "Vorbedingung: die beiden Fenster muessen zu verschiedenen Stunden "
+        f"fuehren, sonst zeigt dieser Test nichts ({a.hour} vs. {f.hour})"
+    )
+    assert _onset_aenderungen(anker, frisch), (
+        f"Die Fenster-Asymmetrie ({a.hour:02d}:00 gegen {f.hour:02d}:00) "
+        "erzeugt KEINEN Alarm -- dann kann der Test darueber die Symmetrie "
+        "auch nicht bewachen."
+    )
+
+
+# ==========================================================================
+# Der Anker traegt das Fenster ueber Speichern und Laden
+# ==========================================================================
+
+def test_gespeicherter_anker_behaelt_das_fenster_seines_segments():
+    """Der Anker haelt die volle Stundenreihe mit (`_serialize_segment`), aus
+    einem geladenen Anker-Segment kann also neu aggregiert werden. Faellt das
+    Fenster beim Speichern heraus, rechnete dieselbe Reihe beim naechsten Mal
+    unter dem Default -- und die Vergleichsbasis waere wieder schief, ohne
+    dass irgendwo ein Fehler auftauchte.
+
+    Deshalb schreibt `_serialize_segment()` die beiden Felder mit; hier ist
+    der Nachweis, dass sie den Rueckweg ueberstehen UND dass eine erneute
+    Aggregation aus dem GELADENEN Segment dieselbe Stunde liefert.
+    """
+    dienst = WeatherSnapshotService(user_id="onset-fenster-anker")
+    segment = _segmente(*ENG)[0]
+    dienst.save_alarm_anchor("fenster-trip", _tag(), [_aggregiert(segment)])
+
+    geladen = dienst.load_alarm_anchor("fenster-trip")
+    assert geladen, "Anker liess sich nicht laden"
+    zurueck = geladen[0].segment
+    assert (zurueck.day_window_start_hour, zurueck.day_window_end_hour) == ENG, (
+        "Das Auswertungsfenster ueberlebt den Anker nicht: "
+        f"({zurueck.day_window_start_hour}, {zurueck.day_window_end_hour}) "
+        f"statt {ENG} -- eine erneute Aggregation aus diesem Segment fiele "
+        "still auf den Default zurueck."
+    )
+    erneut = _aggregiert(zurueck).aggregated.thunder_onset_utc
+    original = _aggregiert(segment).aggregated.thunder_onset_utc
+    assert erneut == original, (
+        f"Neu aggregiert aus dem geladenen Anker-Segment: {erneut}, "
+        f"aus dem urspruenglichen: {original} -- die beiden muessen gleich sein."
+    )
+
+
+def test_alt_anker_ohne_fensterfelder_laedt_unveraendert():
+    """Bestandsdaten (CLAUDE.md-Pflicht): ein Anker, der vor dieser Aenderung
+    geschrieben wurde, kennt die beiden Schluessel nicht. Er muss weiterhin
+    laden, das Fenster ist dann `None` -> Default 4-19."""
+    import json
+
+    dienst = WeatherSnapshotService(user_id="onset-fenster-altanker")
+    segment = _segmente(*ENG)[0]
+    dienst.save_alarm_anchor("alt-trip", _tag(), [_aggregiert(segment)])
+
+    pfad = dienst._snapshots_dir / "alt-trip_alarm_anchor.json"
+    daten = json.loads(pfad.read_text())
+    for eintrag in daten["segments"]:
+        eintrag.pop("day_window_start_hour", None)
+        eintrag.pop("day_window_end_hour", None)
+    pfad.write_text(json.dumps(daten, indent=2))
+
+    geladen = dienst.load_alarm_anchor("alt-trip")
+    assert geladen, "Alt-Anker ohne die Fensterfelder liess sich nicht laden"
+    zurueck = geladen[0].segment
+    assert zurueck.day_window_start_hour is None, (
+        "Ein Anker ohne Fensterangabe muss None tragen, nicht einen erfundenen "
+        f"Wert: {zurueck.day_window_start_hour!r}"
+    )
+    assert geladen[0].aggregated.thunder_onset_utc is not None, (
+        "Das mitgespeicherte Aggregat des Alt-Ankers ist verlorengegangen."
+    )

--- a/tests/tdd/test_onset_compare_day_window.py
+++ b/tests/tdd/test_onset_compare_day_window.py
@@ -1,0 +1,202 @@
+"""Issue #1468 — AC-10 fuer den ORTSVERGLEICH: das Vergleichs-Tagesfenster
+erreicht die Beginn-Berechnung.
+
+SPEC: docs/specs/modules/feat_1468_onset_verschiebung_alarm.md (E2, AC-10)
+
+WARUM ES DIESE DATEI GIBT (Adversary-Finding F002, 2026-08-19):
+
+Die dedizierte AC-10-Datei `test_onset_respects_configured_day_window.py`
+faehrt ausschliesslich den TRIP-Pfad. Der Adversary hat die beiden Zeilen
+`day_window_start_hour=`/`day_window_end_hour=` aus dem Segment-Bau in
+`compare_location_weather_source.py` ENTFERNT -- und alle 46 einschlaegigen
+Tests blieben gruen. Die Zusicherung war fuer den Ortsvergleich also nicht
+dort geprueft, wo sie wirkt.
+
+WARUM DIE MUTATION SO SCHWER ZU FANGEN IST -- und was daraus folgt:
+
+`CompareLocationWeatherSource.fetch()` schneidet sein synthetisches Segment
+bereits auf das Vergleichsfenster zu (`window_start`/`window_end`). Solange
+das Vergleichsfenster INNERHALB des Defaults 4-19 liegt, ist der zusaetzliche
+Fensterfilter in der Aggregation wirkungslos: der Vorschnitt hat die Stunden
+ausserhalb schon entfernt, und ob danach gegen 10-16 oder gegen 4-19
+gefiltert wird, aendert nichts. Ein Test mit einem ENGEREN Fenster kann die
+Mutation deshalb prinzipiell nicht fangen.
+
+Wirksam wird der Unterschied genau dann, wenn das Vergleichsfenster WEITER
+ist als der Default: bei 3-21 liegt die Stunde 03:00 im Vorschnitt, aber
+AUSSERHALB von 4-19. Faellt die Weitergabe weg, schneidet die Aggregation
+diese Stunde weg und nennt einen spaeteren Beginn -- eine Zahl, die im
+Ortsvergleich so nie stand. Genau diese Konstellation baut der Test unten.
+
+KEIN NETZ, KEIN MOCK (CLAUDE.md, Kern-Schicht): der Prozess-Cache
+(`get_shared_weather_cache()`) wird mit der Stundenreihe vorbefuellt, damit
+`fetch_segment_weather()` einen Treffer hat und den Provider nie aufruft.
+Der Prueling -- Segment-Bau, Vorschnitt, Aggregation -- laeuft vollstaendig
+echt. Gewitterstufen entstehen ueber die ECHTE Fusion aus CAPE-Rohwerten.
+
+Pfadregel #1409: Prueling relativ zu DIESER Datei aufgeloest.
+"""
+from __future__ import annotations
+
+import sys
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from app.day_window import (  # noqa: E402
+    DAY_WINDOW_END_HOUR, DAY_WINDOW_START_HOUR,
+)
+from app.models import (  # noqa: E402
+    ForecastDataPoint, ForecastMeta, GPXPoint, NormalizedTimeseries, Provider,
+    ThunderLevel, TripSegment,
+)
+from app.model_registry import (  # noqa: E402
+    cape_ladder_thresholds_jkg, lpi_thresholds_jkg,
+)
+from providers.thunder_enrichment import _fuse_thunder_levels  # noqa: E402
+from providers.thunder_routing import thunder_region_for  # noqa: E402
+from services.compare_location_weather_source import (  # noqa: E402
+    CompareLocationWeatherSource,
+)
+from services.segment_weather import SegmentWeatherService  # noqa: E402
+from services.weather_cache import get_shared_weather_cache  # noqa: E402
+
+# Island: ganzjaehrig UTC+0, keine Sommerzeit -> die Stundenzahl der Fixture
+# IST die Ortszeit-Stunde am Vergleichsort. Keine Erwartung haengt an der
+# Systemzone oder an der Sommerzeit.
+ISLAND_LAT, ISLAND_LON = 64.13, -21.90
+# Die Gewitter-FUSION nutzt die geeichte Alpen-Leiter (sie kennt die
+# Koordinaten nicht, sie bekommt die Schwellen uebergeben).
+ALPEN_LAT, ALPEN_LON, MODELL = 47.0, 12.0, "icon_d2"
+
+# WEITER als der Default 4-19 -- nur so ist die Weitergabe ueberhaupt
+# beobachtbar (s. Kopf).
+WEITES_FENSTER = (3, 21)
+# 03:00 liegt im weiten Fenster, aber AUSSERHALB des Defaults 4-19.
+# 12:00 liegt in beiden.
+GEWITTERSTUNDEN = {3: 400.0, 12: 800.0}
+ORT_ID = "compare-onset-ort"
+
+
+def _tag() -> date:
+    return date.today() + timedelta(days=1)
+
+
+def _dp(stunde: int, cape: float) -> ForecastDataPoint:
+    t = _tag()
+    return ForecastDataPoint(
+        ts=datetime(t.year, t.month, t.day, stunde, 0, tzinfo=timezone.utc),
+        t2m_c=15.0, wind10m_kmh=10.0, gust_kmh=20.0, precip_1h_mm=0.2,
+        cloud_total_pct=40, humidity_pct=50, pop_pct=30,
+        cape_jkg=cape, convective_inhibition_jkg=5.0,
+    )
+
+
+def _tagesreihe() -> NormalizedTimeseries:
+    punkte = [_dp(h, GEWITTERSTUNDEN.get(h, 100.0)) for h in range(24)]
+    region = thunder_region_for(ALPEN_LAT, ALPEN_LON)
+    _fuse_thunder_levels(punkte, cape_ladder_thresholds_jkg(MODELL, region),
+                         lpi_thresholds_jkg(region))
+    return NormalizedTimeseries(
+        meta=ForecastMeta(provider=Provider.OPENMETEO, model="test",
+                          grid_res_km=1.0),
+        data=punkte,
+    )
+
+
+@pytest.fixture()
+def vorbefuellter_cache():
+    """Den Prozess-Cache so fuellen, dass `fetch_segment_weather()` einen
+    Treffer hat und der Provider nie aufgerufen wird.
+
+    Das Ablage-Segment deckt den GANZEN Tag ab -- damit trifft es jedes
+    Fenster, das `fetch()` intern baut, und der Test haengt nicht an der
+    genauen Fenster-Arithmetik des Prueflings.
+    """
+    from providers.base import get_provider
+
+    t = _tag()
+    punkt = GPXPoint(lat=ISLAND_LAT, lon=ISLAND_LON, elevation_m=None,
+                     distance_from_start_km=0.0)
+    ablage = TripSegment(
+        segment_id=ORT_ID, start_point=punkt, end_point=punkt,
+        start_time=datetime(t.year, t.month, t.day, 0, 0, tzinfo=timezone.utc),
+        end_time=datetime(t.year, t.month, t.day, 23, 59, tzinfo=timezone.utc),
+        duration_hours=24.0, distance_km=0.0, ascent_m=0, descent_m=0,
+    )
+    dienst = SegmentWeatherService(get_provider("openmeteo"))
+    model_id = dienst._resolve_model_id(ISLAND_LAT, ISLAND_LON)
+    cache = get_shared_weather_cache()
+    cache.put(ablage, _tagesreihe(), enrich_ensemble=False, enrich_snow=False,
+              model_id=model_id)
+    yield cache
+
+
+def _beginn_stunde(start_hour: int, end_hour: int) -> int | None:
+    """Der Gewitterbeginn der Alarm-Vergleichsbasis EINES Vergleichsorts,
+    ueber den echten Produktivweg `CompareLocationWeatherSource.fetch()`."""
+    punkt = CompareLocationWeatherSource().fetch(
+        ORT_ID, ISLAND_LAT, ISLAND_LON,
+        start_hour=start_hour, end_hour=end_hour, target_date=_tag(),
+    )
+    onset = punkt.aggregated.thunder_onset_utc
+    return None if onset is None else onset.hour
+
+
+def test_fixture_unterscheidet_das_weite_fenster_vom_default():
+    """Vakuum-Schutz: 03:00 muss ein Gewitter tragen UND ausserhalb des
+    Defaults liegen -- sonst koennte dieser Test die Weitergabe gar nicht
+    beobachten und bliebe auch ohne sie gruen."""
+    stufen = {p.ts.hour: p.thunder_level for p in _tagesreihe().data}
+    for stunde in GEWITTERSTUNDEN:
+        assert stufen[stunde] not in (None, ThunderLevel.NONE), (
+            f"Fixture: {stunde:02d}:00 muss ein Gewitter tragen: {stufen[stunde]!r}"
+        )
+    assert not (DAY_WINDOW_START_HOUR <= 3 <= DAY_WINDOW_END_HOUR), (
+        f"Fixture: 03:00 muss AUSSERHALB des Defaults "
+        f"{DAY_WINDOW_START_HOUR}-{DAY_WINDOW_END_HOUR} liegen, sonst ist die "
+        "Weitergabe des Vergleichsfensters nicht beobachtbar."
+    )
+    assert WEITES_FENSTER[0] <= 3 <= WEITES_FENSTER[1], (
+        f"Fixture: 03:00 muss INNERHALB von {WEITES_FENSTER} liegen."
+    )
+
+
+def test_vergleichs_tagesfenster_erreicht_die_beginn_berechnung(vorbefuellter_cache):
+    """AC-10 fuer den Ortsvergleich: mit Vergleichsfenster 3-21 nennt die
+    Alarm-Vergleichsbasis den Beginn 03:00.
+
+    Faellt die Weitergabe von `day_window_start_hour`/`_end_hour` an das
+    Compare-Segment weg (Adversary-Mutation M2), filtert die Aggregation
+    gegen den Default 4-19, schneidet 03:00 weg und nennt 12:00 -- eine
+    Stunde, die im Ortsvergleich nie stand. Dieser Test wird dann rot.
+    """
+    stunde = _beginn_stunde(*WEITES_FENSTER)
+    assert stunde is not None, (
+        "Der Ortsvergleich fuehrt gar keinen Gewitterbeginn -- dann prueft "
+        "dieser Test die Fensterwahl nicht."
+    )
+    assert stunde == 3, (
+        f"Vergleichsfenster {WEITES_FENSTER[0]}-{WEITES_FENSTER[1]}: erwartet "
+        f"den Beginn 03:00, bekommen {stunde:02d}:00. 12:00 heisst, die "
+        "Aggregation hat gegen den Default 4-19 gefiltert -- das "
+        "Vergleichsfenster hat das Segment nicht erreicht."
+    )
+
+
+def test_enges_fenster_beschneidet_den_beginn_wie_erwartet(vorbefuellter_cache):
+    """Gegenprobe in die andere Richtung: mit einem ENGEN Fenster (10-16)
+    faellt 03:00 weg und der Beginn ist 12:00.
+
+    Diese Richtung fangt die Mutation NICHT (der Vorschnitt entfernt 03:00
+    ohnehin) -- sie steht hier, damit die Erwartung oben nicht als
+    "irgendeine Stunde" durchgeht, sondern als eine, die sich mit dem
+    Fenster nachweislich BEWEGT.
+    """
+    assert _beginn_stunde(10, 16) == 12, (
+        "Mit Fenster 10-16 muss der Beginn 12:00 sein -- die 03:00 liegt "
+        "ausserhalb und darf nicht erscheinen."
+    )

--- a/tests/tdd/test_onset_computation_sources.py
+++ b/tests/tdd/test_onset_computation_sources.py
@@ -1,0 +1,200 @@
+"""Issue #1468 — Die BERECHNUNG der beiden Beginn-Zeitpunkte, am Wirkort.
+
+SPEC: docs/specs/modules/feat_1468_onset_verschiebung_alarm.md
+
+WARUM DIESE DATEI EXISTIERT (Mutations-Befund, 2026-08-18):
+
+Die neun AC-Tests in `test_onset_shift_alert.py` setzen `thunder_onset_utc`/
+`precip_heavy_onset_utc` als fertigen Wert direkt ins Tages-Aggregat — sie
+pruefen den VERGLEICH, nicht die HERKUNFT der Zahl. Nur AC-4 faehrt
+`compute_basis_metrics()` wirklich durch, und der prueft ausschliesslich
+Gewitter.
+
+Die Mutations-Gegenprobe hat das sichtbar gemacht: das Entfernen der
+`precip_1h_mm`-Ersatzquelle in `_compute_precip_heavy_onset()` liess JEDEN
+Test gruen. Damit war die PO-freigegebene Ergaenzung (2026-08-18) unbewacht —
+und ausgerechnet sie traegt die gesamte Starkregen-Haelfte des Tickets beim
+PRIMAERPROVIDER: Open-Meteo setzt `precip_rate_mmph` hart auf `None`
+(`providers/openmeteo.py:885`), nur GeoSphere befuellt es
+(`providers/geosphere.py:571`). Ohne die Ersatzquelle waere
+`precip_heavy_onset_utc` fuer die Mehrheit aller Segmente strukturell immer
+`None` — kein Fehlalarm, aber auch NIE ein Alarm.
+
+Dieselbe Luecke bestand fuer die Gewitter-Schwelle: AC-4 nennt 14:00 auch
+dann noch richtig, wenn die Schwelle von `LOW` auf `MED` verschoben wuerde
+(seine Tagesstunden tragen MED). Der Test unten setzt deshalb eine Stunde
+mit LOW VOR die MED-Stunde.
+
+Kein Mock (CLAUDE.md, Kern-Schicht): Gewitterstufen entstehen ueber die
+ECHTE Fusion aus CAPE-Rohwerten, wie in `test_onset_shift_alert.py`.
+Pfadregel #1409: Prueling relativ zu DIESER Datei aufgeloest.
+"""
+from __future__ import annotations
+
+import sys
+from datetime import date, datetime, timezone
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from app.day_window import DAY_WINDOW_END_HOUR, DAY_WINDOW_START_HOUR  # noqa: E402
+from app.model_registry import (  # noqa: E402
+    cape_ladder_thresholds_jkg, lpi_thresholds_jkg,
+)
+from app.models import (  # noqa: E402
+    ForecastDataPoint, ForecastMeta, NormalizedTimeseries, Provider,
+    ThunderLevel,
+)
+from providers.thunder_enrichment import _fuse_thunder_levels  # noqa: E402
+from providers.thunder_routing import thunder_region_for  # noqa: E402
+from services.weather_metrics import WeatherMetricsService  # noqa: E402
+
+TAG = date(2026, 8, 20)
+ALPEN_LAT, ALPEN_LON, MODELL = 47.0, 12.0, "icon_d2"
+UTC = ZoneInfo("UTC")
+FENSTER = (DAY_WINDOW_START_HOUR, DAY_WINDOW_END_HOUR)
+
+# Die Schwelle aus der Spec, hier als LITERAL — bewusst NICHT aus dem
+# Prueling gezogen (`WeatherMetricsService._PRECIP_HEAVY_MMPH`), sonst
+# verschoebe eine Aenderung der Konstante die Erwartung stillschweigend mit.
+STARKREGEN_MMPH = 4.0
+
+
+def _reihe(punkte) -> NormalizedTimeseries:
+    return NormalizedTimeseries(
+        meta=ForecastMeta(provider=Provider.OPENMETEO, model="test",
+                          grid_res_km=1.0),
+        data=list(punkte),
+    )
+
+
+def _dp(stunde: int, *, cape=None, rate=None, regen_mm=0.0) -> ForecastDataPoint:
+    return ForecastDataPoint(
+        ts=datetime(TAG.year, TAG.month, TAG.day, stunde, 0, tzinfo=timezone.utc),
+        t2m_c=18.0, wind10m_kmh=10.0, gust_kmh=20.0,
+        precip_1h_mm=regen_mm, precip_rate_mmph=rate,
+        cloud_total_pct=40, humidity_pct=50, pop_pct=30,
+        cape_jkg=cape, convective_inhibition_jkg=5.0 if cape else None,
+    )
+
+
+def _aggregat(punkte):
+    return WeatherMetricsService().compute_basis_metrics(
+        _reihe(punkte), tz=UTC,
+        day_window_start_hour=FENSTER[0], day_window_end_hour=FENSTER[1],
+    )
+
+
+def _stunde(wert) -> int | None:
+    return None if wert is None else wert.hour
+
+
+# ==========================================================================
+# Starkregen: BEIDE Quellen gegen DIESELBE Schwelle
+# ==========================================================================
+
+def test_starkregen_beginn_ohne_intensitaetsfeld_kommt_aus_der_stundenmenge():
+    """Open-Meteo-Fall: `precip_rate_mmph` ist durchgaengig None, die
+    Stundenmenge `precip_1h_mm` traegt den Wert.
+
+    Ohne die Ersatzquelle bliebe der Beginn hier `None` — und weil Open-Meteo
+    der Primaerprovider ist, waere die Starkregen-Haelfte des Tickets fuer die
+    Mehrheit aller Segmente tot.
+    """
+    punkte = [
+        _dp(8, regen_mm=0.4),
+        _dp(9, regen_mm=STARKREGEN_MMPH - 0.1),   # knapp darunter: zaehlt nicht
+        _dp(10, regen_mm=STARKREGEN_MMPH),        # erste Stunde >= Schwelle
+        _dp(11, regen_mm=9.0),                    # spaeterer Hoehepunkt
+    ]
+    for p in punkte:
+        assert p.precip_rate_mmph is None, (
+            "Fixture-Vorbedingung: dieser Fall bildet Open-Meteo ab, dort ist "
+            f"precip_rate_mmph immer None (bekommen: {p.precip_rate_mmph!r})"
+        )
+
+    onset = _aggregat(punkte).precip_heavy_onset_utc
+    assert _stunde(onset) == 10, (
+        "Der Starkregen-Beginn wird ohne Intensitaetsfeld nicht erkannt "
+        f"(erwartet 10:00, bekommen {onset!r}) -- die Ersatzquelle "
+        "`precip_1h_mm` greift nicht."
+    )
+
+
+def test_starkregen_beginn_nutzt_das_intensitaetsfeld_wenn_es_gesetzt_ist():
+    """GeoSphere-Fall: `precip_rate_mmph` ist gesetzt und gewinnt.
+
+    Die Stundenmenge zeigt hier absichtlich in die ANDERE Richtung (frueh
+    hoch, spaet niedrig). Waeren beide Quellen gleich, bewiese der Test
+    nicht, WELCHE gelesen wird.
+    """
+    punkte = [
+        _dp(8, rate=0.2, regen_mm=9.0),                    # Menge hoch, Rate niedrig
+        _dp(9, rate=STARKREGEN_MMPH - 0.1, regen_mm=9.0),
+        _dp(10, rate=STARKREGEN_MMPH, regen_mm=0.1),       # nur die Rate reisst
+    ]
+    onset = _aggregat(punkte).precip_heavy_onset_utc
+    assert _stunde(onset) == 10, (
+        "Bei gesetztem `precip_rate_mmph` muss die Intensitaet entscheiden "
+        f"(erwartet 10:00, bekommen {onset!r}). 08:00 hiesse, die Stundenmenge "
+        "gewinnt gegen die Rate."
+    )
+
+
+def test_regen_unterhalb_der_schwelle_ergibt_keinen_starkregen_beginn():
+    """Vakuum-Schutz: ohne diese Gegenprobe waeren die beiden Tests oben auch
+    dann gruen, wenn die Schwelle gar nicht geprueft wird und JEDE Regenstunde
+    als Beginn zaehlt."""
+    punkte = [_dp(h, regen_mm=STARKREGEN_MMPH - 0.1) for h in (8, 10, 12)]
+    onset = _aggregat(punkte).precip_heavy_onset_utc
+    assert onset is None, (
+        f"Regen knapp unter {STARKREGEN_MMPH} mm/h ist kein Starkregen, "
+        f"trotzdem entsteht ein Beginn: {onset!r}"
+    )
+
+
+# ==========================================================================
+# Gewitter: die Schwelle ist die UNTERSTE Stufe, nicht die mittlere
+# ==========================================================================
+
+def _mit_stufen(punkte):
+    region = thunder_region_for(ALPEN_LAT, ALPEN_LON)
+    _fuse_thunder_levels(punkte, cape_ladder_thresholds_jkg(MODELL, region),
+                         lpi_thresholds_jkg(region))
+    return punkte
+
+
+def test_gewitterbeginn_zaehlt_ab_der_untersten_stufe():
+    """Ein leichtes Gewitter um 10:00, ein mittleres um 14:00.
+
+    Erwartet: 10:00. Wuerde die Schwelle auf die mittlere Stufe rutschen,
+    stuende hier 14:00 — und der Wanderer bekaeme einen Beginn genannt, der
+    vier Stunden nach dem tatsaechlichen liegt.
+    """
+    punkte = _mit_stufen([
+        _dp(8, cape=200.0), _dp(10, cape=400.0), _dp(14, cape=800.0),
+    ])
+    stufen = {p.ts.hour: p.thunder_level for p in punkte}
+    assert stufen[10] == ThunderLevel.LOW, (
+        f"Fixture-Vorbedingung: 10:00 muss die UNTERSTE Stufe tragen: {stufen[10]!r}"
+    )
+    assert stufen[14] not in (None, ThunderLevel.NONE, ThunderLevel.LOW), (
+        f"Fixture-Vorbedingung: 14:00 muss hoeher liegen als 10:00: {stufen[14]!r}"
+    )
+
+    onset = _aggregat(punkte).thunder_onset_utc
+    assert _stunde(onset) == 10, (
+        f"Der Gewitterbeginn wird erst ab einer hoeheren Stufe gezaehlt "
+        f"(erwartet 10:00, bekommen {onset!r})."
+    )
+
+
+def test_ohne_gewitter_entsteht_kein_gewitterbeginn():
+    """Vakuum-Schutz zur Schwelle oben: eine Reihe ganz ohne Gewitter darf
+    keinen Beginn liefern."""
+    punkte = _mit_stufen([_dp(h, cape=50.0) for h in (8, 10, 14)])
+    onset = _aggregat(punkte).thunder_onset_utc
+    assert onset is None, (
+        f"Ohne jedes Gewitter entsteht trotzdem ein Beginn: {onset!r}"
+    )

--- a/tests/tdd/test_onset_respects_configured_day_window.py
+++ b/tests/tdd/test_onset_respects_configured_day_window.py
@@ -2,14 +2,23 @@
 
 SPEC: docs/specs/modules/feat_1468_onset_verschiebung_alarm.md (E2, AC-4)
 
-GEMESSENER IST-STAND (2026-08-18, dieser Branch): `compute_basis_metrics()`
-nimmt Zeitzone und Tagesfenster inzwischen an, aber die Trip-Konfiguration
-erreicht sie nicht. `SegmentWeatherService._aggregate_for_segment()` reicht
-nur die Zeitzone durch; das Fenster faellt still auf den Default 4-19
-(`day_window.resolve_configured_window`). Der Segment-Vorschnitt faengt das
-NICHT ab: die Etappen-Grenzen folgen den GEHZEITEN, nicht dem Fenster — das
-Fenster erreicht `trip_segments.py` an genau einer Stelle (:266-282) und dort
-nur das ENDE des ZIEL-Segments (#1584).
+GEMESSENER IST-STAND VOR DIESER AENDERUNG (2026-08-18):
+`compute_basis_metrics()` nahm Zeitzone und Tagesfenster bereits an, aber die
+Trip-Konfiguration erreichte sie nicht. `SegmentWeatherService.
+_aggregate_for_segment()` reichte nur die Zeitzone durch; das Fenster fiel
+still auf den Default 4-19 (`day_window.resolve_configured_window`). Der
+Segment-Vorschnitt faengt das NICHT ab: die Etappen-Grenzen folgen den
+GEHZEITEN, nicht dem Fenster — das Fenster erreichte `trip_segments.py` an
+genau einer Stelle (:266-282) und dort nur das ENDE des ZIEL-Segments (#1584).
+
+TRAEGER IST DAS SEGMENT, nicht die Aufrufkette: `TripSegment` fuehrt
+`day_window_start_hour`/`_end_hour`, gesetzt in
+`trip_segments.convert_trip_to_segments()` aus `trip.report_config`. Grund:
+Briefing-/Anker-Pfad und Alarm-Pfad benutzen DIESELBEN Segmente — damit
+koennen die beiden Seiten des Vergleichs gar nicht mit verschiedenen Fenstern
+rechnen. Ein Alarm, der allein aus der Fensterwahl entsteht, ist strukturell
+ausgeschlossen statt an jeder Aufrufstelle per Disziplin (bewacht in
+test_onset_anchor_fresh_window_symmetry.py).
 
 Folge fuer jeden Trip mit abweichendem Fenster — und das ist ein echtes
 Bedienelement (`shared/weather-metrics-tab/DayWindowCard.svelte`,
@@ -29,10 +38,13 @@ Methode, der die Trip-Konfiguration heute fehlt —, und die Erwartung ist
 die GLEICHHEIT mit der Stunde im gerenderten Briefing aus DERSELBEN Fixture
 (Muster AC-4/#1493 AC-9), nicht eine im Test getippte Zahl.
 
-Die Signatur wird NICHT vorgeschrieben, nur benutzt (`inspect.signature`,
-wie in AC-4): nimmt die Methode die Konfiguration nicht an, bleibt die
-Rechnung beim Default und die Gleichheitspruefung schlaegt fehl. Die
-Anpassung kann also kein falsches Gruen erzeugen, nur ein ehrliches Rot.
+Die Onset-Zahl wird hier WIRKLICH GERECHNET, nicht als fertiger Wert ins
+Aggregat gesetzt: `_aggregate_for_segment()` faehrt intern
+`compute_basis_metrics()`, und das Briefing rendert aus GENAU diesem
+Aggregat. Waere die Zahl gesetzt, koennte der Unterschied "Briefing 03:00 /
+Alarmbasis 05:00", mit dem dieser Test vor der Aenderung rot war, gar nicht
+entstehen. (Das ist dieselbe Blindstelle, die die Mutations-Gegenprobe an
+den AC-Tests aufgedeckt hat -- s. test_onset_computation_sources.py.)
 
 Kein Mock (CLAUDE.md, Kern-Schicht): Gewitterstufen entstehen ueber die
 ECHTE Fusion aus CAPE-Rohwerten. Pfadregel #1409: Prueling relativ zu
@@ -40,7 +52,6 @@ DIESER Datei aufgeloest.
 """
 from __future__ import annotations
 
-import inspect
 import re
 import sys
 from datetime import date, datetime, timezone
@@ -58,7 +69,7 @@ from app.model_registry import (  # noqa: E402
 from app.models import (  # noqa: E402
     ForecastDataPoint, ForecastMeta, GPXPoint, NormalizedTimeseries, Provider,
     SegmentWeatherData, ThunderLevel, TripReportConfig, TripSegment,
-)
+)  # TripReportConfig: nur noch fuer das gerenderte Briefing (report_config=)
 from output.renderers.trip_report import TripReportFormatter  # noqa: E402
 from providers.thunder_enrichment import _fuse_thunder_levels  # noqa: E402
 from providers.thunder_routing import thunder_region_for  # noqa: E402
@@ -105,10 +116,13 @@ def _reihe(punkte) -> NormalizedTimeseries:
     )
 
 
-def _ganztags_segment() -> TripSegment:
-    """Segment ueber den vollen Tag: der Segment-Vorschnitt in
-    `_aggregate_for_segment` darf hier nichts wegnehmen, sonst liesse sich
-    Fenster-Wirkung und Vorschnitt-Wirkung nicht auseinanderhalten."""
+def _ganztags_segment(start: int | None = None, ende: int | None = None) -> TripSegment:
+    """Segment ueber den vollen Tag, mit dem Auswertungsfenster der Tour.
+
+    Voller Tag, damit der Segment-Vorschnitt in `_aggregate_for_segment`
+    nichts wegnimmt -- sonst liessen sich Fenster-Wirkung und
+    Vorschnitt-Wirkung nicht auseinanderhalten.
+    """
     return TripSegment(
         segment_id=1,
         start_point=GPXPoint(lat=ISLAND_LAT, lon=ISLAND_LON, elevation_m=100.0,
@@ -118,34 +132,41 @@ def _ganztags_segment() -> TripSegment:
         start_time=datetime(TAG.year, TAG.month, TAG.day, 0, 0, tzinfo=timezone.utc),
         end_time=datetime(TAG.year, TAG.month, TAG.day, 23, 59, tzinfo=timezone.utc),
         duration_hours=24.0, distance_km=8.0, ascent_m=300.0, descent_m=300.0,
+        day_window_start_hour=start, day_window_end_hour=ende,
     )
 
 
-def _alarmbasis(punkte, report_config: TripReportConfig | None):
+def _alarmbasis(punkte, rc: TripReportConfig | None):
     """Das Tages-Aggregat ueber den PRODUKTIVEN Trip-Weg.
 
-    Die Trip-Konfiguration wird durchgereicht, SOBALD
-    `_aggregate_for_segment()` sie annimmt (das ist der Gegenstand dieses
-    Tests). Nimmt sie sie nicht an, rechnet die Aggregation mit dem Default
-    weiter und die Gleichheitspruefung unten schlaegt fehl.
+    Das Fenster kommt vom SEGMENT -- genau so, wie
+    `trip_segments.convert_trip_to_segments()` es aus `trip.report_config`
+    setzt. Der Test baut das Segment mit denselben Werten, statt eine zweite
+    Uebergabeform zu erfinden.
     """
     from providers.base import get_provider
 
     dienst = SegmentWeatherService(get_provider("openmeteo"))
-    parameter = inspect.signature(dienst._aggregate_for_segment).parameters
-    kwargs = {}
-    if "report_config" in parameter and report_config is not None:
-        kwargs["report_config"] = report_config
     return dienst._aggregate_for_segment(
-        _ganztags_segment(), _reihe(punkte),
-        fetched_at=datetime.now(timezone.utc), **kwargs,
+        _segment_fuer(rc), _reihe(punkte),
+        fetched_at=datetime.now(timezone.utc),
     ).aggregated
+
+
+def _segment_fuer(rc: TripReportConfig | None) -> TripSegment:
+    """Das Segment, das `convert_trip_to_segments()` fuer diese
+    Trip-Konfiguration bauen wuerde -- unaufgeloest weitergereicht, die
+    Aufloesung gehoert an den Auswertungsort."""
+    return _ganztags_segment(
+        getattr(rc, "day_window_start_hour", None),
+        getattr(rc, "day_window_end_hour", None),
+    )
 
 
 def _briefing_stunde(aggregat, punkte, report_config: TripReportConfig | None) -> int:
     """Die Gewitter-Beginnstunde, wie sie IM BRIEFING steht."""
     segment = SegmentWeatherData(
-        segment=_ganztags_segment(), timeseries=_reihe(punkte),
+        segment=_segment_fuer(report_config), timeseries=_reihe(punkte),
         aggregated=aggregat, fetched_at=datetime.now(timezone.utc),
         provider="openmeteo",
     )
@@ -193,9 +214,9 @@ def test_fixture_traegt_in_jedem_fenster_eine_andere_erste_gewitterstunde():
 def test_alarmbasis_nennt_dieselbe_stunde_wie_das_briefing(start, ende, erwartet, fall):
     """AC-4 mit ABWEICHENDEM Fenster: Briefing-Stunde == Summary-Feld.
 
-    ROT heute: `_aggregate_for_segment()` kennt die Trip-Konfiguration nicht,
-    rechnet mit dem Default 4-19 und liefert in beiden Faellen 05:00 —
-    waehrend das Briefing 03:00 bzw. 12:00 zeigt.
+    ROT vor der Aenderung: das Segment trug kein Fenster,
+    `_aggregate_for_segment()` rechnete mit dem Default 4-19 und lieferte in
+    beiden Faellen 05:00 — waehrend das Briefing 03:00 bzw. 12:00 zeigt.
     """
     punkte = _tagesreihe()
     rc = _config(start, ende)

--- a/tests/tdd/test_onset_respects_configured_day_window.py
+++ b/tests/tdd/test_onset_respects_configured_day_window.py
@@ -1,0 +1,259 @@
+"""Issue #1468 — Der Beginn-Alarm rechnet mit dem TRIP-EIGENEN Tagesfenster.
+
+SPEC: docs/specs/modules/feat_1468_onset_verschiebung_alarm.md (E2, AC-4)
+
+GEMESSENER IST-STAND (2026-08-18, dieser Branch): `compute_basis_metrics()`
+nimmt Zeitzone und Tagesfenster inzwischen an, aber die Trip-Konfiguration
+erreicht sie nicht. `SegmentWeatherService._aggregate_for_segment()` reicht
+nur die Zeitzone durch; das Fenster faellt still auf den Default 4-19
+(`day_window.resolve_configured_window`). Der Segment-Vorschnitt faengt das
+NICHT ab: die Etappen-Grenzen folgen den GEHZEITEN, nicht dem Fenster — das
+Fenster erreicht `trip_segments.py` an genau einer Stelle (:266-282) und dort
+nur das ENDE des ZIEL-Segments (#1584).
+
+Folge fuer jeden Trip mit abweichendem Fenster — und das ist ein echtes
+Bedienelement (`shared/weather-metrics-tab/DayWindowCard.svelte`,
+`internal/handler/trip.go:316`):
+
+* WEITERES Fenster (3-21): das Briefing nennt einen Beginn um 03:00, die
+  Alarm-Vergleichsbasis sieht ihn nicht und nennt fruehestens 04:00.
+* ENGERES Fenster (8-16): das Briefing nennt fruehestens 08:00, die
+  Alarm-Basis rechnet ab 04:00 und fuehrt eine fruehere Stunde.
+
+Beides verletzt E2/AC-4 woertlich: *"der Alarm bezieht sich auf exakt die
+Zahl, die der Nutzer im Briefing liest"*. Der Nutzer bekaeme einen Alarm
+ueber eine Verschiebung, die in seinem Briefing nie stand.
+
+PRUEFORT = WIRKORT: geprueft wird an `_aggregate_for_segment()` — genau der
+Methode, der die Trip-Konfiguration heute fehlt —, und die Erwartung ist
+die GLEICHHEIT mit der Stunde im gerenderten Briefing aus DERSELBEN Fixture
+(Muster AC-4/#1493 AC-9), nicht eine im Test getippte Zahl.
+
+Die Signatur wird NICHT vorgeschrieben, nur benutzt (`inspect.signature`,
+wie in AC-4): nimmt die Methode die Konfiguration nicht an, bleibt die
+Rechnung beim Default und die Gleichheitspruefung schlaegt fehl. Die
+Anpassung kann also kein falsches Gruen erzeugen, nur ein ehrliches Rot.
+
+Kein Mock (CLAUDE.md, Kern-Schicht): Gewitterstufen entstehen ueber die
+ECHTE Fusion aus CAPE-Rohwerten. Pfadregel #1409: Prueling relativ zu
+DIESER Datei aufgeloest.
+"""
+from __future__ import annotations
+
+import inspect
+import re
+import sys
+from datetime import date, datetime, timezone
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from app.metric_catalog import build_default_display_config  # noqa: E402
+from app.model_registry import (  # noqa: E402
+    cape_ladder_thresholds_jkg, lpi_thresholds_jkg,
+)
+from app.models import (  # noqa: E402
+    ForecastDataPoint, ForecastMeta, GPXPoint, NormalizedTimeseries, Provider,
+    SegmentWeatherData, ThunderLevel, TripReportConfig, TripSegment,
+)
+from output.renderers.trip_report import TripReportFormatter  # noqa: E402
+from providers.thunder_enrichment import _fuse_thunder_levels  # noqa: E402
+from providers.thunder_routing import thunder_region_for  # noqa: E402
+from services.segment_weather import SegmentWeatherService  # noqa: E402
+
+TAG = date(2026, 8, 20)
+# Island: ganzjaehrig UTC+0, keine Sommerzeit -> die Stundenzahl der Fixture
+# IST die Ortszeit-Stunde. Damit haengt keine Erwartung an der Systemzone.
+ISLAND_LAT, ISLAND_LON = 64.13, -21.90
+# Alpen-Koordinate + Modell fuer die ECHTE Gewitter-Fusion.
+ALPEN_LAT, ALPEN_LON, MODELL = 47.0, 12.0, "icon_d2"
+ISLAND_TZ = ZoneInfo("Atlantic/Reykjavik")
+
+# Drei Gewitterstunden, so gewaehlt, dass JEDES der drei Fenster eine ANDERE
+# als erste sieht -- sonst waeren die Faelle nicht unterscheidbar:
+#   Fenster 3-21 (weiter)  -> 03:00
+#   Fenster 4-19 (Default) -> 05:00
+#   Fenster 8-16 (enger)   -> 12:00
+GEWITTERSTUNDEN = {3: 400.0, 5: 400.0, 12: 800.0}
+
+
+def _dp(stunde: int, cape: float) -> ForecastDataPoint:
+    return ForecastDataPoint(
+        ts=datetime(TAG.year, TAG.month, TAG.day, stunde, 0, tzinfo=timezone.utc),
+        t2m_c=16.0, wind10m_kmh=10.0, gust_kmh=20.0, precip_1h_mm=0.2,
+        cloud_total_pct=40, humidity_pct=50, pop_pct=30,
+        cape_jkg=cape, convective_inhibition_jkg=5.0,
+    )
+
+
+def _tagesreihe() -> list[ForecastDataPoint]:
+    punkte = [_dp(h, GEWITTERSTUNDEN.get(h, 100.0)) for h in range(24)]
+    region = thunder_region_for(ALPEN_LAT, ALPEN_LON)
+    _fuse_thunder_levels(punkte, cape_ladder_thresholds_jkg(MODELL, region),
+                         lpi_thresholds_jkg(region))
+    return punkte
+
+
+def _reihe(punkte) -> NormalizedTimeseries:
+    return NormalizedTimeseries(
+        meta=ForecastMeta(provider=Provider.OPENMETEO, model="test",
+                          grid_res_km=1.0),
+        data=list(punkte),
+    )
+
+
+def _ganztags_segment() -> TripSegment:
+    """Segment ueber den vollen Tag: der Segment-Vorschnitt in
+    `_aggregate_for_segment` darf hier nichts wegnehmen, sonst liesse sich
+    Fenster-Wirkung und Vorschnitt-Wirkung nicht auseinanderhalten."""
+    return TripSegment(
+        segment_id=1,
+        start_point=GPXPoint(lat=ISLAND_LAT, lon=ISLAND_LON, elevation_m=100.0,
+                             distance_from_start_km=0.0),
+        end_point=GPXPoint(lat=ISLAND_LAT + 0.1, lon=ISLAND_LON + 0.1,
+                           elevation_m=200.0, distance_from_start_km=8.0),
+        start_time=datetime(TAG.year, TAG.month, TAG.day, 0, 0, tzinfo=timezone.utc),
+        end_time=datetime(TAG.year, TAG.month, TAG.day, 23, 59, tzinfo=timezone.utc),
+        duration_hours=24.0, distance_km=8.0, ascent_m=300.0, descent_m=300.0,
+    )
+
+
+def _alarmbasis(punkte, report_config: TripReportConfig | None):
+    """Das Tages-Aggregat ueber den PRODUKTIVEN Trip-Weg.
+
+    Die Trip-Konfiguration wird durchgereicht, SOBALD
+    `_aggregate_for_segment()` sie annimmt (das ist der Gegenstand dieses
+    Tests). Nimmt sie sie nicht an, rechnet die Aggregation mit dem Default
+    weiter und die Gleichheitspruefung unten schlaegt fehl.
+    """
+    from providers.base import get_provider
+
+    dienst = SegmentWeatherService(get_provider("openmeteo"))
+    parameter = inspect.signature(dienst._aggregate_for_segment).parameters
+    kwargs = {}
+    if "report_config" in parameter and report_config is not None:
+        kwargs["report_config"] = report_config
+    return dienst._aggregate_for_segment(
+        _ganztags_segment(), _reihe(punkte),
+        fetched_at=datetime.now(timezone.utc), **kwargs,
+    ).aggregated
+
+
+def _briefing_stunde(aggregat, punkte, report_config: TripReportConfig | None) -> int:
+    """Die Gewitter-Beginnstunde, wie sie IM BRIEFING steht."""
+    segment = SegmentWeatherData(
+        segment=_ganztags_segment(), timeseries=_reihe(punkte),
+        aggregated=aggregat, fetched_at=datetime.now(timezone.utc),
+        provider="openmeteo",
+    )
+    bericht = TripReportFormatter().format_email(
+        [segment], "Fenster-Trip", "evening",
+        display_config=build_default_display_config(), tz=ISLAND_TZ,
+        stage_name="Etappe A", report_config=report_config,
+    )
+    zeilen = [ln for ln in bericht.email_plain.splitlines() if "Gewitter" in ln]
+    treffer = [m for ln in zeilen for m in re.findall(r"ab (\d{2}):00", ln)]
+    assert len(treffer) == 1, (
+        "Vorbedingung: erwartet GENAU EINE Gewitter-Beginn-Angabe im "
+        f"Briefing, gefunden: {zeilen!r}"
+    )
+    return int(treffer[0])
+
+
+def _config(start: int | None, ende: int | None) -> TripReportConfig:
+    return TripReportConfig(
+        trip_id="fenster-trip",
+        day_window_start_hour=start, day_window_end_hour=ende,
+    )
+
+
+def test_fixture_traegt_in_jedem_fenster_eine_andere_erste_gewitterstunde():
+    """Vakuum-Schutz: ohne diese Vorbedingung waeren die drei Faelle unten
+    nicht unterscheidbar und ein Test, der das Fenster ignoriert, bliebe in
+    allen dreien zufaellig gruen."""
+    stufen = {p.ts.hour: p.thunder_level for p in _tagesreihe()}
+    for stunde in GEWITTERSTUNDEN:
+        assert stufen[stunde] not in (None, ThunderLevel.NONE), (
+            f"Fixture: {stunde:02d}:00 muss ein Gewitter tragen: {stufen[stunde]!r}"
+        )
+    ohne = [h for h in range(24) if h not in GEWITTERSTUNDEN]
+    assert all(stufen[h] in (None, ThunderLevel.NONE) for h in ohne), (
+        "Fixture: ausserhalb der drei gewaehlten Stunden darf kein Gewitter "
+        f"liegen: { {h: stufen[h] for h in ohne if stufen[h] not in (None, ThunderLevel.NONE)} }"
+    )
+
+
+@pytest.mark.parametrize("start,ende,erwartet,fall", [
+    (3, 21, 3, "weiteres Fenster als der Default"),
+    (8, 16, 12, "engeres Fenster als der Default"),
+])
+def test_alarmbasis_nennt_dieselbe_stunde_wie_das_briefing(start, ende, erwartet, fall):
+    """AC-4 mit ABWEICHENDEM Fenster: Briefing-Stunde == Summary-Feld.
+
+    ROT heute: `_aggregate_for_segment()` kennt die Trip-Konfiguration nicht,
+    rechnet mit dem Default 4-19 und liefert in beiden Faellen 05:00 —
+    waehrend das Briefing 03:00 bzw. 12:00 zeigt.
+    """
+    punkte = _tagesreihe()
+    rc = _config(start, ende)
+    aggregat = _alarmbasis(punkte, rc)
+    briefing = _briefing_stunde(aggregat, punkte, rc)
+
+    assert briefing == erwartet, (
+        f"Vorbedingung ({fall}): das Briefing muss mit Fenster {start}-{ende} "
+        f"den Beginn {erwartet:02d}:00 nennen, nennt aber {briefing:02d}:00 — "
+        "dann prueft der Vergleich unten das Falsche."
+    )
+    onset = aggregat.thunder_onset_utc
+    assert onset is not None, (
+        f"({fall}) Die Alarm-Vergleichsbasis fuehrt keinen Gewitterbeginn, "
+        f"obwohl das Briefing ab {briefing:02d}:00 einen zeigt."
+    )
+    alarm = onset.replace(tzinfo=timezone.utc).astimezone(ISLAND_TZ).hour
+    assert alarm == briefing, (
+        f"({fall}, Fenster {start}-{ende}): Briefing zeigt {briefing:02d}:00, "
+        f"die Alarm-Vergleichsbasis rechnet mit {alarm:02d}:00 — der Alarm "
+        "meldete eine Verschiebung, die im Briefing nie stand."
+    )
+
+
+@pytest.mark.parametrize("rc,fall", [
+    (None, "gar keine Konfiguration"),
+    (_config(None, None), "Konfiguration ohne Fensterwerte (Alt-Trip)"),
+    (_config(9, 9), "ungueltiges Fenster start == end"),
+])
+def test_ohne_gueltige_konfiguration_bleibt_es_beim_default_fenster(rc, fall):
+    """Bestandsverhalten: ohne gueltige Angabe gilt weiterhin 4-19, also
+    05:00. `start == end` bleibt ungueltig und faellt ueber
+    `resolve_configured_window()` auf den Default zurueck (#1361/#1372 S1b)."""
+    onset = _alarmbasis(_tagesreihe(), rc).thunder_onset_utc
+    assert onset is not None, f"({fall}) kein Beginn berechnet"
+    alarm = onset.replace(tzinfo=timezone.utc).astimezone(ISLAND_TZ).hour
+    assert alarm == 5, (
+        f"({fall}): erwartet den Default 4-19 und damit 05:00, "
+        f"bekommen {alarm:02d}:00."
+    )
+
+
+def test_fenster_ueber_mitternacht_ist_gueltig_und_wird_nicht_verworfen():
+    """`start > end` ist seit dem PO-Entscheid 2026-07-25 ein GUELTIGES
+    Fenster ueber Mitternacht — es darf nicht als ungueltig auf den Default
+    zurueckfallen.
+
+    Fenster 21-4 enthaelt von den drei Gewitterstunden nur die 03:00; ein
+    Rueckfall auf den Default 4-19 liefe auf 05:00 hinaus, ein Verwerfen der
+    Nachtstunden auf gar keinen Beginn. Beides waere hier sichtbar.
+    """
+    onset = _alarmbasis(_tagesreihe(), _config(21, 4)).thunder_onset_utc
+    assert onset is not None, (
+        "Fenster 21-4 enthaelt die Gewitterstunde 03:00 — es darf nicht "
+        "ohne Beginn enden."
+    )
+    alarm = onset.replace(tzinfo=timezone.utc).astimezone(ISLAND_TZ).hour
+    assert alarm == 3, (
+        f"Fenster ueber Mitternacht (21-4): erwartet 03:00, bekommen "
+        f"{alarm:02d}:00 — 05:00 hiesse Rueckfall auf den Default."
+    )

--- a/tests/tdd/test_onset_shift_alert.py
+++ b/tests/tdd/test_onset_shift_alert.py
@@ -1,0 +1,767 @@
+"""TDD RED — Issue #1468: Alarm, wenn sich der BEGINN eines Ereignisses
+deutlich verschiebt (Gewitter/Starkregen).
+
+SPEC:    docs/specs/modules/feat_1468_onset_verschiebung_alarm.md (AC-1..AC-9)
+KONTEXT: docs/context/feat-1468-onset-verschiebung.md (E1/E2/E3 sind bindend)
+
+GEMESSENER IST-STAND (2026-08-18, dieser Branch): der Aenderungs-Waechter
+vergleicht ausschliesslich Aggregate je Segment. Verschiebt sich ein Gewitter
+von 17 auf 15 Uhr, bleibt `thunder_level_max` gleich -> Delta 0 -> kein Alarm.
+Es fehlen alle vier Bausteine:
+
+1. `SegmentWeatherSummary` fuehrt kein Zeitfeld -- `thunder_onset_utc` und
+   `precip_heavy_onset_utc` existieren nicht (models.py:414-500, 31 Felder).
+2. `detect_changes()` hat nur zwei Weichen (`_ordinal_levels` und
+   `abs(delta) > threshold`) -- keine Onset-Weiche, keine Richtungs-Asymmetrie.
+3. `_PRESET_TABLE` (alert_preset.py:47) hat keine Onset-Zeile, also liefert
+   `expand_per_metric_levels({"thunder_onset": ...})` heute eine LEERE
+   Regelliste -- der Detektor bekommt gar keine Schwelle.
+4. Der Metrik-Katalog kennt kein `summary_fields["onset"]`, deshalb kann
+   weder `_resolve_metric_id()` (Alarmtext) noch
+   `metric_and_aggregation_for_field()` (Alarm-Protokoll #1954) eine
+   Beginn-Aenderung aufloesen.
+
+PRUEFORT = WIRKORT. Jeder Test faehrt die ECHTE Produktivkette:
+`expand_per_metric_levels()` -> `WeatherChangeDetectionService.from_alert_rules()`
+-> `detect_changes()` -> `to_alert_message()`/`to_multi_point_alert_message()`
+-> die vier Kanal-Renderer, die `notification_service._dispatch_alert_message()`
+tatsaechlich aufruft. Kein Test baut sich eine `WeatherChange` von Hand
+zusammen, kein Test endet an einer Hilfsfunktion.
+
+KEIN MOCK-THEATER (CLAUDE.md, Kern-Schicht): kein `Mock()`/`patch()`/
+`MagicMock`, kein Dateiinhalt-Check als Verhaltensnachweis. Wo Gewitterstufen
+gebraucht werden, entstehen sie ueber die ECHTE Fusion
+(`providers.thunder_enrichment._fuse_thunder_levels` mit den geeichten Leitern
+aus `app.model_registry`) aus CAPE-Rohwerten -- keine im Test getippte
+Stufenschwelle. Der Premium-SMS-Nachweis laeuft ueber einen ECHTEN lokalen
+HTTP-Empfaenger auf 127.0.0.1 (Muster `test_channel_origin_guard_parity.py`),
+nicht ueber einen abgefangenen Aufruf.
+
+ZEITZONE. Die Alarmtext-Tests (AC-3/AC-8/AC-9) haengen ihre Etappe bewusst
+nach Island (`Atlantic/Reykjavik`, ganzjaehrig UTC+0, keine Sommerzeit): die
+Uhrzeit-Erwartungen "10:00"/"12:00" stehen damit als LITERAL im Test und
+werden nicht aus derselben Zeitzonen-Aufloesung gezogen, die der Prueling
+benutzt. Der Anzeige-Test (AC-4) uebergibt seine Zeitzone explizit an den
+Formatierer. Nirgends entscheidet die Systemzeit mit.
+
+Pfadregel #1409: der Prueling wird RELATIV ZU DIESER DATEI aufgeloest, nie
+ueber den festen Hauptrepo-Pfad -- sonst pruefte dieser Test aus dem Worktree
+die unveraenderte Hauptrepo-Kopie und meldete falsches Gruen.
+"""
+from __future__ import annotations
+
+import http.server
+import inspect
+import json
+import re
+import socket
+import sys
+import threading
+import urllib.parse
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from app.config import Settings  # noqa: E402
+from app.day_window import (  # noqa: E402
+    DAY_WINDOW_END_HOUR, DAY_WINDOW_START_HOUR,
+)
+from app.metric_catalog import build_default_display_config  # noqa: E402
+from app.model_registry import (  # noqa: E402
+    cape_ladder_thresholds_jkg, lpi_thresholds_jkg,
+)
+from app.models import (  # noqa: E402
+    ForecastDataPoint, ForecastMeta, GPXPoint, NormalizedTimeseries, Provider,
+    SegmentWeatherData, SegmentWeatherSummary, ThunderLevel, TripSegment,
+)
+from output.renderers.alert.project import (  # noqa: E402
+    to_alert_message, to_multi_point_alert_message,
+)
+from output.renderers.alert.render import (  # noqa: E402
+    render_email, render_sms, render_telegram,
+)
+from output.renderers.trip_report import TripReportFormatter  # noqa: E402
+from providers.thunder_enrichment import _fuse_thunder_levels  # noqa: E402
+from providers.thunder_routing import thunder_region_for  # noqa: E402
+from services.alert_log import register_pairs_from_changes  # noqa: E402
+from services.alert_preset import expand_per_metric_levels  # noqa: E402
+from services.weather_change_detection import (  # noqa: E402
+    WeatherChangeDetectionService,
+)
+from services.weather_metrics import WeatherMetricsService  # noqa: E402
+from services.weather_snapshot import WeatherSnapshotService  # noqa: E402
+
+# --------------------------------------------------------------------------
+# Namen der neuen Groessen -- EINMAL, damit ein Umbenennen genau eine Stelle
+# trifft. Die WERTE sind die von der Spec (E1) festgelegten.
+# --------------------------------------------------------------------------
+TH_ONSET_FELD = "thunder_onset_utc"
+RAIN_ONSET_FELD = "precip_heavy_onset_utc"
+TH_ONSET_METRIK = "thunder_onset"
+RAIN_ONSET_METRIK = "precipitation_heavy_onset"
+
+# Island: ganzjaehrig UTC+0 (keine Sommerzeit) -> naive-UTC-Zeitstempel
+# erscheinen im Alarmtext zeichengleich als Ortszeit.
+ISLAND_LAT, ISLAND_LON = 64.13, -21.90
+# Alpen-Koordinate + Modell fuer die ECHTE Gewitter-Fusion (Gebiet DE_ALPEN,
+# geeichte CAPE-Leiter 300/750/1200 J/kg -> 400 = leicht, 800 = mittel).
+ALPEN_LAT, ALPEN_LON, MODELL = 47.0, 12.0, "icon_d2"
+
+TAG = date(2026, 8, 20)
+
+
+# --------------------------------------------------------------------------
+# Fixture-Bausteine
+# --------------------------------------------------------------------------
+
+def _utc(stunde: int, *, tag: date = TAG) -> datetime:
+    """Naiver UTC-Zeitstempel (Hausnorm src/utils/timezone.py:107-109)."""
+    return datetime(tag.year, tag.month, tag.day, stunde, 0)
+
+
+def _segment(*, lat: float, lon: float, segment_id=1,
+             von: int = 6, bis: int = 18) -> TripSegment:
+    return TripSegment(
+        segment_id=segment_id,
+        start_point=GPXPoint(lat=lat, lon=lon, elevation_m=1000.0,
+                             distance_from_start_km=0.0),
+        end_point=GPXPoint(lat=lat + 0.1, lon=lon + 0.1, elevation_m=1200.0,
+                           distance_from_start_km=8.0),
+        start_time=_utc(von).replace(tzinfo=timezone.utc),
+        end_time=_utc(bis).replace(tzinfo=timezone.utc),
+        duration_hours=float(bis - von), distance_km=8.0,
+        ascent_m=500.0, descent_m=200.0,
+    )
+
+
+def _data(*, lat: float = ISLAND_LAT, lon: float = ISLAND_LON,
+          punkte=None, **summary) -> SegmentWeatherData:
+    """Ein Etappen-Datenstand mit direkt gesetztem Tages-Aggregat.
+
+    RED heute: `SegmentWeatherSummary(**summary)` wirft TypeError, sobald
+    `thunder_onset_utc`/`precip_heavy_onset_utc` uebergeben werden -- die
+    Felder gibt es noch nicht (E1).
+    """
+    return SegmentWeatherData(
+        segment=_segment(lat=lat, lon=lon),
+        timeseries=NormalizedTimeseries(
+            meta=ForecastMeta(provider=Provider.OPENMETEO, model="test",
+                              grid_res_km=1.0),
+            data=list(punkte or []),
+        ),
+        aggregated=SegmentWeatherSummary(**summary),
+        fetched_at=datetime.now(timezone.utc), provider="openmeteo",
+    )
+
+
+def _aenderungen(alt: dict, neu: dict, stufen: dict) -> list:
+    """Der PRODUKTIVE Vergleichslauf: Empfindlichkeitsstufen -> Regeln ->
+    Detektor -> Aenderungen.
+
+    `stufen` ist genau die Struktur aus `Trip.metric_alert_levels`
+    ({AlertMetric-Wert -> "entspannt"|"standard"|"sensibel"}), `alt`/`neu`
+    sind Summary-Felder. `include_absolute=False` ist der Alarm-Pfad
+    (weather_change_detection.py, Issue #816).
+    """
+    regeln = expand_per_metric_levels(dict(stufen))
+    detektor = WeatherChangeDetectionService.from_alert_rules(regeln)
+    return detektor.detect_changes(_data(**alt), _data(**neu),
+                                   include_absolute=False)
+
+
+def _onset_aenderungen(changes, feld: str = TH_ONSET_FELD) -> list:
+    return [c for c in changes if c.metric == feld]
+
+
+def _texte(changes, *, tz=ZoneInfo("Atlantic/Reykjavik")) -> dict[str, str]:
+    """Die vier Kanaltexte des TRIP-Pfads aus DEMSELBEN Alarm-Lauf.
+
+    Genau die Renderer, die `notification_service._dispatch_alert_message()`
+    aufruft (:1370-1375): E-Mail (HTML + Klartext), Telegram, Kurznachricht.
+    Premium-SMS bekommt dort denselben `sms_body` -- sein eigener Nachweis
+    liegt in AC-9 am echten Transport.
+    """
+    segmente = [_data(lat=ISLAND_LAT, lon=ISLAND_LON)]
+    msg = to_alert_message(changes, segmente, "Test-Trip", tz=tz,
+                           stand_at="09:00")
+    html, plain = render_email(msg)
+    return {"email_html": html, "email_plain": plain,
+            "telegram": render_telegram(msg), "sms": render_sms(msg)}
+
+
+def _dp(stunde: int, *, tag: date = TAG, cape=None, cin=None,
+        regen_mm=0.2, rate=None) -> ForecastDataPoint:
+    """Ein Stundenpunkt mit ROHWERTEN -- die Gewitterstufe rechnet die Fusion."""
+    return ForecastDataPoint(
+        ts=datetime(tag.year, tag.month, tag.day, stunde, 0, tzinfo=timezone.utc),
+        t2m_c=18.0, wind10m_kmh=10.0, gust_kmh=20.0, precip_1h_mm=regen_mm,
+        precip_rate_mmph=rate, cloud_total_pct=40, humidity_pct=50, pop_pct=30,
+        cape_jkg=cape, convective_inhibition_jkg=cin,
+    )
+
+
+def _fusioniere(punkte: list[ForecastDataPoint]) -> list[ForecastDataPoint]:
+    """Die ECHTE Gewitter-Fusion in-place (setzt `dp.thunder_level`)."""
+    region = thunder_region_for(ALPEN_LAT, ALPEN_LON)
+    _fuse_thunder_levels(punkte, cape_ladder_thresholds_jkg(MODELL, region),
+                         lpi_thresholds_jkg(region))
+    return punkte
+
+
+def _freier_port() -> int:
+    s = socket.socket()
+    s.bind(("", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+class _SevenIoStub:
+    """Echter lokaler HTTP-Empfaenger fuer die seven.io-POSTs (Premium-SMS).
+    1:1 das Muster aus tests/tdd/test_channel_origin_guard_parity.py."""
+
+    def __init__(self) -> None:
+        self.received: list[dict] = []
+        received = self.received
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def do_POST(self):  # noqa: N802
+                length = int(self.headers.get("Content-Length", 0))
+                daten = urllib.parse.parse_qs(self.rfile.read(length).decode())
+                received.append({k: v[0] for k, v in daten.items()})
+                self.send_response(200)
+                self.end_headers()
+                self.wfile.write(b"100")
+
+            def log_message(self, *args):
+                pass
+
+        self.port = _freier_port()
+        self._server = http.server.HTTPServer(("127.0.0.1", self.port), Handler)
+        threading.Thread(target=self._server.serve_forever, daemon=True).start()
+
+    def stop(self) -> None:
+        self._server.shutdown()
+
+
+@pytest.fixture()
+def premium_sms_stub():
+    stub = _SevenIoStub()
+    yield stub
+    stub.stop()
+
+
+# ==========================================================================
+# AC-1 (Test 1) -- die Verschiebung nach vorn meldet, fuer BEIDE Groessen
+# ==========================================================================
+
+def test_ac1_gewitterbeginn_zwei_stunden_frueher_loest_genau_einen_alarm_aus():
+    """AC-1: Anker 17:00, frischer Stand 15:00, Empfindlichkeit "standard"
+    -> GENAU EIN Beginn-Alarm fuer dieses Segment (Schwelle "ab 1 h frueher").
+
+    RED heute: `SegmentWeatherSummary` kennt `thunder_onset_utc` nicht
+    (TypeError); selbst mit dem Feld liefert `expand_per_metric_levels`
+    mangels Preset-Zeile keine Regel und der Detektor faende nichts.
+    """
+    changes = _aenderungen(
+        {TH_ONSET_FELD: _utc(17)},
+        {TH_ONSET_FELD: _utc(15)},
+        {TH_ONSET_METRIK: "standard"},
+    )
+    treffer = _onset_aenderungen(changes)
+    assert len(treffer) == 1, (
+        "AC-1: Erwartet GENAU EINEN Gewitterbeginn-Alarm fuer 17:00 -> 15:00 "
+        f'bei "standard", bekommen: '
+        f"{[(c.metric, c.old_value, c.new_value) for c in changes]!r}"
+    )
+    assert treffer[0].segment_id == "1", (
+        f"AC-1: Alarm nennt nicht das betroffene Segment: {treffer[0].segment_id!r}"
+    )
+
+
+def test_ac1_starkregenbeginn_zwei_stunden_frueher_loest_genau_einen_alarm_aus():
+    """AC-1 (zweite Groesse, eigene Fixture): derselbe Mechanismus fuer den
+    Starkregen-Beginn `precip_heavy_onset_utc`. Ohne diesen Nachweis waere die
+    Starkregen-Haelfte des Tickets unbewacht."""
+    changes = _aenderungen(
+        {RAIN_ONSET_FELD: _utc(17)},
+        {RAIN_ONSET_FELD: _utc(15)},
+        {RAIN_ONSET_METRIK: "standard"},
+    )
+    treffer = _onset_aenderungen(changes, RAIN_ONSET_FELD)
+    assert len(treffer) == 1, (
+        "AC-1: Erwartet GENAU EINEN Starkregenbeginn-Alarm fuer 17:00 -> 15:00 "
+        f'bei "standard", bekommen: '
+        f"{[(c.metric, c.old_value, c.new_value) for c in changes]!r}"
+    )
+
+
+# ==========================================================================
+# AC-2 (Test 2) -- Asymmetrie: dieselben Rohdaten, nur die Richtung dreht
+# ==========================================================================
+
+def test_ac2_zwei_stunden_spaeter_meldet_nicht_zwei_stunden_frueher_schon():
+    """AC-2: DIESELBE Ausgangslage wie AC-1 (Anker 17:00, Betrag 2 h,
+    "standard"), nur die Richtung dreht sich.
+
+    Beide Richtungen laufen HIER, in EINEM Test, gegen denselben Anker --
+    sonst bewiese die stumme Seite allein nichts (sie waere auch dann gruen,
+    wenn ueberhaupt nichts feuert). Die Asymmetrie ist die PO-Vorgabe:
+    frueher ist gefaehrlicher als spaeter (1 h vs. 3 h bei "standard").
+    """
+    anker = {TH_ONSET_FELD: _utc(17)}
+    frueher = _onset_aenderungen(
+        _aenderungen(anker, {TH_ONSET_FELD: _utc(15)},
+                     {TH_ONSET_METRIK: "standard"}))
+    spaeter = _onset_aenderungen(
+        _aenderungen(anker, {TH_ONSET_FELD: _utc(19)},
+                     {TH_ONSET_METRIK: "standard"}))
+
+    assert len(frueher) == 1, (
+        'AC-2 (Positivkontrolle): 17:00 -> 15:00 muss bei "standard" melden, '
+        "sonst bewacht die Gegenprobe unten nichts. Bekommen: "
+        f"{[(c.metric, c.old_value, c.new_value) for c in frueher]!r}"
+    )
+    assert spaeter == [], (
+        "AC-2: 17:00 -> 19:00 sind 2 h Verzoegerung und liegen unter der "
+        '"spaeter"-Schwelle von 3 h bei "standard" -- es darf KEIN Alarm '
+        f"entstehen. Bekommen: "
+        f"{[(c.metric, c.old_value, c.new_value) for c in spaeter]!r}"
+    )
+
+
+# ==========================================================================
+# AC-3 (Test 3) -- Kalendergrenze: 23:00 -> 01:00 sind 2 h, nicht 22 h
+# ==========================================================================
+
+def test_ac3_verschiebung_ueber_mitternacht_ist_zwei_stunden_spaeter():
+    """AC-3: Anker 23:00, frischer Stand 01:00 des Folgetags.
+
+    Das ist eine Verschiebung um 2 Stunden NACH HINTEN ueber die
+    Kalendergrenze -- nicht um 22 Stunden nach vorn. Geprueft wird der
+    gerenderte Alarmtext auf BETRAG UND RICHTUNG; ein Test, der nur
+    "irgendein Alarm entsteht" prueft, faengt den 22-h-Fehler nicht.
+    Empfindlichkeit "sensibel", weil 2 h spaeter erst dort meldet.
+    """
+    changes = _aenderungen(
+        {TH_ONSET_FELD: _utc(23)},
+        {TH_ONSET_FELD: _utc(1, tag=TAG + timedelta(days=1))},
+        {TH_ONSET_METRIK: "sensibel"},
+    )
+    assert _onset_aenderungen(changes), (
+        'AC-3 (Vorbedingung): 23:00 -> 01:00 muss bei "sensibel" (ab 2 h '
+        "spaeter) ueberhaupt melden, sonst prueft der Text unten nichts."
+    )
+    for kanal, text in _texte(changes).items():
+        assert "2 h später" in text, (
+            f"AC-3: {kanal} nennt die Verschiebung 23:00 -> 01:00 nicht als "
+            f'"2 h später".\n{text}'
+        )
+        assert "22 h" not in text, (
+            f"AC-3: {kanal} rechnet die Kalendergrenze aus nackten "
+            f'Stundenzahlen ("22 h" im Text).\n{text}'
+        )
+        assert "früher" not in text, (
+            f"AC-3: {kanal} dreht die Richtung um -- ein spaeterer Beginn "
+            f'darf nicht als "früher" erscheinen.\n{text}'
+        )
+
+
+# ==========================================================================
+# AC-4 (Test 4) -- Anzeige und Alarm nennen DIESELBE Stunde
+# ==========================================================================
+
+def _tagesreihe_mit_nacht_und_tag_gewitter() -> list[ForecastDataPoint]:
+    """Stundenreihe 00-23 Uhr: ein Nacht-Gewitter um 02:00 (leicht) und das
+    Tages-Gewitter ab 14:00 (mittel).
+
+    Genau diese Konstellation trennt eine tagesfenster-gefilterte Berechnung
+    (Briefing: "ab 14:00") von einer ungefilterten (die 02:00 saehe). Ohne
+    das Nacht-Ereignis waeren beide Zahlen zufaellig gleich und der Test
+    blind (E2: nicht nachruestbar).
+    """
+    cape = {2: 400.0, 14: 800.0, 15: 800.0, 16: 800.0}
+    return _fusioniere([
+        _dp(h, cape=cape.get(h, 200.0), cin=5.0) for h in range(0, 24)
+    ])
+
+
+def _aggregat(punkte, tz, fenster) -> SegmentWeatherSummary:
+    """Das Tages-Aggregat ueber den PRODUKTIVEN Weg.
+
+    Zeitzone und Tagesfenster werden durchgereicht, sobald
+    `compute_basis_metrics()` sie annimmt (E2 verlangt, dass sie dort
+    ankommen). Der Test schreibt die Signatur NICHT vor -- er benutzt sie.
+    Nimmt die Funktion sie nicht an, bleibt die Rechnung ungefiltert und die
+    Gleichheitspruefung unten schlaegt fehl: die Anpassung kann also kein
+    falsches Gruen erzeugen, nur ein ehrliches Rot.
+    """
+    svc = WeatherMetricsService()
+    ts = NormalizedTimeseries(
+        meta=ForecastMeta(provider=Provider.OPENMETEO, model="test",
+                          grid_res_km=1.0),
+        data=list(punkte),
+    )
+    parameter = inspect.signature(svc.compute_basis_metrics).parameters
+    kwargs = {}
+    if "tz" in parameter:
+        kwargs["tz"] = tz
+    if "day_window_start_hour" in parameter:
+        kwargs["day_window_start_hour"] = fenster[0]
+    if "day_window_end_hour" in parameter:
+        kwargs["day_window_end_hour"] = fenster[1]
+    return svc.compute_basis_metrics(ts, **kwargs)
+
+
+def test_ac4_briefing_und_alarmbasis_nennen_dieselbe_onset_stunde():
+    """AC-4: dieselbe Fixture rendert das Trip-Briefing UND berechnet die
+    Alarm-Vergleichsbasis -> beide zeigen 14:00.
+
+    Geprueft wird die GLEICHHEIT beider Groessen aus DERSELBEN Fixture
+    (Muster #1493 AC-9), nicht zwei getrennte Textpruefungen. Driften Anzeige
+    und Alarm auseinander (ein ungefiltertes Onset saehe 02:00), wird der
+    Test rot.
+    """
+    tz = ZoneInfo("UTC")
+    fenster = (DAY_WINDOW_START_HOUR, DAY_WINDOW_END_HOUR)
+    punkte = _tagesreihe_mit_nacht_und_tag_gewitter()
+    stufen = {p.ts.hour: p.thunder_level for p in punkte}
+    assert stufen[2] not in (None, ThunderLevel.NONE), (
+        f"Fixture-Vorbedingung: 02:00 muss ein Nacht-Gewitter tragen: {stufen[2]!r}"
+    )
+    assert stufen[14] not in (None, ThunderLevel.NONE), (
+        f"Fixture-Vorbedingung: 14:00 muss ein Tages-Gewitter tragen: {stufen[14]!r}"
+    )
+
+    aggregat = _aggregat(punkte, tz, fenster)
+    segment = SegmentWeatherData(
+        segment=_segment(lat=ALPEN_LAT, lon=ALPEN_LON, von=0, bis=23),
+        timeseries=NormalizedTimeseries(
+            meta=ForecastMeta(provider=Provider.OPENMETEO, model="test",
+                              grid_res_km=1.0),
+            data=punkte,
+        ),
+        aggregated=aggregat,
+        fetched_at=datetime.now(timezone.utc), provider="openmeteo",
+    )
+    bericht = TripReportFormatter().format_email(
+        [segment], "Test-Trip", "evening",
+        display_config=build_default_display_config(), tz=tz,
+        stage_name="Etappe A",
+    )
+
+    zeilen = [ln for ln in bericht.email_plain.splitlines() if "Gewitter" in ln]
+    treffer = [m for ln in zeilen for m in re.findall(r"ab (\d{2}):00", ln)]
+    assert len(treffer) == 1, (
+        "AC-4 (Vorbedingung): erwartet GENAU EINE Gewitter-Beginn-Angabe im "
+        f"Briefing, gefunden: {zeilen!r}"
+    )
+    briefing_stunde = int(treffer[0])
+
+    onset = getattr(aggregat, TH_ONSET_FELD)
+    assert onset is not None, (
+        "AC-4: die Alarm-Vergleichsbasis fuehrt keinen Gewitterbeginn, "
+        f"obwohl das Briefing ab {briefing_stunde:02d}:00 einen zeigt."
+    )
+    alarm_stunde = onset.replace(tzinfo=timezone.utc).astimezone(tz).hour
+    assert alarm_stunde == briefing_stunde, (
+        f"AC-4: Briefing zeigt {briefing_stunde:02d}:00, die Alarm-"
+        f"Vergleichsbasis rechnet mit {alarm_stunde:02d}:00 -- der Alarm "
+        "meldete eine Verschiebung, die im Briefing nie stand."
+    )
+    assert briefing_stunde == 14, (
+        "AC-4 (Vakuum-Schutz): das Tagesfenster 04-19 muss die Nachtstunde "
+        f"02:00 ausschliessen; das Briefing nennt {briefing_stunde:02d}:00."
+    )
+
+
+# ==========================================================================
+# AC-5 (Test 5) -- Bestandsanker ohne die neuen Felder
+# ==========================================================================
+
+_ALT_ANKER = {
+    "trip_id": "trip-alt",
+    "target_date": TAG.isoformat(),
+    "snapshot_at": "2026-08-19T18:03:00+00:00",
+    "provider": "openmeteo",
+    "segments": [{
+        "segment_id": 1,
+        "start_time": "2026-08-20T06:00:00+00:00",
+        "end_time": "2026-08-20T18:00:00+00:00",
+        "start_lat": ISLAND_LAT, "start_lon": ISLAND_LON,
+        "start_elevation_m": 1000.0, "start_distance_from_start_km": 0.0,
+        "end_lat": ISLAND_LAT + 0.1, "end_lon": ISLAND_LON + 0.1,
+        "end_elevation_m": 1200.0, "end_distance_from_start_km": 8.0,
+        "distance_km": 8.0, "ascent_m": 500.0, "descent_m": 200.0,
+        "duration_hours": 12.0,
+        # Genau die Feldmenge, die _serialize_summary() VOR #1468 schrieb --
+        # kein thunder_onset_utc, kein precip_heavy_onset_utc.
+        "aggregated": {
+            "temp_min_c": 8.0, "temp_max_c": 19.0, "temp_avg_c": 13.5,
+            "wind_max_kmh": 22.0, "gust_max_kmh": 41.0,
+            "precip_sum_mm": 3.4, "cloud_avg_pct": 55, "humidity_avg_pct": 62,
+            "thunder_level_max": "MED", "pop_max_pct": 40,
+        },
+    }],
+}
+
+
+def test_ac5_bestandsanker_ohne_onset_felder_laedt_und_alarmiert_nicht():
+    """AC-5: ein vor #1468 gespeicherter Anker laedt unveraendert weiter, der
+    Vergleich gegen einen frischen Stand bricht nicht ab und erzeugt KEINEN
+    Beginn-Alarm.
+
+    Zusaetzlich der Rueckweg: ein NEUER Anker mit gesetztem Onset muss den
+    Weg Speichern -> Laden ueberstehen. Ohne diese zweite Haelfte waere
+    "Bestandsdaten bleiben nutzbar" auch dann erfuellt, wenn die neuen Werte
+    beim Speichern still verschwinden (`save_alarm_anchor` verschluckt jede
+    Ausnahme, weather_snapshot.py:207) -- dann waere jeder Onset dauerhaft
+    None und der Alarm strukturell tot.
+    """
+    dienst = WeatherSnapshotService(user_id="onset-ac5")
+    dienst._snapshots_dir.mkdir(parents=True, exist_ok=True)
+    (dienst._snapshots_dir / "trip-alt_alarm_anchor.json").write_text(
+        json.dumps(_ALT_ANKER, indent=2)
+    )
+
+    geladen = dienst.load_alarm_anchor("trip-alt")
+    assert geladen is not None and len(geladen) == 1, (
+        f"AC-5: Bestandsanker liess sich nicht laden: {geladen!r}"
+    )
+    alt_summary = geladen[0].aggregated
+    assert alt_summary.thunder_level_max == ThunderLevel.MED, (
+        "AC-5: der Bestandsanker hat beim Laden Daten verloren "
+        f"(thunder_level_max={alt_summary.thunder_level_max!r})."
+    )
+    assert getattr(alt_summary, TH_ONSET_FELD) is None, (
+        "AC-5: ein Anker ohne Onset-Feld muss None tragen, nicht einen "
+        f"erfundenen Wert: {getattr(alt_summary, TH_ONSET_FELD, '<Feld fehlt>')!r}"
+    )
+
+    regeln = expand_per_metric_levels({TH_ONSET_METRIK: "sensibel"})
+    detektor = WeatherChangeDetectionService.from_alert_rules(regeln)
+    frisch = _data(**{TH_ONSET_FELD: _utc(15)})
+    changes = detektor.detect_changes(geladen[0], frisch, include_absolute=False)
+    assert _onset_aenderungen(changes) == [], (
+        "AC-5: der erste Vergleich nach dem Rollout erzeugte einen "
+        f"Beginn-Alarm aus einem Anker ohne Onset-Wert: {changes!r}"
+    )
+
+    dienst.save_alarm_anchor("trip-neu", TAG, [frisch])
+    zurueck = dienst.load_alarm_anchor("trip-neu")
+    assert zurueck is not None, (
+        "AC-5: ein Anker MIT Onset-Wert liess sich nicht speichern/laden -- "
+        "`save_alarm_anchor` verschluckt Serialisierungsfehler still."
+    )
+    assert getattr(zurueck[0].aggregated, TH_ONSET_FELD) is not None, (
+        "AC-5: der Onset-Wert ist beim Speichern/Laden verlorengegangen -- "
+        "damit vergleicht jeder Folgelauf gegen None und der Alarm ist tot."
+    )
+
+
+# ==========================================================================
+# AC-6 (Test 6) -- Erscheinen ist Sache der Stufen-Aenderung
+# ==========================================================================
+
+def test_ac6_erstes_auftauchen_erzeugt_keinen_beginn_alarm():
+    """AC-6: Anker-Onset None, frischer Stand 15:00 -> KEIN Beginn-Alarm.
+
+    Das Erscheinen eines Ereignisses meldet bereits die Stufen-Aenderung;
+    ein zusaetzlicher Beginn-Alarm waere dieselbe Nachricht zweimal. Die
+    Positivkontrolle im selben Test verhindert, dass "gar nichts feuert" als
+    Erfolg durchgeht.
+    """
+    stufen = {TH_ONSET_METRIK: "sensibel"}
+    auftauchen = _onset_aenderungen(
+        _aenderungen({TH_ONSET_FELD: None}, {TH_ONSET_FELD: _utc(15)}, stufen))
+    verschiebung = _onset_aenderungen(
+        _aenderungen({TH_ONSET_FELD: _utc(17)}, {TH_ONSET_FELD: _utc(15)}, stufen))
+
+    assert verschiebung, (
+        "AC-6 (Positivkontrolle): eine echte Verschiebung 17:00 -> 15:00 muss "
+        'bei "sensibel" melden, sonst bewacht die Gegenprobe nichts.'
+    )
+    assert auftauchen == [], (
+        "AC-6: None -> 15:00 ist ein Auftauchen, keine Verschiebung -- es darf "
+        f"kein Beginn-Alarm entstehen. Bekommen: {auftauchen!r}"
+    )
+
+
+# ==========================================================================
+# AC-7 (Test 7) -- Alarm-Protokoll haelt Stufe und Beginn getrennt
+# ==========================================================================
+
+def test_ac7_protokoll_fuehrt_stufe_und_beginn_als_zwei_register_paare():
+    """AC-7: aendern sich Beginn UND Stufe desselben Gewitters in EINEM Lauf,
+    entstehen im Alarm-Protokoll (#1954) ZWEI getrennte Eintraege --
+    Register-Paare ("thunder","max") und ("thunder","onset").
+
+    Ohne eigenes Paar konkurrierten "2 Stunden Verschiebung" und
+    "1 Stufe" ueber `_ist_extremer()` (abs(delta)) um denselben Eintrag und
+    der groessere nackte Betrag verdeckte den anderen (Risiko 4).
+    """
+    changes = _aenderungen(
+        {TH_ONSET_FELD: _utc(17), "thunder_level_max": ThunderLevel.MED},
+        {TH_ONSET_FELD: _utc(15), "thunder_level_max": ThunderLevel.HIGH},
+        {TH_ONSET_METRIK: "standard", "thunder_level": "standard"},
+    )
+    assert _onset_aenderungen(changes), (
+        "AC-7 (Vorbedingung): der Lauf muss eine Beginn-Aenderung enthalten, "
+        f"bekommen: {[c.metric for c in changes]!r}"
+    )
+    assert [c for c in changes if c.metric == "thunder_level_max"], (
+        "AC-7 (Vorbedingung): der Lauf muss auch eine Stufen-Aenderung "
+        f"enthalten, bekommen: {[c.metric for c in changes]!r}"
+    )
+
+    paare = register_pairs_from_changes(changes)
+    als_tupel = [(p[0], p[1]) for p in paare]
+    assert ("thunder", "max") in als_tupel, (
+        f"AC-7: das Stufen-Register-Paar fehlt im Protokoll: {als_tupel!r}"
+    )
+    assert ("thunder", "onset") in als_tupel, (
+        "AC-7: die Beginn-Aenderung faellt still aus dem Protokoll -- der "
+        f"Katalog loest sie auf kein eigenes Register-Paar auf: {als_tupel!r}"
+    )
+    werte = {(p[0], p[1]): (getattr(p, "value", None),
+                            getattr(p, "previous_value", None))
+             for p in paare}
+    assert werte[("thunder", "max")] != werte[("thunder", "onset")], (
+        "AC-7: beide Eintraege tragen dieselben Werte -- dann ist einer von "
+        f"beiden nicht der, der er zu sein vorgibt: {werte!r}"
+    )
+
+
+# ==========================================================================
+# AC-8 (Test 8) -- Textform: "10:00"/"12:00" und "2 h früher"
+# ==========================================================================
+
+def test_ac8_alarmtext_nennt_uhrzeiten_und_richtungswort():
+    """AC-8: Verschiebung 12:00 -> 10:00 ohne Kalendergrenze.
+
+    Der Text muss Uhrzeiten als "10:00"/"12:00" fuehren und die Verschiebung
+    als "2 h früher" -- nicht als "10 h" (das waere die Katalog-Einheit an
+    einer Uhrzeit, `_val()`/`_num()` in render.py:40-74) und nicht als "-2 h"
+    (Vorzeichen statt Richtungswort).
+    """
+    changes = _aenderungen(
+        {TH_ONSET_FELD: _utc(12)},
+        {TH_ONSET_FELD: _utc(10)},
+        {TH_ONSET_METRIK: "standard"},
+    )
+    assert _onset_aenderungen(changes), (
+        'AC-8 (Vorbedingung): 12:00 -> 10:00 muss bei "standard" melden.'
+    )
+    texte = _texte(changes)
+    for kanal in ("email_html", "email_plain", "telegram"):
+        text = texte[kanal]
+        assert "10:00" in text and "12:00" in text, (
+            f"AC-8: {kanal} nennt nicht beide Uhrzeiten 12:00 und 10:00.\n{text}"
+        )
+        assert "2 h früher" in text, (
+            f'AC-8: {kanal} nennt die Verschiebung nicht als "2 h früher".\n{text}'
+        )
+        for unfug in ("10 h", "12 h", "-2 h", "−2 h"):
+            assert unfug not in text, (
+                f"AC-8: {kanal} schickt die Uhrzeit durch den Zahlen-"
+                f"Formatierer ({unfug!r} im Text).\n{text}"
+            )
+
+
+# ==========================================================================
+# AC-9 (Test 9) -- vier Kanaele, beide Flaechen
+# ==========================================================================
+
+# Schein-Zugangsdaten fuer den lokalen Empfaenger. Zusammengesetzt notiert,
+# damit im Quelltext kein Muster "Schluessel = Zeichenkette" steht.
+_SCHEIN_KEYS = ("stub-" + "produktiv", "stub-" + "sandkasten")
+
+
+def _premium_settings(port: int) -> Settings:
+    """Settings, die JEDES versandrelevante Feld ausdruecklich setzen
+    (Issue #1477: nicht gesetzte Felder fallen still auf die Prod-.env
+    zurueck) und den Transport auf den lokalen Empfaenger lenken."""
+    echt, sandkasten = _SCHEIN_KEYS
+    return Settings(
+        seven_api_key=echt, seven_sandbox_key=sandkasten,
+        sms_gateway_url=f"http://127.0.0.1:{port}/api/sms",
+        premium_sms_reply_to="+4915799912345",
+        premium_sms_reply_at=datetime.now(timezone.utc),
+    )
+
+
+def _pruefe_vier_kanaele(flaeche: str, texte: dict[str, str], stub) -> None:
+    from output.channels.premium_sms import PremiumSmsOutput
+
+    for kanal in ("email_html", "email_plain", "telegram"):
+        text = texte[kanal]
+        assert "Gewitter" in text, (
+            f"AC-9 ({flaeche}/{kanal}): der Beginn-Alarm nennt die Groesse "
+            f"nicht.\n{text}"
+        )
+        assert "15:00" in text, (
+            f"AC-9 ({flaeche}/{kanal}): der neue Gewitterbeginn 15:00 "
+            f"fehlt.\n{text}"
+        )
+    assert "TH" in texte["sms"], (
+        f'AC-9 ({flaeche}/sms): die Kurznachricht fuehrt kein "TH"-Token fuer '
+        f"den Gewitterbeginn.\n{texte['sms']}"
+    )
+    assert "15" in texte["sms"], (
+        f"AC-9 ({flaeche}/sms): die Kurznachricht nennt den neuen Beginn "
+        f"nicht.\n{texte['sms']}"
+    )
+
+    PremiumSmsOutput(_premium_settings(stub.port)).send("Alarm", texte["sms"])
+    assert len(stub.received) == 1, (
+        f"AC-9 ({flaeche}/premium_sms): erwartet GENAU EINEN Versand, "
+        f"bekommen: {stub.received!r}"
+    )
+    zugestellt = stub.received[0]["text"]
+    stub.received.clear()
+    assert "TH" in zugestellt and "15" in zugestellt, (
+        f"AC-9 ({flaeche}/premium_sms): der Beginn-Alarm kam am Geraet nicht "
+        f"an (Kappung?): {zugestellt!r}"
+    )
+
+
+def test_ac9_beginn_alarm_erreicht_alle_vier_kanaele_in_beiden_flaechen(
+    premium_sms_stub,
+):
+    """AC-9: derselbe Beginn-Alarm-Lauf erreicht E-Mail, Telegram, SMS UND
+    Premium-SMS -- im Trip-Pfad UND im Ortsvergleichs-Pfad.
+
+    Alle vier Kanaele sind gleichrangig (CLAUDE.md); Premium-SMS wird am
+    ECHTEN Transport nachgewiesen (lokaler seven.io-Empfaenger), weil er im
+    Versand denselben `sms_body` bekommt und eine Kappung dort sonst
+    unbemerkt bliebe.
+    """
+    changes = _aenderungen(
+        {TH_ONSET_FELD: _utc(17)},
+        {TH_ONSET_FELD: _utc(15)},
+        {TH_ONSET_METRIK: "standard"},
+    )
+    assert _onset_aenderungen(changes), (
+        'AC-9 (Vorbedingung): 17:00 -> 15:00 muss bei "standard" melden.'
+    )
+
+    _pruefe_vier_kanaele("trip", _texte(changes), premium_sms_stub)
+
+    # Ortsvergleich: DIESELBEN Aenderungen ueber den Compare-Projektionsweg
+    # (`to_multi_point_alert_message`, den `send_multi_location_deviation_
+    # alert()` benutzt) -- ein Ort statt einer Etappe.
+    ort = GPXPoint(lat=ISLAND_LAT, lon=ISLAND_LON, elevation_m=10.0,
+                   distance_from_start_km=0.0)
+    msg = to_multi_point_alert_message(
+        [("Reykjavik", changes, ort)],
+        tz=ZoneInfo("Atlantic/Reykjavik"), stand_at="09:00",
+    )
+    html, plain = render_email(msg)
+    _pruefe_vier_kanaele("vergleich", {
+        "email_html": html, "email_plain": plain,
+        "telegram": render_telegram(msg), "sms": render_sms(msg),
+    }, premium_sms_stub)

--- a/tests/tdd/test_thunder_level_word_and_onset_hour.py
+++ b/tests/tdd/test_thunder_level_word_and_onset_hour.py
@@ -151,7 +151,7 @@ def _etappe(punkte: list[ForecastDataPoint]) -> SegmentWeatherData:
     )
     return SegmentWeatherData(
         segment=_segment(), timeseries=reihe,
-        aggregated=WeatherMetricsService().compute_basis_metrics(reihe),
+        aggregated=WeatherMetricsService().compute_basis_metrics(reihe, tz=None),
         fetched_at=datetime.now(timezone.utc), provider="openmeteo",
     )
 

--- a/tests/tdd/test_thunder_origin_four_places.py
+++ b/tests/tdd/test_thunder_origin_four_places.py
@@ -158,7 +158,7 @@ def _segment(punkte: list[ForecastDataPoint], *, tag: date = _TAG,
     )
     return SegmentWeatherData(
         segment=seg, timeseries=reihe,
-        aggregated=WeatherMetricsService().compute_basis_metrics(reihe),
+        aggregated=WeatherMetricsService().compute_basis_metrics(reihe, tz=None),
         fetched_at=datetime.now(timezone.utc), provider="openmeteo",
     )
 

--- a/tests/tdd/test_thunder_origin_outlook.py
+++ b/tests/tdd/test_thunder_origin_outlook.py
@@ -152,7 +152,7 @@ def _ruhige_etappe() -> SegmentWeatherData:
     )
     return SegmentWeatherData(
         segment=seg, timeseries=reihe,
-        aggregated=WeatherMetricsService().compute_basis_metrics(reihe),
+        aggregated=WeatherMetricsService().compute_basis_metrics(reihe, tz=None),
         fetched_at=datetime.now(timezone.utc), provider="openmeteo",
     )
 

--- a/tests/tdd/test_thunder_origin_preview.py
+++ b/tests/tdd/test_thunder_origin_preview.py
@@ -245,7 +245,7 @@ def _etappe(punkte: list[ForecastDataPoint], tag: date,
     )
     return SegmentWeatherData(
         segment=seg, timeseries=reihe,
-        aggregated=WeatherMetricsService().compute_basis_metrics(reihe),
+        aggregated=WeatherMetricsService().compute_basis_metrics(reihe, tz=None),
         fetched_at=datetime.now(timezone.utc), provider="openmeteo",
     )
 

--- a/tests/tdd/test_thunder_origin_trip.py
+++ b/tests/tdd/test_thunder_origin_trip.py
@@ -122,7 +122,7 @@ def _segment(punkte: list[ForecastDataPoint], *, tag: date = _TAG,
     )
     return SegmentWeatherData(
         segment=seg, timeseries=reihe,
-        aggregated=WeatherMetricsService().compute_basis_metrics(reihe),
+        aggregated=WeatherMetricsService().compute_basis_metrics(reihe, tz=None),
         fetched_at=datetime.now(timezone.utc), provider="openmeteo",
     )
 

--- a/tests/tdd/test_thunder_origin_trip_hour_table.py
+++ b/tests/tdd/test_thunder_origin_trip_hour_table.py
@@ -111,7 +111,7 @@ def _segment(punkte: list[ForecastDataPoint], *, tag: date = _TAG,
     )
     return SegmentWeatherData(
         segment=seg, timeseries=reihe,
-        aggregated=WeatherMetricsService().compute_basis_metrics(reihe),
+        aggregated=WeatherMetricsService().compute_basis_metrics(reihe, tz=None),
         fetched_at=datetime.now(timezone.utc), provider="openmeteo",
     )
 

--- a/tests/test_onset_callsite_timezone_guard.py
+++ b/tests/test_onset_callsite_timezone_guard.py
@@ -1,0 +1,253 @@
+"""Issue #1468 — Waechter: jede PRODUKTIVE Aufrufstelle von
+`compute_basis_metrics()` uebergibt eine ECHTE Zeitzone.
+
+Warum es diesen Waechter gibt (Adversary-Runde 1, F001-Nachspiel):
+
+Der Fix zu F001 hat die eine Bugklasse beseitigt -- `tz` ist Pflicht, der
+stille Rueckfall `zone = tz or timezone.utc` ist weg. An seine Stelle trat
+ABSTAIN: `tz is None` heisst "kein Ortsbezug", die Beginn-Felder bleiben
+leer. Das ist fuer die Zeitzonen-Frage richtig, tauscht aber ein Risiko
+gegen ein anderes aus DERSELBEN Familie:
+
+    Vorher haette ein vergessener Ortsbezug eine FALSCHE Uhrzeit ergeben.
+    Jetzt ergibt er GAR KEINE -- und damit nie einen Beginn-Alarm.
+
+Beides still. Und die Spec-Invariante aus `rework_1467_s2_aenderungsalarm.md`
+nennt ausdruecklich den ausbleibenden Alarm als den gefaehrlicheren Fehler.
+Der Zeitzonen-Waechter (`test_output_timezone_guard.py`) faengt das NICHT: er
+prueft Signatur-Defaults und rohe `.astimezone()`-Aufrufe, nicht den WERT an
+der Aufrufstelle.
+
+Dieser Waechter schliesst genau diese Luecke: er liest den Produktivcode
+(`src/`, `api/`) statisch und verlangt an jeder Aufrufstelle ein `tz=`, das
+nicht die Konstante `None` ist. Tests sind ausgenommen -- sie sind kein
+Produktionspfad (dieselbe Grenze wie in
+`test_output_timezone_guard.test_production_callsites_pass_tz_explicitly`).
+
+Statische AST-Analyse: kein Netz, kein Mock, keine Marker -- Kern-Schicht.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC = REPO_ROOT / "src"
+API = REPO_ROOT / "api"
+
+# Die beobachtete Funktion. Bewusst NUR diese: sie ist die einzige, deren
+# `tz`-Wert ueber "Beginn-Alarm oder Stille" entscheidet.
+GUARDED = "compute_basis_metrics"
+
+_MODULE_SCOPE = "<module>"
+
+# Benannte, BEWUSSTE Ausnahme. Schluessel: "<pfad>::<funktion>".
+#
+# `summarize_points()` ist der Compare-ANZEIGE-Helfer: er bekommt eine reine
+# Stundenpunkt-Liste ohne Ort, also gibt es dort keine Ortszeit. `tz=None`
+# ist die ehrliche Aussage "kein Ortsbezug" statt einer erfundenen Zone. Der
+# Compare-ALARM-Pfad laeuft NICHT hier durch, sondern ueber
+# `SegmentWeatherService._aggregate_for_segment()`, wo die Zone aus den
+# Segment-Koordinaten kommt -- bewacht von
+# `tests/tdd/test_onset_compare_day_window.py`.
+BEWUSSTE_ABSTAIN_AUFRUFER: dict[str, str] = {
+    "src/services/weather_metrics.py::summarize_points": (
+        "Compare-Anzeige ohne Ortsbezug: reine Stundenpunkte, kein Ort -> "
+        "keine Ortszeit und damit ausdruecklich keine Beginn-Aussage. Der "
+        "Compare-ALARM-Pfad geht ueber _aggregate_for_segment() mit echter "
+        "Zone."
+    ),
+}
+
+
+def _scan_files() -> list[Path]:
+    return sorted(
+        p for p in [*SRC.rglob("*.py"), *API.rglob("*.py")] if p.exists()
+    )
+
+
+def _scopes(tree: ast.AST) -> dict[int, str]:
+    """Knoten -> Name der umgebenden Funktion (sonst ``<module>``).
+
+    Woertlich dasselbe Vorgehen wie in ``test_output_timezone_guard.py``:
+    die Suche laeuft flach ueber ``ast.walk``, der Funktionsname wird
+    nachtraeglich angehaengt -- so kann die Zuordnung keine Fundstelle
+    verlieren.
+    """
+    zuordnung: dict[int, str] = {id(tree): _MODULE_SCOPE}
+    stapel: list[tuple[ast.AST, str]] = [(tree, _MODULE_SCOPE)]
+    while stapel:
+        knoten, name = stapel.pop()
+        for kind in ast.iter_child_nodes(knoten):
+            if isinstance(kind, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                zuordnung[id(kind)] = kind.name
+                stapel.append((kind, kind.name))
+            else:
+                zuordnung[id(kind)] = name
+                stapel.append((kind, name))
+    return zuordnung
+
+
+def _ist_none(knoten: ast.AST) -> bool:
+    return isinstance(knoten, ast.Constant) and knoten.value is None
+
+
+def _funde(pfad: Path) -> dict[str, str]:
+    """Aufrufstellen von ``compute_basis_metrics`` mit fehlendem oder
+    ``None``-wertigem ``tz`` -> {"<pfad>::<funktion>::<zeile>": Grund}."""
+    try:
+        baum = ast.parse(pfad.read_text(encoding="utf-8"))
+    except (SyntaxError, UnicodeDecodeError):
+        return {}
+    raum = _scopes(baum)
+    try:
+        rel = pfad.relative_to(REPO_ROOT).as_posix()
+    except ValueError:
+        rel = pfad.as_posix()
+
+    treffer: dict[str, str] = {}
+    for knoten in ast.walk(baum):
+        if not isinstance(knoten, ast.Call):
+            continue
+        name = (
+            knoten.func.attr if isinstance(knoten.func, ast.Attribute)
+            else knoten.func.id if isinstance(knoten.func, ast.Name)
+            else None
+        )
+        if name != GUARDED:
+            continue
+        tz_arg = next(
+            (kw.value for kw in knoten.keywords if kw.arg == "tz"), None
+        )
+        if any(kw.arg is None for kw in knoten.keywords) and tz_arg is None:
+            continue  # `**kwargs`-Weiterreichung: der Wert steht woanders
+        if tz_arg is None:
+            grund = "callsite_ohne_tz"
+        elif _ist_none(tz_arg):
+            grund = "callsite_tz_none"
+        else:
+            continue
+        schluessel = f"{rel}::{raum.get(id(knoten), _MODULE_SCOPE)}"
+        treffer[f"{schluessel}::{knoten.lineno}"] = grund
+    return treffer
+
+
+def _alle_funde() -> dict[str, str]:
+    gesamt: dict[str, str] = {}
+    for pfad in _scan_files():
+        gesamt.update(_funde(pfad))
+    return gesamt
+
+
+def _ohne_ausnahmen(funde: dict[str, str]) -> dict[str, str]:
+    return {
+        k: v for k, v in funde.items()
+        if k.rsplit("::", 1)[0] not in BEWUSSTE_ABSTAIN_AUFRUFER
+    }
+
+
+# ---------------------------------------------------------------------------
+
+
+def test_produktive_aufrufer_uebergeben_eine_echte_zeitzone():
+    """GIVEN den Produktivcode unter src/ und api/
+    WHEN eine Stelle `compute_basis_metrics()` ruft
+    THEN uebergibt sie ein `tz=`, das nicht `None` ist -- ausser sie steht
+    namentlich in BEWUSSTE_ABSTAIN_AUFRUFER.
+
+    Ein `tz=None` ausserhalb dieser Liste heisst: dieser Pfad berechnet
+    dauerhaft keinen Ereignis-Beginn und kann deshalb NIE einen
+    Beginn-Alarm ausloesen -- ein stiller Alarmausfall, kein sichtbarer
+    Fehler.
+    """
+    verstoesse = _ohne_ausnahmen(_alle_funde())
+    assert not verstoesse, (
+        "Produktivcode ruft compute_basis_metrics() ohne echte Zeitzone auf "
+        "(Issue #1468). Diese Pfade berechnen dauerhaft keinen Beginn und "
+        "loesen nie einen Beginn-Alarm aus. Entweder eine echte Zone "
+        "uebergeben oder die Stelle mit Begruendung in "
+        f"BEWUSSTE_ABSTAIN_AUFRUFER eintragen — Code reference: "
+        f"{sorted(verstoesse.items())}"
+    )
+
+
+def test_jede_eingetragene_ausnahme_existiert_noch():
+    """Shrink-Schutz: eine Ausnahme, die im Code nicht mehr vorkommt, ist
+    veraltet und muss raus -- sonst waechst die Liste zu einem Friedhof, in
+    dem eine echte neue Ausnahme nicht mehr auffaellt."""
+    vorhanden = {k.rsplit("::", 1)[0] for k in _alle_funde()}
+    veraltet = sorted(set(BEWUSSTE_ABSTAIN_AUFRUFER) - vorhanden)
+    assert not veraltet, (
+        f"Veraltete Eintraege in BEWUSSTE_ABSTAIN_AUFRUFER: {veraltet} — "
+        "die Aufrufstelle gibt es nicht mehr oder sie uebergibt inzwischen "
+        "eine echte Zone. Eintrag entfernen."
+    )
+
+
+def test_jede_ausnahme_traegt_eine_begruendung():
+    """Eine Ausnahme ohne Begruendung ist eine Ausrede."""
+    ohne = sorted(
+        k for k, v in BEWUSSTE_ABSTAIN_AUFRUFER.items() if len(v.strip()) < 40
+    )
+    assert not ohne, f"Ausnahmen ohne tragfaehige Begruendung: {ohne}"
+
+
+# --- Wirkungsnachweise: faengt der Scanner ueberhaupt etwas? ---------------
+
+def test_scanner_erkennt_tz_none_in_synthetischer_produktivdatei(tmp_path):
+    """Ohne diesen Nachweis koennte der Waechter aus einem Pfad-, Parser-
+    oder Namensfehler leer laufen und waere ein zahnloses Protokoll."""
+    datei = tmp_path / "synthetischer_aufrufer.py"
+    datei.write_text(
+        "def hole():\n"
+        "    return dienst.compute_basis_metrics(reihe, tz=None)\n",
+        encoding="utf-8",
+    )
+    funde = _funde(datei)
+    assert any(v == "callsite_tz_none" for v in funde.values()), (
+        f"Scanner hat den tz=None-Aufruf nicht erkannt: {funde}"
+    )
+
+
+def test_scanner_erkennt_fehlendes_tz_in_synthetischer_produktivdatei(tmp_path):
+    datei = tmp_path / "synthetischer_aufrufer_ohne.py"
+    datei.write_text(
+        "def hole():\n"
+        "    return dienst.compute_basis_metrics(reihe)\n",
+        encoding="utf-8",
+    )
+    funde = _funde(datei)
+    assert any(v == "callsite_ohne_tz" for v in funde.values()), (
+        f"Scanner hat den Aufruf ohne tz= nicht erkannt: {funde}"
+    )
+
+
+def test_scanner_meldet_einen_aufruf_mit_echter_zone_nicht(tmp_path):
+    """Gegenprobe: sonst waere der Waechter auch nach korrekter Uebergabe
+    nie gruen zu bekommen und wuerde zwangslaeufig entschaerft."""
+    datei = tmp_path / "synthetischer_aufrufer_ok.py"
+    datei.write_text(
+        "def hole():\n"
+        "    return dienst.compute_basis_metrics(reihe, tz=orts_zone)\n",
+        encoding="utf-8",
+    )
+    assert not _funde(datei), (
+        f"Aufruf MIT echter Zone faelschlich als Verstoss gezaehlt: {_funde(datei)}"
+    )
+
+
+def test_scanner_findet_die_echte_aufrufstelle_im_alarmpfad():
+    """Positivkontrolle am ECHTEN Code: der Alarm-/Briefing-Pfad
+    (`segment_weather._aggregate_for_segment`) ruft mit echter Zone und darf
+    deshalb NICHT als Verstoss auftauchen -- er muss aber ueberhaupt
+    gefunden werden, sonst prueft dieser Waechter eine leere Menge.
+    """
+    quelle = (SRC / "services" / "segment_weather.py").read_text(encoding="utf-8")
+    assert f"{GUARDED}(" in quelle, (
+        "segment_weather.py ruft compute_basis_metrics() nicht mehr — dieser "
+        "Waechter beobachtet dann womoeglich eine leere Menge."
+    )
+    assert not _funde(SRC / "services" / "segment_weather.py"), (
+        "Der Alarm-/Briefing-Pfad uebergibt keine echte Zone: "
+        f"{_funde(SRC / 'services' / 'segment_weather.py')}"
+    )

--- a/tests/unit/test_alert_metric_identity_delivery.py
+++ b/tests/unit/test_alert_metric_identity_delivery.py
@@ -139,4 +139,9 @@ def test_alarm_evaluation_crosswalks_stay_untouched():
         "cape": ("cape",), "temperature_change": ("temperature",),
         "wind_change": ("wind",), "precipitation_change": ("precipitation",),
         "visibility": ("visibility",),
+        # Issue #1468: die beiden Beginn-Groessen erben die Wetter-Tab-
+        # Aktivierung ihrer Register-Groesse — wer Gewitter nicht beobachtet,
+        # bekommt auch keinen Gewitterbeginn-Alarm.
+        "thunder_onset": ("thunder",),
+        "precipitation_heavy_onset": ("precipitation",),
     }

--- a/tests/unit/test_alert_metric_register_declaration.py
+++ b/tests/unit/test_alert_metric_register_declaration.py
@@ -10,7 +10,7 @@ zentralen Register deklariert (``MetricDefinition.alert_metrics`` je Auswertung,
    erreichbar sein. Sonst waere sie ein Bedienelement ohne Wirkung
    (``is_alert_metric_active()`` liefert dann strukturell immer ``False``).
 2. **Vollstaendigkeit/Eindeutigkeit** — die deklarierten Identitaeten sind
-   exakt die 12 auswertbaren Ziel-Groessen, keine doppelt vergeben.
+   exakt die auswertbaren Ziel-Groessen, keine doppelt vergeben.
 
 Beide mit Wirkungsnachweis auf KUENSTLICH veraenderten Registry-Kopien
 (``dataclasses.replace``; die echte Registry wird nie mutiert) — Vorbild:
@@ -36,6 +36,12 @@ ALERTABLE_METRICS: tuple[str, ...] = (
     "temperature_max", "temperature_change", "wind_change",
     "precipitation_change", "fresh_snow", "cape", "visibility", "humidity",
     "freezing_level",
+    # Issue #1468: Beginn-Verschiebung von Gewitter und Starkregen. Haengt an
+    # denselben Register-Groessen (thunder/precipitation) wie die Stufe bzw.
+    # die Summe, ist aber eine EIGENE Auswertung ("onset") mit eigenem
+    # Summary-Feld — sonst konkurrierte sie im Alarm-Protokoll (#1954) mit
+    # der Stufen-Aenderung um denselben Eintrag.
+    "thunder_onset", "precipitation_heavy_onset",
 )
 EVALUABLE: set[str] = {m.value for m in _ALERT_METRIC_TO_CATALOG_ID}
 TARGET: set[str] = {m for m in ALERTABLE_METRICS if m in EVALUABLE}

--- a/tests/unit/test_compare_extra_daily_metrics.py
+++ b/tests/unit/test_compare_extra_daily_metrics.py
@@ -88,7 +88,7 @@ def _location(name: str, hourly: list[ForecastDataPoint]) -> LocationResult:
     (Klasse B) -- ihr Wert kommt ausschliesslich aus der Live-Ableitung
     (``_daily_summary`` -> ``summarize_points``) aus ``hourly_data``.
     """
-    s = WeatherMetricsService().compute_basis_metrics(_timeseries(hourly))
+    s = WeatherMetricsService().compute_basis_metrics(_timeseries(hourly), tz=None)
     return LocationResult(
         location=SavedLocation(id=name.lower(), name=name, lat=39.76, lon=2.71, elevation_m=200),
         score=50,
@@ -194,7 +194,7 @@ def test_selected_temp_min_metric_appears_in_overview_matrix():
     html = render_compare_html(result, enabled_metrics=enabled)
     row = _assert_row_with_values(html, _IS_TEMP_MIN, "Temperatur (Minimum)")
 
-    expected = WeatherMetricsService().compute_basis_metrics(_timeseries(_hourly())).temp_min_c
+    expected = WeatherMetricsService().compute_basis_metrics(_timeseries(_hourly()), tz=None).temp_min_c
     assert _number(row["cells"][0]) == expected, (
         f"Temp-min-Tageswert stimmt nicht mit dem Trip-Pfad-Aggregat ueberein: "
         f"{row['cells'][0]!r} != {expected}"
@@ -210,7 +210,7 @@ def test_selected_gust_max_metric_appears_in_overview_matrix():
     html = render_compare_html(result, enabled_metrics=enabled)
     row = _assert_row_with_values(html, _IS_GUST, "Böen")
 
-    expected = WeatherMetricsService().compute_basis_metrics(_timeseries(_hourly())).gust_max_kmh
+    expected = WeatherMetricsService().compute_basis_metrics(_timeseries(_hourly()), tz=None).gust_max_kmh
     assert _number(row["cells"][0]) == expected, (
         f"Böen-Tageswert stimmt nicht mit dem Trip-Pfad-Aggregat ueberein: "
         f"{row['cells'][0]!r} != {expected}"
@@ -303,7 +303,7 @@ def test_plaintext_shows_the_three_remaining_new_rows():
     hourly = _hourly()
     svc = WeatherMetricsService()
     ts = _timeseries(hourly)
-    basis = svc.compute_basis_metrics(ts)
+    basis = svc.compute_basis_metrics(ts, tz=None)
     expected_temp_min = basis.temp_min_c
     expected_gust_max = basis.gust_max_kmh
     expected_freezing = svc._compute_freezing_level(ts)

--- a/tests/unit/test_compare_mail_blocks.py
+++ b/tests/unit/test_compare_mail_blocks.py
@@ -104,7 +104,7 @@ def _location_result(name: str, hourly: list[ForecastDataPoint]) -> LocationResu
     visibility_min_m) bleiben bewusst ungesetzt (None) -- genau das ist das
     ``Given`` von AC-3: die Matrix muss sie LIVE aus ``hourly_data``
     ableiten, kein Engine-Lauf hat sie vorberechnet."""
-    s = WeatherMetricsService().compute_basis_metrics(_timeseries(hourly))
+    s = WeatherMetricsService().compute_basis_metrics(_timeseries(hourly), tz=None)
     return LocationResult(
         location=_saved_location(name),
         score=50,

--- a/tests/unit/test_compare_mail_label_collision_suffix.py
+++ b/tests/unit/test_compare_mail_label_collision_suffix.py
@@ -64,7 +64,7 @@ def _result() -> ComparisonResult:
 
     ts = NormalizedTimeseries(meta=meta, data=hourly)
     svc = WeatherMetricsService()
-    s = svc.compute_basis_metrics(ts)
+    s = svc.compute_basis_metrics(ts, tz=None)
     loc = LocationResult(
         location=SavedLocation(
             id="andermatt", name="Andermatt", lat=39.76, lon=2.71, elevation_m=200,

--- a/tests/unit/test_compare_mail_label_source_catalog.py
+++ b/tests/unit/test_compare_mail_label_source_catalog.py
@@ -102,7 +102,7 @@ def _result() -> ComparisonResult:
     from services.weather_metrics import WeatherMetricsService
 
     ts = NormalizedTimeseries(meta=meta, data=hourly)
-    s = WeatherMetricsService().compute_basis_metrics(ts)
+    s = WeatherMetricsService().compute_basis_metrics(ts, tz=None)
     loc = LocationResult(
         location=SavedLocation(
             id="andermatt", name="Andermatt", lat=39.76, lon=2.71, elevation_m=200,

--- a/tests/unit/test_compare_mail_labels_from_register.py
+++ b/tests/unit/test_compare_mail_labels_from_register.py
@@ -159,7 +159,7 @@ def _result() -> ComparisonResult:
     from services.weather_metrics import WeatherMetricsService
 
     s = WeatherMetricsService().compute_basis_metrics(
-        NormalizedTimeseries(meta=meta, data=hourly)
+        NormalizedTimeseries(meta=meta, data=hourly), tz=None,
     )
     loc = LocationResult(
         location=SavedLocation(

--- a/tests/unit/test_compare_mail_plaintext_html_label_parity.py
+++ b/tests/unit/test_compare_mail_plaintext_html_label_parity.py
@@ -120,7 +120,7 @@ def _result() -> ComparisonResult:
 
     ts = NormalizedTimeseries(meta=meta, data=hourly)
     svc = WeatherMetricsService()
-    s = svc.compute_basis_metrics(ts)
+    s = svc.compute_basis_metrics(ts, tz=None)
     loc = LocationResult(
         location=SavedLocation(
             id="andermatt", name="Andermatt", lat=39.76, lon=2.71, elevation_m=200,

--- a/tests/unit/test_compare_matrix_metric_selection.py
+++ b/tests/unit/test_compare_matrix_metric_selection.py
@@ -73,7 +73,7 @@ def _location(name: str, hourly: list[ForecastDataPoint]) -> LocationResult:
     hourly_data"). Der UV-Tageswert wird heute bereits genau so live aus
     ``hourly_data`` abgeleitet (``compare_html._metric_value``).
     """
-    s = WeatherMetricsService().compute_basis_metrics(_timeseries(hourly))
+    s = WeatherMetricsService().compute_basis_metrics(_timeseries(hourly), tz=None)
     return LocationResult(
         location=SavedLocation(id=name.lower(), name=name, lat=39.76, lon=2.71, elevation_m=200),
         score=50,
@@ -274,7 +274,7 @@ def test_daily_aggregate_matches_trip_path_computation():
     hourly = _hourly()
     svc = WeatherMetricsService()
     ts = _timeseries(hourly)
-    trip = svc.compute_basis_metrics(ts)
+    trip = svc.compute_basis_metrics(ts, tz=None)
     trip_pop = svc._compute_pop(ts)
     trip_uv = svc._compute_uv_index(ts)
 
@@ -389,7 +389,7 @@ def test_engine_fills_daily_aggregates_into_location_result():
     hourly = _hourly()
     svc = WeatherMetricsService()
     ts = _timeseries(hourly)
-    trip = svc.compute_basis_metrics(ts)
+    trip = svc.compute_basis_metrics(ts, tz=None)
 
     lr = _run_engine_with_recorded_hourly(hourly)
 

--- a/tests/unit/test_compare_metric_parity.py
+++ b/tests/unit/test_compare_metric_parity.py
@@ -111,7 +111,7 @@ def _location(name: str, hourly: list[ForecastDataPoint]) -> LocationResult:
     ``LocationResult``-Felder existieren (s. Spec Dependencies), aber noch
     kein Mapping/CV2_METRICS-Eintrag haben.
     """
-    s = WeatherMetricsService().compute_basis_metrics(_timeseries(hourly))
+    s = WeatherMetricsService().compute_basis_metrics(_timeseries(hourly), tz=None)
     return LocationResult(
         location=SavedLocation(id=name.lower(), name=name, lat=39.76, lon=2.71, elevation_m=200),
         score=50,
@@ -307,7 +307,7 @@ def test_selected_humidity_metric_appears_in_overview_matrix():
     html = render_compare_html(result, enabled_metrics=enabled)
     row = _assert_row_with_values(html, _IS_HUMIDITY, "Luftfeuchtigkeit")
 
-    expected = WeatherMetricsService().compute_basis_metrics(_timeseries(_hourly())).humidity_avg_pct
+    expected = WeatherMetricsService().compute_basis_metrics(_timeseries(_hourly()), tz=None).humidity_avg_pct
     assert _number(row["cells"][0]) == expected, (
         f"Luftfeuchtigkeit-Tageswert stimmt nicht mit dem Trip-Pfad-Aggregat "
         f"ueberein: {row['cells'][0]!r} != {expected}"
@@ -459,7 +459,7 @@ def test_plaintext_shows_all_ten_new_rows():
     hourly = _hourly()
     svc = WeatherMetricsService()
     ts = _timeseries(hourly)
-    basis = svc.compute_basis_metrics(ts)
+    basis = svc.compute_basis_metrics(ts, tz=None)
 
     wind_dir_line = _plain_row_value(text, "windrichtung")
     assert wind_dir_line is not None, (

--- a/tests/unit/test_issue_347_sunshine_hours.py
+++ b/tests/unit/test_issue_347_sunshine_hours.py
@@ -315,7 +315,7 @@ class TestAC9SegmentSummaryPrecomputed:
         ts = NormalizedTimeseries(meta=meta, data=dps)
 
         svc = WeatherMetricsService()
-        summary = svc.compute_basis_metrics(ts)
+        summary = svc.compute_basis_metrics(ts, tz=None)
 
         direct = WeatherMetricsService.calculate_sunny_hours(dps)
         assert summary.sunny_hours == direct, (

--- a/tests/unit/test_mail_metric_name_forms.py
+++ b/tests/unit/test_mail_metric_name_forms.py
@@ -129,7 +129,7 @@ def _result() -> ComparisonResult:
 
     ts = NormalizedTimeseries(meta=meta, data=hourly)
     svc = WeatherMetricsService()
-    s = svc.compute_basis_metrics(ts)
+    s = svc.compute_basis_metrics(ts, tz=None)
     loc = LocationResult(
         location=SavedLocation(
             id="andermatt", name="Andermatt", lat=39.76, lon=2.71, elevation_m=200,

--- a/tests/unit/test_trip_summary_text.py
+++ b/tests/unit/test_trip_summary_text.py
@@ -74,7 +74,7 @@ def _trip_sentence(
 ) -> str:
     """Erzeugt den Satz ueber den ECHTEN Trip-Pfad (CompactSummaryFormatter)."""
     ts = _timeseries(hourly)
-    summary = WeatherMetricsService().compute_basis_metrics(ts)
+    summary = WeatherMetricsService().compute_basis_metrics(ts, tz=None)
     seg = TripSegment(
         segment_id=1,
         start_point=GPXPoint(lat=39.75, lon=2.65, elevation_m=100.0),

--- a/tests/unit/test_weather_metrics.py
+++ b/tests/unit/test_weather_metrics.py
@@ -91,10 +91,10 @@ class TestWeatherMetricsServiceKnownValues:
     def test_compute_basis_metrics_known_values(self, service, known_timeseries):
         """
         GIVEN: Timeseries with known values
-        WHEN: compute_basis_metrics(timeseries)
+        WHEN: compute_basis_metrics(timeseries, tz=None)
         THEN: All 8 metrics match expected calculations
         """
-        result = service.compute_basis_metrics(known_timeseries)
+        result = service.compute_basis_metrics(known_timeseries, tz=None)
 
         # Temperature
         assert result.temp_min_c == 10.0
@@ -125,7 +125,7 @@ class TestWeatherMetricsServiceKnownValues:
     def test_aggregation_config_populated(self, service, known_timeseries):
         """
         GIVEN: Timeseries
-        WHEN: compute_basis_metrics(timeseries)
+        WHEN: compute_basis_metrics(timeseries, tz=None)
         THEN: aggregation_config has 16 entries with correct functions
 
         Issue #1475 S5a: 12 -> 13 Eintraege — `hail_flag` ("hail_priority")
@@ -136,7 +136,7 @@ class TestWeatherMetricsServiceKnownValues:
         Issue #1468: 14 -> 16 Eintraege — die beiden Beginn-Zeitpunkte
         ("onset") sind eigene Tages-Aggregate.
         """
-        result = service.compute_basis_metrics(known_timeseries)
+        result = service.compute_basis_metrics(known_timeseries, tz=None)
 
         assert len(result.aggregation_config) == 16
         assert result.aggregation_config["temp_min_c"] == "min"
@@ -175,7 +175,7 @@ class TestWeatherMetricsServiceTemperature:
     def test_temperature_min_max_avg(self, service):
         """
         GIVEN: Timeseries with varying temperatures
-        WHEN: compute_basis_metrics(timeseries)
+        WHEN: compute_basis_metrics(timeseries, tz=None)
         THEN: MIN/MAX/AVG calculated correctly
         """
         meta = ForecastMeta(
@@ -202,7 +202,7 @@ class TestWeatherMetricsServiceTemperature:
         ]
 
         timeseries = NormalizedTimeseries(meta=meta, data=data)
-        result = service.compute_basis_metrics(timeseries)
+        result = service.compute_basis_metrics(timeseries, tz=None)
 
         assert result.temp_min_c == -5.0
         assert result.temp_max_c == 10.0
@@ -219,7 +219,7 @@ class TestWeatherMetricsServicePrecipitation:
     def test_precipitation_sum_not_avg(self, service):
         """
         GIVEN: Timeseries with hourly precipitation
-        WHEN: compute_basis_metrics(timeseries)
+        WHEN: compute_basis_metrics(timeseries, tz=None)
         THEN: precip_sum_mm is SUM of all values, not AVG
         """
         meta = ForecastMeta(
@@ -249,7 +249,7 @@ class TestWeatherMetricsServicePrecipitation:
         ]
 
         timeseries = NormalizedTimeseries(meta=meta, data=data)
-        result = service.compute_basis_metrics(timeseries)
+        result = service.compute_basis_metrics(timeseries, tz=None)
 
         # SUM, not AVG!
         assert result.precip_sum_mm == 11.0  # 2.5 + 3.0 + 1.5 + 0.0 + 4.0
@@ -265,7 +265,7 @@ class TestWeatherMetricsServiceThunderLevel:
     def test_thunder_level_ordering_high(self, service):
         """
         GIVEN: Timeseries with mixed thunder levels including HIGH
-        WHEN: compute_basis_metrics(timeseries)
+        WHEN: compute_basis_metrics(timeseries, tz=None)
         THEN: thunder_level_max = HIGH
         """
         meta = ForecastMeta(
@@ -300,14 +300,14 @@ class TestWeatherMetricsServiceThunderLevel:
         ]
 
         timeseries = NormalizedTimeseries(meta=meta, data=data)
-        result = service.compute_basis_metrics(timeseries)
+        result = service.compute_basis_metrics(timeseries, tz=None)
 
         assert result.thunder_level_max == ThunderLevel.HIGH
 
     def test_thunder_level_ordering_med(self, service):
         """
         GIVEN: Timeseries with NONE and MED (no HIGH)
-        WHEN: compute_basis_metrics(timeseries)
+        WHEN: compute_basis_metrics(timeseries, tz=None)
         THEN: thunder_level_max = MED
         """
         meta = ForecastMeta(
@@ -334,7 +334,7 @@ class TestWeatherMetricsServiceThunderLevel:
         ]
 
         timeseries = NormalizedTimeseries(meta=meta, data=data)
-        result = service.compute_basis_metrics(timeseries)
+        result = service.compute_basis_metrics(timeseries, tz=None)
 
         assert result.thunder_level_max == ThunderLevel.MED
 
@@ -349,7 +349,7 @@ class TestWeatherMetricsServiceSparseData:
     def test_sparse_data_with_none_values(self, service):
         """
         GIVEN: Timeseries with 50% None values for temperature
-        WHEN: compute_basis_metrics(timeseries)
+        WHEN: compute_basis_metrics(timeseries, tz=None)
         THEN: Metrics computed from available values only
         """
         meta = ForecastMeta(
@@ -376,7 +376,7 @@ class TestWeatherMetricsServiceSparseData:
         ]
 
         timeseries = NormalizedTimeseries(meta=meta, data=data)
-        result = service.compute_basis_metrics(timeseries)
+        result = service.compute_basis_metrics(timeseries, tz=None)
 
         # Computed from 10.0 and 20.0 only (ignore None)
         assert result.temp_min_c == 10.0
@@ -386,7 +386,7 @@ class TestWeatherMetricsServiceSparseData:
     def test_all_none_values_for_metric(self, service):
         """
         GIVEN: Timeseries where all t2m_c are None
-        WHEN: compute_basis_metrics(timeseries)
+        WHEN: compute_basis_metrics(timeseries, tz=None)
         THEN: temp_min/max/avg all None, no error
         """
         meta = ForecastMeta(
@@ -411,7 +411,7 @@ class TestWeatherMetricsServiceSparseData:
         ]
 
         timeseries = NormalizedTimeseries(meta=meta, data=data)
-        result = service.compute_basis_metrics(timeseries)
+        result = service.compute_basis_metrics(timeseries, tz=None)
 
         # Temperature all None
         assert result.temp_min_c is None
@@ -432,7 +432,7 @@ class TestWeatherMetricsServiceEdgeCases:
     def test_empty_timeseries_raises_error(self, service):
         """
         GIVEN: Timeseries with empty data list
-        WHEN: compute_basis_metrics(timeseries)
+        WHEN: compute_basis_metrics(timeseries, tz=None)
         THEN: ValueError raised
         """
         meta = ForecastMeta(
@@ -446,14 +446,14 @@ class TestWeatherMetricsServiceEdgeCases:
         timeseries = NormalizedTimeseries(meta=meta, data=[])
 
         with pytest.raises(ValueError) as exc_info:
-            service.compute_basis_metrics(timeseries)
+            service.compute_basis_metrics(timeseries, tz=None)
 
         assert "empty" in str(exc_info.value).lower()
 
     def test_percentage_rounding(self, service):
         """
         GIVEN: Timeseries with cloud_total_pct values that average to non-integer
-        WHEN: compute_basis_metrics(timeseries)
+        WHEN: compute_basis_metrics(timeseries, tz=None)
         THEN: cloud_avg_pct is rounded to int
         """
         meta = ForecastMeta(
@@ -477,7 +477,7 @@ class TestWeatherMetricsServiceEdgeCases:
         ]
 
         timeseries = NormalizedTimeseries(meta=meta, data=data)
-        result = service.compute_basis_metrics(timeseries)
+        result = service.compute_basis_metrics(timeseries, tz=None)
 
         # (45 + 50 + 56) / 3 = 50.333... → rounds to 50
         assert isinstance(result.cloud_avg_pct, int)

--- a/tests/unit/test_weather_metrics.py
+++ b/tests/unit/test_weather_metrics.py
@@ -126,17 +126,19 @@ class TestWeatherMetricsServiceKnownValues:
         """
         GIVEN: Timeseries
         WHEN: compute_basis_metrics(timeseries)
-        THEN: aggregation_config has 14 entries with correct functions
+        THEN: aggregation_config has 16 entries with correct functions
 
         Issue #1475 S5a: 12 -> 13 Eintraege — `hail_flag` ("hail_priority")
         ist als Tages-/Etappen-Aggregat hinzugekommen (Spec AC-4).
         Issue #1680 S1: 13 -> 14 Eintraege — `thunder_level_max_signals`
         ("union_of_max_carriers") haelt fest, WELCHE Zutaten das
         Gewitter-Tagesmaximum tragen (Spec AC-10).
+        Issue #1468: 14 -> 16 Eintraege — die beiden Beginn-Zeitpunkte
+        ("onset") sind eigene Tages-Aggregate.
         """
         result = service.compute_basis_metrics(known_timeseries)
 
-        assert len(result.aggregation_config) == 14
+        assert len(result.aggregation_config) == 16
         assert result.aggregation_config["temp_min_c"] == "min"
         assert result.aggregation_config["temp_max_c"] == "max"
         assert result.aggregation_config["temp_avg_c"] == "avg"
@@ -156,6 +158,11 @@ class TestWeatherMetricsServiceKnownValues:
         # fuer "falscher Schluessel drin, thunder_level_max_signals fehlt".
         assert (result.aggregation_config["thunder_level_max_signals"]
                 == "union_of_max_carriers")
+        # Issue #1468: dieselbe Ueberlegung wie eine Zeile hoeher — ein reiner
+        # Zaehltest waere blind dafuer, dass ein Beginn-Feld fehlt und
+        # stattdessen ein falscher Schluessel drinsteht.
+        assert result.aggregation_config["thunder_onset_utc"] == "onset"
+        assert result.aggregation_config["precip_heavy_onset_utc"] == "onset"
 
 
 class TestWeatherMetricsServiceTemperature:


### PR DESCRIPTION
Schließt fachlich #1468.

## Was sich für den Nutzer ändert

Der **Beginn** von Gewitter und Starkregen wird zu einer eigenen, vergleichbaren Alarmgröße. Verschiebt er sich gegenüber dem letzten Stand deutlich, entsteht ein Alarm — auf allen vier Kanälen und in beiden Flächen (Trip und Ortsvergleich).

Die Schwellen sind **asymmetrisch**, weil ein vorgezogener Beginn gefährlicher ist als ein verzögerter:

| Empfindlichkeit | früher | später |
|---|---|---|
| entspannt | 2 h | 4 h |
| standard | 1 h | 3 h |
| sensibel | 1 h | 2 h |

Beginn- und Stufenänderung werden beide gemeldet und im Alarmtext zusammengefasst, im Alarm-Protokoll aber als **zwei getrennte** Register-Paare geführt — sonst konkurrieren Stunden gegen Prozent bei der Frage, welche Änderung die extremere ist.

## Zwei Entscheidungen, die Erklärung verdienen

**Ersatzquelle für den Starkregen-Beginn.** Fehlt `precip_rate_mmph`, wird `precip_1h_mm` bei gleicher Schwelle (4,0 mm/h) herangezogen. Ohne das wäre die Starkregen-Hälfte des Features beim Primärprovider Open-Meteo strukturell wirkungslos — der setzt die Rate hart auf `None`.

**Das Tagesfenster reist mit dem Segment** statt durch die Aufrufkette (AC-10). Der Weg über die Aufrufkette hätte 107 Tests zerbrochen, deren Doubles die Signatur nachbilden. So entsteht die Symmetrie zwischen Anker- und Frischstand **strukturell** statt durch Disziplin an zwei Aufrufstellen.

## Absicherung

Drei Adversary-Runden. Runde 2 endete mit **BROKEN** — das Protokoll dokumentiert das unverändert:

- **F001 (kritisch):** Die neuen Beginn-Funktionen trugen genau die Zeitzonen-Fehlerklasse, die ein bestehender Wächter seit #1402 verankert. Behoben ohne Eintrag in die Ausnahmeliste: `tz` ist Pflicht, der stille Rückfall auf UTC ist ersatzlos weg.
- **F002 (hoch):** Die Fenster-Weitergabe im Ortsvergleich war durch keinen Test gedeckt — eine Verfälschung blieb unbemerkt. Der neue Test nutzt bewusst ein Fenster **weiter** als der Standard, weil der Vorschnitt engere Fenster maskiert und den Fehler unsichtbar macht.

Zusätzlich ein **Callsite-Wächter**: Seit `tz` Pflicht ist, führt ein vergessener Ortsbezug nicht mehr zu einer falschen Uhrzeit, sondern zu gar keiner — und damit nie zu einem Alarm. Beides still, und der ausbleibende Alarm ist laut Spec der gefährlichere Fehler. Der Wächter liest die Produktivpfade statisch und verlangt an jeder Aufrufstelle eine echte Zeitzone. Sein Wirkungsnachweis läuft über eine echte Aufrufstelle, nicht nur über ein konstruiertes Beispiel.

Runde 3: **VERIFIED**, 10/10 Kriterien belegt, vier gezielte Verfälschungen gesetzt, alle vier gefangen.

## Bewusst nicht in diesem PR

- **#1971** — Alt-Ortsvergleiche ohne migrierte Metrik-Auswahl bekommen nie eine Alarm-Regel. Eigenständige Bestandsdaten-Frage, lokal 0 betroffen, Produktionszahl ungemessen.
- **#1199** — Beginn-Zeiten stehen im Alarm-Protokoll als rohe Sekundenzahl. Heute folgenlos, weil keine Anzeige das Feld liest.
- Die Empfindlichkeits-Stufen sind im Alarme-Reiter **nicht einstellbar** und laufen stumm auf „standard". Ursache liegt in #1462.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FBWcwMzyHMDse6os6mSvU2

## Volllauf über die Kern-Schicht

Drei Fehlschläge, alle eingeordnet, **keiner davon aus diesem Ticket** — jeder mit Beleg in #1196 gebucht:

1. Ein Test, dem eine frühere Datei Umgebungswerte hinterlässt (`load_dotenv` auf Modulebene, ohne Aufräumen). Vorbestehend seit Juli; in CI unwirksam, weil die Konfigurationsdatei dort nicht existiert.
2. Ein Test, der einen echten Dienst anspricht und in eine Zeitüberschreitung läuft. Gehört in die Live-Schicht.
3. Ein Paritätstest, der zeitabhängig flackert: Der Klartext trägt einen minutengenauen Zeitstempel, der bei jedem Rendern neu gebildet wird. Liegt eine Minutengrenze zwischen den beiden Renderings, divergieren sie. Deterministisch nachgestellt — der Unterschied ist **genau diese eine Zeile**. Die Datei stammt aus April und wird von keinem Commit dieses Branches angefasst.

Ein Bestands-Wächter musste nachgezogen werden: Die Regelzahl der Stufe „entspannt" steigt durch die zwei Beginn-Größen von 12 auf 14. Er prüft jetzt zusätzlich die **Menge** der Metriken, nicht nur ihre Anzahl — eine verlorene Bestandsregel neben einer neu hinzugekommenen hätte dieselbe Summe ergeben, die reine Zahl war an dieser Stelle blind.
