### PR TITLE
fix(#1727 S5e): Sperrcache folgt dem Kalendertag, Konto-Anzeige ehrlich

### DIFF
--- a/docs/context/fix-1727-s5e-sperrcache-anzeige.md
+++ b/docs/context/fix-1727-s5e-sperrcache-anzeige.md
@@ -1,0 +1,208 @@
+# Context: fix-1727-s5e-sperrcache-anzeige
+
+Issue #1727, Scheibe S5e. Erstellt 2026-08-19, Session `replicated-cuddling-sphinx`.
+
+## Request Summary
+
+Zwei Reste aus dem Umgebungsuhr-Umbau (ADR-0051): Der Zugangssperren-Cache schlüsselt nicht nach
+Kalendertag und kann deshalb Vortagesdaten als heutige ausliefern. Die Konto-Seite beschriftet einen
+technischen Prüftakt als Versandtermin und formatiert ihn fest in Wiener Zeit.
+
+## 🔴 Der Issue-Umfang von #1727 S5 ist abgearbeitet
+
+**Am Ist-Code gemessen (2026-08-19), nicht aus dem Issue-Text übernommen.** Alle acht dort genannten
+Fundstellen sind durch S5a–S5d behoben; die Zeilennummern sind verschoben, die Muster nirgends mehr
+vorhanden:
+
+| Fundstelle laut Issue | Ist-Stand |
+|---|---|
+| `preview_service.py:94` | behoben — `now_utc` Pflichtparameter, Fallback `trip_local_today(trip, now_utc)` |
+| `compare_preview_service.py:250` | behoben — `_resolve_target_date(..., datetime.now(timezone.utc))` → `local_dt(...)` (`:152/275`) |
+| `comparison_engine.py:407` | kein Fund mehr in der ganzen Datei |
+| `api/routers/compare.py:55/58` | behoben — `first_resolvable_tz`+`local_dt` (`:49-63`) |
+| `inbound_telegram_reader.py:358` | behoben — `_find_active_trip(self, now_utc: datetime, ...)` (`:359-360`) |
+| `trip_command_processor.py:1076/1227` | behoben — Kommentar `:1186` erinnert nur an den Altzustand |
+| `gpx_processing.py:183/189/193/223` | behoben — `compute_default_start_date` entfernt, `tz_for_coords` (`:214`) |
+| `compare_html.py:1377` | behoben — Tag jetzt `local_dt(datetime.now(timezone.utc), tz).date()` (`:1450`) |
+
+Auch das Titelversprechen „Ausnahmeliste auf null" ist nicht der Ist-Stand: `KNOWN_VIOLATIONS`
+(`tests/test_output_timezone_guard.py:526-654`) hat **43 Einträge** — 2 dauerhaft, 18 mit abgesicherter
+Aufrufseite, 21 dokumentierte UTC-Umrechnungen. Die **Muster-A-Rubrik** (Umgebungsuhr) ist leer; das war
+das Ziel von S5a–S5d und ist erreicht.
+
+## (A) Zugangssperren-Cache
+
+### Was falsch ist
+
+`src/services/official_alerts/massif_closure.py` — `_get_cached_daily_json(src, ymd)` (`:98-112`) bildet
+den Cache-Schlüssel als `cache_key=src`. Der Kalendertag `ymd` fließt in die Request-URL
+(`:106`, `_ENDPOINT.format(src=src, ymd=ymd)`), **nicht** in den Schlüssel. TTL 1800 s bei Erfolg
+(`:39-40`, `warn_egress.WARN_SUCCESS_TTL`).
+
+`fetch()` selbst berechnet `ymd` bereits korrekt über
+`local_dt(datetime.now(timezone.utc), tz_for_coords(lat, lon))` (`:125-131`) — das ist der S5d-Fix und
+funktioniert. Die Lücke liegt allein in der Schlüsselbildung.
+
+**Wirkung:** Wechselt der Kalendertag innerhalb der 30-Minuten-Frist, liefert der Cache den
+Vortages-Datensatz für dieselbe Quelle zurück, ohne dass am Schlüssel erkennbar wäre, dass er zu einem
+anderen Tag gehört. Eine über Nacht neu verhängte Waldbrand-Zugangssperre erscheint bis zu 30 Minuten
+lang nicht.
+
+Aus dem S5d-Abschluss (nachgemessen 2026-08-15): Beide Tage liefern **HTTP 200 mit verschiedenem Inhalt**
+(`…/20260815.json` md5 `675a8459…` vs. `…/20260814.json` md5 `76c84d74…`). Der Fehlerpfad ist also
+nicht fail-soft — veraltete Daten werden als gültige Antwort behandelt.
+
+### Die Lücke ist singulär — 9 Aufrufstellen ausgezählt
+
+`cached_fetch()` (`src/services/official_alerts/warn_egress.py:377ff`) wird von 6 Diensten an 9 Stellen
+benutzt. Für jede geprüft, ob ein Datum in die Ressource fließt, das nicht im Schlüssel steht:
+
+| Aufrufer | `cache_key` | Lücke? |
+|---|---|---|
+| `massif_closure.py:109` | `src` | **JA — die einzige** |
+| `dpc.py:165` | `"national"` | nein — statische URL; Frische nach dem Abruf über `_select_day_records()` (`:172-181`) geprüft |
+| `vigilance.py:94` | `"national"` | nein — kein Datumsparameter (`:89-90`) |
+| `meteo_forets.py:92` | `department` | nein — nur `id-departement` (`:79-88`) |
+| `geosphere_warn.py:100` | `_round_coord(lat, lon)` | nein — nur `lat/lon/lang` (`:90-96`) |
+| `meteoalarm_feed.py:212` | `country` | nein — statischer Feed-Pfad (`:207-208`) |
+| `meteoalarm.py:768` | `f"{country}:{slot}:p{page}"` | nein — **trägt den Zeitanteil explizit** (`_slot_key(slot_end)`, `:665-687`) |
+| `meteoalarm.py:963/980` | ID-basiert (Geometrie/CAP) | nein — nicht datumsgebunden |
+
+**`meteoalarm.py:768` ist das hausinterne Vorbild:** dort ist der Zeitanteil bereits Teil des Schlüssels.
+`dpc.py` löst dasselbe Problem anders — es prüft nach dem Abruf, zu welchem Tag der Datensatz gehört, und
+dokumentiert das ausdrücklich (`:173-174`: „NIE blind 'today' als 'heute' interpretieren").
+
+### Cache-Mechanik
+
+- **Speicher:** Prozessspeicher, ein eigenes Modul-Dict je Dienst (`massif_closure.py:43` `_cache = {}`);
+  `_store_entry()` (`warn_egress.py:165-177`) legt `{"data", "fetched_at", "ttl"}` ab. Kein Redis, keine
+  Datei, nichts prozessübergreifend (`warn_egress.py:17-18`).
+- **Schlüssel:** `cached_fetch(cache, cache_key, ...)` nimmt den Schlüssel als Parameter und baut nichts
+  selbst zusammen — die Verantwortung liegt vollständig beim Aufrufer.
+- **Zeitquelle:** `clock: Callable[[], float] = time.monotonic` (`:385`) — bewusst **nicht**
+  wanduhrgebunden und damit **nicht** über `freeze_time` steuerbar. Das ist für den Test entscheidend.
+- **Invalidierung:** keine. Ablauf ausschließlich über TTL-Vergleich beim nächsten Zugriff (`:431-434`).
+  `_cache.clear()` existiert nur als Test-Hilfsmittel.
+
+### Testlage
+
+**Kein Test deckt den Fall ab.** Vorhanden:
+
+- `tests/tdd/test_issue_1037_massif_closure.py` — 10 Methoden zu Niveau-Badges, Massiv-Überlappung,
+  Fail-soft, Attribution. Kein Cache-Bezug.
+- `tests/unit/test_massif_closure_capture_ambiguity.py` — 3 Methoden zur Herkunfts-Kennung (#1944).
+- `tests/tdd/test_import_und_fremdquellen_folgen_ortstag.py::test_ac3_massif_closure_ymd_folgt_dem_pariser_tag`
+  (`:181-208`) — prüft nur, dass die **URL** den Pariser Tag trägt.
+
+🔴 Der Testhelfer dort (`:162-178`) leert den Cache **vor jedem Aufruf** mit dem Kommentar, dass
+`cached_fetch` `time.monotonic` statt `freeze_time` nutzt (`:164-166`). Das Gerüst **umgeht** die
+Tagesgrenzen-Frage aktiv, statt sie zu prüfen — genau deshalb ist der Fehler nie aufgefallen.
+
+### Anspruch vs. Implementierung
+
+`docs/specs/_archive/modules/issue_1037_official_alerts_massif_closure.md:97` nennt die Funktion wörtlich
+`_load_cached_daily_json(hit.src)  # Tages-Cache pro Source-DEPT`. **Die Spec nennt es „Tages-Cache",
+obwohl der Tag nie im Schlüssel stand.** Die geteilte Spec `docs/specs/modules/warn_service_consumption.md:174`
+listet `cache_key (Land/Koordinate/Département/Source-DEPT)` — ein Datum ist dort für keinen Dienst
+vorgesehen.
+
+## (B) Konto-Anzeige
+
+### Was falsch ist
+
+`frontend/src/routes/account/+page.svelte:264-281` — `formatNextRun()` enthält **vier** feste
+`timeZone: 'Europe/Vienna'`-Literale (`:269, :270, :271, :279`). Gerendert bei `:598-599` als
+`Nächster: {formatNextRun(job.next_run)}`, Jobname aus `userJobs` (`:288-290`, nur
+`trip_reports_hourly` → „Trip-Checks").
+
+### Die Zahl bedeutet etwas anderes, als die Beschriftung sagt
+
+`next_run` stammt aus `internal/scheduler/scheduler.go:772/781` (`e.Next.Format(time.RFC3339)`) — dem
+`robfig/cron`-Eintrag des Jobs `trip_reports_hourly` mit Ausdruck `"0 * * * *"` (`:189`), berechnet in
+`SchedulerTimezone` (`internal/config/config.go:20`, Vorgabe `Europe/Vienna`). Das ist der **generische
+stündliche Poll-Tick**, nicht der Versandzeitpunkt eines Trips.
+
+**Der tatsächliche Versand** entsteht in `src/services/trip_report_scheduler.py:180-189`:
+`vor_ort = trip_local_now(trip, moment)` wird gegen `_slot_stunde(trip, report_type)` in einem
+3-Stunden-Nachholfenster geprüft (`:96-106`); die Zone kommt aus dem ersten Wegpunkt über
+`tz_for_coords(...)` (`:1279`).
+
+### Die Eingabe-Kette ist stimmig — hier ist kein Fehler
+
+Nutzer tippt eine nackte Uhrzeit (`VTSchedulePlan.svelte:101-113`, Label nur „Uhrzeit", keine Zone) →
+naiv gespeichert (`VersandTab.svelte:149` `toHHMMSS`, `internal/model/trip.go:157` `MorningTime *string`,
+`src/app/models.py:1076-1077` naives `datetime.time`, **kein Zonenfeld**) → korrekt als **Ortszeit des
+Trip-Startpunkts** ausgewertet. Das ist ADR-0051 Regel 2 konform.
+
+Die Naht liegt **allein in der Anzeige**.
+
+### Frontend-Bestand
+
+- **Es gibt keinen geteilten Formatierungs-Baustein.** Vorhanden sind unabhängige Einzellösungen:
+  `compare/subscriptionHelpers.ts:54-58` (`formatNextSend`, rohe `Date`-Getter),
+  `:61-70` (`formatLastSent`), `_home/TripKachel.svelte:11`, `+page.svelte:50/141/407`,
+  `lib/utils/tripHero.ts:5` (bewusst eigene Monatsnamen-Map).
+- **Alle anderen Zeitanzeigen laufen ohne `timeZone`-Angabe**, also implizit in der Ausführungszone
+  (Browser). `account/+page.svelte` ist die **einzige** Stelle mit fest verdrahteter Zone.
+- **`timeZoneName` kommt im gesamten Frontend null-mal vor** — ein Zonenkürzel wird heute nirgends
+  angezeigt.
+- **Keine Tests** berühren die Konto-Seite oder `formatNextRun` (weder `frontend/src/**/*.test.ts` noch
+  `frontend/e2e/`).
+
+### Konsumenten
+
+Einziger Konsument des Endpunkts ist `frontend/src/routes/account/+page.server.ts:23`. Route registriert
+in `internal/router/router.go:202`, in `internal/middleware/auth.go:34` als **öffentliche Route ohne
+Cookie-Pflicht** geführt. Andere Health-Aggregate schreiben in denselben Endpunkt
+(`briefing_health.go:63`, `tier_request_health.go:11`), betreffen aber andere Felder.
+
+**Nicht messbar von hier:** ob externes Monitoring in `henemm-infra` (anderes Repo) `next_run` parst.
+Als Lücke benannt, nicht geschätzt.
+
+## Dependencies
+
+- **Upstream (A):** `warn_egress.cached_fetch`, `tz_for_coords`, `local_dt`
+- **Downstream (A):** die Warnquellen-Registry ruft `covers`/`fetch` in `try/except Exception`
+  (`base.py:137-148`) — ein Fehler **deaktiviert die Quelle still**, statt laut zu brechen. Signatur darf
+  nicht erweitert werden (Präzedenz aus S5d).
+- **Upstream (B):** `/api/scheduler/status` → `data.scheduler.jobs[].next_run`
+- **Downstream (B):** nur die Konto-Seite
+
+## Risks & Considerations
+
+1. **Stiller Ausfall der Warnquelle.** `try/except Exception` in der Registry — ein Fehler in
+   `massif_closure` macht die Quelle wirkungslos, ohne dass ein Test rot wird. Der Nachweis muss die
+   **Wirkung** prüfen (kommt die neue Sperre an?), nicht nur den Schlüsselaufbau.
+2. **Testbarkeit gegen `time.monotonic`.** Der Cache ist bewusst nicht wanduhrgebunden. Ein Test für den
+   Tageswechsel kann die Uhr nicht einfrieren — er muss über den `clock`-Parameter (`warn_egress.py:385`)
+   oder über zwei Aufrufe mit verschiedenem `ymd` bei gleichem `src` arbeiten. Der bestehende Helfer, der
+   den Cache vorher leert, ist als Muster **untauglich** — er würde die Lücke erneut verdecken.
+3. **Unbegrenztes Wachstum des Schlüsselraums.** Kommt `ymd` in den Schlüssel, entsteht pro Quelle und
+   Kalendertag ein Eintrag, der nie entfernt wird (keine Invalidierung, Ablauf nur beim Zugriff). Klein,
+   aber real. In der Analyse zu entscheiden: beim Schreiben ältere Einträge derselben Quelle verwerfen,
+   oder als vernachlässigbar dokumentieren. `meteoalarm.py:768` hat dasselbe Muster ohne Aufräumen.
+4. **Zonenwechsel des Nutzers ist eine sichtbare Änderung.** Wer heute in Wien sitzt, sieht dieselbe Zahl
+   wie bisher; wer anderswo sitzt, sieht eine andere. Das ist beabsichtigt, gehört aber in die
+   Screenshot-Prüfung.
+5. **Kein Vorbild für Zonenkürzel im Repo.** `timeZoneName` wird erstmalig eingeführt — die Darstellung
+   muss zu den Design-Leitprinzipien passen (Lesbarkeit vor weicher Optik).
+6. **Sperrzone #1929:** `src/services/official_alerts/official_alerts.py:1896-2104` gehört einer fremden
+   Session. `massif_closure.py` ist nicht betroffen, aber die Nachbarschaft ist zu beachten.
+
+## Existing Specs
+
+- `docs/specs/_archive/modules/issue_1037_official_alerts_massif_closure.md` — archiviert; nennt den
+  „Tages-Cache" (`:97`), der nie einer war
+- `docs/specs/modules/warn_service_consumption.md:174` — geteiltes Cache-Design aller Warndienste
+- `docs/adr/0051-drei-zeitbegriffe-zone-an-den-daten.md` — Regel 3 (`:67-69`), Status **„Vorgeschlagen"**
+  (in #1199 gebucht)
+- `docs/adr/0044` — die vier in ADR-0044 ausgegrenzten Befehlspfade (durch S5c erledigt)
+
+## Abgegrenzt — nicht in dieser Scheibe
+
+- **#1969** (neu angelegt): die Konto-Seite soll den tatsächlichen nächsten Versandzeitpunkt je Trip in
+  dessen Ortszeit zeigen. Größerer Umbau, PO-entschieden ausgelagert.
+- Suchfläche des Wächters auf `src/providers/` + `src/app/loader.py` ausweiten (4 ortsbezugslose Treffer)
+  → #1199
+- Muster 3 des Wächters (`.hour`/`.date()` auf nicht zonenaufgelöstem Zeitstempel) — eigener Umfang
+- Go-Seite (225 × `time.Now()`) — laut Issue ausdrücklich nicht Teil von S5

--- a/docs/specs/modules/fix_1727_s5e_sperrcache_anzeige.md
+++ b/docs/specs/modules/fix_1727_s5e_sperrcache_anzeige.md
@@ -31,9 +31,13 @@ in der Zeitzone des Nutzers.
 
 ## Estimated Scope
 
-- **LoC:** ~45 Produktivcode (A: ~10, B: ~15 plus ~20 verschobene Zeilen) + ~100 Tests
+- **LoC:** ~45 Produktivcode (A: ~10, B: ~15 plus ~20 verschobene Zeilen) + ~140 Tests
 - **Files:** 3 Produktivdateien (`massif_closure.py`, `account/+page.svelte`, neu
-  `lib/utils/schedulerTime.ts`) + 3 Testdateien (Kern-Test A, Unit-Test B, Browser-Test B)
+  `lib/utils/schedulerTime.ts`) + 4 Testdateien (Kern-Test A, Unit-Test B, **Playwright-Test B**,
+  **Live-Ausgabe-Test A**)
+- **Nachweis-Schichten:** Kern (deterministisch) für den Tageswechsel · Browser (Playwright gegen
+  Staging, zwei Zeitzonen) für die Anzeige · Live-Ausgabe (echte Staging-Mail per IMAP + echte
+  Telegram-Nachricht) für die Wirkung der Sperre auf das Briefing
 - **Effort:** low
 
 ## Dependencies
@@ -149,6 +153,8 @@ in der Zeitzone des Nutzers.
     überhaupt wirkt. Ein Testgerüst, in dem `TZ` folgenlos bleibt, liefert zwei identische Strings und
     wäre auch bei fest verdrahtetem Wien grün — der Nachweis wäre wertlos. Die beiden erwarteten
     Uhrzeiten sind deshalb als konkrete Werte zu prüfen, nicht nur auf Ungleichheit.
+  - 🔴 **Der Unit-Test allein genügt nicht** — die Wirkung ist zusätzlich im echten Browser zu belegen,
+    siehe AC-7.
 
 - **AC-6:** Given die bestehende Versandkette (nackte Eingabe-Uhrzeit → naive Speicherung → Auswertung
   als Ortszeit des Trip-Startpunkts über `trip_report_scheduler.py:180-189`) ist ADR-0051-konform und
@@ -159,9 +165,41 @@ in der Zeitzone des Nutzers.
     als eigene zählt) zeigt ausschließlich `massif_closure.py`, `account/+page.svelte`,
     `lib/utils/schedulerTime.ts` plus die zugehörigen Testdateien; bestehende
     `trip_report_scheduler`-Tests laufen unmodifiziert durch.
+- **AC-7:** Given die Konto-Seite läuft auf Staging und ein Browser wird einmal mit der Zeitzone
+  `Europe/Vienna` und einmal mit `America/New_York` gestartet, When dieselbe Seite in beiden Fällen
+  geöffnet wird, Then zeigt die Scheduler-Zeile beide Male den Text „Nächste Prüfung", **verschiedene**
+  Uhrzeiten und jeweils das zur Browser-Zone passende Zonenkürzel.
+  - Test: Playwright gegen `https://staging.gregor20.henemm.com`, zwei Browser-Kontexte mit
+    `timezoneId: 'Europe/Vienna'` bzw. `timezoneId: 'America/New_York'`; der sichtbare Text der Zeile
+    wird ausgelesen und verglichen. Das ist der Nachweis für AC-4 **und** AC-5 an der Stelle, an der die
+    Änderung wirkt — im gerenderten Browser, nicht in einer Testumgebung.
+  - 🔴 Die beiden Uhrzeiten **müssen** sich unterscheiden. Wären sie gleich, wäre entweder die feste
+    Zone noch drin oder der Zonenwechsel des Testbrowsers folgenlos — beides ist ein Fehlschlag, kein
+    Grenzfall.
+
+- **AC-8:** Given eine amtliche Waldbrand-Zugangssperre liegt für ein Massiv des Test-Trips vor, When
+  ein Briefing über Staging versendet wird, Then erscheint diese Sperre in der **zugestellten E-Mail**
+  und in der **zugestellten Telegram-Nachricht**.
+  - Test: Live-Schicht. Versand über Staging, E-Mail per IMAP aus `gregor-test@henemm.com` abgeholt und
+    im Text nachgewiesen; Telegram-Nachricht im Zielchat nachgewiesen. Damit ist belegt, dass der
+    geänderte Cache-Pfad die Ausgabe tatsächlich erreicht — nicht nur, dass ein Dict den richtigen
+    Schlüssel trägt.
+  - 🔴 **Ehrliche Grenze:** Ein echter Kalendertagwechsel ist auf Staging nicht herstellbar. AC-8 ist
+    deshalb die **Positivkontrolle des Ausgabewegs** (die Sperre kommt an), nicht der Nachweis des
+    Tageswechsels — den führt AC-1 in der Kern-Schicht. Beide zusammen decken die Zusicherung ab;
+    einzeln tut es keines von beiden. Liegt zum Testzeitpunkt für kein Massiv eine Sperre vor, ist das
+    als SKIP mit Begründung zu dokumentieren, **niemals** als bestanden zu melden.
 
 ## Known Limitations
 
+- **Der Kalendertagwechsel ist auf Staging nicht herstellbar.** Er wird deshalb in der Kern-Schicht
+  gegen einen lokalen Sentinel nachgewiesen (AC-1); Staging belegt den Ausgabeweg (AC-8). Wer nur eines
+  von beiden vorzeigt, hat die Zusicherung nicht belegt.
+- **Nachgewiesene Ausgabekanäle sind E-Mail und Telegram** (AC-8, PO-Vorgabe 2026-08-19). SMS und
+  Premium-SMS durchlaufen denselben Renderweg für amtliche Warnungen, werden hier aber nicht
+  eigens versendet — Begründung: kein zusätzlicher Erkenntnisgewinn für diese Änderung, dafür echter
+  Versand an ein Satellitengerät. Falls die Sperren-Darstellung in den Kurzformaten später abweicht,
+  ist das ein eigener Befund, kein Regress dieser Scheibe.
 - Der eigentliche nächste Versandzeitpunkt je Trip in dessen Ortszeit wird weiterhin **nicht** angezeigt
   — das bleibt ausdrücklich #1969 (PO-entschieden ausgelagert, größerer Umbau).
 - Ob externes Monitoring in `henemm-infra` den bisherigen Label-Text „Nächster" oder das ISO-Feld

--- a/docs/specs/modules/fix_1727_s5e_sperrcache_anzeige.md
+++ b/docs/specs/modules/fix_1727_s5e_sperrcache_anzeige.md
@@ -1,0 +1,194 @@
+---
+entity_id: fix_1727_s5e_sperrcache_anzeige
+type: bugfix
+created: 2026-08-19
+updated: 2026-08-19
+status: draft
+version: "1.0"
+tags: [official-alerts, massif-closure, account-page, adr-0051]
+---
+
+# Fix #1727 S5e — Sperrcache tagesbewusst schlüsseln + Konto-Anzeige ehrlich beschriften
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Zwei Reste aus dem Umgebungsuhr-Umbau (ADR-0051, Issue #1727): (A) der Zugangssperren-Cache für
+französische Waldbrand-Massive schlüsselt nicht nach Kalendertag und kann deshalb bis zu 30 Minuten
+lang eine über Nacht neu verhängte Sperre verschweigen; (B) die Konto-Seite beschriftet den
+generischen stündlichen Scheduler-Tick als Versandtermin und formatiert ihn fest in Wiener Zeit statt
+in der Zeitzone des Nutzers.
+
+## Source
+
+- **File A:** `src/services/official_alerts/massif_closure.py`
+- **Identifier A:** `_get_cached_daily_json(src, ymd)` (`:98-112`)
+- **File B:** `frontend/src/routes/account/+page.svelte`
+- **Identifier B:** `formatNextRun(iso)` (`:264-281`)
+
+## Estimated Scope
+
+- **LoC:** ~45 Produktivcode (A: ~10, B: ~15 plus ~20 verschobene Zeilen) + ~100 Tests
+- **Files:** 3 Produktivdateien (`massif_closure.py`, `account/+page.svelte`, neu
+  `lib/utils/schedulerTime.ts`) + 3 Testdateien (Kern-Test A, Unit-Test B, Browser-Test B)
+- **Effort:** low
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `warn_egress.cached_fetch` | function | TTL-Cache-Kern, unverändert — Schlüssel bleibt Aufrufer-Verantwortung |
+| `utils.timezone.local_dt` / `tz_for_coords` | function | liefert bereits korrekt den Herausgebertag (S5d) — unverändert |
+| `official_alerts/base.py:137-148` | Registry | ruft `covers`/`fetch` in `try/except Exception` — Signatur von `MassifClosureSource` darf nicht erweitert werden, sonst deaktiviert ein Fehler die Quelle still statt laut zu brechen |
+| `/api/scheduler/status` → `jobs[].next_run` | API-Feld | Datenquelle für (B), unverändert — nur die Anzeige ändert sich |
+| `trip_report_scheduler.py:180-189` | scheduling | tatsächliche Versandlogik, **nicht** Teil dieser Scheibe — Invariante: bleibt unberührt |
+
+## Implementation Details
+
+### (A) `src/services/official_alerts/massif_closure.py`
+
+1. **Cache-Schlüssel trägt den Kalendertag.** Vorbild `meteoalarm.py:768`
+   (`f"{country}:{slot}:p{page}"`), dort ist der Zeitanteil bereits Teil des Schlüssels. Neuer Schlüssel:
+   `f"{src}:{ymd}"` statt bisher `src`.
+2. **Aufräumen beim Ablegen.** `warn_egress.cached_fetch`/`_store_entry` kennen keine Invalidierung
+   (Ablauf nur beim Zugriff, `warn_egress.py:431-434`) — ohne Aufräumen wüchse `_cache` in einem
+   langlebigen Prozess pro Quelle und Kalendertag unbegrenzt. Vor dem Aufruf von
+   `warn_egress.cached_fetch(...)` entfernt `_get_cached_daily_json` alle vorhandenen Einträge in
+   `massif_closure._cache`, deren Schlüssel mit `f"{src}:"` beginnt und vom aktuellen `cache_key`
+   abweicht (also Einträge derselben Quelle für einen anderen Tag).
+3. **Keine Signaturänderung.** `_get_cached_daily_json(src, ymd)`, `MassifClosureSource.covers()` und
+   `MassifClosureSource.fetch()` behalten ihre bestehenden Signaturen — die Änderung bleibt vollständig
+   innerhalb der Schlüsselbildung. `warn_egress.py` (der geteilte Kern) und `base.py` (Registry) werden
+   nicht angefasst.
+
+### (B) `frontend/src/routes/account/+page.svelte`
+
+1. **Label:** `Nächster:` (`:599`) wird zu `Nächste Prüfung:` — sagt, was der Wert ist (generischer
+   Poll-Tick, kein Versandtermin).
+2. **Zone:** alle vier `timeZone: 'Europe/Vienna'`-Literale (`:269, :270, :271, :279`) entfallen. Ohne
+   `timeZone`-Option formatiert `Intl`/`Date` implizit in der Zeitzone des ausführenden Browsers — analog
+   zu allen übrigen Zeitanzeigen im Frontend (`compare/subscriptionHelpers.ts:54-58`,
+   `_home/TripKachel.svelte:11`, `+page.svelte:50/141/407`), die schon heute ohne `timeZone`-Angabe
+   arbeiten.
+3. **Zonenkürzel sichtbar:** die Uhrzeit-Formatierung (`:271`) erhält `timeZoneName: 'short'`, damit die
+   Zahl trotz wegfallender fester Zone eindeutig bleibt. Erstmalige Einführung dieser Option im
+   Frontend — Darstellung muss WCAG-AA-Kontrast einhalten (Design-Leitprinzipien, `CLAUDE.md`).
+4. **Relativlogik unverändert:** `heute um …` / `morgen um …` bleibt erhalten, der Tagesvergleich
+   (`:273-278`) rechnet nur noch ohne die feste Zonen-Option statt gegen `Europe/Vienna`.
+5. 🔴 **Funktion auslagern, damit sie prüfbar wird.** `formatNextRun()` liegt heute als interne Funktion
+   im `<script>`-Block von `+page.svelte` und ist damit **von außen nicht aufrufbar** — ein Unit-Test
+   kann sie nicht importieren. Sie wandert unverändert in ein eigenes Modul
+   `frontend/src/lib/utils/schedulerTime.ts` und wird dort exportiert; `+page.svelte` importiert sie.
+   Das ist die Voraussetzung für AC-5 und zugleich der erste geteilte Zeit-Baustein im Frontend (bisher
+   existiert keiner — jede Stelle formatiert eigenständig). Kein Verhalten ändert sich durch die
+   Verschiebung selbst.
+
+## Expected Behavior
+
+- **Input A:** zwei `fetch()`-Aufrufe für dieselbe Präfektur-Quelle an zwei unterschiedlichen
+  Kalendertagen, innerhalb der 1800s-Erfolgs-TTL, ohne Cache-Löschung dazwischen.
+- **Output A:** der zweite Aufruf löst einen echten zweiten HTTP-Request gegen den Endpunkt des
+  zweiten Tages aus und liefert dessen Daten; nach dem zweiten Aufruf enthält `_cache` genau einen
+  Eintrag für diese Quelle (den des zweiten Tages).
+- **Side effects A:** keine — Egress-Zähler/Journal-Verhalten von `cached_fetch` unverändert.
+- **Input B:** `job.next_run` (ISO-Zeitstempel) aus `/api/scheduler/status`, gerendert im Browser eines
+  Nutzers in beliebiger Zeitzone.
+- **Output B:** Label „Nächste Prüfung", Uhrzeit in der Browser-Zeitzone mit sichtbarem Zonenkürzel.
+- **Side effects B:** keine — reine Anzeigeänderung, kein Einfluss auf `next_run` selbst oder auf die
+  tatsächliche Versandlogik.
+
+## Acceptance Criteria
+
+- **AC-1:** Given zwei aufeinanderfolgende Kalendertage innerhalb der 1800s-Erfolgs-TTL für dieselbe
+  Massiv-Quelle, When `MassifClosureSource().fetch()` am zweiten Tag erneut aufgerufen wird, ohne dass
+  der Cache zwischen den Aufrufen geleert wird, Then löst der zweite Aufruf einen echten zweiten
+  HTTP-Request gegen den Endpunkt des zweiten Tages aus (nicht nur einen Cache-Treffer auf den ersten
+  Tag).
+  - Test: lokaler HTTP-Sentinel (Vorbild `_lokaler_massif_server()` in
+    `test_import_und_fremdquellen_folgen_ortstag.py`) zeichnet angefragte Pfade auf; zwei `fetch()`-Aufrufe
+    unter `freeze_time` auf zwei verschiedene Kalendertage, `massif_closure._cache` wird zwischen den
+    Aufrufen **nicht** geleert (Gegenteil des bestehenden Testhelfer-Musters `:164-166`, das den Fall aktiv
+    umgeht). Erwartung: `len(requested_paths) == 2`, zweiter Pfad trägt das `ymd` des zweiten Tages.
+
+- **AC-2:** Given der Cache enthält nach dem ersten Aufruf einen Eintrag für Quelle+Tag-1, When der
+  zweite Aufruf für Quelle+Tag-2 abgeschlossen ist, Then ist der Eintrag für Tag-1 aus
+  `massif_closure._cache` entfernt und es existiert nur noch der Eintrag für Tag-2 (kein unbegrenztes
+  Wachstum je Quelle über die Zeit).
+  - Test: direkt im Anschluss an AC-1-Testlauf `massif_closure._cache.keys()` prüfen — genau ein
+    Schlüssel, der mit dem zweiten `ymd` endet.
+
+- **AC-3:** Given die Official-Alerts-Registry ruft `MassifClosureSource.covers()`/`.fetch()` in
+  `try/except Exception` (`base.py:137-148`), When die Cache-Schlüsseländerung umgesetzt ist, Then
+  bleiben beide Methodensignaturen unverändert und der bestehende Registry-Testpfad
+  (`tests/tdd/test_issue_1037_massif_closure.py`) läuft unverändert und grün — kein Fehler wird durch
+  eine neue Pflichtangabe still verschluckt.
+  - Test: bestehende Testsuite `test_issue_1037_massif_closure.py` unverändert ausführen, alle 10
+    Methoden weiterhin grün, keine Signaturänderung nötig.
+
+- **AC-4:** Given die Konto-Seite zeigt den nächsten Prüf-Zeitpunkt eines Scheduler-Jobs, When die Seite
+  gerendert wird, Then steht dort sichtbar „Nächste Prüfung" statt „Nächster" vor dem formatierten
+  Zeitwert.
+  - Test: **echter Browser-Test** (Playwright, `frontend/e2e/`) — Konto-Seite aufrufen, den sichtbaren
+    Text der Scheduler-Zeile auslesen und auf „Nächste Prüfung" prüfen. Ein Dateiinhalt-Grep auf
+    `+page.svelte` ist als Nachweis **ausdrücklich untersagt** (Test-Politik: Dateiinhalt-Checks belegen
+    kein Verhalten); die Beschriftung ist statisches Markup und nur im gerenderten Zustand prüfbar.
+
+- **AC-5:** Given ein Browser läuft in einer von Wien abweichenden Zeitzone (z. B. `America/New_York`),
+  When `formatNextRun()` einen ISO-Zeitstempel rendert, Then erscheint die Uhrzeit in der Zeitzone des
+  Browsers (nicht mehr fest `Europe/Vienna`) und trägt ein sichtbares Zonenkürzel
+  (`timeZoneName: 'short'`), sodass sich der Anzeigewert nachweisbar ändert, wenn die simulierte
+  Browser-Zone wechselt.
+  - Test: Unit-Test gegen das neue Modul `frontend/src/lib/utils/schedulerTime.ts` (Auslagerung siehe
+    Implementation Details B.5 — ohne sie ist die Funktion nicht importierbar). Derselbe ISO-Input wird
+    unter zwei gesetzten Zonen (`Europe/Vienna` vs. `America/New_York`) formatiert; erwartet werden
+    **unterschiedliche** Uhrzeit-Strings, beide mit Zonenkürzel.
+  - 🔴 **Positivkontrolle Pflicht:** Der Test muss belegen, dass die Zonen-Umschaltung im Testaufbau
+    überhaupt wirkt. Ein Testgerüst, in dem `TZ` folgenlos bleibt, liefert zwei identische Strings und
+    wäre auch bei fest verdrahtetem Wien grün — der Nachweis wäre wertlos. Die beiden erwarteten
+    Uhrzeiten sind deshalb als konkrete Werte zu prüfen, nicht nur auf Ungleichheit.
+
+- **AC-6:** Given die bestehende Versandkette (nackte Eingabe-Uhrzeit → naive Speicherung → Auswertung
+  als Ortszeit des Trip-Startpunkts über `trip_report_scheduler.py:180-189`) ist ADR-0051-konform und
+  korrekt, When diese Scheibe umgesetzt ist, Then ist an `trip_report_scheduler.py`, `models.py`,
+  `internal/model/trip.go` oder anderen Versand-Dateien keine Zeile geändert, und die bestehende
+  Scheduler-Testsuite bleibt unverändert grün.
+  - Test: `git diff --stat` gegen `origin/main` (Drei-Punkt-Vergleich, damit fremde Parallelarbeit nicht
+    als eigene zählt) zeigt ausschließlich `massif_closure.py`, `account/+page.svelte`,
+    `lib/utils/schedulerTime.ts` plus die zugehörigen Testdateien; bestehende
+    `trip_report_scheduler`-Tests laufen unmodifiziert durch.
+
+## Known Limitations
+
+- Der eigentliche nächste Versandzeitpunkt je Trip in dessen Ortszeit wird weiterhin **nicht** angezeigt
+  — das bleibt ausdrücklich #1969 (PO-entschieden ausgelagert, größerer Umbau).
+- Ob externes Monitoring in `henemm-infra` den bisherigen Label-Text „Nächster" oder das ISO-Feld
+  `next_run` maschinell parst, ist von hier aus nicht messbar (anderes Repo) — als Lücke benannt, nicht
+  geschätzt.
+- Muster-3 des Zeitzonen-Wächters (`.hour`/`.date()` auf nicht zonenaufgelöstem Zeitstempel) und die
+  Ausweitung der Wächter-Suchfläche auf `src/providers/`/`src/app/loader.py` sind eigener Umfang
+  (#1199), nicht Teil dieser Scheibe.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine neue — Umsetzung folgt ADR-0051 Regel 2/3 (Zeitbegriffe, Zone an den Daten),
+  Status dort weiterhin „Vorgeschlagen" (in #1199 gebucht, unverändert durch diese Scheibe).
+- **Rationale:** (A) ist eine reine Cache-Schlüssel-Korrektur ohne neues Architekturmuster — das Vorbild
+  (`meteoalarm.py:768`) existiert bereits im selben Modulverbund. (B) ist eine reine Anzeigekorrektur,
+  die das Frontend an das bestehende Muster „keine feste `timeZone`" angleicht, das an allen anderen
+  Stellen schon gilt.
+
+## Changelog
+
+- 2026-08-19: Initial spec created
+
+## Offene Punkte
+
+- Die Testvorgabe in AC-1 verlangt, dass der bestehende lokale HTTP-Sentinel (`_lokaler_massif_server()`)
+  wiederverwendet wird, aber **ohne** dessen Cache-Leerung zwischen den Aufrufen — der Handler liefert
+  aktuell für jeden Pfad denselben statischen Body (`{"massifs": {"831": [1]}}`). Das genügt für AC-1
+  (Nachweis über die **Pfade**, nicht über unterschiedliche Inhalte), sollte aber beim Schreiben des
+  Tests explizit so kommentiert werden, damit niemand versehentlich einen Inhaltsvergleich erwartet, den
+  der Sentinel gar nicht liefert.

--- a/docs/specs/modules/fix_1727_s5e_sperrcache_anzeige.md
+++ b/docs/specs/modules/fix_1727_s5e_sperrcache_anzeige.md
@@ -15,6 +15,10 @@ tags: [official-alerts, massif-closure, account-page, adr-0051]
 - [x] Approved — PO (Henning) am 2026-08-19, Freigabe „go" nach zwei Nachschärfungen:
   Frontend-Zusagen im echten Browser (AC-7), Ausgabe-Zusagen an der zugestellten Nachricht
   inklusive SMS-Kurzstil über Telegram (AC-8).
+- [x] Nachtrag freigegeben — PO (Henning) am 2026-08-19, „go": AC-9 (Nullwert-Termin erscheint als
+  „—") aufgenommen, Zonenkürzel in **beiden** Anzeigefällen. Danach als nicht führbar erkannt und
+  vom PO entschieden: **AC-7 wird zurückgestellt** (Grenze dokumentiert, Nachholen über Issue #1972),
+  weil keine Testumgebung einen echten Termin liefert.
 
 ## Purpose
 
@@ -79,11 +83,21 @@ in der Zeitzone des Nutzers.
    zu allen übrigen Zeitanzeigen im Frontend (`compare/subscriptionHelpers.ts:54-58`,
    `_home/TripKachel.svelte:11`, `+page.svelte:50/141/407`), die schon heute ohne `timeZone`-Angabe
    arbeiten.
-3. **Zonenkürzel sichtbar:** die Uhrzeit-Formatierung (`:271`) erhält `timeZoneName: 'short'`, damit die
-   Zahl trotz wegfallender fester Zone eindeutig bleibt. Erstmalige Einführung dieser Option im
-   Frontend — Darstellung muss WCAG-AA-Kontrast einhalten (Design-Leitprinzipien, `CLAUDE.md`).
+3. **Zonenkürzel sichtbar:** **beide** Ausgabe-Formatierungen (`:271` naher Fall „heute/morgen um …",
+   `:279` ferner Fall „24.12., 22:30") erhalten `timeZoneName: 'short'`, damit die Zahl trotz
+   wegfallender fester Zone eindeutig bleibt. PO-Entscheid 2026-08-19: das Kürzel gilt in beiden Fällen
+   — eine Anzeige ohne Kürzel wäre nach Wegfall der festen Zone mehrdeutig, unabhängig davon, wie weit
+   der Termin entfernt ist. Erstmalige Einführung dieser Option im Frontend — Darstellung muss
+   WCAG-AA-Kontrast einhalten (Design-Leitprinzipien, `CLAUDE.md`).
 4. **Relativlogik unverändert:** `heute um …` / `morgen um …` bleibt erhalten, der Tagesvergleich
    (`:273-278`) rechnet nur noch ohne die feste Zonen-Option statt gegen `Europe/Vienna`.
+4b. 🔴 **Die Uhrzeit wird erst im Browser gesetzt.** Die Konto-Seite wird serverseitig vorgerendert
+   (`account/+page.server.ts`), der Node-Prozess läuft in `Etc/UTC`. Fällt die feste Wiener Zone weg,
+   formatiert also zuerst der Server in UTC; ob der Browser den Text beim Übernehmen zuverlässig
+   ersetzt, ist nicht garantiert. Bliebe der Servertext stehen, sähen **alle** Nutzer UTC statt Wien —
+   schlechter als der heutige Zustand. Die Zeitanzeige wird deshalb nach dem Mounten gesetzt (bis dahin
+   `—`). Das schließt die Serverzone durch die Bauweise aus. Nachweis: Adversary-Prüfpunkt, kein
+   Ausgabetest — ein solcher bräuchte den echten Terminwert, den keine Umgebung liefert (s. AC-7).
 5. 🔴 **Funktion auslagern, damit sie prüfbar wird.** `formatNextRun()` liegt heute als interne Funktion
    im `<script>`-Block von `+page.svelte` und ist damit **von außen nicht aufrufbar** — ein Unit-Test
    kann sie nicht importieren. Sie wandert unverändert in ein eigenes Modul
@@ -178,6 +192,45 @@ in der Zeitzone des Nutzers.
   - 🔴 Die beiden Uhrzeiten **müssen** sich unterscheiden. Wären sie gleich, wäre entweder die feste
     Zone noch drin oder der Zonenwechsel des Testbrowsers folgenlos — beides ist ein Fehlschlag, kein
     Grenzfall.
+  - 🔴 **NICHT FÜHRBAR — als Grenze dokumentiert, nicht erfüllt** (Nachtrag 2026-08-19, gemessen;
+    PO-Entscheid: später nachholen, Nachfolge-Issue #1972). In **keiner** verfügbaren Umgebung existiert
+    ein echter Termin, gegen den zwei Zonen verglichen werden könnten:
+    - **Staging:** `SchedulerEnabled()` (`internal/scheduler/scheduler_gate.go:11-13`) gibt für
+      `env=staging` `false` zurück — Staging teilt sich das tägliche Open-Meteo-Kontingent mit
+      Produktion (#1329). `/api/scheduler/status` liefert dort für alle zehn Jobs dauerhaft
+      `next_run: "0001-01-01T00:00:00Z"`, `last_run: null`.
+    - **Lokaler E2E-Stack:** startet die Go-API ebenfalls mit `GZ_ENV=staging`
+      (`frontend/e2e/ci-stack.sh:57`) — derselbe Ausschluss.
+    - **Produktion:** hätte echte Werte, Testläufe dagegen sind verboten.
+    - Ein Stub im Browser (`page.route()`) hilft **nicht**: die Konto-Seite lädt
+      `/api/scheduler/status` serverseitig (`account/+page.server.ts:23`), der Browser sieht nur
+      fertiges HTML. Den Scheduler im Testaufbau einzuschalten ist ausgeschlossen — es würde echte
+      Briefings und Alarme auslösen.
+    - **Ersatznachweis:** der Zonenwechsel wird in AC-5 mit konkreten Sollwerten belegt (22:30 MEZ
+      gegen 16:30 GMT-5), die Browser-Schicht prüft AC-4 und AC-9 in zwei Zonen. Ein Nachweis auf
+      einem erfundenen Wert wäre kein Nachweis.
+
+  - 🔴 **Anschlussrisiko, das AC-7 mitgenommen hätte** (siehe Implementation Details B.6): Die Seite
+    wird serverseitig vorgerendert, der Server läuft in `Etc/UTC`. Ohne feste Zone formatiert zuerst
+    der Node-Prozess in UTC. Das ist eine **Bauweise-Vorgabe, kein prüfbares AC** — ein Ausgabetest
+    dafür bräuchte denselben echten Zeitwert, den es nirgends gibt. Er wird deshalb bewusst nicht
+    behauptet, sondern durch die Umsetzung ausgeschlossen und ist expliziter Prüfpunkt des Adversary.
+
+- **AC-9:** Given `/api/scheduler/status` liefert für einen Job keinen Termin — in der Praxis den
+  Go-Nullwert `0001-01-01T00:00:00Z`, wie auf Staging dauerhaft der Fall (#1329) —, When die
+  Konto-Seite diese Zeile rendert, Then erscheint „Nächste Prüfung: —" und **kein** aus dem Nullwert
+  abgeleitetes Datum.
+  - Gemessener Ist-Zustand (2026-08-19, Staging): die Seite zeigt „Nächster: 01.01., 01:05". Die
+    Uhrzeit entsteht daraus, dass Wien im Jahr 1 eine Ortszeit von +01:05 gegenüber UTC hatte — der
+    Nullwert wird also als gültiges Datum durchformatiert. `formatNextRun()` prüft heute nur `if (!iso)`
+    und erkennt einen vorhandenen, aber bedeutungslosen Zeitstempel nicht.
+  - Umsetzung: `formatNextRun()` behandelt einen Zeitstempel vor einer Plausibilitätsgrenze wie einen
+    fehlenden Wert. Die Grenze wird am Jahr gezogen (`getFullYear() < 2000`), nicht an `getTime() <= 0`
+    — letzteres ließe Zeitpunkte zwischen 1970 und heute durch, die ebenso wenig ein Termin sind.
+  - Test: Unit-Test gegen `schedulerTime.ts` mit `'0001-01-01T00:00:00Z'` → `'—'`, und Browser-Test
+    (AC-7-Aufbau, Nullwert-Antwort) → die Zeile zeigt „Nächste Prüfung: —".
+  - 🔴 **Positivkontrolle Pflicht:** derselbe Test prüft mit, dass ein *echter* Zeitstempel weiterhin
+    formatiert wird. Eine Grenze, die versehentlich alles verschluckt, wäre sonst grün.
 
 - **AC-8:** Given eine amtliche Waldbrand-Zugangssperre liegt für ein Massiv des Test-Trips vor, When
   ein Briefing über Staging versendet wird, Then erscheint diese Sperre in der **zugestellten E-Mail**,
@@ -214,6 +267,15 @@ in der Zeitzone des Nutzers.
 - **Premium-SMS wird nicht eigens geprüft.** Sie teilt den Kurzstil-Renderweg mit SMS; geprüft wird
   hier der Inhalt, und der ist identisch. Eine Abweichung im Transportweg wäre ein eigener Befund,
   kein Regress dieser Scheibe.
+- **Der Zonenwechsel ist im echten Browser nicht nachweisbar** (AC-7, zurückgestellt auf #1972).
+  Keine verfügbare Umgebung liefert einen echten Termin: Staging und der lokale E2E-Stack fahren beide
+  mit `GZ_ENV=staging` und damit ohne Scheduler (#1329), Produktion ist für Testläufe gesperrt. Ein
+  Browser-Stub scheidet aus, weil die Seite serverseitig lädt. Belegt ist der Zonenwechsel deshalb im
+  Unit-Test mit konkreten Sollwerten (AC-5); im Browser sind Beschriftung (AC-4) und Nullwert-
+  Darstellung (AC-9) belegt. Wer daraus „im Browser verifiziert" macht, überdehnt den Nachweis.
+- **Dass die Serverzone nie sichtbar wird, ist durch die Bauweise sichergestellt, nicht durch einen
+  Test** (Implementation Details B.6) — derselbe fehlende Terminwert macht auch hier jeden
+  Ausgabetest unmöglich.
 - Der eigentliche nächste Versandzeitpunkt je Trip in dessen Ortszeit wird weiterhin **nicht** angezeigt
   — das bleibt ausdrücklich #1969 (PO-entschieden ausgelagert, größerer Umbau).
 - Ob externes Monitoring in `henemm-infra` den bisherigen Label-Text „Nächster" oder das ISO-Feld
@@ -235,6 +297,12 @@ in der Zeitzone des Nutzers.
 ## Changelog
 
 - 2026-08-19: Initial spec created
+- 2026-08-19 (Nachtrag, **erneut freigabepflichtig**): AC-9 ergänzt (Nullwert-Termin erscheint als
+  „—" statt als abgeleitetes Datum) und AC-7 präzisiert (Zeitwert wird per `page.route()` gesetzt,
+  weil Staging nach #1329 dauerhaft keinen Scheduler fährt). Auslöser: beim RED-Lauf gegen Staging
+  gemessen, dass die Zeile dort „Nächster: 01.01., 01:05" zeigt — der durchformatierte Go-Nullwert.
+  PO-Entscheid am 2026-08-19: in diese Scheibe aufnehmen statt eigenes Issue. Zusätzlich entschieden:
+  das Zonenkürzel erscheint in **beiden** Anzeigefällen (nah und fern), nicht nur im nahen.
 
 ## Offene Punkte
 

--- a/docs/specs/modules/fix_1727_s5e_sperrcache_anzeige.md
+++ b/docs/specs/modules/fix_1727_s5e_sperrcache_anzeige.md
@@ -12,7 +12,9 @@ tags: [official-alerts, massif-closure, account-page, adr-0051]
 
 ## Approval
 
-- [ ] Approved
+- [x] Approved — PO (Henning) am 2026-08-19, Freigabe „go" nach zwei Nachschärfungen:
+  Frontend-Zusagen im echten Browser (AC-7), Ausgabe-Zusagen an der zugestellten Nachricht
+  inklusive SMS-Kurzstil über Telegram (AC-8).
 
 ## Purpose
 

--- a/docs/specs/modules/fix_1727_s5e_sperrcache_anzeige.md
+++ b/docs/specs/modules/fix_1727_s5e_sperrcache_anzeige.md
@@ -178,12 +178,23 @@ in der Zeitzone des Nutzers.
     Grenzfall.
 
 - **AC-8:** Given eine amtliche Waldbrand-Zugangssperre liegt für ein Massiv des Test-Trips vor, When
-  ein Briefing über Staging versendet wird, Then erscheint diese Sperre in der **zugestellten E-Mail**
-  und in der **zugestellten Telegram-Nachricht**.
+  ein Briefing über Staging versendet wird, Then erscheint diese Sperre in der **zugestellten E-Mail**,
+  in der **zugestellten Telegram-Nachricht im Vollformat** (`telegram_style: 'rich'`) und im
+  **SMS-Kurzstil** (`telegram_style: 'kurzform'`).
   - Test: Live-Schicht. Versand über Staging, E-Mail per IMAP aus `gregor-test@henemm.com` abgeholt und
     im Text nachgewiesen; Telegram-Nachricht im Zielchat nachgewiesen. Damit ist belegt, dass der
     geänderte Cache-Pfad die Ausgabe tatsächlich erreicht — nicht nur, dass ein Dict den richtigen
     Schlüssel trägt.
+  - 🔴 **SMS wird über den Telegram-Kurzstil geprüft, nicht durch echten SMS-Versand** (PO-Dauerregel).
+    Der Schalter „Telegram im SMS-Kurzstil" (`TelegramKurzstilToggle.svelte`, Feld
+    `report_config.telegram_style`, Werte `'rich'` | `'kurzform'`, Spec
+    `docs/specs/modules/feat_1260_telegram_kurzstil.md`) lässt Telegram denselben kurzen Ein-Zeilen-Text
+    ausliefern wie SMS. Damit ist das SMS-**Format** an einer echt zugestellten Nachricht belegt, ohne
+    Kosten und ohne Versand ans Satellitengerät. Der Nachweis ist mit beiden Stellungen des Schalters zu
+    führen, weil die Sperren-Darstellung im Kurzstil eine andere ist als im Vollformat.
+  - Grenze: Der Kurzstil belegt den **Inhalt** des SMS-Formats, nicht den **Transportweg** (Provider,
+    Zeichenzählung beim Versand, Zustellung am Gerät). Für diese Änderung genügt der Inhalt — der
+    Transport ist von ihr nicht berührt.
   - 🔴 **Ehrliche Grenze:** Ein echter Kalendertagwechsel ist auf Staging nicht herstellbar. AC-8 ist
     deshalb die **Positivkontrolle des Ausgabewegs** (die Sperre kommt an), nicht der Nachweis des
     Tageswechsels — den führt AC-1 in der Kern-Schicht. Beide zusammen decken die Zusicherung ab;
@@ -195,11 +206,12 @@ in der Zeitzone des Nutzers.
 - **Der Kalendertagwechsel ist auf Staging nicht herstellbar.** Er wird deshalb in der Kern-Schicht
   gegen einen lokalen Sentinel nachgewiesen (AC-1); Staging belegt den Ausgabeweg (AC-8). Wer nur eines
   von beiden vorzeigt, hat die Zusicherung nicht belegt.
-- **Nachgewiesene Ausgabekanäle sind E-Mail und Telegram** (AC-8, PO-Vorgabe 2026-08-19). SMS und
-  Premium-SMS durchlaufen denselben Renderweg für amtliche Warnungen, werden hier aber nicht
-  eigens versendet — Begründung: kein zusätzlicher Erkenntnisgewinn für diese Änderung, dafür echter
-  Versand an ein Satellitengerät. Falls die Sperren-Darstellung in den Kurzformaten später abweicht,
-  ist das ein eigener Befund, kein Regress dieser Scheibe.
+- **Nachgewiesene Ausgabeformate sind E-Mail, Telegram-Vollformat und SMS-Kurzstil** (AC-8). Das
+  SMS-Format wird über den Telegram-Kurzstil geprüft — echter SMS-Versand findet nicht statt und ist
+  für einen Inhaltsnachweis auch nicht nötig (PO-Dauerregel 2026-08-19).
+- **Premium-SMS wird nicht eigens geprüft.** Sie teilt den Kurzstil-Renderweg mit SMS; geprüft wird
+  hier der Inhalt, und der ist identisch. Eine Abweichung im Transportweg wäre ein eigener Befund,
+  kein Regress dieser Scheibe.
 - Der eigentliche nächste Versandzeitpunkt je Trip in dessen Ortszeit wird weiterhin **nicht** angezeigt
   — das bleibt ausdrücklich #1969 (PO-entschieden ausgelagert, größerer Umbau).
 - Ob externes Monitoring in `henemm-infra` den bisherigen Label-Text „Nächster" oder das ISO-Feld

--- a/frontend/e2e/konto-naechste-pruefung.staging.setup.ts
+++ b/frontend/e2e/konto-naechste-pruefung.staging.setup.ts
@@ -1,0 +1,35 @@
+import { test as setup, expect } from '@playwright/test';
+import { assertNotProdBaseURL } from './prodUrlGuard';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+// Staging-Auth fuer Issue #1727 S5e (Konto-Seite, AC-4/AC-7). Muster:
+// kuerzel-marken-sichtbar.staging.setup.ts — nginx-Basic-Auth (GZ_VALIDATOR_*)
+// und App-Login (GZ_AUTH_*) sind ZWEI getrennte Credential-Paare, und die
+// Staging-Instanz hat ein eigenes App-Passwort (CLAUDE.md, "Zugangsdaten").
+// Ein storageState statt Login je Test: der Zonenvergleich oeffnet zwei
+// Kontexte, zwei Logins liefen unnoetig gegen das Rate-Limit (#703).
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const authFile = path.join(__dirname, 'playwright', '.auth', 'staging-1727-s5e.json');
+
+setup('authenticate via API (staging) — fix_1727_s5e_konto_naechste_pruefung', async ({
+	playwright
+}) => {
+	const base = process.env.GZ_SVELTE_BASE ?? 'https://staging.gregor20.henemm.com';
+	assertNotProdBaseURL(base);
+	const nginxUser = process.env.GZ_VALIDATOR_USER ?? 'admin';
+	const nginxPass = process.env.GZ_VALIDATOR_PASS ?? 'test1234';
+	const appUser = process.env.GZ_AUTH_USER ?? process.env.E2E_USER ?? 'admin';
+	const appPass = process.env.GZ_AUTH_PASS ?? process.env.E2E_PASS ?? 'test1234';
+
+	const ctx = await playwright.request.newContext({
+		baseURL: base,
+		ignoreHTTPSErrors: true,
+		httpCredentials: { username: nginxUser, password: nginxPass }
+	});
+	const res = await ctx.post('/api/auth/login', {
+		data: { username: appUser, password: appPass }
+	});
+	expect(res.ok(), `login HTTP ${res.status()}`).toBeTruthy();
+	await ctx.storageState({ path: authFile });
+	await ctx.dispose();
+});

--- a/frontend/e2e/konto-naechste-pruefung.staging.spec.ts
+++ b/frontend/e2e/konto-naechste-pruefung.staging.spec.ts
@@ -1,22 +1,35 @@
 // TDD RED — E2E (Staging), Issue #1727 S5e (B): die Konto-Seite beschriftet
-// den Scheduler-Tick ehrlich und zeigt ihn in der Zone des Browsers.
+// den Scheduler-Tick ehrlich und behauptet keinen Termin, den es nicht gibt.
 //
 // Spec: docs/specs/modules/fix_1727_s5e_sperrcache_anzeige.md
 //   AC-4  sichtbarer Text "Nächste Prüfung" statt "Nächster"
-//   AC-7  zwei Browser-Zonen -> zwei verschiedene Uhrzeiten, je eigenes Kuerzel
+//   AC-9  kein Termin -> "—", kein aus dem Nullwert abgeleitetes Datum
 //
 // WARUM IM BROWSER UND NICHT PER GREP: Die Beschriftung ist statisches Markup
-// (`account/+page.svelte:599`), die Zone entsteht erst beim Formatieren im
-// Browser. Ein Dateiinhalt-Check auf `+page.svelte` ist als Nachweis
-// ausdruecklich untersagt (Spec AC-4; CLAUDE.md "Test-Politik") — er belegt
-// kein Verhalten. Geprueft wird der GERENDERTE Text der Zeile.
+// (`account/+page.svelte:599`), die Formatierung entsteht erst beim Rendern.
+// Ein Dateiinhalt-Check auf `+page.svelte` ist als Nachweis ausdruecklich
+// untersagt (Spec AC-4; CLAUDE.md "Test-Politik") — er belegt kein Verhalten.
 //
-// RED-Grund (gemessen): Staging traegt den alten Stand — die Zeile heisst dort
-// "Nächster:" und formatiert fest in `Europe/Vienna` (vier `timeZone`-Literale,
-// `:269-279`). Beide Zonen liefern deshalb heute denselben String.
+// WAS HIER BEWUSST NICHT GEPRUEFT WIRD: der Zonenwechsel (AC-7). Auf Staging
+// startet der Scheduler nie (`scheduler_gate.go:11-13`, `env=staging`, Issue
+// #1329 — geteiltes Open-Meteo-Kontingent), `/api/scheduler/status` liefert
+// dort fuer alle zehn Jobs dauerhaft `next_run: "0001-01-01T00:00:00Z"`. Es
+// gibt also keinen echten Termin, gegen den zwei Zonen vergleichbar waeren;
+// der lokale E2E-Stack faehrt aus demselben Grund ohne Scheduler
+// (`ci-stack.sh:57`), und Prod-Testlaeufe sind verboten. Ein Stub im Browser
+// hilft nicht, weil die Seite serverseitig laedt (`+page.server.ts:23`).
+// Der Zonenwechsel ist deshalb im Unit-Test belegt (AC-5, konkrete Sollwerte);
+// das Nachholen im Browser ist Issue #1972. Diese Datei behauptet ihn NICHT.
+//
+// Genau dieser Umstand macht aber AC-9 hier besonders gut pruefbar: der
+// Nullwert liegt auf Staging ECHT an, nicht gestellt.
+//
+// RED-Grund (gemessen 2026-08-19): Staging traegt den alten Stand und zeigt
+// "Nächster: 01.01., 01:05" — die alte Beschriftung UND der durchformatierte
+// Nullwert. Die krumme Uhrzeit stammt daher, dass Wien im Jahr 1 eine Ortszeit
+// von +01:05 gegenueber UTC hatte.
 //
 // Ausfuehren (aus frontend/, gegen Staging):
-//   set -a; source /home/hem/gregor_zwanzig/validator.env; set +a
 //   npx playwright test --config=e2e/playwright.konto-naechste-pruefung.staging.config.ts
 
 import { test, expect, type Browser, type Page } from '@playwright/test';
@@ -45,7 +58,11 @@ async function schedulerZeile(page: Page): Promise<string> {
 
 /** Konto-Seite in einem Browser-Kontext mit fest gesetzter Zeitzone oeffnen.
  *  `browser.newContext()` erbt die `use`-Optionen der Config NICHT — Basis-URL,
- *  nginx-Zugang und Anmeldezustand muessen hier explizit mitgegeben werden. */
+ *  nginx-Zugang und Anmeldezustand muessen hier explizit mitgegeben werden.
+ *
+ *  Die Zone wird gesetzt, obwohl AC-7 hier nicht geprueft wird: AC-4 und AC-9
+ *  muessen in JEDER Zone gelten, und ein zonenabhaengiges Ergebnis waere ein
+ *  Befund. */
 async function kontoSeiteInZone(browser: Browser, timezoneId: string): Promise<string> {
 	const ctx = await browser.newContext({
 		baseURL: BASE,
@@ -66,7 +83,7 @@ async function kontoSeiteInZone(browser: Browser, timezoneId: string): Promise<s
 	}
 }
 
-test.describe('#1727 S5e — Konto-Seite: "Nächste Prüfung" in der Browser-Zone', () => {
+test.describe('#1727 S5e — Konto-Seite: ehrliche Beschriftung und kein Fantasie-Termin', () => {
 	test.beforeAll(() => {
 		assertNotProdBaseURL(BASE);
 	});
@@ -86,59 +103,33 @@ test.describe('#1727 S5e — Konto-Seite: "Nächste Prüfung" in der Browser-Zon
 		).not.toMatch(/Nächster:/);
 	});
 
-	test('AC-7: zwei Browser-Zonen zeigen zwei verschiedene Uhrzeiten mit Kuerzel', async ({
+	test('AC-9: ohne echten Termin steht ein Gedankenstrich, kein abgeleitetes Datum', async ({
 		browser
 	}) => {
+		// Staging liefert echt den Go-Nullwert (siehe Kopf) — der Fall ist hier
+		// nicht gestellt, sondern der Normalzustand dieser Umgebung.
 		const wien = await kontoSeiteInZone(browser, 'Europe/Vienna');
 		const newYork = await kontoSeiteInZone(browser, 'America/New_York');
 
-		// Positivkontrolle: ohne echten Zeitwert ist der Vergleich wertlos.
-		// Steht dort "—", liefert der Scheduler kein `next_run` — dann ist das
-		// ein Fehlschlag des Testaufbaus, kein bestandener Nachweis.
 		for (const [zone, wert] of [
 			['Europe/Vienna', wien],
 			['America/New_York', newYork]
 		] as const) {
 			expect(
 				wert,
-				`In ${zone} steht ${JSON.stringify(wert)} — der Scheduler liefert kein ` +
-					`next_run. Ohne Zeitwert ist der Zonenvergleich nicht fuehrbar.`
-			).toMatch(/\d{2}:\d{2}/);
+				`In ${zone}: ${JSON.stringify(wert)} — erwartet "Nächste Prüfung: —". Eine ` +
+					`Uhrzeit an dieser Stelle ist der durchformatierte Nullwert und behauptet ` +
+					`einen Termin, den der Scheduler nie gesetzt hat.`
+			).not.toMatch(/\d{1,2}:\d{2}/);
+			expect(wert, `In ${zone} fehlt der Gedankenstrich: ${JSON.stringify(wert)}`).toContain('—');
 		}
 
-		// Kernzusicherung AC-7 steht bewusst VOR der Beschriftungspruefung: sonst
-		// bricht der Test schon an der noch offenen AC-4 ab und sagt ueber die
-		// Zone gar nichts aus. Die beiden ACs sollen unabhaengig voneinander
-		// diagnostizierbar sein.
-		const uhrzeit = (s: string) => s.match(/\d{2}:\d{2}/)?.[0] ?? '';
+		// Zonenunabhaengig: dieselbe Aussage in beiden Zonen. Waere sie es nicht,
+		// haenge die Nullwert-Erkennung an der Zone — das waere ein Befund.
 		expect(
-			uhrzeit(newYork),
-			`Wien zeigt ${JSON.stringify(wien)}, New York ${JSON.stringify(newYork)} — ` +
-				`gleiche Uhrzeit bedeutet: die Anzeige haengt weiterhin fest an ` +
-				`Europe/Vienna (oder der Zonenwechsel des Testbrowsers ist folgenlos). ` +
-				`Beides ist ein Fehlschlag, kein Grenzfall.`
-		).not.toBe(uhrzeit(wien));
-
-		// Jede Anzeige traegt ihr eigenes Zonenkuerzel, sonst ist die Zahl mehrdeutig.
-		const kuerzel = (s: string) => s.replace(/^.*\d{2}:\d{2}\s*/, '').trim();
-		for (const [zone, wert] of [
-			['Europe/Vienna', wien],
-			['America/New_York', newYork]
-		] as const) {
-			expect(
-				kuerzel(wert),
-				`In ${zone} folgt der Uhrzeit kein Zonenkuerzel (${JSON.stringify(wert)}) — ` +
-					`ohne feste Zone waere die Zahl allein nicht mehr eindeutig.`
-			).not.toBe('');
-		}
-		expect(
-			kuerzel(newYork),
-			`Beide Zonen zeigen dasselbe Kuerzel ${JSON.stringify(kuerzel(wien))} — es ist ` +
-				`nicht das der jeweiligen Browser-Zone.`
-		).not.toBe(kuerzel(wien));
-
-		// Zuletzt: die Beschriftung gilt zonenunabhaengig (AC-4, hier mitgeprueft).
-		expect(wien).toContain('Nächste Prüfung:');
-		expect(newYork).toContain('Nächste Prüfung:');
+			newYork,
+			`Wien zeigt ${JSON.stringify(wien)}, New York ${JSON.stringify(newYork)} — die ` +
+				`Erkennung "kein Termin" darf nicht von der Browser-Zone abhaengen.`
+		).toBe(wien);
 	});
 });

--- a/frontend/e2e/konto-naechste-pruefung.staging.spec.ts
+++ b/frontend/e2e/konto-naechste-pruefung.staging.spec.ts
@@ -1,0 +1,144 @@
+// TDD RED — E2E (Staging), Issue #1727 S5e (B): die Konto-Seite beschriftet
+// den Scheduler-Tick ehrlich und zeigt ihn in der Zone des Browsers.
+//
+// Spec: docs/specs/modules/fix_1727_s5e_sperrcache_anzeige.md
+//   AC-4  sichtbarer Text "Nächste Prüfung" statt "Nächster"
+//   AC-7  zwei Browser-Zonen -> zwei verschiedene Uhrzeiten, je eigenes Kuerzel
+//
+// WARUM IM BROWSER UND NICHT PER GREP: Die Beschriftung ist statisches Markup
+// (`account/+page.svelte:599`), die Zone entsteht erst beim Formatieren im
+// Browser. Ein Dateiinhalt-Check auf `+page.svelte` ist als Nachweis
+// ausdruecklich untersagt (Spec AC-4; CLAUDE.md "Test-Politik") — er belegt
+// kein Verhalten. Geprueft wird der GERENDERTE Text der Zeile.
+//
+// RED-Grund (gemessen): Staging traegt den alten Stand — die Zeile heisst dort
+// "Nächster:" und formatiert fest in `Europe/Vienna` (vier `timeZone`-Literale,
+// `:269-279`). Beide Zonen liefern deshalb heute denselben String.
+//
+// Ausfuehren (aus frontend/, gegen Staging):
+//   set -a; source /home/hem/gregor_zwanzig/validator.env; set +a
+//   npx playwright test --config=e2e/playwright.konto-naechste-pruefung.staging.config.ts
+
+import { test, expect, type Browser, type Page } from '@playwright/test';
+import { assertNotProdBaseURL } from './prodUrlGuard';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const AUTH_STATE = path.join(__dirname, 'playwright', '.auth', 'staging-1727-s5e.json');
+const BASE = process.env.GZ_SVELTE_BASE ?? 'https://staging.gregor20.henemm.com';
+
+/** Die Zeile im Bereich "Deine Reports", die den naechsten Lauf zeigt.
+ *  Bewusst gegen BEIDE Beschriftungen gematcht (alt "Nächster:", neu
+ *  "Nächste Prüfung:") — sonst faende der Test im RED-Zustand gar nichts und
+ *  meldete "Element nicht da" statt des tatsaechlichen Ist-Textes. */
+async function schedulerZeile(page: Page): Promise<string> {
+	const zeile = page
+		.locator('#system-status span')
+		.filter({ hasText: /(Nächste Prüfung|Nächster):/ })
+		.first();
+	await expect(zeile, 'Zeile mit dem naechsten Lauf im Bereich "Deine Reports"').toBeVisible({
+		timeout: 20_000
+	});
+	return (await zeile.innerText()).trim();
+}
+
+/** Konto-Seite in einem Browser-Kontext mit fest gesetzter Zeitzone oeffnen.
+ *  `browser.newContext()` erbt die `use`-Optionen der Config NICHT — Basis-URL,
+ *  nginx-Zugang und Anmeldezustand muessen hier explizit mitgegeben werden. */
+async function kontoSeiteInZone(browser: Browser, timezoneId: string): Promise<string> {
+	const ctx = await browser.newContext({
+		baseURL: BASE,
+		timezoneId,
+		storageState: AUTH_STATE,
+		ignoreHTTPSErrors: true,
+		httpCredentials: {
+			username: process.env.GZ_VALIDATOR_USER ?? 'admin',
+			password: process.env.GZ_VALIDATOR_PASS ?? 'test1234'
+		}
+	});
+	try {
+		const page = await ctx.newPage();
+		await page.goto('/account', { waitUntil: 'domcontentloaded' });
+		return await schedulerZeile(page);
+	} finally {
+		await ctx.close();
+	}
+}
+
+test.describe('#1727 S5e — Konto-Seite: "Nächste Prüfung" in der Browser-Zone', () => {
+	test.beforeAll(() => {
+		assertNotProdBaseURL(BASE);
+	});
+
+	test('AC-4: die Zeile heisst "Nächste Prüfung", nicht "Nächster"', async ({ browser }) => {
+		const text = await kontoSeiteInZone(browser, 'Europe/Vienna');
+
+		expect(
+			text,
+			`Sichtbarer Text der Scheduler-Zeile: ${JSON.stringify(text)} — erwartet die ` +
+				`Beschriftung "Nächste Prüfung:". "Nächster:" gibt den generischen ` +
+				`stuendlichen Poll-Tick faelschlich als Versandtermin aus.`
+		).toContain('Nächste Prüfung:');
+		expect(
+			text,
+			`Die alte Beschriftung "Nächster:" steht noch in ${JSON.stringify(text)}.`
+		).not.toMatch(/Nächster:/);
+	});
+
+	test('AC-7: zwei Browser-Zonen zeigen zwei verschiedene Uhrzeiten mit Kuerzel', async ({
+		browser
+	}) => {
+		const wien = await kontoSeiteInZone(browser, 'Europe/Vienna');
+		const newYork = await kontoSeiteInZone(browser, 'America/New_York');
+
+		// Positivkontrolle: ohne echten Zeitwert ist der Vergleich wertlos.
+		// Steht dort "—", liefert der Scheduler kein `next_run` — dann ist das
+		// ein Fehlschlag des Testaufbaus, kein bestandener Nachweis.
+		for (const [zone, wert] of [
+			['Europe/Vienna', wien],
+			['America/New_York', newYork]
+		] as const) {
+			expect(
+				wert,
+				`In ${zone} steht ${JSON.stringify(wert)} — der Scheduler liefert kein ` +
+					`next_run. Ohne Zeitwert ist der Zonenvergleich nicht fuehrbar.`
+			).toMatch(/\d{2}:\d{2}/);
+		}
+
+		// Kernzusicherung AC-7 steht bewusst VOR der Beschriftungspruefung: sonst
+		// bricht der Test schon an der noch offenen AC-4 ab und sagt ueber die
+		// Zone gar nichts aus. Die beiden ACs sollen unabhaengig voneinander
+		// diagnostizierbar sein.
+		const uhrzeit = (s: string) => s.match(/\d{2}:\d{2}/)?.[0] ?? '';
+		expect(
+			uhrzeit(newYork),
+			`Wien zeigt ${JSON.stringify(wien)}, New York ${JSON.stringify(newYork)} — ` +
+				`gleiche Uhrzeit bedeutet: die Anzeige haengt weiterhin fest an ` +
+				`Europe/Vienna (oder der Zonenwechsel des Testbrowsers ist folgenlos). ` +
+				`Beides ist ein Fehlschlag, kein Grenzfall.`
+		).not.toBe(uhrzeit(wien));
+
+		// Jede Anzeige traegt ihr eigenes Zonenkuerzel, sonst ist die Zahl mehrdeutig.
+		const kuerzel = (s: string) => s.replace(/^.*\d{2}:\d{2}\s*/, '').trim();
+		for (const [zone, wert] of [
+			['Europe/Vienna', wien],
+			['America/New_York', newYork]
+		] as const) {
+			expect(
+				kuerzel(wert),
+				`In ${zone} folgt der Uhrzeit kein Zonenkuerzel (${JSON.stringify(wert)}) — ` +
+					`ohne feste Zone waere die Zahl allein nicht mehr eindeutig.`
+			).not.toBe('');
+		}
+		expect(
+			kuerzel(newYork),
+			`Beide Zonen zeigen dasselbe Kuerzel ${JSON.stringify(kuerzel(wien))} — es ist ` +
+				`nicht das der jeweiligen Browser-Zone.`
+		).not.toBe(kuerzel(wien));
+
+		// Zuletzt: die Beschriftung gilt zonenunabhaengig (AC-4, hier mitgeprueft).
+		expect(wien).toContain('Nächste Prüfung:');
+		expect(newYork).toContain('Nächste Prüfung:');
+	});
+});

--- a/frontend/e2e/playwright.konto-naechste-pruefung.staging.config.ts
+++ b/frontend/e2e/playwright.konto-naechste-pruefung.staging.config.ts
@@ -1,0 +1,41 @@
+import { defineConfig } from '@playwright/test';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+// E2E-Config Issue #1727 S5e (AC-4, AC-7): die Konto-Seite beschriftet den
+// Scheduler-Tick als "Nächste Prüfung" und zeigt ihn in der Zone des Browsers.
+// Kein lokaler webServer — geprueft wird die auf Staging deployte App selbst.
+// Staging steht hinter nginx-Basic-Auth (GZ_VALIDATOR_*) + App-Login (GZ_AUTH_*).
+//
+// Liegt bewusst UNTER frontend/e2e/ (nicht frontend/ root): das RED-Phasen-
+// Edit-Gate laesst nur die Ordner test/tests/__tests__/spec/e2e zu.
+// testDir '.' loest relativ zu dieser Datei auf.
+//
+// Die Zeitzonen werden NICHT hier gesetzt, sondern je Browser-Kontext im Test
+// (`browser.newContext({ timezoneId })`) — beide Zonen gehoeren in denselben
+// Testlauf, damit der Vergleich beider Anzeigen eine einzige Zusicherung ist.
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const user = process.env.GZ_VALIDATOR_USER ?? process.env.E2E_USER ?? 'admin';
+const pass = process.env.GZ_VALIDATOR_PASS ?? process.env.E2E_PASS ?? 'test1234';
+
+export default defineConfig({
+	testDir: '.',
+	timeout: 90_000,
+	retries: 0,
+	use: {
+		baseURL: process.env.GZ_SVELTE_BASE ?? 'https://staging.gregor20.henemm.com',
+		headless: true,
+		ignoreHTTPSErrors: true,
+		httpCredentials: { username: user, password: pass }
+	},
+	projects: [
+		{ name: 'setup', testMatch: /konto-naechste-pruefung\.staging\.setup\.ts/ },
+		{
+			name: 'tests',
+			testMatch: /konto-naechste-pruefung\.staging\.spec\.ts/,
+			dependencies: ['setup'],
+			use: {
+				storageState: path.join(__dirname, 'playwright', '.auth', 'staging-1727-s5e.json')
+			}
+		}
+	]
+});

--- a/frontend/src/lib/utils/__tests__/schedulerTime.test.ts
+++ b/frontend/src/lib/utils/__tests__/schedulerTime.test.ts
@@ -1,0 +1,157 @@
+// TDD RED — Issue #1727 S5e (B): die Scheduler-Zeit folgt der Browser-Zone.
+//
+// Spec: docs/specs/modules/fix_1727_s5e_sperrcache_anzeige.md
+//   AC-5  Uhrzeit in der Zone des Browsers + sichtbares Zonenkuerzel
+//
+// `formatNextRun()` liegt heute als interne Funktion im <script>-Block von
+// `frontend/src/routes/account/+page.svelte` (:264-281) und ist von aussen
+// NICHT aufrufbar — ein Unit-Test kann sie dort nicht importieren. Sie wandert
+// deshalb nach `frontend/src/lib/utils/schedulerTime.ts` (Spec, Implementation
+// Details B.5); die Seite importiert sie von dort.
+//
+// RED-Gruende (gemessen, nicht vermutet):
+//   1. `../schedulerTime.ts` existiert noch nicht -> Import schlaegt fehl.
+//   2. Nach der reinen Verschiebung waeren die vier `timeZone: 'Europe/Vienna'`-
+//      Literale weiterhin drin: beide Zonen lieferten "22:30" statt 22:30/16:30,
+//      und ohne `timeZoneName: 'short'` fehlte jedes Kuerzel.
+//
+// POSITIVKONTROLLE (Spec, AC-5, roter Punkt): der erste Test belegt, dass das
+// Umschalten von `process.env.TZ` in DIESEM Prozess ueberhaupt wirkt. Ein
+// Testgeruest, in dem TZ folgenlos bleibt, liefert zwei identische Strings —
+// und waere auch bei fest verdrahtetem Wien gruen. Der Nachweis liefe ins
+// Leere. Darum werden konkrete Uhrzeiten geprueft, nicht nur Ungleichheit.
+// Gemessen mit node v22.22.2: 2026-12-24T21:30:00Z ist 22:30 in Wien (MEZ)
+// und 16:30 in New York (GMT-5).
+//
+// Ausfuehren (aus frontend/):
+//   npm test -- src/lib/utils/__tests__/schedulerTime.test.ts
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { formatNextRun } from '../schedulerTime.ts';
+
+/** Winter-Zeitpunkt: beide Zonen stehen auf Normalzeit, der Abstand ist
+ *  stabil 6 Stunden (kein Sommerzeit-Versatz zwischen den Zonen). */
+const ISO_FERN = '2026-12-24T21:30:00Z';
+const WIEN_STUNDE = 22;
+const NEWYORK_STUNDE = 16;
+
+/** Fuehrt `fn` mit gesetzter Prozess-Zeitzone aus und stellt sie danach
+ *  wieder her. Node liest TZ bei jedem Date-/Intl-Aufruf neu ein. */
+function mitZone<T>(tz: string, fn: () => T): T {
+	const vorher = process.env.TZ;
+	process.env.TZ = tz;
+	try {
+		return fn();
+	} finally {
+		if (vorher === undefined) delete process.env.TZ;
+		else process.env.TZ = vorher;
+	}
+}
+
+describe('formatNextRun — Zone des Browsers statt fest Wien (#1727 S5e, AC-5)', () => {
+	test('Positivkontrolle: das Umschalten der Zone wirkt im Testaufbau', () => {
+		// Ohne diesen Nachweis waere jeder folgende Test wertlos: bleibt TZ
+		// folgenlos, sind zwei Ergebnisse immer gleich — auch bei fest
+		// verdrahtetem Europe/Vienna im Pruefling.
+		const wien = mitZone('Europe/Vienna', () => new Date(ISO_FERN).getHours());
+		const newYork = mitZone('America/New_York', () => new Date(ISO_FERN).getHours());
+
+		assert.equal(
+			wien,
+			WIEN_STUNDE,
+			`Testaufbau: Date sieht in Europe/Vienna Stunde ${wien}, erwartet ${WIEN_STUNDE}`
+		);
+		assert.equal(
+			newYork,
+			NEWYORK_STUNDE,
+			`Testaufbau: Date sieht in America/New_York Stunde ${newYork}, erwartet ${NEWYORK_STUNDE}`
+		);
+	});
+
+	test('AC-5: derselbe Zeitpunkt ergibt in zwei Zonen zwei verschiedene Uhrzeiten', () => {
+		const wien = mitZone('Europe/Vienna', () => formatNextRun(ISO_FERN));
+		const newYork = mitZone('America/New_York', () => formatNextRun(ISO_FERN));
+
+		assert.match(
+			wien,
+			/\b22:30\b/,
+			`In Europe/Vienna formatiert: ${JSON.stringify(wien)} — erwartet die ` +
+				`Wiener Uhrzeit 22:30.`
+		);
+		assert.match(
+			newYork,
+			/\b16:30\b/,
+			`In America/New_York formatiert: ${JSON.stringify(newYork)} — erwartet ` +
+				`die New Yorker Uhrzeit 16:30. Steht dort 22:30, ist die Zone noch ` +
+				`fest auf Europe/Vienna verdrahtet.`
+		);
+		assert.notEqual(
+			wien,
+			newYork,
+			'Beide Zonen liefern denselben String — die Anzeige folgt der Browser-Zone nicht.'
+		);
+	});
+
+	test('AC-5: die Ausgabe traegt in beiden Zonen ein sichtbares Zonenkuerzel', () => {
+		// Ohne Kuerzel waere die Zahl nach Wegfall der festen Zone mehrdeutig:
+		// "22:30" allein sagt dem Leser nicht, in welcher Zone das gilt.
+		const wien = mitZone('Europe/Vienna', () => formatNextRun(ISO_FERN));
+		const newYork = mitZone('America/New_York', () => formatNextRun(ISO_FERN));
+
+		assert.match(
+			wien,
+			/22:30\s+\S+/,
+			`In Europe/Vienna: ${JSON.stringify(wien)} — nach der Uhrzeit fehlt das ` +
+				`Zonenkuerzel (erwartet z.B. "22:30 MEZ", Option timeZoneName: 'short').`
+		);
+		assert.match(
+			newYork,
+			/16:30\s+\S+/,
+			`In America/New_York: ${JSON.stringify(newYork)} — nach der Uhrzeit fehlt ` +
+				`das Zonenkuerzel (erwartet z.B. "16:30 GMT-5").`
+		);
+		assert.notEqual(
+			wien.replace(/[\d:.,\s]/g, ''),
+			newYork.replace(/[\d:.,\s]/g, ''),
+			'Beide Ausgaben tragen dasselbe Zonenkuerzel — es ist nicht das der jeweiligen Zone.'
+		);
+	});
+
+	test('AC-5: auch der nahe Fall ("heute um …") traegt Zone und Kuerzel', () => {
+		// Der Regelfall auf der Konto-Seite: `next_run` liegt innerhalb der
+		// naechsten Stunde, die Anzeige nimmt den relativen Zweig. Genau dieser
+		// Zweig ist auf Staging sichtbar (AC-7) — er darf das Kuerzel nicht
+		// verlieren. Bezugspunkt ist die Laufzeit-Uhr, deshalb wird die Struktur
+		// geprueft, nicht ein fester Wert.
+		const in30Minuten = new Date(Date.now() + 30 * 60_000).toISOString();
+
+		const wien = mitZone('Europe/Vienna', () => formatNextRun(in30Minuten));
+		const newYork = mitZone('America/New_York', () => formatNextRun(in30Minuten));
+
+		for (const [zone, wert] of [
+			['Europe/Vienna', wien],
+			['America/New_York', newYork]
+		] as const) {
+			assert.match(
+				wert,
+				/^(heute|morgen) um \d{2}:\d{2}\s+\S+$/,
+				`In ${zone}: ${JSON.stringify(wert)} — erwartet "heute um HH:MM <Kuerzel>" ` +
+					`(bzw. "morgen um …"). Fehlt der Teil nach der Uhrzeit, fehlt das Zonenkuerzel.`
+			);
+		}
+		assert.notEqual(
+			wien,
+			newYork,
+			`Beide Zonen liefern ${JSON.stringify(wien)} — die Anzeige folgt der Browser-Zone nicht.`
+		);
+	});
+
+	test('leerer Wert bleibt unveraendert ein Gedankenstrich', () => {
+		// Bestandsverhalten (:265) — die Auslagerung darf es nicht veraendern.
+		assert.equal(formatNextRun(null), '—');
+		assert.equal(formatNextRun(undefined), '—');
+		assert.equal(formatNextRun(''), '—');
+	});
+});

--- a/frontend/src/lib/utils/__tests__/schedulerTime.test.ts
+++ b/frontend/src/lib/utils/__tests__/schedulerTime.test.ts
@@ -155,3 +155,51 @@ describe('formatNextRun — Zone des Browsers statt fest Wien (#1727 S5e, AC-5)'
 		assert.equal(formatNextRun(''), '—');
 	});
 });
+
+describe('formatNextRun — kein Termin ist kein Datum (#1727 S5e, AC-9)', () => {
+	// Gemessen auf Staging am 2026-08-19: `/api/scheduler/status` liefert dort
+	// fuer alle zehn Jobs `next_run: "0001-01-01T00:00:00Z"` — den Go-Nullwert
+	// fuer `time.Time`, weil der Scheduler bei `env=staging` bewusst nie
+	// startet (`scheduler_gate.go:11-13`, Issue #1329). Die Konto-Seite zeigte
+	// daraufhin "Nächster: 01.01., 01:05": der Nullwert wird durchformatiert,
+	// als waere er ein Termin. Die krumme Uhrzeit stammt daher, dass Wien im
+	// Jahr 1 eine Ortszeit von +01:05 gegenueber UTC hatte.
+	const NULLWERT = '0001-01-01T00:00:00Z';
+
+	test('AC-9: der Go-Nullwert erscheint als Gedankenstrich, nicht als Datum', () => {
+		const wien = mitZone('Europe/Vienna', () => formatNextRun(NULLWERT));
+		const newYork = mitZone('America/New_York', () => formatNextRun(NULLWERT));
+
+		assert.equal(
+			wien,
+			'—',
+			`In Europe/Vienna: ${JSON.stringify(wien)} — erwartet '—'. Ein Wert wie ` +
+				`"01.01., 01:05" ist der durchformatierte Nullwert und behauptet einen ` +
+				`Termin, den es nicht gibt.`
+		);
+		assert.equal(newYork, '—', `In America/New_York: ${JSON.stringify(newYork)} — erwartet '—'.`);
+	});
+
+	test('AC-9: auch andere unplausibel fruehe Zeitstempel gelten als "kein Termin"', () => {
+		// Die Grenze wird am Jahr gezogen, nicht bei `getTime() <= 0`: sonst
+		// rutschten Zeitpunkte zwischen 1970 und heute durch, die ebenso wenig
+		// ein Termin sind. 1970-01-01 ist der Unix-Nullpunkt und liegt exakt
+		// auf der Kante, die eine `<= 0`-Pruefung noch faengt — 1985 nicht mehr.
+		assert.equal(mitZone('Europe/Vienna', () => formatNextRun('1970-01-01T00:00:00Z')), '—');
+		assert.equal(mitZone('Europe/Vienna', () => formatNextRun('1985-06-01T12:00:00Z')), '—');
+	});
+
+	test('Positivkontrolle: ein echter Zeitstempel wird weiterhin formatiert', () => {
+		// Ohne diese Gegenprobe waere AC-9 auch durch eine Grenze erfuellt, die
+		// ALLES verschluckt — die Zeile zeigte dann nie wieder eine Uhrzeit.
+		const echt = mitZone('Europe/Vienna', () => formatNextRun(ISO_FERN));
+
+		assert.notEqual(
+			echt,
+			'—',
+			`Ein echter Termin (${ISO_FERN}) wird als '—' angezeigt — die ` +
+				`Plausibilitaetsgrenze verschluckt gueltige Werte.`
+		);
+		assert.match(echt, /22:30/, `Erwartet die Wiener Uhrzeit 22:30, bekam ${JSON.stringify(echt)}`);
+	});
+});

--- a/frontend/src/lib/utils/schedulerTime.ts
+++ b/frontend/src/lib/utils/schedulerTime.ts
@@ -1,0 +1,39 @@
+// Issue #1727 S5e — Anzeige des naechsten Scheduler-Laufs auf der Konto-Seite.
+// Ausgelagert aus `routes/account/+page.svelte` (:264-281), damit die Funktion
+// ueberhaupt pruefbar ist (Spec `fix_1727_s5e_sperrcache_anzeige.md`, B.5).
+//
+// Ohne `timeZone`-Option formatiert `Intl` in der Zone der ausfuehrenden
+// Umgebung — also im Browser des Nutzers (Muster aller uebrigen Zeitanzeigen im
+// Frontend). Frueher stand hier fest `Europe/Vienna`. Damit die Zahl eindeutig
+// bleibt, traegt die Ausgabe in beiden Faellen ein Zonenkuerzel.
+
+// Vor dieser Grenze ist ein Zeitstempel kein Termin, sondern ein Nullwert:
+// die Go-API liefert fuer nie gelaufene Jobs `0001-01-01T00:00:00Z` (#1329).
+// Die Grenze liegt am Jahr, nicht bei `getTime() <= 0` — sonst rutschten
+// Zeitpunkte zwischen 1970 und heute durch, die ebenso wenig ein Termin sind.
+const PLAUSIBLES_MINDESTJAHR = 2000;
+
+export function formatNextRun(iso: string | null | undefined): string {
+	if (!iso) return '—';
+	try {
+		const date = new Date(iso);
+		if (date.getFullYear() < PLAUSIBLES_MINDESTJAHR) return '—';
+		const now = new Date();
+		const time = date.toLocaleString('de-AT', { hour: '2-digit', minute: '2-digit', timeZoneName: 'short' });
+
+		// Der Tagesvergleich liest `now`/`date` direkt aus. Frueher lief er ueber
+		// `new Date(x.toLocaleString('en-US'))` — mit fester Wiener Zone eine echte
+		// Umrechnung, ohne sie ein Hin-und-Zurueck in derselben Zone und damit
+		// wirkungslos. Das Rueck-Einlesen ist zudem heikel: manche ICU-/V8-Kombina-
+		// tionen setzen ein schmales geschuetztes Leerzeichen vor AM/PM, das der
+		// Parser als `Invalid Date` zurueckweist — der "heute/morgen"-Zweig fiele
+		// dann unbemerkt auf den fernen Zweig zurueck.
+		const todayDate = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+		const targetDate = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+		const diffDays = Math.round((targetDate.getTime() - todayDate.getTime()) / 86400000);
+
+		if (diffDays === 0) return `heute um ${time}`;
+		if (diffDays === 1) return `morgen um ${time}`;
+		return date.toLocaleString('de-AT', { day: '2-digit', month: '2-digit', hour: '2-digit', minute: '2-digit', timeZoneName: 'short' });
+	} catch { return iso; }
+}

--- a/frontend/src/routes/account/+page.svelte
+++ b/frontend/src/routes/account/+page.svelte
@@ -5,12 +5,14 @@
 	import { Btn } from '$lib/components/atoms';
 	import { api } from '$lib/api.js';
 	import { invalidateAll } from '$app/navigation';
+	import { onMount } from 'svelte';
 	import PencilIcon from '@lucide/svelte/icons/pencil';
 	import Trash2Icon from '@lucide/svelte/icons/trash-2';
 	import CheckIcon from '@lucide/svelte/icons/check';
 	import XIcon from '@lucide/svelte/icons/x';
 	import type { MetricPreset, UserTier } from '$lib/types';
 	import { metricCountLabel, showDefaultBadge, isValidRename, applyRename, removePreset, isEmpty } from '$lib/utils/presetCardHelpers';
+	import { formatNextRun } from '$lib/utils/schedulerTime';
 	let { data } = $props();
 
 	let displayName = $state(data.profile?.display_name ?? '');
@@ -261,24 +263,12 @@
 		return `vor ${days} Tag${days > 1 ? 'en' : ''}`;
 	}
 
-	function formatNextRun(iso: string | null | undefined): string {
-		if (!iso) return '—';
-		try {
-			const date = new Date(iso);
-			const now = new Date();
-			const today = new Date(now.toLocaleString('en-US', { timeZone: 'Europe/Vienna' }));
-			const target = new Date(date.toLocaleString('en-US', { timeZone: 'Europe/Vienna' }));
-			const time = date.toLocaleString('de-AT', { timeZone: 'Europe/Vienna', hour: '2-digit', minute: '2-digit' });
-
-			const todayDate = new Date(today.getFullYear(), today.getMonth(), today.getDate());
-			const targetDate = new Date(target.getFullYear(), target.getMonth(), target.getDate());
-			const diffDays = Math.round((targetDate.getTime() - todayDate.getTime()) / 86400000);
-
-			if (diffDays === 0) return `heute um ${time}`;
-			if (diffDays === 1) return `morgen um ${time}`;
-			return date.toLocaleString('de-AT', { timeZone: 'Europe/Vienna', day: '2-digit', month: '2-digit', hour: '2-digit', minute: '2-digit' });
-		} catch { return iso; }
-	}
+	// Issue #1727 S5e: Die Seite wird serverseitig vorgerendert und der Node-Prozess
+	// laeuft in Etc/UTC. Ohne feste Zone formatierte also zuerst der Server — alle
+	// Nutzer saehen UTC statt ihrer eigenen Zone. Die Uhrzeit entsteht deshalb erst
+	// nach dem Mounten im Browser; bis dahin steht dort '—'.
+	let imBrowser = $state(false);
+	onMount(() => { imBrowser = true; });
 
 	function getProvider(lat: number, lon: number): string {
 		return (lat >= 45 && lat <= 50 && lon >= 8 && lon <= 18)
@@ -596,7 +586,7 @@
 									<span class="font-medium">{userJobs[job.id]}</span>
 								</div>
 								<div class="flex items-center gap-4 text-sm text-muted-foreground">
-									<span>Nächster: {formatNextRun(job.next_run)}</span>
+									<span>Nächste Prüfung: {imBrowser ? formatNextRun(job.next_run) : '—'}</span>
 									<span>Zuletzt: {job.last_run?.time ? timeAgo(job.last_run.time) : '—'}</span>
 								</div>
 							</div>

--- a/src/services/official_alerts/massif_closure.py
+++ b/src/services/official_alerts/massif_closure.py
@@ -105,8 +105,20 @@ def _get_cached_daily_json(src: str, ymd: str) -> Optional[dict]:
     def _do_request() -> httpx.Response:
         return httpx.get(_ENDPOINT.format(src=src, ymd=ymd), timeout=TIMEOUT)
 
+    # Issue #1727 S5e: der Tag gehoert in den Schluessel (Vorbild meteoalarm.py:768),
+    # sonst liefert der Zwischenspeicher ueber Mitternacht hinweg den Vortag.
+    cache_key = f"{src}:{ymd}"
+    # ``warn_egress`` kennt keine Invalidierung (Ablauf nur beim Zugriff auf
+    # DENSELBEN Schluessel) -- ohne Aufraeumen wuechse ``_cache`` in einem
+    # langlebigen Prozess pro Quelle und Kalendertag unbegrenzt.
+    for alt_key in [
+        k for k in _cache
+        if k.startswith(f"{src}:") and k != cache_key
+    ]:
+        _cache.pop(alt_key, None)
+
     return warn_egress.cached_fetch(
-        cache=_cache, cache_key=src, service="massif_closure",
+        cache=_cache, cache_key=cache_key, service="massif_closure",
         host="www.risque-prevention-incendie.fr", request_fn=_do_request,
         parse_fn=lambda resp: resp.json(), log=logger,
     )

--- a/tests/tdd/test_massif_sperrcache_folgt_kalendertag.py
+++ b/tests/tdd/test_massif_sperrcache_folgt_kalendertag.py
@@ -1,0 +1,190 @@
+"""TDD RED — Issue #1727 S5e (A): Der Sperren-Zwischenspeicher folgt dem Kalendertag.
+
+SPEC: docs/specs/modules/fix_1727_s5e_sperrcache_anzeige.md (AC-1, AC-2)
+
+``_get_cached_daily_json(src, ymd)`` (``massif_closure.py:98-112``) uebergibt
+``cache_key=src`` an ``warn_egress.cached_fetch`` -- der Tag ``ymd`` steht zwar
+in der URL, aber NICHT im Schluessel. Innerhalb der 1800s-Erfolgs-TTL liefert
+der Zwischenspeicher darum ueber einen Kalendertagwechsel hinweg die Daten des
+VORTAGS: eine ueber Nacht neu verhaengte Zugangssperre bleibt bis zu 30 Minuten
+unsichtbar. Vorbild fuer die Loesung ist ``meteoalarm.py:768``
+(``f"{country}:{slot}:p{page}"``) -- dort ist der Zeitanteil laengst Teil des
+Schluessels.
+
+RED-Gruende (gemessen, nicht vermutet):
+- AC-1: zweiter Abruf am Folgetag trifft den Eintrag von ``"83"`` und loest
+  keinen zweiten HTTP-Request aus -> ``len(requested_paths) == 1``.
+- AC-2: der einzige Schluessel im Zwischenspeicher heisst ``"83"`` und traegt
+  keinen Tag -> die Tages-Zuordnung ist von aussen gar nicht pruefbar.
+
+**Warum 10 Minuten und nicht 24 Stunden Abstand:** ``cached_fetch`` misst die
+TTL ueber ``time.monotonic`` (``warn_egress.py:431``), dessen Verhalten unter
+``freeze_time`` nicht Teil der Zusicherung ist. Ein 24-Stunden-Sprung koennte
+die TTL ablaufen lassen und damit den zweiten Request AUCH OHNE Fix erzwingen
+-- der Nachweis waere wertlos. Die beiden Zeitpunkte liegen darum nur 10
+Minuten auseinander (600s << 1800s TTL) und trotzdem in verschiedenen
+PARISER Kalendertagen, weil sie die dortige Mitternacht einschliessen. Damit
+kann der zweite Request nur eine Ursache haben: den Tag im Schluessel.
+
+Die Gegenprobe ``test_positivkontrolle_...`` haelt fest, dass der
+Zwischenspeicher INNERHALB eines Tages weiterhin greift -- sonst waere AC-1
+auch dadurch zu erfuellen, dass man das Zwischenspeichern ganz abschaltet.
+
+Testpolitik (CLAUDE.md "Zwei Schichten"): Kern-Schicht, kein Netz nach aussen.
+Der lokale ``http.server``-Sentinel wird aus ``#1727 S5d`` wiederverwendet
+statt kopiert. Er liefert fuer JEDEN Pfad denselben Rumpf
+(``{"massifs": {"831": [1]}}``) -- der Nachweis laeuft deshalb ueber die
+angefragten PFADE, nicht ueber unterschiedliche Inhalte (Spec, "Offene Punkte").
+"""
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+
+from freezegun import freeze_time
+
+from tests.tdd.conftest import _anker
+from tests.tdd.test_import_und_fremdquellen_folgen_ortstag import (
+    TOULON,
+    _lokaler_massif_server,
+)
+
+# 2026-06-01 21:55 UTC = 23:55 CEST (Pariser Tag 06-01)
+# 2026-06-01 22:05 UTC = 00:05 CEST (Pariser Tag 06-02)  -> Tageswechsel
+VOR_MITTERNACHT = datetime(2026, 6, 1, 21, 55, 0, tzinfo=timezone.utc)
+NACH_MITTERNACHT = datetime(2026, 6, 1, 22, 5, 0, tzinfo=timezone.utc)
+TAG_DAVOR = date(2026, 6, 1)
+TAG_DANACH = date(2026, 6, 2)
+
+# Zweiter Zeitpunkt am SELBEN Pariser Tag, gleicher Abstand -- Gegenprobe.
+SPAETER_AM_SELBEN_TAG = datetime(2026, 6, 1, 22, 5, 0, tzinfo=timezone.utc).replace(
+    hour=21, minute=59,
+)
+
+
+def _zwei_abrufe_ohne_leerung(monkeypatch, erster: datetime, zweiter: datetime):
+    """Zwei ``fetch()``-Aufrufe gegen denselben lokalen Sentinel, ohne den
+    Zwischenspeicher dazwischen zu leeren.
+
+    Das ist die bewusste Umkehrung des Bestands-Helfers
+    ``_fetch_gegen_lokalen_server()`` (``test_import_und_fremdquellen_folgen_
+    ortstag.py:163-180``), der vor JEDEM Aufruf ``_cache.clear()`` ruft und
+    damit genau den Fall umgeht, den diese Scheibe prueft.
+
+    Rueckgabe: (angefragte Pfade, Kopie der Schluessel des Zwischenspeichers).
+    """
+    from services.official_alerts import massif_closure
+    from services.official_alerts.massif_closure import MassifClosureSource
+
+    massif_closure._cache.clear()  # sauberer Start -- NICHT zwischen den Aufrufen
+    try:
+        with _lokaler_massif_server() as (srv, requested_paths):
+            monkeypatch.setattr(
+                massif_closure, "_ENDPOINT",
+                f"http://127.0.0.1:{srv.server_port}"
+                "/static/{src}/import_data/{ymd}.json",
+            )
+            with freeze_time(erster):
+                MassifClosureSource().fetch(*TOULON)
+            with freeze_time(zweiter):
+                MassifClosureSource().fetch(*TOULON)
+            schluessel = sorted(massif_closure._cache.keys())
+        return list(requested_paths), schluessel
+    finally:
+        massif_closure._cache.clear()  # kein Uebersprung in Nachbartests
+
+
+def test_ac1_zweiter_kalendertag_loest_echten_zweiten_abruf_aus(monkeypatch):
+    """AC-1.
+
+    GIVEN fuer dieselbe Massiv-Quelle wurde kurz vor Pariser Mitternacht das
+          Tages-JSON abgerufen und liegt innerhalb der 1800s-Erfolgs-TTL im
+          Zwischenspeicher,
+    WHEN  zehn Minuten spaeter -- nach Mitternacht in Paris, also am naechsten
+          Kalendertag des HERAUSGEBERS -- erneut ``fetch()`` laeuft, ohne dass
+          der Zwischenspeicher dazwischen geleert wurde,
+    THEN  loest der zweite Aufruf einen echten zweiten HTTP-Request aus, und
+          dieser fragt den Endpunkt des ZWEITEN Tages ab.
+
+    RED-Grund: ``cache_key=src`` (``massif_closure.py:108``) kennt keinen Tag
+    -- der zweite Aufruf trifft den Eintrag des Vortags und schweigt.
+    """
+    _anker(NACH_MITTERNACHT, "Europe/Paris", TAG_DANACH)
+    assert VOR_MITTERNACHT.astimezone(timezone.utc).date() == TAG_DAVOR
+    assert (NACH_MITTERNACHT - VOR_MITTERNACHT).total_seconds() == 600, (
+        "Testaufbau: die beiden Zeitpunkte muessen INNERHALB der 1800s-TTL "
+        "liegen, sonst erzwingt schon der Ablauf den zweiten Request"
+    )
+
+    pfade, _ = _zwei_abrufe_ohne_leerung(
+        monkeypatch, VOR_MITTERNACHT, NACH_MITTERNACHT,
+    )
+
+    erwartet_tag1 = f"/static/83/import_data/{TAG_DAVOR:%Y%m%d}.json"
+    erwartet_tag2 = f"/static/83/import_data/{TAG_DANACH:%Y%m%d}.json"
+    assert pfade == [erwartet_tag1, erwartet_tag2], (
+        f"angefragte Pfade: {pfade!r} -- erwartet genau zwei Abrufe "
+        f"({erwartet_tag1}, dann {erwartet_tag2}). Nur ein Pfad bedeutet: der "
+        f"Zwischenspeicher hat ueber den Kalendertagwechsel hinweg die Daten "
+        f"des Vortags geliefert -- eine ueber Nacht verhaengte Sperre bliebe "
+        f"bis zu 30 Minuten unsichtbar."
+    )
+
+
+def test_ac2_zwischenspeicher_behaelt_nur_den_eintrag_des_aktuellen_tages(monkeypatch):
+    """AC-2.
+
+    GIVEN der Zwischenspeicher enthaelt nach dem ersten Abruf einen Eintrag
+          fuer Quelle 83 und den Pariser Tag 2026-06-01,
+    WHEN  der zweite Abruf fuer dieselbe Quelle am Tag 2026-06-02
+          abgeschlossen ist,
+    THEN  ist der Eintrag des Vortags entfernt und es existiert genau ein
+          Schluessel fuer diese Quelle -- der des zweiten Tages.
+
+    Ohne das Aufraeumen wuechse ``_cache`` in einem langlebigen Prozess pro
+    Quelle und Kalendertag unbegrenzt: ``warn_egress`` kennt keine
+    Invalidierung, Eintraege verfallen nur beim Zugriff auf DENSELBEN
+    Schluessel (``warn_egress.py:431-434``).
+
+    RED-Grund: es gibt heute genau einen, tageslosen Schluessel ``"83"``.
+    """
+    _anker(NACH_MITTERNACHT, "Europe/Paris", TAG_DANACH)
+
+    _, schluessel = _zwei_abrufe_ohne_leerung(
+        monkeypatch, VOR_MITTERNACHT, NACH_MITTERNACHT,
+    )
+
+    eigene = [k for k in schluessel if k == "83" or k.startswith("83:")]
+    assert eigene == [f"83:{TAG_DANACH:%Y%m%d}"], (
+        f"Schluessel im Zwischenspeicher fuer Quelle 83: {eigene!r} -- "
+        f"erwartet genau einen, naemlich '83:{TAG_DANACH:%Y%m%d}'. Ein "
+        f"tagesloser Schluessel '83' kann den Tageswechsel nicht abbilden; "
+        f"zwei Schluessel bedeuten, dass der Vortag nicht aufgeraeumt wurde."
+    )
+
+
+def test_positivkontrolle_zwischenspeicher_greift_innerhalb_eines_tages(monkeypatch):
+    """Gegenprobe -- KEIN AC, sondern der Waechter gegen die billige Loesung.
+
+    GIVEN zwei Abrufe derselben Quelle liegen zehn Minuten auseinander, aber
+          im SELBEN Pariser Kalendertag,
+    WHEN  beide ``fetch()``-Aufrufe ohne Leerung des Zwischenspeichers laufen,
+    THEN  kommt genau EIN HTTP-Request beim Sentinel an.
+
+    Dieser Test ist heute gruen und muss es bleiben. Er schliesst aus, dass
+    AC-1 dadurch erfuellt wird, dass das Zwischenspeichern ueberhaupt
+    abgeschaltet oder der Schluessel z.B. auf die Uhrzeit gestuetzt wird --
+    beides wuerde den Egress-Schutz aushebeln, den ``cached_fetch`` gerade
+    bereitstellt (Issue #1348).
+    """
+    assert SPAETER_AM_SELBEN_TAG.astimezone(timezone.utc).date() == TAG_DAVOR
+    assert (SPAETER_AM_SELBEN_TAG - VOR_MITTERNACHT).total_seconds() == 240
+
+    pfade, _ = _zwei_abrufe_ohne_leerung(
+        monkeypatch, VOR_MITTERNACHT, SPAETER_AM_SELBEN_TAG,
+    )
+
+    assert pfade == [f"/static/83/import_data/{TAG_DAVOR:%Y%m%d}.json"], (
+        f"angefragte Pfade: {pfade!r} -- erwartet genau EINEN Abruf. Zwei "
+        f"Abrufe am selben Kalendertag bedeuten, dass der Zwischenspeicher "
+        f"nicht mehr greift (Egress-Schutz aus #1348 verloren)."
+    )

--- a/tests/tdd/test_warn_services_rest.py
+++ b/tests/tdd/test_warn_services_rest.py
@@ -151,7 +151,10 @@ _CONFIGS = [
         "service": "massif_closure",
         "host": "www.risque-prevention-incendie.fr",
         "keyed": True,
-        "cache_key": lambda mod: "83",
+        # #1727 S5e: der Schluessel traegt den Kalendertag -- er MUSS denselben
+        # Tag nennen wie der ``call`` darueber, sonst legt der Test den Eintrag
+        # unter einem anderen Schluessel ab als der Code sucht (Miss statt Hit).
+        "cache_key": lambda mod: "83:20260101",
         "needs_mf_key": False,
     },
     {

--- a/tests/unit/test_massif_closure_capture_ambiguity.py
+++ b/tests/unit/test_massif_closure_capture_ambiguity.py
@@ -44,13 +44,21 @@ def _capture_records() -> list[dict]:
 
 
 def _kennung_fuer_cache_key(cache_key: str) -> str:
-    treffer = [
-        r for r in _capture_records()
-        if r.get("payload", {}).get("cache_key") == cache_key
-    ]
+    # #1727 S5e: der Massiv-Schluessel traegt seit dem tagesbewussten Umbau den
+    # Kalendertag (``"83:20260601"``). Der Aufrufer uebergibt weiterhin die
+    # Quelle (``Massif.src``), darum passt ein Datensatz, dessen ``cache_key``
+    # exakt gleich ist ODER mit ``f"{cache_key}:"`` beginnt. Der Doppelpunkt
+    # gehoert zwingend zum Praefix -- sonst wuerde Quelle "8" auf "83:..."
+    # passen. Die Zusicherung "genau EIN Mitschnitt je Abruf" bleibt unberuehrt.
+    praefix = f"{cache_key}:"
+    treffer = []
+    for r in _capture_records():
+        k = r.get("payload", {}).get("cache_key")
+        if k == cache_key or (isinstance(k, str) and k.startswith(praefix)):
+            treffer.append(r)
     assert len(treffer) == 1, (
-        f"Erwartet genau EINEN Mitschnitt fuer cache_key={cache_key!r}, "
-        f"gefunden {len(treffer)}."
+        f"Erwartet genau EINEN Mitschnitt fuer cache_key={cache_key!r} "
+        f"(exakt oder mit Tages-Suffix {praefix!r}), gefunden {len(treffer)}."
     )
     return treffer[0]["capture_id"]
 


### PR DESCRIPTION
## Was

Scheibe S5e zu #1727.

- **Sperrcache tagesbewusst geschlüsselt:** Der Zwischenspeicher für Massif-Sperrungen wurde bisher nur unter der Massif-Nummer abgelegt (`83`). Über den Tageswechsel hinweg lieferte er damit die Daten des Vortags weiter. Der Schlüssel trägt jetzt den Kalendertag (`83:20260602`), der Abruf für den Folgetag findet statt.
- **Konto-Anzeige ehrlich beschriftet:** `formatNextRun()` lag unaufrufbar im script-Block von `account/+page.svelte`. Die Funktion liegt jetzt in `frontend/src/lib/utils/schedulerTime.ts`, rechnet in die Browser-Zeitzone um und schreibt das Zonenkürzel dazu.

## Nachweise

- Kern: 10 passed / 0 failed (3 deselected = `live`-Marker im unveränderten Bestandstest 1037)
- Frontend-Unit: 8 tests / 8 pass / 0 fail / 0 skipped
- RED-Gegenprobe belegt, dass die Zusicherungen die inhaltliche Änderung bewachen, nicht nur die Existenz der neuen Datei
- Adversary-Verdict: **VERIFIED** (7 Mutations-Gegenproben, 6 gefangen; die siebte ist die von der Spec als Bauweise-Vorgabe B.4b benannte Grenze)

Issue #1727 bleibt offen — S5e ist eine Scheibe, nicht das ganze Ticket.