### PR TITLE
fix(#1948): SMS-Sofortfix Δ-Alarm (Scheibe S3) — @HH:MM-Kopf weg, ->-Notation, Stufenbuchstaben

### DIFF
--- a/docs/context/fix-1948-s3-sms-sofortfix.md
+++ b/docs/context/fix-1948-s3-sms-sofortfix.md
@@ -1,0 +1,37 @@
+# Context: fix-1948-s3-sms-sofortfix
+
+## Request Summary
+Scheibe S3 des freigegebenen Alarm-Format-Konzepts v3 (#1948, `docs/analysis/alarm-format-konzept-2026-08.md` §8):
+Δ-Alarm-SMS (Zweig a) — Vergleichszeitpunkt-Präfix `@HH:MM` komplett aus dem SMS-Kopf entfernen
+(löst Auslöser-Bug #1948 UND #1939 strukturell), `->`-Notation ohne Vorzeichen-Präfix einführen (§3),
+`LEVELS`-Stufenbuchstaben in `_sms_token()` verdrahten (§9). Zielbild: `Ziel: TH:M->H@16` · `Ziel: VS1400->280@14`.
+
+## Related Files
+| File | Relevance |
+|------|-----------|
+| `src/output/renderers/alert/render.py` | EINZIGE Quelldatei. `render_sms` Z.793-794 (`@{reference_at}`-Präfix), `_sms_token` Z.707-713 (`{sign}{code}{von}>{bis}` + `@{occurred_at[:2]}`), `_code` Z.104 (`get_sms_code`) |
+| `src/output/tokens/metrics.py:14` | `LEVELS = {0:"-",1:"L",2:"M",3:"H"}` — existiert, wird nur vom Briefing-Builder genutzt |
+| `src/app/metric_catalog.py:415-431` | thunder-Metrik: `sms_code="TH"`, `dp_field="thunder_level"`, `default_format_mode="symbol"` — Kandidat für Level-Erkennung |
+| `src/output/tokens/builder.py:18,479` | Briefing-Referenz: `FORECAST_TH = "TH:"` (Doppelpunkt hardcoded), `is_level=True` nur dort |
+| `tests/tdd/test_alert_reference_timestamp.py` | 6 Tests aus #1916 — SMS-Assertions drehen auf „kein `@HH:MM` mehr"; E-Mail-Assertions bleiben |
+| `tests/tdd/test_alert_sms_segment_head.py` | #1935/#1779: assertet `-VS1400>280`, `+G30>80@15`, `+R2>30@16` → auf `->`-Notation umstellen |
+| `tests/tdd/test_alert_sms_location_positions.py` | #1939 K1-K4 (`live`-markiert): erwarten kopflosen Compare-Pfad OHNE Zeitstempel — werden durch S3 grün |
+
+## Existing Patterns
+- Briefing-SMS ist lebende Referenz: `TH:M@14(H@18)` via `render_threshold_peak_value(is_level=True)` + `LEVELS` (`metrics.py`). Doppelpunkt gehört zum TH-Symbol (`FORECAST_TH="TH:"`), numerische Metriken ohne Doppelpunkt (`VS1400`).
+- `@` = Beginn-Zeitpunkt, Stundenauflösung ohne führende Null im Briefing (`sms_format.md:52`); `_sms_token` nutzt heute `occurred_at[:2]` (ergibt `@09` MIT führender Null).
+- Compare-Änderungspfad (`location_positions is not None`): kopflos, Token `{sign}{code}{bis}` — Ortsvergleich ist im Konzept ZURÜCKGESTELLT, Token bleibt byte-identisch (#1467 AC-9).
+
+## Dependencies
+- Upstream: `AlertEvent` (`model.py:12`, `value_from/value_to/occurred_at/metric_id`), `get_sms_code` (`metric_catalog.py:1213`), `AlertMessage.reference_at` (bleibt im DTO — E-Mail nutzt ihn weiter, Z.547/602).
+- Downstream: Premium-SMS nutzt denselben Renderer (kein eigener) → erbt automatisch. Telegram zeigt `reference_at` heute gar nicht → S6-Frage, hier tabu. Dedupe-Schlüssel basiert auf Events, nicht auf gerendertem Text (#1954) — unberührt.
+
+## Existing Specs
+- Obsolet: `docs/specs/modules/fix_1948_1939_alarm_sms_referenzzeitpunkt.md` (laut Konzept v3 §8 durch S3 VOLLSTÄNDIG ersetzt — „entfernen statt umformulieren").
+- Konzept (PO-freigegeben, Runde 4): `docs/analysis/alarm-format-konzept-2026-08.md`.
+
+## Risks & Considerations
+- **Level-Erkennung im Alarm-Pfad existiert nicht** — Briefing hardcodet `is_level=True` im TH-Zweig. S3 braucht eine Erkennungsregel aus dem Katalog (kein Renderer-Hardcode); Kandidat: thunder-spezifische Katalog-Eigenschaft. Doppelpunkt-Form `TH:` muss für Level-Token erzeugt werden (Katalog liefert `TH` ohne Doppelpunkt).
+- Mehrere Bestandstests asserten das alte Format byte-genau — Anpassung ist Teil der Scheibe, KEIN Ausweichen auf „Tests grün lassen".
+- Compare-Pfad-Invariante (byte-identisch) darf nicht kippen; #1939-K-Tests sind `live`-markiert und laufen nicht im Commit-Gate.
+- Verifikation lt. Konzept-Leitprinzip: echte S1-Aufzeichnungen über S2 (`/api/trips/{id}/alert-preview`, changes-Payload) einspeisen, sonst Fixtures.

--- a/docs/specs/modules/fix_1935_1779_alarm_nachricht_klarheit.md
+++ b/docs/specs/modules/fix_1935_1779_alarm_nachricht_klarheit.md
@@ -9,6 +9,14 @@ workflow: fix-1935-1779-alarm-nachricht-klarheit
 
 # Alarm-Nachricht klar formulieren: Änderungsbetrag statt Messwert, Ortsbezug statt Kilometerspanne (#1935, #1779)
 
+> **Teilweise überholt durch `docs/specs/modules/fix_1948_s3_sms_sofortfix.md`
+> (#1948 Scheibe S3):** Die hier dokumentierten SMS-Token-Beispiele mit
+> Vorzeichen-Präfix und `>`-Notation (`-VS1400>280`) gelten seit S3 nur noch
+> für den Ortsvergleich-Änderungspfad. Der Trip-Δ-Pfad (dieselben Beispiele
+> hier) schreibt seither `VS1400->280` ohne Vorzeichen. Diese Datei bleibt als
+> historischer Nachweis für Ortsbezug/Änderungsbetrag (#1935/#1779) unverändert
+> — nur die Notation ist an der genannten Stelle abgelöst.
+
 ## Approval
 
 - [ ] Approved

--- a/docs/specs/modules/fix_1948_s3_sms_sofortfix.md
+++ b/docs/specs/modules/fix_1948_s3_sms_sofortfix.md
@@ -1,0 +1,223 @@
+---
+entity_id: fix_1948_s3_sms_sofortfix
+type: bugfix
+created: 2026-08-19
+updated: 2026-08-19
+status: draft
+version: "1.0"
+tags: [alarm, sms, format]
+---
+
+# SMS-Sofortfix Δ-Alarm (Zweig a) — #1948 Scheibe S3
+
+> **Ersetzt vollständig:** `docs/specs/modules/fix_1948_1939_alarm_sms_referenzzeitpunkt.md`
+> (laut Konzept v3 `docs/analysis/alarm-format-konzept-2026-08.md` §8 obsolet —
+> „entfernen statt umformulieren"). Deren Notations-ACs (`@HH:MM`-Umformulierung
+> im Kopf) sind durch diese Spec vollständig überholt; die alte Spec-Datei ist
+> im Repo nicht mehr vorhanden.
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Die Δ-Alarm-SMS (Zweig a) verliert den redundanten Vergleichszeitpunkt-Präfix
+`@HH:MM` im Kopf (behebt den #1948-Auslöser-Bug UND macht #1939 strukturell
+unmöglich), wechselt die Von-Bis-Notation von `>` (liest sich als „größer
+als") auf `->` ohne Vorzeichen-Präfix, und rendert Gewitter-Stufen (`thunder`)
+künftig als Buchstaben (`M->H`) statt als Rohzahlen (`2->3`) — dieselbe
+`LEVELS`-Leiter, die das Trip-Briefing bereits produktiv nutzt. Ziel: EIN
+Alarm-Format, das der Empfänger aus dem täglichen Briefing bereits kennt
+(PO-Leitsatz „Format folgt dem Phänomen, nicht der Quelle", Konzept §0).
+
+## Source
+
+- **File:** `src/output/renderers/alert/render.py`
+- **Identifier:** `render_sms()` (Kopf-Zweig, Z.793-794), `_sms_token()` (Z.707-715)
+
+## Estimated Scope
+
+- **LoC:** ~60-90 (Renderer-Logik + neues Katalog-Feld + Testanpassungen)
+- **Files:** 3 Quelldateien + 3 Bestandstestdateien angepasst + mind. 1 neue Testdatei
+- **Effort:** medium
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `AlertEvent` | dataclass (`src/output/renderers/alert/model.py:12`) | Liefert `value_from`/`value_to`/`occurred_at`/`metric_id` — Grundlage jedes Δ-Tokens |
+| `get_sms_code()` | function (`src/app/metric_catalog.py:1213`) | Liefert das Metrik-Kürzel (`TH`, `VS`, ...) für `_code()` |
+| `LEVELS` | dict (`src/output/tokens/metrics.py:14`) | Bestehende Stufenbuchstaben-Map `{0:"-",1:"L",2:"M",3:"H"}`, bislang nur vom Briefing-Builder genutzt |
+| `MetricDefinition` | dataclass (`src/app/metric_catalog.py:28-91`) | Trägt das neue additive Feld `is_level`; Katalog-Eintrag `thunder` (Z.413-431) bekommt `is_level=True` |
+| Premium-SMS-Renderer | — | Nutzt denselben `render_sms()` wie Standard-SMS (kein eigener Renderer) — erbt die Änderung automatisch |
+| Dedupe-Schlüssel (#1954) | — | Basiert auf Events, nicht auf gerendertem Text — von dieser Scheibe unberührt |
+
+## Implementation Details
+
+**1. Kopf-Präfix entfernen (`render_sms`, Z.788-794).** Der Block
+
+```
+if msg.reference_at:
+    head += f"@{msg.reference_at} "
+```
+
+entfällt ersatzlos, für ALLE Kopf-Zweige (Ein-Ort, Mehr-Orte-Bündel, Trip-Δ,
+kopfloser Compare-Pfad). `AlertMessage.reference_at` bleibt als DTO-Feld
+bestehen — nur `render_sms()` liest es nicht mehr. `render_email()` (Z.547,
+602 „verglichen mit HH:MM") bleibt unverändert; Telegram nutzt das Feld
+schon heute nicht (S6-Frage, hier tabu).
+
+**2. `->`-Notation ohne Vorzeichen im Trip-Δ-Pfad (`_sms_token`, Z.707-711).**
+Nur der Zweig `location_positions is None` (Trip-Δ) ändert sich:
+
+- Vorzeichen-Präfix `{sign}` entfällt vollständig.
+- Trennzeichen wechselt von `>` auf `->` (ASCII, zwei GSM-7-Basis-Zeichen).
+- Beispiel numerisch: `-VS1400>280` (alt) → `VS1400->280` (neu).
+
+Der Compare-Änderungspfad (`location_positions` gesetzt) bleibt **byte-
+identisch** inklusive Vorzeichen-Präfix und `>`-Notation (`{sign}{code}{bis}`,
+Invariante #1467 AC-9) — dort ändert sich ausschließlich der Wegfall des
+`@HH:MM`-Kopf-Präfix aus Schritt 1 (das ist der #1939-Fix).
+
+**3. Stufenbuchstaben für `is_level`-Metriken.** Neues additives Feld
+`is_level: bool = False` an `MetricDefinition` (`src/app/metric_catalog.py`).
+Nur der `thunder`-Eintrag bekommt `is_level=True`; alle anderen Metriken
+bleiben beim Default `False` (insbesondere `cape` und andere
+`default_format_mode="symbol"`-Metriken — dieses Feld ist als Trigger
+untauglich, da es auch nicht-stufige Größen trägt). `_sms_token()` fragt den
+Katalog für `e.metric_id` ab: ist `is_level=True`, werden `value_from`/
+`value_to` über die bestehende `LEVELS`-Map (`output/tokens/metrics.py:14`,
+`{0:"-",1:"L",2:"M",3:"H"}`) in Buchstaben übersetzt statt als Zahl
+formatiert, UND der Code-Teil bekommt einen Doppelpunkt-Suffix (`TH:` statt
+`TH`, analog `FORECAST_TH="TH:"` im Briefing-Builder,
+`src/output/tokens/builder.py:18`). Numerische Metriken (kein `is_level`)
+bleiben ohne Doppelpunkt. Die Stufenbuchstaben-Übersetzung gilt NUR im
+Trip-Δ-Pfad (Schritt 2) — der Compare-Pfad bleibt unverändert (Invariante).
+
+**4. Unverändert (explizite Nicht-Ziele dieser Scheibe).** `_render_sms_onset`
+(Zweig c, Onset-Token `TH!{minuten}`), `_sms_corridor_token` (reiner
+Schwellen-Alarm, `!{code}{wert}`), `official_alerts.py` (Zweig b, amtliche
+Warnungen) — alle drei sind spätere Scheiben (S4/S5).
+
+## Expected Behavior
+
+- **Input:** `AlertMessage` mit `reference_at` gesetzt und mind. einem
+  `AlertEvent` im Trip-Δ-Pfad (`location_positions=None`), inkl. Gewitter-
+  Events (`metric_id="thunder"`) und numerischen Events (z.B. `visibility`).
+- **Output:** `render_sms()` liefert einen String ohne `@HH:MM`-Kopf-Präfix;
+  numerische Δ-Token im Format `{code}{von}->{bis}[@{stunde}]` ohne
+  Vorzeichen; Gewitter-Δ-Token im Format `{code}:{buchstabe_von}->{buchstabe_bis}[@{stunde}]`.
+  Compare-Pfad-Token (`location_positions` gesetzt) bleiben byte-identisch
+  zum Vor-S3-Zustand, nur ohne den `@HH:MM`-Kopf-Präfix.
+- **Side effects:** keine — reine Renderer-Formatierung, kein Datenmodell-
+  Wandel, keine Persistenz betroffen.
+
+## Acceptance Criteria
+
+- **AC-1:** Given ein Trip-Δ-Alarm mit `AlertMessage.reference_at="18:03"` und
+  einem Sicht-Ereignis (Segment „Ziel", 1400→280m) / When `render_sms(msg)`
+  gerendert wird / Then enthält der resultierende Text an keiner Stelle
+  `@18:03` — der Kopf endet direkt mit `"Ziel: "`, gefolgt vom Token.
+  - Test: `render_sms()` mit gesetztem `reference_at` aufrufen, Ergebnis-
+    String auf Abwesenheit von `msg.reference_at` prüfen (kein
+    Dateiinhalt-Check — echter DTO-Aufruf durch den echten Renderer).
+
+- **AC-2:** Given denselben Fall wie AC-1 / When gerendert / Then lautet das
+  Ereignis-Token exakt `VS1400->280@14` — kein führendes `+`/`-`, ASCII `->`
+  statt `>`.
+  - Test: Token per Regex/Substring aus dem gerenderten String extrahieren
+    und auf exakten Wert `VS1400->280@14` prüfen.
+
+- **AC-3:** Given ein Trip-Δ-Alarm mit einem Gewitter-Ereignis
+  (`metric_id="thunder"`, `value_from=2.0`, `value_to=3.0`,
+  `occurred_at="16"`) / When gerendert / Then lautet das Token exakt
+  `TH:M->H@16` — Doppelpunkt nach `TH`, Stufenbuchstaben `M`/`H` statt der
+  Rohzahlen `2`/`3`.
+  - Test: gerenderten String auf exakten Substring `TH:M->H@16` prüfen.
+
+- **AC-4:** Given ein Ortsvergleich-Änderungspfad-Ereignis mit gesetztem
+  `location_positions` (z.B. Regen 2→45mm, Position 2) / When gerendert /
+  Then lautet das Token weiterhin `2:+R45` — Vorzeichen-Präfix UND `>`-freie
+  Bis-Wert-Notation bleiben exakt wie vor S3 (Invariante #1467 AC-9); die
+  `->`-Notation und Stufenbuchstaben aus AC-2/AC-3 gelten NICHT für diesen
+  Pfad.
+  - Test: `render_sms(msg, location_positions={...})` aufrufen, Ergebnis
+    gegen den vor-S3 gemessenen Goldstring vergleichen (Regressionstest,
+    Vorbild `test_alert_sms_location_positions.py`).
+
+- **AC-5:** Given einen Ortsvergleich-Änderungsalarm über den echten
+  Aufrufpfad (`CompareAlertService.check_all_compare_presets()`), bei dem
+  intern `reference_at` gesetzt wird / When die SMS an der Senke ankommt /
+  Then bleibt der Kopf weiterhin vollständig leer (kein Ortsname, kein
+  Vergleichsname, Regressionsschutz K-1 bis K-4) UND enthält keinen
+  `@HH:MM`-Zeitstempel — das ist der strukturelle #1939-Fix.
+  - Test: `test_alert_sms_location_positions.py` K1-K4 (bereits vorhanden,
+    `live`-markiert) laufen ohne inhaltliche Änderung grün, sobald der
+    Kopf-Präfix aus Schritt 1 der Implementation Details entfernt ist.
+
+- **AC-6:** Given denselben Trip-Δ-Alarm wie AC-1 / When `render_email(msg)`
+  gerendert wird / Then enthält der Mail-Text weiterhin den Referenz-
+  Zeitpunkt-Footer („verglichen mit ...HH:MM", `render.py:547/602`)
+  unverändert zum Vor-S3-Zustand.
+  - Test: `render_email()` direkt aufrufen, Footer-Text auf Anwesenheit der
+    Referenzzeit prüfen (Regressionsschutz, kein Dateiinhalt-Check).
+
+- **AC-7:** Given ein Onset-Ereignis (Zweig c, `OnsetEvent` mit
+  `location_label=None`) / When `render_sms()` über `_render_sms_onset`
+  rendert / Then bleibt das Token-Format (`{code}!{minuten}`, z.B. `TH!8`)
+  byte-identisch zum Vor-S3-Zustand — S3 rührt `_render_sms_onset` nicht an.
+  - Test: bestehende Onset-Regressionstests (z.B.
+    `test_regression_trip_radar_alert_sms_text_unchanged`) bleiben grün ohne
+    Anpassung.
+
+- **AC-8:** Given einen reinen Schwellen-Alarm (Corridor-Event, kein
+  Δ-Vergleich) / When `render_sms()` über `_render_sms_corridor_only`
+  rendert / Then bleibt das Corridor-Token-Format (`!{code}{wert}`, z.B.
+  `!G55`) byte-identisch zum Vor-S3-Zustand.
+  - Test: bestehender Corridor-Regressionstest bleibt grün ohne Anpassung.
+
+- **AC-9:** Given eine amtliche Warnung (Zweig b, `official_alerts.py`) /
+  When ihre SMS gerendert wird / Then bleiben Kopf, Stufennotation
+  (`GELB1/3` etc.) und Trip-Präfix (`KHW403`) unverändert zum Vor-S3-Zustand
+  — Zweig b ist S5-Scope, hier nicht angefasst.
+  - Test: bestehende `official_alerts.py`-Tests bleiben grün ohne Anpassung.
+
+## Offene Entscheidungsfrage (NEU — PO-Entscheid ausstehend, NICHT Teil dieser Scheibe)
+
+**Führende Null im Stunden-Suffix.** `_sms_token()` baut den Zeitsuffix
+heute über `@{e.occurred_at[:2]}`, was bei einstelligen Stunden eine
+führende Null erzeugt (`@09`). Die Briefing-Notation (`sms_format.md:52`,
+Konzept-Regel 5) verzichtet auf die führende Null (`@9`). Da die
+Zielbild-Beispiele dieser Scheibe (`@16`, `@14`) beide zweistellig sind,
+entscheidet keines der ACs oben diese Frage — **S3 lässt das bestehende
+`occurred_at[:2]`-Verhalten (mit führender Null) unverändert.** Empfehlung
+für eine Folge-Scheibe: angleichen (ohne führende Null), da Regel 5
+verlangt, dass dieselbe `@`-Notation identisch in Briefing- UND Alarm-SMS
+gilt. Wird hier ausdrücklich NICHT vorentschieden.
+
+## Known Limitations
+
+- Zweig c (Nowcast) und Zweig b (amtlich) bleiben im heutigen Format —
+  Folgescheiben S4/S5.
+- Der Compare-Änderungspfad bekommt keine Stufenbuchstaben und keine
+  `->`-Notation — Ortsvergleich ist laut Konzept durchgehend zurückgestellt.
+- Die führende-Null-Frage (s.o.) bleibt offen und wird nicht in dieser
+  Scheibe entschieden.
+- Telegram-Parität (S6) ist eine Folgefrage, die erst durch diese Scheibe
+  entsteht (Telegram zeigte `reference_at` bisher gar nicht, E-Mail zeigt
+  ihn weiterhin — ob Telegram künftig dem neuen SMS-Verhalten folgt, ist
+  offen).
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Reine Renderer-Formatänderung innerhalb eines bereits
+  bestehenden, PO-freigegebenen Konzepts (`docs/analysis/alarm-format-konzept-2026-08.md`,
+  PO-Runde 4). Kein neues Datenmodell, keine neue Architekturentscheidungs-
+  fläche (kein neuer Kanal, kein neuer Provider, keine Persistenz-Änderung).
+
+## Changelog
+
+- 2026-08-19: Initial spec created (S3 des Alarm-Format-Konzepts #1948, löst
+  #1939 strukturell mit).

--- a/src/app/metric_catalog.py
+++ b/src/app/metric_catalog.py
@@ -60,6 +60,11 @@ class MetricDefinition:
     # Erlaubte Werte: "raw" | "scale" | "simplified" | "symbol"
     format_modes: tuple[str, ...] = ("raw",)
     default_format_mode: str = "raw"
+    # Issue #1948 S3: die Groesse ist eine Stufenleiter (0-3), keine Messzahl --
+    # Alarm-SMS rendert sie als Buchstaben (LEVELS, output/tokens/metrics.py)
+    # statt als Rohzahl. Bewusst getrennt von default_format_mode="symbol", das
+    # auch nicht-stufige Groessen wie CAPE traegt.
+    is_level: bool = False
     # Issue #710/#715: selectable=False excludes a metric from the user-visible
     # catalog (get_all_metrics(), /api/metrics) while keeping it in _METRICS for
     # internal computation/aggregation (e.g. confidence for forecast hints).
@@ -438,6 +443,7 @@ _METRICS: list[MetricDefinition] = [
         format_modes=("raw", "symbol"),
         default_format_mode="symbol",
         sms_code="TH", decimals=0, cmp="über", alert_label="Gewitter",
+        is_level=True,  # Issue #1948 S3
         trip_default_rank=5,  # Issue #1552: Trip-Anlege-Standard, Rang 5
     ),
     MetricDefinition(

--- a/src/output/renderers/alert/render.py
+++ b/src/output/renderers/alert/render.py
@@ -15,6 +15,7 @@ from app.metric_catalog import (
 from output.renderers.email.design_tokens import (
     FONT_DATA, FONT_UI, G_ACCENT, G_DANGER, G_INK, G_INK_MUTED, G_SUCCESS,
 )
+from output.tokens.metrics import LEVELS
 from utils.ascii_fold import fold_ascii
 
 from .model import (
@@ -103,6 +104,15 @@ def _unit_display(e: AlertEvent) -> str:
 
 def _code(e: AlertEvent) -> str:
     return get_sms_code(e.metric_id) or e.metric_id
+
+
+def _is_level_metric(metric_id: str) -> bool:
+    """Stufenleiter statt Messzahl (Issue #1948 S3). Unbekannte Kennungen
+    bleiben numerisch -- derselbe Nachsichtigkeits-Vertrag wie in `_code()`."""
+    try:
+        return get_metric(metric_id).is_level
+    except KeyError:
+        return False
 
 
 def _label(e: AlertEvent) -> str:
@@ -805,15 +815,26 @@ def _sms_token(
 
     Issue #1935/#1779 (E3): traegt das Ereignis KEINE Ortsposition (also der
     Trip-Δ-Pfad, `location_positions is None`), fuehrt das Token zusaetzlich
-    den Von-Wert (`{sign}{code}{von}>{bis}` statt nur `{sign}{code}{bis}`) --
-    der Ausschlag wird lesbar, ohne dass der Empfaenger den letzten Mailstand
-    kennen muss (AC-6). Der Ortsvergleich-Aenderungspfad (`location_positions`
-    gesetzt) behaelt sein Token byte-identisch (AC-9, #1467 S2 AG3b).
+    den Von-Wert statt nur den Bis-Wert -- der Ausschlag wird lesbar, ohne
+    dass der Empfaenger den letzten Mailstand kennen muss (AC-6). Der
+    Ortsvergleich-Aenderungspfad (`location_positions` gesetzt) behaelt sein
+    Token byte-identisch (AC-9, #1467 S2 AG3b).
+
+    Issue #1948 S3: der Trip-Δ-Pfad schreibt `{code}{von}->{bis}` OHNE
+    Vorzeichen-Praefix (`>` las sich als "groesser als"); Stufen-Metriken
+    (`is_level`, z.B. Gewitter) sprechen dabei dieselbe Buchstabenleiter wie
+    das Briefing (`TH:M->H`). Der Compare-Pfad bleibt bei `{sign}{code}{bis}`.
     """
-    sign = "+" if e.value_to >= e.value_from else "-"
     if location_positions is None:
-        tok = f"{sign}{_code(e)}{int(round(e.value_from))}>{int(round(e.value_to))}"
+        if _is_level_metric(e.metric_id):
+            tok = (
+                f"{_code(e)}:{LEVELS.get(int(round(e.value_from)), '-')}"
+                f"->{LEVELS.get(int(round(e.value_to)), '-')}"
+            )
+        else:
+            tok = f"{_code(e)}{int(round(e.value_from))}->{int(round(e.value_to))}"
     else:
+        sign = "+" if e.value_to >= e.value_from else "-"
         tok = f"{sign}{_code(e)}{int(round(e.value_to))}"
     if e.occurred_at:
         tok = tok + f"@{e.occurred_at[:2]}"
@@ -893,13 +914,6 @@ def render_sms(
         # wie Betreff/E-Mail/Telegram (`_km_str`), Emoji ENTFERNT statt
         # transliteriert (AC-7), kein Trip-Name mehr (AC-5).
         head = f"{_ascii_alert_location(_km_str(msg))}: "
-    # Issue #1916 (AC-3/AC-4): der Referenz-Zeitpunkt gehoert in den KOPF
-    # (immer enthalten), NICHT in die Token-Liste -- sonst wuerde er bei
-    # Laengendruck wie ein normales Event-Token weggekuerzt statt "notfalls
-    # weiter verkuerzt" (Spec AC-3) zu bleiben. `None` -> unveraendert
-    # (Regressions-Invariante).
-    if msg.reference_at:
-        head += f"@{msg.reference_at} "
     # Issue #1444 S1 (AC-6): Schwellen-Treffer-Tokens desselben Laufs mit.
     tokens = (
         [_sms_token(e, location_positions) for e in evs]

--- a/tests/tdd/test_alert_reference_timestamp.py
+++ b/tests/tdd/test_alert_reference_timestamp.py
@@ -158,9 +158,13 @@ def test_ac3_sms_referenz_zeitpunkt_haelt_160_zeichen_budget_ein():
         f"AC-3: SMS/Premium-SMS duerfen 160 Zeichen nie ueberschreiten "
         f"(gemessen: {len(sms)}). Text: {sms!r}"
     )
-    assert "18:03" in sms, (
-        f"AC-3: der Referenz-Zeitpunkt muss trotz Kuerzungsdruck im Text "
-        f"erscheinen. Text: {sms!r}"
+    # Issue #1948 Scheibe S3: der Referenz-Zeitpunkt-Kopf-Praefix entfaellt
+    # ersatzlos aus der SMS (loest #1948/#1939 strukturell) -- die
+    # urspruengliche AC-3-Zusicherung ("muss trotz Kuerzungsdruck erscheinen")
+    # ist damit ueberholt und ins Gegenteil gedreht.
+    assert "18:03" not in sms, (
+        f"AC-3 (S3-ueberholt): der Referenz-Zeitpunkt darf NICHT mehr im "
+        f"SMS-Text erscheinen. Text: {sms!r}"
     )
 
 
@@ -198,9 +202,12 @@ def test_ac4_compare_pfad_zeigt_referenz_zeitpunkt_ueber_denselben_renderer():
         f"AC-4: der Referenz-Zeitpunkt der Compare-Snapshot-Quelle muss im "
         f"E-Mail-Footer erscheinen. Mail-Body:\n{plain}"
     )
-    assert "13:10" in sms, (
-        f"AC-4: derselbe Referenz-Zeitpunkt muss auch im SMS-Text erscheinen. "
-        f"Text: {sms!r}"
+    # Issue #1948 Scheibe S3: der SMS-Kopf-Praefix entfaellt ersatzlos --
+    # ueberholt die urspruengliche Zusicherung "muss auch im SMS-Text
+    # erscheinen" (E-Mail bleibt unveraendert, nur SMS aendert sich).
+    assert "13:10" not in sms, (
+        f"AC-4 (S3-ueberholt): der Referenz-Zeitpunkt darf NICHT mehr im "
+        f"SMS-Text erscheinen. Text: {sms!r}"
     )
 
 

--- a/tests/tdd/test_alert_sms_delta_notation.py
+++ b/tests/tdd/test_alert_sms_delta_notation.py
@@ -1,0 +1,136 @@
+"""TDD RED — Issue #1948 Scheibe S3: Δ-Alarm-SMS (Zweig a) verliert den
+redundanten Vergleichszeitpunkt-Präfix `@HH:MM` im Kopf (löst #1939
+strukturell mit), wechselt die Von-Bis-Notation von `>` auf `->` ohne
+Vorzeichen-Präfix, und rendert Gewitter-Stufen als Buchstaben statt Rohzahlen.
+
+SPEC: docs/specs/modules/fix_1948_s3_sms_sofortfix.md — AC-1 bis AC-4.
+KONTEXT: docs/context/fix-1948-s3-sms-sofortfix.md
+
+Kein Mock, keine Dateiinhalt-Checks -- echte `AlertEvent`/`AlertMessage`
+durch den echten Renderer (Vorbild: `test_alert_sms_segment_head.py`).
+"""
+from __future__ import annotations
+
+from output.renderers.alert.model import AlertEvent, AlertMessage
+from output.renderers.alert.render import render_sms
+
+
+def _visibility_event(*, occurred_at: str | None = "14:00") -> AlertEvent:
+    return AlertEvent(
+        metric_id="visibility", value_from=1400.0, value_to=280.0, threshold=1000.0,
+        cmp="unter", occurred_at=occurred_at, km_from=8.0, km_to=8.0, segment_id="Ziel",
+    )
+
+
+def _thunder_event() -> AlertEvent:
+    return AlertEvent(
+        metric_id="thunder", value_from=2.0, value_to=3.0, threshold=1.0,
+        cmp="über", occurred_at="16:00", km_from=8.0, km_to=8.0, segment_id="Ziel",
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-1 — Kein @HH:MM-Kopf-Präfix mehr im Trip-Δ-Pfad
+# ---------------------------------------------------------------------------
+
+
+def test_ac1_kein_at_praefix_im_trip_delta_kopf():
+    """AC-1: Given ein Trip-Δ-Alarm mit `reference_at='18:03'` und einem
+    Sicht-Ereignis / When gerendert / Then enthaelt der Text an keiner
+    Stelle `@18:03` -- der Kopf endet direkt mit 'Ziel: '.
+
+    HEUTE ROT: `render_sms()` (Z.793-794) haengt `@{msg.reference_at} ` immer
+    an den Kopf an, sobald `reference_at` gesetzt ist.
+    """
+    msg = AlertMessage(
+        trip_short="KHW 403", stand_at="10:00", events=(_visibility_event(),),
+        reference_at="18:03",
+    )
+    sms = render_sms(msg)
+
+    assert "@18:03" not in sms, (
+        f"AC-1: kein @HH:MM-Kopf-Praefix mehr erwartet: {sms!r}"
+    )
+    assert sms.startswith("Ziel: "), (
+        f"AC-1: der Kopf muss direkt mit 'Ziel: ' beginnen: {sms!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-2 — Numerisches Δ-Token: `->`-Notation ohne Vorzeichen
+# ---------------------------------------------------------------------------
+
+
+def test_ac2_numerisches_delta_token_ohne_vorzeichen_pfeil_notation():
+    """AC-2: Given denselben Fall wie AC-1 (ohne `reference_at`) / When
+    gerendert / Then lautet das Ereignis-Token exakt 'VS1400->280@14' -- kein
+    fuehrendes '+'/'-', ASCII '->' statt '>'.
+
+    HEUTE ROT: `_sms_token()` (Z.707-711) liefert '-VS1400>280@14'.
+    """
+    msg = AlertMessage(
+        trip_short="KHW 403", stand_at="10:00", events=(_visibility_event(),),
+    )
+    sms = render_sms(msg)
+
+    assert sms == "Ziel: VS1400->280@14", (
+        f"AC-2: exaktes Zielbild erwartet, gemessen: {sms!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-3 — Gewitter-Δ-Token: Stufenbuchstaben statt Rohzahlen
+# ---------------------------------------------------------------------------
+
+
+def test_ac3_gewitter_delta_token_stufenbuchstaben():
+    """AC-3: Given ein Gewitter-Ereignis (`thunder`, 2.0 -> 3.0, `@16`) /
+    When gerendert / Then lautet das Token exakt 'TH:M->H@16' -- Doppelpunkt
+    nach 'TH', Stufenbuchstaben 'M'/'H' statt der Rohzahlen '2'/'3'.
+
+    HEUTE ROT: `_sms_token()` kennt keine Level-Erkennung -> 'TH2>3@16'.
+    """
+    msg = AlertMessage(
+        trip_short="KHW 403", stand_at="10:00", events=(_thunder_event(),),
+    )
+    sms = render_sms(msg)
+
+    assert sms == "Ziel: TH:M->H@16", (
+        f"AC-3: exaktes Zielbild erwartet, gemessen: {sms!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-4 — Compare-Änderungspfad: Token byte-identisch, Kopf-Präfix entfällt
+# ---------------------------------------------------------------------------
+
+
+def test_ac4_compare_pfad_token_bleibt_byte_identisch_ohne_at_praefix():
+    """AC-4: Given ein Ortsvergleich-Änderungspfad-Ereignis mit gesetztem
+    `location_positions` (Regen 2->45mm, Position 2) UND gesetztem
+    `reference_at` / When gerendert / Then lautet das Token weiterhin
+    '2:+R45' -- Vorzeichen-Präfix UND '>'-freie Bis-Wert-Notation bleiben wie
+    vor S3 (Invariante #1467 AC-9); NUR der `@HH:MM`-Kopf-Präfix entfaellt
+    (struktureller #1939-Fix).
+
+    HEUTE ROT: der `reference_at`-Block (Z.793-794) haengt sich VOR den Kopf-
+    Wegfall des Compare-Pfads -- Ergebnis heute '@18:03 2:+R45' statt
+    '2:+R45'. Das ist der #1939-Auslöser.
+    """
+    e = AlertEvent(
+        metric_id="precipitation", value_from=2.0, value_to=45.0, threshold=5.0,
+        cmp="über", occurred_at=None, km_from=0.0, km_to=0.0,
+        location_label="Ort",
+    )
+    msg = AlertMessage(
+        trip_short="Vergleich", stand_at="10:00", events=(e,), reference_at="18:03",
+    )
+    sms = render_sms(msg, location_positions={"Ort": 2})
+
+    assert "@18:03" not in sms, (
+        f"AC-4: kein @HH:MM-Kopf-Praefix im Compare-Pfad erwartet: {sms!r}"
+    )
+    assert sms == "2:+R45", (
+        f"AC-4: Compare-Token bleibt byte-identisch (Vorzeichen+'>'-Notation "
+        f"invariant), gemessen: {sms!r}"
+    )

--- a/tests/tdd/test_alert_sms_location_positions.py
+++ b/tests/tdd/test_alert_sms_location_positions.py
@@ -919,7 +919,10 @@ def test_regression_trip_deviation_alert_sms_text_unchanged():
         # Issue #1935/#1779 (E3/E4): Kopf spricht seither die Segment-Sprache
         # statt einer km-Spanne (kein Trip-Name mehr), Token traegt Von- UND
         # Bis-Wert (`_trip_segment().segment_id=1` -> "Segment 1").
-        assert stub.texts() == ["Segment 1: +R2>30"], (
+        # Issue #1948 S3: das Vorzeichen-Praefix ist im Trip-Δ-Pfad entfallen
+        # und `>` durch `->` ersetzt -- der Compare-Pfad (unten) behaelt beides,
+        # deshalb aendert sich hier genau ein Goldstring und keiner der anderen.
+        assert stub.texts() == ["Segment 1: R2->30"], (
             "Regression: der SMS-Text des Trip-Aenderungsalarms muss ohne "
             "Orts-Positionszuordnung unveraendert bleiben, gemessen: "
             f"{stub.texts()!r}"

--- a/tests/tdd/test_alert_sms_segment_head.py
+++ b/tests/tdd/test_alert_sms_segment_head.py
@@ -31,9 +31,10 @@ from output.renderers.alert.render import render_sms, render_subject
 
 _SUBJECT_RE = re.compile(r"^\[[^\]]*\]\s+(?P<where>.+?)\s+·\s+.+$")
 
-# Token-Muster nach AC-6: Vorzeichen + 1-2 Buchstaben-Kuerzel + Von-Wert +
-# '>' + Bis-Wert, optional '@HH'-Suffix.
-_TOKEN_RE = re.compile(r"[+-][A-Z]{1,2}\d+>\d+(?:@\d{2})?")
+# Token-Muster (Issue #1948 S3): 1-2 Buchstaben-Kuerzel + Von-Wert + '->' +
+# Bis-Wert, optional '@HH'-Suffix. KEIN Vorzeichen-Praefix mehr (loeste die
+# alte '>'-Notation ab).
+_TOKEN_RE = re.compile(r"[A-Z]{1,2}\d+->\d+(?:@\d{2})?")
 
 
 def _location_slot(subject: str) -> str:
@@ -98,14 +99,18 @@ def test_ac5_sms_kopf_nennt_denselben_ortstext_wie_der_betreff():
 
 def test_ac6_sms_token_traegt_von_und_bis_wert():
     """AC-6: Given denselben Fall wie AC-5 / When das Token gerendert wird /
-    Then lautet es exakt '-VS1400>280' -- Von- UND Bis-Wert, nicht mehr nur
-    der Bis-Wert von heute ('-VS280')."""
+    Then lautet es exakt 'VS1400->280' -- Von- UND Bis-Wert, nicht mehr nur
+    der Bis-Wert von heute ('-VS280').
+
+    Issue #1948 S3: die urspruengliche Vorzeichen+'>'-Notation ('-VS1400>280')
+    ist durch die vorzeichenfreie '->'-Notation abgeloest."""
     msg = _delta_msg(_delta_event(segment_id="Ziel", value_from=1400.0, value_to=280.0))
     sms = render_sms(msg)
 
     match = _TOKEN_RE.search(sms)
-    assert match, f"Kein Von>Bis-Token im Muster [+-][A-Z]{{1,2}}\\d+>\\d+ gefunden: {sms!r}"
-    assert match.group() == "-VS1400>280", f"Token: {match.group()!r} (SMS: {sms!r})"
+    assert match, f"Kein Von->Bis-Token im Muster [A-Z]{{1,2}}\\d+->\\d+ gefunden: {sms!r}"
+    assert match.group() == "VS1400->280", f"Token: {match.group()!r} (SMS: {sms!r})"
+    assert "-VS1400>280" not in sms, f"Alte Vorzeichen+'>'-Notation noch vorhanden: {sms!r}"
     assert "-VS280" not in sms, f"Alter Nur-Bis-Wert-Token noch vorhanden: {sms!r}"
 
 
@@ -168,9 +173,9 @@ def test_ac8_sms_buendelkopf_traegt_zusammengefasste_segmentsprache():
     assert ":checkered_flag:" not in sms, f"Ziel-Emoji transliteriert: {sms!r}"
 
     tokens = _TOKEN_RE.findall(sms)
-    assert "+G30>80@15" in tokens, f"Boeen-Token fehlt/falsch: {sms!r} ({tokens!r})"
-    assert "-VS1400>280@14" in tokens, f"Sicht-Token fehlt/falsch: {sms!r} ({tokens!r})"
-    assert "+R2>30@16" in tokens, f"Niederschlags-Token fehlt/falsch: {sms!r} ({tokens!r})"
+    assert "G30->80@15" in tokens, f"Boeen-Token fehlt/falsch: {sms!r} ({tokens!r})"
+    assert "VS1400->280@14" in tokens, f"Sicht-Token fehlt/falsch: {sms!r} ({tokens!r})"
+    assert "R2->30@16" in tokens, f"Niederschlags-Token fehlt/falsch: {sms!r} ({tokens!r})"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tdd/test_channel_metric_matrix.py
+++ b/tests/tdd/test_channel_metric_matrix.py
@@ -1804,17 +1804,26 @@ _GEWITTER_ID = _ALERT_METRIC_TO_CATALOG_ID[AlertMetric.THUNDER_LEVEL][0]
 _UNIT_PROBE_VALUE = 12.0
 _EINHEITEN_UNTER_BEOBACHTUNG = sorted({m.unit for m in _METRICS} | set(_HANDLED_UNITS))
 
-# Alarm-SMS-Tokengrammatik (render.py ``_sms_token`` / ``_sms_corridor_token``):
-# {Vorzeichen}{Kuerzel}{Wert}[>{Bis}][@HH], optional mit vorangestellter
-# Ortsposition "{n}:". Der ``>{Bis}``-Teil ist neu seit #1935/#1779 (AC-6):
-# der Trip-Δ-Pfad ohne Ortsposition fuehrt seither Von- UND Bis-Wert
-# ("+VS1400>280"), damit der Ausschlag ohne Kenntnis des letzten Mailstands
-# lesbar ist; der Ortsvergleich-Aenderungspfad (Ortsposition gesetzt) bleibt
-# beim reinen Bis-Wert (AC-9, #1467 S2 AG3b). Eine reine Teilstring-Suche
-# waere hier unbrauchbar -- 'N' (temperature_cold) ist Wortanfang von 'NS'
-# (fresh_snow), s. AC-S1-2-Gegenprobe.
+# Alarm-SMS-Tokengrammatik (render.py ``_sms_token`` / ``_sms_corridor_token``),
+# vier Formen -- die Grammatik muss alle vier zerlegen, ohne zur Teilstring-
+# Suche zu verwaessern ('N' (temperature_cold) ist Wortanfang von 'NS'
+# (fresh_snow), s. AC-S1-2-Gegenprobe):
+#
+#   {n}:{+|-}{Kuerzel}{Bis}[@HH]      Ortsvergleich-Aenderung (#1467 S2 AG3b)
+#   !{Kuerzel}{Wert}                  Schwellen-Treffer (#1444 S1)
+#   {Kuerzel}{Von}->{Bis}[@HH]        Trip-Δ numerisch (#1935/#1779, #1948 S3)
+#   {Kuerzel}:{Stufe}->{Stufe}[@HH]   Trip-Δ Stufenleiter (#1948 S3, LEVELS)
+#
+# Issue #1948 S3 hat die beiden Trip-Δ-Formen geaendert: das Vorzeichen-Praefix
+# ist dort entfallen (es las sich als Rechenzeichen) und Stufen-Groessen tragen
+# Doppelpunkt + Buchstaben statt Rohzahlen. Der Ortsvergleich-Aenderungspfad
+# behaelt sein Vorzeichen -- eine vorangestellte Ortsposition ist deshalb NUR
+# zusammen mit einem Vorzeichen zulaessig.
 _ALERT_SMS_TOKEN = re.compile(
-    r"^(?:\d+:)?[+\-!]([A-Za-z][A-Za-z/]*)-?\d+(?:>-?\d+)?(?:@\d+)?$"
+    r"^(?:(?:\d+:)?[+-]|!)?"
+    r"([A-Za-z][A-Za-z/]*)"
+    r"(?::[-LMH]->[-LMH]|-?\d+(?:->-?\d+)?)"
+    r"(?:@\d+)?$"
 )
 
 

--- a/tests/tdd/test_issue_917_alert_renderer.py
+++ b/tests/tdd/test_issue_917_alert_renderer.py
@@ -460,15 +460,23 @@ class TestAC5SMS:
         assert k >= 1, f"k muss ≥1 sein: {k}"
 
     def test_token_format_sign_code_value(self):
-        """Token-Format: +/-CODE<to> im SMS-Output."""
+        """Token-Format im Trip-Δ-Pfad: CODE{von}->{bis} im SMS-Output.
+
+        Issue #1948 S3: das Vorzeichen-Praefix ist hier entfallen (es las sich
+        als Rechenzeichen); der Ausschlag steht jetzt als Von->Bis da. Der
+        Compare-Pfad behaelt sein `{sign}{code}{bis}` -- das prueft
+        `test_alert_sms_delta_notation.py::test_ac4_...`.
+        """
         from src.output.renderers.alert.render import render_sms
         from app.metric_catalog import get_sms_code
         msg = self._make_msg_single()
         result = render_sms(msg)
         code = get_sms_code("gust")
-        # "+" (increase) + Code + Wert
-        assert f"+{code}" in result or f"-{code}" in result, (
-            f"Token '+{code}' oder '-{code}' nicht in SMS: {result!r}"
+        assert f"{code}50->80" in result, (
+            f"Token '{code}50->80' nicht in SMS: {result!r}"
+        )
+        assert f"+{code}" not in result and f"-{code}" not in result, (
+            f"Vorzeichen-Praefix im Trip-Δ-Pfad noch vorhanden: {result!r}"
         )
 
 


### PR DESCRIPTION
Loest #1939 strukturell mit: der redundante Vergleichszeitpunkt-Praefix
@HH:MM entfaellt aus render_sms(), der Trip-Delta-Pfad wechselt von
Vorzeichen+'>' auf vorzeichenfreies '->' und rendert Gewitter-Stufen
als Buchstaben (TH:M->H) statt Rohzahlen, ueber das neue additive
MetricDefinition-Feld is_level. Der Ortsvergleich-Aenderungspfad bleibt
byte-identisch (Invariante #1467 AC-9).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
