### PR TITLE
fix(#1848 C): Gehzeit-Groessen bleiben trip-exklusiv — Waechter

### DIFF
--- a/api/routers/compare.py
+++ b/api/routers/compare.py
@@ -10,12 +10,14 @@ router = APIRouter(tags=["compare"])
 
 @router.get("/api/compare/metrics")
 def get_compare_metrics():
-    """Backend-Katalog der 26 Ortsvergleich-Metriken (Issue #1350 Teil 1).
+    """Backend-Katalog der Ortsvergleich-Metriken (Issue #1350).
 
     Read-only, kein user_id-Bezug (statischer Katalog, analog /api/metrics).
-    Teil 1 der Strangler-Migration: der Endpoint wird bereitgestellt, aber
-    vom Frontend noch nicht konsumiert (compareMetricDefs.ts bleibt Quelle
-    bis Teil 2).
+    Die Strangler-Migration ist mit #1350 Teil 3 abgeschlossen: das Frontend
+    konsumiert diesen Endpoint produktiv ueber
+    `frontend/src/lib/components/shared/corridor-editor/compareMetricCatalogLoader.ts`
+    (`fetchCompareMetricCatalogOnce()`); der Backend-Katalog ist damit die
+    Quelle, nicht mehr compareMetricDefs.ts.
     """
     from output.renderers.compare_metric_catalog import get_compare_metric_catalog
 

--- a/docs/context/feat-1848-c-waechter-gehzeit.md
+++ b/docs/context/feat-1848-c-waechter-gehzeit.md
@@ -55,7 +55,14 @@ erzeugt die Bedingung, mit der er begründet wird.
    vom 2026-08-19 sagt das Gegenteil: sie bleiben trip-exklusiv.
 2. **Vier Einzelvermerke** (`:79-82`): jeder der vier Einträge trägt zusätzlich den Text
    `Rueckbau mit #1848`. Auch das ist überholt — es genügt nicht, nur den Blockkommentar zu ändern.
-3. **Falscher Funktionsname** (`src/app/metric_catalog.py:168,187,256,267`): Die Blockkommentare
+3. **Überholter Docstring am Endpoint** (`api/routers/compare.py:13-19`): behauptet, der Endpoint
+   werde „vom Frontend noch nicht konsumiert (compareMetricDefs.ts bleibt Quelle bis Teil 2)".
+   Nachgemessen falsch: `compareMetricCatalogLoader.ts:101` konsumiert ihn produktiv, die Migration
+   ist mit #1350 Teil 3 gelaufen. **Zweiter Fall derselben Klasse wie der Rückbaupfad-Kommentar** —
+   eine Feststellung, die bei Abfassung stimmte und deren Voraussetzung eine spätere Scheibe
+   aufgehoben hat, ohne den Satz mitzuziehen. Genau die Klasse, die die abgetrennte Auditfrage
+   systematisch sucht.
+4. **Falscher Funktionsname** (`src/app/metric_catalog.py:168,187,256,267`): Die Blockkommentare
    nennen `_collect_hiking_window_dps()`. **Diese Funktion existiert nicht.** Sie heißt
    `collect_hiking_window_points()` (`src/output/renderers/day_window.py:186`). Gefunden beim
    Auszählen dieser Scheibe — der Kommentar, den der PO-Entscheid ausdrücklich für „tragend"
@@ -90,6 +97,12 @@ erzeugt die Bedingung, mit der er begründet wird.
   vorkommen muss (z. B. `temperature`). Vgl. [[reference_erreichbarkeit_vor_schwere_pruefen]]
 - **Drei Wege in die Ortsvergleich-Auswahl** (Katalog, Stundenverlauf, 3-Tages-Ausblick). Ein
   Wächter, der nur den Katalog prüft, lässt zwei Türen offen.
+- **Die Bedienfläche hängt am Python-Katalog — nachgemessen, nicht angenommen.**
+  `frontend/.../corridor-editor/compareMetricCatalogLoader.ts:101` holt
+  `GET /api/compare/metrics` und baut daraus die `CompareMetricDef`-Objekte
+  (`fetchCompareMetricCatalogOnce().then(buildCompareMetricDefs)`); der Endpoint liefert
+  `get_compare_metric_catalog()` (`api/routers/compare.py:20-22`). **Folge:** ein Wächter auf der
+  Python-Seite deckt die Auswahl-Oberfläche mit ab, es braucht keinen zweiten im Frontend.
 - **Kommentar-Zusicherungen nicht an feste Zeilennummern hängen** — ein absoluter Zeilenanker bricht
   beim nächsten Einschub. Muster #1466: laufzeitaufgelöst prüfen.
   Vgl. [[reference_formataenderung_macht_test_hilfsparser_blind]]
@@ -108,6 +121,67 @@ erzeugt die Bedingung, mit der er begründet wird.
 - `docs/specs/modules/feat_1848_a_kaskade_eine_quelle.md` — Scheibe A dieses Epics
 - `docs/specs/modules/feat_1848_b_einheiten_register.md` — Scheibe B dieses Epics
 - `docs/specs/modules/feat_1680_s5a_gewitter_herkunft_ausblick.md` — trägt die „compare-exklusiv"-Zusage, die laut Issue-Kommentar vom 2026-08-15 neu zu messen ist (abgetrennt als eigene Scheibe)
+
+## Analysis
+
+### Type
+
+**Feature** (Wächter + Kommentar-Korrekturen). Kein Bug: es funktioniert heute nichts falsch — die
+Invariante hält, sie ist nur unbewacht.
+
+### Technical Approach
+
+Vier Zusicherungen, alle in der Kern-Schicht (kein Netz, kein Mock, kein Datei-I/O am Prüfling):
+
+1. **Ausnahmeliste bewachen, statt sie zu glauben.** Für jede der vier Kennungen wird zugesichert,
+   dass **kein** Ortsvergleich-Eintrag sie als `metric_id` trägt. Das ist die Umkehrung der heutigen
+   Prüfung: heute werden sie abgezogen, künftig werden sie geprüft. Gebaut nach dem Vorbild von
+   `test_aggregation_exemptions_only_shrink` (`:317`), das die Schwesterliste schon so bewacht.
+2. **Positivkontrolle im Test selbst.** Derselbe Suchweg muss eine Kennung finden, die dort
+   vorkommen MUSS (`temperature` über `temp_min_c`). Ohne das wäre der Test auch grün, wenn er am
+   falschen Ort sucht — die Fehlerklasse, die in dieser Scheibe zweimal aufgetreten ist.
+3. **Alle drei Türen, nicht nur die vordere.** Geprüft werden Katalog, Stundenverlauf
+   (`HOURLY_EXCLUDED_METRIC_IDS`) und 3-Tages-Ausblick. Die Bedienfläche braucht keinen eigenen
+   Wächter, weil sie den Python-Katalog über den Endpoint bezieht (oben nachgemessen).
+4. **„(Gehzeit)" an den Daten festnageln, nicht am Kommentar.** Die Zusicherung greift auf
+   `MetricDefinition.label_de` zu — das ist Daten, kein Fließtext, und überlebt jede
+   Zeilenverschiebung.
+
+**Für den falschen Funktionsnamen die verallgemeinerte Form**, nach dem Muster #1466
+(`tests/test_guard_findings_survive_line_shifts.py`: Schlüssel `pfad::funktion::ordinal`, Auflösung
+per `ast` zur Laufzeit statt über Zeilennummern): Der Wächter prüft nicht „in Zeile 168 steht der
+richtige Name", sondern **dass jeder in den Kommentaren von `metric_catalog.py` genannte
+Funktionsname im Code auflösbar ist**. Diese Form hätte `_collect_hiking_window_dps()` gefangen und
+fängt den nächsten Umbenennungs-Rückstand mit. Ein Zeilenanker hätte beim ersten Einschub gerissen.
+
+### Affected Files
+
+| Datei | Änderung | Beschreibung |
+|---|---|---|
+| `tests/unit/test_gehzeit_metriken_bleiben_trip_exklusiv.py` | CREATE | Der Wächter: vier Kennungen in keiner der drei Ortsvergleich-Türen, Positivkontrolle, „(Gehzeit)"-Festnagelung, Mutations-Gegenproben |
+| `tests/unit/test_compare_catalog_derives_from_central_catalog.py` | MODIFY | Rückbaupfad-Blockkommentar (`:72-78`) und vier Einzelvermerke (`:79-82`) auf den PO-Entscheid umschreiben |
+| `src/app/metric_catalog.py` | MODIFY | Vier Blockkommentare: `_collect_hiking_window_dps()` → `collect_hiking_window_points()` |
+| `api/routers/compare.py` | MODIFY | Überholten Docstring (`:13-19`) richtigstellen — Frontend konsumiert den Endpoint seit #1350 Teil 3 |
+
+### Scope Assessment
+
+- Dateien: 4 (1 neu, 3 geändert)
+- Geschätzt: +200/−15 LoC, davon ~180 Test
+- **Produktivcode-Verhaltensänderung: keine.** Die drei Änderungen an `src/`/`api/` sind
+  ausschließlich Kommentare und Docstrings.
+- Risiko: **LOW**. Ein falsch gebauter Wächter blockt Commits, verändert aber keine Ausgabe.
+
+### Dependencies
+
+- **Reihenfolge mit #1468 vereinbart:** #1468 (`feat-1468-onset-verschiebung`) zuerst, weil klein und
+  additiv. Konsequenz für den Wächter: er zielt auf die **vier namentlich genannten** Kennungen, nie
+  auf ein Namensmuster wie „alles mit `_day_`" — sonst macht ihn ein neuer Register-Eintrag rot.
+- Kein Frontend-Anteil, kein Go-Anteil.
+
+### Open Questions
+
+Keine offenen fachlichen Fragen — der Fenster-Entscheid vom 2026-08-19 hat den einzigen Blocker
+aufgelöst.
 
 ## Abgrenzung
 

--- a/docs/context/feat-1848-c-waechter-gehzeit.md
+++ b/docs/context/feat-1848-c-waechter-gehzeit.md
@@ -1,0 +1,117 @@
+# Context: feat-1848-c-waechter-gehzeit
+
+## Request Summary
+
+Die vier Gehzeit-Größen bleiben laut PO-Entscheid vom 2026-08-19 **trip-exklusiv** und werden im
+Ortsvergleich nie angeboten. Diese Scheibe sichert die Unterscheidung gegen stilles Verschwinden ab
+(Wächter) und räumt drei Kommentar-Aussagen auf, die durch den Entscheid überholt oder schon vorher
+falsch waren.
+
+Betroffene Kennungen: `temperature_day_low`, `temperature_day_high`, `wind_chill_day_low`,
+`wind_chill_day_high`.
+
+## Gemessener Ist-Stand (vor der Arbeit)
+
+Damit der Wächter nicht als Reparatur erscheint, die er nicht ist:
+
+| Prüfung | Ergebnis | Beleg |
+|---|---|---|
+| Kommen die vier im Ortsvergleich-Katalog vor? | **Nein**, 0 Treffer in allen drei Compare-Dateien | `compare_metric_catalog.py`, `compare_metric_ids.py`, `compare_outlook_metric_ids.py` |
+| Positivkontrolle desselben Suchmusters | `temp_min_c` wird gefunden ⇒ Suchweg trägt | `compare_metric_catalog.py` |
+| Tragen alle vier „(Gehzeit)" im `label_de`? | **Ja**, alle vier | `src/app/metric_catalog.py:173,190,260,271` |
+| Stundenverlauf-Ausschluss vorhanden? | **Ja**, benannte Menge mit Begründungstext | `src/output/renderers/compare_hourly_metric_ids.py:59-64`, Begründung ab `:85-95` |
+
+**Die Invariante hält heute. Der Wächter ist vorbeugend, nicht korrigierend.**
+
+## Die eigentliche Lücke (Kern dieser Scheibe)
+
+Der bestehende Drift-Wächter `tests/unit/test_compare_catalog_derives_from_central_catalog.py` führt
+die vier Kennungen in der Ausnahmeliste `CENTRAL_METRICS_COVERED_ELSEWHERE` (`:44-82`). Diese Liste
+wird an **genau einer** Stelle benutzt — sie wird von der Prüfmenge **abgezogen**:
+
+```
+:130     - set(CENTRAL_METRICS_COVERED_ELSEWHERE)
+```
+
+Damit gilt: Für diese vier Kennungen ist die Zusicherung „hat keinen Compare-Eintrag" **trivial
+wahr**, weil sie aus der Prüfung herausgenommen sind. Bekäme eine der vier morgen einen
+Compare-Eintrag, würde **kein Test rot** — die Ausnahme würde stillschweigend zur Lüge, und die
+fachliche Unterscheidung (Gehzeit-Fenster vs. konfiguriertes Tagesfenster) wäre verloren. Genau das
+benennt Punkt 4 der PO-Folgearbeiten.
+
+**Die Asymmetrie ist der Beleg, dass hier etwas fehlt:** Die Schwesterliste
+`AGGREGATION_CHECK_EXEMPTIONS` hat sehr wohl einen Wächter, der sie bewacht —
+`test_aggregation_exemptions_only_shrink` (`:317`) prüft auf `stale` und `fixed` Einträge, und
+`test_aggregation_check_exemptions_empty_after_1391_1392_fix` (`:305`) nagelt fest, dass sie leer
+ist. Für `CENTRAL_METRICS_COVERED_ELSEWHERE` existiert nichts davon.
+
+Fehlerklasse: [[reference_ausschluss_erzeugt_die_bedingung_die_ihn_begruendet]] — der Ausschluss
+erzeugt die Bedingung, mit der er begründet wird.
+
+## Zu korrigierende Aussagen
+
+1. **Überholter Rückbaupfad** (`tests/unit/test_compare_catalog_derives_from_central_catalog.py:72-78`):
+   behauptet „Rueckbaupfad: #1848 … Danach fallen diese vier Zeilen ersatzlos weg." Der PO-Entscheid
+   vom 2026-08-19 sagt das Gegenteil: sie bleiben trip-exklusiv.
+2. **Vier Einzelvermerke** (`:79-82`): jeder der vier Einträge trägt zusätzlich den Text
+   `Rueckbau mit #1848`. Auch das ist überholt — es genügt nicht, nur den Blockkommentar zu ändern.
+3. **Falscher Funktionsname** (`src/app/metric_catalog.py:168,187,256,267`): Die Blockkommentare
+   nennen `_collect_hiking_window_dps()`. **Diese Funktion existiert nicht.** Sie heißt
+   `collect_hiking_window_points()` (`src/output/renderers/day_window.py:186`). Gefunden beim
+   Auszählen dieser Scheibe — der Kommentar, den der PO-Entscheid ausdrücklich für „tragend"
+   erklärt, zeigt auf einen Namen, den es nicht gibt.
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `tests/unit/test_compare_catalog_derives_from_central_catalog.py` | Trägt die Ausnahmeliste und die überholten Kommentare; hier kommt der neue Wächter hin oder daneben |
+| `src/app/metric_catalog.py:167-275` | Die vier Register-Einträge samt tragender „(Gehzeit)"-Beschriftung und der vier falschen Funktionsnamen |
+| `src/output/renderers/compare_metric_catalog.py` | Kuratierter Ortsvergleich-Katalog (26 Einträge), `get_compare_metric_catalog()` |
+| `src/output/renderers/compare_hourly_metric_ids.py:59-64` | `HOURLY_EXCLUDED_METRIC_IDS` — zweiter Weg in die Ortsvergleich-Auswahl |
+| `src/output/renderers/compare_outlook_metric_ids.py` | Dritter Weg: 3-Tages-Ausblick |
+| `src/output/renderers/day_window.py:186` | `collect_hiking_window_points()` — der echte Name |
+
+## Existing Patterns
+
+- **Mengen-Vergleich statt harter Anzahl** — Vorbild laut Docstring des Drift-Wächters:
+  `tests/unit/test_compare_metric_catalog_consistency.py`.
+- **Wirkungsnachweis im Test selbst**: der Drift-Wächter enthält Tests, die den Guard *künstlich
+  brechen* (`test_guard_actually_fails_when_a_central_metric_has_no_compare_entry:428`,
+  `test_aggregation_guard_actually_fails_on_a_wrong_aggregation:463`). Nur **Kopien** werden
+  manipuliert, nie die echten Katalog-Listen. Dieses Muster übernimmt der neue Wächter.
+- **Ausnahmeliste, die nur schrumpfen darf**, mit Test dagegen: `:317`.
+- **Kern-Schicht-Reinheit**: kein Netz, kein Mock, kein Datei-I/O (Docstring `:15-17`).
+
+## Risks & Considerations
+
+- **Ein Abwesenheits-Test ohne Positivkontrolle ist wertlos** — er ist auch grün, wenn er am
+  falschen Ort sucht. Der Wächter MUSS mitprüfen, dass sein Suchweg eine Kennung findet, die dort
+  vorkommen muss (z. B. `temperature`). Vgl. [[reference_erreichbarkeit_vor_schwere_pruefen]]
+- **Drei Wege in die Ortsvergleich-Auswahl** (Katalog, Stundenverlauf, 3-Tages-Ausblick). Ein
+  Wächter, der nur den Katalog prüft, lässt zwei Türen offen.
+- **Kommentar-Zusicherungen nicht an feste Zeilennummern hängen** — ein absoluter Zeilenanker bricht
+  beim nächsten Einschub. Muster #1466: laufzeitaufgelöst prüfen.
+  Vgl. [[reference_formataenderung_macht_test_hilfsparser_blind]]
+- **Fremde Arbeit an derselben Datei:** #1468 (`feat-1468-onset-verschiebung`, noch nicht gemerged)
+  fügt `src/app/metric_catalog.py` **additiv** zwei Register-Einträge und eine Aggregationsart
+  `onset` hinzu, ohne `unit`/`decimals` bestehender Einträge zu ändern. Vereinbarte Reihenfolge:
+  #1468 zuerst. Ein neuer Register-Eintrag darf den Wächter nicht rot machen — er darf nur auf die
+  vier benannten Kennungen zielen, nicht auf „alles mit `_day_` im Namen".
+- **Kein Produktivcode-Verhalten ändert sich.** Erwartete Ausgabe-Wirkung: keine. Damit ist die
+  Staging-Verifikation ausgabeneutral und braucht den Nachweis am Baum statt an einer Mail
+  (Muster #1758 AC-9).
+
+## Existing Specs
+
+- `docs/specs/modules/feat_1373_s2_ein_katalog.md` — Spec des bestehenden Drift-Wächters (AC-1/2/5)
+- `docs/specs/modules/feat_1848_a_kaskade_eine_quelle.md` — Scheibe A dieses Epics
+- `docs/specs/modules/feat_1848_b_einheiten_register.md` — Scheibe B dieses Epics
+- `docs/specs/modules/feat_1680_s5a_gewitter_herkunft_ausblick.md` — trägt die „compare-exklusiv"-Zusage, die laut Issue-Kommentar vom 2026-08-15 neu zu messen ist (abgetrennt als eigene Scheibe)
+
+## Abgrenzung
+
+**Nicht in dieser Scheibe:** die Auditfrage aus dem Issue-Kommentar vom 2026-08-15 („welche weiteren
+‚Am Code gemessen'-Feststellungen hängen an aufgehobenen Voraussetzungen?"). Gemessener Umfang: 18
+Spec-Dateien nennen `metrics=None`, 4 tragen eine „compare-exklusiv"-Zusage. Offenes Ergebnis, kann
+PO-Entscheide auslösen — eigene Scheibe, PO-bestätigt beim Intake 2026-08-19.

--- a/docs/reference/gates_und_ratschen.md
+++ b/docs/reference/gates_und_ratschen.md
@@ -190,6 +190,7 @@ Verfahren, Abbruchgrenze).
 | Frontend-Browser-Gate (#1558) | 2026-11-05 | #1552 (Kernseite unbedienbar bei grüner Ampel) |
 | 6. Check `e2e` (#1771 S2) | 2026-11-11 | offen — Kriterium: eine Regression, die die anderen fünf durchlassen |
 | staging_gate — `frontend/e2e/` nicht als Code klassifiziert (#1197) | 2026-11-15 | Live erlebt 2026-08-15 (PR-Stack #1736/#1852/#1881/#1882), Fix folgt |
+| `_SELF_EXEMPT`-Eintrag `test_gehzeit_metriken_bleiben_trip_exklusiv.py` in `test_765_backend_hygiene_compliance.py` (#1848 C) | 2026-11-17 | Kommentar-Wächter liest `src/app/metric_catalog.py` als DATEN für eine AST-Prüfung (sind in Kommentaren genannte Funktionsnamen auflösbar?) — kein Verhaltensnachweis auf Code-Strings; Freigabe Tech-Lead 2026-08-19 |
 
 Am Prüfdatum gilt: kein nachweisbarer Fang → **Rückbau**. Wirkmodell:
 `docs/analysis/backlog-spirale-2026-07.md`.

--- a/docs/specs/modules/feat_1848_c_waechter_gehzeit_trip_exklusiv.md
+++ b/docs/specs/modules/feat_1848_c_waechter_gehzeit_trip_exklusiv.md
@@ -172,6 +172,15 @@ die echten Katalog-Listen veraendert.
 - AC-5 prüft Namen, die wie Funktionsaufrufe geschrieben sind (`name()`). Ein Kommentar, der eine
   Funktion in Prosa ohne Klammern nennt, wird nicht erfasst.
 - AC-6 (c) ist nicht maschinell bewacht (siehe dort).
+- **Tür 3 (3-Tages-Ausblick) ist nur als Nebeneffekt geschützt.** Die vier Kennungen sind dort
+  unauflösbar, weil sie keine `summary_fields` tragen — nicht, weil der Ausblick sie namentlich
+  ausschlösse. Der Wächter sichert diesen Zusammenhang nicht zu: entfernt jemand die Katalogprüfung
+  im Ausblick, bleibt er grün. Adversary-Befund vom 2026-08-19, Stufe LOW.
+- **Eine Umgehung im Frontend-Code selbst fällt nicht auf.** Der Wächter deckt die Python-Seite ab
+  (Katalog, Register, Endpoint-Antwort). Eine Gehzeit-Größe, die fest in `buildCompareMetricDefs()`
+  (`frontend/src/lib/components/shared/corridor-editor/compareMetricCatalogLoader.ts`) eingetragen
+  wird, erreicht die Bedienfläche am geprüften Weg vorbei. Adversary-Befund vom 2026-08-19,
+  Stufe LOW.
 
 ## Architektur-Entscheidung (ADR)
 

--- a/docs/specs/modules/feat_1848_c_waechter_gehzeit_trip_exklusiv.md
+++ b/docs/specs/modules/feat_1848_c_waechter_gehzeit_trip_exklusiv.md
@@ -93,6 +93,28 @@ Positivkontrolle je Tuer: derselbe Suchweg muss eine Kennung finden, die dort
 vorkommen MUSS (Tuer 1: temperature ueber temp_min_c). Ohne sie waere der Test
 auch gruen, wenn er am falschen Ort sucht.
 
+Nach den Adversary-Runden zusaetzlich (beide waren Luecken, keine Haertung):
+
+Tuer 1b  get_compare_metrics()             -> die ANTWORT des Endpoints, nicht
+         (api/routers/compare.py)             nur die Katalogfunktion. Zwischen
+                                              Funktion und Antwort passt eine
+                                              Aenderung (Runde 1, F001).
+                                              Geprueft werden ZWEI Felder:
+                                              `metric_id` UND der Zusatz
+                                              '(Gehzeit)' in `label` -- die
+                                              Bedienflaeche baut ihre Auswahl
+                                              aus key/label, `metric_id` ist
+                                              dort optional (Runde 2, F-ADV2-1).
+                                              Der Beschriftungs-Weg ist bewusst
+                                              UNABHAENGIG von der bewachten
+                                              Liste.
+
+Menge    Die vier Kennungen stehen nicht nur als Literal im Test. Die erwartete
+         Menge wird aus dem Zentralregister ABGELEITET (alle Eintraege mit
+         '(Gehzeit)' im label_de) und gegen das Literal verglichen, Differenz in
+         BEIDE Richtungen. Ohne das liess sich die bewachte Menge still von vier
+         auf zwei schrumpfen (Runde 1, F002).
+
 Mutations-Gegenprobe im Test selbst (Muster des bestehenden Drift-Waechters,
 :428/:463): eine KOPIE des Katalogs bekommt kuenstlich einen Eintrag mit
 metric_id="temperature_day_low"; der Waechter MUSS darauf anschlagen. Nie werden
@@ -168,7 +190,23 @@ die echten Katalog-Listen veraendert.
 
 - Der Wächter schützt gegen **Hinzufügen** der vier Kennungen zum Ortsvergleich. Er schützt nicht
   gegen eine Umbenennung der Kennungen selbst — dann zielt er ins Leere. Bewusst nicht adressiert,
-  weil eine Umbenennung ohnehin breit rot wird.
+  weil eine Umbenennung ohnehin breit rot wird. **Nachtrag Adversary-Runde 3:** Für eine echte
+  Umbenennung gemessen bestätigt (5 Tests rot). **Für einen additiven Klon gilt es nicht:** legt
+  jemand dieselbe Größe unter neuer Kennung mit `summary_fields` an, bleiben alle 33 Tests grün und
+  der Eintrag steht in der Endpoint-Antwort. Fachlich ist das kein Verstoß — der Ortsvergleich hat
+  keine Gehzeit, der Klon liefert den Tagesfenster-Wert —, aber die Begründung „wird ohnehin breit
+  rot" trägt diesen Fall nicht.
+- **Der Wächter bewacht seine Menge, aber nicht seine Quelle.** Stellt jemand die geprüfte Nutzlast
+  von der Endpoint-Antwort zurück auf die Katalogfunktion, ist der Befund F001 aus Adversary-Runde 1
+  wiederhergestellt und **kein Test merkt es**. Die Mengen-Ableitung schützt gegen das Schrumpfen
+  der bewachten Kennungen, nicht gegen das Zurückdrehen der Bezugsquelle. Adversary-Runde 3,
+  Stufe LOW.
+- **Der Beschriftungs-Weg ist ein buchstabengetreuer Textabgleich.** `(gehzeit)`, `(GEHZEIT)` oder
+  `(Gehzeit-Fenster)` laufen durch; ebenso ein Antwort-Eintrag ganz ohne Kennung und ohne den
+  Zusatz. Am Produktivpfad folgenlos, weil der Katalog `entry["metric_id"]` mit eckigen Klammern
+  liest (ein Eintrag ohne Kennung verlässt ihn gar nicht) und die Beschriftung danach aus dem
+  Register abgeleitet wird — beide Prüfungen feuern dort zwangsläufig gemeinsam. Gilt nur für einen
+  von Hand in die Endpoint-Antwort geschriebenen Eintrag. Adversary-Runde 3, Stufe LOW.
 - AC-5 prüft Namen, die wie Funktionsaufrufe geschrieben sind (`name()`). Ein Kommentar, der eine
   Funktion in Prosa ohne Klammern nennt, wird nicht erfasst.
 - AC-6 (c) ist nicht maschinell bewacht (siehe dort).

--- a/docs/specs/modules/feat_1848_c_waechter_gehzeit_trip_exklusiv.md
+++ b/docs/specs/modules/feat_1848_c_waechter_gehzeit_trip_exklusiv.md
@@ -1,0 +1,197 @@
+---
+entity_id: feat_1848_c_waechter_gehzeit_trip_exklusiv
+type: module
+created: 2026-08-19
+updated: 2026-08-19
+status: draft
+version: "1.0"
+tags: [metrik-register, ortsvergleich, waechter, 1848]
+---
+
+# #1848 Scheibe C — Die vier Gehzeit-Größen bleiben trip-exklusiv (Wächter)
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Der PO hat am 2026-08-19 entschieden, dass die vier Gehzeit-Größen dem Trip vorbehalten bleiben und
+im Ortsvergleich **nie** angeboten werden. Diese Scheibe macht den Entscheid maschinell haltbar:
+Heute hält die Unterscheidung nur, weil niemand sie verletzt hat — kein Test bewacht sie. Zusätzlich
+werden drei Aussagen im Code richtiggestellt, die durch den Entscheid überholt oder schon vorher
+falsch waren.
+
+Betroffene Kennungen: `temperature_day_low`, `temperature_day_high`, `wind_chill_day_low`,
+`wind_chill_day_high`.
+
+## Warum das nötig ist — die gemessene Lücke
+
+`tests/unit/test_compare_catalog_derives_from_central_catalog.py` führt die vier Kennungen in der
+Ausnahmeliste `CENTRAL_METRICS_COVERED_ELSEWHERE` (`:44-82`). Diese Liste wird an **genau einer**
+Stelle verwendet — sie wird von der Prüfmenge **abgezogen** (`:130`).
+
+Für diese vier ist die Zusicherung „hat keinen Ortsvergleich-Eintrag" damit **trivial wahr**: sie
+sind aus der Prüfung herausgenommen. Bekäme eine der vier morgen einen Ortsvergleich-Eintrag, würde
+**kein Test rot**; die Ausnahme würde stillschweigend zur Lüge, und die fachliche Unterscheidung
+zwischen Gehzeit-Fensterung und konfiguriertem Tagesfenster wäre still verloren.
+
+**Beleg, dass hier wirklich etwas fehlt (Asymmetrie):** Die Schwesterliste
+`AGGREGATION_CHECK_EXEMPTIONS` in derselben Datei wird sehr wohl bewacht —
+`test_aggregation_exemptions_only_shrink` (`:317`) prüft auf veraltete und auf behobene Einträge,
+`test_aggregation_check_exemptions_empty_after_1391_1392_fix` (`:305`) nagelt fest, dass sie leer
+ist. Für `CENTRAL_METRICS_COVERED_ELSEWHERE` existiert nichts davon.
+
+## Ist-Stand vor der Arbeit (nachgemessen, nicht angenommen)
+
+| Prüfung | Ergebnis |
+|---|---|
+| Kommen die vier im Ortsvergleich-Katalog vor? | **Nein** — 0 Treffer in `compare_metric_catalog.py`, `compare_metric_ids.py`, `compare_outlook_metric_ids.py` |
+| Positivkontrolle desselben Suchmusters | `temp_min_c` wird gefunden ⇒ der Suchweg trägt |
+| Tragen alle vier „(Gehzeit)" im `label_de`? | **Ja** — `metric_catalog.py:173,190,260,271` |
+| Stundenverlauf-Ausschluss vorhanden? | **Ja** — `compare_hourly_metric_ids.py:59-64` |
+
+**Die Invariante hält heute. Der Wächter ist vorbeugend, nicht korrigierend.** Das ist ausdrücklich
+so vermerkt, damit niemand die Scheibe später als Fehlerbehebung liest.
+
+## Source
+
+- **File:** `tests/unit/test_gehzeit_metriken_bleiben_trip_exklusiv.py` (neu)
+- **Identifier:** Wächter-Modul, keine Produktivschnittstelle
+
+Schicht: **Python-Core** (`src/app`, `src/output/renderers`, `api/`) plus Kern-Testschicht.
+Kein Frontend-Anteil, kein Go-Anteil — nachgemessen, siehe „Abgrenzung".
+
+## Estimated Scope
+
+- **LoC:** ~+200 / −15 (davon ~180 Test)
+- **Files:** 4 (1 neu, 3 geändert)
+- **Effort:** low
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|---|---|---|
+| `src/app/metric_catalog.py` | liest | Quelle der vier Kennungen samt `label_de` |
+| `src/output/renderers/compare_metric_catalog.py` | liest | `get_compare_metric_catalog()` — Tür 1 |
+| `src/output/renderers/compare_hourly_metric_ids.py` | liest | `HOURLY_EXCLUDED_METRIC_IDS` — Tür 2 |
+| `src/output/renderers/compare_outlook_metric_ids.py` | liest | 3-Tages-Ausblick — Tür 3 |
+| #1468 (`feat-1468-onset-verschiebung`) | Reihenfolge | Geht **zuerst**; fügt additiv zwei Register-Einträge hinzu |
+
+## Implementation Details
+
+```
+Der Wächter zielt auf VIER NAMENTLICH GENANNTE Kennungen — nie auf ein Namensmuster
+(kein "alles mit _day_"). Grund: #1468 fügt additiv Register-Eintraege hinzu; ein
+Musterwaechter wuerde davon rot, ein Namenswaechter nicht.
+
+Tuer 1  get_compare_metric_catalog()      -> keine der vier als metric_id
+Tuer 2  HOURLY_EXCLUDED_METRIC_IDS        -> alle vier ENTHALTEN (Ausschluss ist Soll)
+Tuer 3  Ausblick-Kennungen                -> keine der vier waehlbar
+
+Positivkontrolle je Tuer: derselbe Suchweg muss eine Kennung finden, die dort
+vorkommen MUSS (Tuer 1: temperature ueber temp_min_c). Ohne sie waere der Test
+auch gruen, wenn er am falschen Ort sucht.
+
+Mutations-Gegenprobe im Test selbst (Muster des bestehenden Drift-Waechters,
+:428/:463): eine KOPIE des Katalogs bekommt kuenstlich einen Eintrag mit
+metric_id="temperature_day_low"; der Waechter MUSS darauf anschlagen. Nie werden
+die echten Katalog-Listen veraendert.
+```
+
+## Expected Behavior
+
+- **Input:** keiner — reiner Kern-Test ohne Netz, ohne Mock, ohne Datei-I/O am Prüfling
+- **Output:** grün, solange die vier Kennungen trip-exklusiv bleiben
+- **Side effects:** keine. **Kein Produktivcode-Verhalten ändert sich** — die drei Änderungen an
+  `src/`/`api/` sind ausschließlich Kommentare und Docstrings. Erwartete Wirkung auf jede Ausgabe
+  (Mail, SMS, Telegram, Premium-SMS, Oberfläche): **keine**.
+
+## Acceptance Criteria
+
+- **AC-1:** Given der Ortsvergleich-Katalog wird geladen / When geprüft wird, ob eine der vier
+  Gehzeit-Kennungen als `metric_id` eines Eintrags vorkommt / Then trägt kein einziger Eintrag eine
+  von ihnen, und der Wächter benennt bei Verstoß die betroffene Kennung im Fehlertext.
+  - Test: Gegenprobe an einer **Kopie** des Katalogs, der künstlich ein Eintrag mit
+    `metric_id="temperature_day_low"` hinzugefügt wird — der Wächter muss anschlagen und den Namen
+    nennen. Ohne diese Gegenprobe wäre nicht bewiesen, dass er überhaupt etwas prüft.
+
+- **AC-2:** Given derselbe Suchweg, mit dem AC-1 die Abwesenheit feststellt / When er auf eine
+  Kennung angewendet wird, die im Ortsvergleich vorkommen MUSS (`temperature` über den Eintrag
+  `temp_min_c`) / Then findet er sie.
+  - Test: Positivkontrolle im selben Testlauf. Sie ist der Beweis, dass das Grün von AC-1 aus
+    Abwesenheit stammt und nicht daraus, dass am falschen Ort gesucht wurde.
+
+- **AC-3:** Given es gibt drei Wege, auf denen eine Kennung in die Ortsvergleich-Auswahl gerät
+  (Katalog, Stundenverlauf, 3-Tages-Ausblick) / When der Wächter läuft / Then deckt er alle drei ab,
+  und für den Stundenverlauf sichert er zu, dass die vier in `HOURLY_EXCLUDED_METRIC_IDS`
+  **enthalten** sind.
+  - Test: je Tür eine eigene Zusicherung mit eigener Gegenprobe. Ein Wächter, der nur den Katalog
+    prüft, ließe zwei Türen offen.
+
+- **AC-4:** Given der Zusatz „(Gehzeit)" ist laut PO-Entscheid tragend und nicht kosmetisch / When
+  eine der vier Registerdefinitionen ihren `label_de` verliert oder den Zusatz einbüßt / Then wird
+  der Wächter rot.
+  - Test: Zusicherung gegen `MetricDefinition.label_de` — also gegen **Daten**, nicht gegen
+    Fließtext. Gegenprobe an einer Kopie mit entferntem Zusatz.
+
+- **AC-5:** Given Kommentare in `src/app/metric_catalog.py` nennen Funktionsnamen / When ein
+  genannter Name im Code nicht auflösbar ist / Then wird der Wächter rot und nennt den toten Namen.
+  - Test: Der heutige Bestand enthält genau so einen Fall — `_collect_hiking_window_dps()` existiert
+    nicht, die Funktion heißt `collect_hiking_window_points()`
+    (`src/output/renderers/day_window.py:186`). Der Wächter muss ihn **vor** der Korrektur melden
+    und danach schweigen. **Dieser Test ist ein Doku-Konformitätstest und wird als
+    `# doc-compliance-test` markiert** — er liest Quelltext und ist ausdrücklich kein
+    Verhaltensnachweis. Auflösung laufzeitbasiert nach Muster #1466
+    (`tests/test_guard_findings_survive_line_shifts.py`), **nicht** über feste Zeilennummern.
+
+- **AC-6:** Given drei Aussagen im Bestand sind überholt / When sie nach dieser Scheibe gelesen
+  werden / Then geben sie den Stand vom 2026-08-19 wieder:
+  (a) der Rückbaupfad-Blockkommentar
+  (`test_compare_catalog_derives_from_central_catalog.py:72-78`) sagt nicht mehr, die vier Zeilen
+  fielen mit #1848 ersatzlos weg, sondern dass sie trip-exklusiv bleiben;
+  (b) die vier Einzelvermerke `Rueckbau mit #1848` (`:79-82`) ebenso — der Blockkommentar allein
+  genügt nicht;
+  (c) der Docstring von `GET /api/compare/metrics` (`api/routers/compare.py:13-19`) behauptet nicht
+  mehr, das Frontend konsumiere den Endpoint nicht.
+  - Test: für (c) reicht der Auflösungs-Wächter aus AC-5 nicht; hier genügt die Sichtprüfung im
+    Review, weil die Aussage keine maschinell prüfbare Zusicherung trägt. **Als solche benannt statt
+    mit einem Scheinwächter überdeckt.**
+
+- **AC-7:** Given #1468 fügt dem Register additiv zwei neue Einträge und eine Aggregationsart
+  `onset` hinzu / When dieser Wächter auf dem Stand nach #1468 läuft / Then bleibt er grün.
+  - Test: Der Wächter nennt die vier Kennungen namentlich und leitet nichts aus einem Namensmuster
+    ab. Nachweis: ein künstlich hinzugefügter Register-Eintrag mit `_day_` im Namen macht den
+    Wächter **nicht** rot.
+
+## Known Limitations
+
+- Der Wächter schützt gegen **Hinzufügen** der vier Kennungen zum Ortsvergleich. Er schützt nicht
+  gegen eine Umbenennung der Kennungen selbst — dann zielt er ins Leere. Bewusst nicht adressiert,
+  weil eine Umbenennung ohnehin breit rot wird.
+- AC-5 prüft Namen, die wie Funktionsaufrufe geschrieben sind (`name()`). Ein Kommentar, der eine
+  Funktion in Prosa ohne Klammern nennt, wird nicht erfasst.
+- AC-6 (c) ist nicht maschinell bewacht (siehe dort).
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Der fachliche Entscheid (Gehzeit-Größen bleiben trip-exklusiv) ist im Issue #1848
+  dokumentiert und PO-bestätigt; diese Scheibe setzt ihn nur durch und trifft keine eigene
+  Richtungsentscheidung. Kein neues Vokabular, kein neues Datenformat, keine Kanal- oder
+  Persistenz-Änderung.
+
+## Abgrenzung
+
+- **Nicht enthalten:** die Auditfrage aus dem Issue-Kommentar vom 2026-08-15 („welche weiteren ‚Am
+  Code gemessen'-Feststellungen hängen an aufgehobenen Voraussetzungen?"). Gemessener Umfang: 18
+  Spec-Dateien nennen `metrics=None`, 4 tragen eine „compare-exklusiv"-Zusage. Offenes Ergebnis,
+  kann PO-Entscheide auslösen — eigene Scheibe, beim Intake am 2026-08-19 abgetrennt.
+- **Kein eigener Frontend-Wächter nötig:** nachgemessen, dass die Auswahl-Oberfläche den
+  Python-Katalog über den Endpoint bezieht
+  (`frontend/.../corridor-editor/compareMetricCatalogLoader.ts:101` →
+  `GET /api/compare/metrics` → `get_compare_metric_catalog()`).
+
+## Changelog
+
+- 2026-08-19: Initial spec created (#1848 Scheibe C)

--- a/docs/specs/modules/feat_1848_c_waechter_gehzeit_trip_exklusiv.md
+++ b/docs/specs/modules/feat_1848_c_waechter_gehzeit_trip_exklusiv.md
@@ -12,7 +12,7 @@ tags: [metrik-register, ortsvergleich, waechter, 1848]
 
 ## Approval
 
-- [ ] Approved
+- [x] Approved — PO (Henning), 2026-08-19, „freigabe"
 
 ## Purpose
 

--- a/docs/specs/modules/feat_1848_c_waechter_gehzeit_trip_exklusiv.md
+++ b/docs/specs/modules/feat_1848_c_waechter_gehzeit_trip_exklusiv.md
@@ -176,6 +176,17 @@ die echten Katalog-Listen veraendert.
   unauflösbar, weil sie keine `summary_fields` tragen — nicht, weil der Ausblick sie namentlich
   ausschlösse. Der Wächter sichert diesen Zusammenhang nicht zu: entfernt jemand die Katalogprüfung
   im Ausblick, bleibt er grün. Adversary-Befund vom 2026-08-19, Stufe LOW.
+  **Nachtrag Adversary-Runde 2:** Die Grenze ist **weiter** als hier zunächst beschrieben — der
+  Schutz steht auf zwei Beinen (Katalogprüfung **und** `_summary_field`-Prüfung), und **jedes von
+  beiden ist einzeln entfernbar**, ohne dass ein Test rot wird. Der ursprüngliche Wortlaut nannte
+  nur das Katalog-Bein und hat damit untertrieben.
+- **Die Ableitung bewacht sich nicht selbst.** Die erwartete Menge wird aus dem Register abgeleitet
+  (alle `label_de` mit `(Gehzeit)`) und gegen das Literal im Wächter geprüft — das fängt jede
+  *einseitige* Änderung. Wer jedoch **drei Stellen im Einklang** ändert (Zusatz aus einem `label_de`
+  entfernen, Literal schrumpfen, Erwartungsliste der Gegenprobe mitziehen), macht eine Kennung
+  unbewacht, ohne dass etwas rot wird. Bewusst als Grenze benannt, nicht als Fehler behandelt: drei
+  abgestimmte Änderungen sind ein gewollter Rückbau, kein Versehen. Adversary-Runde 2 vom
+  2026-08-19, Stufe LOW.
 - **Eine Umgehung im Frontend-Code selbst fällt nicht auf.** Der Wächter deckt die Python-Seite ab
   (Katalog, Register, Endpoint-Antwort). Eine Gehzeit-Größe, die fest in `buildCompareMetricDefs()`
   (`frontend/src/lib/components/shared/corridor-editor/compareMetricCatalogLoader.ts`) eingetragen

--- a/src/app/metric_catalog.py
+++ b/src/app/metric_catalog.py
@@ -177,7 +177,7 @@ _METRICS: list[MetricDefinition] = [
     # SMS-Token K/D: KEINE summary_fields (= keine Auswertungs-Pills, keine
     # Tabellenspalte), keine Alarm-Deklaration. Der Zahlenwert kommt
     # unveraendert aus der Gehzeit-Aggregation in sms_trip.py.
-    # 🔴 Gehzeit-Fensterung (_collect_hiking_window_dps()), NICHT das
+    # 🔴 Gehzeit-Fensterung (collect_hiking_window_points()), NICHT das
     # Tagesfenster 04-19 von temperature_min/temperature_max
     # (Alarm-Vokabular, models.py:1123-1124) -- zwei fachlich verschiedene
     # Dinge mit aehnlichem Namen, in getrennten Namensraeumen.
@@ -196,7 +196,7 @@ _METRICS: list[MetricDefinition] = [
     # alert/render.py:93) und war damit ein toter Wert. Das tatsaechlich
     # gesendete Kuerzel "D" traegt jetzt ausschliesslich sms_multi_symbols;
     # sms_code ist leer.
-    # 🔴 Gehzeit-Fensterung (_collect_hiking_window_dps()), NICHT das
+    # 🔴 Gehzeit-Fensterung (collect_hiking_window_points()), NICHT das
     # Tagesfenster 04-19 von temperature_min/temperature_max.
     MetricDefinition(
         id="temperature_day_high", label_de="Tages-Höchsttemperatur (Gehzeit)",
@@ -265,7 +265,7 @@ _METRICS: list[MetricDefinition] = [
     # Fix #1887 E6 Scheibe A (PO-Entscheid): "WC" (vormals Wintersport-
     # Tageskennzahl bei "wind_chill") entfaellt ERSATZLOS -- verdoppelte
     # nachweislich "FK" (identisches Feld, Fenster, Aggregation).
-    # 🔴 Gehzeit-Fensterung (_collect_hiking_window_dps()), NICHT das
+    # 🔴 Gehzeit-Fensterung (collect_hiking_window_points()), NICHT das
     # Tagesfenster 04-19 von temperature_min/temperature_max.
     MetricDefinition(
         id="wind_chill_day_low",
@@ -276,7 +276,7 @@ _METRICS: list[MetricDefinition] = [
         providers={"openmeteo": True, "geosphere": True},
         sms_code="FL", sms_multi_symbols=("FL",), decimals=0,
     ),
-    # 🔴 Gehzeit-Fensterung (_collect_hiking_window_dps()), NICHT das
+    # 🔴 Gehzeit-Fensterung (collect_hiking_window_points()), NICHT das
     # Tagesfenster 04-19 von temperature_min/temperature_max.
     MetricDefinition(
         id="wind_chill_day_high",

--- a/tests/tdd/test_765_backend_hygiene_compliance.py
+++ b/tests/tdd/test_765_backend_hygiene_compliance.py
@@ -113,6 +113,20 @@ _SELF_EXEMPT = {
     # gehoert dieser Eintrag wieder raus.
     # Spec: docs/specs/modules/feat_1717_s3_premium_sms_ui.md
     "test_premium_sms_ttl_drift.py",
+    # #1848 Scheibe C AC-5 (Tech-Lead-Freigabe 2026-08-19): Kommentar-Waechter
+    # liest die Kommentare in src/app/metric_catalog.py als DATEN, um per AST
+    # zu pruefen, ob die dort genannten Funktionsnamen im Code tatsaechlich
+    # aufloesbar sind — kein Verhaltensnachweis auf Code-Strings, gleiche
+    # Werkzeug-Klasse wie test_alert_metric_mapping_parity.py (#1435 E5 AC-8),
+    # der ebenfalls Kommentare in Produkt-Python gegen den echten Mechanismus
+    # stellt. Nachweisbarer Fang: der Test fand den toten Namen
+    # `_collect_hiking_window_dps()`, der 4x in Kommentaren stand und auf
+    # keine existierende Funktion zeigte (korrekt ist
+    # `collect_hiking_window_points()`).
+    # Pruefdatum: 2026-11-17 — kein weiterer nachweisbarer Fang bis dahin =>
+    # Eintrag zurueckbauen (Regel-Budget, CLAUDE.md "Backlog & Nebenbefunde").
+    # Spec: docs/specs/modules/feat_1848_c_waechter_gehzeit_trip_exklusiv.md
+    "test_gehzeit_metriken_bleiben_trip_exklusiv.py",
 }
 # #1408 F005 / #1469: `test_validator_log_unique_filenames.py` stand hier als
 # ausdruecklicher FEHLALARM-Eintrag, weil `_collect_listed_product_paths()`

--- a/tests/unit/test_compare_catalog_derives_from_central_catalog.py
+++ b/tests/unit/test_compare_catalog_derives_from_central_catalog.py
@@ -63,23 +63,28 @@ CENTRAL_METRICS_COVERED_ELSEWHERE: dict[str, str] = {
     # verschieden und liefern deshalb VERSCHIEDENE ZAHLEN:
     #   * Trip K/D: `collect_hiking_window_points()` -- die GEHZEIT entlang
     #     der Route, Segmentgrenzen inklusiv/exklusiv gemischt
-    #     (sms_trip.py:237-239, renderers/day_window.py:183).
+    #     (sms_trip.py:237-239, renderers/day_window.py:186).
     #   * Compare temp_min_c/temp_max_c: `resolve_configured_window()` --
     #     ein KONFIGURIERTES Tagesfenster (Vorgabe 04-19) am festen Ort
     #     (services/compare_location_weather_source.py:110, app/day_window.py:20).
     # Eine fruehere Fassung dieses Kommentars behauptete "buchstaeblich
     # dieselbe Zahl". Das war falsch und ist nachgemessen widerlegt.
     #
-    # Rueckbaupfad: #1848 (Zusammenfuehrung von Ortsvergleich-Katalog,
-    # 3-Tages-Ausblick und Trip-Katalog auf EIN Vokabular, PO-Entscheid E4
-    # zu #1728). Danach fallen diese vier Zeilen ersatzlos weg. WER DAS TUT,
-    # MUSS DEN FENSTERUNTERSCHIED ZUERST AUFLOESEN: zwei Kennungen mit
-    # gleicher Bedeutung, aber verschiedener Fensterung zusammenzufuehren
-    # erzeugt eine Groesse, die je nach Aufrufer eine andere Zahl liefert.
-    "temperature_day_low": "#1728 — bedeutungsgleich mit temp_min_c (temperature/min), anderes Zeitfenster (s. Blockkommentar); Rueckbau mit #1848",
-    "temperature_day_high": "#1728 — bedeutungsgleich mit temp_max_c (temperature/max), anderes Zeitfenster (s. Blockkommentar); Rueckbau mit #1848",
-    "wind_chill_day_low": "#1728 — bedeutungsgleich mit wind_chill_min_c (wind_chill/min), anderes Zeitfenster (s. Blockkommentar); Rueckbau mit #1848",
-    "wind_chill_day_high": "#1728 — bedeutungsgleich mit wind_chill_max_c (wind_chill/max), anderes Zeitfenster (s. Blockkommentar); Rueckbau mit #1848",
+    # KEIN Rueckbaupfad -- die vier bleiben trip-exklusiv (PO-Entscheid
+    # 2026-08-19 zu #1848, Scheibe C). Die frueher hier angekuendigte
+    # Zusammenfuehrung auf EIN Vokabular umfasst diese vier NICHT: auf Tour
+    # zaehlt das Wetter, WAEHREND man geht -- die vier fenstern ueber die
+    # Gehzeit entlang der Route. Der Ortsvergleich hat keine Route und damit
+    # keine Gehzeit; er nutzt ein konfiguriertes Tagesfenster (Vorgabe 04-19).
+    # Zwei verschiedene Fragen, keine Dopplung. Ein Zusammenfuehren erzeugte
+    # eine Kennung, die je nach Aufrufer eine andere Zahl liefert -- genau der
+    # Fensterunterschied oben. Die vier Zeilen bleiben deshalb stehen; der
+    # Ortsvergleich bietet die Groessen nie an (Waechter:
+    # tests/unit/test_gehzeit_metriken_bleiben_trip_exklusiv.py).
+    "temperature_day_low": "#1728 — bedeutungsgleich mit temp_min_c (temperature/min), anderes Zeitfenster (s. Blockkommentar); bleibt trip-exklusiv (PO-Entscheid 2026-08-19, #1848)",
+    "temperature_day_high": "#1728 — bedeutungsgleich mit temp_max_c (temperature/max), anderes Zeitfenster (s. Blockkommentar); bleibt trip-exklusiv (PO-Entscheid 2026-08-19, #1848)",
+    "wind_chill_day_low": "#1728 — bedeutungsgleich mit wind_chill_min_c (wind_chill/min), anderes Zeitfenster (s. Blockkommentar); bleibt trip-exklusiv (PO-Entscheid 2026-08-19, #1848)",
+    "wind_chill_day_high": "#1728 — bedeutungsgleich mit wind_chill_max_c (wind_chill/max), anderes Zeitfenster (s. Blockkommentar); bleibt trip-exklusiv (PO-Entscheid 2026-08-19, #1848)",
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_gehzeit_metriken_bleiben_trip_exklusiv.py
+++ b/tests/unit/test_gehzeit_metriken_bleiben_trip_exklusiv.py
@@ -488,16 +488,43 @@ def test_f002_gegenprobe_geschrumpfte_und_gewachsene_menge_werden_benannt():
 # Aenderung. Reiner Funktionsaufruf: kein Netz, kein HTTP-Client, kein
 # TestClient-Server, kein Mock.
 # ---------------------------------------------------------------------------
+# Herkunft einer Fundstelle -- die Meldung muss unterscheidbar sagen, ueber
+# WELCHES Feld der Verstoss aufgefallen ist, sonst raetselt der naechste Leser.
+_FUND_UEBER_METRIC_ID = "ueber metric_id"
+_FUND_UEBER_LABEL = "ueber Beschriftung"
+
+
 def _verbotene_ids_in_endpoint_antwort(
     verboten: tuple[str, ...] = GEHZEIT_METRIC_IDS, payload: dict | None = None
 ) -> list[str]:
-    """Welche der genannten Kennungen traegt die Nutzlast von
-    `GET /api/compare/metrics` (`{"metrics": [...]}`)? Leer = in Ordnung."""
+    """Welche Eintraege der Nutzlast von `GET /api/compare/metrics`
+    (`{"metrics": [...]}`) tragen eine Gehzeit-Groesse an die Bedienflaeche?
+    Leer = in Ordnung.
+
+    ZWEI Wege, weil die Bedienflaeche zwei Felder liest (F-ADV2-1):
+    `compareMetricCatalogLoader.ts:57-58` baut Auswahl und Wertebereichs-Zeile
+    aus `key`/`label`, `metric_id` ist dort optional und nur Filterfeld (:136).
+    Ein Antwort-Eintrag OHNE `metric_id`, aber mit dem Zusatz '(Gehzeit)' in
+    der Beschriftung, erreicht den Wertebereichs-Editor und den Trip-Reiter
+    genauso -- ueber `metric_id` allein waere er unsichtbar.
+    """
     if payload is None:
         payload = get_compare_metrics()
     eintraege = payload.get("metrics") or []
-    vorhanden = {e.get("metric_id") for e in eintraege if e.get("metric_id")}
-    return sorted(set(verboten) & vorhanden)
+    fundstellen = {
+        f"{e['metric_id']} ({_FUND_UEBER_METRIC_ID})"
+        for e in eintraege
+        if e.get("metric_id") in set(verboten)
+    }
+    # Beschriftungs-Weg: unabhaengig von `verboten`, denn '(Gehzeit)' IST das
+    # Merkmal der Gehzeit-Fensterung im Register (vgl. _register_gehzeit_ids).
+    fundstellen |= {
+        f"{e.get('key') or e.get('metric_id') or '<ohne key>'} "
+        f"({_FUND_UEBER_LABEL}: {e.get('label')!r})"
+        for e in eintraege
+        if GEHZEIT_LABEL_ZUSATZ in (e.get("label") or "")
+    }
+    return sorted(fundstellen)
 
 
 def test_f001_endpoint_antwort_bietet_keine_gehzeit_kennung_an():
@@ -514,7 +541,8 @@ def test_f001_positivkontrolle_derselbe_suchweg_findet_temperature_in_der_antwor
     """Ohne sie waere die Zusicherung oben wieder nur 'gruen, weil am falschen
     Ort gesucht': derselbe Suchweg muss finden, was in der Antwort stehen MUSS
     (`temperature`, getragen vom Eintrag `temp_min_c`)."""
-    assert _verbotene_ids_in_endpoint_antwort(verboten=("temperature",)) == ["temperature"], (
+    erwartet = f"temperature ({_FUND_UEBER_METRIC_ID})"
+    assert _verbotene_ids_in_endpoint_antwort(verboten=("temperature",)) == [erwartet], (
         "Der Suchweg findet 'temperature' nicht in der Endpoint-Antwort -- das "
         "Gruen stammt dann nicht aus Abwesenheit, sondern aus dem falschen Ort."
     )
@@ -525,16 +553,50 @@ def test_f001_positivkontrolle_derselbe_suchweg_findet_temperature_in_der_antwor
 
 
 def test_f001_gegenprobe_an_die_antwort_gehaengte_kennung_wird_gemeldet():
-    """F001 Wirkungsnachweis: eine KOPIE der Nutzlast mit angehaengter
-    Gehzeit-Groesse -- genau die Mutation, die der Adversary gefahren hat."""
+    """F001 Wirkungsnachweis an KOPIEN der Nutzlast, auf BEIDEN Wegen -- (a) mit
+    `metric_id` (die Mutation des ersten Adversary), (b) OHNE `metric_id`, nur
+    mit '(Gehzeit)' in der Beschriftung (F-ADV2-1: dieser Eintrag erreichte den
+    Wertebereichs-Editor, ohne dass ein Test rot wurde)."""
     echt = get_compare_metrics()
-    kopie = {"metrics": list(echt.get("metrics") or []) + [
+
+    # (a) Weg ueber das Filterfeld `metric_id`.
+    kopie_a = {"metrics": list(echt.get("metrics") or []) + [
         {"key": "kunst_wind_chill_day_high", "unit": "°C", "decimals": 0, "kind": "range",
          "metric_id": "wind_chill_day_high", "aggregation": "max"}
     ]}
-    assert _verbotene_ids_in_endpoint_antwort(payload=kopie) == ["wind_chill_day_high"], (
-        "Der Waechter bemerkt eine an die Endpoint-Antwort gehaengte Kennung nicht."
+    assert _verbotene_ids_in_endpoint_antwort(payload=kopie_a) == [
+        f"wind_chill_day_high ({_FUND_UEBER_METRIC_ID})"
+    ], "Der Waechter bemerkt eine an die Endpoint-Antwort gehaengte Kennung nicht."
+
+    # (b) Weg ueber die Beschriftung -- Eintrag OHNE `metric_id`.
+    label = "Gefuehlte Tages-Hoechsttemperatur (Gehzeit)"
+    kopie_b = {"metrics": list(echt.get("metrics") or []) + [
+        {"key": "wind_chill_day_high_c", "unit": "°C", "decimals": 0, "kind": "range",
+         "label": label, "aggregation": "max"}
+    ]}
+    assert _verbotene_ids_in_endpoint_antwort(payload=kopie_b) == [
+        f"wind_chill_day_high_c ({_FUND_UEBER_LABEL}: {label!r})"
+    ], (
+        "Ein Antwort-Eintrag OHNE `metric_id`, aber mit '(Gehzeit)' in der "
+        "Beschriftung faellt nicht auf -- er erreicht die Bedienflaeche ueber "
+        "`key`/`label` trotzdem (compareMetricCatalogLoader.ts:57-58)."
     )
+
     assert _verbotene_ids_in_endpoint_antwort() == [], (
         "Die Gegenprobe hat die ECHTE Antwort veraendert."
+    )
+
+
+def test_f001_regulaerer_eintrag_ohne_gehzeit_zusatz_gilt_nicht_als_verstoss():
+    """Falsch-Positiv-Probe zum Beschriftungs-Weg: ein normaler Antwort-Eintrag
+    ohne '(Gehzeit)' im Label darf NICHT anschlagen -- sonst waere die Roete
+    des Waechters wertlos, weil jeder neue Ortsvergleich-Eintrag sie ausloest."""
+    echt = get_compare_metrics()
+    kopie = {"metrics": list(echt.get("metrics") or []) + [
+        {"key": "kunst_humidity", "unit": "%", "decimals": 0, "kind": "range",
+         "label": "Relative Luftfeuchte (Tagesfenster)", "aggregation": "max"}
+    ]}
+    assert _verbotene_ids_in_endpoint_antwort(payload=kopie) == [], (
+        "Der Waechter meldet einen regulaeren Eintrag ohne '(Gehzeit)'-Zusatz "
+        "als Verstoss -- Falsch-Positiv."
     )

--- a/tests/unit/test_gehzeit_metriken_bleiben_trip_exklusiv.py
+++ b/tests/unit/test_gehzeit_metriken_bleiben_trip_exklusiv.py
@@ -1,0 +1,391 @@
+"""Die vier Gehzeit-Groessen bleiben trip-exklusiv (#1848 Scheibe C).
+
+SPEC: docs/specs/modules/feat_1848_c_waechter_gehzeit_trip_exklusiv.md
+
+PO-Entscheid 2026-08-19: `temperature_day_low`, `temperature_day_high`,
+`wind_chill_day_low`, `wind_chill_day_high` sind dem Trip vorbehalten und
+werden im Ortsvergleich NIE angeboten. Bisher haelt das nur, weil es niemand
+verletzt hat: der bestehende Drift-Waechter
+(`test_compare_catalog_derives_from_central_catalog.py`) ZIEHT die vier ueber
+`CENTRAL_METRICS_COVERED_ELSEWHERE` von seiner Pruefmenge AB -- fuer sie ist
+"hat keinen Compare-Eintrag" trivial wahr.
+
+🔴 EHRLICHKEITSVERMERK ZUR ROETE: Die Invariante haelt am Bestand. AC-1 bis
+AC-4 und AC-7 sind deshalb sofort gruen -- sie nageln Bestandsverhalten fest,
+und ihre Aussagekraft kommt NICHT aus ihrer Roete, sondern aus den
+Gegenproben (jede Zusicherung laeuft ueber eine benannte Hilfsfunktion, die
+im selben Lauf gegen eine kuenstlich gebrochene KOPIE gefuehrt wird) und aus
+den Positivkontrollen (derselbe Suchweg findet, was dort stehen MUSS). Echt
+rot am Bestand sind AC-5 (toter Funktionsname `_collect_hiking_window_dps()`)
+und AC-6 (ueberholte Rueckbau-Zusagen).
+
+Test-Politik: Kern-Schicht -- kein Netz, kein Mock, kein `patch()`. Die echten
+Katalog-/Registerlisten werden NIE veraendert, nur Kopien. Pfadregel #1409:
+Prueflinge relativ zu DIESER Testdatei aufgeloest.
+"""
+from __future__ import annotations
+
+import ast
+import builtins
+import importlib.util
+import io
+import re
+import tokenize
+from dataclasses import replace
+from pathlib import Path
+
+from app.metric_catalog import MetricDefinition, get_all_metrics
+from output.renderers.compare_hourly_metric_ids import HOURLY_EXCLUDED_METRIC_IDS
+from output.renderers.compare_metric_catalog import get_compare_metric_catalog
+from output.renderers.compare_outlook_metric_ids import resolve_outlook_metrics
+
+# Pfadregel #1409: Prueflinge relativ zur eigenen Testdatei, nie ueber einen
+# festen Hauptrepo-Pfad -- sonst kaeme falsches Gruen aus dem Worktree.
+_UNIT_DIR = Path(__file__).resolve().parent
+_REPO = _UNIT_DIR.parents[1]
+_METRIC_CATALOG_PY = _REPO / "src" / "app" / "metric_catalog.py"
+_DRIFT_GUARD_PY = _UNIT_DIR / "test_compare_catalog_derives_from_central_catalog.py"
+
+# AC-7: VIER NAMENTLICH GENANNTE Kennungen -- ausdruecklich kein Namensmuster
+# ("alles mit _day_"). #1468 fuegt dem Register additiv Eintraege hinzu; ein
+# Musterwaechter wuerde davon rot, ein Namenswaechter nicht.
+GEHZEIT_METRIC_IDS: tuple[str, ...] = (
+    "temperature_day_low", "temperature_day_high",
+    "wind_chill_day_low", "wind_chill_day_high",
+)
+GEHZEIT_LABEL_ZUSATZ = "(Gehzeit)"
+
+
+# ---------------------------------------------------------------------------
+# Hilfsfunktionen -- jede nimmt ihre Eingabe als Parameter (Default = echte
+# Daten), damit Produktions-Zusicherung und Gegenprobe DIESELBE Logik fahren.
+# ---------------------------------------------------------------------------
+def _verbotene_ids_im_compare_katalog(
+    verboten: tuple[str, ...] = GEHZEIT_METRIC_IDS, entries: list[dict] | None = None
+) -> list[str]:
+    """Tuer 1: welche der genannten Kennungen traegt ein Ortsvergleich-Katalog-
+    Eintrag als `metric_id`? Leer = in Ordnung."""
+    if entries is None:
+        entries = get_compare_metric_catalog()
+    vorhanden = {e.get("metric_id") for e in entries if e.get("metric_id")}
+    return sorted(set(verboten) & vorhanden)
+
+
+def _verstoss_meldung(gefunden: list[str]) -> str:
+    """EIN Meldungsaufbau fuer Zusicherung und Gegenprobe -- AC-1 verlangt,
+    dass der Fehlertext die betroffene Kennung BENENNT."""
+    return (
+        "Gehzeit-Kennungen im Ortsvergleich angeboten (trip-exklusiv laut "
+        f"PO-Entscheid 2026-08-19, #1848): {gefunden}"
+    )
+
+
+def _gehzeit_ids_ohne_stundenausschluss(
+    excluded: frozenset[str] | set[str] = HOURLY_EXCLUDED_METRIC_IDS,
+) -> list[str]:
+    """Tuer 2: welche der vier fehlen in `HOURLY_EXCLUDED_METRIC_IDS`? Hier ist
+    ENTHALTENSEIN das Soll -- der Ausschluss ist die Zusicherung."""
+    return sorted(set(GEHZEIT_METRIC_IDS) - set(excluded))
+
+
+def _im_ausblick_waehlbar(
+    metric_ids: tuple[str, ...] = GEHZEIT_METRIC_IDS, resolver=resolve_outlook_metrics
+) -> list[str]:
+    """Tuer 3: welche der genannten Kennungen loest der 3-Tages-Ausblick auf?
+    Probiert je Kennung alle im Register vorgesehenen Auswertungen durch."""
+    register = {m.id: m for m in get_all_metrics()}
+    treffer: list[str] = []
+    for metric_id in metric_ids:
+        aggregationen = getattr(register.get(metric_id), "default_aggregations", ("min", "max"))
+        for aggregation in aggregationen or ("min", "max"):
+            if resolver([{"metric_id": metric_id, "aggregation": aggregation}]):
+                treffer.append(f"{metric_id}/{aggregation}")
+    return sorted(treffer)
+
+
+def _gehzeit_labels_ohne_zusatz(
+    definitionen: list[MetricDefinition] | None = None,
+) -> list[str]:
+    """AC-4 gegen DATEN (`MetricDefinition.label_de`), nicht gegen Fliesstext:
+    welche der vier haben keinen Registereintrag oder keinen '(Gehzeit)'?"""
+    if definitionen is None:
+        definitionen = get_all_metrics()
+    register = {m.id: m for m in definitionen}
+    return sorted(
+        metric_id for metric_id in GEHZEIT_METRIC_IDS
+        if GEHZEIT_LABEL_ZUSATZ not in (getattr(register.get(metric_id), "label_de", "") or "")
+    )
+
+
+def _kommentartext(quelltext: str) -> str:
+    """Alle Kommentare einer Python-Quelle als EIN normalisierter Text.
+    Zeilenumbrueche und Einrueckung fallen weg -- so haengt keine Zusicherung
+    an einer Zeilennummer (Muster #1466)."""
+    kommentare = [
+        tok.string.lstrip("#").strip()
+        for tok in tokenize.generate_tokens(io.StringIO(quelltext).readline)
+        if tok.type == tokenize.COMMENT
+    ]
+    return re.sub(r"\s+", " ", " ".join(kommentare))
+
+
+def _definierte_funktionsnamen(wurzeln: tuple[Path, ...]) -> set[str]:
+    """Alle im Baum per `def`/`async def` definierten Namen (AST, zur Laufzeit
+    aufgeloest) plus die Builtins."""
+    namen = set(dir(builtins))
+    for wurzel in wurzeln:
+        for datei in wurzel.rglob("*.py"):
+            baum = ast.parse(datei.read_text(encoding="utf-8"), filename=str(datei))
+            namen.update(
+                knoten.name for knoten in ast.walk(baum)
+                if isinstance(knoten, (ast.FunctionDef, ast.AsyncFunctionDef))
+            )
+    return namen
+
+
+def _tote_kommentar_namen(quelltext: str, definiert: set[str]) -> list[str]:
+    """AC-5: in Kommentaren als `name()` genannte Funktionsnamen, die der Code
+    nicht kennt. Schluessel ist der NAME, nicht die Zeile."""
+    genannt = set(re.findall(r"([A-Za-z_][A-Za-z0-9_]*)\(\)", _kommentartext(quelltext)))
+    return sorted(genannt - definiert)
+
+
+def _drift_guard_modul():
+    """Den Nachbar-Waechter als Modul laden (relativ zur eigenen Testdatei),
+    damit AC-6 (b) gegen DATEN statt gegen Dateitext prueft."""
+    spec = importlib.util.spec_from_file_location("_drift_guard_1848c", _DRIFT_GUARD_PY)
+    modul = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(modul)
+    return modul
+
+
+# ---------------------------------------------------------------------------
+# AC-1 / AC-2 -- Tuer 1 (Katalog) samt Positivkontrolle
+# ---------------------------------------------------------------------------
+def test_ac1_kein_ortsvergleich_eintrag_traegt_eine_gehzeit_kennung():
+    """AC-1. Gruen am Bestand (Invariante haelt, s. Modul-Docstring); die
+    Aussagekraft liefert die Gegenprobe unten."""
+    gefunden = _verbotene_ids_im_compare_katalog()
+    assert gefunden == [], _verstoss_meldung(gefunden)
+
+
+def test_ac1_gegenprobe_kuenstlicher_katalogeintrag_wird_namentlich_gemeldet():
+    """AC-1 Wirkungsnachweis: dieselbe Pruef-Funktion gegen eine KOPIE des
+    Katalogs mit kuenstlichem `temperature_day_low`-Eintrag. Ohne diesen
+    Nachweis waere nicht bewiesen, dass der Waechter ueberhaupt etwas prueft."""
+    kopie = list(get_compare_metric_catalog()) + [
+        {"key": "kunst_temp_day_low", "unit": "°C", "decimals": 0, "kind": "range",
+         "metric_id": "temperature_day_low", "aggregation": "min"}
+    ]
+    gefunden = _verbotene_ids_im_compare_katalog(entries=kopie)
+    assert gefunden == ["temperature_day_low"], (
+        f"Waechter erkennt den kuenstlich hinzugefuegten Eintrag nicht: {gefunden}"
+    )
+    assert "temperature_day_low" in _verstoss_meldung(gefunden), (
+        f"Fehlertext nennt die Kennung nicht: {_verstoss_meldung(gefunden)}"
+    )
+    assert _verbotene_ids_im_compare_katalog() == [], (
+        "Die Gegenprobe hat den ECHTEN Katalog veraendert -- es darf nur eine "
+        "Kopie manipuliert werden."
+    )
+
+
+def test_ac2_positivkontrolle_derselbe_suchweg_findet_temperature():
+    """AC-2, der wichtigste Test dieser Datei: derselbe Suchweg, der oben die
+    Abwesenheit feststellt, angewendet auf eine Kennung, die im Ortsvergleich
+    vorkommen MUSS (`temperature` ueber den Eintrag `temp_min_c`). Ohne ihn
+    waere AC-1 auch gruen, wenn am falschen Ort gesucht wird."""
+    assert _verbotene_ids_im_compare_katalog(verboten=("temperature",)) == ["temperature"], (
+        "Der Suchweg findet 'temperature' nicht im Ortsvergleich-Katalog -- "
+        "das Gruen von AC-1 stammt dann nicht aus Abwesenheit, sondern daraus, "
+        "dass am falschen Ort gesucht wird."
+    )
+    keys = {e.get("key") for e in get_compare_metric_catalog()}
+    assert "temp_min_c" in keys, f"Erwarteter Traeger-Eintrag temp_min_c fehlt: {sorted(keys)[:5]}"
+
+
+# ---------------------------------------------------------------------------
+# AC-3 -- Tuer 2 (Stundenverlauf) und Tuer 3 (3-Tages-Ausblick)
+# ---------------------------------------------------------------------------
+def test_ac3_tuer2_alle_vier_stehen_im_stundenverlaufs_ausschluss():
+    """AC-3, Tuer 2: ENTHALTENSEIN in `HOURLY_EXCLUDED_METRIC_IDS` ist das
+    Soll. Gruen am Bestand (#1728 hat den Ausschluss gesetzt)."""
+    fehlend = _gehzeit_ids_ohne_stundenausschluss()
+    assert fehlend == [], (
+        f"Gehzeit-Kennungen ohne Stundenverlaufs-Ausschluss: {fehlend}"
+    )
+
+
+def test_ac3_tuer2_gegenprobe_entfernter_ausschluss_wird_gemeldet():
+    """AC-3 Wirkungsnachweis Tuer 2 an einer KOPIE der Ausschlussmenge."""
+    kopie = set(HOURLY_EXCLUDED_METRIC_IDS) - {"wind_chill_day_high"}
+    assert _gehzeit_ids_ohne_stundenausschluss(kopie) == ["wind_chill_day_high"], (
+        "Waechter bemerkt eine aus der Ausschlussmenge entfernte Kennung nicht."
+    )
+    assert _gehzeit_ids_ohne_stundenausschluss() == [], (
+        "Die Gegenprobe hat die ECHTE Ausschlussmenge veraendert."
+    )
+
+
+def test_ac3_tuer3_keine_gehzeit_kennung_ist_im_ausblick_aufloesbar():
+    """AC-3, Tuer 3: der 3-Tages-Ausblick verwirft alle vier."""
+    waehlbar = _im_ausblick_waehlbar()
+    assert waehlbar == [], f"Gehzeit-Kennungen im 3-Tages-Ausblick waehlbar: {waehlbar}"
+
+
+def test_ac3_tuer3_positivkontrolle_temperature_ist_aufloesbar():
+    """AC-3/AC-2 fuer Tuer 3: derselbe Suchweg loest `temperature` auf --
+    sonst waere die Abwesenheit oben nur die Abwesenheit des Suchwegs."""
+    assert _im_ausblick_waehlbar(metric_ids=("temperature",)), (
+        "Der Ausblick-Resolver loest nicht einmal 'temperature' auf -- der "
+        "Suchweg traegt nicht."
+    )
+
+
+def test_ac3_tuer3_gegenprobe_durchlassender_resolver_wird_gemeldet():
+    """AC-3 Wirkungsnachweis Tuer 3: ein kuenstlicher Resolver, der alles
+    annimmt (kein Mock -- eine im Test definierte Funktion), muss alle vier
+    Kennungen als waehlbar melden."""
+    alles_durchlassend = lambda eintraege: list(eintraege)  # noqa: E731
+    gemeldet = _im_ausblick_waehlbar(resolver=alles_durchlassend)
+    assert {t.split("/")[0] for t in gemeldet} == set(GEHZEIT_METRIC_IDS), (
+        f"Waechter meldet bei durchlassendem Resolver nicht alle vier: {gemeldet}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-4 -- "(Gehzeit)" ist tragend, an den Daten festgenagelt
+# ---------------------------------------------------------------------------
+def test_ac4_alle_vier_label_de_tragen_den_gehzeit_zusatz():
+    """AC-4. Gruen am Bestand (metric_catalog.py:173,190,260,271)."""
+    ohne = _gehzeit_labels_ohne_zusatz()
+    assert ohne == [], (
+        f"Registereintraege ohne tragenden Zusatz '{GEHZEIT_LABEL_ZUSATZ}': {ohne} -- "
+        "der Zusatz unterscheidet Gehzeit-Fensterung vom konfigurierten Tagesfenster."
+    )
+
+
+def test_ac4_gegenprobe_kopie_ohne_zusatz_wird_gemeldet():
+    """AC-4 Wirkungsnachweis an einer KOPIE des Registers (dataclasses.replace,
+    kein Mock): der entfernte Zusatz muss auffallen."""
+    kopie = [
+        replace(m, label_de="Tages-Tiefsttemperatur") if m.id == "temperature_day_low" else m
+        for m in get_all_metrics()
+    ]
+    assert _gehzeit_labels_ohne_zusatz(kopie) == ["temperature_day_low"], (
+        "Waechter bemerkt den entfernten '(Gehzeit)'-Zusatz nicht."
+    )
+    assert _gehzeit_labels_ohne_zusatz() == [], "Die Gegenprobe hat das ECHTE Register veraendert."
+
+
+# ---------------------------------------------------------------------------
+# AC-5 -- in Kommentaren genannte Funktionsnamen sind auflösbar
+# doc-compliance-test
+# ---------------------------------------------------------------------------
+def test_ac5_kommentar_funktionsnamen_sind_im_code_aufloesbar():  # doc-compliance-test
+    """AC-5, ROT AM BESTAND: die vier Blockkommentare zu den Gehzeit-Groessen
+    nennen `_collect_hiking_window_dps()` -- diese Funktion existiert nicht,
+    sie heisst `collect_hiking_window_points()` (renderers/day_window.py).
+    Geprueft wird laufzeitaufgeloest ueber `ast` (Muster #1466), NICHT ueber
+    Zeilennummern. Doku-Konformitaetstest, kein Verhaltensnachweis."""
+    definiert = _definierte_funktionsnamen((_REPO / "src", _REPO / "api"))
+    tot = _tote_kommentar_namen(_METRIC_CATALOG_PY.read_text(encoding="utf-8"), definiert)
+    assert tot == [], (
+        f"Kommentare in {_METRIC_CATALOG_PY.relative_to(_REPO)} nennen Funktionsnamen, "
+        f"die im Code nicht auflösbar sind: {tot} -- Name korrigieren oder Kommentar "
+        "streichen; ein Kommentar, der auf einen nicht existierenden Namen zeigt, "
+        "führt jeden Leser in die Irre."
+    )
+
+
+def test_ac5_aufloeser_findet_echte_namen_und_meldet_erfundene():  # doc-compliance-test
+    """AC-5 Positivkontrolle + Gegenprobe: der Aufloeser darf nach der
+    Korrektur nicht trivial gruen sein. Gegen einen KUENSTLICHEN Quelltext
+    (kein Dateizugriff): ein existierender Name schweigt, ein erfundener wird
+    gemeldet."""
+    definiert = _definierte_funktionsnamen((_REPO / "src",))
+    assert "collect_hiking_window_points" in definiert, (
+        "Der AST-Scan findet nicht einmal collect_hiking_window_points() -- "
+        "die Scanflaeche stimmt nicht."
+    )
+    kunst = "# richtig: collect_hiking_window_points()\n# falsch: _gibt_es_nicht_1848c()\nX = 1\n"
+    assert _tote_kommentar_namen(kunst, definiert) == ["_gibt_es_nicht_1848c"], (
+        "Aufloeser meldet den erfundenen Namen nicht oder meldet den echten mit."
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-6 -- die ueberholten Rueckbau-Zusagen
+# doc-compliance-test
+# ---------------------------------------------------------------------------
+def test_ac6a_rueckbaupfad_kommentar_gibt_den_po_entscheid_wieder():  # doc-compliance-test
+    """AC-6 (a), ROT AM BESTAND: der Blockkommentar behauptet, die vier Zeilen
+    fielen mit #1848 'ersatzlos weg'. Der PO-Entscheid vom 2026-08-19 sagt das
+    Gegenteil. Geprueft wird der ueber alle Kommentarzeilen normalisierte Text
+    (kein Zeilenanker). Doku-Konformitaetstest."""
+    text = _kommentartext(_DRIFT_GUARD_PY.read_text(encoding="utf-8"))
+    assert "Deckungs-Ausnahme" in text, (
+        "Positivkontrolle: die Kommentar-Extraktion liefert nicht einmal die "
+        "Ueberschrift des Ausnahme-Blocks -- der Suchweg traegt nicht. "
+        "(Docstrings sind KEINE Kommentare; hier wird bewusst nur `#` gelesen.)"
+    )
+    assert "ersatzlos weg" not in text.lower(), (
+        "Der Rueckbaupfad-Kommentar behauptet weiterhin, die vier Zeilen fielen "
+        "mit #1848 ersatzlos weg. Ueberholt durch den PO-Entscheid 2026-08-19: "
+        "die vier Gehzeit-Groessen bleiben trip-exklusiv."
+    )
+    assert "trip-exklusiv" in text.lower(), (
+        "Der Kommentar sagt nicht, dass die vier Kennungen trip-exklusiv bleiben."
+    )
+
+
+def test_ac6b_die_vier_einzelvermerke_sind_ebenfalls_aktualisiert():  # doc-compliance-test
+    """AC-6 (b), ROT AM BESTAND: jeder der vier Ausnahme-Eintraege traegt den
+    Text 'Rueckbau mit #1848'. Geprueft gegen die importierten DATEN, nicht
+    gegen Dateitext. Der Blockkommentar allein genuegt nicht."""
+    ausnahmen = _drift_guard_modul().CENTRAL_METRICS_COVERED_ELSEWHERE
+    fehlend = sorted(set(GEHZEIT_METRIC_IDS) - set(ausnahmen))
+    assert fehlend == [], (
+        f"Die vier Gehzeit-Kennungen fehlen in CENTRAL_METRICS_COVERED_ELSEWHERE: "
+        f"{fehlend} -- ohne sie waere diese Zusicherung ueber die leere Menge "
+        "trivial wahr. Sie bleiben trip-exklusiv und damit ausgenommen."
+    )
+    ueberholt = sorted(m for m in GEHZEIT_METRIC_IDS if "rueckbau" in ausnahmen[m].lower())
+    assert ueberholt == [], (
+        f"Einzelvermerke kuendigen weiterhin einen Rueckbau mit #1848 an: {ueberholt} -- "
+        "ueberholt durch den PO-Entscheid 2026-08-19 (trip-exklusiv)."
+    )
+    ohne_entscheid = sorted(
+        m for m in GEHZEIT_METRIC_IDS if "trip-exklusiv" not in ausnahmen[m].lower()
+    )
+    assert ohne_entscheid == [], (
+        f"Einzelvermerke nennen den Stand vom 2026-08-19 nicht: {ohne_entscheid}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-7 -- namentlich, nie ueber ein Namensmuster
+# ---------------------------------------------------------------------------
+def test_ac7_neuer_register_eintrag_mit_day_im_namen_macht_nicht_rot():
+    """AC-7: #1468 fuegt dem Register additiv Eintraege hinzu. Ein Waechter,
+    der 'alles mit _day_' verboete, wuerde davon rot. Nachweis an KOPIEN:
+    weder ein Compare-Eintrag noch ein Registereintrag mit `_day_` im Namen
+    (aber nicht unter den vier) loest einen Befund aus."""
+    fremd = "thunder_onset_day_shift_h"
+    katalog_kopie = list(get_compare_metric_catalog()) + [
+        {"key": "kunst_onset", "unit": "h", "decimals": 0, "kind": "range",
+         "metric_id": fremd, "aggregation": "min"}
+    ]
+    assert _verbotene_ids_im_compare_katalog(entries=katalog_kopie) == [], (
+        f"Waechter schlaegt auf die fremde Kennung '{fremd}' an -- er leitet aus "
+        "einem Namensmuster ab statt aus den vier benannten Kennungen (AC-7)."
+    )
+
+    vorbild = next(m for m in get_all_metrics() if m.id == "temperature_day_low")
+    register_kopie = list(get_all_metrics()) + [
+        replace(vorbild, id=fremd, label_de="Vorverlagerung des Gewitterbeginns")
+    ]
+    assert _gehzeit_labels_ohne_zusatz(register_kopie) == [], (
+        f"Die '(Gehzeit)'-Zusicherung verlangt den Zusatz auch von '{fremd}' -- "
+        "sie zielt auf ein Namensmuster statt auf die vier benannten Kennungen."
+    )

--- a/tests/unit/test_gehzeit_metriken_bleiben_trip_exklusiv.py
+++ b/tests/unit/test_gehzeit_metriken_bleiben_trip_exklusiv.py
@@ -34,6 +34,7 @@ import tokenize
 from dataclasses import replace
 from pathlib import Path
 
+from api.routers.compare import get_compare_metrics
 from app.metric_catalog import MetricDefinition, get_all_metrics
 from output.renderers.compare_hourly_metric_ids import HOURLY_EXCLUDED_METRIC_IDS
 from output.renderers.compare_metric_catalog import get_compare_metric_catalog
@@ -388,4 +389,152 @@ def test_ac7_neuer_register_eintrag_mit_day_im_namen_macht_nicht_rot():
     assert _gehzeit_labels_ohne_zusatz(register_kopie) == [], (
         f"Die '(Gehzeit)'-Zusicherung verlangt den Zusatz auch von '{fremd}' -- "
         "sie zielt auf ein Namensmuster statt auf die vier benannten Kennungen."
+    )
+
+
+# ---------------------------------------------------------------------------
+# F002 -- die bewachte Menge selbst ist bewacht
+#
+# Adversary-Befund: `GEHZEIT_METRIC_IDS` auf zwei Kennungen zu kuerzen liess
+# ALLE Tests gruen -- `temperature_day_high` und `wind_chill_day_low` haetten
+# danach ausser dem Literal keinen Anker mehr gehabt. Genau die Fehlerklasse,
+# gegen die diese Scheibe gebaut ist: eine Liste, deren Zusicherung still zur
+# Luege wird. Die erwartete Menge wird deshalb aus dem ZENTRALREGISTER
+# abgeleitet und gegen das Literal gestellt.
+# ---------------------------------------------------------------------------
+def _register_gehzeit_ids(
+    definitionen: list[MetricDefinition] | None = None,
+) -> list[str]:
+    """Welche Registereintraege tragen den Zusatz '(Gehzeit)' im `label_de`?
+    Das ist die im Register erkennbare Menge der Gehzeit-Groessen -- unabhaengig
+    davon, was dieser Waechter oben als Literal fuehrt."""
+    if definitionen is None:
+        definitionen = get_all_metrics()
+    return sorted(
+        m.id for m in definitionen
+        if GEHZEIT_LABEL_ZUSATZ in (getattr(m, "label_de", "") or "")
+    )
+
+
+def _mengen_abweichung(
+    bewacht: tuple[str, ...] | list[str], abgeleitet: list[str]
+) -> tuple[list[str], list[str]]:
+    """Differenz in BEIDE Richtungen: (fehlt im Waechter, fehlt im Register).
+    EIN Aufbau fuer Zusicherung und Gegenprobe."""
+    return (
+        sorted(set(abgeleitet) - set(bewacht)),
+        sorted(set(bewacht) - set(abgeleitet)),
+    )
+
+
+def test_f002_bewachte_menge_deckt_sich_mit_den_gehzeit_eintraegen_des_registers():
+    """Die vier Kennungen stehen nicht mehr allein als Literal da: die erwartete
+    Menge kommt aus dem Register (`label_de` traegt '(Gehzeit)'). Schrumpft das
+    Literal, wird das rot -- kommt ueber #1468 eine neue Gehzeit-Groesse dazu,
+    die hier nicht mitbewacht wird, ebenfalls."""
+    abgeleitet = _register_gehzeit_ids()
+    assert abgeleitet, (
+        "Positivkontrolle: das Register liefert keinen einzigen Eintrag mit dem "
+        f"Zusatz '{GEHZEIT_LABEL_ZUSATZ}' -- die Ableitung traegt dann nichts und "
+        "eine Uebereinstimmung waere ueber die leere Menge trivial wahr."
+    )
+    fehlt_im_waechter, fehlt_im_register = _mengen_abweichung(GEHZEIT_METRIC_IDS, abgeleitet)
+    assert (fehlt_im_waechter, fehlt_im_register) == ([], []), (
+        "Die bewachte Menge deckt sich nicht mit den Gehzeit-Eintraegen des "
+        f"Zentralregisters. Im Waechter (GEHZEIT_METRIC_IDS) fehlen: {fehlt_im_waechter} "
+        f"-- im Register fehlt der '{GEHZEIT_LABEL_ZUSATZ}'-Eintrag zu: {fehlt_im_register}. "
+        "Beides ist ein Befund: eine hier stillschweigend entfernte Kennung waere "
+        "unbewacht, eine neue Gehzeit-Groesse im Register muss mitbewacht werden."
+    )
+
+
+def test_f002_gegenprobe_geschrumpfte_und_gewachsene_menge_werden_benannt():
+    """F002 Wirkungsnachweis an KOPIEN, in beide Richtungen -- ohne ihn waere
+    nicht bewiesen, dass die Abweichung ueberhaupt auffaellt."""
+    abgeleitet = _register_gehzeit_ids()
+
+    # (a) Waechter geschrumpft: zwei Kennungen ohne Anker.
+    geschrumpft = ("temperature_day_low", "wind_chill_day_high")
+    fehlt_im_waechter, fehlt_im_register = _mengen_abweichung(geschrumpft, abgeleitet)
+    assert fehlt_im_waechter == ["temperature_day_high", "wind_chill_day_low"], (
+        f"Eine geschrumpfte Waechter-Menge faellt nicht auf: {fehlt_im_waechter}"
+    )
+    assert fehlt_im_register == [], f"Falschmeldung in der Gegenrichtung: {fehlt_im_register}"
+
+    # (b) Register um eine neue Gehzeit-Groesse gewachsen, Waechter unveraendert.
+    vorbild = next(m for m in get_all_metrics() if m.id == "temperature_day_low")
+    register_kopie = list(get_all_metrics()) + [
+        replace(vorbild, id="humidity_day_high", label_de="Tages-Höchstfeuchte (Gehzeit)")
+    ]
+    fehlt_im_waechter, fehlt_im_register = _mengen_abweichung(
+        GEHZEIT_METRIC_IDS, _register_gehzeit_ids(register_kopie)
+    )
+    assert fehlt_im_waechter == ["humidity_day_high"], (
+        f"Eine neue Gehzeit-Groesse im Register faellt nicht auf: {fehlt_im_waechter}"
+    )
+    assert _register_gehzeit_ids() == abgeleitet, (
+        "Die Gegenprobe hat das ECHTE Register veraendert."
+    )
+
+
+# ---------------------------------------------------------------------------
+# F001 -- geprueft wird die LEITUNG, nicht nur die Funktion
+#
+# Adversary-Befund: haengt `GET /api/compare/metrics` eine Gehzeit-Groesse an
+# die ANTWORT, blieb alles gruen -- der Waechter prueft nur
+# `get_compare_metric_catalog()`. Die Spec begruendet den Verzicht auf einen
+# Frontend-Waechter aber damit, dass die Bedienflaeche den ENDPOINT liest
+# (compareMetricCatalogLoader.ts:101). Zwischen Funktion und Antwort passt eine
+# Aenderung. Reiner Funktionsaufruf: kein Netz, kein HTTP-Client, kein
+# TestClient-Server, kein Mock.
+# ---------------------------------------------------------------------------
+def _verbotene_ids_in_endpoint_antwort(
+    verboten: tuple[str, ...] = GEHZEIT_METRIC_IDS, payload: dict | None = None
+) -> list[str]:
+    """Welche der genannten Kennungen traegt die Nutzlast von
+    `GET /api/compare/metrics` (`{"metrics": [...]}`)? Leer = in Ordnung."""
+    if payload is None:
+        payload = get_compare_metrics()
+    eintraege = payload.get("metrics") or []
+    vorhanden = {e.get("metric_id") for e in eintraege if e.get("metric_id")}
+    return sorted(set(verboten) & vorhanden)
+
+
+def test_f001_endpoint_antwort_bietet_keine_gehzeit_kennung_an():
+    """Die Antwort selbst -- nicht die dahinterliegende Funktion -- fuehrt keine
+    der vier Kennungen. Das ist die Leitung, die die Bedienflaeche liest."""
+    gefunden = _verbotene_ids_in_endpoint_antwort()
+    assert gefunden == [], (
+        "GET /api/compare/metrics liefert Gehzeit-Kennungen an die "
+        f"Bedienflaeche aus: {gefunden} -- " + _verstoss_meldung(gefunden)
+    )
+
+
+def test_f001_positivkontrolle_derselbe_suchweg_findet_temperature_in_der_antwort():
+    """Ohne sie waere die Zusicherung oben wieder nur 'gruen, weil am falschen
+    Ort gesucht': derselbe Suchweg muss finden, was in der Antwort stehen MUSS
+    (`temperature`, getragen vom Eintrag `temp_min_c`)."""
+    assert _verbotene_ids_in_endpoint_antwort(verboten=("temperature",)) == ["temperature"], (
+        "Der Suchweg findet 'temperature' nicht in der Endpoint-Antwort -- das "
+        "Gruen stammt dann nicht aus Abwesenheit, sondern aus dem falschen Ort."
+    )
+    keys = {e.get("key") for e in get_compare_metrics().get("metrics") or []}
+    assert "temp_min_c" in keys, (
+        f"Erwarteter Traeger-Eintrag temp_min_c fehlt in der Antwort: {sorted(keys)[:5]}"
+    )
+
+
+def test_f001_gegenprobe_an_die_antwort_gehaengte_kennung_wird_gemeldet():
+    """F001 Wirkungsnachweis: eine KOPIE der Nutzlast mit angehaengter
+    Gehzeit-Groesse -- genau die Mutation, die der Adversary gefahren hat."""
+    echt = get_compare_metrics()
+    kopie = {"metrics": list(echt.get("metrics") or []) + [
+        {"key": "kunst_wind_chill_day_high", "unit": "°C", "decimals": 0, "kind": "range",
+         "metric_id": "wind_chill_day_high", "aggregation": "max"}
+    ]}
+    assert _verbotene_ids_in_endpoint_antwort(payload=kopie) == ["wind_chill_day_high"], (
+        "Der Waechter bemerkt eine an die Endpoint-Antwort gehaengte Kennung nicht."
+    )
+    assert _verbotene_ids_in_endpoint_antwort() == [], (
+        "Die Gegenprobe hat die ECHTE Antwort veraendert."
     )


### PR DESCRIPTION
## Worum es geht

PO-Entscheid vom 2026-08-19: Die vier Gehzeit-Größen bleiben dem Trip vorbehalten und werden im Ortsvergleich **nie** angeboten. Diese Scheibe macht den Entscheid maschinell haltbar.

Betroffene Kennungen: `temperature_day_low`, `temperature_day_high`, `wind_chill_day_low`, `wind_chill_day_high`.

## Die gemessene Lücke

`CENTRAL_METRICS_COVERED_ELSEWHERE` zog die vier Kennungen von der Prüfmenge **ab** — die Zusicherung „hat keinen Ortsvergleich-Eintrag" war für sie **trivial wahr**. Bekäme eine der vier morgen einen Eintrag, würde kein Test rot.

**Die Invariante hält heute.** Der Wächter ist vorbeugend, nicht korrigierend.

## Was der Wächter bewacht

- **Drei Türen:** Ortsvergleich-Katalog, Stundenverlauf-Ausschluss, 3-Tages-Ausblick
- **Leitung statt Katalogfunktion:** prüft die Endpoint-Antwort direkt, über `metric_id` **und** über die Beschriftung
- **Menge statt Literal:** die erwartete Menge wird aus dem Zentralregister abgeleitet (`label_de` trägt „(Gehzeit)"), Differenz in **beide** Richtungen — schrumpft das Literal, wird das rot; kommt über #1468 eine neue Gehzeit-Größe dazu, ebenfalls
- **Sperre gegen die leere Menge:** Positivkontrollen verhindern, dass Grün aus einer leeren Prüfmenge entsteht

Zusätzlich richtiggestellt: ein toter Funktionsname in Kommentaren (`_collect_hiking_window_dps()` → `collect_hiking_window_points()`, 4×), überholte Rückbau-Vermerke, und ein Docstring, der die abgeschlossene #1350-Migration noch als offen beschrieb.

## Hygiene-Gate

`test_765_no_product_source_read` flaggte den Kommentar-Wächter (liest `metric_catalog.py` als Daten). Aufgenommen in `_SELF_EXEMPT` statt zurückgebaut — wörtlicher Präzedenzfall: `test_alert_metric_mapping_parity.py` (#1435 E5 AC-8). Erkennungslogik unangetastet (14 Einfügungen, null Löschungen). **Prüffrist 2026-11-17** in der Regel-Budget-Tabelle.

## Nachweise

- Feature-Tests: 33 passed
- Betroffener Bereich inkl. Hygiene-Gate: 1083 passed, Exit 0
- Adversary: **VERIFIED** (3 Runden, 26 Punkte, F001/F002 geschlossen)

Teil des Epics #1848 (Scheibe C) — das Epic bleibt offen.