### PR TITLE
fix(#1727 S5f): raw_astimezone-Formbereinigung (weather_cache/trip_segments/segment_weather)

### DIFF
--- a/docs/context/fix-1727-s5f-weather-cache-tz.md
+++ b/docs/context/fix-1727-s5f-weather-cache-tz.md
@@ -1,0 +1,117 @@
+# Context: fix-1727-s5f-weather-cache-tz
+
+## Request Summary
+S5f zu #1727: drei `raw_astimezone`-Fundstellen (9 Codestellen) aus `KNOWN_VIOLATIONS`
+(`tests/test_output_timezone_guard.py`) abbauen — `weather_cache.py::get/put`,
+`trip_segments.py::convert_trip_to_segments`, `segment_weather.py::_aggregate_for_segment`.
+Der ursprüngliche Verdacht (analog zum S5e-Cache-Key-Bug in `massif_closure.py`) wurde
+recherchiert und **widerlegt** — siehe Existing Patterns.
+
+## Related Files
+
+| File | Relevanz |
+|------|----------|
+| `src/services/weather_cache.py` (get :126-127, put :177-178) | Cache-Key aus Fenstergrenzen via `.astimezone(timezone.utc)` |
+| `src/services/trip_segments.py::convert_trip_to_segments` (:194, :199, :287 — Zeilendrift ggü. KNOWN_VIOLATIONS-Ordinalen :184/:189/:275) | Segmentstart/-ende aus Etappentag+Startstunde in Ortszone, dann UTC; Ankunftstag am Ziel in Zielortzone |
+| `src/services/segment_weather.py::_aggregate_for_segment` (:246/:249 — Zeilendrift ggü. :254/:257) | Segmentbeginn/-ende auf volle UTC-Stunde gerundet (naiv), Adversary-Fund F001 |
+| `src/app/models.py:412-413` | `TripSegment.start_time`/`end_time` Vertrag: bereits UTC-aware (`# UTC!`) |
+| `src/services/official_alerts/massif_closure.py` | Vorbild für S5e-Cache-Key-Fix (Tag im Key) — hier NICHT einschlägig, siehe unten |
+| `tests/test_output_timezone_guard.py:526-654` | `KNOWN_VIOLATIONS`-Register, hier abzubauende Einträge |
+
+## Existing Patterns
+
+- **Muster A (S5a–S5d):** Umgebungsuhr (`date.today()`/`datetime.now()` ohne Zone) → ersetzt durch expliziten Auflöser (`tz_for_coords(lat, lon)`, `trip_local_today(trip, now_utc)`). Nicht einschlägig für S5f (kein Muster-A-Fund hier).
+- **Cache-Key-Fix (S5e, `massif_closure.py`, Commit `fdc8443c`):** Bug war ein zu grober Key (`cache_key=src`, Kalendertag NICHT im Schlüssel) → über Mitternacht stale Vortagsdaten. Fix: `cache_key = f"{src}:{ymd}"`.
+  **Recherche-Ergebnis für S5f:** `weather_cache.py::_storage_key` baut den Key bereits aus vollen ISO-Zeitstempeln (`f"{bucket}|{window_start.isoformat()}|{window_end.isoformat()}"`), zusätzlich strukturelles Coverage-Matching statt Key-Gleichheit. **Kein analoger Bug** — die drei Funde dort sind laut Rubrik-Kommentar in `test_output_timezone_guard.py:601-604` reine "Umrechnungen NACH UTC (nach Hausnorm #1345 unauffällig)", die der AST-Scanner nur deshalb listet, weil er nicht zwischen rohem und korrektem `.astimezone()` unterscheiden kann.
+- **Erwartete Lösungsform für S5f:** Form-Bereinigung — rohe `.astimezone(timezone.utc)`-Aufrufe durch einen benannten, zentralen Helfer ersetzen. `utils/timezone.py` ist vom Scanner explizit ausgenommen (dort existiert aktuell nur ein naiver `_as_utc(dt)`-Guard, kein exportierter `to_utc()`); mehrere Module haben stattdessen lokal duplizierte `_as_utc`-Helfer (`weather_change_detection.py:284`, `meteoalarm.py:358`, `dwd_eu.py:188`, `dwd.py:173`, `meteofrance.py:257`). Ein zentraler, exportierter `to_utc()`-Helfer in `utils/timezone.py` wäre konsistent mit dem Vorbild der übrigen Scheiben.
+- **`trip_segments.py`-Konvertierung selbst ist historisch korrekt und bewusst** (Fix für Bug #401, `tests/tdd/test_bug_401_segment_localtime.py`): lokale Etappenzeit wird über `tz_for_coords()` aufgelöst und explizit nach UTC gewandelt, damit der `# UTC!`-Vertrag von `TripSegment` gilt. Auch hier ist der Umbau reine Aufrufform, keine Verhaltensänderung.
+- **`segment_weather.py::_aggregate_for_segment`** hat bereits einen dedizierten Pinning-Test für das Zonenverhalten: `tests/test_provider_tz_normalization.py::test_f001_aggregate_for_segment_converts_non_utc_offset_before_flooring` (:465).
+
+## Existing Specs
+
+- `docs/specs/modules/weather_cache.md`
+- `docs/specs/modules/segment_weather.md`
+- Kein Spec-Eintrag für `trip_segments.py` gefunden — ggf. in `/30-write-spec` als neue oder erweiterte Spec berücksichtigen.
+
+## Dependencies
+
+- **Upstream:** `TripSegment`-Datenmodell (`src/app/models.py`), `tz_for_coords()` (Ortszonen-Auflösung).
+- **Downstream (sehr breite, produktionskritische Aufruferfläche):**
+  - `convert_trip_to_segments`: `stage_weather.py:49`, `trip_report_scheduler.py::_convert_trip_to_segments`-Wrapper (Briefing-Versand, mehrfach aufgerufen), `trip_command_processor.py:301-302`, `preview_service.py:153`, `api/routers/validator.py:325/388`, `api/routers/debug.py:69/76`, rekursiv in `trip_segments.py` selbst.
+  - `_aggregate_for_segment`: über `fetch_segment_weather` (public Entry-Point) an Briefing-Pfad, Radar-/Onset-Alarmpfad (`trip_alert.py`), Compare-Pfad (`compare_location_weather_source.py`); zusätzlich direkt in vielen TDD-Tests aufgerufen (Bypass des Public-Pfads).
+  - `weather_cache.py::get/put`: ausschließlich über `segment_weather.py:144`/`:222`.
+
+## Bestehende Tests als TDD-Vorbild
+
+| Datei | Bezug |
+|---|---|
+| `tests/unit/test_weather_cache.py` | Direkte Unit-Tests `WeatherCacheService` |
+| `tests/integration/test_segment_weather_cache.py` | Integration Cache ↔ `SegmentWeatherService` |
+| `tests/unit/test_forecast_cache_sharing.py` | Cache-Sharing (#1329-Kontext) |
+| `tests/test_provider_tz_normalization.py:465` | Bestes Vorbild für `_aggregate_for_segment`-Zonenverhalten |
+| `tests/tdd/test_bug_401_segment_localtime.py` | Historischer RED-Test für das UTC-Konvertierungsverhalten von `convert_trip_to_segments` |
+| `tests/tdd/test_issue_1004_ssot_callers.py`, `test_issue_995_segment_start_time.py`, `test_onset_respects_configured_day_window.py` | Golden-Master/Symmetrie-Tests, dürfen sich nicht ändern |
+| `tests/unit/test_alarm_zeitfenster_ziel.py` | Ziel-Segment-Fenster (Ankunftstag) |
+
+## Risks & Considerations
+
+- **Sehr hohe Aufruferfläche mit dichtem Golden-Master-Testnetz** — Umbau muss "gleiche Semantik, andere Aufrufform" bleiben, keine Verhaltensänderung. Höheres Regressionsrisiko als die vorangegangenen Muster-A-Scheiben.
+- **Zeilendrift in `KNOWN_VIOLATIONS`:** die dort eingetragenen Zeilennummern (:184/:189/:275 bzw. :254/:257) stimmen nicht mehr mit dem aktuellen Stand überein (:194/:199/:287 bzw. :246/:249) — beim Eintragen des Fixes/der Entfernung korrigieren, sonst entsteht dieselbe Falle wie in `reference_bei_formataenderungen_nach_dem_wert_suchen.md`.
+- **Kein funktionaler Bug gefunden** — anders als bei S5e ist dies eine reine Formbereinigung. Sollte in der Spec klar so benannt werden, damit keine falsche Erwartung ("Bug behoben") entsteht.
+- **Möglicher zentraler Helfer (`to_utc()` in `utils/timezone.py`)** würde auch die lokal duplizierten `_as_utc`-Varianten in anderen Modulen als Vorbild dienen können — Scope-Entscheidung für `/20-analyse`: nur die 9 KNOWN_VIOLATIONS-Stellen umbauen, oder gleich zentralisieren? Tendenz: nur die 9 Stellen, Zentralisierung wäre Scope-Creep für eine Standard-Track-Scheibe.
+
+## Analysis
+
+### Type
+Feature/Tech-Debt-Cleanup (kein Bug — siehe Risks: reine Formbereinigung, kein funktionaler Fehler).
+
+### Wichtige Korrektur ggü. Context-Phase
+Die 9 Fundstellen sind **nicht alle gleichartig**: 8 konvertieren Richtung UTC, **1 Stelle**
+(`trip_segments.py:287`, `arrival_time.astimezone(dest_tz)` — Ankunftstag am Ziel) konvertiert
+Richtung **Ortszone des Ziels**. Dafür existiert bereits der passende öffentliche Helfer
+`local_dt(dt, tz)` in `utils/timezone.py` — dort ist kein neuer Code nötig, nur die
+Aufrufform tauschen.
+
+### Affected Files (with changes)
+
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `src/utils/timezone.py` | MODIFY | neue Funktion `to_utc(dt)` = `_as_utc(dt).astimezone(timezone.utc)` — naiv wird nach Hausnorm #1345 als UTC gelabelt, aware wird ECHT konvertiert (Regressionsschutz Adversary-Fund F001) |
+| `src/services/weather_cache.py` | MODIFY | `get`/`put` (4 Call-Sites) auf `to_utc()` umstellen — praktisch No-op, da `segment.start_time`/`end_time` per Vertrag schon UTC-aware sind |
+| `src/services/segment_weather.py` | MODIFY | `_aggregate_for_segment` (2 Call-Sites) auf `to_utc()` umstellen, **Kettung an `.replace(minute=0,...)` erhalten** (`to_utc(x).replace(...)`, nicht die replace-Kette anfassen); neuer Import aus `utils.timezone` nötig (bisher keiner vorhanden) |
+| `src/services/trip_segments.py` | MODIFY | Segmentstart/-ende (2 Call-Sites) → `to_utc()`; Ankunftstag (:287) → `local_dt()` statt `to_utc()` (sonst Westziel-Tagesverschiebungsbug); `timezone`-Import aus `datetime` wird nach dem Umbau ungenutzt und muss raus (nur dafür importiert) |
+| `tests/test_output_timezone_guard.py` | MODIFY | 9 Einträge aus `KNOWN_VIOLATIONS` entfernen (funktionsbezogene Schlüssel, Zeilendrift in den Begründungstexten ist für die Entfernung selbst irrelevant) |
+| `tests/unit/test_utils_timezone.py` | CREATE (optional) | Isolierter Unit-Test für `to_utc()`: naiv/UTC-aware/Offset-aware |
+
+### Scope Assessment
+- Files: 4 Produktivdateien + 1 Testdatei (+ optional 1 neue Testdatei)
+- Estimated LoC: **~20–30 Produktivcode** (weit unter dem 250-LoC-Limit)
+- Risk Level: MEDIUM — kein Konzeptrisiko (da `to_utc()` für aware Eingaben bit-identisch zum bisherigen rohen Aufruf ist), aber dichtes Golden-Master-Testnetz an `convert_trip_to_segments`/`_aggregate_for_segment` macht Ausführungsfehler teuer
+
+### Technical Approach
+Zentraler `to_utc()`-Helfer in `utils/timezone.py` (Komposition aus vorhandenem `_as_utc` +
+`.astimezone(timezone.utc)`) für die 8 UTC-Zielstellen; die 9. Stelle (`trip_segments.py:287`)
+auf den bereits existierenden `local_dt()`-Helfer umstellen. Keine Migration der fünf
+anderswo duplizierten lokalen `_as_utc`-Varianten (bleibt bewusst außerhalb dieser Scheibe).
+
+**Umbau-Reihenfolge (sicherstes zuerst):**
+1. `to_utc()` schreiben + isoliert testen (naiv/UTC-aware/Offset-aware, 3 Fälle)
+2. `weather_cache.py` (No-op-Risiko am geringsten) — Tests: `test_weather_cache.py`, `test_segment_weather_cache.py`, `test_forecast_cache_sharing.py`
+3. `segment_weather.py` (hat dedizierten F001-Test als Sicherheitsnetz) — Test: `test_provider_tz_normalization.py::test_f001_...`
+4. `trip_segments.py` (dichtestes Golden-Master-Netz, zwei verschiedene Helfer in einer Funktion) — Golden-Master-Tests aus der Tabelle oben
+5. `KNOWN_VIOLATIONS` bereinigen — `test_known_violations_only_shrink` + `test_no_unlisted_output_timezone_violations` müssen grün werden
+6. Volle Testsuite: `pytest tests/ -k "timezone or trip_segments or weather_cache or segment_weather or output_timezone_guard or provider_tz_normalization or bug_401"`
+
+### Dependencies
+Siehe oben (Related Files/Dependencies) — keine neuen Erkenntnisse ggü. Context-Phase.
+
+### AC-Kandidaten für /30-write-spec
+1. `to_utc()`: naiver Zeitstempel → als UTC gelabelt (Hausnorm #1345), identischer Wanduhrwert.
+2. `to_utc()`: aware Zeitstempel in Nicht-UTC-Zone (z. B. +02:00) → korrekt nach UTC konvertiert, nicht nur `tzinfo`-Ersatz (Regressionsschutz F001).
+3. Die 9 gelisteten Fundstellen verschwinden exakt aus `KNOWN_VIOLATIONS`, kein anderer Eintrag ändert sich, Guard-Tests bleiben grün.
+4. Golden-Master-Suiten für `convert_trip_to_segments` und `_aggregate_for_segment` bleiben unverändert grün — keine Werteänderung.
+5. `trip_segments.py:287` nutzt `local_dt()`, Ankunftstag bleibt Ortstag am Ziel (nicht UTC-Tag).
+6. Keine unbenutzten Imports (`timezone` aus `datetime` in `trip_segments.py` entfernt), keine neuen Lint-Fehler.
+
+### Open Questions
+- [ ] Soll `tests/unit/test_utils_timezone.py` als eigene neue Testdatei angelegt werden, oder reicht Abdeckung über die bestehenden Verbraucher-Tests? (Empfehlung: eigene Datei, da `to_utc()` sonst nie isoliert getestet wäre.)

--- a/docs/specs/modules/fix_1727_s5f_raw_astimezone_formbereinigung.md
+++ b/docs/specs/modules/fix_1727_s5f_raw_astimezone_formbereinigung.md
@@ -1,0 +1,219 @@
+---
+entity_id: fix_1727_s5f_raw_astimezone_formbereinigung
+type: refactor
+created: 2026-08-19
+updated: 2026-08-19
+status: draft
+workflow: fix-1727-s5f-weather-cache-tz
+tags: [timezone, weather-cache, trip-segments, segment-weather, adr-0051]
+---
+
+# Fix #1727 S5f — raw_astimezone-Formbereinigung (weather_cache.py, trip_segments.py, segment_weather.py)
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Reine Formbereinigung, **kein Bugfix**: die 9 `KNOWN_VIOLATIONS`-Fundstellen in `weather_cache.py`,
+`segment_weather.py` und `trip_segments.py`, die roh `.astimezone(timezone.utc)` aufrufen, werden
+durch einen zentralen, benannten Helfer `to_utc()` in `src/utils/timezone.py` ersetzt (an einer
+Stelle durch den bereits bestehenden `local_dt()`). Die Recherche in der Analyse-Phase hat den
+ursprünglichen Verdacht eines S5e-artigen Cache-Key-Bugs widerlegt (siehe Known Limitations) — es
+gibt hier kein fehlerhaftes Verhalten, nur eine vom AST-Scanner nicht von einer echten Verletzung
+unterscheidbare, aber nach Hausnorm #1345 unauffällige Aufrufform.
+
+## Source
+
+- **File A:** `src/services/weather_cache.py`
+- **Identifier A:** `get`/`put` (je 2 Call-Sites, `:126-127`/`:177-178`)
+- **File B:** `src/services/segment_weather.py`
+- **Identifier B:** `_aggregate_for_segment` (2 Call-Sites, `:246`/`:249`)
+- **File C:** `src/services/trip_segments.py`
+- **Identifier C:** `convert_trip_to_segments` (Segmentstart/-ende `:194`/`:199` → `to_utc()`;
+  Ankunftstag `:287` → `local_dt()`)
+- **File D (neu):** `src/utils/timezone.py`
+- **Identifier D:** neue Funktion `to_utc(dt)`
+
+## Estimated Scope
+
+- **LoC:** ~20-30 Produktivcode
+- **Files:** 4 Produktivdateien + 1 Testdatei-Änderung + optional 1 neue Testdatei
+- **Effort:** low-medium (kein Konzeptrisiko, aber dichtes Golden-Master-Testnetz an
+  `convert_trip_to_segments`/`_aggregate_for_segment`)
+
+### Affected Files
+
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `src/utils/timezone.py` | MODIFY | neue Funktion `to_utc(dt)` = `_as_utc(dt).astimezone(timezone.utc)` |
+| `src/services/weather_cache.py` | MODIFY | `get`/`put` auf `to_utc()` umgestellt (4 Call-Sites), praktisch No-op |
+| `src/services/segment_weather.py` | MODIFY | `_aggregate_for_segment` auf `to_utc()` umgestellt (2 Call-Sites), neuer Import aus `utils.timezone` |
+| `src/services/trip_segments.py` | MODIFY | Segmentstart/-ende auf `to_utc()`, Ankunftstag am Ziel auf `local_dt()`, ungenutzten `timezone`-Import aus `datetime` entfernt |
+| `tests/test_output_timezone_guard.py` | MODIFY | 9 `KNOWN_VIOLATIONS`-Einträge entfernt |
+| `tests/unit/test_utils_timezone.py` | CREATE (optional) | isolierter Unit-Test für `to_utc()` (naiv/UTC-aware/Offset-aware) |
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `utils.timezone._as_utc` | function | Bestehender naiver Guard, Basis für den neuen `to_utc()`-Helfer |
+| `utils.timezone.local_dt` | function | Bereits bestehender Helfer, für die 9. Fundstelle (Ankunftstag am Ziel) genutzt statt eines neuen Codes |
+| `TripSegment.start_time`/`end_time` | Datenmodell-Vertrag | `src/app/models.py:412-413` — bereits UTC-aware per Vertrag; Umbau ändert daran nichts |
+| `docs/specs/modules/weather_cache.md` | Spec | bestehende Modul-Spec, hier nur um den Aufruf-Formwechsel ergänzt, nicht dupliziert |
+| `docs/specs/modules/segment_weather.md` | Spec | bestehende Modul-Spec, hier nur um den Aufruf-Formwechsel ergänzt, nicht dupliziert |
+| `stage_weather.py`, `trip_report_scheduler.py`, `trip_command_processor.py`, `preview_service.py`, `api/routers/validator.py`, `api/routers/debug.py` | Caller | Downstream-Aufrufer von `convert_trip_to_segments` — sehr breite Aufruferfläche, Verhalten unverändert |
+| `trip_alert.py`, `compare_location_weather_source.py` | Caller | Downstream-Aufrufer von `_aggregate_for_segment` über `fetch_segment_weather` — Verhalten unverändert |
+
+## Implementation Details
+
+Reihenfolge (sicherstes zuerst), siehe Analyse in `docs/context/fix-1727-s5f-weather-cache-tz.md`:
+
+1. **`to_utc(dt)` in `src/utils/timezone.py`:** `return _as_utc(dt).astimezone(timezone.utc)`. Naiver
+   Input wird nach Hausnorm #1345 als UTC gelabelt (kein Wert-Sprung); aware Input in Nicht-UTC-Zone
+   wird echt konvertiert (Regressionsschutz Adversary-Fund F001, nicht nur `tzinfo`-Ersatz).
+2. **`weather_cache.py::get`/`put`:** 4 Call-Sites auf `to_utc()` umstellen. Praktisch No-op, da
+   `segment.start_time`/`end_time` per Vertrag schon UTC-aware sind.
+3. **`segment_weather.py::_aggregate_for_segment`:** 2 Call-Sites auf `to_utc()` umstellen, Kettung an
+   `.replace(minute=0, second=0, microsecond=0)` bleibt erhalten (`to_utc(x).replace(...)`) — die
+   replace-Kette selbst wird nicht angefasst. Neuer Import aus `utils.timezone` nötig (bisher keiner
+   vorhanden).
+4. **`trip_segments.py::convert_trip_to_segments`:** Segmentstart/-ende (2 Call-Sites) → `to_utc()`.
+   Ankunftstag am Ziel (1 Call-Site, `:287`) → `local_dt()` statt `to_utc()` — bewusst NICHT
+   vereinheitlicht, weil `to_utc()` an dieser Stelle einen Westziel-Tagesverschiebungsbug einführen
+   würde (der Ankunftstag muss der Ortstag am Ziel bleiben, kein UTC-Tag). Der `timezone`-Import aus
+   `datetime` wird nach dem Umbau ungenutzt (er wurde nur für die entfallenden rohen
+   `.astimezone(timezone.utc)`-Aufrufe gebraucht) und muss entfernt werden.
+5. **`tests/test_output_timezone_guard.py`:** die 9 zugehörigen Einträge aus `KNOWN_VIOLATIONS`
+   entfernen (funktionsbezogene Schlüssel — die im Register vermerkten Zeilennummern sind gegenüber
+   dem aktuellen Stand verschoben, das ist für die Entfernung selbst irrelevant, siehe Known
+   Limitations).
+
+Keine Migration der fünf anderswo bereits vorhandenen, lokal duplizierten `_as_utc`-Varianten
+(`weather_change_detection.py`, `meteoalarm.py`, `dwd_eu.py`, `dwd.py`, `meteofrance.py`) — bewusst
+außerhalb des Scopes dieser Scheibe.
+
+## Expected Behavior
+
+- **Input:** dieselben Eingaben wie heute (Segment-Zeitgrenzen, Etappentag+Startstunde in Ortszone,
+  Ankunftszeit am Ziel).
+- **Output:** identische Werte wie vor dem Umbau — die Umstellung ist reine Aufrufform, keine
+  Verhaltensänderung. Einzige beobachtbare Änderung ist das Schrumpfen von `KNOWN_VIOLATIONS` um
+  genau 9 Einträge.
+- **Side effects:** keine.
+
+## Test Plan
+
+### Automated Tests (TDD RED)
+
+- [ ] Test 1: GIVEN ein naiver `datetime`-Wert WHEN `to_utc(dt)` aufgerufen wird THEN ist das Ergebnis
+  UTC-aware mit identischem Wanduhrwert (Hausnorm #1345 — kein Wert-Sprung durch das Labeln).
+- [ ] Test 2: GIVEN ein aware `datetime`-Wert in einer Nicht-UTC-Zone (z.B. `+02:00`) WHEN `to_utc(dt)`
+  aufgerufen wird THEN wird der Wert echt nach UTC konvertiert (Stundenverschiebung sichtbar, nicht
+  nur `tzinfo`-Ersatz — Regressionsschutz Adversary-Fund F001).
+- [ ] Test 3: GIVEN die 9 in `KNOWN_VIOLATIONS` gelisteten Fundstellen aus `weather_cache.py`/
+  `segment_weather.py`/`trip_segments.py` WHEN der Umbau abgeschlossen ist THEN verschwinden genau
+  diese 9 Einträge aus dem Register, kein anderer Eintrag ändert sich, und
+  `test_known_violations_only_shrink` sowie `test_no_unlisted_output_timezone_violations` laufen grün.
+- [ ] Test 4: GIVEN die bestehenden Golden-Master-Suiten für `convert_trip_to_segments` (u.a.
+  `test_bug_401_segment_localtime.py`, `test_issue_1004_ssot_callers.py`,
+  `test_issue_995_segment_start_time.py`, `test_onset_respects_configured_day_window.py`,
+  `test_alarm_zeitfenster_ziel.py`) und für `_aggregate_for_segment`
+  (`test_provider_tz_normalization.py::test_f001_aggregate_for_segment_converts_non_utc_offset_before_flooring`)
+  WHEN der Umbau abgeschlossen ist THEN laufen alle unverändert grün, ohne dass ein Assert angepasst
+  werden musste.
+- [ ] Test 5: GIVEN ein Trip mit einer Zielzone westlich der Startzone (z.B. Zielankunft die lokal noch
+  am Vortag des UTC-Tages liegt) WHEN `convert_trip_to_segments` den Ankunftstag am Ziel berechnet
+  THEN bleibt der Ankunftstag der Ortstag am Ziel (über `local_dt()`), nicht der ggf. abweichende
+  UTC-Tag.
+- [ ] Test 6: GIVEN der fertige Umbau WHEN ein Linter/Import-Check über die vier geänderten
+  Produktivdateien läuft THEN gibt es keine unbenutzten Imports (insbesondere `timezone` aus
+  `datetime` in `trip_segments.py`) und keine neuen Lint-Fehler.
+
+## Acceptance Criteria
+
+- **AC-1:** Given ein naiver (zonenloser) `datetime`-Wert, When `to_utc(dt)` in
+  `src/utils/timezone.py` aufgerufen wird, Then ist das Ergebnis UTC-aware mit identischem
+  Wanduhrwert — der naive Wert wird nach Hausnorm #1345 als UTC gelabelt, nicht umgerechnet.
+  - Test: Unit-Test in `tests/unit/test_utils_timezone.py` — naiver `datetime(2026, 8, 19, 12, 0)`
+    rein, erwartet `datetime(2026, 8, 19, 12, 0, tzinfo=timezone.utc)` raus (Stunde und Minute
+    unverändert).
+
+- **AC-2:** Given ein aware `datetime`-Wert in einer Nicht-UTC-Zone (z.B. `+02:00`), When `to_utc(dt)`
+  aufgerufen wird, Then wird der Wert echt nach UTC konvertiert — die Wanduhrzeit verschiebt sich um
+  genau die Zonendifferenz (Regressionsschutz gegen Adversary-Fund F001, nicht nur `tzinfo`-Ersatz).
+  - Test: Unit-Test in `tests/unit/test_utils_timezone.py` —
+    `datetime(2026, 8, 19, 14, 0, tzinfo=timezone(timedelta(hours=2)))` rein, erwartet
+    `datetime(2026, 8, 19, 12, 0, tzinfo=timezone.utc)` raus.
+
+- **AC-3:** Given die 9 in `KNOWN_VIOLATIONS` (`tests/test_output_timezone_guard.py`) gelisteten
+  Fundstellen aus `weather_cache.py::get/put` (4), `segment_weather.py::_aggregate_for_segment` (2)
+  und `trip_segments.py::convert_trip_to_segments` (3), When der Umbau auf `to_utc()`/`local_dt()`
+  abgeschlossen ist, Then sind genau diese 9 Einträge aus dem Register entfernt, kein anderer Eintrag
+  hat sich geändert, und `test_known_violations_only_shrink` sowie
+  `test_no_unlisted_output_timezone_violations` laufen grün.
+  - Test: `uv run pytest tests/test_output_timezone_guard.py -k "known_violations_only_shrink or
+    no_unlisted_output_timezone_violations"` — beide grün, Registergröße um exakt 9 geschrumpft.
+
+- **AC-4:** Given die bestehenden Golden-Master-Testsuiten für `convert_trip_to_segments` und
+  `_aggregate_for_segment` (u.a. `test_bug_401_segment_localtime.py`,
+  `test_issue_1004_ssot_callers.py`, `test_issue_995_segment_start_time.py`,
+  `test_onset_respects_configured_day_window.py`, `test_alarm_zeitfenster_ziel.py`,
+  `test_provider_tz_normalization.py::test_f001_aggregate_for_segment_converts_non_utc_offset_before_flooring`),
+  When der Umbau abgeschlossen ist, Then laufen alle Suiten unverändert grün — kein Assert-Wert musste
+  angepasst werden.
+  - Test: `uv run pytest tests/tdd/test_bug_401_segment_localtime.py
+    tests/tdd/test_issue_1004_ssot_callers.py tests/tdd/test_issue_995_segment_start_time.py
+    tests/tdd/test_onset_respects_configured_day_window.py tests/unit/test_alarm_zeitfenster_ziel.py
+    tests/test_provider_tz_normalization.py -k f001` — alle grün, Diff der Testdateien selbst leer.
+
+- **AC-5:** Given ein Trip, dessen Zielzone westlich der Startzone liegt und dessen Ankunftszeitpunkt
+  lokal noch auf dem vorherigen Kalendertag der UTC-Zeit liegt, When `convert_trip_to_segments` den
+  Ankunftstag am Ziel berechnet, Then bleibt der ermittelte Ankunftstag der Ortstag am Ziel (Aufruf
+  über `local_dt()`), nicht der davon abweichende UTC-Tag.
+  - Test: bestehender Golden-Master `tests/unit/test_alarm_zeitfenster_ziel.py` erweitert bzw.
+    gegengeprüft um einen Westziel-Fall mit UTC-Tagesgrenze; erwartet wird der Ortstag, nicht der
+    UTC-Tag.
+
+- **AC-6:** Given die vier geänderten Produktivdateien (`utils/timezone.py`, `weather_cache.py`,
+  `segment_weather.py`, `trip_segments.py`), When der Umbau abgeschlossen ist, Then enthält keine der
+  vier einen unbenutzten Import — insbesondere ist der `timezone`-Import aus `datetime` in
+  `trip_segments.py` entfernt, da er nach dem Umbau keine Verwendung mehr hat — und der Lint-Lauf
+  zeigt keine neuen Findings gegenüber dem Stand vor dieser Scheibe.
+  - Test: `uv run ruff check src/utils/timezone.py src/services/weather_cache.py
+    src/services/segment_weather.py src/services/trip_segments.py` (bzw. das projektübliche
+    Lint-Kommando) — keine `F401`-Findings (unused import) und keine neuen Findings insgesamt.
+
+## Known Limitations
+
+- **Kein funktionaler Bug** — anders als S5e (Cache-Key-Bug in `massif_closure.py`) ist dies eine
+  reine Formbereinigung. Der ursprüngliche Verdacht wurde in der Analyse-Phase recherchiert und
+  widerlegt: `weather_cache.py::_storage_key` baut den Cache-Key bereits aus vollen
+  ISO-Zeitstempeln mit strukturellem Coverage-Matching, kein analoger Bug zu S5e.
+- **Zeilendrift im `KNOWN_VIOLATIONS`-Register:** die dort eingetragenen Zeilennummern (`:184`/`:189`/
+  `:275` bzw. `:254`/`:257`) stimmen nicht mehr mit dem aktuellen Stand überein (`:194`/`:199`/`:287`
+  bzw. `:246`/`:249`) — beim Entfernen der Einträge ist über den funktionsbezogenen Schlüssel zu
+  identifizieren, nicht über die veraltete Zeilennummer.
+- **Die fünf anderswo bereits vorhandenen, lokal duplizierten `_as_utc`-Varianten**
+  (`weather_change_detection.py:284`, `meteoalarm.py:358`, `dwd_eu.py:188`, `dwd.py:173`,
+  `meteofrance.py:257`) werden NICHT migriert — bewusst außerhalb des Scopes dieser Scheibe. Eine
+  Zentralisierung dieser fünf Stellen wäre Scope-Creep für eine Standard-Track-Scheibe und bliebe
+  künftiger Arbeit vorbehalten.
+- **Sehr hohe Aufruferfläche** (Briefing-Versand, Radar-/Onset-Alarmpfad, Compare-Pfad, mehrere
+  API-Router, Debug-Router) — das dichte Golden-Master-Testnetz aus AC-4 ist der primäre Schutz
+  gegen eine unbeabsichtigte Verhaltensänderung, nicht ein neuer dedizierter Test.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine neue — Umsetzung folgt ADR-0051 Regel 1/2 (Zeitpunkt vs. Kalenderzeit, Zone an
+  den Daten), Status dort weiterhin „Vorgeschlagen". Die Hausnorm aus #1345 (Wetterdaten tragen
+  zonenlose UTC-Zeitstempel) bleibt unverändert gültig und ist die Grundlage für `to_utc()`.
+- **Rationale:** Diese Scheibe führt kein neues Architekturmuster ein, sondern zentralisiert eine
+  bereits etablierte, korrekte Umrechnung in einen benannten Helfer — konsistent mit dem in
+  ADR-0051 beschriebenen Wächter-Modell (`KNOWN_VIOLATIONS` darf nur schrumpfen). Ein eigenes ADR
+  wäre für eine reine Aufruf-Formbereinigung ohne Verhaltensänderung unangemessen.
+
+## Changelog
+
+- 2026-08-19: Initial spec created

--- a/src/services/segment_weather.py
+++ b/src/services/segment_weather.py
@@ -17,6 +17,7 @@ from app.config import Location
 from app.day_window import display_end_time
 from app.debug import DebugBuffer
 from app.models import SegmentWeatherData, SegmentWeatherSummary, TripSegment
+from utils.timezone import to_utc
 
 logger = logging.getLogger(__name__)
 
@@ -252,10 +253,10 @@ class SegmentWeatherService:
         # tzinfo gestrippt wird -- ein reines .replace(tzinfo=None) wuerde
         # die lokale Uhrzeit als UTC missdeuten und falsche Stunden
         # zuordnen (analog zu app/models.py:155).
-        start_floor = segment.start_time.astimezone(timezone.utc).replace(
+        start_floor = to_utc(segment.start_time).replace(
             minute=0, second=0, microsecond=0, tzinfo=None
         )
-        end_floor = segment.end_time.astimezone(timezone.utc).replace(
+        end_floor = to_utc(segment.end_time).replace(
             minute=0, second=0, microsecond=0, tzinfo=None
         )
         # Bug #806: Randstunde exklusiv am Ende (< end_floor), damit jede Stunde

--- a/src/services/trip_segments.py
+++ b/src/services/trip_segments.py
@@ -11,14 +11,14 @@ from __future__ import annotations
 
 import logging
 import math
-from datetime import date, datetime, time, timedelta, timezone
+from datetime import date, datetime, time, timedelta
 from typing import TYPE_CHECKING, List, Optional, Tuple
 
 import app.day_window as day_window
 from app.day_window import resolve_configured_window
 from app.models import GPXPoint, TripSegment
 from utils.geo import haversine_km
-from utils.timezone import tz_for_coords
+from utils.timezone import local_dt, to_utc, tz_for_coords
 
 if TYPE_CHECKING:
     from app.trip import Trip
@@ -188,15 +188,13 @@ def convert_trip_to_segments(trip: "Trip", target_date: date) -> List[TripSegmen
             wp2_start = wp1_start
 
         seg_tz = tz_for_coords(wp1.lat, wp1.lon)
-        start_dt = (
+        start_dt = to_utc(
             datetime.combine(target_date + timedelta(days=wp_days[i]), wp1_start)
             .replace(tzinfo=seg_tz)
-            .astimezone(timezone.utc)
         )
-        end_dt = (
+        end_dt = to_utc(
             datetime.combine(target_date + timedelta(days=wp_days[i + 1]), wp2_start)
             .replace(tzinfo=seg_tz)
-            .astimezone(timezone.utc)
         )
 
         if end_dt <= start_dt:
@@ -284,7 +282,7 @@ def convert_trip_to_segments(trip: "Trip", target_date: date) -> List[TripSegmen
         # UTC-Tag: bei einem Ziel westlich von Greenwich faellt die Ankunft
         # in UTC schon auf den Folgetag, waehrend es am Ziel noch derselbe
         # Tag ist — der UTC-Tag wuerde das Fenster um 24 h verschieben.
-        arrival_local_date = arrival_time.astimezone(dest_tz).date()
+        arrival_local_date = local_dt(arrival_time, dest_tz).date()
         # Issue #1599: Die Obergrenze ist INKLUSIV — die Endstunde zaehlt
         # vollstaendig mit, das Fenster endet zeitlich bei (end_hour+1):00
         # Ortszeit. Die Umrechnung wohnt in app/day_window.py, damit sie nicht

--- a/src/services/weather_cache.py
+++ b/src/services/weather_cache.py
@@ -34,6 +34,7 @@ from threading import Lock
 from typing import Optional
 
 from app.models import NormalizedTimeseries, TripSegment
+from utils.timezone import to_utc
 
 
 @dataclass
@@ -123,8 +124,8 @@ class WeatherCacheService:
             - Moves the matched entry to end (LRU)
         """
         bucket = self._bucket_key(segment, enrich_ensemble, enrich_snow, model_id)
-        req_start = segment.start_time.astimezone(timezone.utc)
-        req_end = segment.end_time.astimezone(timezone.utc)
+        req_start = to_utc(segment.start_time)
+        req_end = to_utc(segment.end_time)
         prefix = bucket + "|"
 
         with self._lock:
@@ -174,8 +175,8 @@ class WeatherCacheService:
               already present (e.g. TTL-refresh of the same request)
         """
         bucket = self._bucket_key(segment, enrich_ensemble, enrich_snow, model_id)
-        window_start = segment.start_time.astimezone(timezone.utc)
-        window_end = segment.end_time.astimezone(timezone.utc)
+        window_start = to_utc(segment.start_time)
+        window_end = to_utc(segment.end_time)
         key = self._storage_key(bucket, window_start, window_end)
 
         with self._lock:

--- a/src/utils/timezone.py
+++ b/src/utils/timezone.py
@@ -111,6 +111,15 @@ def _as_utc(dt: datetime) -> datetime:
     return dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt
 
 
+def to_utc(dt: datetime) -> datetime:
+    """Zentraler Helfer fuer rohe ``.astimezone(timezone.utc)``-Aufrufe (Fix
+    #1727 S5f). Naive Zeitstempel werden nach Hausnorm (#1345) als UTC
+    gelabelt (kein Wert-Sprung); aware Zeitstempel in Nicht-UTC-Zonen werden
+    echt konvertiert (Regressionsschutz Adversary-Fund F001, nicht nur ein
+    ``tzinfo``-Ersatz)."""
+    return _as_utc(dt).astimezone(timezone.utc)
+
+
 def local_dt(dt: datetime, tz: ZoneInfo) -> datetime:
     """UTC datetime → aware datetime in local timezone."""
     return _as_utc(dt).astimezone(tz)

--- a/tests/test_output_timezone_guard.py
+++ b/tests/test_output_timezone_guard.py
@@ -638,18 +638,9 @@ KNOWN_VIOLATIONS: dict[str, str] = {
     "src/services/official_alerts/meteoalarm_budget.py::_now_ts::0": "raw_astimezone (:167) — Kontingent-Zeitstempel bewusst in UTC.",
     "src/services/official_alerts/meteoalarm_budget.py::_today_utc::0": "raw_astimezone (:176) — Kontingent-Tag bewusst in UTC.",
     "src/services/scheduler_dispatch_service.py::run_compare_presets_daily::0": "raw_astimezone (:179) — Faelligkeit in der Ortszone des Presets (#1724).",
-    "src/services/segment_weather.py::_aggregate_for_segment::0": "raw_astimezone (:254) — Segmentbeginn auf volle UTC-Stunde.",
-    "src/services/segment_weather.py::_aggregate_for_segment::1": "raw_astimezone (:257) — Segmentende auf volle UTC-Stunde.",
     "src/services/stage_weather.py::_to_utc_date::0": "raw_astimezone (:62) — Etappendatum in UTC.",
     "src/services/trip_alert.py::_briefing_precip_for_onset::0": "raw_astimezone (:872) — Einsetzstunde auf volle UTC-Stunde.",
     "src/services/trip_alert.py::check_radar_alerts::0": "raw_astimezone (:1092) — Einsetzzeit in der Ortszone ausgegeben.",
-    "src/services/trip_segments.py::convert_trip_to_segments::0": "raw_astimezone (:184) — Segmentstart aus Etappentag + Startstunde.",
-    "src/services/trip_segments.py::convert_trip_to_segments::1": "raw_astimezone (:189) — Segmentende aus Folgetag + Startstunde.",
-    "src/services/trip_segments.py::convert_trip_to_segments::2": "raw_astimezone (:275) — Ankunftstag in der Zielortzone.",
-    "src/services/weather_cache.py::get::0": "raw_astimezone (:126) — Cache-Schluessel Fensterbeginn in UTC.",
-    "src/services/weather_cache.py::get::1": "raw_astimezone (:127) — Cache-Schluessel Fensterende in UTC.",
-    "src/services/weather_cache.py::put::0": "raw_astimezone (:177) — Cache-Ablage Fensterbeginn in UTC.",
-    "src/services/weather_cache.py::put::1": "raw_astimezone (:178) — Cache-Ablage Fensterende in UTC.",
     "src/services/weather_extractor.py::_to_naive_utc::0": "raw_astimezone (:32) — Naiv-Guard nach Hausnorm #1345 (naiv == UTC).",
 }
 

--- a/tests/unit/test_utils_timezone.py
+++ b/tests/unit/test_utils_timezone.py
@@ -1,0 +1,50 @@
+"""Fix #1727 S5f: isolierter Unit-Test fuer den neuen zentralen Helfer
+``to_utc()`` in ``src/utils/timezone.py``.
+
+SPEC: docs/specs/modules/fix_1727_s5f_raw_astimezone_formbereinigung.md
+(AC-1, AC-2)
+
+Reine Formbereinigung, kein Bugfix: ``to_utc()`` ersetzt 9 rohe
+``.astimezone(timezone.utc)``-Aufrufe in ``weather_cache.py``,
+``segment_weather.py`` und ``trip_segments.py``. Diese Datei testet nur den
+neuen Helfer isoliert -- die Golden-Master-Suiten fuer die Aufrufer bleiben
+unveraendert (AC-4).
+
+Kern-Schicht, netzfrei, keine Mocks (CLAUDE.md-Pflicht) -- reine
+Werteberechnung ohne externe Abhaengigkeit.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from utils.timezone import to_utc
+
+
+def test_to_utc_naiver_wert_wird_als_utc_gelabelt():
+    """AC-1: Ein naiver (zonenloser) datetime-Wert wird nach Hausnorm #1345
+    als UTC gelabelt -- kein Wert-Sprung, nur ``tzinfo`` gesetzt."""
+    naive = datetime(2026, 8, 19, 12, 0)
+
+    result = to_utc(naive)
+
+    assert result == datetime(2026, 8, 19, 12, 0, tzinfo=timezone.utc)
+    assert result.hour == 12 and result.minute == 0, (
+        "AC-1: der Wanduhrwert darf sich beim Labeln eines naiven "
+        f"Zeitstempels nicht veraendern, bekam aber {result.isoformat()}."
+    )
+
+
+def test_to_utc_aware_wert_in_nicht_utc_zone_wird_echt_konvertiert():
+    """AC-2 (Regressionsschutz Adversary-Fund F001): Ein aware Wert in einer
+    Nicht-UTC-Zone wird ECHT nach UTC umgerechnet (Stundenverschiebung
+    sichtbar), nicht nur mit ``tzinfo=UTC`` ueberschrieben."""
+    aware = datetime(2026, 8, 19, 14, 0, tzinfo=timezone(timedelta(hours=2)))
+
+    result = to_utc(aware)
+
+    assert result == datetime(2026, 8, 19, 12, 0, tzinfo=timezone.utc)
+    assert result.hour == 12, (
+        "AC-2: 14:00 in +02:00 muss nach 12:00 UTC konvertiert werden, "
+        f"bekam aber {result.isoformat()} -- das waere nur ein "
+        "tzinfo-Ersatz statt einer echten Konvertierung."
+    )


### PR DESCRIPTION
## Summary
- Reine Formbereinigung (kein Bugfix): 9 rohe `.astimezone(timezone.utc)`-Aufrufe in `weather_cache.py`, `segment_weather.py`, `trip_segments.py` durch neuen zentralen Helfer `to_utc()` (bzw. den bereits bestehenden `local_dt()` für den Ankunftstag-Sonderfall) ersetzt.
- `KNOWN_VIOLATIONS`-Register in `tests/test_output_timezone_guard.py` um genau diese 9 Einträge geschrumpft.
- Kein Verhalten geändert — Adversary-Verifikation (VERIFIED) inkl. 3 gezielter Mutations-Gegenproben, die u.a. die Verwechslungsgefahr `local_dt()` vs. `to_utc()` am Ankunftstag-Sonderfall (AC-5) gezielt geprüft haben.

Teil von #1727 (Scheibe S5f) — Issue bleibt offen, da weitere `KNOWN_VIOLATIONS`-Einträge außerhalb dieser Scheibe verbleiben.

## Test plan
- [x] `tests/unit/test_utils_timezone.py` (neu) — `to_utc()` naiv/aware
- [x] `tests/unit/test_weather_cache.py`, `tests/integration/test_segment_weather_cache.py`, `tests/unit/test_forecast_cache_sharing.py`
- [x] `tests/test_provider_tz_normalization.py` (F001-Regressionsschutz)
- [x] Golden-Master: `test_bug_401_segment_localtime.py`, `test_issue_1004_ssot_callers.py`, `test_issue_995_segment_start_time.py`, `test_onset_respects_configured_day_window.py`, `test_alarm_zeitfenster_ziel.py`
- [x] `tests/test_output_timezone_guard.py` (Register-Schrumpfung)
- [x] `ruff check` sauber
- [x] Adversary-Verdict: VERIFIED (3 Mutations-Gegenproben gefangen)

🤖 Generated with [Claude Code](https://claude.com/claude-code)