### PR TITLE
docs(#1927): v1.1-Freigabe-Checkbox in der Spec nachgetragen

### DIFF
--- a/docs/specs/modules/fix_1927_risk_dot_kombi_regel.md
+++ b/docs/specs/modules/fix_1927_risk_dot_kombi_regel.md
@@ -13,7 +13,7 @@ workflow: fix-1927-risk-dot-kombi-regel
 
 ## Approval
 
-- [ ] Approved (Revision v1.1 — wartet auf Freigabe der geänderten ACs)
+- [x] Approved (Revision v1.1, Henning, 2026-08-19) — Freigabe der geänderten ACs im Workflow-State erfasst (`spec_approved: true`, Übergang zu `phase4_approved` 2026-08-19T14:29:41), Checkbox nachträglich am 2026-08-19 nachgetragen.
 - [x] Approved (Henning, 2026-08-19) — **galt für v1.0**, durch Adversary-Verdict
   BROKEN und PO-Scope-Entscheid vom 2026-08-19 abgelöst (siehe Changelog).
 


### PR DESCRIPTION
Checkbox stand noch auf offen, obwohl die Freigabe der geaenderten ACs laut
Workflow-State (spec_approved: true, Uebergang phase4_approved 14:29:41)
bereits erfolgt war und die Implementierung darauf aufbauend geliefert wurde.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
