### PR TITLE
fix(#1971): fehlende Alarmstufen ohne active_metrics auf standard ergaenzen

### DIFF
--- a/docs/context/fix-1971-legacy-preset-alarm.md
+++ b/docs/context/fix-1971-legacy-preset-alarm.md
@@ -1,0 +1,168 @@
+# Context: fix-1971-legacy-preset-alarm
+
+Issue: [#1971](https://github.com/henemm/gregor_zwanzig/issues/1971) — „Alt-Ortsvergleiche ohne
+migrierte `active_metrics` bekommen nie eine Alarm-Regel (stiller Alarm-Ausfall)"
+
+## Request Summary
+
+Das Issue behauptet: Ein Ortsvergleich, dessen `display_config` `None` ist (nie auf
+`active_metrics` migriert), bekommt für neu eingeführte Metriken — konkret die
+Beginn-Verschiebungs-Alarme aus #1468 — **nie** eine Alarm-Regel. Der Alarm bliebe still.
+Herkunft: zurückgestelltes Adversary-Finding F004 aus #1468.
+
+**Die Behauptung in dieser Form ist durch Messung widerlegt** (siehe „Messungen"). Es gibt
+eine Lücke, aber unter einer deutlich engeren Bedingung als beschrieben, und sie ist in
+Produktion aktuell unbesetzt.
+
+## Messungen (Phase 1, belegt)
+
+### M1 — Produktions-Ausmaß: 0 betroffene Presets
+
+Das Issue nennt „erst zählen" als ersten Schritt. Gemessen wurde auf dem **echten**
+Produktions-Datenverzeichnis `/var/lib/gregor` (aus `systemctl show gregor-api -p Environment`
+→ `GZ_DATA_DIR=/var/lib/gregor`), **nicht** im Repo-`data/`.
+
+| Ablage | Vergleichs-Presets | davon ohne `active_metrics` |
+|---|---|---|
+| `/var/lib/gregor/users/*/briefings/*.json` (aktuell, seit #1250 S7b) | 5 | **0** |
+| `/var/lib/gregor/users/*/compare_presets.json` (Alt-Ablage) | 5 | **0** |
+
+Alle fünf Presets (Nutzer `henning`) tragen `active_metrics` mit 4–11 Metriken.
+Nutzer `default`, `steffi`, `validator-issue110` haben keine Vergleichs-Presets.
+
+> **Zwei Messfallen, beide umgangen:** (1) Das Repo-`data/`-Verzeichnis ist **nicht** die
+> Produktionsablage — dort hätte die Messung fälschlich „0 von 0" ergeben. (2) Presets liegen
+> seit #1250 Scheibe 7b in `briefings/<id>.json`; nur `compare_presets.json` zu messen hätte
+> die aktuelle Ablage verfehlt. Beide Ablagen wurden gemessen.
+
+### M2 — Kernbehauptung widerlegt: der Legacy-Pfad erzeugt sehr wohl Onset-Regeln
+
+Ausgeführt, nicht aus dem Code geschlossen:
+
+```
+expand_per_metric_levels(_STANDARD_METRIC_LEVELS, display_config=None)
+  → 14 Regeln, darunter thunder_onset UND precipitation_heavy_onset
+```
+
+Grund: `compare_alert.py:530-533` setzt bei fehlendem `metric_alert_levels` den Fallback
+`_STANDARD_METRIC_LEVELS`, und der leitet sich aus `_PRESET_TABLE` ab
+(`compare_alert.py:51`). Beide Onset-Metriken **stehen** in `_PRESET_TABLE`
+(`alert_preset.py:74-75`, dort per #1468 eingetragen). Der im Issue genannte Backfill-Pfad
+wird also gar nicht gebraucht — die Regeln entstehen über den Level-Fallback.
+
+**Positivkontrolle:** `expand_per_metric_levels({}, display_config=None)` → **0 Regeln**.
+Die Messung kann „keine Regel" darstellen; das Ergebnis ist nicht trivial wahr.
+
+### M3 — Die tatsächliche Lücke
+
+Sie öffnet sich nur, wenn **beide** Bedingungen zusammentreffen:
+
+1. `display_config.metric_alert_levels` ist **gesetzt** → der `_STANDARD_METRIC_LEVELS`-Fallback
+   greift nicht, es zählen nur die dort gelisteten Metriken; **und**
+2. `display_config.active_metrics` **fehlt** → `_display_config_from_active_metrics()` liefert
+   `None` (`compare_alert.py:568-570`) → der Backfill in `alert_preset.py:346` läuft nicht.
+
+Gemessen:
+
+```
+expand_per_metric_levels({wind_gust, precipitation_sum, thunder_level}, display_config=None)
+  → 3 Regeln, thunder_onset NICHT dabei
+```
+
+Genau diese Konstellation hat in Produktion **kein** Preset: das einzige Preset mit gesetztem
+`metric_alert_levels` („Le Var", `cp-eb6ba0b239d90e37`) hat auch `active_metrics` (11 Metriken)
+— sein `metric_alert_levels` listet 7 Metriken **ohne** Onset, doch weil `display_config` nicht
+`None` ist, füllt der Backfill die Onset-Regeln nach.
+
+### M4 — Register-Differenz (strukturelles Restrisiko)
+
+| Register | Größe |
+|---|---|
+| `_ALERT_METRIC_TO_CATALOG_ID` (speist den Backfill) | 15 |
+| `_PRESET_TABLE` (speist `_STANDARD_METRIC_LEVELS`) | 14 |
+| Nur im Backfill-Register | `snow_line` |
+| Nur in der Preset-Tabelle | — (leer) |
+
+`snow_line` ist per #959 bewusst nach `freezing_level` konsolidiert (Alt-Levels migriert in
+`loader._migrate_metric_alert_levels`), also keine echte Lücke. **Aber:** Die beiden Register
+sind getrennt gepflegt. Eine künftige Metrik, die nur in `_ALERT_METRIC_TO_CATALOG_ID`
+landet, wäre im Legacy-Pfad still — das ist die eigentliche, dauerhafte Fehlerquelle hinter
+diesem Issue.
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `src/services/alert_preset.py:178-181` | Signatur `expand_per_metric_levels(levels, display_config=None)` |
+| `src/services/alert_preset.py:315-321` | #961-Deaktivieren-Filter — bei `display_config=None` übersprungen |
+| `src/services/alert_preset.py:346-385` | Backfill-Pfad — komplett hinter `if display_config is not None` |
+| `src/services/alert_preset.py:53-77` | `_PRESET_TABLE` inkl. beider Onset-Zeilen (#1468) |
+| `src/services/compare_alert.py:51` | `_STANDARD_METRIC_LEVELS` = alle `_PRESET_TABLE`-Metriken auf `standard` |
+| `src/services/compare_alert.py:530-533` | Level-Fallback — der Grund, warum M2 Regeln liefert |
+| `src/services/compare_alert.py:544-570` | `_display_config_from_active_metrics()` — `None` bei fehlendem `active_metrics` |
+| `src/services/deviation_alert_engine.py:174-200` | `_select_detector()` — einzige Detektor-Wahl für Trip UND Vergleich (seit #1168) |
+| `src/services/weather_change_detection.py:96-118` | `_ALERT_METRIC_TO_CATALOG_ID` (Backfill-Register) |
+| `src/services/weather_change_detection.py:200-259` | `is_alert_metric_active()` — leere `metrics[]` = konservativ aktiv; `None` → `False` |
+| `scripts/migrate_1191_compare_active_metrics.py` | Bestehende Migration: füllt fehlendes `active_metrics` auf vollen Satz |
+| `scripts/migrate_1373_compare_active_metrics_format.py` | Format-Migration String → `{metric_id, aggregation}` |
+
+## Existing Patterns
+
+- **Eine Detektor-Wahl für beide Flächen:** Seit #1168 delegiert `TripAlertService._select_change_detector()`
+  (`trip_alert.py:438-453`) an `DeviationAlertEngine._select_detector()`. Trip und Ortsvergleich
+  laufen durch **denselben** Code — passend zur PO-Vorgabe „möglichst viel Code teilen".
+- **`display_config=None` ist bewusst konservativ:** `compare_alert.py:548-559` (Bug #1191,
+  Adversary F001) hält ausdrücklich fest, dass ein fehlendes `active_metrics` als Legacy gilt
+  und dann *alles* feuern soll — statt still zu verstummen. Ein Fix muss diese Absicht
+  fortschreiben, nicht umkehren.
+- **Leere `metrics[]` = konservativ aktiv** (`weather_change_detection.py:224-227`, Finding F002):
+  dasselbe Prinzip an der Trip-Seite.
+- **Migration statt Dauer-Fallback:** Für `active_metrics` existieren bereits zwei
+  Einmal-Migrationsskripte mit Dry-Run-Default (`--execute` nötig).
+
+## Dependencies
+
+- **Upstream:** `_PRESET_TABLE` / `_STANDARD_METRIC_LEVELS`, `_ALERT_METRIC_TO_CATALOG_ID`,
+  `is_alert_metric_active`, Preset-Persistenz (Go `internal/handler/compare_preset.go`,
+  `internal/store/compare_preset.go` — Read-Modify-Write-Merge auf `DisplayConfig`)
+- **Downstream:** `WeatherChangeDetectionService.from_alert_rules()` → Änderungs-Alarme in
+  **beiden** Flächen (Trip + Ortsvergleich) und **allen vier** Kanälen
+
+## Existing Specs
+
+- `docs/specs/modules/issue_1191_compare_alert_deactivated_metric.md` (AC-4: die Migration)
+- `docs/specs/modules/feat_1373_s2b_metrik_speicherformat.md` (AC-6/AC-7: Formatwechsel)
+- `docs/features/rework_1467_s2_aenderungsalarm.md` — Leitsatz „Der gefährlichste Fehler ist
+  der ausbleibende Alarm."
+
+## Testabdeckung (Ist-Stand)
+
+- `tests/tdd/test_onset_alert_armed_from_weather_tab.py` — bewacht die Onset-Scharfschaltung,
+  aber **ausschließlich mit gesetztem `display_config`** (Zeilen 128, 159, 192). Kein
+  `None`-Pendant.
+- `tests/tdd/test_compare_alert_metric_gating.py` — #1191-Gating (Deaktivieren-Lücke).
+- `tests/tdd/test_issue_946_alert_architecture.py`, `test_issue_1168_alert_engine_extract.py` —
+  #961-Backfill.
+- **Kein einziger Test** schickt ein Vergleichs-Preset **ohne** `active_metrics` durch die volle
+  Alarm-Kette. Das ist die im Issue benannte Testlücke — sie besteht, unabhängig davon, dass die
+  Kernbehauptung so nicht zutrifft.
+
+## Risks & Considerations
+
+- **R1 — Das Issue beschreibt den Mechanismus falsch.** Ein Fix, der stur „den Backfill auch für
+  `display_config=None` öffnen" umsetzt (Weg 1 im Issue), behebt für die Onset-Metriken nichts,
+  was nicht schon funktioniert, und ändert für `snow_line` das Verhalten. Vor der Spec muss der
+  Ziel-Zustand am tatsächlichen Mechanismus (M3) ausgerichtet werden.
+- **R2 — Produktionszahl ist 0.** Nach der Logik des Issues („ist die Zahl 0, reicht eine
+  dokumentierte Notiz") ist Weg 3 der belegte Kandidat. Das ist eine PO-Entscheidung, keine
+  technische.
+- **R3 — Alarm-Flut statt Stille.** Öffnet man den Backfill für `display_config=None`, erben
+  Alt-Presets die volle Grundauswahl. Das ist die konservative Richtung (Leitsatz #1467), kann
+  aber bei einem Preset mit bewusst reduziertem `metric_alert_levels` als ungewollte
+  Zusatz-Alarmierung ankommen.
+- **R4 — Zwei getrennte Register (M4) sind die eigentliche Fehlerquelle.** Ein Fix, der nur den
+  heutigen Symptomfall abdeckt, lässt sie bestehen; ein Wächter-Test auf Register-Deckung würde
+  die Klasse schließen statt des Einzelfalls.
+- **R5 — Datenbestand.** Jede Migrations-Variante fällt unter die Read-Modify-Write-Pflicht
+  (BUG-DATALOSS-GR221 / #102); die bestehenden Skripte haben Dry-Run-Default und lassen ein
+  bewusst leeres `active_metrics: []` unangetastet.

--- a/docs/context/fix-1971-legacy-preset-alarm.md
+++ b/docs/context/fix-1971-legacy-preset-alarm.md
@@ -89,6 +89,34 @@ sind getrennt gepflegt. Eine künftige Metrik, die nur in `_ALERT_METRIC_TO_CATA
 landet, wäre im Legacy-Pfad still — das ist die eigentliche, dauerhafte Fehlerquelle hinter
 diesem Issue.
 
+### M5 — Der Legacy-Zustand ist **nicht** historisch, er kann neu entstehen
+
+Das Issue behandelt fehlendes `active_metrics` als Altlast („Alt-Ortsvergleiche", „vor der
+Migration"). Das trifft nicht zu:
+
+- `frontend/src/lib/.../compareEditorSave.ts:407-409` lässt den Schlüssel `active_metrics`
+  **weg**, solange `fields.activeMetricKeys === null` — und `null` ist der Init-Wert
+  (`compareWizardState.svelte.ts:32`).
+- `internal/handler/compare_preset.go:193-277` (`CreateComparePresetHandler`) setzt zwar
+  Defaults für `weekday`, `forecast_hours`, `morning_time`, `official_warnings` — aber
+  **keinen** für `active_metrics`.
+- Weder `internal/store/compare_preset.go:89-132` (`normalizeLoadedComparePreset`) noch
+  `src/app/loader.py:262` heilen das Feld beim Laden.
+
+Ein heute angelegter Ortsvergleich, bei dem der Nutzer die Metrik-Auswahl nie anfasst, wird
+also **ohne** `active_metrics` persistiert. Trifft das mit einem gesetzten
+`metric_alert_levels` zusammen (Nutzer stellt im Alarme-Reiter Empfindlichkeiten ein, ohne
+den Metriken-Reiter zu berühren), steht genau die Konstellation aus M3 — und neue Metriken
+bleiben still.
+
+Für den **Render**-Pfad ist das abgefedert: `resolve_enabled_metrics(None)` bedeutet „alle
+Metriken sichtbar" (`compare_metric_ids.py:168-169`). Nur der **Alarm**-Pfad hat diesen
+Auffang nicht.
+
+> Damit verschiebt sich die Bewertung: Weg 3 des Issues („dokumentieren, wenn die
+> Produktionszahl 0 ist") stützt sich auf einen Bestand, der jederzeit wieder wachsen kann.
+> Die Zahl 0 ist eine Momentaufnahme, keine Eigenschaft des Systems.
+
 ## Related Files
 
 | Datei | Relevanz |

--- a/docs/context/fix-1971-legacy-preset-alarm.md
+++ b/docs/context/fix-1971-legacy-preset-alarm.md
@@ -117,6 +117,47 @@ Auffang nicht.
 > Produktionszahl 0 ist") stützt sich auf einen Bestand, der jederzeit wieder wachsen kann.
 > Die Zahl 0 ist eine Momentaufnahme, keine Eigenschaft des Systems.
 
+### M6 — Der naheliegende Fix erzeugt einen NEUEN stillen Ausfall (verworfen)
+
+Erste Spec-Fassung schlug vor, `_display_config_from_active_metrics()` im `None`-Fall ein
+voll-aktiviertes `UnifiedWeatherDisplayConfig` liefern zu lassen. Simuliert und gemessen:
+
+```
+AC-4-Fall (kein metric_alert_levels): VORHER 14 Regeln → NACHHER 13
+   verloren: ['cape']
+```
+
+Sobald `display_config` nicht mehr `None` ist, greift der #961-Filter (`alert_preset.py:315-321`),
+der bisher übersprungen wurde. `is_alert_metric_active()` behandelt CAPE seit #1585 als **nie
+aktiv** (alle gemappten Katalog-Größen `selectable=False`). Ein Fix gegen stille Alarm-Ausfälle,
+der selbst einen erzeugt, ist nicht lieferbar. **Weg verworfen.**
+
+### M7 — Gewählter Weg: Ergänzung auf der Level-Ebene
+
+Ansatzpunkt `_build_eval_config()` (`compare_alert.py:530-533`) — dort, wo der
+`_STANDARD_METRIC_LEVELS`-Fallback ohnehin sitzt. Fehlt `active_metrics`, werden gesetzte
+`metric_alert_levels` mit dem Standard-Satz **ergänzt** statt allein verwendet; explizite
+Einträge (auch `off`) gewinnen. `display_config` bleibt `None`, der Filter bleibt übersprungen.
+
+| Fall | Ergebnis |
+|---|---|
+| AC-1: levels ohne Onset, kein `active_metrics` | **14 Regeln, Onset ✓, CAPE ✓** (vorher 3) |
+| AC-4: keine levels | **14 Regeln, CAPE ✓** — unverändert |
+| Abwahl-Probe `{wind_gust: off, …}` | **13 Regeln, `wind_gust` fehlt** — `off` bleibt wirksam |
+| AC-2/AC-3: `active_metrics` vorhanden | von der Änderung nicht berührt |
+
+### M8 — Nebenbefund: `metric_alert_levels` mischt zwei Vokabulare → Issue #1981
+
+Am echten Prod-Preset `cp-eb6ba0b239d90e37` („Le Var") gemessen: das Feld enthält
+Summary-Keys (`temp_max_c`, `gust_max_kmh`, …) **und** Metrik-Namen (`wind_gust`, …).
+`expand_per_metric_levels` löst über `AlertMetric(metric_str)` auf — Summary-Keys werfen
+`ValueError` und werden verworfen. **8 von 11 Einträgen wirkungslos, darunter vier bewusste
+Abwahlen.** Belegt, dass die Abwahl schaden kann: Metrik im Metriken-Reiter aktiv +
+`temp_max_c: off` → Temperatur-Alarm feuert trotzdem.
+
+Nicht Teil dieser Lieferung (Le Var hat `active_metrics`, ist also nicht der #1971-Fall).
+Als eigenes Issue **#1981** geführt (Triage a: nutzersichtbares Fehlverhalten).
+
 ## Related Files
 
 | Datei | Relevanz |

--- a/docs/context/fix-1971-legacy-preset-alarm.md
+++ b/docs/context/fix-1971-legacy-preset-alarm.md
@@ -158,6 +158,50 @@ Abwahlen.** Belegt, dass die Abwahl schaden kann: Metrik im Metriken-Reiter akti
 Nicht Teil dieser Lieferung (Le Var hat `active_metrics`, ist also nicht der #1971-Fall).
 Als eigenes Issue **#1981** geführt (Triage a: nutzersichtbares Fehlverhalten).
 
+### M9 — 🔴 Der Merge-Ansatz kann AC-7 auf Alarm-Ebene NICHT erfüllen (Phase 4, offen)
+
+Gefunden beim RED-Testlauf. `wind_gust: "off"` verschwindet zwar aus der **Regelmenge**, die
+Böen-Größe wird aber weiterhin **überwacht** — eingeschleust über `wind_change`, das dasselbe
+Summary-Feld abdeckt (`weather_change_detection.py:73`,
+`WIND_CHANGE: ("wind_max_kmh", "gust_max_kmh")`). Gemessen:
+
+```
+Preset ohne active_metrics, {wind_gust: "off", precipitation_sum: "standard"}
+  VORHER   1 Regel   → gust_max_kmh bewacht: None
+  NACHHER 13 Regeln  → gust_max_kmh bewacht: 25.0     ⇒ der Fix FÜHRT das EIN
+```
+
+**Entscheidend:** Das ist kein Fremddefekt. Der `display_config`-Pfad hat den Schutz bereits:
+
+```
+MIT    display_config → wind_change trägt suppressed_fields ['gust_max_kmh'] → nicht bewacht
+OHNE   display_config → suppressed_fields leer                               → bewacht (25.0)
+```
+
+Der Mechanismus ist `claimed_fields` (`alert_preset.py:347-358`): Felder von Metriken, die
+**explizit** in `levels` stehen (auch mit `"off"`), werden vor dem Nachfüllen geschützt. Er
+sitzt hinter `if display_config is not None` — derselbe Riegel wie beim Backfill.
+
+**Warum der Merge das nicht heilen kann:** Nach `{**_STANDARD_METRIC_LEVELS, **levels}` sind
+ergänzte und ausdrücklich gesetzte Einträge nicht mehr unterscheidbar. `claimed_fields` braucht
+genau diese Unterscheidung. Der Merge in `_build_eval_config` löscht die Information, die der
+Schutz benötigt.
+
+**Konsequenz — Lösungsweg muss wechseln:** Statt in `_build_eval_config` zu mergen, gehört das
+Nachfüllen in `expand_per_metric_levels` in den `display_config is None`-Zweig, wo `levels`
+(explizit) und Nachfüllung (ergänzt) getrennt bleiben und `claimed_fields` greifen kann. Der
+`is_alert_metric_active`-Filter bleibt dort weiterhin übersprungen → CAPE bleibt erhalten
+(AC-4/AC-6 unberührt).
+
+**Offene Randbedingung, vor der Implementierung zu klären:** Das Nachfüllen darf **nicht**
+bedingungslos im `None`-Zweig laufen — ein Trip ohne `display_config` und ohne `levels` bekäme
+sonst 14 Regeln statt heute 0. Vorschlag: ein ausdrücklicher Parameter, den nur der
+Vergleichs-Pfad setzt, damit der Trip-Pfad nachweislich unberührt bleibt.
+
+> Der RED-Agent ist im AC-7-Alarmtest auf kollisionsfreie Größen ausgewichen (`fresh_snow`
+> statt `wind_gust`). Das umgeht den Defekt, statt ihn zu zeigen — der Test ist auf `wind_gust`
+> zurückzuführen, sonst bewacht AC-7 die Zusage nicht, die freigegeben wurde.
+
 ## Related Files
 
 | Datei | Relevanz |

--- a/docs/reference/api_contract.md
+++ b/docs/reference/api_contract.md
@@ -3529,6 +3529,19 @@ gespeicherter Wert unter `display_config.metric_alert_levels.thunder_onset` /
 `.precipitation_heavy_onset` wirkt weiterhin, wird von der Oberfläche aber weder gezeigt noch
 gesetzt. Die eigene Bedienbarkeit gehört zu #1462.
 
+**Fehlt `display_config.active_metrics` ganz** (Schlüssel absent oder `None`), greift dieser
+Backfill NICHT — er sitzt hinter `if display_config is not None`. Ein Ortsvergleichs-Preset in
+diesem Zustand ließ deshalb jede Metrik still, die sein `metric_alert_levels` nicht namentlich
+auflistet (#1971). Seit #1971 ergänzt `expand_per_metric_levels()` in genau diesem Fall die
+fehlenden `_PRESET_TABLE`-Metriken auf **„standard"** — aktiviert über den Parameter
+`supplement_missing_levels`, den **allein** der Vergleichs-Pfad
+(`CompareAlertService._build_eval_config`) setzt; der Trip-Pfad lässt den Default `False`.
+Ausdrücklich gesetzte Einträge gewinnen dabei immer, auch `"off"`: sie werden übersprungen UND
+sperren ihre Summary-Felder gegen Ergänzungen (`claimed_fields`), damit eine Abwahl nicht über
+eine zweite Regel mit demselben Feld wieder scharf wird (`wind_change` ⊃ `gust_max_kmh`).
+`display_config` bleibt in diesem Fall bewusst `None` — sonst entfiele die CAPE-Regel, deren
+Katalog-Größe seit #1585 `selectable=False` trägt.
+
 **`corridors[].metric` trug zwei Namensräume** (#1444 S2a, aus `resolve_corridor_summary_field()`
 in `corridor_threshold.py`): eine `AlertMetric`-Kennung (die 5 fest verdrahteten Zeilen, z.B.
 `wind_gust`, `snow_line`) ODER einen Katalog-`key` (die 18 seit #1425 aus dem Katalog gespeisten

--- a/docs/specs/modules/issue_1971_legacy_preset_alarm_fallback.md
+++ b/docs/specs/modules/issue_1971_legacy_preset_alarm_fallback.md
@@ -1,0 +1,311 @@
+---
+entity_id: issue_1971_legacy_preset_alarm_fallback
+type: module
+created: 2026-08-19
+updated: 2026-08-19
+status: draft
+version: "1.0"
+tags: [alarm, ortsvergleich, bug]
+---
+
+<!-- Issue #1971 ("Alt-Ortsvergleiche ohne migrierte active_metrics bekommen
+     nie eine Alarm-Regel"). Grundlage: PFLICHTLEKTUERE
+     docs/context/fix-1971-legacy-preset-alarm.md — die dortigen Messungen
+     M1-M5 sind BELEGT und werden hier nicht neu recherchiert. Die
+     Kernbehauptung des Issues ist in ihrer ursprünglichen Form WIDERLEGT
+     (M2); die tatsächliche Lücke ist enger (M3) und entsteht neu, nicht nur
+     historisch (M5).
+
+     WICHTIG: Ein erster Lösungsentwurf (display_config im None-Fall
+     voll-aktivieren) wurde durch Messung VERWORFEN — er entfernt die
+     CAPE-Regel (14 → 13 Regeln, siehe „Verworfener Lösungsweg" unten). Der
+     hier festgeschriebene Weg wirkt stattdessen auf der Level-Ebene, nicht
+     auf der display_config-Ebene. -->
+
+# Alarm-Pfad: fehlendes `active_metrics` bei gesetztem `metric_alert_levels` lässt neue Metriken still (#1971)
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+`CompareAlertService._build_eval_config()` verwendet `metric_alert_levels`
+heute entweder komplett aus dem Preset (falls gesetzt) oder komplett aus
+`_STANDARD_METRIC_LEVELS` (falls nicht gesetzt) — ein reines Entweder-Oder
+(`compare_alert.py:530-533`). Ist `metric_alert_levels` gesetzt, aber listet
+eine neu eingeführte Metrik (z. B. die Beginn-Alarme aus #1468) noch nicht
+auf, UND fehlt zugleich `display_config.active_metrics`, bleibt genau diese
+Metrik still, weil der `None`-Fallback in
+`_display_config_from_active_metrics()` den #961-Backfill blockiert (M3).
+Dieser Zustand ist nicht auf Alt-Bestand beschränkt — der Compare-Editor
+kann `active_metrics` bis heute weglassen (M5), die Lücke kann also
+jederzeit neu entstehen. Diese Spec schließt sie **auf der Level-Ebene**:
+Fehlt `active_metrics`, werden die gesetzten `metric_alert_levels` mit
+`_STANDARD_METRIC_LEVELS` ergänzt statt allein verwendet — analog zur
+bereits so funktionierenden Grundidee des Render-Pfads („fehlende
+Konfiguration heißt: alles gilt"), aber ohne den `display_config`-Filter zu
+berühren, der CAPE (seit #1585 `selectable=False`) sonst aus jeder Regel
+entfernen würde.
+
+## Source
+
+> **Schicht-Hinweis:** Ausschließlich **Python-Core**
+> (`src/services/`). Kein Go-, kein Frontend-Anteil — der Fix wirkt beim
+> Auswerten der Alarm-Kette, nicht beim Speichern/Laden des Presets.
+
+- **File:** `src/services/compare_alert.py`
+  - **Identifier:** `CompareAlertService._build_eval_config()`, konkret die
+    Konstruktion von `metric_alert_levels` (Zeile 530-533). Die Nachbar-
+    Methode `_display_config_from_active_metrics()` (Zeile 544-570) bleibt
+    UNVERÄNDERT — sie ist bewusst NICHT der Ansatzpunkt dieser Spec (siehe
+    „Verworfener Lösungsweg").
+
+## Estimated Scope
+
+- **LoC:** ~10-15 produktiv (`compare_alert.py`, eine Stelle) + ~150-180
+  Testcode (zwei neue Testdateien) — deutlich unter dem Workflow-Limit von
+  250
+- **Files:** 1 Produktivdatei geändert, 2 Testdateien neu
+- **Effort:** low — lokale Änderung an einer bereits bestehenden
+  Fallback-Verzweigung, kein neues Datenmodell, kein neuer Kanal
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `_STANDARD_METRIC_LEVELS` (`src/services/compare_alert.py:51`) | Register | Bisheriger Alles-oder-nichts-Fallback; wird künftig als ERGÄNZUNG statt als Ersatz genutzt |
+| `_PRESET_TABLE` (`src/services/alert_preset.py:53-77`) | Register | Quelle von `_STANDARD_METRIC_LEVELS`; 14 Einträge |
+| `expand_per_metric_levels()` (`src/services/alert_preset.py:178-387`) | Funktion | Der `display_config is not None`-Zweig (Filter Zeile 315-321, Backfill Zeile 346-385) bleibt für diesen Fix ÜBERSPRUNGEN — `display_config` bleibt im `None`-Fall weiterhin `None`, nur `levels` ändert sich |
+| `is_alert_metric_active()` / CAPE-Sonderfall (`src/services/weather_change_detection.py:229-233`) | Funktion | Dokumentiert, dass CAPE (Katalog-ID `cape`, `selectable=False` seit #1585, `src/app/metric_catalog.py:480`) NIE als aktiv gilt, sobald ein `display_config` ausgewertet wird — der Grund, warum der verworfene Lösungsweg CAPE stumm geschaltet hätte |
+| `_ALERT_METRIC_TO_CATALOG_ID` (`src/services/weather_change_detection.py:96-118`) | Register | Speist den Backfill; 15 Einträge — Grundlage für den AC-5-Wächter-Test (unverändert) |
+| `tests/tdd/test_compare_alert_metric_gating.py::test_f001a_empty_active_metrics_wind_delta_does_not_fire` | Test | MUSS nach dem Fix unverändert grün bleiben (Regressionsschutz #1191) |
+
+## Implementation Details
+
+### Verworfener Lösungsweg (nicht umsetzen — Messbeleg)
+
+Ein erster Entwurf ließ `_display_config_from_active_metrics()` im
+`None`-Fall ein voll-aktiviertes `UnifiedWeatherDisplayConfig` liefern statt
+`None`. Gemessen (echte Kette, keine Simulation):
+
+```
+AC-4-Fall (kein metric_alert_levels, kein active_metrics):
+  VORHER 14 Regeln, NACHHER 13 — verloren: ['cape']
+```
+
+Ursache: Sobald `display_config` nicht mehr `None` ist, greift der
+#961-Filter (`alert_preset.py:315-321`), der vorher übersprungen wurde.
+`is_alert_metric_active()` behandelt CAPE seit #1585 als **nie aktiv**,
+weil seine einzige gemappte Katalog-Größe `cape` `selectable=False` trägt
+(`weather_change_detection.py:229-233`). Ein Fix gegen stille Alarm-Ausfälle,
+der selbst einen neuen stillen Ausfall erzeugt, ist nicht lieferbar — dieser
+Weg wird verworfen.
+
+### Umgesetzter Lösungsweg
+
+Ansatzpunkt ist `_build_eval_config()` (`compare_alert.py:508-542`), genau
+dort, wo der `_STANDARD_METRIC_LEVELS`-Fallback ohnehin schon sitzt
+(Zeile 530-533). `display_config` (Zeile 535,
+`_display_config_from_active_metrics(preset)`) bleibt **unverändert** —
+fehlt `active_metrics`, liefert diese Methode weiterhin `None`, der
+#961-Filter/-Backfill in `expand_per_metric_levels()` bleibt also
+übersprungen, CAPE bleibt erhalten.
+
+Stattdessen wird `metric_alert_levels` neu zusammengesetzt:
+
+```
+active = (preset.get("display_config") or {}).get("active_metrics")
+levels = (preset.get("display_config") or {}).get("metric_alert_levels")
+if active is None:
+    # Kein active_metrics -> Standard-Levels als Grundlage, explizite
+    # Preset-Eintraege (auch "off") ueberschreiben sie gezielt.
+    effektiv = {**_STANDARD_METRIC_LEVELS, **(levels or {})}
+else:
+    effektiv = levels or _STANDARD_METRIC_LEVELS  # unveraendert
+```
+
+`levels or {}` bzw. `levels or _STANDARD_METRIC_LEVELS` entsprechen der
+bisherigen `preset.get(...) or _STANDARD_METRIC_LEVELS`-Formulierung; neu
+ist ausschließlich die Fallunterscheidung nach `active is None` und das
+Merge mit „explizite Einträge gewinnen" (Python-Dict-Merge-Reihenfolge:
+`_STANDARD_METRIC_LEVELS` zuerst, `levels` zuletzt).
+
+**Wirkung entlang der Kette (nachvollzogen, gemessen, nicht nur behauptet):**
+
+| Fall | Ergebnis |
+|---|---|
+| AC-1: `metric_alert_levels` gesetzt ohne Onset, kein `active_metrics` | **14 Regeln, Onset ✓, CAPE ✓** (vorher: 3 Regeln, kein Onset — M3) |
+| AC-4: kein `metric_alert_levels`, kein `active_metrics` | **14 Regeln, CAPE ✓** — unverändert gegenüber M2 |
+| Abwahl-Probe: `{wind_gust: "off", precipitation_sum: "standard"}`, kein `active_metrics` | **13 Regeln, `wind_gust` NICHT dabei** — explizites `off` bleibt wirksam (AC-7) |
+| AC-2/AC-3: `active_metrics` vorhanden (leer `[]` oder Teil-Auswahl) | von dieser Änderung **nicht berührt** — nimmt weiterhin den `else`-Zweig |
+
+Der `off`-Schutz ergibt sich strukturell aus dem Merge (das Preset-`levels`
+wird ZULETZT gemergt, sein `"off"`-Eintrag überschreibt den
+`_STANDARD_METRIC_LEVELS`-Eintrag) — kein Sonderfall-Code nötig, aber
+AC-7 macht das als eigenen Test verbindlich, damit eine spätere
+Umformulierung (z. B. vertauschte Merge-Reihenfolge) sofort rot wird.
+
+### Wächter-Test: Register-Deckung (unverändert gegenüber dem ursprünglichen Entwurf)
+
+Zwei getrennt gepflegte Register speisen die zwei Wege, auf denen eine
+Metrik scharf werden kann (M4): `_ALERT_METRIC_TO_CATALOG_ID`
+(`weather_change_detection.py:96-118`, Backfill) und `_PRESET_TABLE`
+(`alert_preset.py:53-77`, Preset-Fallback). Ein neuer Test vergleicht die
+Metrik-Mengen beider Register direkt (keine Dateiinhalt-Prüfung, sondern
+Import und Iteration der echten Register) und lässt nur die dokumentierte
+Ausnahme `AlertMetric.SNOW_LINE` (per #959 bewusst nach `FREEZING_LEVEL`
+konsolidiert) unbeanstandet. Jede künftige Metrik, die nur in einem der
+beiden Register landet, macht den Test rot — schließt die Fehlerklasse
+hinter #1971, nicht nur den heutigen Symptomfall.
+
+## Expected Behavior
+
+- **Input:** Ein Ortsvergleichs-Preset, dessen `display_config` entweder
+  `active_metrics` fehlt (Key absent oder `None`) oder eine bewusst leere
+  Liste `[]` trägt, kombiniert mit gesetztem oder fehlendem
+  `metric_alert_levels`.
+- **Output:** Fehlt `active_metrics` (Key absent/`None`), werden fehlende
+  `metric_alert_levels`-Einträge auf `standard` ergänzt — unabhängig davon,
+  ob `metric_alert_levels` überhaupt gesetzt ist; explizit gesetzte
+  Einträge (inklusive `off`) bleiben unverändert wirksam. Ist
+  `active_metrics` eine leere Liste `[]` oder eine Teil-Auswahl, bleibt das
+  Verhalten exakt wie heute (unverändert, #1191).
+- **Side effects:** Keine Persistenz-Änderung — die Auswertung wirkt nur
+  zur Laufzeit der Alarm-Kette, das Preset auf Platte bleibt unangetastet.
+
+## Acceptance Criteria
+
+- **AC-1:** Given ein Ortsvergleichs-Preset ohne `display_config.active_metrics`
+  (Schlüssel fehlt) und mit gesetztem `metric_alert_levels`, das die
+  Onset-Metriken `thunder_onset`/`precipitation_heavy_onset` NICHT auflistet
+  / When die Alarm-Kette (`_build_eval_config` → `expand_per_metric_levels`
+  → `WeatherChangeDetectionService.from_alert_rules` → `detect_changes`) für
+  einen deutlichen Vorverschiebungs-Sprung im Gewitterbeginn ausgewertet
+  wird / Then entsteht eine `thunder_onset`-Alarmregel und der Sprung löst
+  einen Alarm aus, obwohl `metric_alert_levels` die Metrik nie genannt hat.
+  - Test: `tests/tdd/test_compare_alert_missing_active_metrics_with_levels.py::test_onset_alarm_fires_without_active_metrics_key` — echte Kette, kein Mock, Fixture nach Vorbild `test_onset_alert_armed_from_weather_tab.py`.
+
+- **AC-2:** Given ein Ortsvergleichs-Preset mit `active_metrics: []` (der
+  Nutzer hat im Editor bewusst alles abgewählt) / When derselbe Wind-Δ-Sprung
+  ausgewertet wird, der ohne Abwahl feuern würde / Then bleibt es still
+  (kein Alarm) — der Fix darf die bewusste Leer-Auswahl nicht mit dem
+  fehlenden Schlüssel verwechseln.
+  - Test: bestehender `tests/tdd/test_compare_alert_metric_gating.py::test_f001a_empty_active_metrics_wind_delta_does_not_fire` — MUSS nach dieser Änderung unverändert grün laufen (Regressionsschutz #1191 F001a, kein neuer Testcode nötig, nur Nachweis im Validierungslauf).
+
+- **AC-3:** Given ein Ortsvergleichs-Preset mit einer Teil-Auswahl in
+  `active_metrics` (z. B. nur `wind_gust` gewählt, Niederschlag abgewählt)
+  / When ein Δ-Sprung in der NICHT gewählten Niederschlags-Metrik ausgewertet
+  wird, während zeitgleich ein Δ-Sprung in der gewählten Wind-Metrik vorliegt
+  / Then feuert für Niederschlag kein Alarm, während der Wind-Alarm
+  unverändert feuert — die Teil-Auswahl bleibt vom Fix unberührt.
+  - Test: `tests/tdd/test_compare_alert_missing_active_metrics_with_levels.py::test_partial_active_metrics_only_selected_metric_fires`.
+
+- **AC-4:** Given ein Ortsvergleichs-Preset OHNE `active_metrics` UND OHNE
+  `metric_alert_levels` (der bereits vor dem Fix funktionierende Fall, M2) /
+  When die Alarm-Kette ausgewertet wird / Then entstehen exakt dieselben 14
+  Regeln wie vor dem Fix, weiterhin inklusive beider Onset-Metriken UND der
+  CAPE-Metrik — der bereits korrekte Level-Fallback-Pfad darf durch die
+  Änderung nicht verschoben werden.
+  - Test: `tests/tdd/test_compare_alert_missing_active_metrics_with_levels.py::test_legacy_preset_without_levels_unchanged_rule_count` — zählt die entstandenen `AlertRule`-Objekte und prüft Onset- UND CAPE-Metriken namentlich.
+
+- **AC-5:** Given die beiden Register `_ALERT_METRIC_TO_CATALOG_ID`
+  (`weather_change_detection.py:96-118`, speist den Backfill) und
+  `_PRESET_TABLE` (`alert_preset.py:53-77`, speist den Level-Fallback) / When
+  eine Metrik nur in einem der beiden Register vorkommt und nicht auf der
+  dokumentierten Ausnahmeliste (`AlertMetric.SNOW_LINE`) steht / Then schlägt
+  der Wächter-Test rot — die strukturelle Ursache hinter #1971 (zwei
+  getrennt gepflegte Register) bleibt dauerhaft überwacht, nicht nur der
+  heutige Symptomfall.
+  - Test: `tests/tdd/test_alert_metric_register_coverage.py::test_registers_agree_outside_documented_exceptions` — vergleicht die Metrik-Mengen beider Register direkt aus dem importierten Code, kein Dateiinhalt-Grep.
+
+- **AC-6:** Given ein Ortsvergleichs-Preset ohne `active_metrics` (Key
+  absent oder `None`) / When die Alarm-Kette ausgewertet wird / Then enthält
+  die entstandene Regelmenge weiterhin eine `cape`-Regel — CAPE ist seit
+  #1585 `selectable=False` und würde durch jede Lösung, die im `None`-Fall
+  ein `display_config` mit dem #961-Filter aktiviert, still verschwinden
+  (siehe „Verworfener Lösungsweg").
+  - Test: `tests/tdd/test_compare_alert_missing_active_metrics_with_levels.py::test_cape_rule_survives_missing_active_metrics` — prüft explizit auf `metric == "cape"` in der Regelmenge, sowohl mit als auch ohne gesetztes `metric_alert_levels`.
+
+- **AC-7:** Given ein Ortsvergleichs-Preset ohne `active_metrics`, dessen
+  `metric_alert_levels` eine Metrik ausdrücklich auf `"off"` setzt (z. B.
+  `wind_gust: "off"`) / When die Alarm-Kette ausgewertet wird / Then entsteht
+  für diese Metrik keine Regel, während die durch den Fix ergänzten
+  Standard-Metriken (z. B. Niederschlag) weiterhin feuern — die Ergänzung
+  darf eine bewusste Abwahl des Nutzers nie überschreiben (Schutz gegen
+  Bevormundung, CLAUDE.md).
+  - Test: `tests/tdd/test_compare_alert_missing_active_metrics_with_levels.py::test_explicit_off_survives_standard_levels_merge` — Δ-Sprung in der abgewählten UND in einer ergänzten Metrik, nur letztere löst einen Alarm aus.
+
+## Known Limitations
+
+- **Frontend-Anlege-Pfad bleibt unverändert:** `compareEditorSave.ts:407-409`
+  lässt `active_metrics` weiterhin weg, solange `activeMetricKeys === null`
+  (Init-Wert, M5). Diese Spec behebt das NICHT an der Quelle — der Auffang
+  im Alarm-Pfad deckt die Konsequenz ab, unabhängig davon, ob der Frontend-
+  Defekt später separat geschlossen wird.
+- **Produktionsbestand aktuell 0 betroffene Presets** (M1): Der Fix wirkt
+  vorbeugend gegen künftig neu entstehende Presets, nicht gegen einen
+  bestehenden Datenschaden — es ist keine Migration nötig.
+- **Register bleiben strukturell getrennt:** Der neue Wächter-Test (AC-5)
+  schließt die Fehlerklasse „Metrik nur in einem Register" durch
+  Beobachtung, vereinheitlicht aber nicht die beiden Register selbst — das
+  wäre ein größerer Refactor außerhalb dieses Scopes.
+- **`snow_line` bleibt die einzige dokumentierte Ausnahme** im Wächter-Test;
+  jede neue Ausnahme braucht eine explizite Begründung in derselben Liste,
+  sonst schlägt AC-5 fehl.
+- **Vokabular-Mischung in bestehenden Presets ist ein separater, bekannter
+  Defekt und NICHT Teil dieser Lieferung.** Gemessen am echten
+  Produktions-Preset `cp-eb6ba0b239d90e37` („Le Var"): dessen
+  `metric_alert_levels` mischt zwei Vokabulare — Summary-Keys
+  (`gust_max_kmh`, `cape_max_jkg`, `temp_max_c`, …) und Metrik-Namen
+  (`wind_gust`, `precipitation_sum`, `thunder_level`). Ausgewertet werden
+  ausschließlich die Metrik-Namen; ein Summary-Key-Eintrag wie
+  `gust_max_kmh: "off"` ist bereits heute wirkungslos.
+
+  **Der hier eingeführte Merge verstärkt diesen Defekt messbar** — das ist
+  ein bewusst in Kauf genommener Trade-off, keine Nebensache. Gemessen an
+  einem Preset OHNE `active_metrics` mit `{temp_max_c: "off", wind_gust:
+  "standard"}` (Temperatur im ignorierten Vokabular abgewählt):
+
+  ```
+  VORHER   1 Regel  [wind_gust]                  → temperature_max feuert NICHT
+  NACHHER 14 Regeln [.., temperature_max, ..]    → temperature_max feuert
+  ```
+
+  Der `off`-Schutz aus AC-7 greift nur für Einträge im **Metrik-Vokabular**
+  (`wind_gust: "off"`); eine Abwahl im Summary-Key-Vokabular wird vom
+  Standard-Satz überschrieben. Die Richtung ist die konservative
+  (mehr Alarm statt Stille, Leitsatz #1467 „Der gefährlichste Fehler ist der
+  ausbleibende Alarm"), aber sie kann für einen betroffenen Nutzer wie
+  ungewollte Zusatz-Alarmierung wirken. Betroffen wären ausschließlich
+  Presets ohne `active_metrics` — davon existiert in Produktion derzeit
+  **keines** (M1), weshalb der Trade-off heute niemanden trifft.
+
+  `Le Var` selbst hat `active_metrics` gesetzt und wird von dieser Änderung
+  nicht berührt. Der Vokabular-Defekt wird separat als **Issue #1981**
+  geführt; wird er dort behoben, entfällt diese Limitation von selbst.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Der Fix ändert weder die Detektor-Architektur (ADR-0021,
+  gemeinsame `DeviationAlertEngine` für Trip und Vergleich — bleibt
+  unberührt, beide Flächen laufen weiterhin durch denselben Code) noch die
+  Bedeutung der Empfindlichkeitsstufe (ADR-0043 — die Stufen-Semantik ändert
+  sich nicht, nur welche Metriken überhaupt eine Regel bekommen). Er
+  korrigiert eine bereits im Code dokumentierte Absicht
+  (`compare_alert.py:548-559`, Bug #1191 Adversary F001: „fehlendes
+  `active_metrics` = konservativ, alles feuert") dahin, dass sie auch bei
+  gesetztem `metric_alert_levels` greift — auf der Level-Ebene statt der
+  display_config-Ebene, um die #1585-Sonderregel für CAPE nicht zu berühren.
+  Keine neue Entscheidungsfläche im Sinne von CLAUDE.md (kein neuer Kanal,
+  Provider, Datenmodell, Auth- oder Editor-Paradigma).
+
+## Changelog
+
+- 2026-08-19: Initial spec created
+- 2026-08-19: Lösungsweg korrigiert — display_config-Ansatz verworfen
+  (CAPE-Regression, 14→13 Regeln, Messbeleg Team-Lead), umgestellt auf
+  Level-Merge in `_build_eval_config()`; AC-6 (CAPE-Regressionsschutz) und
+  AC-7 (explizites `off` bleibt wirksam) ergänzt; Known Limitations um
+  Vokabular-Mischungs-Befund (`cp-eb6ba0b239d90e37`) ergänzt

--- a/docs/specs/modules/issue_1971_legacy_preset_alarm_fallback.md
+++ b/docs/specs/modules/issue_1971_legacy_preset_alarm_fallback.md
@@ -26,7 +26,7 @@ tags: [alarm, ortsvergleich, bug]
 
 ## Approval
 
-- [ ] Approved
+- [x] Approved — PO-Freigabe („go") am 2026-08-19, alle 7 ACs
 
 ## Purpose
 

--- a/docs/specs/modules/issue_1971_legacy_preset_alarm_fallback.md
+++ b/docs/specs/modules/issue_1971_legacy_preset_alarm_fallback.md
@@ -54,12 +54,20 @@ entfernen würde.
 > (`src/services/`). Kein Go-, kein Frontend-Anteil — der Fix wirkt beim
 > Auswerten der Alarm-Kette, nicht beim Speichern/Laden des Presets.
 
+- **File:** `src/services/alert_preset.py`
+  - **Identifier:** `expand_per_metric_levels()`, neuer Supplement-Zweig im
+    `display_config is None`-Fall hinter dem Parameter
+    `supplement_missing_levels`.
 - **File:** `src/services/compare_alert.py`
-  - **Identifier:** `CompareAlertService._build_eval_config()`, konkret die
-    Konstruktion von `metric_alert_levels` (Zeile 530-533). Die Nachbar-
-    Methode `_display_config_from_active_metrics()` (Zeile 544-570) bleibt
-    UNVERÄNDERT — sie ist bewusst NICHT der Ansatzpunkt dieser Spec (siehe
-    „Verworfener Lösungsweg").
+  - **Identifier:** `CompareAlertService._build_eval_config()` — setzt den
+    Schalter (Zeile 541). Die Konstruktion von `metric_alert_levels`
+    (Zeile 530-533) und die Nachbar-Methode
+    `_display_config_from_active_metrics()` (Zeile 544-570) bleiben
+    UNVERÄNDERT — sie sind bewusst NICHT der Ansatzpunkt dieser Spec (siehe
+    „Verworfener Lösungsweg" und M9).
+- **Files (Durchreichung):** `src/services/point_weather.py`
+  (`AlertEvaluationConfig.supplement_missing_levels`, Default `False`) und
+  `src/services/deviation_alert_engine.py` (`_select_detector`).
 
 ## Estimated Scope
 
@@ -104,47 +112,79 @@ Weg wird verworfen.
 
 ### Umgesetzter Lösungsweg
 
-Ansatzpunkt ist `_build_eval_config()` (`compare_alert.py:508-542`), genau
-dort, wo der `_STANDARD_METRIC_LEVELS`-Fallback ohnehin schon sitzt
-(Zeile 530-533). `display_config` (Zeile 535,
-`_display_config_from_active_metrics(preset)`) bleibt **unverändert** —
+> **Wegwechsel in Phase 5 (M9):** Ein Dict-Merge in `_build_eval_config()`
+> (`effektiv = {**_STANDARD_METRIC_LEVELS, **(levels or {})}`) war der
+> ursprünglich hier festgeschriebene Weg. Der RED-Lauf hat ihn **widerlegt**:
+> nach dem Merge sind ergänzte und ausdrücklich gesetzte Einträge nicht mehr
+> unterscheidbar, und genau diese Unterscheidung braucht der
+> `claimed_fields`-Schutz. Folge: `wind_gust: "off"` verschwindet zwar aus der
+> Regelmenge, das Summary-Feld `gust_max_kmh` wird aber über `wind_change`
+> **neu** bewacht (gemessen: `None` → `25.0`) — der Fix führte einen eigenen
+> stillen Fehler ein und verletzte AC-7 auf Alarm-Ebene. Messbeleg:
+> `docs/context/fix-1971-legacy-preset-alarm.md`, Abschnitt M9.
+
+Ansatzpunkt ist stattdessen `expand_per_metric_levels()`
+(`alert_preset.py:178-425`) im `display_config is None`-Zweig — dort bleiben
+`levels` (explizit) und Nachfüllung (ergänzt) getrennt, sodass der
+bestehende `claimed_fields`-Schutz greifen kann.
+`_build_eval_config()` bleibt an der Level-Konstruktion (Zeile 530-533)
+**unverändert**, ebenso `_display_config_from_active_metrics()` (Zeile 535):
 fehlt `active_metrics`, liefert diese Methode weiterhin `None`, der
-#961-Filter/-Backfill in `expand_per_metric_levels()` bleibt also
-übersprungen, CAPE bleibt erhalten.
+#961-Filter/-Backfill bleibt übersprungen, CAPE bleibt erhalten.
 
-Stattdessen wird `metric_alert_levels` neu zusammengesetzt:
+Neu ist ein ausdrücklicher Parameter, mit dem der Aufrufer erklärt, dass
+`levels` nur eine TEIL-Angabe ist:
 
 ```
-active = (preset.get("display_config") or {}).get("active_metrics")
-levels = (preset.get("display_config") or {}).get("metric_alert_levels")
-if active is None:
-    # Kein active_metrics -> Standard-Levels als Grundlage, explizite
-    # Preset-Eintraege (auch "off") ueberschreiben sie gezielt.
-    effektiv = {**_STANDARD_METRIC_LEVELS, **(levels or {})}
-else:
-    effektiv = levels or _STANDARD_METRIC_LEVELS  # unveraendert
+def expand_per_metric_levels(levels, display_config=None,
+                             supplement_missing_levels=False):
+    ...
+    if display_config is None and supplement_missing_levels:
+        claimed_fields = Vereinigung der Felder ALLER explizit gesetzten Metriken
+        for row in _PRESET_TABLE:
+            if row.metric in levels:
+                continue                      # explizit gesetzt (inkl. "off")
+            if Felder(row.metric) vollstaendig in claimed_fields:
+                continue                      # Feld bereits belegt
+            Regel auf "standard" ergaenzen, kollidierende Felder unterdruecken
 ```
 
-`levels or {}` bzw. `levels or _STANDARD_METRIC_LEVELS` entsprechen der
-bisherigen `preset.get(...) or _STANDARD_METRIC_LEVELS`-Formulierung; neu
-ist ausschließlich die Fallunterscheidung nach `active is None` und das
-Merge mit „explizite Einträge gewinnen" (Python-Dict-Merge-Reihenfolge:
-`_STANDARD_METRIC_LEVELS` zuerst, `levels` zuletzt).
+Gesetzt wird der Schalter **allein** vom Vergleichs-Pfad
+(`CompareAlertService._build_eval_config`, `compare_alert.py:541`); der
+Trip-Pfad lässt den Default `False` stehen und bleibt damit nachweislich
+unverändert (`trip_alert.py:311`, `:446` übergeben ihn nicht). Durchgereicht
+wird er über das neue Feld `AlertEvaluationConfig.supplement_missing_levels`
+(`point_weather.py:77`) und `DeviationAlertEngine._select_detector`
+(`deviation_alert_engine.py:196-200`).
 
 **Wirkung entlang der Kette (nachvollzogen, gemessen, nicht nur behauptet):**
 
 | Fall | Ergebnis |
 |---|---|
-| AC-1: `metric_alert_levels` gesetzt ohne Onset, kein `active_metrics` | **14 Regeln, Onset ✓, CAPE ✓** (vorher: 3 Regeln, kein Onset — M3) |
+| AC-1: `metric_alert_levels` gesetzt ohne Onset, kein `active_metrics` | **13 Regeln, Onset ✓, CAPE ✓** (vorher: 3 Regeln, kein Onset — M3) |
 | AC-4: kein `metric_alert_levels`, kein `active_metrics` | **14 Regeln, CAPE ✓** — unverändert gegenüber M2 |
-| Abwahl-Probe: `{wind_gust: "off", precipitation_sum: "standard"}`, kein `active_metrics` | **13 Regeln, `wind_gust` NICHT dabei** — explizites `off` bleibt wirksam (AC-7) |
-| AC-2/AC-3: `active_metrics` vorhanden (leer `[]` oder Teil-Auswahl) | von dieser Änderung **nicht berührt** — nimmt weiterhin den `else`-Zweig |
+| Abwahl-Probe: `{wind_gust: "off", precipitation_sum: "standard"}`, kein `active_metrics` | **12 Regeln, `wind_gust` NICHT dabei**, `gust_max_kmh` bleibt unbewacht — explizites `off` bleibt wirksam (AC-7) |
+| AC-2/AC-3: `active_metrics` vorhanden (leer `[]` oder Teil-Auswahl) | von dieser Änderung **nicht berührt** — der Schalter wirkt nur bei `display_config is None` |
 
-Der `off`-Schutz ergibt sich strukturell aus dem Merge (das Preset-`levels`
-wird ZULETZT gemergt, sein `"off"`-Eintrag überschreibt den
-`_STANDARD_METRIC_LEVELS`-Eintrag) — kein Sonderfall-Code nötig, aber
-AC-7 macht das als eigenen Test verbindlich, damit eine spätere
-Umformulierung (z. B. vertauschte Merge-Reihenfolge) sofort rot wird.
+Die Zahlen sind gemessen, nicht geschätzt (Artefakte
+`docs/artifacts/fix-1971-legacy-preset-alarm/messung-varianz-und-ac-faelle.txt`
+und `messung-m9-wirkort.txt`). Zwei Zahlen liegen **niedriger** als der reine
+Standard-Satz erwarten ließe, beide aus demselben Grund: der
+`claimed_fields`-Feldschutz unterdrückt eine Ergänzung, deren Felder bereits
+von einem ausdrücklichen Eintrag belegt sind. Bei AC-1 entfällt so
+`precipitation_change` (Feld `precip_sum_mm` gehört dem gesetzten
+`precipitation_sum`), bei der Abwahl-Probe zusätzlich `wind_gust` selbst.
+Andernfalls überschriebe eine ergänzte `standard`-Schwelle eine bewusst
+gesetzte `entspannt`-Schwelle auf demselben Feld — was
+`test_issue_1170_compare_alert_config.py::test_ac5_stored_entspannt_level_makes_alert_less_sensitive`
+ausdrücklich verbietet.
+
+Der `off`-Schutz ergibt sich strukturell daraus, dass explizit gesetzte
+Metriken im Supplement-Zweig übersprungen werden UND ihre Felder für
+ergänzte Regeln gesperrt bleiben — kein Sonderfall-Code nötig. AC-7 macht
+das als eigenen Test verbindlich, und zwar **auf Feld-Ebene** (Schwellen des
+Detektors), nicht nur an der Regelmenge: nur dort zeigt sich, ob eine
+abgewählte Größe über eine zweite Regel wieder unter Überwachung gerät (M9).
 
 ### Wächter-Test: Register-Deckung (unverändert gegenüber dem ursprünglichen Entwurf)
 
@@ -200,6 +240,7 @@ hinter #1971, nicht nur den heutigen Symptomfall.
   / Then feuert für Niederschlag kein Alarm, während der Wind-Alarm
   unverändert feuert — die Teil-Auswahl bleibt vom Fix unberührt.
   - Test: `tests/tdd/test_compare_alert_missing_active_metrics_with_levels.py::test_partial_active_metrics_only_selected_metric_fires`.
+  - Test (Adversary-Finding F003): `…::test_partial_active_metrics_with_partial_levels_keeps_single_watched_field` — Teil-`active_metrics` UND partielles `metric_alert_levels` **gleichzeitig**. Der erste Test ist gegen ein Durchschlagen der Ergänzung blind, weil sein Preset über den vollen `_STANDARD_METRIC_LEVELS`-Fallback läuft und der Supplement-Zweig dann nichts mehr zu ergänzen findet. Der zweite prüft am Wirkort (`detektor._thresholds`) auf genau ein bewachtes Feld; bei einem Leck wären es elf (Rot-Nachweis per Doppel-Mutation, `docs/artifacts/fix-1971-legacy-preset-alarm/test-red-f003-mutation.txt`).
 
 - **AC-4:** Given ein Ortsvergleichs-Preset OHNE `active_metrics` UND OHNE
   `metric_alert_levels` (der bereits vor dem Fix funktionierende Fall, M2) /
@@ -234,7 +275,9 @@ hinter #1971, nicht nur den heutigen Symptomfall.
   Standard-Metriken (z. B. Niederschlag) weiterhin feuern — die Ergänzung
   darf eine bewusste Abwahl des Nutzers nie überschreiben (Schutz gegen
   Bevormundung, CLAUDE.md).
-  - Test: `tests/tdd/test_compare_alert_missing_active_metrics_with_levels.py::test_explicit_off_survives_standard_levels_merge` — Δ-Sprung in der abgewählten UND in einer ergänzten Metrik, nur letztere löst einen Alarm aus.
+  - Test: `tests/tdd/test_compare_alert_missing_active_metrics_with_levels.py::test_explicit_off_survives_standard_levels_merge` — Regelmengen-Ebene (12 Regeln, `wind_gust` fehlt).
+  - Test (Alarm-Ebene, M9): `…::test_explicit_off_wind_gust_stays_silent_while_supplemented_metric_fires` — Δ-Sprung in der abgewählten UND in einer ergänzten Metrik, nur letztere löst einen Alarm aus. **Dieser Test ist der eigentliche AC-7-Nachweis:** Nur auf Feld-Ebene zeigt sich, ob eine abgewählte Größe über eine zweite Regel (`wind_change` ⊃ `gust_max_kmh`) wieder unter Überwachung gerät — genau daran scheiterte der verworfene Lösungsweg.
+  - Test (Gegenbeleg): `…::test_explicit_off_collision_free_metric_stays_silent` — dieselbe Zusage für eine Metrik ohne Feld-Überschneidung; trennt die beiden Ursachen.
 
 ## Known Limitations
 
@@ -262,7 +305,7 @@ hinter #1971, nicht nur den heutigen Symptomfall.
   ausschließlich die Metrik-Namen; ein Summary-Key-Eintrag wie
   `gust_max_kmh: "off"` ist bereits heute wirkungslos.
 
-  **Der hier eingeführte Merge verstärkt diesen Defekt messbar** — das ist
+  **Die hier eingeführte Ergänzung verstärkt diesen Defekt messbar** — das ist
   ein bewusst in Kauf genommener Trade-off, keine Nebensache. Gemessen an
   einem Preset OHNE `active_metrics` mit `{temp_max_c: "off", wind_gust:
   "standard"}` (Temperatur im ignorierten Vokabular abgewählt):
@@ -304,6 +347,15 @@ hinter #1971, nicht nur den heutigen Symptomfall.
 ## Changelog
 
 - 2026-08-19: Initial spec created
+- 2026-08-19: **Lösungsweg erneut korrigiert (Phase 5, Befund M9)** — der
+  Dict-Merge in `_build_eval_config()` ist widerlegt (er löscht die
+  Unterscheidung explizit/ergänzt, die der `claimed_fields`-Schutz braucht,
+  und bewacht `gust_max_kmh` bei `wind_gust: "off"` neu). Umgesetzt wird
+  stattdessen ein Supplement-Zweig in `expand_per_metric_levels()` hinter dem
+  neuen Parameter `supplement_missing_levels`, den allein der Vergleichs-Pfad
+  setzt. Wirkungstabelle auf die gemessenen Zahlen korrigiert (AC-1 14→13,
+  Abwahl-Probe 13→12; Ursache: Feldschutz). Die 7 ACs sind unverändert —
+  keine erneute PO-Freigabe nötig. Adversary-Finding F002.
 - 2026-08-19: Lösungsweg korrigiert — display_config-Ansatz verworfen
   (CAPE-Regression, 14→13 Regeln, Messbeleg Team-Lead), umgestellt auf
   Level-Merge in `_build_eval_config()`; AC-6 (CAPE-Regressionsschutz) und

--- a/src/services/alert_preset.py
+++ b/src/services/alert_preset.py
@@ -178,6 +178,7 @@ def expand_preset(name: str) -> list[AlertRule]:
 def expand_per_metric_levels(
     levels: dict[str, str],
     display_config: "UnifiedWeatherDisplayConfig | None" = None,
+    supplement_missing_levels: bool = False,
 ) -> list[AlertRule]:
     """Konvertiert metric_alert_levels (metric → SensLevel) in AlertRule-Liste.
 
@@ -195,6 +196,13 @@ def expand_per_metric_levels(
         Backfill-Overwrite).
     Ohne `display_config` (Default None): altes Verhalten (Abwärtskompatibilität,
     keine Filterung, kein Backfill).
+
+    Issue #1971 — `supplement_missing_levels` (nur wirksam ohne `display_config`):
+    Der Aufrufer erklärt damit, dass `levels` eine TEIL-Angabe ist und fehlende
+    `_PRESET_TABLE`-Metriken auf 'standard' zu ergänzen sind. Gesetzt wird der
+    Schalter allein vom Vergleichs-Pfad (`CompareAlertService._build_eval_config`)
+    für Presets ohne `display_config.active_metrics`; der Trip-Pfad lässt ihn beim
+    Default `False` und bleibt unverändert.
 
     `levels` (die Trip-JSON-Quelle) wird NIE verändert — reine Auswertungslogik.
     """
@@ -378,6 +386,37 @@ def expand_per_metric_levels(
             remaining = metric_fields - blocked
             if metric_fields and not remaining:
                 continue  # alle Felder belegt/ab-gewählt → Regel komplett unterdrücken (AC-6)
+            rule = _make_rule(metric_str, "standard")
+            if rule is not None:
+                if colliding:
+                    rule.suppressed_fields = set(colliding)
+                rules.append(rule)
+
+    # Issue #1971: Ergänzung ohne `display_config`. Fehlt im Vergleichs-Preset
+    # `active_metrics`, bleibt `display_config` bewusst None (sonst schaltete der
+    # #961-Filter CAPE stumm, `selectable=False` seit #1585) — dann greift der
+    # Backfill oben nicht, und ein `metric_alert_levels`, das eine später
+    # eingeführte Metrik (Beginn-Alarme #1468) nicht auflistet, lässt sie still.
+    # Hier wird auf 'standard' ergänzt, mit DEMSELBEN Feld-Schutz wie oben:
+    # explizit gesetzte Metriken (jede Stufe, auch 'off') belegen ihre
+    # Summary-Felder, eine ergänzte Metrik armiert sie nicht nach. Sonst
+    # unterwanderte die Ergänzung die Nutzer-Entscheidung gleich doppelt — eine
+    # Abwahl (wind_change ⊃ gust_max_kmh bei wind_gust='off') ebenso wie eine
+    # bewusste Schwellenwahl (precipitation_change 'standard' überschriebe
+    # precipitation_sum 'entspannt' auf demselben Feld precip_sum_mm, Issue
+    # #1170 AC-5).
+    if display_config is None and supplement_missing_levels:
+        claimed_fields = set()
+        for metric_str in levels:
+            claimed_fields |= _fields_for(metric_str)
+        for row in _PRESET_TABLE:
+            metric_str = row[0].value
+            if metric_str in levels:
+                continue  # explizit gesetzt (inkl. 'off') → Nutzer entscheidet
+            metric_fields = _fields_for(metric_str)
+            colliding = metric_fields & claimed_fields
+            if metric_fields and not (metric_fields - claimed_fields):
+                continue  # jedes Feld belegt → Ergänzung komplett unterdrücken
             rule = _make_rule(metric_str, "standard")
             if rule is not None:
                 if colliding:

--- a/src/services/compare_alert.py
+++ b/src/services/compare_alert.py
@@ -533,6 +533,12 @@ class CompareAlertService:
             ),
             channels=effective_compare_channels(preset, self._settings, self._user_id),
             display_config=self._display_config_from_active_metrics(preset),
+            # Issue #1971: das Preset-`metric_alert_levels` ist eine TEIL-Angabe —
+            # eine später eingeführte Metrik (Beginn-Alarme #1468) steht darin
+            # nicht und bliebe ohne `active_metrics` (display_config=None) still.
+            # Wirkt ausschliesslich in diesem Fall; sobald `active_metrics`
+            # vorliegt, schliesst der #961-Backfill die Lücke wie bisher.
+            supplement_missing_levels=True,
             # Issue #1726: Zone des ERSTEN aufloesbaren Orts (#1378 AC-4,
             # AC-15) — die EINE Stelle, an der der Vergleich sie bildet.
             zone=first_resolvable_tz(

--- a/src/services/deviation_alert_engine.py
+++ b/src/services/deviation_alert_engine.py
@@ -196,7 +196,11 @@ class DeviationAlertEngine:
             )
             return WeatherChangeDetectionService.from_alert_rules(rules)
 
-        rules = expand_per_metric_levels(config.metric_alert_levels or {}, display_config=None)
+        rules = expand_per_metric_levels(
+            config.metric_alert_levels or {},
+            display_config=None,
+            supplement_missing_levels=config.supplement_missing_levels,
+        )
         return WeatherChangeDetectionService.from_alert_rules(rules)
 
     @staticmethod

--- a/src/services/point_weather.py
+++ b/src/services/point_weather.py
@@ -70,6 +70,11 @@ class AlertEvaluationConfig:
     # Eintrag). None = kein Backfill (Abwärtskompatibilität für generische
     # Aufrufer ohne Weather-Tab-Kontext, z. B. reine metric_alert_levels-Nutzung).
     display_config: Optional["UnifiedWeatherDisplayConfig"] = None
+    # Issue #1971: der Erbauer erklärt, dass `metric_alert_levels` nur eine
+    # TEIL-Angabe ist — fehlende Metriken sind auf 'standard' zu ergänzen.
+    # Wirkt nur bei `display_config is None` (sonst schließt der #961-Backfill
+    # die Lücke bereits). Der Trip-Pfad lässt den Default `False` stehen.
+    supplement_missing_levels: bool = False
     # Issue #1726: Ortszone des Gegenstands fuer die Ruhezeit-Pruefung (Trip:
     # `anchor_tz`, Vergleich: `first_resolvable_tz`). `None` = der Erbauer
     # kennt keine; die Engine rechnet dann in Weltzeit statt zu raten.

--- a/tests/tdd/test_alert_metric_register_coverage.py
+++ b/tests/tdd/test_alert_metric_register_coverage.py
@@ -1,0 +1,129 @@
+"""Issue #1971 — Waechter: die beiden Alarm-Register duerfen nicht
+auseinanderlaufen.
+
+SPEC:    docs/specs/modules/issue_1971_legacy_preset_alarm_fallback.md (AC-5)
+KONTEXT: docs/context/fix-1971-legacy-preset-alarm.md (Messung M4)
+
+WARUM (die Fehlerklasse hinter #1971):
+Eine Metrik kann auf ZWEI getrennten Wegen scharf werden, und jeder Weg hat
+sein eigenes, von Hand gepflegtes Register:
+
+  1. `_ALERT_METRIC_TO_CATALOG_ID` (`weather_change_detection.py`) speist den
+     #961-Backfill — er greift nur, wenn ein `display_config` vorliegt.
+  2. `_PRESET_TABLE` (`alert_preset.py`) speist ueber
+     `_STANDARD_METRIC_LEVELS` den Level-Fallback — er greift, wenn kein
+     `metric_alert_levels` gesetzt ist.
+
+Wird eine neue Metrik nur in EINES der beiden Register eingetragen, ist sie
+auf dem jeweils anderen Weg still — ohne dass irgendetwas fehlschlaegt. Genau
+so entsteht der Ausfall, den #1971 beschreibt. Dieser Test schliesst die
+Klasse statt des Einzelfalls.
+
+GUARD: laeuft HEUTE bereits gruen (M4: 15 gegen 14 Eintraege, Differenz genau
+`snow_line`). Er soll ab jetzt bewachen, nicht erst gruen werden.
+
+KEIN Dateiinhalt-Check: verglichen werden die IMPORTIERTEN Register, nicht
+ihr Quelltext.
+
+Pfadregel #1409: der Prueling wird RELATIV ZU DIESER DATEI aufgeloest.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from app.models import AlertMetric  # noqa: E402
+from services.alert_preset import _PRESET_TABLE  # noqa: E402
+from services.weather_change_detection import (  # noqa: E402
+    _ALERT_METRIC_TO_CATALOG_ID,
+)
+
+# Issue #959: die Nullgradgrenze wurde bewusst auf EINE Zeile
+# (`freezing_level`) konsolidiert; `snow_line` bleibt nur im Backfill-Register
+# als Uebergangs-Mapping stehen und wird beim Laden migriert
+# (`loader._migrate_metric_alert_levels`). JEDE weitere Ausnahme braucht hier
+# eine eigene Begruendung — eine unbegruendete Zeile ist ein Freibrief fuer
+# genau die Luecke, die dieser Test bewachen soll.
+DOKUMENTIERTE_AUSNAHMEN: dict[AlertMetric, str] = {
+    AlertMetric.SNOW_LINE: "Issue #959: nach FREEZING_LEVEL konsolidiert, "
+                           "alt-persistierte Levels werden beim Laden migriert",
+}
+
+
+def _backfill_register() -> set[AlertMetric]:
+    return set(_ALERT_METRIC_TO_CATALOG_ID)
+
+
+def _preset_register() -> set[AlertMetric]:
+    return {zeile[0] for zeile in _PRESET_TABLE}
+
+
+def test_registers_agree_outside_documented_exceptions():
+    """AC-5 (GUARD) GIVEN die beiden getrennt gepflegten Register.
+
+    WHEN eine Metrik nur in einem von beiden steht und nicht auf der
+    dokumentierten Ausnahmeliste (`AlertMetric.SNOW_LINE`) gefuehrt wird.
+
+    THEN schlaegt dieser Test fehl — mit dem Namen der Metrik und dem
+    Register, in dem sie fehlt.
+    """
+    backfill = _backfill_register()
+    preset = _preset_register()
+
+    # Positivkontrolle: der Vergleich darf nicht deshalb bestehen, weil beide
+    # Mengen leer sind oder ein Import ins Leere zeigt.
+    assert backfill and preset, (
+        f"Mindestens ein Register ist leer — der Vergleich waere trivial wahr. "
+        f"Backfill: {len(backfill)}, Preset-Tabelle: {len(preset)}"
+    )
+    assert AlertMetric.WIND_GUST in backfill & preset, (
+        "Die Boeen-Metrik steht nicht in beiden Registern — dann vergleicht "
+        "dieser Test nicht das, was er zu vergleichen glaubt. Backfill: "
+        f"{sorted(m.value for m in backfill)!r}, Preset-Tabelle: "
+        f"{sorted(m.value for m in preset)!r}"
+    )
+
+    nur_backfill = backfill - preset - set(DOKUMENTIERTE_AUSNAHMEN)
+    nur_preset = preset - backfill - set(DOKUMENTIERTE_AUSNAHMEN)
+
+    assert not nur_backfill, (
+        "Diese Metriken stehen nur in `_ALERT_METRIC_TO_CATALOG_ID` und fehlen "
+        "in `_PRESET_TABLE`: "
+        f"{sorted(m.value for m in nur_backfill)!r}. Sie werden nur scharf, "
+        "wenn ein `display_config` vorliegt — bei fehlendem `active_metrics` "
+        "bleiben sie still (Fehlerklasse #1971). Eintragen oder in "
+        "DOKUMENTIERTE_AUSNAHMEN begruenden."
+    )
+    assert not nur_preset, (
+        "Diese Metriken stehen nur in `_PRESET_TABLE` und fehlen in "
+        "`_ALERT_METRIC_TO_CATALOG_ID`: "
+        f"{sorted(m.value for m in nur_preset)!r}. Sie werden vom "
+        "#961-Backfill nie nachgefuellt und lassen sich im Wetter-Reiter nicht "
+        "abwaehlen. Eintragen oder in DOKUMENTIERTE_AUSNAHMEN begruenden."
+    )
+
+
+def test_documented_exceptions_are_still_exceptions():
+    """AC-5 (GUARD, Gegenprobe) — eine Ausnahme, die keine mehr ist, gehoert
+    geloescht.
+
+    Stuende `snow_line` eines Tages in BEIDEN Registern, wuerde die Zeile in
+    `DOKUMENTIERTE_AUSNAHMEN` still weiterwirken und eine kuenftige echte
+    Luecke unter demselben Namen verdecken. Dieser Test haelt die
+    Ausnahmeliste so kurz wie noetig.
+    """
+    backfill = _backfill_register()
+    preset = _preset_register()
+
+    ueberfluessig = {
+        m.value for m in DOKUMENTIERTE_AUSNAHMEN
+        if (m in backfill) == (m in preset)
+    }
+    assert not ueberfluessig, (
+        f"Diese Ausnahmen sind keine mehr: {sorted(ueberfluessig)!r} — die "
+        "Metrik steht inzwischen in beiden Registern (oder in keinem). Zeile "
+        "aus DOKUMENTIERTE_AUSNAHMEN entfernen, sonst deckt sie einen "
+        "kuenftigen echten Ausfall zu."
+    )

--- a/tests/tdd/test_compare_alert_missing_active_metrics_with_levels.py
+++ b/tests/tdd/test_compare_alert_missing_active_metrics_with_levels.py
@@ -1,0 +1,371 @@
+"""Issue #1971 — Fehlt `active_metrics`, waehrend `metric_alert_levels`
+gesetzt ist, bleiben neu eingefuehrte Metriken still.
+
+SPEC:    docs/specs/modules/issue_1971_legacy_preset_alarm_fallback.md
+KONTEXT: docs/context/fix-1971-legacy-preset-alarm.md (Messungen M1-M8)
+
+WORUM ES GEHT (M3):
+`CompareAlertService._build_eval_config()` behandelt `metric_alert_levels`
+heute als reines Entweder-Oder — entweder komplett aus dem Preset oder
+komplett aus `_STANDARD_METRIC_LEVELS`. Steht im Preset ein
+`metric_alert_levels`, das eine spaeter eingefuehrte Groesse (die
+Beginn-Alarme aus #1468) nicht auffuehrt, UND fehlt zugleich
+`display_config.active_metrics`, dann greift weder der Level-Fallback noch
+der #961-Backfill (der haengt hinter `display_config is not None`). Genau
+diese Groesse bekommt nie eine Regel und meldet nie.
+
+PRUEFORT = WIRKORT. Gefahren wird die echte Kette
+`CompareAlertService._build_eval_config(preset, ...)` ->
+`DeviationAlertEngine._select_detector()` (der Produktions-Waehler, der
+`expand_per_metric_levels` + `from_alert_rules` in sich traegt) ->
+`detect_changes()`. Keine handgesetzte Regel-Liste, kein `Mock()`/`patch()`
+(CLAUDE.md, Kern-Schicht).
+
+RED (neues Verhalten, schlaegt HEUTE fehl):
+  - test_onset_alarm_fires_without_active_metrics_key                (AC-1)
+  - test_cape_rule_survives_missing_active_metrics_with_levels_set   (AC-6, zweite Haelfte)
+  - test_explicit_off_survives_standard_levels_merge                 (AC-7)
+  - test_explicit_off_metric_stays_silent_while_supplemented_metric_fires (AC-7)
+
+GUARD (bestehendes Verhalten, HEUTE schon gruen, darf nicht kippen):
+  - test_partial_active_metrics_only_selected_metric_fires           (AC-3)
+  - test_legacy_preset_without_levels_unchanged_rule_count           (AC-4)
+  - test_cape_rule_survives_missing_active_metrics                   (AC-6, erste Haelfte)
+
+AC-2 hat bewusst KEINEN Test in dieser Datei — er ist durch den bestehenden
+`test_compare_alert_metric_gating.py::test_f001a_empty_active_metrics_wind_delta_does_not_fire`
+abgedeckt (Regressionsschutz #1191 F001a) und wird nur im Lauf mitgeprueft.
+
+Pfadregel #1409: der Prueling wird RELATIV ZU DIESER DATEI aufgeloest.
+"""
+from __future__ import annotations
+
+import sys
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from app.config import Settings  # noqa: E402
+from app.models import (  # noqa: E402
+    ForecastMeta, GPXPoint, NormalizedTimeseries, Provider, SegmentWeatherData,
+    SegmentWeatherSummary, TripSegment,
+)
+from services.alert_preset import expand_per_metric_levels  # noqa: E402
+from services.compare_alert import CompareAlertService  # noqa: E402
+from services.deviation_alert_engine import DeviationAlertEngine  # noqa: E402
+
+TAG = date(2026, 8, 20)
+
+# Die drei Groessen, die ein Nutzer im Alarme-Reiter typischerweise angefasst
+# hat, BEVOR es die Beginn-Groessen ueberhaupt gab (#1468).
+LEVELS_OHNE_ONSET = {
+    "wind_gust": "standard",
+    "precipitation_sum": "standard",
+    "thunder_level": "standard",
+}
+
+
+def _utc(stunde: int) -> datetime:
+    return datetime(TAG.year, TAG.month, TAG.day, stunde, 0)
+
+
+def _segment() -> TripSegment:
+    return TripSegment(
+        segment_id=1,
+        start_point=GPXPoint(lat=47.0, lon=12.0, elevation_m=1000.0,
+                             distance_from_start_km=0.0),
+        end_point=GPXPoint(lat=47.1, lon=12.1, elevation_m=1200.0,
+                           distance_from_start_km=8.0),
+        start_time=_utc(6).replace(tzinfo=timezone.utc),
+        end_time=_utc(18).replace(tzinfo=timezone.utc),
+        duration_hours=12.0, distance_km=8.0, ascent_m=500.0, descent_m=200.0,
+    )
+
+
+def _data(**summary) -> SegmentWeatherData:
+    return SegmentWeatherData(
+        segment=_segment(),
+        timeseries=NormalizedTimeseries(
+            meta=ForecastMeta(provider=Provider.OPENMETEO, model="test",
+                              grid_res_km=1.0),
+            data=[],
+        ),
+        aggregated=SegmentWeatherSummary(**summary),
+        fetched_at=datetime.now(timezone.utc), provider="openmeteo",
+    )
+
+
+def _preset(display_config: dict | None) -> dict:
+    """Ein Vergleichs-Preset, wie es unter `briefings/<id>.json` liegt.
+
+    `location_ids` bleibt leer: `_build_eval_config` leitet daraus nur die
+    Zeitzone ab (UTC-Rueckfall, protokolliert) — fuer die Metrik-Auswahl,
+    um die es hier geht, ist sie ohne Belang.
+    """
+    preset: dict = {
+        "id": "cp-1971", "name": "cp-1971", "user_id": "tdd-1971",
+        "location_ids": [], "schedule": "daily", "hour_from": 9, "hour_to": 16,
+        "empfaenger": ["gregor-test@henemm.com"],
+    }
+    if display_config is not None:
+        preset["display_config"] = display_config
+    return preset
+
+
+def _eval_config(display_config: dict | None):
+    """Echte `_build_eval_config`-Auswertung — die Naht, an der der Fix wirkt."""
+    service = CompareAlertService(
+        settings=Settings(smtp_host="dummy.invalid", smtp_user="dummy",
+                          smtp_pass="dummy", mail_to="dummy@example.com"),
+        user_id="tdd-1971",
+    )
+    return service._build_eval_config(_preset(display_config), 120, {})
+
+
+def _regeln(config):
+    """Regelmenge GENAU so gebildet wie in `DeviationAlertEngine._select_detector`."""
+    return expand_per_metric_levels(
+        config.metric_alert_levels or {}, display_config=config.display_config
+    )
+
+
+def _namen(regeln) -> list[str]:
+    return sorted(str(r.metric) for r in regeln)
+
+
+def _gemeldet(config, alt: dict, neu: dict) -> set[str]:
+    """Produktions-Detektorwahl + Δ-Auswertung (`include_absolute=False` wie
+    im Alarm-Pfad, `DeviationAlertEngine._detect_all_changes`)."""
+    detektor = DeviationAlertEngine._select_detector(config)
+    return {
+        c.metric for c in detektor.detect_changes(
+            _data(**alt), _data(**neu), include_absolute=False
+        )
+    }
+
+
+# ══════════════════════════════ AC-1 (RED) ═══════════════════════════════════
+
+def test_onset_alarm_fires_without_active_metrics_key():
+    """AC-1 (RED) GIVEN ein Preset OHNE `display_config.active_metrics`
+    (Schluessel fehlt) und mit gesetztem `metric_alert_levels`, das die
+    Beginn-Groessen nicht auffuehrt.
+
+    WHEN der Gewitterbeginn um 2 h vorgezogen wird (17:00 -> 15:00, ueber der
+    Standard-Schwelle "ab 1 h frueher").
+
+    THEN entsteht eine `thunder_onset`-Regel UND der Sprung wird gemeldet.
+
+    RED heute: `metric_alert_levels` gilt als Gesamtbild, der
+    `_STANDARD_METRIC_LEVELS`-Fallback greift nicht, `display_config` bleibt
+    `None` -> der #961-Backfill laeuft nicht -> 3 Regeln, keine Beginn-Regel,
+    kein Alarm.
+
+    Positivkontrolle im selben Lauf: der zeitgleiche Boeen-Sprung
+    (20 -> 60 km/h) wird HEUTE wie NACH dem Fix gemeldet — ein leeres Ergebnis
+    beweist damit einen stillen Beginn-Alarm und nicht bloss eine tote Fixture.
+    """
+    config = _eval_config({"metric_alert_levels": dict(LEVELS_OHNE_ONSET)})
+    namen = _namen(_regeln(config))
+
+    assert "thunder_onset" in namen, (
+        "Gesetztes `metric_alert_levels` ohne Beginn-Eintrag plus fehlendes "
+        "`active_metrics`: der Gewitterbeginn bekommt keine Regel. Erzeugt "
+        f"wurden {len(namen)} Regeln: {namen!r}"
+    )
+
+    gemeldet = _gemeldet(
+        config,
+        alt={"thunder_onset_utc": _utc(17), "gust_max_kmh": 20.0},
+        neu={"thunder_onset_utc": _utc(15), "gust_max_kmh": 60.0},
+    )
+    assert "gust_max_kmh" in gemeldet, (
+        "Positivkontrolle gescheitert: der Boeen-Sprung 20 -> 60 km/h muesste "
+        f"schon heute melden. Gemeldet wurde: {sorted(gemeldet)!r}"
+    )
+    assert "thunder_onset_utc" in gemeldet, (
+        "Der Gewitterbeginn verschiebt sich um 2 h nach vorn und es entsteht "
+        f"kein Alarm. Gemeldet wurde: {sorted(gemeldet)!r}"
+    )
+
+
+# ══════════════════════════════ AC-3 (GUARD) ═════════════════════════════════
+
+def test_partial_active_metrics_only_selected_metric_fires():
+    """AC-3 (GUARD) GIVEN eine Teil-Auswahl `active_metrics=["gust_max_kmh"]`
+    (Boeen gewaehlt, Niederschlag abgewaehlt) ohne `metric_alert_levels`.
+
+    WHEN Boeen (20 -> 60 km/h, Δ=40 > 20) und Niederschlag (2 -> 20 mm,
+    Δ=18 > 10) ZEITGLEICH springen.
+
+    THEN meldet nur der Boeen-Alarm, der Niederschlag bleibt still.
+
+    GUARD: funktioniert heute bereits (der `else`-Zweig mit vorhandenem
+    `active_metrics` wird vom Fix nicht angefasst) und darf nicht kippen —
+    sonst waere der Fix zur Bevormundung geworden.
+    """
+    config = _eval_config({"active_metrics": ["gust_max_kmh"]})
+    gemeldet = _gemeldet(
+        config,
+        alt={"gust_max_kmh": 20.0, "precip_sum_mm": 2.0},
+        neu={"gust_max_kmh": 60.0, "precip_sum_mm": 20.0},
+    )
+    assert "gust_max_kmh" in gemeldet, (
+        "Die im Editor GEWAEHLTE Boeen-Metrik meldet nicht — erwartet wurde "
+        f"ein Alarm bei Δ=40. Gemeldet wurde: {sorted(gemeldet)!r}"
+    )
+    assert "precip_sum_mm" not in gemeldet, (
+        "Die im Editor ABGEWAEHLTE Niederschlags-Metrik meldet trotzdem "
+        f"(Δ=18). Gemeldet wurde: {sorted(gemeldet)!r}"
+    )
+
+
+# ══════════════════════════════ AC-4 (GUARD) ═════════════════════════════════
+
+def test_legacy_preset_without_levels_unchanged_rule_count():
+    """AC-4 (GUARD) GIVEN ein Preset OHNE `active_metrics` UND OHNE
+    `metric_alert_levels` — der bereits vor dem Fix funktionierende Pfad (M2).
+
+    THEN entstehen exakt 14 Regeln, darunter beide Beginn-Groessen UND `cape`.
+
+    GUARD: der Level-Fallback ist heute schon richtig; der Fix darf ihn weder
+    verkuerzen noch verlaengern. Die Zahl 14 ist gemessen (M2), nicht geraten.
+    """
+    config = _eval_config(None)
+    namen = _namen(_regeln(config))
+
+    assert len(namen) == 14, (
+        f"Der Level-Fallback hat sich verschoben: erwartet 14 Regeln, "
+        f"erhalten {len(namen)}: {namen!r}"
+    )
+    for metrik in ("thunder_onset", "precipitation_heavy_onset", "cape"):
+        assert metrik in namen, (
+            f"`{metrik}` fehlt im Legacy-Fallback (ohne active_metrics, ohne "
+            f"metric_alert_levels). Erzeugt wurden: {namen!r}"
+        )
+
+
+# ══════════════════════════════ AC-6 ═════════════════════════════════════════
+
+def test_cape_rule_survives_missing_active_metrics():
+    """AC-6 (GUARD) GIVEN `active_metrics` ausdruecklich als `None` gesetzt
+    (Schluessel vorhanden, Wert leer — die zweite von der Spec genannte Form)
+    und kein `metric_alert_levels`.
+
+    THEN bleibt eine `cape`-Regel bestehen.
+
+    GUARD gegen den VERWORFENEN Loesungsweg: haette der Fix im `None`-Fall ein
+    voll-aktiviertes `display_config` erzeugt, griffe der #961-Filter, und
+    `is_alert_metric_active()` fuehrt CAPE seit #1585 (`selectable=False`) NIE
+    als aktiv -> 14 Regeln wuerden zu 13, CAPE waere still (M6).
+    """
+    config = _eval_config({"active_metrics": None})
+    namen = _namen(_regeln(config))
+
+    assert config.display_config is None, (
+        "Fehlendes `active_metrics` muss weiterhin `display_config=None` "
+        "ergeben — sonst greift der #961-Filter und schaltet CAPE stumm "
+        f"(verworfener Loesungsweg M6). Erhalten: {config.display_config!r}"
+    )
+    assert "cape" in namen, (
+        f"Die CAPE-Regel ist verschwunden. Erzeugt wurden: {namen!r}"
+    )
+
+
+def test_cape_rule_survives_missing_active_metrics_with_levels_set():
+    """AC-6 (RED, zweite Haelfte) GIVEN dasselbe fehlende `active_metrics`,
+    diesmal MIT gesetztem `metric_alert_levels` (ohne CAPE-Eintrag).
+
+    THEN enthaelt die Regelmenge trotzdem eine `cape`-Regel.
+
+    RED heute: das gesetzte `metric_alert_levels` verdraengt den Standard-Satz
+    vollstaendig -> nur die 3 dort genannten Groessen bekommen eine Regel,
+    CAPE ist still. Die Spec verlangt CAPE ausdruecklich "sowohl mit als auch
+    ohne gesetztes `metric_alert_levels`".
+    """
+    config = _eval_config({"metric_alert_levels": dict(LEVELS_OHNE_ONSET)})
+    namen = _namen(_regeln(config))
+
+    assert "cape" in namen, (
+        "Bei gesetztem `metric_alert_levels` ohne `active_metrics` verschwindet "
+        f"die CAPE-Regel. Erzeugt wurden {len(namen)} Regeln: {namen!r}"
+    )
+
+
+# ══════════════════════════════ AC-7 (RED) ═══════════════════════════════════
+
+def test_explicit_off_survives_standard_levels_merge():
+    """AC-7 (RED) GIVEN ein Preset ohne `active_metrics`, dessen
+    `metric_alert_levels` `wind_gust` ausdruecklich auf `"off"` setzt und
+    `precipitation_sum` auf `"standard"`.
+
+    THEN entstehen 13 Regeln: der Standard-Satz ergaenzt die fehlenden
+    Groessen (Beginn-Groessen, CAPE), `wind_gust` bleibt aber ABGEWAEHLT.
+
+    RED heute: es entsteht genau 1 Regel (`precipitation_sum`) — die
+    Ergaenzung gibt es noch nicht. Die 13 sind gemessen (Spec-Tabelle
+    "Abwahl-Probe"), nicht geraten. Der Test sichert zugleich die
+    Merge-Reihenfolge ab: wuerde spaeter jemand `_STANDARD_METRIC_LEVELS`
+    ZULETZT mergen, kaeme `wind_gust` zurueck und der Test wird rot.
+    """
+    config = _eval_config({"metric_alert_levels": {
+        "wind_gust": "off", "precipitation_sum": "standard",
+    }})
+    namen = _namen(_regeln(config))
+
+    assert "wind_gust" not in namen, (
+        "Die ausdrueckliche Abwahl `wind_gust: 'off'` wurde vom Standard-Satz "
+        f"ueberschrieben — Bevormundung. Erzeugt wurden: {namen!r}"
+    )
+    for metrik in ("thunder_onset", "precipitation_heavy_onset", "cape"):
+        assert metrik in namen, (
+            f"`{metrik}` wurde nicht ergaenzt. Erzeugt wurden "
+            f"{len(namen)} Regeln: {namen!r}"
+        )
+    assert len(namen) == 13, (
+        f"Erwartet 13 Regeln (14 Standard-Groessen minus das abgewaehlte "
+        f"`wind_gust`), erhalten {len(namen)}: {namen!r}"
+    )
+
+
+def test_explicit_off_metric_stays_silent_while_supplemented_metric_fires():
+    """AC-7 (RED) — dieselbe Zusicherung, aber bis zum Alarm durchgefahren.
+
+    GIVEN ein Preset ohne `active_metrics` mit `metric_alert_levels =
+    {fresh_snow: "off", precipitation_sum: "standard"}`.
+
+    WHEN Neuschnee (0 -> 40 cm, Δ=40 weit ueber der Standard-Schwelle 8) und
+    die Nullgradgrenze (2500 -> 1500 m, Δ=1000 > 400) ZEITGLEICH springen.
+
+    THEN meldet nur die vom Fix ERGAENZTE Nullgradgrenze; der ausdruecklich
+    abgewaehlte Neuschnee bleibt still.
+
+    RED heute: heute ist nur `precipitation_sum` scharf, die Nullgradgrenze
+    also ebenfalls still -> die erste Zusicherung schlaegt fehl.
+
+    WARUM NICHT `wind_gust` WIE IN DER SPEC-ILLUSTRATION: `wind_change` deckt
+    laut `_ALERT_DELTA_METRIC_TO_FIELDS` DASSELBE Summary-Feld `gust_max_kmh`
+    ab. Ein Boeen-Sprung meldet daher auch bei `wind_gust: "off"` — ueber die
+    ergaenzte `wind_change`-Regel, nicht ueber eine kaputte Abwahl. Der
+    Nachweis "abgewaehlt bleibt still" braucht deshalb eine Groesse mit
+    EIGENEM Feld; `fresh_snow` (`snow_new_sum_cm`) und `freezing_level`
+    (`freezing_level_m`) sind kollisionsfrei. Die Regelmengen-Zusicherung fuer
+    `wind_gust` steht unveraendert im Test darueber.
+    """
+    config = _eval_config({"metric_alert_levels": {
+        "fresh_snow": "off", "precipitation_sum": "standard",
+    }})
+    gemeldet = _gemeldet(
+        config,
+        alt={"snow_new_sum_cm": 0.0, "freezing_level_m": 2500.0},
+        neu={"snow_new_sum_cm": 40.0, "freezing_level_m": 1500.0},
+    )
+    assert "freezing_level_m" in gemeldet, (
+        "Die vom Standard-Satz ergaenzte Nullgradgrenze meldet nicht "
+        f"(Δ=1000 m > 400 m). Gemeldet wurde: {sorted(gemeldet)!r}"
+    )
+    assert "snow_new_sum_cm" not in gemeldet, (
+        "Der ausdruecklich abgewaehlte Neuschnee (`fresh_snow: 'off'`) meldet "
+        f"trotzdem (Δ=40 cm). Gemeldet wurde: {sorted(gemeldet)!r}"
+    )

--- a/tests/tdd/test_compare_alert_missing_active_metrics_with_levels.py
+++ b/tests/tdd/test_compare_alert_missing_active_metrics_with_levels.py
@@ -133,9 +133,17 @@ def _eval_config(display_config: dict | None):
 
 
 def _regeln(config):
-    """Regelmenge GENAU so gebildet wie in `DeviationAlertEngine._select_detector`."""
+    """Regelmenge GENAU so gebildet wie in `DeviationAlertEngine._select_detector`.
+
+    Alle drei Argumente stammen aus der echten `_build_eval_config`-Ausgabe —
+    inklusive `supplement_missing_levels` (#1971), das der Vergleichs-Pfad setzt
+    und der Trip-Pfad beim Default `False` laesst. Wer diese Zeile von der
+    Produktions-Fassung entkoppelt, misst nicht mehr den Wirkort.
+    """
     return expand_per_metric_levels(
-        config.metric_alert_levels or {}, display_config=config.display_config
+        config.metric_alert_levels or {},
+        display_config=config.display_config,
+        supplement_missing_levels=config.supplement_missing_levels,
     )
 
 
@@ -230,6 +238,69 @@ def test_partial_active_metrics_only_selected_metric_fires():
     )
 
 
+def test_partial_active_metrics_with_partial_levels_keeps_single_watched_field():
+    """AC-3 (GUARD, Feld-Ebene) GIVEN eine Teil-Auswahl
+    `active_metrics=["gust_max_kmh"]` UND ZEITGLEICH ein partielles
+    `metric_alert_levels={"wind_gust": "standard"}` — die Kombination, die im
+    Editor entsteht, sobald der Nutzer sowohl Metriken abwaehlt als auch eine
+    Empfindlichkeitsstufe setzt.
+
+    WHEN der Produktions-Waehler `DeviationAlertEngine._select_detector()`
+    daraus einen Detektor baut.
+
+    THEN bewacht dieser GENAU EIN Summary-Feld: `gust_max_kmh`.
+
+    WARUM ES DEN BESTEHENDEN AC-3-TEST NICHT DOPPELT:
+    `test_partial_active_metrics_only_selected_metric_fires` setzt
+    `active_metrics` OHNE `metric_alert_levels`. Dadurch greift in
+    `CompareAlertService._build_eval_config` (`compare_alert.py:530-533`) der
+    volle `_STANDARD_METRIC_LEVELS`-Rueckfall — alle 14 Metriken stehen dann
+    schon als Schluessel in `levels`, und der #1971-Ergaenzungszweig
+    (`alert_preset.py:408`) findet strukturell nichts mehr zu ergaenzen. Der
+    bestehende Test kann die Regression also gar nicht ausloesen, die er
+    bewachen soll — nicht weil sie unmoeglich waere, sondern weil seine
+    Testdaten sie zufaellig umgehen. Erst ein PARTIELLES
+    `metric_alert_levels` laesst 13 der 14 Metriken offen und macht die
+    Ergaenzung ueberhaupt erreichbar.
+
+    ZU DEN ZAHLEN 1 UND 11 (gemessen, nicht geraten):
+      Ist-Verhalten          1 Feld  ['gust_max_kmh']
+      bei einem Leck        11 Felder ['cape_max_jkg', 'freezing_level_m',
+                                       'gust_max_kmh', 'precip_heavy_onset_utc',
+                                       'precip_sum_mm', 'snow_new_sum_cm',
+                                       'temp_max_c', 'temp_min_c',
+                                       'thunder_level_max', 'thunder_onset_utc',
+                                       'wind_max_kmh']
+    Das Leck entsteht, sobald die #1971-Ergaenzung trotz vorhandenem
+    `display_config` durchschlaegt — also wenn entweder
+    `deviation_alert_engine.py:188-197` `supplement_missing_levels`
+    durchreicht oder `alert_preset.py:408` seine `display_config is None`-
+    Bedingung verliert. Dann ergaenzt der Standard-Satz die 13 nicht
+    genannten Metriken; nur die vom expliziten `wind_gust`-Eintrag belegten
+    Felder bleiben verschont. Die Abwahl des Nutzers waere damit
+    unterwandert — Bevormundung, die AC-3 ausdruecklich ausschliesst.
+
+    PRUEFORT = WIRKORT: geprueft werden die Schwellen des fertigen Detektors
+    (`_thresholds`), nicht die Regelmenge davor — die Explosion zeigt sich
+    erst dort, wo die Regeln zu bewachten Feldern werden.
+    """
+    config = _eval_config({
+        "active_metrics": ["gust_max_kmh"],
+        "metric_alert_levels": {"wind_gust": "standard"},
+    })
+    detektor = DeviationAlertEngine._select_detector(config)
+    bewacht = sorted(detektor._thresholds)
+
+    assert bewacht == ["gust_max_kmh"], (
+        "Teil-Auswahl `active_metrics=['gust_max_kmh']` mit partiellem "
+        "`metric_alert_levels={'wind_gust': 'standard'}`: der Detektor "
+        f"bewacht {len(bewacht)} Felder statt genau eines — {bewacht!r}. Die "
+        "#1971-Ergaenzung (alert_preset.py:408) hat trotz vorhandenem "
+        "`display_config` durchgeschlagen und die Abwahl des Nutzers "
+        "unterwandert (AC-3: 'die Teil-Auswahl bleibt vom Fix unberuehrt')."
+    )
+
+
 # ══════════════════════════════ AC-4 (GUARD) ═════════════════════════════════
 
 def test_legacy_preset_without_levels_unchanged_rule_count():
@@ -309,14 +380,26 @@ def test_explicit_off_survives_standard_levels_merge():
     `metric_alert_levels` `wind_gust` ausdruecklich auf `"off"` setzt und
     `precipitation_sum` auf `"standard"`.
 
-    THEN entstehen 13 Regeln: der Standard-Satz ergaenzt die fehlenden
+    THEN entstehen 12 Regeln: der Standard-Satz ergaenzt die fehlenden
     Groessen (Beginn-Groessen, CAPE), `wind_gust` bleibt aber ABGEWAEHLT.
 
     RED heute: es entsteht genau 1 Regel (`precipitation_sum`) — die
-    Ergaenzung gibt es noch nicht. Die 13 sind gemessen (Spec-Tabelle
-    "Abwahl-Probe"), nicht geraten. Der Test sichert zugleich die
-    Merge-Reihenfolge ab: wuerde spaeter jemand `_STANDARD_METRIC_LEVELS`
-    ZULETZT mergen, kaeme `wind_gust` zurueck und der Test wird rot.
+    Ergaenzung gibt es noch nicht. Der Test sichert zugleich die Rangfolge ab:
+    wuerde spaeter jemand den Standard-Satz die expliziten Eintraege
+    ueberschreiben lassen, kaeme `wind_gust` zurueck und der Test wird rot.
+
+    ZUR ZAHL 12 (Phase 5, Team-Lead-Vorgabe M9): Die Spec-Tabelle nannte 13 —
+    gemessen am spaeter VERWORFENEN Dict-Merge in `_build_eval_config`, der
+    ergaenzte und explizite Eintraege ununterscheidbar macht. Der umgesetzte
+    Weg ergaenzt in `expand_per_metric_levels` und nimmt dabei den bestehenden
+    Feld-Schutz (`claimed_fields`) mit: `precipitation_change` belegt allein
+    `precip_sum_mm`, das der explizite `precipitation_sum`-Eintrag bereits
+    beansprucht — die Regel entfaellt deshalb komplett (dieselbe Regel wie im
+    `display_config`-Zweig, `alert_preset.py:379-380`). Ohne diesen Schutz
+    ueberschriebe die ergaenzte `standard`-Schwelle (7 mm) eine bewusst
+    gesetzte `entspannt`-Schwelle (20 mm) auf demselben Feld — genau das
+    verbietet `test_issue_1170_compare_alert_config.py::
+    test_ac5_stored_entspannt_level_makes_alert_less_sensitive`.
     """
     config = _eval_config({"metric_alert_levels": {
         "wind_gust": "off", "precipitation_sum": "standard",
@@ -332,9 +415,16 @@ def test_explicit_off_survives_standard_levels_merge():
             f"`{metrik}` wurde nicht ergaenzt. Erzeugt wurden "
             f"{len(namen)} Regeln: {namen!r}"
         )
-    assert len(namen) == 13, (
-        f"Erwartet 13 Regeln (14 Standard-Groessen minus das abgewaehlte "
-        f"`wind_gust`), erhalten {len(namen)}: {namen!r}"
+    assert "precipitation_change" not in namen, (
+        "`precipitation_change` wurde ergaenzt, obwohl sein einziges Feld "
+        "`precip_sum_mm` bereits vom expliziten `precipitation_sum`-Eintrag "
+        "belegt ist — die ergaenzte Standard-Schwelle wuerde die bewusst "
+        f"gesetzte ueberschreiben (#1170 AC-5). Erzeugt wurden: {namen!r}"
+    )
+    assert len(namen) == 12, (
+        f"Erwartet 12 Regeln (14 Standard-Groessen minus das abgewaehlte "
+        f"`wind_gust` minus das feld-belegte `precipitation_change`), "
+        f"erhalten {len(namen)}: {namen!r}"
     )
 
 

--- a/tests/tdd/test_compare_alert_missing_active_metrics_with_levels.py
+++ b/tests/tdd/test_compare_alert_missing_active_metrics_with_levels.py
@@ -24,8 +24,17 @@ PRUEFORT = WIRKORT. Gefahren wird die echte Kette
 RED (neues Verhalten, schlaegt HEUTE fehl):
   - test_onset_alarm_fires_without_active_metrics_key                (AC-1)
   - test_cape_rule_survives_missing_active_metrics_with_levels_set   (AC-6, zweite Haelfte)
-  - test_explicit_off_survives_standard_levels_merge                 (AC-7)
-  - test_explicit_off_metric_stays_silent_while_supplemented_metric_fires (AC-7)
+  - test_explicit_off_survives_standard_levels_merge                 (AC-7, Regel-Ebene)
+  - test_explicit_off_wind_gust_stays_silent_while_supplemented_metric_fires
+                                                                     (AC-7, Feld-Ebene)
+  - test_explicit_off_collision_free_metric_stays_silent             (AC-7, Gegenbeleg)
+
+Der `wind_gust`-Test der Feld-Ebene bleibt auch nach einem reinen
+Level-Merge rot: die nachgefuellte `wind_change`-Regel deckt dasselbe
+Summary-Feld `gust_max_kmh` ab. Das ist Absicht — er bewacht, dass das
+Nachfuellen den bestehenden Feld-Schutz (`claimed_fields`, alert_preset.py)
+in den `display_config is None`-Zweig mitnimmt, statt die Abwahl des Nutzers
+zu unterwandern.
 
 GUARD (bestehendes Verhalten, HEUTE schon gruen, darf nicht kippen):
   - test_partial_active_metrics_only_selected_metric_fires           (AC-3)
@@ -329,29 +338,81 @@ def test_explicit_off_survives_standard_levels_merge():
     )
 
 
-def test_explicit_off_metric_stays_silent_while_supplemented_metric_fires():
-    """AC-7 (RED) — dieselbe Zusicherung, aber bis zum Alarm durchgefahren.
+def test_explicit_off_wind_gust_stays_silent_while_supplemented_metric_fires():
+    """AC-7 (RED) — der Fall, der in der Praxis vorkommt, bis zum Alarm
+    durchgefahren.
 
     GIVEN ein Preset ohne `active_metrics` mit `metric_alert_levels =
-    {fresh_snow: "off", precipitation_sum: "standard"}`.
+    {wind_gust: "off", precipitation_sum: "standard"}`.
+
+    WHEN die Boeen (20 -> 60 km/h) und die Nullgradgrenze (2500 -> 1500 m,
+    Δ=1000 > 400) ZEITGLEICH springen.
+
+    THEN meldet nur die vom Fix ERGAENZTE Nullgradgrenze; die ausdruecklich
+    abgewaehlten Boeen bleiben still.
+
+    ROT UND ROT BLEIBEND — dieser Test bewacht die FELD-Ebene, nicht die
+    Regel-Ebene. Gemessen:
+
+        HEUTE               1 Regel   | gust_max_kmh bewacht: None
+                                      | gemeldet: []
+        NAIVER LEVEL-MERGE  13 Regeln | gust_max_kmh bewacht: 25.0
+                                      | gemeldet: ['freezing_level_m',
+                                                   'gust_max_kmh']
+
+    Heute faellt er ueber die Nullgradgrenze (nichts ist ergaenzt). Ein
+    blosser `{**_STANDARD_METRIC_LEVELS, **levels}`-Merge macht ihn NICHT
+    gruen, sondern verschiebt den Fehlschlag auf die zweite Zusicherung: die
+    nachgefuellte `wind_change`-Regel deckt laut
+    `_ALERT_DELTA_METRIC_TO_FIELDS` (`weather_change_detection.py:74`)
+    DASSELBE Summary-Feld `gust_max_kmh` ab und stellt es mit 25.0 wieder
+    scharf — die Abwahl des Nutzers waere unterwandert, obwohl die Regelmenge
+    (Test darueber) richtig aussieht.
+
+    Gruen wird er erst, wenn das Nachfuellen den bereits vorhandenen
+    Feld-Schutz mitbenutzt: `claimed_fields`/`suppressed_fields`
+    (`alert_preset.py:347-358`) schuetzen die Felder ausdruecklich gesetzter
+    Metriken — bisher nur im Zweig `display_config is not None`.
+    """
+    config = _eval_config({"metric_alert_levels": {
+        "wind_gust": "off", "precipitation_sum": "standard",
+    }})
+    gemeldet = _gemeldet(
+        config,
+        alt={"gust_max_kmh": 20.0, "freezing_level_m": 2500.0},
+        neu={"gust_max_kmh": 60.0, "freezing_level_m": 1500.0},
+    )
+    assert "freezing_level_m" in gemeldet, (
+        "Die vom Standard-Satz ergaenzte Nullgradgrenze meldet nicht "
+        f"(Δ=1000 m > 400 m). Gemeldet wurde: {sorted(gemeldet)!r}"
+    )
+    assert "gust_max_kmh" not in gemeldet, (
+        "Die ausdruecklich abgewaehlten Boeen (`wind_gust: 'off'`) melden "
+        f"trotzdem (Δ=40 km/h). Gemeldet wurde: {sorted(gemeldet)!r} — die "
+        "nachgefuellte `wind_change`-Regel deckt dasselbe Summary-Feld "
+        "`gust_max_kmh` ab und unterwandert die Abwahl. Der Feld-Schutz "
+        "(`claimed_fields`/`suppressed_fields`, alert_preset.py:347-358) "
+        "greift im Zweig `display_config is None` noch nicht."
+    )
+
+
+def test_explicit_off_collision_free_metric_stays_silent():
+    """AC-7 (RED, kollisionsfreier Gegenbeleg) — dieselbe Zusicherung mit
+    einer Groesse, deren Summary-Feld KEINE zweite Metrik teilt.
+
+    GIVEN `metric_alert_levels = {fresh_snow: "off", precipitation_sum:
+    "standard"}` ohne `active_metrics`.
 
     WHEN Neuschnee (0 -> 40 cm, Δ=40 weit ueber der Standard-Schwelle 8) und
-    die Nullgradgrenze (2500 -> 1500 m, Δ=1000 > 400) ZEITGLEICH springen.
+    die Nullgradgrenze (2500 -> 1500 m) ZEITGLEICH springen.
 
-    THEN meldet nur die vom Fix ERGAENZTE Nullgradgrenze; der ausdruecklich
-    abgewaehlte Neuschnee bleibt still.
+    THEN meldet nur die ergaenzte Nullgradgrenze.
 
-    RED heute: heute ist nur `precipitation_sum` scharf, die Nullgradgrenze
-    also ebenfalls still -> die erste Zusicherung schlaegt fehl.
-
-    WARUM NICHT `wind_gust` WIE IN DER SPEC-ILLUSTRATION: `wind_change` deckt
-    laut `_ALERT_DELTA_METRIC_TO_FIELDS` DASSELBE Summary-Feld `gust_max_kmh`
-    ab. Ein Boeen-Sprung meldet daher auch bei `wind_gust: "off"` — ueber die
-    ergaenzte `wind_change`-Regel, nicht ueber eine kaputte Abwahl. Der
-    Nachweis "abgewaehlt bleibt still" braucht deshalb eine Groesse mit
-    EIGENEM Feld; `fresh_snow` (`snow_new_sum_cm`) und `freezing_level`
-    (`freezing_level_m`) sind kollisionsfrei. Die Regelmengen-Zusicherung fuer
-    `wind_gust` steht unveraendert im Test darueber.
+    Er ERSETZT den `wind_gust`-Test oben NICHT, sondern trennt zwei Ursachen:
+    `fresh_snow` haengt allein an `snow_new_sum_cm`, `freezing_level` allein
+    an `freezing_level_m`. Bleibt dieser Test rot, waehrend der obere gruen
+    ist, liegt es an der Ergaenzung selbst; bleibt nur der obere rot, liegt es
+    ausschliesslich an der Feld-Kollision `wind_change` ⊃ `gust_max_kmh`.
     """
     config = _eval_config({"metric_alert_levels": {
         "fresh_snow": "off", "precipitation_sum": "standard",


### PR DESCRIPTION
## Problem

Fehlt `display_config.active_metrics` (Schlüssel absent oder `None`), blieb im Ortsvergleich jede Metrik still, die `metric_alert_levels` nicht namentlich auflistet — der #961-Backfill sitzt hinter `if display_config is not None` und war in diesem Fall übersprungen. Betroffen vor allem die Beginn-Alarme aus #1468 (Gewitter-/Starkregenbeginn).

Produktionsbestand aktuell **0 betroffene Presets**, der Zustand kann über den Compare-Editor aber jederzeit neu entstehen (Spec, M5).

## Lösung

`expand_per_metric_levels()` ergänzt im `display_config is None`-Zweig fehlende `_PRESET_TABLE`-Metriken auf `standard`, aktiviert über den neuen Parameter `supplement_missing_levels`. Gesetzt wird er **allein** vom Vergleichs-Pfad; der Trip-Pfad lässt den Default `False`.

**Der in der Spec ursprünglich festgeschriebene Weg (Dict-Merge in `_build_eval_config`) wurde verworfen** — Befund M9 aus der RED-Phase: Nach dem Merge sind ergänzte und ausdrücklich gesetzte Einträge ununterscheidbar, der `claimed_fields`-Schutz fällt aus. `wind_gust: "off"` wäre zwar aus der Regelmenge verschwunden, `gust_max_kmh` aber über `wind_change` **neu** bewacht worden (`None` → `25.0`). Ein Fix, der selbst einen stillen Fehler einführt, ist nicht lieferbar. Die Spec ist auf den tatsächlichen Weg nachgezogen; die 7 ACs sind unverändert.

## Nachweise

| | |
|---|---|
| Adversary | **VERIFIED**, 3 Runden, 6 Mutationen (3 gefangen, 3 als Findings gemeldet) |
| Gezielte Strecke | 41 passed (inkl. Trip-Regressionsschutz), nach Rebase erneut grün |
| Volllauf | 10237 Tests, 10121 passed |
| Wirkort-Messung | `gust_max_kmh` bleibt bei `wind_gust: "off"` unbewacht; Positivkontrolle ohne Abwahl zeigt 20.0 |
| Trip-Pfad | Default `False`, per Mutation belegt (Default auf `True` dreht `TestAlertOnChangesConfig` rot) |

Die 1 failed + 3 errors im Volllauf sind vorbestehende Volllauf-Interferenz (isoliert alle grün, kein Bezug zu den geänderten Dateien) — gebucht in #1196.

## Findings

- **F002** (Spec-Prosa beschrieb den verworfenen Weg) — behoben
- **F003** (AC-3-Kombination Teil-`active_metrics` + partielles `metric_alert_levels` ungetestet) — behoben, Zusatztest mit Rot-Nachweis per Doppel-Mutation
- **F001** (redundanter Guard, LOW) — gebucht in #1199

## Bekannte Einschränkung

Abwahlen im Summary-Key-Vokabular (`temp_max_c: "off"` statt `temperature_max`) waren schon bisher wirkungslos und werden durch die Ergänzung sichtbarer. Betrifft nur Presets ohne `active_metrics` — davon existiert in Produktion keines. Separat als #1981 geführt.

Refs #1971

🤖 Generated with [Claude Code](https://claude.com/claude-code)
