### PR TITLE
fix(#1948 S4): Nowcast-SMS nennt Zeitpunkt statt Countdown

### DIFF
--- a/docs/context/fix-1948-s4-nowcast-sms.md
+++ b/docs/context/fix-1948-s4-nowcast-sms.md
@@ -72,6 +72,9 @@ S3 hat #1744 AC-5 für Zweig a genauso abgelöst) — oder das Zielbild ist so n
 
 ## Offene Entscheidungsfragen für die Spec
 
+> **Stand Phase 2: alle beantwortet** — siehe PO-Entscheide-Tabelle im Analysis-Teil unten.
+> Der Zielkonflikt oben ist entschieden: der Test wird dokumentiert abgelöst.
+
 1. **Zieht der Regen-Zweig mit?** Konzept nennt nur `TH@15:40`. Ob `R!{min}` ebenfalls auf
    `R@{onset_time}` wechselt, ist nirgends entschieden. Bestimmt, wie viele Tests rot werden.
 2. **Compare-Onset mit genau EINEM Ort nennt den Ort heute gar nicht.** `location_label` bleibt
@@ -124,3 +127,102 @@ Einspeiseweg (S2), erprobt und deterministisch im Kern-Testlauf:
 `POST /api/trips/{trip_id}/alert-preview?user_id=…` mit `{"nowcast_frames": {source, frames[], km_from, km_to}}`
 → Antwort trägt `onset_detected` und das gerenderte `sms`. Der Replay nutzt dasselbe
 `_derive_result` wie der Live-Pfad, keinen Test-Sonderweg.
+
+---
+
+# Analysis (Phase 2)
+
+### Type
+Feature (Format-Konsolidierung innerhalb Epic #1948)
+
+### PO-Entscheide — verbindlich
+
+| # | Frage | Entscheid |
+|---|---|---|
+| 1 | Zieht der Regen-Zweig mit? | **Ja** — `R!{min}` → `R@{onset_time}`, gleiches Muster wie Gewitter |
+| 2 | Segment-Sprache im Kopf? | **Ja** — Zielbild `Ziel: TH@15:40`; `test_kurznachricht_des_nowcasts_nennt_keinen_ort` wird dokumentiert abgelöst |
+| 3 | Ortsvergleich mitheilen? | **Ja**, beide Fälle |
+| 3a | Ein-Ort-Compare (Sonderfall nötig) | **Ja, in S4 mitbauen** — trotz Empfehlung „eigenes Ticket"; PO wählte bewusst |
+| 3b | `+N`-Zähler bei mehreren Orten | **Nein** — die Nachricht wertet nur den führenden Ort aus; ein Zähler verspräche Vollständigkeit, die sie nicht einlöst |
+
+### Technical Approach
+
+Neuer Funktionskörper (`render.py:422`), Muster übernommen vom Trip-Δ-Kopf (`render.py:916`):
+
+```python
+token = f"TH@{e.onset_time}" if e.is_convective else f"R@{e.onset_time}"
+head = _ascii_alert_location(_location_of((e,), _onset_label(msg, e)))
+body = f"{head}: {token}"
+```
+
+Begründung der Bausteinwahl:
+- **Nicht** `_km_str_onset(e)` — die unterdrückt `location_label` absichtlich und wird von
+  Telegram/Betreff mitbenutzt (`render.py:416`, `render.py:284`); eine Änderung dort würde
+  ungefragt zwei weitere Kanäle verändern.
+- **Nicht** `_km_str(msg)` — liest `msg.location_label`, das für Onset-Nachrichten von **keinem**
+  Konstruktor je gesetzt wird und damit strukturell immer `None` ist.
+- Ein **lokaler** `_location_of((e,), <label>)`-Aufruf lässt die geteilten Bausteine unangetastet.
+
+### 🔴 Der Ein-Ort-Compare-Sonderfall (PO-Entscheid 3a)
+
+Belegte Ursache: `to_multi_location_onset_alert_message` setzt `location_label` nur bei mehr als
+einem Ort (`project.py:387`, `location_label=location_name if multi else None`); die Invariante ist
+explizit getestet (`test_multi_location_onset_alert.py:351`). Bei genau einem Ort steht der
+Ortsname ausschließlich in `msg.trip_short` (`project.py:392-393`), und `km_from=km_to=0.0`.
+
+Die nötige Fallunterscheidung hängt am Marker `msg.source == "compare-radar"` (`project.py:397`) —
+heute ein Freitext ohne Vertrag. **Härtung statt Hinnahme:** Der Marker wird zu einer benannten
+Konstante (z.B. `COMPARE_RADAR_SOURCE`) angehoben und an Setz- wie Lesestelle darüber referenziert.
+Damit bricht ein Umbenennen sichtbar, statt die Ortsanzeige still auf `km 0–0` zurückfallen zu
+lassen. Ein Wächter-Test muss genau diese stille Rückfall-Situation abdecken.
+
+### Gemessen, nicht vermutet
+
+**Zeichensatz — kein UCS-2-Risiko.** `_ascii_alert_location` (`render.py:989-992`) ruft
+`_strip_pictographs` (entfernt Unicode-Kategorie `So`) **vor** `fold_ascii`:
+
+```
+format_alert_location(None, ['Ziel'], 8, 8)  →  '🏁 Ziel'
+_ascii(...)                                  →  ':checkered_flag: Ziel'   ← falsch, nicht nutzen
+_ascii_alert_location(...)                   →  'Ziel'                    ← richtig
+```
+
+Der Unterschied ist der Grund, warum `_ascii_alert_location` als eigene Funktion existiert. Ein
+Charset-Problem entstünde nur durch Verwechslung der beiden — das gehört als Mutations-Kandidat
+in die Adversary-Runde.
+
+**Längen-Budget — unkritisch** (Limit 140, harter Endschnitt `body[:limit]`):
+
+| Szenario | alt | neu | Δ |
+|---|---|---|---|
+| Trip mit Segmentnamen | `km8-8: TH!8` (11) | `Ziel: TH@15:40` (14) | +3 |
+| Trip, km-Rückfall | `km5-18: R!12` (12) | `km 5-18: R@14:35` (16) | +4 |
+| Compare, kurzer Ortsname | `Vergleich km5-18: R!12` (22) | `Vergleich: R@14:08` (18) | **−4** |
+| Compare, 35-Zeichen-Ortsname | (Name auf 16 gekappt, 27) | **ungekappt** (45) | +18 |
+
+Geerbtes Restrisiko: `format_alert_location` Stufe 1 kappt den Ortsnamen **nicht** — der Trip-Δ-Pfad
+hat dieselbe Lücke (`render.py:916`). Wird nicht in S4 gelöst, aber in der Spec benannt.
+
+### Scope Assessment
+
+- Dateien: 1 Produktivdatei (+1 für die Marker-Konstante) + 8 Testdateien
+- Geschätzte LoC: ~30–40 Produktiv, ~90–130 Test → **~120–170**, unter dem Limit 250
+- Risk Level: **MEDIUM** — Kernlogik eines kritischen Nutzerpfads, aber eng umgrenzte Funktion
+
+Zwei Posten mit echter Schätzunsicherheit: `test_alert_sms_location_positions.py` und
+`test_alert_preview_nowcast_replay.py` prüfen künftig einen **wanduhr-abhängigen** Wert
+(`onset_time` statt Countdown-Minuten) und brauchen Zeitfenster-Toleranz statt Goldstring.
+
+### Reihenfolge
+
+1. TDD-RED gebündelt in **einem** neuen Testmodul (neue Zusicherung: `TH@`/`R@`-Form,
+   Segment-Kopf, GSM-7-Reinheit, Ein-Ort-Compare nennt den Ort)
+2. `_render_sms_onset` + Marker-Konstante implementieren
+3. Bestandstests fortschreiben, aufsteigend nach Komplexität: statische Goldstrings zuerst
+   (`test_issue_919…`, `test_multi_location_onset_alert`, `test_952…`), dann der Pendant-Wächter
+   `test_alert_sms_segment_head.py` AC-12 (**Differenzlogik erhalten, nicht nur Strings tauschen**),
+   dann die beiden zeitabhängigen, zuletzt die bewusste Ablösung in
+   `test_alert_location_vocabulary.py:573` mit Begründung im Docstring.
+
+### Open Questions
+- keine offen — alle fünf Entscheidungsfragen sind PO-beantwortet (Tabelle oben).

--- a/docs/context/fix-1948-s4-nowcast-sms.md
+++ b/docs/context/fix-1948-s4-nowcast-sms.md
@@ -1,0 +1,126 @@
+# Context: #1948 Scheibe S4 — Zweig-c-Zielbild (Nowcast/Onset-SMS)
+
+**Workflow:** `fix-1948-s4-nowcast-sms` · **Issue:** #1948 · **Track:** Full Process (Score 4)
+**Erstellt:** 2026-08-19
+
+## Request Summary
+
+Die Nowcast-/Onset-Kurznachricht (Zweig c) soll auf das einheitliche Alarm-Format nachziehen:
+Kopf über die gemeinsame Ortsauflösung statt selbstgebautem `km{a}-{b}:`, und Token von
+`TH!{onset_minutes}` (Countdown) auf `TH@{onset_time}` (konkrete Uhrzeit). PO-Zielbild aus
+Konzept v3 Abschnitt 1: **`Ziel: TH@15:40`** — heute lautet dieselbe Nachricht `km8-8: TH!8`.
+
+## Ist-Zustand (belegt)
+
+`src/output/renderers/alert/render.py:422-438` (`_render_sms_onset`) nutzt **weder** `_km_str`
+**noch** `_km_str_onset` **noch** `format_alert_location` — der Kopf ist hand-verdrahtet:
+
+```python
+token = f"TH!{e.onset_minutes}" if e.is_convective else f"R!{e.onset_minutes}"
+a, b = int(round(e.km_from)), int(round(e.km_to))
+if getattr(e, "location_label", None):
+    body = f"{trip} km{a}-{b}: {token}"     # Compare, >1 Ort
+else:
+    body = f"km{a}-{b}: {token}"            # Trip UND Compare mit genau 1 Ort
+```
+
+Schreibweise weicht vom gemeinsamen Kopf ab: `km8-8` (kein Leerzeichen, ASCII-Bindestrich) vs.
+`km 8–8` (Leerzeichen, En-Dash) aus `format_alert_location` (`segments.py:101`).
+
+Vorbild für den Zielzustand ist der Trip-Δ-Kopf in `render_sms` (`render.py:910-916`):
+`head = f"{_ascii_alert_location(_km_str(msg))}: "`.
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `src/output/renderers/alert/render.py:422` | `_render_sms_onset` — **die** zu ändernde Funktion |
+| `src/output/renderers/alert/render.py:129-170` | `_location_of`, `_km_str`, `_km_str_onset` — die Kopf-Bausteine |
+| `src/output/renderers/alert/segments.py:91` | `format_alert_location` — Auflösungsreihenfolge label → Segment → km |
+| `src/output/renderers/alert/model.py:36-51` | `OnsetEvent` — `onset_time` (`str`, nie `None`), `onset_minutes`, `segment_id`, `location_label` |
+| `src/output/renderers/alert/project.py:319-398` | `to_multi_location_onset_alert_message` — setzt `location_label` nur bei >1 Ort |
+| `src/services/notification_service.py:1373` | einziger Produktiv-Aufruf `render_sms`, Ergebnis geht an SMS **und** Premium-SMS |
+| `src/services/validator_render_service.py:217-259` | `_render_nowcast_replay` — S2-Einspeiseweg, nutzt echtes `_derive_result` |
+
+## Dependencies
+
+- **Upstream:** `OnsetEvent.onset_time` wird lokal-ortszeitlich als `"HH:MM"` befüllt
+  (`trip_alert.py:1274`, `project.py:382`), Typ `str`, kein `None`-Fall im Produktivcode.
+- **Downstream:** ein einziges Rendering bedient **beide** Kurzkanäle — `limit=140` gilt für
+  SMS und Premium-SMS gemeinsam (`notification_service.py:1543/1558`), kein eigener Grenzwert
+  für Premium-SMS. Kürzung ist ein harter Endschnitt `body[:limit]`, keine Token-Priorisierung.
+
+## Existing Specs
+
+- `docs/specs/modules/fix_1948_s3_sms_sofortfix.md` — direkte Vorlage (Zweig a). Dessen **AC-7**
+  sichert ausdrücklich zu, dass `_render_sms_onset` byte-identisch bleibt; genau diese Zusicherung
+  läuft mit S4 planmäßig aus.
+- `docs/specs/modules/alarm_testeinspeisung.md` — S2-Einspeiseweg (`nowcast_frames`-Payload)
+- `docs/specs/modules/alarm_eingangsprotokoll.md` — S1-Mitschnitt
+
+## 🔴 Zielkonflikt — muss die Spec entscheiden
+
+`tests/tdd/test_alert_location_vocabulary.py:573-585`
+(`test_kurznachricht_des_nowcasts_nennt_keinen_ort`) fordert heute wörtlich das **Gegenteil** des
+Zielbilds: `"Segment" not in sms`, `"Ziel" not in sms`, `"🏁" not in sms`, und `re.search(r"km\d", sms)`
+**muss** matchen. Docstring: *„der Betreff wechselt auf '🏁 Ziel', die Kurznachricht bleibt bei 'km8-8'."*
+
+Das PO-Zielbild `Ziel: TH@15:40` ist genau die Segment-Sprache, die dieser Test verbietet. Sobald
+`_render_sms_onset` über `format_alert_location` geht und das Event eine `segment_id` trägt, löst
+der Kopf zu `🏁 Ziel` auf statt zu `km 8–8`. Entweder wird der Test bewusst abgelöst (Präzedenz:
+S3 hat #1744 AC-5 für Zweig a genauso abgelöst) — oder das Zielbild ist so nicht umsetzbar.
+
+## Offene Entscheidungsfragen für die Spec
+
+1. **Zieht der Regen-Zweig mit?** Konzept nennt nur `TH@15:40`. Ob `R!{min}` ebenfalls auf
+   `R@{onset_time}` wechselt, ist nirgends entschieden. Bestimmt, wie viele Tests rot werden.
+2. **Compare-Onset mit genau EINEM Ort nennt den Ort heute gar nicht.** `location_label` bleibt
+   per Invariante `None` (`project.py:378`), `km_from=km_to=0.0` → SMS lautet `km0-0: R!25`; der
+   Ortsname steht ungenutzt in `msg.trip_short`. Heilt S4 das mit (`format_alert_location` Stufe 1),
+   oder bleibt der Ortsvergleich byte-identisch?
+3. **Doppelpunkt-Form:** Leitsatz sagt „ein Gewitter heißt in allen drei Zweigen `TH:`", das
+   Zielbild für Zweig c schreibt `TH@15:40` ohne Doppelpunkt. Bei c folgt kein Stufenwert.
+
+## Risks & Considerations
+
+- **7 bestehende Tests werden rot** und müssen fortgeschrieben werden (nicht gelöscht):
+  `test_multi_location_onset_alert.py:262` (Goldstring `km5-18: R!12`) ·
+  `test_issue_919_radar_alert_canonical.py:143-165` (`R!12`/`TH!8`) ·
+  `test_952_onset_alert_fidelity.py:336` (Regex `km(\d+)-(\d+)` bricht am Leerzeichen) ·
+  `test_alert_sms_segment_head.py:194-227` (AC-12, **zugleich Pendant-Wächter**) ·
+  `test_alert_sms_location_positions.py:934/960` (2× Versandpfad, Marker `live`) ·
+  `test_alert_preview_nowcast_replay.py:105` (Regex `R!(\d+)` + Minuten-Semantik) ·
+  `test_alert_location_vocabulary.py:573` (der Zielkonflikt oben).
+- **Pendant-Wächter erhalten:** `test_ac12_...` vergleicht Trip- und Compare-Ergebnis
+  gegeneinander. Er darf auf das neue Format umgestellt werden, aber die Differenzlogik
+  (Compare behält den Namen, Trip nicht) muss als Vergleich bestehen bleiben.
+- **Leitplanke #1599 ist präventiv, nicht scharf** (Korrektur zur Intake-Annahme): Der
+  Alarm-Renderer importiert `app.day_window` **nicht**; `display_end_time()` liegt außerhalb der
+  Aufrufkette, und `onset_time` entsteht als reine Uhrzeit-Arithmetik in `radar_service.py:274`.
+  Die Regel bleibt trotzdem als Nicht-Berührungs-Nachweis in der Spec stehen.
+- **AC-4-Bedenken entschärft** (Korrektur zur Intake-Annahme): Der Kommentar an `_km_str_onset`
+  nennt nur „AC-4", nicht #1170/#1467, und betrifft den **Telegram**-Pfad. `_km_str_onset` nimmt
+  `location_label` gar nicht entgegen — eine Wiederverwendung im SMS-Kopf bricht die Zusicherung
+  nicht. Das reale Risiko liegt bei `segment_id` (Zielkonflikt oben).
+- **AC-10 (#1935/#1779) hat keinen eigenen Test** — nur indirekt über die Regressionstests
+  mitgeprüft. Lückenbefund, gehört nach #1196/#1199, nicht in diese Scheibe.
+
+## Verifikation nach Konzept-Leitprinzip — Grenze belegt
+
+Echte S1-Zweig-c-Mitschnitte existieren auf dem Server (nicht im Repo, `data/` ist ungetrackt):
+
+| Ablage | Aufzeichnungen | mit Regen ≥0,1 mm/h | mit konvektivem Frame | Maximum |
+|---|---|---|---|---|
+| Prod `/var/lib/gregor/debug/alert_input/nowcast/` | 50 (INCA, 46.5641/13.4792 = KHW) | 14 | **0** | 2,8 mm/h |
+| Staging `/var/lib/gregor-staging/…` | 6 (AROME-FR, INCA, radar) | 3 | **0** | 9,2 mm/h |
+
+**Folge:** Der Regen-Pfad ist mit echten Meldungen verifizierbar. Der Gewitter-Pfad — also genau
+das Zielbild `TH@15:40` — ist es **nicht**, weil in keiner der 56 Aufzeichnungen ein konvektiver
+Frame steckt. Für Gewitter bleibt eine abgeleitete Variante (echte Frames, `is_convective` gesetzt)
+plus Unit-Test. Das gehört als Grenze in die Spec, statt später als „mit echten Daten verifiziert"
+verbucht zu werden.
+
+Einspeiseweg (S2), erprobt und deterministisch im Kern-Testlauf:
+`POST /api/trips/{trip_id}/alert-preview?user_id=…` mit `{"nowcast_frames": {source, frames[], km_from, km_to}}`
+→ Antwort trägt `onset_detected` und das gerenderte `sms`. Der Replay nutzt dasselbe
+`_derive_result` wie der Live-Pfad, keinen Test-Sonderweg.

--- a/docs/features/architecture.md
+++ b/docs/features/architecture.md
@@ -387,7 +387,9 @@ Scheibe 3 (#1170). Scheduler: `POST /api/scheduler/compare-alert-checks`, Go-Cro
        2026-08-13 noch die km-Spanne)
      - `render_email(msg)` — HTML + Plain mit Onset-Uhrzeit, Intensity-Label, Quellenangabe, Cooldown-Block
      - `render_telegram(msg)` — Fettzeile + Detail mit Onset-Uhrzeit und Quelle
-     - `render_sms(msg)` — Token `R!<min>` (Regen) oder `TH!<min>` (Gewitter), ≤140 Zeichen GSM-7
+     - `render_sms(msg)` — Token `R@<hh:mm>` (Regen) oder `TH@<hh:mm>` (Gewitter), Zeitpunkt statt
+       Countdown (seit #1948 S4; Kurznachricht kürzt bei der Stunde die führende Null,
+       `TH@9:05` statt `TH@09:05`), ≤140 Zeichen GSM-7
      - `OnsetEvent`-Datenklasse: `onset_minutes`, `onset_time`, `km_from`/`km_to`, `is_convective`, `intensity_label`, `source_label`
      - `AlertMessage.cooldown_display` trägt den dynamischen Cooldown-Text (z.B. „2 Stunden")
      - `src/outputs/radar_alert.py` ist gelöscht — kein separater Inline-Body-Bau mehr

--- a/docs/specs/modules/fix_1948_s4_nowcast_sms_zielbild.md
+++ b/docs/specs/modules/fix_1948_s4_nowcast_sms_zielbild.md
@@ -1,0 +1,308 @@
+---
+entity_id: fix_1948_s4_nowcast_sms_zielbild
+type: feature
+created: 2026-08-19
+updated: 2026-08-19
+status: draft
+version: "1.0"
+tags: [alarm, sms, nowcast, format]
+---
+
+# Nowcast/Onset-SMS-Zielbild (Zweig c) — #1948 Scheibe S4
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Die Nowcast-/Onset-Kurznachricht (Zweig c: Gewitter- und Regen-Anmarsch) zieht auf das
+einheitliche Alarm-Format nach: Der Kopf spricht künftig die gemeinsame Ortsauflösung
+(`format_alert_location`, Segment-Sprache statt selbstgebauter km-Notation), und das
+Ereignis-Token wechselt vom Countdown (`TH!8`, „in 8 Minuten") auf einen konkreten
+Zeitpunkt (`TH@15:40`, „ab 15:40 Uhr"). PO-Zielbild (Konzept v3, §1): **`Ziel: TH@15:40`**
+— heute lautet dieselbe Nachricht `km8-8: TH!8`. Zusätzlich heilt diese Scheibe den
+Ortsvergleich-Sonderfall mit genau einem Ort, der heute strukturell keinen Ortsnamen
+zeigen kann.
+
+## Source
+
+- **File:** `src/output/renderers/alert/render.py`
+- **Identifier:** `_render_sms_onset()` (Z. 422-438)
+
+Begleitend: `src/output/renderers/alert/project.py` (`to_multi_location_onset_alert_message`,
+Z. 319-398 — neue benannte Konstante statt Freitext-Marker `"compare-radar"`).
+
+## Estimated Scope
+
+- **LoC:** ~120–170 (Renderer-Logik + Marker-Konstante + Testanpassungen, unter dem
+  250-LoC-Workflow-Limit)
+- **Files:** 2 Produktivdateien (`render.py`, `project.py`) + 7 Bestandstestdateien
+  fortgeschrieben + mind. 1 neues Testmodul (TDD-RED)
+- **Effort:** medium
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `OnsetEvent` | dataclass (`src/output/renderers/alert/model.py:37-56`) | Liefert `onset_time` (`str`, nie `None`), `onset_minutes`, `segment_id`, `location_label` — Grundlage jedes Onset-Tokens |
+| `format_alert_location()` | function (`src/output/renderers/alert/segments.py:91-111`) | Die eine gemeinsame Ortsauflösung (`location_label` → Segment → km), die auch Trip-Δ/E-Mail/Telegram nutzen |
+| `_location_of()` | function (`render.py:123-135`) | Ruft `format_alert_location` mit der km-Spanne eines Event-Tupels auf — Baustein des neuen Kopfes |
+| `_ascii_alert_location()` | function (`render.py:989+`) | Entfernt Piktogramme (`🏁`) VOR der ASCII-Faltung — die einzig korrekte Trennstelle für SMS-Text (Verwechslungsgefahr mit `_ascii()`, s. Known Limitations) |
+| `to_multi_location_onset_alert_message()` | function (`project.py:319-398`) | Baut die Ortsvergleich-Onset-`AlertMessage`; Quelle des Freitext-Markers `"compare-radar"`, der diese Scheibe zur benannten Konstante anhebt |
+| `POST /api/trips/{trip_id}/alert-preview` | Endpunkt (S2, `alarm_testeinspeisung.md`) | Einspeiseweg für den Verifikationsnachweis über `nowcast_frames`, nutzt denselben `_derive_result` wie der Live-Pfad |
+| `notification_service.render_sms`-Aufrufer | — (`src/services/notification_service.py:1373`) | Einziger Produktiv-Aufruf; Ergebnis geht an SMS **und** Premium-SMS mit gemeinsamem `limit=140` |
+
+## Implementation Details
+
+Neuer Funktionskörper für `_render_sms_onset` (Muster übernommen vom bereits produktiven
+Trip-Δ-Kopf, `render.py:916`):
+
+```python
+COMPARE_RADAR_SOURCE = "compare-radar"  # in project.py definiert, hier importiert
+
+def _render_sms_onset(msg: AlertMessage, limit: int = 140) -> str:
+    e = msg.events[0]
+    token = f"TH@{e.onset_time}" if e.is_convective else f"R@{e.onset_time}"
+    if getattr(e, "location_label", None):
+        # Mehr-Orte-Compare-Bündel: Kopf = Ortsname des führenden Events.
+        head = _ascii_alert_location(e.location_label)
+    elif msg.source == COMPARE_RADAR_SOURCE:
+        # Ein-Ort-Compare (PO-Entscheid 3a): location_label bleibt laut
+        # Invariante None, der Ortsname steht in msg.trip_short.
+        head = _ascii_alert_location(msg.trip_short)
+    else:
+        # Trip-Radar: dieselbe Ortsauflösung wie Betreff/E-Mail/Telegram.
+        head = _ascii_alert_location(_location_of((e,), None))
+    body = f"{head}: {token}"
+    return body if len(body) <= limit else body[:limit]
+```
+
+Begründung der Bausteinwahl (übernommen aus der Analyse):
+
+- **Nicht** `_km_str_onset(e)` — die unterdrückt `location_label` absichtlich und wird von
+  Telegram/Betreff mitbenutzt (`render.py:416`, Betreff-Zweig); eine Änderung dort würde
+  ungefragt zwei weitere Kanäle mitverändern. `_km_str_onset` bleibt unangetastet.
+- **Nicht** `_km_str(msg)` — liest `msg.location_label`, das für Onset-Nachrichten von
+  keinem Konstruktor je gesetzt wird und damit strukturell immer `None` ist.
+- Ein **lokaler** `_location_of((e,), …)`-Aufruf lässt die geteilten Bausteine unangetastet.
+
+**Marker-Härtung (PO-Entscheid 3a).** `to_multi_location_onset_alert_message` setzt heute
+den Freitext-Marker `source="compare-radar"` (`project.py:397`) ohne Vertrag. Diese Scheibe
+hebt ihn zu einer benannten Konstante (`COMPARE_RADAR_SOURCE`) an und referenziert sie an
+**beiden** Stellen — Setzen in `project.py`, Lesen in `render.py`. Ein künftiges Umbenennen
+bricht damit sichtbar (Import-Fehler oder Konstanten-Vergleich schlägt fehl), statt die
+Ortsanzeige unbemerkt auf `km 0–0` zurückfallen zu lassen (AC-7 sichert das ab).
+
+**Testfalle — Wanduhr-Abhängigkeit (nicht Teil der Implementierung, aber Pflicht für die
+Testanpassung):** `test_alert_sms_location_positions.py` und
+`test_alert_preview_nowcast_replay.py` prüfen künftig `onset_time` (eine aus der aktuellen
+Wanduhr abgeleitete Uhrzeit) statt der bisherigen Minutenzahl. Ein fester Goldstring wäre
+zeitabhängig rot — beide Tests brauchen ein Zeitfenster-Toleranzband (z. B. Regex `\d{2}:\d{2}`
+plus Plausibilitätsprüfung gegen `datetime.now()`) statt eines exakten Textvergleichs.
+
+## Expected Behavior
+
+- **Input:** `AlertMessage` mit `source` gesetzt (Onset-Zweig) und genau einem führenden
+  `OnsetEvent` — Trip-Radar (`source="radar"`, `location_label=None`), Ortsvergleich-Bündel
+  mit >1 Ort (`location_label` gesetzt), oder Ortsvergleich mit genau 1 Ort
+  (`source=COMPARE_RADAR_SOURCE`, `location_label=None`).
+- **Output:** `render_sms()` liefert für den Onset-Zweig einen String der Form
+  `{Ortsangabe}: TH@{HH:MM}` bzw. `{Ortsangabe}: R@{HH:MM}` — Ortsangabe je nach obiger
+  Fallunterscheidung Segmentname, km-Rückfall, oder Ortsname (Bündel- bzw. Ein-Ort-Compare).
+  Kein `+N`-Zähler, keine Countdown-Minuten, keine Piktogramme.
+- **Side effects:** keine — reine Renderer-Formatierung; kein Datenmodell-Wandel, keine
+  Persistenz betroffen. E-Mail-, Telegram- und Betreff-Rendering des Onset-Zweigs bleiben
+  unverändert (nutzen weiterhin `_km_str_onset`).
+
+## Acceptance Criteria
+
+- **AC-1:** Given ein Trip-Onset-Alarm mit einem konvektiven Ereignis (`is_convective=True`,
+  `onset_time="15:40"`, ohne `location_label`) / When `render_sms(msg)` über den Onset-Zweig
+  gerendert wird / Then enthält der Text exakt das Token `TH@15:40`, jedoch nirgends mehr
+  `TH!` oder eine Minutenzahl als Countdown.
+  - Test: Unit-Test gegen `_render_sms_onset` mit konstruiertem `OnsetEvent`, Substring-Vergleich
+    auf `TH@15:40` und Abwesenheit von `TH!`.
+
+- **AC-2:** Given denselben Aufbau wie AC-1, aber mit `is_convective=False` und
+  `onset_time="14:35"` (Regen-Anmarsch statt Gewitter) / When `render_sms(msg)` erneut über
+  denselben Onset-Zweig gerendert wird / Then enthält der Text exakt das Token `R@14:35` und
+  nirgends mehr `R!` oder eine Minutenzahl als Countdown.
+  - Test: Unit-Test, gespiegelt zu AC-1, Substring-Vergleich auf `R@14:35`.
+
+- **AC-3:** Given einen Trip-Onset-Alarm, dessen führendes Ereignis eine Segment-Kennung
+  trägt (`segment_id="Ziel"`, kein `location_label`, konvektiv mit `onset_time="15:40"`) /
+  When die SMS über den echten Einspeiseweg (S2-Endpunkt) gerendert wird / Then lautet der
+  Kopf exakt `Ziel: TH@15:40` — dieselbe Segment-Sprache, die `format_alert_location` Stufe 2
+  auch für Betreff und E-Mail liefert, statt der alten `km8-8: TH!8`-Notation.
+  - Test: Endpunkt-Test über `POST /api/trips/{trip_id}/alert-preview?user_id=…` mit
+    `nowcast_frames`, die einen konvektiven Frame am Segment „Ziel" erzeugen; Antwortfeld
+    `sms` auf den exakten Kopf geprüft.
+
+- **AC-4:** Given einen Trip-Onset-Alarm, dessen führendes Ereignis keine verwertbare
+  Segment-Kennung trägt (`segment_id=None`, Altdaten-Fall ohne `location_label`) / When
+  `render_sms(msg)` über den Onset-Zweig ohne Segment-Kennung gerendert wird / Then fällt der
+  Kopf weiterhin auf die km-Spanne zurück (`format_alert_location` Stufe 3, z. B.
+  „km 5–18: "), keine Segment-Sprache erscheint an dieser Stelle.
+  - Test: Unit-Test gegen `_render_sms_onset` mit `segment_id=None`, Substring-Vergleich auf
+    den km-Rückfall.
+
+- **AC-5:** Given einen Ortsvergleich-Bündel-Onset-Alarm mit mehr als einem Ort, bei dem das
+  führende Ereignis ein gesetztes `location_label` trägt (z. B. „Zermatt") / When
+  `render_sms(msg)` über den gebündelten Ortsvergleich-Onset-Zweig gerendert wird / Then
+  beginnt der Kopf exakt mit „Zermatt: ", enthält weder ein `+N`-Suffix noch eine
+  `km0-0`-Spanne.
+  - Test: Unit-Test über `to_multi_location_onset_alert_message` mit zwei Orts-Gruppen,
+    gerendertes `sms` auf Kopf und Abwesenheit von `+` bzw. `km0` geprüft.
+
+- **AC-6:** Given einen Ortsvergleich-Onset-Alarm mit genau einem Ort (Invariante:
+  `location_label=None`, `msg.source=COMPARE_RADAR_SOURCE`, Ortsname ausschließlich in
+  `msg.trip_short`) / When `render_sms(msg)` über denselben Ein-Ort-Compare-Zweig gerendert
+  wird / Then nennt der Kopf den Ortsnamen aus `trip_short` statt der bisherigen
+  `km0-0`-Spanne — der heute unmögliche Sonderfall (PO-Entscheid 3a) ist damit geschlossen.
+  - Test: Unit-Test über `to_multi_location_onset_alert_message` mit genau einer Gruppe,
+    gerendertes `sms` gegen den erwarteten Ortsnamen geprüft (Regressionsnachweis: derselbe
+    Aufbau lieferte vor S4 `km0-0: …`).
+
+- **AC-7:** Given eine `AlertMessage`, deren `source`-Feld NICHT der Compare-Radar-Konstante
+  entspricht, aber inhaltlich sonst identisch zum Ein-Ort-Compare-Fall aus AC-6 ist
+  (`location_label=None`, km_from=km_to=0.0, Ortsname in `trip_short`) / When
+  `render_sms(msg)` mit diesem manipulierten `source`-Wert gerendert wird / Then fällt der
+  Kopf auf „km 0–0" zurück statt den Ortsnamen zu zeigen — dieser Test beweist, dass die
+  Fallunterscheidung tatsächlich an der Konstante hängt, nicht an einer zufälligen
+  String-Übereinstimmung, und muss rot schlagen, sobald Setz- und Lesestelle auseinanderdriften.
+  - Test: Unit-Test (Wächter), der bewusst einen abweichenden `source`-Wert setzt und den
+    km-Rückfall als feste Erwartung prüft — kein Dateiinhalt-Check, echter Renderer-Aufruf.
+
+- **AC-8:** Given einen Trip-Onset-Alarm mit Segment-Kennung „Ziel" (führt über
+  `format_alert_location` zu `🏁 Ziel`) / When der Kopf über `_ascii_alert_location`
+  gerendert wird / Then enthält der resultierende SMS-Text weder das Zeichen `🏁` noch dessen
+  Transliteration `:checkered_flag:` — nur das Wort „Ziel" bleibt stehen, die Ausgabe ist
+  GSM-7-rein.
+  - Test: Unit-Test, gerenderten String auf Abwesenheit beider verbotener Zeichenketten
+    geprüft; Mutations-Kandidat für die Adversary-Runde ist das Vertauschen von
+    `_ascii_alert_location` gegen `_ascii`.
+
+- **AC-9:** Given zwei strukturell identische Onset-`AlertMessage`s, die sich nur in
+  `location_label`/`source` unterscheiden — eine echter Trip-Radar-Alarm (kein Ortsname),
+  eine Ortsvergleich-Bündel-Alarm (Ortsname gesetzt) / When beide über `render_sms`
+  gerendert werden / Then trägt NUR das Compare-Ergebnis den Ortsnamen im Kopf, während das
+  Trip-Ergebnis weiterhin direkt mit der aufgelösten Ortsangabe ohne Namenspräfix beginnt —
+  die Zusicherung ist der Vergleich beider Ergebnisse, keine isolierte Einzelprüfung.
+  - Test: Vergleichstest — Fortschreibung von
+    `test_alert_sms_segment_head.py::test_ac12_trip_radar_sms_verliert_den_namen_compare_radar_sms_behaelt_ihn`
+    auf das neue `TH@`/`R@`-Format, die Differenzlogik zwischen beiden Ergebnissen bleibt
+    erhalten.
+
+- **AC-10:** Given der geänderte Onset-Renderpfad in `_render_sms_onset` / When dieselben
+  Eingaben zusätzlich über `_render_email_onset`, `_render_telegram_onset` und
+  `_render_subject_onset` gerendert werden / Then bleiben deren Ausgaben byte-identisch zum
+  Vor-S4-Zustand, weil `_km_str_onset`/`_km_str` von dieser Scheibe nicht angefasst werden und
+  `src/app/day_window.py`/`display_end_time()` weiterhin außerhalb der Aufrufkette liegen
+  (#1599-Leitplanke).
+  - Test: Vergleichstest — bestehende E-Mail-/Telegram-/Betreff-Onset-Regressionstests laufen
+    unverändert grün (Verhaltensnachweis); ergänzend ein struktureller Importe-Check, dass
+    `render.py` `app.day_window` nicht importiert (kein Verhaltensnachweis, nur Nicht-Berührung).
+
+## Zusätzliche Prüfpunkte (aus der Abhängigkeitsanalyse, Phase 2 Step 2a)
+
+**Bestehender ASCII-Wächter muss grün bleiben.** `tests/tdd/test_ascii_folding.py:101-123` prüft am
+gerenderten SMS-Text: `sms.isascii()`, `len(sms) <= 140` und dass **gefaltete Ortsnamen** tatsächlich
+erscheinen (`"Hyeres" in sms`, `"Muenchen" in sms`). Das ist kein Goldstring des alten Formats,
+sondern der bestehende Wächter für dieselbe Zusicherung wie AC-8 — er wird **nicht angepasst** und
+muss den Umbau unverändert überstehen. Wird er rot, ist der Kopf-Umbau falsch verdrahtet.
+
+**Premium-SMS erbt das Format ungeprüft.** `docs/specs/modules/feat_1701_alarm_premium_sms.md`
+beschreibt Premium-SMS als vierten Kanal, der denselben `render_sms`-Aufruf mitbenutzt
+(`notification_service.py:1373` rendert **einmal**, `:1543` und `:1558` versenden dasselbe Ergebnis).
+Vor Abschluss ist zu prüfen, dass `tests/unit/test_premium_sms_versand.py` und
+`tests/unit/test_alert_channel_premium_sms.py` keine Onset-Token-Goldstrings festhalten — nach
+bisheriger Sichtung prüfen sie nur Versand-Infrastruktur, aber das ist als Prüfpunkt zu bestätigen,
+nicht als Annahme zu führen.
+
+**Warum AC-7 nötig ist — belegt.** Kein einziger Test prüft heute den String `"compare-radar"`
+direkt; `msg.source` wird an vier Stellen (`render.py:442/622/757/890`) nur auf `is not None`
+geprüft. Ein Auseinanderdriften von Setz- und Lesestelle der neuen Konstante würde daher von
+**keinem** Bestandstest bemerkt. AC-7 schließt genau diese Lücke.
+
+**Zwei Agenten-Fehlmeldungen, gegengeprüft und verworfen** (damit ihnen niemand nachläuft):
+`tests/tdd/test_compare_radar_alert.py` enthält keine relevante Fundstelle. Und
+`compare_preview_service.py:111` / `preview_service.py:349` sind **Definitionen** einer eigenen
+Methode `render_sms_preview`, keine Aufrufe des Alarm-Renderers — es besteht keine
+Preview-Abhängigkeit vom Onset-Pfad.
+
+## Abgelöste Zusicherungen
+
+- **`tests/tdd/test_alert_location_vocabulary.py:573-585`
+  (`test_kurznachricht_des_nowcasts_nennt_keinen_ort`)** fordert wörtlich das Gegenteil des
+  S4-Zielbilds: `"Segment" not in sms`, `"Ziel" not in sms`, `"🏁" not in sms`, und einen
+  verpflichtenden `km\d`-Treffer. Der Docstring selbst benennt die künftige Ablösung
+  („der Betreff wechselt auf '🏁 Ziel', die Kurznachricht bleibt bei 'km8-8'" — genau diese
+  Trennung entfällt mit S4). Der PO-Entscheid (Analyse-Tabelle, Frage 2) löst den Test
+  **bewusst** ab: die Kurznachricht spricht künftig dieselbe Segment-Sprache wie der Betreff.
+  Präzedenz: S3 hat für Zweig a `#1744 AC-5` in derselben Weise abgelöst. Der Test wird
+  **fortgeschrieben** (Docstring + Assertions auf das neue Verhalten umgestellt), nicht
+  gelöscht — er bleibt als Regressionsschutz relevant, gilt aber nach S4 nicht mehr für den
+  Onset-/Nowcast-Pfad.
+- **`docs/specs/modules/fix_1948_s3_sms_sofortfix.md` AC-7** sichert ausdrücklich zu, dass
+  `_render_sms_onset` byte-identisch zum Vor-S3-Zustand bleibt. Diese Zusicherung läuft mit
+  S4 **planmäßig aus** — S4 ist genau die Scheibe, die `_render_sms_onset` gezielt ändert.
+  AC-7 aus S3 gilt ab dieser Spec als abgelöst, nicht als gebrochen.
+
+## Known Limitations
+
+- **Gewitter-Pfad mit echten Aufzeichnungen nicht verifizierbar.** Von 56 echten
+  Zweig-c-Mitschnitten auf Prod (50) und Staging (6) enthält **keiner** einen konvektiven
+  Frame (17 mit Regen, 0 mit Gewitter). AC-1/AC-3/AC-8 sind deshalb nur über konstruierte
+  bzw. abgeleitete `nowcast_frames`/`OnsetEvent`-Fixtures plus Unit-Tests verifizierbar, nicht
+  über einen echten End-to-End-Mitschnitt. Sobald eine echte konvektive Aufzeichnung entsteht,
+  gehört ein Nachtrag in eine Folge-Scheibe oder #1199.
+- **`format_alert_location` Stufe 1 kappt lange Ortsnamen nicht.** Geerbtes Risiko — der
+  Trip-Δ-Pfad (`render.py:916`) trägt dieselbe Lücke. Bei einem 35-Zeichen-Ortsnamen wächst
+  die Compare-SMS ungekappt (gemessen: +18 Zeichen gegenüber dem alten, hart auf 16 Zeichen
+  gekürzten `trip`-Präfix). Wird in S4 nicht gelöst.
+  - **Längen-Budget insgesamt unkritisch** (Limit 140, harter Endschnitt `body[:limit]`):
+    Trip mit Segmentnamen +3 Zeichen, Trip-km-Rückfall +4 Zeichen, Compare mit kurzem
+    Ortsnamen −4 Zeichen (kürzer als vorher), nur der lange Ortsname wächst nennenswert.
+- **Kurznachricht wertet weiterhin nur das führende Event aus** — kein `+N`-Zähler, PO-Entscheid
+  3b. Bei mehreren gleichzeitig auslösenden Orten verschweigt die Nachricht die übrigen; das
+  ist gewollt (ein Zähler würde Vollständigkeit versprechen, die er nicht einlöst), gehört aber
+  als bekannte Grenze dokumentiert.
+- **AC-10 hat keinen eigenen dedizierten Test** — nur indirekt über die unveränderten
+  E-Mail-/Telegram-/Betreff-Regressionstests mitgeprüft. Lückenbefund, gehört nach #1196/#1199,
+  nicht in diese Scheibe.
+
+## Verifikation
+
+- **Endpunkt-Nachweis (S2-Einspeiseweg):**
+  `POST /api/trips/{trip_id}/alert-preview?user_id=…` mit Payload
+  `{"nowcast_frames": {source, frames[], km_from, km_to}}` → die Antwort trägt
+  `onset_detected` und das gerenderte `sms`-Feld. Der Replay nutzt dasselbe `_derive_result`
+  wie der Live-Pfad, keinen Test-Sonderweg — geeignet für AC-3 (Segment-Sprache) und als
+  zusätzlicher Regen-Nachweis mit echten Frame-Daten.
+- **Kern-Unit-Tests:** direkte Aufrufe von `_render_sms_onset` mit konstruierten
+  `OnsetEvent`/`AlertMessage`-Fixtures für alle zehn ACs, deterministisch, ohne Netz.
+- **Grenze:** Für den konvektiven Zweig existiert kein echter S1-Mitschnitt (s. Known
+  Limitations) — der Endpunkt-Nachweis für AC-3 nutzt deshalb konstruierte, nicht
+  aufgezeichnete `nowcast_frames`.
+
+## Nicht Teil dieser Scheibe
+
+- **Zweig b (amtliche Warnungen, `official_alerts.py`)** — eigene Scheibe S5.
+- **Telegram-Parität** (`_render_telegram_onset` bleibt unverändert, nutzt weiterhin
+  `_km_str_onset`) — eigene Scheibe S6.
+- Die führende-Null-Frage im Stunden-Suffix (aus S3 offen gelassen) — betrifft den Trip-Δ-Pfad,
+  nicht den Onset-Pfad dieser Scheibe, weiterhin nicht vorentschieden.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Reine Renderer-Formatänderung plus eine additive Konstanten-Härtung
+  innerhalb eines bereits PO-freigegebenen Konzepts (`docs/analysis/alarm-format-konzept-2026-08.md`).
+  Kein neues Datenmodell, keine neue Architekturentscheidungsfläche (kein neuer Kanal, kein
+  neuer Provider, keine Persistenz-Änderung).
+
+## Changelog
+
+- 2026-08-19: Initial spec created (S4 des Alarm-Format-Konzepts #1948, Zweig c
+  Nowcast/Onset-SMS-Zielbild).

--- a/docs/specs/modules/fix_1948_s4_nowcast_sms_zielbild.md
+++ b/docs/specs/modules/fix_1948_s4_nowcast_sms_zielbild.md
@@ -204,6 +204,18 @@ plus Plausibilitätsprüfung gegen `datetime.now()`) statt eines exakten Textver
     unverändert grün (Verhaltensnachweis); ergänzend ein struktureller Importe-Check, dass
     `render.py` `app.day_window` nicht importiert (kein Verhaltensnachweis, nur Nicht-Berührung).
 
+- **AC-11:** Given einen Onset-Alarm, dessen `onset_time` in eine Vormittagsstunde mit führender
+  Null fällt (Feldwert `"09:05"`, wie ihn `strftime("%H:%M")` an allen Setzstellen erzeugt) /
+  When derselbe Alarm einmal über `render_sms` und einmal über `_render_email_onset` bzw.
+  `_render_telegram_onset` gerendert wird / Then trägt allein die Kurznachricht die Stunde **ohne**
+  führende Null (`TH@9:05`, Zeichenbudget), während E-Mail und Telegram die volle Form `09:05`
+  behalten — die Minuten bleiben in allen Kanälen zweistellig, und das Feld `onset_time` selbst
+  wird nicht verändert, nur seine Darstellung in der Kurznachricht.
+  - Test: Vergleichstest über alle drei Renderer mit demselben `OnsetEvent` (`onset_time="09:05"`);
+    geprüft wird `TH@9:05` in der SMS **und** `09:05` in E-Mail und Telegram — ein Test, der beide
+    Seiten gegeneinander stellt, damit eine Kürzung an der falschen Stelle rot schlägt.
+    PO-Entscheid 2026-08-19, `issuecomment-5345456988`.
+
 ## Zusätzliche Prüfpunkte (aus der Abhängigkeitsanalyse, Phase 2 Step 2a)
 
 **Bestehender ASCII-Wächter muss grün bleiben.** `tests/tdd/test_ascii_folding.py:101-123` prüft am

--- a/docs/specs/modules/fix_1948_s4_nowcast_sms_zielbild.md
+++ b/docs/specs/modules/fix_1948_s4_nowcast_sms_zielbild.md
@@ -12,7 +12,7 @@ tags: [alarm, sms, nowcast, format]
 
 ## Approval
 
-- [ ] Approved
+- [x] Approved — PO-Freigabe („go") am 2026-08-19, alle 11 Akzeptanzkriterien.
 
 ## Purpose
 

--- a/docs/specs/modules/fix_1948_s4_nowcast_sms_zielbild.md
+++ b/docs/specs/modules/fix_1948_s4_nowcast_sms_zielbild.md
@@ -280,9 +280,12 @@ Preview-Abhängigkeit vom Onset-Pfad.
   3b. Bei mehreren gleichzeitig auslösenden Orten verschweigt die Nachricht die übrigen; das
   ist gewollt (ein Zähler würde Vollständigkeit versprechen, die er nicht einlöst), gehört aber
   als bekannte Grenze dokumentiert.
-- **AC-10 hat keinen eigenen dedizierten Test** — nur indirekt über die unveränderten
-  E-Mail-/Telegram-/Betreff-Regressionstests mitgeprüft. Lückenbefund, gehört nach #1196/#1199,
-  nicht in diese Scheibe.
+- **AC-10 ist in der Umsetzung geschlossen** — der ursprünglich erwartete Lückenbefund
+  („kein eigener dedizierter Test") ist überholt. `tests/tdd/test_alert_sms_onset_zeitpunkt.py`
+  enthält jetzt zwei dedizierte AC-10-Tests: `test_ac10_email_telegram_betreff_bleiben_am_countdown_format`
+  (Zeile 432, Verhaltensnachweis über Betreff/E-Mail/Telegram am unveränderten Countdown-Format)
+  und `test_ac10_render_modul_importiert_day_window_nicht` (Zeile 463, struktureller
+  Nicht-Berührungs-Nachweis über `app.day_window`).
 
 ## Verifikation
 

--- a/src/output/renderers/alert/project.py
+++ b/src/output/renderers/alert/project.py
@@ -20,6 +20,14 @@ from .segments import normalize_segment_id
 
 logger = logging.getLogger("alert_project")
 
+# Marker im `source`-Feld eines Ortsvergleich-Onset-Alarms (Issue #1948 S4).
+# Gesetzt in `to_multi_location_onset_alert_message`, GELESEN in
+# `render._render_sms_onset` — nur so kann der Ein-Ort-Fall (Invariante:
+# `location_label is None`) den Ortsnamen aus `trip_short` zeigen statt der
+# sinnlosen km-0-0-Spanne. Benannte Konstante statt Freitext, damit ein
+# Auseinanderdriften von Setz- und Lesestelle sichtbar bricht.
+COMPARE_RADAR_SOURCE = "compare-radar"
+
 
 def _resolve_metric_id(field: str, direction: str) -> str:
     """summary_field → catalog metric_id, disambiguiert per Richtung.
@@ -346,8 +354,10 @@ def to_multi_location_onset_alert_message(
 
     INVARIANTE: bei GENAU einer Gruppe bleibt `location_label=None` — fällt
     damit auf den unveränderten Single-Onset-Renderpfad zurück (AC-5).
-    `source` trägt den festen Marker "compare-radar", damit die Renderer
-    weiterhin über den Onset-Zweig (`msg.source is not None`) routen.
+    `source` trägt den Marker `COMPARE_RADAR_SOURCE`, damit die Renderer
+    weiterhin über den Onset-Zweig (`msg.source is not None`) routen — und
+    damit `_render_sms_onset` den Ein-Ort-Fall an genau dieser Konstante
+    erkennt (Issue #1948 S4, AC-6/AC-7).
 
     `cooldown_display`: optionaler, bereits formatierter Cooldown-Hinweis-Text
     (Issue Pflicht-Fix, analog `send_radar_alert()`s `cooldown_display`) —
@@ -394,7 +404,7 @@ def to_multi_location_onset_alert_message(
     )
     return AlertMessage(
         trip_short=trip_short, stand_at=stand_at, events=tuple(events),
-        source="compare-radar", cooldown_display=cooldown_display,
+        source=COMPARE_RADAR_SOURCE, cooldown_display=cooldown_display,
     )
 
 

--- a/src/output/renderers/alert/render.py
+++ b/src/output/renderers/alert/render.py
@@ -22,6 +22,7 @@ from .model import (
     AlertEvent, AlertMessage, CorridorEvent, OnsetEvent, OnsetShiftEvent,
     arrow, delta_pct, km_span, over_thr, severity, side_label,
 )
+from .project import COMPARE_RADAR_SOURCE
 from .segments import _renderable_segment_ids, format_alert_location
 
 
@@ -419,22 +420,46 @@ def _render_telegram_onset(msg: AlertMessage) -> str:
     return "\n".join([first, second])
 
 
+def _sms_onset_time(onset_time: str) -> str:
+    """Zeitpunkt-Darstellung der Kurznachricht (Issue #1948 S4, AC-11): die
+    Stunde OHNE fuehrende Null (`09:05` -> `9:05`, Zeichenbudget), die Minuten
+    bleiben zweistellig. Gilt AUSSCHLIESSLICH hier -- E-Mail, Telegram und
+    Betreff lesen `e.onset_time` unveraendert, und das Feld selbst wird nicht
+    angefasst."""
+    hour, sep, rest = onset_time.partition(":")
+    if not sep:
+        return onset_time
+    return f"{hour.lstrip('0') or '0'}:{rest}"
+
+
 def _render_sms_onset(msg: AlertMessage, limit: int = 140) -> str:
-    """Issue #1935/#1779 (E4): der Trip-Radar/Onset-Kopf verliert den
-    Trip-Namen -- er trug auf einer Kurznachricht an den Trip-Teilnehmer
-    selbst keine Information. AUSNAHME (AC-10/AC-12): traegt das fuehrende
-    Event ein `location_label` (gebuendelter Ortsvergleich-Onset,
-    `to_multi_location_onset_alert_message`), ist `msg.trip_short` in
-    Wahrheit der Orts-Sammelname (z.B. 'Zermatt, Chamoni') und bleibt
-    unangetastet -- die Trip/Compare-Weiche selbst."""
+    """Issue #1948 S4: die Nowcast-/Onset-Kurznachricht nennt einen ZEITPUNKT
+    (`TH@15:40`) statt eines Countdowns (`TH!8`) und spricht im Kopf dieselbe
+    Ortssprache wie Betreff und E-Mail (`format_alert_location`: Ortsname ->
+    Segment -> km-Rueckfall) statt der selbstgebauten `km8-8`-Notation.
+
+    Drei Kopf-Faelle:
+      * `location_label` gesetzt -> gebuendelter Ortsvergleich (>1 Ort), Kopf
+        ist der Ortsname des fuehrenden Events (Issue #1935/#1779 E4-Weiche).
+      * `msg.source == COMPARE_RADAR_SOURCE` -> Ortsvergleich mit GENAU einem
+        Ort; dort bleibt `location_label` laut Konstruktor-Invariante `None`,
+        der Ortsname steht allein in `msg.trip_short` (AC-6).
+      * sonst -> Trip-Radar, dieselbe Ortsaufloesung wie die anderen Kanaele.
+
+    `_ascii_alert_location` (nicht `_ascii`) entfernt Piktogramme VOR der
+    ASCII-Faltung -- sonst stuende `:checkered_flag:` in der SMS (AC-8).
+    `_km_str_onset` bleibt bewusst unangetastet: Telegram und Betreff lesen
+    ihn mit (AC-10)."""
     e = msg.events[0]
-    token = f"TH!{e.onset_minutes}" if e.is_convective else f"R!{e.onset_minutes}"
-    a, b = int(round(e.km_from)), int(round(e.km_to))
+    kuerzel = "TH" if e.is_convective else "R"
+    token = f"{kuerzel}@{_sms_onset_time(e.onset_time)}"
     if getattr(e, "location_label", None):
-        trip = _ascii(msg.trip_short)[:16].rstrip(" (-_")
-        body = f"{trip} km{a}-{b}: {token}"
+        head = _ascii_alert_location(e.location_label)
+    elif msg.source == COMPARE_RADAR_SOURCE:
+        head = _ascii_alert_location(msg.trip_short)
     else:
-        body = f"km{a}-{b}: {token}"
+        head = _ascii_alert_location(_location_of((e,), None))
+    body = f"{head}: {token}"
     return body if len(body) <= limit else body[:limit]
 
 

--- a/tests/tdd/test_952_onset_alert_fidelity.py
+++ b/tests/tdd/test_952_onset_alert_fidelity.py
@@ -589,14 +589,19 @@ class TestAC6SmsOnlyRadarDispatch:
             import urllib.parse
             payload = urllib.parse.unquote_plus(stub.received[0].decode())
             # FORTGESCHRIEBEN (Issue #1948 S4): Zeitpunkt-Token statt
-            # Countdown, und der Kopf spricht `format_alert_location` — dieses
-            # Trip-Fixture traegt Etappen, der Kopf ist also die Segment-Sprache
-            # ("Segment 1"), nicht mehr der km-Rueckfall. `onset_time` leitet
-            # der Live-Pfad aus der Wanduhr ab -> Struktur statt Goldstring.
+            # Countdown. Geprueft wird bewusst der AUFBAU `<Ort>: <Token>` und
+            # NICHT der konkrete Ortsname: `onset_time` stammt aus der Wanduhr,
+            # und welche Stufe von `format_alert_location` den Kopf liefert,
+            # haengt am Segment-Schnitt dieses Fixtures — beides ist kein
+            # Goldstring-Material. Der Kopf muss aber nichtleer und
+            # doppelpunktfrei sein, sonst waere der Aufbau gar nicht bewacht.
             match = re.search(
-                r"text=[^&]+: (R|TH)@\d{1,2}:\d{2}(?:&|$)", payload,
+                r"text=([^&:]+): (R|TH)@\d{1,2}:\d{2}(?:&|$)", payload,
             )
             assert match, f"SMS-Body-Token-Format falsch: {payload!r}"
+            assert not re.search(r"(R|TH)!\d", payload), (
+                f"Altes Countdown-Token im SMS-Body: {payload!r}"
+            )
         finally:
             stub.close()
             _clean_user(uid)

--- a/tests/tdd/test_952_onset_alert_fidelity.py
+++ b/tests/tdd/test_952_onset_alert_fidelity.py
@@ -334,7 +334,10 @@ class TestAC2KmRoundingConsistentAcrossChannels:
         subj_m = KM_RE.search(subject)
         plain_m = KM_RE.search(plain)
         tg_m = KM_RE.search(telegram)
-        sms_m = re.search(r"km(\d+)-(\d+)", sms)
+        # FORTGESCHRIEBEN (Issue #1948 S4): die SMS fuehrt den km-Kopf seit
+        # S4 in `format_alert_location`-Schreibweise (`km 10-15`) — dieselben
+        # gerundeten Zahlen, ein Leerzeichen mehr.
+        sms_m = re.search(r"km ?(\d+)-(\d+)", sms)
 
         assert subj_m, f"km-Format fehlt im Betreff: {subject!r}"
         assert plain_m, f"km-Format fehlt im Plain-Text: {plain!r}"
@@ -585,7 +588,14 @@ class TestAC6SmsOnlyRadarDispatch:
             # Fehlerklasse wie AC-1: Anzeige-Text vs. Kodierungs-Ebene).
             import urllib.parse
             payload = urllib.parse.unquote_plus(stub.received[0].decode())
-            match = re.search(r"km\d+-\d+: (R|TH)!\d+", payload)
+            # FORTGESCHRIEBEN (Issue #1948 S4): Zeitpunkt-Token statt
+            # Countdown, und der Kopf spricht `format_alert_location` — dieses
+            # Trip-Fixture traegt Etappen, der Kopf ist also die Segment-Sprache
+            # ("Segment 1"), nicht mehr der km-Rueckfall. `onset_time` leitet
+            # der Live-Pfad aus der Wanduhr ab -> Struktur statt Goldstring.
+            match = re.search(
+                r"text=[^&]+: (R|TH)@\d{1,2}:\d{2}(?:&|$)", payload,
+            )
             assert match, f"SMS-Body-Token-Format falsch: {payload!r}"
         finally:
             stub.close()
@@ -677,8 +687,10 @@ class TestAC7AlertPreviewOnsetPayload:
             assert "Radar-Nowcast" in data["email_html"], (
                 f"Onset-Badge fehlt im Preview-HTML: {data['email_html']!r}"
             )
-            assert re.search(r"!\d+", data["sms"]), (
-                f"SMS-Token (R!/TH!) fehlt im Preview-SMS: {data['sms']!r}"
+            # FORTGESCHRIEBEN (Issue #1948 S4): Zeitpunkt-Token statt Countdown.
+            assert re.search(r"\b(TH|R)@\d{1,2}:\d{2}\b", data["sms"]), (
+                f"SMS-Zeitpunkt-Token (R@/TH@) fehlt im Preview-SMS: "
+                f"{data['sms']!r}"
             )
         finally:
             _clean_user(uid)

--- a/tests/tdd/test_alert_location_vocabulary.py
+++ b/tests/tdd/test_alert_location_vocabulary.py
@@ -552,37 +552,47 @@ def test_kurznachricht_des_abweichungsalarms_ueber_mehrere_segmente_nennt_densel
     )
 
 
-def _assert_kurznachricht_ohne_ort(sms: str) -> None:
-    """PO-Entscheid 2026-08-04 (#1467 S2 AG3b): Alarm-Kurznachrichten nennen
-    keinen Ort. Gilt seit PO-Entscheid 2026-08-17 NUR NOCH fuer den
-    Radar-/Nowcast-Pfad ohne `location_label` (Trip-Δ-Pfad s.o. abgeloest,
-    AC-10/AC-12). SMS und Premium-SMS teilen denselben gerenderten Text
-    (`render_alert_sms`, notification_service.py:1318 -> :1488 SMS / :1502
-    Premium-SMS) — ein Nachweis deckt beide Kanaele.
+def _assert_kurznachricht_spricht_segment_sprache(sms: str) -> None:
+    """FORTGESCHRIEBEN (Issue #1948 S4, 2026-08-19): der Radar-/Nowcast-Pfad
+    spricht in der Kurznachricht seit S4 DIESELBE Ortssprache wie Betreff und
+    E-Mail (`format_alert_location`: Ortsname -> Segment -> km-Rueckfall). Die
+    Vorgaenger-Zusicherung „Kurznachricht nennt keinen Ort" (PO-Entscheid
+    2026-08-04, #1467 S2 AG3b) ist damit fuer diesen Pfad abgeloest — nicht
+    gebrochen: der PO-Entscheid zu S4 loest sie ausdruecklich ab.
+
+    Was BLEIBT: die Kurznachricht ist GSM-7-rein (Piktogramm ENTFERNT, nicht
+    transliteriert) und haelt das 140-Zeichen-Alarmlimit. SMS und Premium-SMS
+    teilen denselben gerenderten Text — ein Nachweis deckt beide Kanaele.
     """
-    assert "Segment" not in sms, f"Kurznachricht nennt ein Segment: {sms!r}"
-    assert "Ziel" not in sms, f"Kurznachricht nennt das Ziel: {sms!r}"
-    assert "🏁" not in sms, f"Kurznachricht traegt das Ziel-Symbol: {sms!r}"
-    assert re.search(r"km\d", sms), (
-        f"Kurznachricht hat ihren km-Kopf verloren: {sms!r}"
+    assert sms.startswith("Ziel: "), (
+        f"Kurznachricht muss die Segment-Sprache des Betreffs sprechen: {sms!r}"
     )
+    assert "🏁" not in sms, f"Kurznachricht traegt das Ziel-Symbol: {sms!r}"
+    assert ":checkered_flag:" not in sms, (
+        f"Piktogramm wurde transliteriert statt entfernt: {sms!r}"
+    )
+    assert not re.search(r"km\d", sms), (
+        f"Mit Segment-Kennung darf kein km-Kopf mehr erscheinen: {sms!r}"
+    )
+    assert sms.isascii(), f"Kurznachricht ist nicht ASCII-rein: {sms!r}"
     # Alarm-Grenze ist 140, NICHT 160 (render.py:285/621, official_alerts.py:1836).
     assert len(sms) <= 140, f"Kurznachricht ist {len(sms)} Zeichen lang: {sms!r}"
 
 
-def test_kurznachricht_des_nowcasts_nennt_keinen_ort():
-    """AC-5 (weiterhin GRUEN, Invariante fuer den Radar-/Nowcast-Pfad):
-    dieselbe Zusicherung fuer den Radar-Nowcast -- dieser Pfad ist von der
-    Ablösung 2026-08-17 NICHT betroffen (AC-10/AC-12).
+def test_kurznachricht_des_nowcasts_nennt_das_segment():
+    """AC-5 (FORTGESCHRIEBEN, Issue #1948 S4): Given ein Radar-Nowcast-Alarm,
+    dessen Ereignis die Segment-Kennung „Ziel" traegt / When die Kurznachricht
+    gerendert wird / Then nennt ihr Kopf dasselbe Segment wie der Betreff
+    (`Ziel: `), piktogrammfrei und ASCII-rein.
 
-    ROT bis der RED-Vertrag Punkt 1 erfuellt ist (`OnsetEvent.segment_id`):
-    ohne das Feld laesst sich der Fall „Nowcast KENNT das Ziel-Segment" gar
-    nicht herstellen. Danach ist es eine reine Invariante — der Betreff wechselt
-    auf '🏁 Ziel', die Kurznachricht bleibt bei 'km8-8'.
+    Vorher (bis S4): der Betreff wechselte auf '🏁 Ziel', die Kurznachricht
+    blieb bei 'km8-8' — genau diese Trennung entfaellt mit S4.
     """
     from output.renderers.alert.render import render_sms
 
-    _assert_kurznachricht_ohne_ort(render_sms(_onset_message(segment_id="Ziel")))
+    _assert_kurznachricht_spricht_segment_sprache(
+        render_sms(_onset_message(segment_id="Ziel")),
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tdd/test_alert_preview_nowcast_replay.py
+++ b/tests/tdd/test_alert_preview_nowcast_replay.py
@@ -102,16 +102,27 @@ class TestAC6_OnsetReplayDetectsOnset:
                 f"AC-6: '{field}' darf bei erkanntem Onset nicht leer sein: {data!r}"
             )
 
-        match = re.search(r"R!(\d+)", data["sms"])
-        assert match, (
-            f"AC-6: SMS muss ein nicht-konvektives 'R!<Minuten>'-Token "
+        # FORTGESCHRIEBEN (Issue #1948 S4): die Kurznachricht nennt seit S4
+        # den ZEITPUNKT (`R@HH:MM`) statt des Countdowns (`R!<Minuten>`). Die
+        # abgeleiteten Minuten bleiben ueber `email_plain`/`telegram` pruefbar,
+        # die dieselbe `_derive_result`-Ableitung wie der Live-Pfad tragen.
+        assert re.search(r"\bR@\d{1,2}:\d{2}\b", data["sms"]), (
+            f"AC-6: SMS muss ein nicht-konvektives 'R@HH:MM'-Zeitpunkt-Token "
             f"tragen: {data['sms']!r}"
+        )
+        assert not re.search(r"\b(TH|R)!\d+", data["sms"]), (
+            f"AC-6: das Countdown-Format ist abgeloest: {data['sms']!r}"
+        )
+        match = re.search(r"Regen in (\d+) Min", data["telegram"])
+        assert match, (
+            f"AC-6: Telegram muss die Countdown-Minuten weiter fuehren: "
+            f"{data['telegram']!r}"
         )
         actual_minutes = int(match.group(1))
         assert abs(actual_minutes - 20) <= 1, (
             f"AC-6: onset_minutes muss aus derselben _derive_result-"
             f"Ableitung stammen wie der Live-Radar-Pfad (erster nasser "
-            f"Frame bei ~20 Min), bekam R!{actual_minutes}"
+            f"Frame bei ~20 Min), bekam {actual_minutes}"
         )
         assert (
             "Mäßiger Regen" in data["email_plain"]

--- a/tests/tdd/test_alert_sms_location_positions.py
+++ b/tests/tdd/test_alert_sms_location_positions.py
@@ -949,7 +949,10 @@ def test_regression_trip_radar_alert_sms_text_unchanged():
         )
         # Issue #1935/#1779 (E4): Trip-Radar/Onset-Kopf verliert den Trip-Namen,
         # km-Spanne bleibt (kein Segment-Bezug im Radar-Request dieser Fixture).
-        assert stub.texts() == ["km5-18: R!12"], (
+        # FORTGESCHRIEBEN (Issue #1948 S4): km-Kopf in
+        # `format_alert_location`-Schreibweise + Zeitpunkt statt Countdown;
+        # `onset_time` ist in dieser Fixture fest ("14:35"), also goldstring-fest.
+        assert stub.texts() == ["km 5-18: R@14:35"], (
             "Regression: der SMS-Text des Trip-Radar-Alarms muss unveraendert "
             f"bleiben, gemessen: {stub.texts()!r}"
         )
@@ -980,9 +983,18 @@ def test_regression_compare_radar_alert_sms_text_unchanged():
         svc.send_multi_location_radar_alert(
             [("Zermatt", loc_a, nc_a), ("Chamonix", loc_b, nc_b)], {"sms"},
         )
-        assert stub.texts() == ["Zermatt, Chamoni km0-0: R!8"], (
-            "Regression: der SMS-Text des Ortsvergleich-Radar-Alarms muss "
-            f"unveraendert bleiben, gemessen: {stub.texts()!r}"
+        # FORTGESCHRIEBEN (Issue #1948 S4): der Buendel-Kopf nennt den Ortsnamen
+        # des fuehrenden Events statt des gekuerzten Sammelnamens mit km0-0.
+        # `onset_time` leitet der Konstruktor aus `datetime.now()` ab -> Struktur
+        # statt Goldstring (Wanduhr-Ratsche #1940).
+        texte = stub.texts()
+        assert len(texte) == 1, f"Erwartet genau eine SMS, bekam: {texte!r}"
+        assert re.fullmatch(r"Zermatt: R@\d{1,2}:\d{2}", texte[0]), (
+            "Regression: der SMS-Text des Ortsvergleich-Radar-Alarms muss dem "
+            f"S4-Zielbild 'Zermatt: R@HH:MM' folgen, gemessen: {texte!r}"
+        )
+        assert "km0" not in texte[0] and "Chamoni" not in texte[0], (
+            f"Buendel-SMS traegt noch km0-0 bzw. den Sammelnamen: {texte!r}"
         )
     finally:
         stub.stop()

--- a/tests/tdd/test_alert_sms_onset_zeitpunkt.py
+++ b/tests/tdd/test_alert_sms_onset_zeitpunkt.py
@@ -1,0 +1,540 @@
+"""TDD RED — Issue #1948 Scheibe S4: die Nowcast-/Onset-Kurznachricht nennt
+einen ZEITPUNKT (`TH@15:40`) statt eines Countdowns (`TH!8`) und spricht im
+Kopf dieselbe Ortssprache wie Betreff/E-Mail (`format_alert_location`:
+Ortsname -> Segment -> km-Rueckfall) statt der selbstgebauten `km8-8`-Notation.
+
+SPEC: docs/specs/modules/fix_1948_s4_nowcast_sms_zielbild.md (AC-1 bis AC-11)
+
+Betrifft AUSSCHLIESSLICH `_render_sms_onset` (der Onset-Zweig von
+`render_sms`, `render.py:422`) und die Marker-Konstante `COMPARE_RADAR_SOURCE`
+in `project.py`. E-Mail-, Telegram- und Betreff-Rendering des Onset-Zweigs
+bleiben unveraendert (AC-10) — bis auf die kanalabhaengige fuehrende Null,
+die AUSSCHLIESSLICH die Kurznachricht kuerzt (AC-11).
+
+Kein Mock, keine Dateiinhalt-Asserts: echte `OnsetEvent`/`AlertMessage`-
+Objekte bzw. der echte Konstruktor `to_multi_location_onset_alert_message`
+durch die echten Renderer. Alle `onset_time`-Werte sind FEST gesetzt, wo der
+Aufbau es zulaesst; wo der Konstruktor die Zeit selbst aus `datetime.now()`
+ableitet (Compare-Buendel), wird auf Struktur statt auf einen Goldstring
+geprueft (Wanduhr-Ratsche #1940).
+"""
+from __future__ import annotations
+
+import ast
+import inspect
+import re
+import uuid
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from output.renderers.alert.model import AlertMessage, OnsetEvent
+from output.renderers.alert.render import (
+    render_email, render_sms, render_subject, render_telegram,
+)
+
+# Zeitpunkt-Token: 1-2 Buchstaben-Kuerzel + '@' + H:MM oder HH:MM.
+_ZEITPUNKT_TOKEN_RE = re.compile(r"\b(TH|R)@(\d{1,2}):(\d{2})\b")
+# Countdown-Token des Alt-Formats (`TH!8` / `R!25`) — darf nirgends mehr stehen.
+_COUNTDOWN_TOKEN_RE = re.compile(r"\b(TH|R)!\d+")
+
+
+def _onset_event(**kw) -> OnsetEvent:
+    """Ein Trip-Radar-Onset-Ereignis mit festen Feldern (keine Wanduhr)."""
+    fields = dict(
+        onset_minutes=8, onset_time="15:40", km_from=8.0, km_to=8.0,
+        is_convective=True, intensity_label="Gewitter mit Hagel",
+        source_label="Radar (ICON-D2)",
+    )
+    fields.update(kw)
+    return OnsetEvent(**fields)
+
+
+def _onset_msg(event: OnsetEvent, *, trip_short: str = "KHW 403",
+               source: str = "radar") -> AlertMessage:
+    """`source is not None` routet `render_sms` in den Onset-Zweig."""
+    return AlertMessage(
+        trip_short=trip_short, stand_at="10:00", events=(event,), source=source,
+    )
+
+
+def _kopf(sms: str) -> str:
+    """Der Kopf-Anteil vor dem ': ' — die Ortsangabe der Kurznachricht."""
+    assert ": " in sms, f"Kurznachricht hat keinen '<Ort>: <Token>'-Aufbau: {sms!r}"
+    return sms.split(": ", 1)[0]
+
+
+def _nowcast(minutes: int = 30, *, convective: bool = False):
+    from services.radar_service import NowcastResult
+    return NowcastResult(
+        onset_minutes=minutes, intensity_label="leichter Regen",
+        source="radar", is_convective=convective,
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-1 — konvektives Ereignis: Zeitpunkt-Token statt Countdown
+# ---------------------------------------------------------------------------
+
+
+def test_ac1_konvektiver_onset_traegt_zeitpunkt_token_statt_countdown():
+    """AC-1: Given ein Trip-Onset-Alarm mit konvektivem Ereignis
+    (`onset_time="15:40"`, ohne `location_label`, ohne Segment) / When
+    `render_sms` ueber den Onset-Zweig rendert / Then steht `TH@15:40` im
+    Text und nirgends mehr ein `TH!`-Countdown."""
+    sms = render_sms(_onset_msg(_onset_event()))
+
+    assert "TH@15:40" in sms, f"Zeitpunkt-Token 'TH@15:40' fehlt: {sms!r}"
+    assert "TH!" not in sms, f"Alt-Countdown 'TH!' steht noch im Text: {sms!r}"
+    assert not _COUNTDOWN_TOKEN_RE.search(sms), (
+        f"Kurznachricht traegt noch eine Countdown-Minutenzahl: {sms!r}"
+    )
+    assert sms == "km 8-8: TH@15:40", (
+        f"Erwartet 'km 8-8: TH@15:40' (km-Rueckfall + Zeitpunkt), "
+        f"bekam {sms!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-2 — Regen-Anmarsch: gespiegelt zu AC-1
+# ---------------------------------------------------------------------------
+
+
+def test_ac2_regen_onset_traegt_zeitpunkt_token_statt_countdown():
+    """AC-2: Given denselben Aufbau wie AC-1, aber `is_convective=False` und
+    `onset_time="14:35"` / When `render_sms` erneut rendert / Then steht
+    `R@14:35` im Text und nirgends mehr ein `R!`-Countdown."""
+    event = _onset_event(
+        is_convective=False, onset_time="14:35", onset_minutes=25,
+        intensity_label="Maessiger Regen",
+    )
+    sms = render_sms(_onset_msg(event))
+
+    assert "R@14:35" in sms, f"Zeitpunkt-Token 'R@14:35' fehlt: {sms!r}"
+    assert "R!" not in sms, f"Alt-Countdown 'R!' steht noch im Text: {sms!r}"
+    assert not _COUNTDOWN_TOKEN_RE.search(sms), (
+        f"Kurznachricht traegt noch eine Countdown-Minutenzahl: {sms!r}"
+    )
+    assert sms == "km 8-8: R@14:35", (
+        f"Erwartet 'km 8-8: R@14:35', bekam {sms!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-3 — Segment-Sprache im Kopf
+# ---------------------------------------------------------------------------
+
+
+def test_ac3_segment_kennung_erscheint_als_kopf_der_kurznachricht():
+    """AC-3: Given ein Trip-Onset-Alarm mit `segment_id="Ziel"` / When die
+    SMS gerendert wird / Then lautet der Kopf exakt `Ziel: TH@15:40` —
+    dieselbe Segment-Sprache, die `format_alert_location` Stufe 2 auch dem
+    Betreff liefert.
+
+    ABWEICHUNG VON DER SPEC (Testweg, nicht Zusicherung): Die Spec nennt als
+    Test den Endpunkt-Weg `POST /api/trips/{trip_id}/alert-preview` mit
+    `nowcast_frames`. Dieser Weg kann den Fall STRUKTURELL nicht herstellen:
+    weder `NowcastFramesPayload` (`api/routers/validator.py:259-264`) noch die
+    `OnsetEvent`-Konstruktion im Preview (`validator_render_service.py:110-118`)
+    kennen ein `segment_id`-Feld, und `onset_time` leitet der Replay aus
+    `datetime.now()` ab — ein exakter Goldstring `Ziel: TH@15:40` ist dort
+    also weder erzeugbar noch wanduhrfest. Die Zusicherung wird deshalb hier
+    als Unit-Test gefuehrt; den Endpunkt-Weg deckt der Test darunter
+    (Token-Form + km-Kopf ueber den echten Einspeiseweg) ab.
+    """
+    sms = render_sms(_onset_msg(_onset_event(segment_id="Ziel")))
+
+    assert sms == "Ziel: TH@15:40", (
+        f"Erwartet den Segment-Kopf 'Ziel: TH@15:40', bekam {sms!r}"
+    )
+
+
+@pytest.mark.real_data_root
+def test_ac3_endpunkt_replay_liefert_zeitpunkt_token_ueber_den_echten_einspeiseweg():
+    """AC-3 (Endpunkt-Anteil): Given ein Frame-Mitschnitt mit Regen-Onset am
+    S2-Einspeiseweg / When `POST /api/trips/{id}/alert-preview` gerendert
+    wird / Then traegt das `sms`-Feld ein `R@HH:MM`-Zeitpunkt-Token und den
+    km-Rueckfall-Kopf in `format_alert_location`-Schreibweise — kein
+    `R!<Minuten>`-Countdown, keine `km2-6`-Notation.
+
+    Wanduhrfest: der Replay leitet `onset_time` aus `datetime.now()` ab,
+    deshalb Struktur- statt Goldstring-Pruefung (Muster
+    `test_alert_preview_nowcast_replay.py`).
+    """
+    import json
+    import shutil
+
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from api.routers import validator
+
+    user_id = f"test_1948s4_{uuid.uuid4().hex[:8]}"
+    trip_id = "trip-s4"
+    trip_dir = Path("data/users") / user_id / "briefings"
+    trip_dir.mkdir(parents=True, exist_ok=True)
+    (trip_dir / f"{trip_id}.json").write_text(json.dumps({
+        "id": trip_id, "name": "S4 Trip", "stages": [],
+    }))
+    try:
+        app = FastAPI()
+        app.include_router(validator.router)
+        client = TestClient(app)
+        now = datetime.now(timezone.utc)
+        body = {"nowcast_frames": {
+            "source": "radar",
+            "frames": [
+                {"timestamp": (now + timedelta(minutes=5)).isoformat(),
+                 "precip_mm_h": 0.0, "is_convective": False},
+                {"timestamp": (now + timedelta(minutes=20)).isoformat(),
+                 "precip_mm_h": 2.5, "is_convective": False},
+            ],
+            "km_from": 2.0, "km_to": 6.0,
+        }}
+        resp = client.post(
+            f"/api/trips/{trip_id}/alert-preview",
+            params={"user_id": user_id}, json=body,
+        )
+        assert resp.status_code == 200, f"Body: {resp.text[:300]}"
+        sms = resp.json()["sms"]
+    finally:
+        shutil.rmtree(Path("data/users") / user_id, ignore_errors=True)
+
+    match = _ZEITPUNKT_TOKEN_RE.search(sms)
+    assert match, f"Endpunkt-SMS traegt kein '<Kuerzel>@HH:MM'-Token: {sms!r}"
+    assert match.group(1) == "R", (
+        f"Nicht-konvektiver Frame muss ein 'R@'-Token liefern: {sms!r}"
+    )
+    assert not _COUNTDOWN_TOKEN_RE.search(sms), (
+        f"Endpunkt-SMS traegt noch das Countdown-Format: {sms!r}"
+    )
+    assert _kopf(sms) == "km 2-6", (
+        f"Endpunkt-SMS muss den km-Rueckfall in "
+        f"format_alert_location-Schreibweise fuehren, bekam {sms!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-4 — km-Rueckfall ohne Segment-Kennung
+# ---------------------------------------------------------------------------
+
+
+def test_ac4_ohne_segment_kennung_bleibt_der_km_rueckfall():
+    """AC-4: Given ein Onset-Ereignis ohne Segment-Kennung (Altdaten-Fall,
+    km 5-18) / When die SMS gerendert wird / Then nennt der Kopf die km-Spanne
+    in `format_alert_location`-Schreibweise (`km 5–18`, nach ASCII-Faltung
+    `km 5-18`) — keine Segment-Sprache."""
+    event = _onset_event(segment_id=None, km_from=5.0, km_to=18.0)
+    sms = render_sms(_onset_msg(event))
+
+    assert _kopf(sms) == "km 5-18", (
+        f"Kopf muss der km-Rueckfall 'km 5-18' sein, bekam {sms!r}"
+    )
+    assert sms == "km 5-18: TH@15:40", (
+        f"Erwartet 'km 5-18: TH@15:40', bekam {sms!r}"
+    )
+    assert "Segment" not in sms, f"Segment-Sprache im km-Fall: {sms!r}"
+
+
+# ---------------------------------------------------------------------------
+# AC-5 — Ortsvergleich-Buendel (>1 Ort): Ortsname als Kopf
+# ---------------------------------------------------------------------------
+
+
+def test_ac5_compare_buendel_kopf_nennt_nur_den_ortsnamen():
+    """AC-5: Given ein Ortsvergleich-Buendel-Onset mit ZWEI Orten (das
+    fuehrende Event traegt `location_label="Zermatt"`) / When die SMS
+    gerendert wird / Then beginnt der Kopf mit `Zermatt: `, ohne `+N`-Suffix
+    und ohne `km0-0`-Spanne.
+
+    Wanduhrfest: `to_multi_location_onset_alert_message` leitet `onset_time`
+    aus `datetime.now()` ab -> Strukturpruefung des Tokens, exakter Vergleich
+    nur am Kopf."""
+    from output.renderers.alert.project import to_multi_location_onset_alert_message
+
+    msg = to_multi_location_onset_alert_message(
+        [("Zermatt", _nowcast()), ("Chamonix", _nowcast())],
+        tz=timezone.utc, stand_at="10:00",
+    )
+    sms = render_sms(msg)
+
+    assert sms.startswith("Zermatt: "), (
+        f"Buendel-Kopf muss der Ortsname des fuehrenden Events sein, "
+        f"bekam {sms!r}"
+    )
+    assert "+" not in sms, f"Kurznachricht traegt einen '+N'-Zaehler: {sms!r}"
+    assert "km0" not in sms and "km 0" not in sms, (
+        f"Kurznachricht traegt noch die sinnlose km0-Spanne: {sms!r}"
+    )
+    assert _ZEITPUNKT_TOKEN_RE.search(sms), (
+        f"Buendel-SMS traegt kein '<Kuerzel>@HH:MM'-Token: {sms!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-6 — Ortsvergleich mit GENAU einem Ort: Name aus `trip_short`
+# ---------------------------------------------------------------------------
+
+
+def test_ac6_ein_ort_compare_nennt_den_ortsnamen_aus_trip_short():
+    """AC-6: Given ein Ortsvergleich-Onset mit GENAU einem Ort (Invariante:
+    `location_label is None`, Ortsname nur in `msg.trip_short`) / When die SMS
+    gerendert wird / Then nennt der Kopf den Ortsnamen statt der bisherigen
+    `km0-0`-Spanne."""
+    from output.renderers.alert.project import to_multi_location_onset_alert_message
+
+    msg = to_multi_location_onset_alert_message(
+        [("Zermatt", _nowcast())], tz=timezone.utc, stand_at="10:00",
+    )
+
+    # Invariante des Konstruktors — Grundlage der Fallunterscheidung.
+    assert msg.events[0].location_label is None, (
+        "Bei genau einem Ort muss `location_label` None bleiben"
+    )
+    assert msg.trip_short == "Zermatt"
+
+    sms = render_sms(msg)
+
+    assert _kopf(sms) == "Zermatt", (
+        f"Ein-Ort-Compare muss den Ortsnamen aus trip_short zeigen, "
+        f"bekam {sms!r}"
+    )
+    assert "km0" not in sms and "km 0" not in sms, (
+        f"Ein-Ort-Compare zeigt noch die km0-0-Spanne: {sms!r}"
+    )
+    assert _ZEITPUNKT_TOKEN_RE.search(sms), (
+        f"Ein-Ort-Compare-SMS traegt kein '<Kuerzel>@HH:MM'-Token: {sms!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-7 — Waechter: die Weiche haengt an der Konstante
+# ---------------------------------------------------------------------------
+
+
+def test_ac7_abweichender_source_wert_faellt_auf_die_km_spanne_zurueck():
+    """AC-7 (Waechter): Given dieselbe Nachricht wie AC-6, aber mit einem
+    `source`-Wert, der NICHT der Compare-Radar-Konstante entspricht / When die
+    SMS gerendert wird / Then faellt der Kopf auf `km 0-0` zurueck statt den
+    Ortsnamen zu zeigen.
+
+    Beweist, dass die Fallunterscheidung an der benannten Konstante haengt und
+    nicht an einer zufaelligen String-Uebereinstimmung: driften Setz- und
+    Lesestelle auseinander, schlaegt entweder dieser Test oder AC-6 rot.
+
+    Lazy import: `COMPARE_RADAR_SOURCE` existiert vor der Implementierung noch
+    nicht — der Import steht deshalb IN der Funktion, damit nur DIESER Test
+    daran scheitert und nicht die ganze Datei am Sammeln.
+    """
+    from output.renderers.alert.project import (
+        COMPARE_RADAR_SOURCE, to_multi_location_onset_alert_message,
+    )
+
+    msg = to_multi_location_onset_alert_message(
+        [("Zermatt", _nowcast())], tz=timezone.utc, stand_at="10:00",
+    )
+    # Setzstelle liest dieselbe Konstante wie die Lesestelle im Renderer.
+    assert msg.source == COMPARE_RADAR_SOURCE, (
+        f"Der Compare-Onset-Konstruktor muss COMPARE_RADAR_SOURCE setzen, "
+        f"setzte {msg.source!r}"
+    )
+
+    fremd = replace(msg, source=COMPARE_RADAR_SOURCE + "-abweichend")
+    sms = render_sms(fremd)
+
+    assert _kopf(sms) == "km 0-0", (
+        f"Ohne die Compare-Radar-Konstante muss der Kopf auf die km-Spanne "
+        f"zurueckfallen, bekam {sms!r}"
+    )
+    assert "Zermatt" not in sms, (
+        f"Ortsname darf ohne die Konstante nicht erscheinen: {sms!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-8 — GSM-7-Reinheit: Piktogramm entfernt, Wort bleibt
+# ---------------------------------------------------------------------------
+
+
+def test_ac8_ziel_segment_bleibt_ohne_piktogramm_und_gsm7_rein():
+    """AC-8: Given ein Onset-Alarm mit Segment-Kennung "Ziel"
+    (`format_alert_location` liefert `🏁 Ziel`) / When die SMS gerendert wird /
+    Then steht dort das Wort "Ziel", aber weder `🏁` noch dessen
+    Transliteration `:checkered_flag:` — die Ausgabe ist ASCII-rein."""
+    sms = render_sms(_onset_msg(_onset_event(segment_id="Ziel")))
+
+    assert "Ziel" in sms, (
+        f"Das Segment-Wort 'Ziel' muss stehenbleiben: {sms!r}"
+    )
+    assert "\U0001F3C1" not in sms, f"Piktogramm 🏁 steht in der SMS: {sms!r}"
+    assert ":checkered_flag:" not in sms, (
+        f"Piktogramm wurde transliteriert statt entfernt: {sms!r}"
+    )
+    assert sms.isascii(), f"Kurznachricht ist nicht ASCII-rein: {sms!r}"
+    assert len(sms) <= 140, f"Kurznachricht ist {len(sms)} Zeichen lang: {sms!r}"
+
+
+# ---------------------------------------------------------------------------
+# AC-9 — Vergleich: nur der Ortsvergleich traegt einen Ortsnamen
+# ---------------------------------------------------------------------------
+
+
+def test_ac9_nur_das_compare_ergebnis_traegt_den_ortsnamen():
+    """AC-9: Given zwei strukturell identische Onset-Nachrichten — eine
+    Trip-Radar-Nachricht (kein Ortsname) und eine Ortsvergleich-Buendel-
+    Nachricht (Ortsname gesetzt) / When beide gerendert werden / Then traegt
+    NUR das Compare-Ergebnis den Ortsnamen im Kopf; das Trip-Ergebnis nennt
+    die aufgeloeste Ortsangabe ohne Namenspraefix.
+
+    Die Zusicherung ist der VERGLEICH beider Ergebnisse."""
+    from output.renderers.alert.project import to_multi_location_onset_alert_message
+
+    trip_sms = render_sms(_onset_msg(
+        _onset_event(is_convective=False, onset_time="14:35", km_from=0.0,
+                     km_to=0.0, intensity_label="leichter Regen"),
+    ))
+    compare_sms = render_sms(to_multi_location_onset_alert_message(
+        [("Zermatt", _nowcast()), ("Chamonix", _nowcast())],
+        tz=timezone.utc, stand_at="10:00",
+    ))
+
+    trip_kopf, compare_kopf = _kopf(trip_sms), _kopf(compare_sms)
+
+    assert compare_kopf == "Zermatt", (
+        f"Compare-Kopf muss der Ortsname sein, bekam {compare_sms!r}"
+    )
+    assert trip_kopf == "km 0-0", (
+        f"Trip-Kopf muss die aufgeloeste Ortsangabe ohne Namen sein, "
+        f"bekam {trip_sms!r}"
+    )
+    assert trip_kopf != compare_kopf, (
+        f"Trip- und Compare-Kopf duerfen nicht zusammenfallen: "
+        f"{trip_sms!r} / {compare_sms!r}"
+    )
+    assert "Zermatt" not in trip_sms, (
+        f"Trip-SMS darf keinen Ortsnamen tragen: {trip_sms!r}"
+    )
+    # Beide sprechen dieselbe Token-Sprache — nur der Kopf unterscheidet sie.
+    for sms in (trip_sms, compare_sms):
+        assert _ZEITPUNKT_TOKEN_RE.search(sms), (
+            f"Beide Nachrichten muessen ein Zeitpunkt-Token tragen: {sms!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-10 — E-Mail/Telegram/Betreff bleiben unberuehrt
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("segment_id, ort", [(None, "km 8–8"), ("Ziel", "🏁 Ziel")])
+def test_ac10_email_telegram_betreff_bleiben_am_countdown_format(segment_id, ort):
+    """AC-10: Given dieselben Eingaben wie AC-1/AC-3 / When zusaetzlich
+    Betreff, E-Mail und Telegram gerendert werden / Then bleiben deren
+    Ausgaben unveraendert: `_km_str_onset`-Sprache (`km 8–8` mit Gedankenstrich
+    bzw. `🏁 Ziel` mit Piktogramm) und Countdown-Formulierung "in 8 Min".
+
+    Nicht-Beruehrungs-Nachweis: dieser Test ist vor UND nach S4 gruen."""
+    msg = _onset_msg(_onset_event(segment_id=segment_id))
+
+    subject = render_subject(msg)
+    telegram = render_telegram(msg)
+    _html, plain = render_email(msg)
+
+    assert subject == f"[KHW 403] {ort} · Gewitter in 8 Min", (
+        f"Betreff hat sich veraendert: {subject!r}"
+    )
+    assert telegram == (
+        f"<b>KHW 403 · {ort} · Gewitter in 8 Min</b>\n"
+        f"15:40 · Gewitter mit Hagel · Radar (ICON-D2)"
+    ), f"Telegram hat sich veraendert: {telegram!r}"
+    assert "Gewitter in 8 Min" in plain, (
+        f"E-Mail hat die Countdown-Ueberschrift verloren: {plain!r}"
+    )
+    assert f"Wo & wann: {ort} · ab 15:40" in plain, (
+        f"E-Mail hat die 'Wo & wann'-Zeile veraendert: {plain!r}"
+    )
+    assert "TH@" not in plain and "TH@" not in telegram and "TH@" not in subject, (
+        "Das SMS-Zeitpunkt-Token darf in keinen anderen Kanal auslaufen"
+    )
+
+
+def test_ac10_render_modul_importiert_day_window_nicht():
+    """AC-10 (struktureller Nicht-Beruehrungs-Nachweis, kein
+    Verhaltensnachweis): `render.py` importiert `app.day_window` /
+    `display_end_time()` nicht — die #1599-Leitplanke bleibt ausserhalb der
+    Onset-Aufrufkette.
+
+    Der Prueflings-Quelltext wird ueber das IMPORTIERTE Modul aufgeloest
+    (`inspect.getsource`), nie ueber einen festen Repo-Pfad — sonst pruefte
+    der Test aus einem Worktree heraus die falsche Datei."""
+    from output.renderers.alert import render as render_module
+
+    # Nachweis, dass der Prueling aus DIESEM Arbeitsbaum stammt.
+    modul_pfad = Path(inspect.getfile(render_module)).resolve()
+    arbeitsbaum = Path(__file__).resolve().parents[2]
+    assert modul_pfad.is_relative_to(arbeitsbaum), (
+        f"Prueling stammt nicht aus diesem Arbeitsbaum: {modul_pfad}"
+    )
+
+    baum = ast.parse(inspect.getsource(render_module))
+    module_namen: set[str] = set()
+    for node in ast.walk(baum):
+        if isinstance(node, ast.Import):
+            module_namen.update(a.name for a in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            module_namen.add(node.module)
+
+    verletzungen = {m for m in module_namen if m.endswith("day_window")}
+    assert not verletzungen, (
+        f"render.py importiert day_window: {sorted(verletzungen)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-11 — fuehrende Null nur in der Kurznachricht
+# ---------------------------------------------------------------------------
+
+
+def test_ac11_nur_die_kurznachricht_kuerzt_die_fuehrende_null():
+    """AC-11: Given ein Onset-Alarm mit `onset_time="09:05"` / When derselbe
+    Alarm ueber SMS, E-Mail und Telegram gerendert wird / Then traegt ALLEIN
+    die Kurznachricht die Stunde ohne fuehrende Null (`TH@9:05`), waehrend
+    E-Mail und Telegram die volle Form `09:05` behalten. Die Minuten bleiben
+    ueberall zweistellig, das Feld `onset_time` selbst bleibt unveraendert.
+
+    Ein Test, der beide Seiten gegeneinanderstellt — eine Kuerzung an der
+    falschen Stelle schlaegt hier rot."""
+    event = _onset_event(onset_time="09:05", onset_minutes=12)
+    msg = _onset_msg(event)
+
+    sms = render_sms(msg)
+    telegram = render_telegram(msg)
+    _html, plain = render_email(msg)
+
+    assert "TH@9:05" in sms, (
+        f"Kurznachricht muss die Stunde ohne fuehrende Null zeigen: {sms!r}"
+    )
+    assert "09:05" not in sms, (
+        f"Kurznachricht traegt noch die fuehrende Null: {sms!r}"
+    )
+    treffer = _ZEITPUNKT_TOKEN_RE.search(sms)
+    assert treffer and treffer.group(3) == "05", (
+        f"Die Minuten muessen zweistellig bleiben: {sms!r}"
+    )
+
+    assert "09:05" in telegram, (
+        f"Telegram muss die volle Form '09:05' behalten: {telegram!r}"
+    )
+    assert "9:05 ·" not in telegram.replace("09:05 ·", ""), (
+        f"Telegram darf die Stunde nicht kuerzen: {telegram!r}"
+    )
+    assert "ab 09:05" in plain, (
+        f"E-Mail muss die volle Form '09:05' behalten: {plain!r}"
+    )
+
+    assert event.onset_time == "09:05", (
+        "Das Feld onset_time selbst darf nicht veraendert werden — nur seine "
+        "Darstellung in der Kurznachricht"
+    )

--- a/tests/tdd/test_alert_sms_segment_head.py
+++ b/tests/tdd/test_alert_sms_segment_head.py
@@ -216,11 +216,18 @@ def test_ac12_trip_radar_sms_verliert_den_namen_compare_radar_sms_behaelt_ihn():
     sms_trip = render_sms(trip_msg)
     sms_compare = render_sms(compare_msg)
 
-    assert sms_trip.startswith("km5-18: "), (
+    # FORTGESCHRIEBEN (Issue #1948 S4 AC-9): das Format wechselte auf
+    # `format_alert_location`-Schreibweise + Zeitpunkt-Token; die
+    # DIFFERENZLOGIK zwischen beiden Ergebnissen bleibt die Zusicherung.
+    assert sms_trip.startswith("km 5-18: "), (
         f"Trip-Radar-SMS traegt weiterhin einen Namens-Kopf: {sms_trip!r}"
     )
     assert "KHW 403" not in sms_trip, f"Trip-Name noch in der SMS: {sms_trip!r}"
 
-    assert sms_compare.startswith("Vergleich km5-18: "), (
-        f"Compare-Radar-SMS hat ihren Sammelnamen verloren: {sms_compare!r}"
+    assert sms_compare.startswith("Vergleich: "), (
+        f"Compare-Radar-SMS hat ihren Ortsnamen verloren: {sms_compare!r}"
+    )
+    assert sms_trip != sms_compare, (
+        f"Trip- und Compare-Kopf duerfen nicht zusammenfallen: "
+        f"{sms_trip!r} / {sms_compare!r}"
     )

--- a/tests/tdd/test_ascii_folding.py
+++ b/tests/tdd/test_ascii_folding.py
@@ -214,31 +214,29 @@ def test_radar_alert_trip_short_survives_double_truncation():
     falten, dann nochmal kuerzen), die Buchstaben frisst, weil 'ü' -> 'ue'
     beim Falten waechst.
 
-    Retargeted (Issue #1935/#1779 E4, PO-Entscheid 2026-08-17): der reine
-    TRIP-Radar/Onset-Pfad (`OnsetEvent.location_label=None`, wie ihn
-    `radar_alert_service.py::build_onset_alert_message` baut) fuehrt seither
-    KEINEN Namen mehr im SMS-Kopf — die urspruengliche Fixture ueber
-    `build_onset_alert_message` wuerde den Pruefling (die Doppelkuerzungs-
-    Logik `_ascii(msg.trip_short)[:16].rstrip(...)`) gar nicht mehr
-    durchlaufen und still bedeutungslos gruen bleiben (kein `trip_short` mehr
-    im Kopf, also nichts mehr zu kuerzen). Dieselbe Kuerzungslogik greift
-    unveraendert im Compare-Radar-Buendel-Pfad (`OnsetEvent.location_label`
-    gesetzt, Issue #1935/#1779 AC-10/AC-12 — dort ist `trip_short` der
-    Orts-Sammelname und bleibt bewusst stehen), dorthin verlegt dieser Test
-    die Fixture, ohne die Pruefling-Logik selbst zu aendern."""
-    from output.renderers.alert.model import AlertMessage, OnsetEvent
+    Retargeted ZWEIMAL, jedesmal weil der VORHERIGE Traeger-Pfad die
+    Doppelkuerzung verlor — die Pruefling-Logik selbst blieb unveraendert:
+    (1) Issue #1935/#1779 E4: weg vom reinen Trip-Radar/Onset-Pfad, der
+    seither keinen Namen mehr im Kopf fuehrt, hin zum Compare-Radar-
+    Buendel-Pfad. (2) Issue #1948 S4 (2026-08-19): auch der Onset-Buendel-Kopf
+    fuehrt seither den Ortsnamen aus `location_label` statt des gekuerzten
+    `trip_short` — die Kuerzungslogik `_ascii(msg.trip_short)[:16].rstrip(...)`
+    lebt unveraendert im Schwellen-Alarm-Kopf (`_render_sms_corridor_only`,
+    render.py:872) und im Trip-Aenderungs-Kopf (render.py:922) weiter. Dorthin
+    verlegt dieser Test die Fixture — wieder ohne den Pruefling zu aendern.
+    Blieben wir am Onset-Pfad, waere der Test still bedeutungslos gruen."""
+    from output.renderers.alert.model import AlertMessage, CorridorEvent
     from output.renderers.alert.render import render_sms
     from utils.ascii_fold import fold_ascii
 
     trip_short = "Wandergruppe München"
-    onset = OnsetEvent(
-        onset_minutes=12, onset_time="14:00", km_from=0.0, km_to=5.0,
-        is_convective=False, intensity_label="leichter Regen",
-        source_label="Radar", location_label="Buendel-Ort",
+    corridor = CorridorEvent(
+        metric_id="temperature", value=31.0, bound=30.0, direction="above",
+        occurred_at="14:00", km_from=0.0, km_to=5.0,
     )
     msg = AlertMessage(
-        trip_short=trip_short, stand_at="14:00", events=(onset,),
-        source="Radar", cooldown_display="60 Min",
+        trip_short=trip_short, stand_at="14:00", events=(),
+        corridor_events=(corridor,), cooldown_display="60 Min",
     )
 
     sms = render_sms(msg)

--- a/tests/tdd/test_issue_919_radar_alert_canonical.py
+++ b/tests/tdd/test_issue_919_radar_alert_canonical.py
@@ -138,7 +138,13 @@ class TestAC4Telegram:
 # ---------------------------------------------------------------------------
 
 class TestAC5SMS:
-    """AC-5: render_sms — '!'-Onset-Token, ≤140 Zeichen, GSM-7-only."""
+    """AC-5: render_sms — Onset-Token, ≤140 Zeichen, GSM-7-only.
+
+    FORTGESCHRIEBEN (Issue #1948 S4, 2026-08-19): das Token nennt seither den
+    ZEITPUNKT (`R@14:35`) statt des Countdowns (`R!12`) — PO-Zielbild aus
+    `docs/analysis/alarm-format-konzept-2026-08.md`. Laenge und GSM-7-Reinheit
+    sind unveraendert zugesichert und bleiben hier der eigentliche Wachposten.
+    """
 
     def test_ac5_render_sms_onset_regen_token(self):
         from src.output.renderers.alert.render import render_sms
@@ -146,7 +152,7 @@ class TestAC5SMS:
         msg = _make_onset_msg(is_convective=False, onset_minutes=12)
         sms = render_sms(msg)
 
-        assert "R!12" in sms, f"Regen-Onset-Token 'R!12' fehlt: {sms!r}"
+        assert "R@14:35" in sms, f"Regen-Onset-Token 'R@14:35' fehlt: {sms!r}"
         assert len(sms) <= 140, f"SMS zu lang ({len(sms)}): {sms!r}"
         assert set(sms) <= GSM7_BASIC, (
             f"Nicht-GSM-7-Zeichen: {set(sms) - GSM7_BASIC!r} in {sms!r}"
@@ -158,7 +164,9 @@ class TestAC5SMS:
         msg = _make_onset_msg(is_convective=True, onset_minutes=8)
         sms = render_sms(msg)
 
-        assert "TH!8" in sms, f"Gewitter-Onset-Token 'TH!8' fehlt: {sms!r}"
+        assert "TH@14:35" in sms, (
+            f"Gewitter-Onset-Token 'TH@14:35' fehlt: {sms!r}"
+        )
         assert len(sms) <= 140, f"SMS zu lang ({len(sms)}): {sms!r}"
         assert set(sms) <= GSM7_BASIC, (
             f"Nicht-GSM-7-Zeichen: {set(sms) - GSM7_BASIC!r} in {sms!r}"

--- a/tests/tdd/test_multi_location_onset_alert.py
+++ b/tests/tdd/test_multi_location_onset_alert.py
@@ -97,7 +97,9 @@ EXPECTED_TELEGRAM = (
     '<b>GR20-Test · km 5–18 · Regen in 12 Min</b>\n14:35 · leichter Regen · Radar (DWD)'
 )
 # Issue #1935/#1779 (E4): Trip-Radar/Onset-Kopf verliert den Trip-Namen.
-EXPECTED_SMS = 'km5-18: R!12'
+# FORTGESCHRIEBEN (Issue #1948 S4): Zeitpunkt statt Countdown, Kopf in
+# `format_alert_location`-Schreibweise. Telegram bleibt unveraendert.
+EXPECTED_SMS = 'km 5-18: R@14:35'
 
 
 def _fresh_user(prefix: str) -> str:


### PR DESCRIPTION
## Was sich ändert

#1948 Scheibe S4 (Zweig c): Die Nowcast-/Onset-Kurznachricht zieht auf das einheitliche Alarm-Format nach.

| | vorher | nachher |
|---|---|---|
| Ereignis-Token | `TH!8` („in 8 Minuten") | `TH@15:40` („ab 15:40 Uhr") |
| Kopf | selbstgebaute km-Notation `km8-8` | gemeinsame Ortsauflösung (`Ziel`, Ortsname, km-Rückfall) |
| Ein-Ort-Ortsvergleich | strukturell `km0-0`, kein Ortsname möglich | Ortsname aus `trip_short` |

Zusätzlich: Der Freitext-Marker `"compare-radar"` wird zur benannten Konstante `COMPARE_RADAR_SOURCE` — Setz- und Lesestelle können nicht mehr stillschweigend auseinanderlaufen.

Die führende Null der Stunde entfällt **ausschließlich** in der Kurznachricht (`TH@9:05`); E-Mail, Telegram und Betreff lesen `onset_time` unverändert.

## Nachweis

- **11 von 11 ACs** erfüllt, jedes mit dediziertem Test in `tests/tdd/test_alert_sms_onset_zeitpunkt.py`
- **Adversary VERIFIED** — 10 Mutationen, 8 gefangen
- Feature-Tests: 120 passed, 0 failed (nach Rebase, inkl. #1971-Nachbartests)
- Kern-Suite in CI-Aufrufform: 9943 passed, 2 failed — beide umgebungsbedingt (Telegram-ENV-Guard, Staging-Port-Timeout), keine der beiden Dateien importiert den geänderten Renderer

## Nicht in dieser Scheibe

Zwei Adversary-Nebenbefunde sind gebucht statt hier gefixt:

- **#1196** — `test_alert_sms_location_positions.py` trägt modulweit `pytest.mark.live`; neun Tests laufen nie in der CI-Ampel mit. Vorbestehend, nicht von S4 verursacht.
- **#1199** — der 140-Zeichen-Schnitt in `_render_sms_onset` ist von keinem Test bewacht; dieselbe Lücke besteht bei den Geschwisterfunktionen `_render_sms_onset_shift_only` und `_render_sms_corridor_only`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
