### PR TITLE
fix(#1911): Gewitter-Stufenliste aus dem Backend-Katalog ableiten

### DIFF
--- a/docs/context/fix-1911-thunder-katalog.md
+++ b/docs/context/fix-1911-thunder-katalog.md
@@ -1,0 +1,153 @@
+# Context: fix-1911-thunder-katalog
+
+Issue: [#1911](https://github.com/henemm/gregor_zwanzig/issues/1911) — Gewitter-Stufenliste in
+`WeatherMetricsTab.svelte` ist eine lokale Kopie statt Backend-Katalog (#1488 Scheibe A2).
+Track: Standard. Worktree `intake-1462`, Branch `worktree-intake-1462`.
+
+## Request Summary
+
+Die Gewitter-Stufenliste im Wetter-Metriken-Reiter soll nicht länger im Frontend hart codiert
+stehen, sondern aus dem Backend-Katalog kommen — damit dieselben vier Wörter nicht an mehreren
+Stellen von Hand gepflegt werden.
+
+## 🔴 Drei Befunde, die die Ticket-Prämisse korrigieren
+
+### B1 — Der Block ist ein Alarm-**Schwellen**wähler mit drei Einträgen, keine Anzeige-Skala mit vier
+
+`WeatherMetricsTab.svelte:1634-1638` führt genau drei Einträge:
+
+```js
+{ id: 'leicht', label: 'Leicht', float: 1.0 },
+{ id: 'mittel', label: 'Mittel', float: 2.0 },
+{ id: 'hoch',   label: 'Hoch',   float: 3.0 }
+```
+
+Kein `kein` — und das ist **richtig so**: Der Block füttert `ThresholdMetricRow.svelte`, also die
+Frage „ab welcher Stufe soll alarmiert werden?". „Ab Stufe *kein* alarmieren" ist keine sinnvolle
+Einstellung. `thunderThresholdLevels.test.ts:83-126` sichert die Drei ausdrücklich ab (genau drei
+Stufen, kein `kein`).
+
+Der Katalog liefert dagegen **vier** Labels (`kein/leicht/mittel/hoch`, `scale [0,3]`).
+
+**Folge für die Umsetzung:** Nicht „Liste ersetzen", sondern „Liste **ableiten**" — Katalog ohne
+die Nullstufe, `float` = Ordinalindex. Die Ableitungsregel muss benannt und getestet sein, sonst
+bricht die Umstellung einen bewussten Wächter und erzeugt eine fachlich unsinnige vierte Option.
+Die Ticket-Formulierung „Diese Liste wurde in #1474b bereits … auf die korrekten 4 Stufen
+korrigiert" trifft auf diesen Block nicht zu.
+
+### B2 — Der Backend-Katalog ist selbst eine handgepflegte Kopie
+
+`src/output/renderers/compare_metric_catalog.py:104-112` trägt `ordinalLabels` als **Literal**.
+Die Datei importiert nichts aus `src/output/metric_format.py`; `THUNDER_LABEL_DE`,
+`_THUNDER_ORDER` und `_THUNDER_LABEL_VALUE` (`metric_format.py:283-288`, re-exportiert aus
+`src/app/thunder_scale.py:42-43`) werden dort **nicht referenziert**. Die Übereinstimmung der vier
+Wörter entsteht durch Pflege, nicht durch Ableitung.
+
+Der Kommentar an Ort und Stelle dokumentiert die bereits eingetretene Drift selbst:
+
+> „eine dritte Stelle hier war seit der Ordinalverschiebung um eine Stufe zu kurz"
+
+**Folge:** Stellt man nur das Frontend um, **wandert** die Kopie ins Backend, sie verschwindet
+nicht. Die Zahl der handgepflegten Stellen sinkt von zwei auf eine — das Ticket-Ziel „kanonische
+Quelle" ist damit nicht erreicht. Das ist die Entscheidung, die in die Spec gehört (siehe
+„Offene Entscheidung" unten).
+
+### B3 — Es gibt keinen trip-tauglichen Endpoint mit `ordinalLabels`
+
+| Endpoint | Quelle | trägt `ordinalLabels`? | Zuschnitt |
+|---|---|---|---|
+| `GET /api/metrics` | `api/routers/config.py:72-115` → `metric_catalog.get_all_metrics()` | **nein** — `MetricDefinition` (`src/app/metric_catalog.py:27-90`) hat kein solches Feld | zentraler Trip-Katalog: `category`, `aggregations[]`, `sms_code`, `format_modes`, `selectable`-Filter |
+| `GET /api/compare/metrics` | `api/routers/compare.py:11-24` → `compare_metric_catalog.py` | **ja** | Bedienstruktur für Schwellenregler: `kind`, `rangeMin/Max`, `ordinalLabels`, `enumValues` |
+
+Der Go-Proxy (`internal/router/router.go:125,158`, `internal/handler/proxy.go:45-71`) ist reines
+Byte-Passthrough und beschneidet nichts.
+
+**Der gute Teil:** Der Weg ist bereits gebahnt. `WeatherMetricsTab.svelte` ruft
+`loadCompareSelectionEntries()` (Z.514) **auch im Trip-Kontext** — der `context === 'route'`-Zweig
+direkt darunter beweist es. `compareCatalog` steht im Trip-Kontext also schon zur Verfügung; das
+Template greift nur daran vorbei. Der Loader hat mit `buildRouteMetricDefsFromCatalog` (Z.131) und
+`loadRouteExtraMetricDefs` (Z.170) bereits ausdrücklich route-seitige Bausteine — der
+Compare-Endpoint als Trip-Datenquelle ist im Repo etabliert, kein Präzedenzbruch.
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `frontend/src/lib/components/shared/WeatherMetricsTab.svelte:1634-1638` | der umzustellende Block; Katalog liegt bereits als `compareCatalog` (`$state`, Z.206) vor |
+| `frontend/src/lib/components/shared/weather-metrics-tab/ThresholdMetricRow.svelte:28,40,44,46` | Verbraucher der `Level[]`-Form (`id`, `label`, `float`) |
+| `frontend/src/lib/components/shared/corridor-editor/compareMetricCatalogLoader.ts` | Ladepfad (`/api/compare/metrics`, Promise-Cache Z.86-98); braucht einen Mapper `ordinalLabels → Level[]` |
+| `src/output/renderers/compare_metric_catalog.py:104-112` | kanonische Quelle laut Ticket — faktisch handgepflegtes Literal (B2) |
+| `src/output/metric_format.py:283-288` / `src/app/thunder_scale.py:42-43` | die *echte* kanonische Stufenquelle |
+| `frontend/.../__tests__/thunderThresholdLevels.test.ts:35,49-70,83-126` | parst den hart codierten Block per Regex — wird durch die Umstellung obsolet, muss ersetzt statt gelöscht werden |
+| `frontend/.../corridor-editor/__tests__/compareMetricCatalogParity.test.ts:37-51` | Vorbild: liest die Python-Quelle **live** per `execFileSync('uv', …)`; CI-seitig abgesichert (`.github/workflows/ci.yml:91-109`) |
+
+## Existing Patterns
+
+- **Katalog-Parität per Live-Read.** `compareMetricCatalogParity.test.ts` fährt einen echten
+  Python-Prozess und vergleicht gegen den echten Katalog. Der CI-Job `frontend-test` installiert
+  dafür bereits `uv` + `uv sync`. Das ist der erprobte Weg, eine Frontend-Zusicherung gegen die
+  Backend-Wahrheit zu prüfen — und das Vorbild für den Test dieser Umstellung.
+- **Ein geteilter Baustein, Parameter `context`.** CLAUDE.md „Trip/Ortsvergleich-Code-Teilung":
+  eine neue trip-eigene Katalogkomponente wäre ein Verstoß.
+- **Promise-Cache statt Mehrfach-Fetch** (`compareMetricCatalogLoader.ts:86-98`, Issue #1373).
+
+## Dependencies
+
+- **Upstream:** `/api/compare/metrics` (Python) über den Go-Proxy; `ThunderLevel` /
+  `thunder_ordinal()` als Zählreferenz.
+- **Downstream:** `ThresholdMetricRow.svelte`; die gespeicherten SMS-/Alarm-Schwellenwerte im
+  Trip (`float`-Werte 1.0/2.0/3.0 — **Bestandsdaten**, die Ableitung muss dieselben Zahlen
+  erzeugen, sonst verschieben sich gespeicherte Schwellen um eine Stufe).
+
+## Existing Specs
+
+| Spec | Bezug |
+|---|---|
+| `docs/specs/modules/compare_weather_metrics_tab.md` (AC ab Z.281) | Migration der Komponente nach `shared/`, Kontext `trip`\|`vergleich` |
+| `docs/specs/modules/compare_metric_catalog_endpoint.md` (AC ab Z.118) | Ursprungsspec des Endpoints |
+| `docs/specs/modules/compare_metric_ssot_final.md` (AC ab Z.241) | SSoT-Migration, enthält den Thunder-Ordinal-Sonderfall |
+| `docs/specs/modules/rework_1351_compare_catalog.md` (AC ab Z.149) | Katalog-Erweiterung |
+
+Keine Spec referenziert #1911.
+
+## Risks & Considerations
+
+1. **Bestandsdaten-Risiko (höchstes).** Die gespeicherten Schwellen sind `float`-Werte. Erzeugt
+   die Ableitung andere Zahlen (z.B. 0/1/2 statt 1/2/3), verschieben sich alle gespeicherten
+   Gewitter-Alarmschwellen still um eine Stufe. Genau dieser Fehlertyp ist in #1474 schon einmal
+   passiert („um eine Stufe zu kurz").
+2. **Der bewachende Test wird zum Hindernis.** `thunderThresholdLevels.test.ts` prüft heute die
+   Existenz des hart codierten Literals per Regex. Er darf nicht ersatzlos gelöscht werden —
+   sonst verliert die Zusicherung „genau drei Schwellen, kein `kein`" ihren Wächter. Er muss auf
+   die Ableitung umgestellt werden (Vorbild: Parity-Test).
+3. **Ladezustand.** `compareCatalog` ist asynchron. Das Template muss einen Zustand vor dem Laden
+   überstehen, ohne eine leere Schwellenliste zu rendern (`compareCatalogLoaded`-Flag existiert).
+   Fehlerfall: `compareCatalogError` wird gesetzt — was zeigt die Zeile dann?
+4. **Sieben Montagepunkte**, davon vier im Trip-Kontext, drei im Compare-Kontext — die Änderung
+   wirkt in beiden Flächen (`TripTabs.svelte:224`, `TripNewEditor.svelte:881/1113`,
+   `CompareTabs.svelte:1396`, `CompareNewEditor.svelte:394/491`).
+5. **Kollision:** Session `1848` fasst dieselbe Datei in ihrer Scheibe A3 an. Abgestimmt:
+   #1911 zuerst, #1848 rebast danach.
+
+## Nebenbefunde (nicht in diesem Scope)
+
+- **`TripEditView.svelte` ist toter Code.** Kein Importpfad von `frontend/src/routes/`; die echte
+  Trip-Detail-Route mountet `TripTabs.svelte`. Referenziert nur aus drei reinen
+  Dateiinhalt-Tests. Es ist zugleich Montagepunkt Nr. 1 von `WeatherMetricsTab` (Z.201) — dieser
+  Mount ist unerreichbar.
+- **`AlertsPreviewCard.svelte`** hängt nur am Barrel `trip-detail/index.ts:8`, der selbst nirgends
+  importiert wird. Verdacht bestätigt, aber `deadTripOverviewComponentsRemoved.test.ts` führt ihn
+  nicht in seiner Löschliste.
+- Beide sind Aufräumarbeit, nicht die Katalog-Frage. Vorschlag: als eigene Scheibe oder
+  Sammel-Eintrag, nicht in diesen Workflow ziehen (LoC-Limit 250).
+
+## 🔴 Offene Entscheidung für die Analyse-/Spec-Phase
+
+**Reicht „Frontend liest Backend-Literal", oder muss `compare_metric_catalog.py` seine
+`ordinalLabels` für `thunder_level_max` aus `THUNDER_LABEL_DE` ableiten?**
+
+- **Nur Frontend:** kleiner Eingriff, erfüllt den Ticket-Wortlaut, lässt aber eine handgepflegte
+  Kopie im Backend stehen — die, die nachweislich schon einmal gedriftet ist.
+- **Frontend + Backend-Ableitung:** erfüllt das Ticket-Ziel („kanonische Quelle"), ist die
+  Voraussetzung dafür, dass der Wächter aus #1480 später überhaupt etwas Sinnvolles bewachen
+  kann, kostet aber Änderungen an einer Datei mit eigener Spec-Historie.

--- a/docs/context/fix-1911-thunder-katalog.md
+++ b/docs/context/fix-1911-thunder-katalog.md
@@ -141,13 +141,99 @@ Keine Spec referenziert #1911.
 - Beide sind Aufräumarbeit, nicht die Katalog-Frage. Vorschlag: als eigene Scheibe oder
   Sammel-Eintrag, nicht in diesen Workflow ziehen (LoC-Limit 250).
 
-## 🔴 Offene Entscheidung für die Analyse-/Spec-Phase
+## Analysis
 
-**Reicht „Frontend liest Backend-Literal", oder muss `compare_metric_catalog.py` seine
-`ordinalLabels` für `thunder_level_max` aus `THUNDER_LABEL_DE` ableiten?**
+### Type
 
-- **Nur Frontend:** kleiner Eingriff, erfüllt den Ticket-Wortlaut, lässt aber eine handgepflegte
-  Kopie im Backend stehen — die, die nachweislich schon einmal gedriftet ist.
-- **Frontend + Backend-Ableitung:** erfüllt das Ticket-Ziel („kanonische Quelle"), ist die
-  Voraussetzung dafür, dass der Wächter aus #1480 später überhaupt etwas Sinnvolles bewachen
-  kann, kostet aber Änderungen an einer Datei mit eigener Spec-Historie.
+Feature (Wartbarkeit/Code-Teilung) — kein nutzersichtbares Fehlverhalten heute.
+
+### Entschiedener Zuschnitt
+
+**Frontend-Ableitung UND Backend-Ableitung.** Begründung: Der Ticket-Kern ist „kanonische Quelle
+statt Kopie". Stellt man nur das Frontend um, sinkt die Zahl handgepflegter Stellen von zwei auf
+eine — das Ziel ist dann nicht erreicht, und der Wächter aus #1480 (nächster Workflow) müsste
+ausgerechnet die kanonische Quelle als geduldete Ausnahme führen. Die Backend-Ableitung kostet
+~8 LoC.
+
+### Affected Files
+
+| Datei | Typ | Beschreibung | LoC |
+|---|---|---|---|
+| `src/output/renderers/compare_metric_catalog.py` | MODIFY | Literal Z.111 → Ableitung aus `THUNDER_LABEL_DE` | +8/-3 |
+| `frontend/.../weather-metrics-tab/compareMetricSelection.ts` | MODIFY | `ordinalLabels`-Durchreichung (Interface Z.7-30 + Mapping Z.60ff.) | +3 |
+| `frontend/.../corridor-editor/compareMetricCatalogLoader.ts` | MODIFY | neue Exportfunktion `deriveThunderThresholdLevels` | +10 |
+| `frontend/.../shared/WeatherMetricsTab.svelte` | MODIFY | Z.1634-1638 Literal → Funktionsaufruf | +2/-5 |
+| `frontend/.../__tests__/thunderThresholdLevels.test.ts` | MODIFY | Regex-Parsing → echte Funktion gegen Live-Backend-Antwort | +40/-60 |
+
+**Scope:** 5 Dateien, ~70-90 LoC netto. Risiko **MEDIUM** — nicht wegen Umfang, sondern wegen
+Punkt „Bestandsdaten" unten.
+
+### Technischer Ansatz
+
+**Backend.** `THUNDER_LABEL_DE` (`metric_format.py:283-288`) ist ein `dict[ThunderLevel, str]`.
+Die Reihenfolge **nicht** über die Dict-Einfügereihenfolge nehmen (impliziter Vertrag), sondern
+über die öffentliche Funktion `thunder_ordinal()` (`src/app/thunder_scale.py:47-57`, re-exportiert
+und in `metric_format.__all__`):
+
+```python
+_THUNDER_ORDINAL_LABELS = [
+    THUNDER_LABEL_DE[lvl] for lvl in sorted(ThunderLevel, key=thunder_ordinal)
+]
+```
+
+Zyklenfrei: `metric_format.py` importiert nur aus `app.*`, nie aus `output.renderers.*`.
+Präzedenz für genau diesen Import besteht (`renderers/narrow.py:36`, `renderers/comparison.py:48`).
+
+**Frontend.** 🔴 **Lücke gegenüber dem Kontext-Teil oben:** `compareCatalog`
+(`WeatherMetricsTab.svelte:206`) ist vom Typ `CompareSelectionEntry[]`, erzeugt von
+`toCompareSelectionEntries()` (`compareMetricSelection.ts:41-80`) — und diese Funktion reicht
+`ordinalLabels` **nicht** durch. Die Rohinfo ist im Trip-Kontext also noch nicht verfügbar; die
+Durchreichung ist ein eigener, additiver Schritt (Muster wie `sms_code`).
+
+Danach eine Ableitungsfunktion, die die Nullstufe verwirft und `float` = Ordinalindex setzt —
+Index 1/2/3 für leicht/mittel/hoch, also **wertgleich zum heutigen Literal**.
+
+### 🔴 Bestandsdaten: der Fehler, der still wirken würde
+
+Der gewählte Wert landet als `sms_threshold` am `MetricConfig` des Trips
+(`WeatherMetricsTab.svelte:235,424-426`) und wird backendseitig als Zahl interpretiert:
+`email/helpers.py:993` (`sms_threshold_thunder`), verglichen in `src/output/tokens/metrics.py:52`
+(`s.value >= threshold`).
+
+**Verschiebt die Ableitung die Zahlen um eins (0/1/2 statt 1/2/3), passiert Folgendes:** Wer
+bewusst „Hoch" eingestellt hat, bekäme `2` gespeichert und würde ab da schon bei *mittel*
+alarmiert — genau die Stufenverschiebung, die in #1474 schon einmal auftrat. Nichts daran ist
+sichtbar; es fällt erst bei einem Fehlalarm auf.
+
+**Befund:** `tests/tdd/test_thunder_mention_threshold_shared.py:172-219` prüft nur die
+Backend-*Interpretation* eines übergebenen Werts und bekommt literale `1.0`/`2.0` — eine falsche
+Frontend-Ableitung macht ihn **nicht** rot. Eine Ende-zu-Ende-Absicherung von der
+Frontend-Ableitung bis zur Backend-Auswertung existiert heute nicht.
+
+### Mutations-Gegenprobe (vorbereitet)
+
+| Verfälschung | muss rot machen |
+|---|---|
+| Nullstufe nicht verworfen | umgebauter `thunderThresholdLevels.test.ts` — „genau 3 Stufen" |
+| `float`-Offset um 1 verschoben | derselbe Test — Zuordnung Label↔float |
+| Reihenfolge umgedreht | derselbe Test |
+| Backend-Ableitung wieder durch Literal ersetzt | 🔴 **kein bestehender Test** — `compareMetricCatalogParity.test.ts` vergleicht den *Wert*, nicht die *Herkunft*. Braucht einen eigenen Test, sonst driftet B2 lautlos erneut |
+
+### Reihenfolge (kein deploybarer Zwischenzustand mit verschobenen Schwellen)
+
+1. Backend auf Ableitung umstellen — die Endpoint-Antwort bleibt **wertgleich**, nichts im
+   Frontend ändert sich.
+2. `ordinalLabels`-Durchreichung in `compareMetricSelection.ts` — rein additiv.
+3. Ableitungsfunktion schreiben und **vor** der Verdrahtung gegen den umgebauten Test nachweisen,
+   dass sie 1.0/2.0/3.0 liefert.
+4. Erst dann `WeatherMetricsTab.svelte:1634-1638` umstellen — der einzige Schritt, der die
+   gerenderten Schwellen anfasst.
+
+### Open Questions
+
+- [ ] Rendert der Gewitter-Block schon, bevor `compareCatalog` befüllt ist? (`compareCatalogLoaded`
+      existiert, aber die Bedingung am Block ist nicht verifiziert.) → in der TDD-Phase klären,
+      nicht raten.
+- [ ] Soll der Test „Backend-Ableitung darf kein Literal sein" in dieser Scheibe entstehen oder
+      dem Wächter aus #1480 überlassen bleiben? → Vorschlag: hier ein schmaler, gezielter Test;
+      der generische Wächter bleibt #1480.

--- a/docs/specs/modules/thunder_threshold_katalog.md
+++ b/docs/specs/modules/thunder_threshold_katalog.md
@@ -1,0 +1,234 @@
+---
+entity_id: thunder_threshold_katalog
+type: feature
+created: 2026-08-20
+updated: 2026-08-20
+status: draft
+version: "1.0"
+tags: [thunder, compare, metrics, frontend, backend, ssot]
+workflow: fix-1911-thunder-katalog
+---
+
+# Gewitter-Schwellenliste: Ableitung statt Doppel-Kopie (#1911)
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Die Alarmschwellenliste (leicht/mittel/hoch) im Gewitter-Block des Wetter-Metriken-Reiters
+(`WeatherMetricsTab.svelte`) ist heute ein hart codiertes Frontend-Literal. Sie soll stattdessen
+aus dem Backend-Katalog abgeleitet werden. Der Backend-Katalog selbst
+(`compare_metric_catalog.py::ordinalLabels`) ist dabei aber ebenfalls nur ein handgepflegtes
+Literal — er muss zuerst seinerseits aus der kanonischen Stufenquelle `THUNDER_LABEL_DE`
+abgeleitet werden, sonst wandert die Kopie lediglich vom Frontend ins Backend, statt zu
+verschwinden. Beide Ableitungen zusammen schließen die Kette: kanonische Quelle →
+Backend-Katalog → Frontend-Auswahlliste, mit genau einer Stelle, an der die vier Gewitter-Wörter
+gepflegt werden.
+
+## Source
+
+- **File:** `src/output/renderers/compare_metric_catalog.py` (Backend-Ableitung),
+  `frontend/src/lib/components/shared/WeatherMetricsTab.svelte` (Frontend-Verdrahtung)
+- **Identifier:** `COMPARE_METRIC_CATALOG`-Eintrag `thunder_level_max` (`compare_metric_catalog.py:104-112`),
+  Level-Literal `{ id: 'leicht'|'mittel'|'hoch', label, float }` (`WeatherMetricsTab.svelte:1634-1638`)
+
+> Schicht-Hinweis: **Python-Core** (`src/output/renderers/compare_metric_catalog.py`,
+> `src/output/metric_format.py`, `src/app/thunder_scale.py`) für die Backend-Ableitung;
+> **Frontend** (`frontend/src/lib/components/shared/...`, SvelteKit) für Durchreichung und
+> Verdrahtung. Kein Go-Touch — der Proxy ist reines Byte-Passthrough.
+
+## Estimated Scope
+
+- **LoC:** ~70-90 (siehe Betroffene Dateien) — unterhalb des 250-LoC-Limits, kein Override nötig.
+- **Files:** 5 (4 MODIFY Frontend/Backend, 1 MODIFY Test)
+- **Effort:** medium — nicht wegen Umfang, sondern wegen des Bestandsdaten-Risikos
+  (gespeicherte `float`-Schwellen dürfen sich nicht um eine Stufe verschieben).
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `THUNDER_LABEL_DE` (`src/output/metric_format.py:283-288`) | module | kanonische deutsche Beschriftung je `ThunderLevel` — neue Quelle für `ordinalLabels` |
+| `thunder_ordinal()` (`src/app/thunder_scale.py:47-57`) | function | kanonische Sortier-/Zählreferenz für die Stufenreihenfolge, re-exportiert über `metric_format.py` |
+| `GET /api/compare/metrics` (`api/routers/compare.py:11-24`) | backend endpoint | einziger Endpoint, der `ordinalLabels` trägt; Antwort bleibt wertgleich |
+| `compareMetricSelection.ts::toCompareSelectionEntries` | frontend module | Mapper Endpoint-Antwort → `CompareSelectionEntry[]`, muss `ordinalLabels` künftig durchreichen |
+| `compareMetricCatalogLoader.ts` | frontend module | Ladepfad + Promise-Cache für `compareCatalog`, bekommt neue Exportfunktion `deriveThunderThresholdLevels` |
+| `ThresholdMetricRow.svelte` | frontend component | Verbraucher der `Level[]`-Form (`id`/`label`/`float`), unverändert |
+| `email/helpers.py::sms_threshold_thunder`, `src/output/tokens/metrics.py:52` | module | Backend-Interpretation des gespeicherten `float`-Werts — Zielwerte 1.0/2.0/3.0 müssen exakt erhalten bleiben |
+
+## Implementation Details
+
+**1. Backend-Ableitung (`compare_metric_catalog.py:104-112`).** `ordinalLabels` wird nicht mehr
+als Literal-Liste geschrieben, sondern aus `THUNDER_LABEL_DE` gebaut, sortiert über
+`thunder_ordinal()` — nicht über die Dict-Einfügereihenfolge (impliziter, nicht erzwungener
+Vertrag):
+
+```
+_THUNDER_ORDINAL_LABELS = [
+    THUNDER_LABEL_DE[lvl] for lvl in sorted(ThunderLevel, key=thunder_ordinal)
+]
+```
+
+Ergebnis bleibt exakt `["kein", "leicht", "mittel", "hoch"]` — die Endpoint-Antwort ändert sich
+nicht, nur ihre Herkunft. Zyklenfrei: `metric_format.py` importiert nur aus `app.*`, nie aus
+`output.renderers.*` (Präzedenz: `renderers/narrow.py:36`, `renderers/comparison.py:48`).
+
+**2. Durchreichung (`compareMetricSelection.ts`).** `toCompareSelectionEntries()` reicht
+`ordinalLabels` aus der Endpoint-Antwort in `CompareSelectionEntry` durch (additiv, Muster wie
+`sms_code`) — heute geht die Information hier verloren, `compareCatalog` im Trip-Kontext trägt sie
+noch nicht.
+
+**3. Ableitungsfunktion (`compareMetricCatalogLoader.ts`).** Neue Exportfunktion
+`deriveThunderThresholdLevels(ordinalLabels: string[]): Level[]`: verwirft Index 0 (die
+Nullstufe `kein`), bildet die verbleibenden Einträge auf `{ id, label, float }` ab mit
+`float = Ordinalindex` (1/2/3 für leicht/mittel/hoch) — wertgleich zum heutigen Literal. Reine,
+testbare Funktion ohne Svelte-Import.
+
+**4. Verdrahtung (`WeatherMetricsTab.svelte:1634-1638`).** Das Literal wird durch einen Aufruf von
+`deriveThunderThresholdLevels(compareCatalog-Eintrag für thunder_level_max)` ersetzt. Solange
+`compareCatalog` noch nicht geladen ist (`compareCatalogLoaded === false`) oder das Laden
+fehlschlug (`compareCatalogError` gesetzt), rendert der Block einen definierten Leer-/
+Fehlerzustand statt eine leere oder kaputte Liste zu zeigen — kein Absturz, keine unwählbare
+Schwelle.
+
+**Reihenfolge (kein deploybarer Zwischenzustand mit verschobenen Schwellen):**
+1. Backend auf Ableitung umstellen (wertgleich, Frontend unberührt).
+2. `ordinalLabels`-Durchreichung in `compareMetricSelection.ts` (additiv).
+3. Ableitungsfunktion schreiben, vor der Verdrahtung gegen den umgebauten Test nachweisen, dass
+   sie 1.0/2.0/3.0 liefert.
+4. Erst dann `WeatherMetricsTab.svelte:1634-1638` umstellen.
+
+## Expected Behavior
+
+- **Input:** Öffnen des Gewitter-Schwellenreglers im Wetter-Metriken-Reiter (Trip- oder
+  Compare-Kontext).
+- **Output:** genau drei wählbare Stufen (leicht/mittel/hoch) mit denselben Labels und
+  denselben `float`-Werten (1.0/2.0/3.0) wie vor der Umstellung; die Labels stammen aus dem
+  Backend-Katalog, der seinerseits aus `THUNDER_LABEL_DE` abgeleitet ist.
+- **Side effects:** keine neuen Netzwerk-Requests (nutzt den bereits vorhandenen
+  `/api/compare/metrics`-Fetch/Cache); keine Änderung an gespeicherten Trip-Daten für
+  unveränderte Nutzereingaben.
+
+## Acceptance Criteria
+
+- **AC-1:** Given der Gewitter-Schwellenregler im Wetter-Metriken-Reiter ist geladen / When die
+  Optionsliste gerendert wird / Then zeigt sie genau drei Einträge (leicht/mittel/hoch) und die
+  Nullstufe „kein" erscheint NICHT als wählbare Alarmschwelle.
+  - Test: umgebauter `thunderThresholdLevels.test.ts` ruft `deriveThunderThresholdLevels()` mit
+    der echten Vier-Stufen-Antwort auf und prüft Länge 3 sowie Abwesenheit von `kein`
+    (Verhaltenstest der Ableitungsfunktion, kein Regex-Parsing des Frontend-Literals mehr).
+
+- **AC-2:** Given ein Bestandstrip mit gespeicherter Alarmschwelle „hoch" (`float=3.0`) / When der
+  Reiter nach der Umstellung neu geöffnet und die Schwelle unverändert gespeichert wird / Then
+  bleibt der gespeicherte Zahlenwert exakt `3.0` — keine Verschiebung auf `2.0` oder einen anderen
+  Wert; dieselbe Prüfung gilt analog für „leicht" (`1.0`) und „mittel" (`2.0`).
+  - Test: Kern-Test ruft `deriveThunderThresholdLevels(["kein","leicht","mittel","hoch"])` auf und
+    vergleicht die drei zurückgegebenen `float`-Werte Feld für Feld gegen `1.0`/`2.0`/`3.0`;
+    ergänzt um einen Backend-Test, der `sms_threshold_thunder`/`src/output/tokens/metrics.py:52`
+    mit denselben drei Werten gegen die heutige Interpretation absichert.
+
+- **AC-3:** Given die Beschriftungen im Schwellenregler / When Backend und Frontend verglichen
+  werden / Then stammen die drei Label-Texte nachweislich aus `THUNDER_LABEL_DE` und stehen an
+  keiner Stelle mehr als eigenständiges Frontend-Literal im Quelltext von `WeatherMetricsTab.svelte`.
+  - **Zulässige Abweichung: allein die Groß-/Kleinschreibung des Anfangsbuchstabens.** Der Katalog
+    führt `leicht`/`mittel`/`hoch` klein, die Schaltflächen zeigen heute `Leicht`/`Mittel`/`Hoch`.
+    Diese Anzeigeform bleibt unverändert — die Ableitung stellt den Anfangsbuchstaben groß. Der
+    Vergleich erfolgt daher gegen die normalisierte Form; jede andere Abweichung ist ein Verstoß.
+  - Test: `compareMetricCatalogParity.test.ts`-artiger Live-Read gegen `THUNDER_LABEL_DE`
+    (`execFileSync('uv', …)`) plus statischer Nachweis (Test oder Grep-Assertion mit
+    `# doc-compliance-test`-Kennzeichnung), dass das alte `{ id: 'leicht', label: 'Leicht', ... }`-
+    Literal aus `WeatherMetricsTab.svelte` entfernt ist.
+
+- **AC-4:** Given `src/output/renderers/compare_metric_catalog.py` / When der Eintrag
+  `thunder_level_max` inspiziert wird / Then wird sein `ordinalLabels`-Feld aus `THUNDER_LABEL_DE`
+  abgeleitet (nicht als Literal geschrieben) und die Antwort von `GET /api/compare/metrics` bleibt
+  dabei wertgleich zu heute (`["kein", "leicht", "mittel", "hoch"]`).
+  - Test: bestehender `test_compare_metric_catalog_endpoint.py` bleibt grün (Wertevergleich der
+    Endpoint-Antwort); neuer Kern-Test importiert `THUNDER_LABEL_DE` und prüft, dass sich eine
+    Änderung an `THUNDER_LABEL_DE` unmittelbar in `COMPARE_METRIC_CATALOG['thunder_level_max']
+    ['ordinalLabels']` niederschlägt (Ableitungsnachweis, nicht nur Wertegleichheit).
+
+- **AC-5:** Given die vier `ThunderLevel`-Werte in `THUNDER_LABEL_DE` / When die Reihenfolge der
+  abgeleiteten `ordinalLabels` bestimmt wird / Then entsteht sie über `thunder_ordinal()`
+  (NONE=0 < LOW=1 < MED=2 < HIGH=3), nicht über die Einfügereihenfolge des Dicts.
+  - Test: Kern-Test baut eine `THUNDER_LABEL_DE`-Kopie mit absichtlich vertauschter
+    Einfügereihenfolge und prüft, dass die Ableitung trotzdem die korrekte, über
+    `thunder_ordinal()` sortierte Reihenfolge liefert.
+
+- **AC-6:** Given eine fünfte, hypothetische Gewitterstufe würde `ThunderLevel`, `THUNDER_LABEL_DE`
+  und `thunder_ordinal()` backendseitig hinzugefügt / When der Schwellenregler ohne jede
+  Frontend-Codeänderung neu geladen wird / Then erscheint die neue Stufe automatisch in der
+  Optionsliste (abzüglich der weiterhin verworfenen Nullstufe).
+  - Test: Kern-Test ruft `deriveThunderThresholdLevels()` mit einer synthetischen
+    Fünf-Stufen-Fixture (`["kein","leicht","mittel","hoch","extrem"]`) auf und prüft vier
+    zurückgegebene Einträge mit `float`-Werten 1.0-4.0 — ohne Änderung an der
+    Ableitungsfunktion selbst.
+
+- **AC-7:** Given `compareCatalog` ist noch nicht geladen (`compareCatalogLoaded === false`) oder
+  das Laden ist fehlgeschlagen (`compareCatalogError` gesetzt) / When der Wetter-Metriken-Reiter
+  gerendert wird / Then wirft der Gewitter-Block keinen Laufzeitfehler und zeigt einen definierten
+  Lade- bzw. Fehlerzustand statt einer leeren oder kaputten Optionsliste.
+  - Test: Component-Test rendert `WeatherMetricsTab` mit `compareCatalogLoaded=false` bzw. mit
+    gesetztem `compareCatalogError` und prüft Abwesenheit eines Exceptions/Absturzes sowie
+    Präsenz des definierten Platzhalter-Testids.
+
+## Nicht-Ziele
+
+- Der generische Wächter gegen lokale Stufen-Kopien (Issue #1480) wird hier **nicht** gebaut —
+  diese Spec liefert nur den gezielten Test für den Gewitter-Sonderfall, der breitere Wächter
+  bleibt ein eigener, späterer Workflow.
+- Das Aufräumen von totem Code (`TripEditView.svelte`, `AlertsPreviewCard.svelte`) gehört
+  **nicht** in diesen Scope — es ist ein unabhängiger Nebenbefund, kein Teil der
+  Katalog-Ableitung.
+- Die sechs übrigen Metrik-Schwellenlisten in `WeatherMetricsTab.svelte` (wind, gust,
+  precipitation, rain_probability, snow_depth, snowfall_limit) bleiben **unverändert** — sie sind
+  keine Ordinal-Skalen mit Backend-`ordinalLabels` und daher nicht Teil dieser Ableitung.
+- Keine Änderung am Persistenzformat des Trips (`sms_threshold`/`metric_alert_levels`) — nur die
+  Herkunft der im UI angebotenen Auswahlwerte ändert sich, nicht ihr gespeichertes Format.
+
+## Betroffene Dateien
+
+| Datei | Typ | Beschreibung | LoC |
+|---|---|---|---|
+| `src/output/renderers/compare_metric_catalog.py` | MODIFY | Literal Z.111 → Ableitung aus `THUNDER_LABEL_DE` | +8/-3 |
+| `frontend/src/lib/components/shared/weather-metrics-tab/compareMetricSelection.ts` | MODIFY | `ordinalLabels`-Durchreichung (Interface Z.7-30 + Mapping Z.60ff.) | +3 |
+| `frontend/src/lib/components/shared/corridor-editor/compareMetricCatalogLoader.ts` | MODIFY | neue Exportfunktion `deriveThunderThresholdLevels` | +10 |
+| `frontend/src/lib/components/shared/WeatherMetricsTab.svelte` | MODIFY | Z.1634-1638 Literal → Funktionsaufruf inkl. Lade-/Fehlerzustand (AC-7) | +2/-5 |
+| `frontend/.../__tests__/thunderThresholdLevels.test.ts` | MODIFY | Regex-Parsing → echte Funktion gegen Live-Backend-Antwort | +40/-60 |
+
+## Testnachweis
+
+Mutations-Gegenprobe (CLAUDE.md, Adversary Verification, Sektion „Mutations-Gegenprobe ist
+PFLICHT"):
+
+| Verfälschung | muss rot machen |
+|---|---|
+| Nullstufe nicht verworfen | umgebauter `thunderThresholdLevels.test.ts` — „genau 3 Stufen" (AC-1) |
+| `float`-Offset um 1 verschoben | derselbe Test — Zuordnung Label↔float (AC-2) |
+| Reihenfolge umgedreht | derselbe Test (AC-1/AC-5) |
+| Backend-Ableitung wieder durch Literal ersetzt | 🔴 **kein bestehender Test fängt das heute** — `compareMetricCatalogParity.test.ts` vergleicht nur den *Wert* der Endpoint-Antwort, nicht ihre *Herkunft*. Dieser Test entsteht **neu** in der TDD-Phase dieser Spec (AC-4-Test: Änderung an `THUNDER_LABEL_DE` muss sich in der Katalog-Antwort niederschlagen) — ohne ihn driftet Befund B2 aus der Analyse lautlos erneut. |
+
+## Known Limitations
+
+- Der Backend-Katalog bleibt weiterhin die einzige Quelle für den Frontend-Reiter; fällt
+  `GET /api/compare/metrics` dauerhaft aus, zeigt der Gewitter-Block den in AC-7 geforderten
+  Fehlerzustand statt einer Auswahlliste — es gibt bewusst keinen stillen Fallback auf ein
+  Frontend-Literal, das nach dieser Umstellung nicht mehr existiert.
+- `WeatherMetricsTab.svelte` lädt `compareCatalog` bereits heute für andere Metriken; diese Spec
+  fügt keinen zusätzlichen Request hinzu, sondern nutzt den bestehenden Ladepfad/Cache mit.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Reine Ableitungs-/Wartbarkeitsänderung entlang einer bereits etablierten
+  Migrationsrichtung (Backend-Katalog als autoritative Quelle für Compare-/Trip-Metrik-Präsentation,
+  vgl. `docs/specs/modules/compare_metric_ssot_final.md`). Keine neue Entscheidungsfläche (Kanäle,
+  Provider, Datenmodell, Auth, Editor-Paradigma, Test-/Deploy-Strategie) — das Persistenzformat der
+  gespeicherten Schwellen bleibt unverändert (AC-2).
+
+## Changelog
+
+- 2026-08-20: Initial spec created (Issue #1911, Frontend- + Backend-Ableitung der
+  Gewitter-Schwellenliste)

--- a/frontend/src/lib/components/shared/WeatherMetricsTab.svelte
+++ b/frontend/src/lib/components/shared/WeatherMetricsTab.svelte
@@ -98,7 +98,7 @@
 	// Hub-Hydration; `toCompareSelectionEntries()` darin fuellt den Umkehr-Index
 	// Auswahl-Schluessel <-> Groesse+Auswertung.
 	import {
-		loadCompareSelectionEntries, deriveThunderThresholdLevels
+		loadCompareSelectionEntries, thunderThresholdLevelsFromCatalog
 	} from './corridor-editor/compareMetricCatalogLoader.ts';
 	// Issue #1359 Scheibe 1: reihenfolge-erhaltendes An-/Abwaehlen als reine,
 	// testbare Funktion (Muster: weatherMetricsTabSections.ts nebenan).
@@ -1634,7 +1634,7 @@
 									metricId="thunder"
 									smsSymbol={metricSymbols['thunder']?.[0]}
 									label="Gewitter"
-									levels={deriveThunderThresholdLevels(compareCatalog.find((e) => e.metric === 'thunder_level_max')?.ordinalLabels)}
+									levels={thunderThresholdLevelsFromCatalog(compareCatalog)}
 									currentFloat={smsThresholds['thunder'] !== undefined && smsThresholds['thunder'] !== '' ? parseFloat(smsThresholds['thunder']) : null}
 									onChange={(id, f) => { userTouched = true; smsThresholds = { ...smsThresholds, [id]: String(f) }; scheduleAutoSave(); }}
 								/>

--- a/frontend/src/lib/components/shared/WeatherMetricsTab.svelte
+++ b/frontend/src/lib/components/shared/WeatherMetricsTab.svelte
@@ -97,7 +97,9 @@
 	// Anfrage pro Seiten-Load fuer Auswahlliste, Schwellen-Editor und
 	// Hub-Hydration; `toCompareSelectionEntries()` darin fuellt den Umkehr-Index
 	// Auswahl-Schluessel <-> Groesse+Auswertung.
-	import { loadCompareSelectionEntries } from './corridor-editor/compareMetricCatalogLoader.ts';
+	import {
+		loadCompareSelectionEntries, deriveThunderThresholdLevels
+	} from './corridor-editor/compareMetricCatalogLoader.ts';
 	// Issue #1359 Scheibe 1: reihenfolge-erhaltendes An-/Abwaehlen als reine,
 	// testbare Funktion (Muster: weatherMetricsTabSections.ts nebenan).
 	// Issue #1366 F002: materializeActiveMetricKeys/toggleCompareMetricKeyFromState
@@ -1627,18 +1629,21 @@
 								/>
 								{/if}
 								{#if !buckets.off.includes('thunder')}
+								{#if compareCatalogLoaded && !compareCatalogError}
 								<ThresholdMetricRow
 									metricId="thunder"
 									smsSymbol={metricSymbols['thunder']?.[0]}
 									label="Gewitter"
-									levels={[
-										{ id: 'leicht', label: 'Leicht', float: 1.0 },
-										{ id: 'mittel', label: 'Mittel', float: 2.0 },
-										{ id: 'hoch', label: 'Hoch', float: 3.0 }
-									]}
+									levels={deriveThunderThresholdLevels(compareCatalog.find((e) => e.metric === 'thunder_level_max')?.ordinalLabels)}
 									currentFloat={smsThresholds['thunder'] !== undefined && smsThresholds['thunder'] !== '' ? parseFloat(smsThresholds['thunder']) : null}
 									onChange={(id, f) => { userTouched = true; smsThresholds = { ...smsThresholds, [id]: String(f) }; scheduleAutoSave(); }}
 								/>
+								{:else}
+								<tr data-testid="threshold-metric-row-thunder-placeholder">
+									<td class="metric-label">Gewitter</td>
+									<td class="segmented-control">{compareCatalogError ? 'Schwellen nicht ladbar' : 'Lädt…'}</td>
+								</tr>
+								{/if}
 								{/if}
 								{#if !buckets.off.includes('snow_depth')}
 								<ThresholdMetricRow

--- a/frontend/src/lib/components/shared/corridor-editor/compareMetricCatalogLoader.ts
+++ b/frontend/src/lib/components/shared/corridor-editor/compareMetricCatalogLoader.ts
@@ -219,3 +219,18 @@ export function deriveThunderThresholdLevels(
 		float: index + 1
 	}));
 }
+
+/**
+ * Kapselt die GANZE Naht Katalog -> Gewitter-Schwellenliste (Adversary-Runde
+ * 2, Findings F003/F004): Katalog-Suche nach `thunder_level_max` UND Aufruf
+ * von `deriveThunderThresholdLevels(...)` in EINER testbaren Funktion statt
+ * verstreut im Template (WeatherMetricsTab.svelte), wo nur AST-Formpruefung
+ * moeglich war. Fehlender Eintrag/fehlende/leere/`undefined` `ordinalLabels`
+ * -> leeres Array, kein Absturz (AC-7).
+ */
+export function thunderThresholdLevelsFromCatalog(
+	entries: CompareSelectionEntry[]
+): ThunderThresholdLevel[] {
+	const entry = (entries ?? []).find((e) => e.metric === 'thunder_level_max');
+	return deriveThunderThresholdLevels(entry?.ordinalLabels);
+}

--- a/frontend/src/lib/components/shared/corridor-editor/compareMetricCatalogLoader.ts
+++ b/frontend/src/lib/components/shared/corridor-editor/compareMetricCatalogLoader.ts
@@ -188,3 +188,34 @@ export function loadRouteExtraMetricDefs(): Promise<RouteMetricDef[]> {
 export function loadCompareSelectionEntries(): Promise<CompareSelectionEntry[]> {
 	return fetchCompareMetricCatalogOnce().then(toCompareSelectionEntries);
 }
+
+// ════════════════════════════════════════════════════════════════════════
+// Issue #1911: Gewitter-Schwellenliste (ThresholdMetricRow) abgeleitet aus
+// dem Katalog-Feld `ordinalLabels` statt hart codiert in WeatherMetricsTab.svelte.
+// ════════════════════════════════════════════════════════════════════════
+
+export interface ThunderThresholdLevel {
+	id: string;
+	label: string;
+	float: number;
+}
+
+/**
+ * Reiner, testbarer Mapper: `ordinalLabels` (Katalog-Eintrag `thunder_level_max`,
+ * z.B. ["kein","leicht","mittel","hoch"]) -> waehlbare Alarmschwellen. Die
+ * Nullstufe (Index 0, "kein") wird verworfen — "ab Stufe kein alarmieren" ist
+ * keine sinnvolle Einstellung (Kontext B1). `float` = Ordinalindex im
+ * Katalog-Array (1/2/3 fuer leicht/mittel/hoch) — wertgleich zum vorherigen
+ * Literal, Bestandsdaten-kritisch (AC-2). Kein Absturz bei leerem/fehlendem
+ * Katalog (AC-7).
+ */
+export function deriveThunderThresholdLevels(
+	ordinalLabels: string[] | undefined
+): ThunderThresholdLevel[] {
+	if (!ordinalLabels || ordinalLabels.length === 0) return [];
+	return ordinalLabels.slice(1).map((label, index) => ({
+		id: label,
+		label: label.charAt(0).toUpperCase() + label.slice(1),
+		float: index + 1
+	}));
+}

--- a/frontend/src/lib/components/shared/weather-metrics-tab/__tests__/thunderThresholdCatalogGuard.test.ts
+++ b/frontend/src/lib/components/shared/weather-metrics-tab/__tests__/thunderThresholdCatalogGuard.test.ts
@@ -110,6 +110,49 @@ function findThunderThresholdRow(fragment: unknown): {
 	return hit;
 }
 
+/**
+ * Sucht im Subtree nach einem `<catalog>.find((e) => e.<field> === '<literalValue>')`-
+ * Aufruf (Adversary-Finding F001: der bisherige Test prueft nur, DASS `levels` ein
+ * Funktionsaufruf ist, nicht WELCHER Katalog-Schluessel als Argument hineingeht --
+ * ein Katalog-Eintrag ohne `ordinalLabels`, z.B. `wind_max_kmh`, liefert eine leere
+ * Schwellenliste, ohne dass ein bestehender Test rot wird). Liefert den gefundenen
+ * `find(...)`-CallExpression-Knoten oder `null`.
+ */
+function findCatalogLookupComparingTo(node: unknown, literalValue: string): any {
+	let found: any = null;
+	function visit(n: unknown): void {
+		if (found || n === null || typeof n !== 'object') return;
+		if (Array.isArray(n)) {
+			n.forEach(visit);
+			return;
+		}
+		const rec = n as Record<string, any>;
+		if (
+			rec.type === 'CallExpression' &&
+			rec.callee?.type === 'MemberExpression' &&
+			rec.callee.property?.name === 'find'
+		) {
+			const arrowArg = (rec.arguments ?? [])[0];
+			const body = arrowArg?.body;
+			const comparesToLiteral =
+				body?.type === 'BinaryExpression' &&
+				(body.operator === '===' || body.operator === '==') &&
+				((body.left?.type === 'Literal' && body.left.value === literalValue) ||
+					(body.right?.type === 'Literal' && body.right.value === literalValue));
+			if (comparesToLiteral) {
+				found = rec;
+				return;
+			}
+		}
+		for (const key of Object.keys(rec)) {
+			if (key === 'parent') continue;
+			visit(rec[key]);
+		}
+	}
+	visit(node);
+	return found;
+}
+
 describe('#1911 AC-3 (Verdrahtung): die Gewitter-Zeile bezieht `levels` aus deriveThunderThresholdLevels(...)', () => {
 	test('`levels`-Attribut ist ein Aufruf von deriveThunderThresholdLevels, kein Array-Literal', () => {
 		const ast = parseComponent();
@@ -133,6 +176,28 @@ describe('#1911 AC-3 (Verdrahtung): die Gewitter-Zeile bezieht `levels` aus deri
 			'deriveThunderThresholdLevels',
 			`AC-3 FAIL: \`levels\` ruft nicht `+
 				`\`deriveThunderThresholdLevels\` auf, sondern \`${levelsExpr?.callee?.name}\`.`
+		);
+	});
+
+	test('das Argument von deriveThunderThresholdLevels stammt aus dem Katalog-Eintrag "thunder_level_max" (Adversary F001)', () => {
+		const ast = parseComponent();
+		const hit = findThunderThresholdRow(ast.fragment);
+		assert.ok(hit, 'Keine <ThresholdMetricRow metricId="thunder" .../> im Template gefunden.');
+
+		const levelsExpr = attrValue(hit!.component, 'levels') as { type?: string; arguments?: unknown } | undefined;
+		assert.equal(
+			levelsExpr?.type,
+			'CallExpression',
+			'Vorbedingung (s. vorheriger Test) nicht erfuellt -- `levels` ist kein Funktionsaufruf.'
+		);
+
+		const lookupCall = findCatalogLookupComparingTo(levelsExpr!.arguments, 'thunder_level_max');
+		assert.ok(
+			lookupCall,
+			'AC-3 FAIL: das Argument von `deriveThunderThresholdLevels(...)` enthaelt keinen ' +
+				'`....find((e) => e.metric === \'thunder_level_max\')`-Aufruf -- die Ableitung liest ' +
+				'moeglicherweise den falschen Katalog-Eintrag (z.B. einen Range-Eintrag ohne ' +
+				'`ordinalLabels`), was still eine leere Schwellenliste liefert.'
 		);
 	});
 });
@@ -169,6 +234,131 @@ describe('#1911 AC-7: definierter Lade-/Fehlerzustand statt kaputter/leerer Opti
 			'AC-7 FAIL: der Guard-Block um die Gewitter-Schwellenzeile hat keinen `{:else}`-Zweig -- ' +
 				'ohne geladenen Katalog gibt es keinen definierten Platzhalter-/Fehlerzustand, nur ein ' +
 				'stilles Nichts-Rendern (das Template zeigt dann weder die Zeile noch einen Hinweis).'
+		);
+	});
+});
+
+/**
+ * Minimaler boolescher Auswerter fuer den Guard-Test-Ausdruck (Adversary-Finding
+ * F002: der bisherige Test prueft nur, DASS ein `{#if}`-Block mit `{:else}`-Zweig
+ * existiert -- nicht die RICHTUNG der Bedingung. Eine Invertierung zu
+ * `{#if !compareCatalogLoaded || compareCatalogError}` behaelt Struktur und
+ * Zweige exakt bei, vertauscht aber, WELCHER Zweig bei geladenem/fehlerfreiem
+ * Katalog gerendert wird -- rein strukturelle Tests bleiben dafuer blind).
+ * Unterstuetzt nur die hier vorkommenden Knotentypen bewusst eng, damit ein
+ * unbekannter Ausdruckstyp den Test klar scheitern laesst statt still `false`
+ * zurueckzugeben.
+ */
+function evalGuardTest(node: any, env: Record<string, unknown>): boolean {
+	switch (node?.type) {
+		case 'Identifier':
+			return Boolean(env[node.name]);
+		case 'UnaryExpression':
+			if (node.operator === '!') return !evalGuardTest(node.argument, env);
+			throw new Error(`evalGuardTest: unsupported unary operator "${node.operator}"`);
+		case 'LogicalExpression':
+			if (node.operator === '&&') return evalGuardTest(node.left, env) && evalGuardTest(node.right, env);
+			if (node.operator === '||') return evalGuardTest(node.left, env) || evalGuardTest(node.right, env);
+			throw new Error(`evalGuardTest: unsupported logical operator "${node.operator}"`);
+		case 'Literal':
+			return Boolean(node.value);
+		default:
+			throw new Error(`evalGuardTest: unsupported node type "${node?.type}" -- Guard-Test-Ausdruck zu weit veraendert, um ihn auszuwerten.`);
+	}
+}
+
+/** Sucht in einem Fragment-Subtree (z.B. `IfBlock.consequent`/`.alternate`) nach
+ *  der `<ThresholdMetricRow metricId="thunder" .../>`-Komponente. */
+function fragmentContainsThunderRow(fragment: unknown): boolean {
+	return findThunderThresholdRow(fragment) !== null;
+}
+
+/** Sucht in einem Fragment-Subtree nach dem Platzhalter-`<tr>` der Gewitter-Zeile. */
+function fragmentContainsPlaceholder(fragment: unknown): boolean {
+	let found = false;
+	function visit(node: unknown): void {
+		if (found || node === null || typeof node !== 'object') return;
+		if (Array.isArray(node)) {
+			node.forEach(visit);
+			return;
+		}
+		const n = node as Record<string, any>;
+		if (n.type === 'RegularElement') {
+			const attrs = n.attributes ?? [];
+			const testIdAttr = attrs.find((a: any) => a.type === 'Attribute' && a.name === 'data-testid');
+			const val = Array.isArray(testIdAttr?.value) ? testIdAttr.value.map((v: any) => v.data ?? '').join('') : undefined;
+			if (val === 'threshold-metric-row-thunder-placeholder') {
+				found = true;
+				return;
+			}
+		}
+		for (const key of Object.keys(n)) {
+			if (key === 'parent') continue;
+			visit(n[key]);
+		}
+	}
+	visit(fragment);
+	return found;
+}
+
+describe('#1911 AC-7 Richtung (Adversary F002): der Guard-Test waehlt den echten Zweig genau dann, wenn der Katalog bereit ist', () => {
+	function findGuardBlock() {
+		const ast = parseComponent();
+		const hit = findThunderThresholdRow(ast.fragment);
+		assert.ok(hit, 'Keine <ThresholdMetricRow metricId="thunder" .../> im Template gefunden.');
+		const guardBlock = hit!.ancestorIfBlocks.find(
+			(block) => identifiers(block.test).has('compareCatalogLoaded') || identifiers(block.test).has('compareCatalogError')
+		);
+		assert.ok(guardBlock, 'Kein Guard-Block gefunden.');
+		return guardBlock;
+	}
+
+	test('Guard-Test ist wahr bei geladenem, fehlerfreiem Katalog und falsch waehrend des Ladens bzw. bei Fehler', () => {
+		const guardBlock = findGuardBlock();
+
+		const ready = evalGuardTest(guardBlock.test, { compareCatalogLoaded: true, compareCatalogError: undefined });
+		assert.equal(
+			ready,
+			true,
+			'AC-7 FAIL: bei compareCatalogLoaded=true und compareCatalogError=undefined (Katalog bereit) ' +
+				'muss der Guard-Test wahr sein -- sonst rendert der Platzhalter, obwohl der Katalog fertig ' +
+				'geladen ist (invertierte Bedingung).'
+		);
+
+		const stillLoading = evalGuardTest(guardBlock.test, { compareCatalogLoaded: false, compareCatalogError: undefined });
+		assert.equal(
+			stillLoading,
+			false,
+			'AC-7 FAIL: bei compareCatalogLoaded=false (noch am Laden) darf der Guard-Test nicht wahr sein -- ' +
+				'sonst rendert die echte Zeile mit ungeladenem Katalog statt des "Lädt…"-Platzhalters.'
+		);
+
+		const errored = evalGuardTest(guardBlock.test, { compareCatalogLoaded: true, compareCatalogError: 'Netzwerkfehler' });
+		assert.equal(
+			errored,
+			false,
+			'AC-7 FAIL: bei gesetztem compareCatalogError darf der Guard-Test nicht wahr sein -- sonst ' +
+				'rendert die echte Zeile trotz Ladefehler statt der Fehlermeldung.'
+		);
+	});
+
+	test('die echte Zeile steht im Wahr-Zweig (consequent), der Platzhalter im {:else}-Zweig -- nicht umgekehrt', () => {
+		const guardBlock = findGuardBlock();
+
+		const consequentHasRow = fragmentContainsThunderRow(guardBlock.consequent);
+		const alternateHasRow = fragmentContainsThunderRow(guardBlock.alternate);
+		assert.ok(
+			consequentHasRow && !alternateHasRow,
+			'AC-7 FAIL: die <ThresholdMetricRow metricId="thunder" .../> steht nicht (ausschliesslich) im ' +
+				`Wahr-Zweig des Guard-Blocks (consequent: ${consequentHasRow}, alternate: ${alternateHasRow}).`
+		);
+
+		const consequentHasPlaceholder = fragmentContainsPlaceholder(guardBlock.consequent);
+		const alternateHasPlaceholder = fragmentContainsPlaceholder(guardBlock.alternate);
+		assert.ok(
+			alternateHasPlaceholder && !consequentHasPlaceholder,
+			'AC-7 FAIL: der Platzhalter steht nicht (ausschliesslich) im {:else}-Zweig des Guard-Blocks ' +
+				`(consequent: ${consequentHasPlaceholder}, alternate: ${alternateHasPlaceholder}).`
 		);
 	});
 });

--- a/frontend/src/lib/components/shared/weather-metrics-tab/__tests__/thunderThresholdCatalogGuard.test.ts
+++ b/frontend/src/lib/components/shared/weather-metrics-tab/__tests__/thunderThresholdCatalogGuard.test.ts
@@ -1,6 +1,6 @@
 // Issue #1911 AC-3 (Verdrahtung) / AC-7 (Ladezustand): die Gewitter-
 // Schwellenzeile in WeatherMetricsTab.svelte muss (a) ihre `levels` ueber
-// `deriveThunderThresholdLevels(...)` beziehen statt ueber das alte
+// `thunderThresholdLevelsFromCatalog(...)` beziehen statt ueber das alte
 // Array-Literal, und (b) darf keinen kaputten/leeren Zustand rendern,
 // solange `compareCatalog` noch nicht geladen ist (`compareCatalogLoaded
 // === false`) oder das Laden fehlschlug (`compareCatalogError` gesetzt).
@@ -11,6 +11,17 @@
 // das denselben Ancestor-IfBlock-Nachweis fuer ganze Sections liefert. Diese
 // Datei uebertraegt das Muster von "Section" auf eine einzelne
 // <ThresholdMetricRow metricId="thunder" .../>-Komponente.
+//
+// Adversary-Runde 2 (Findings F001/F004): die Katalog-Suche nach
+// `thunder_level_max` UND die Ableitung selbst sind seit
+// `thunderThresholdLevelsFromCatalog()` (compareMetricCatalogLoader.ts) aus
+// dem Template in eine reine, direkt aufrufbare Funktion gewandert. Die
+// AST-Formpruefung "welcher Katalog-Schluessel wird im Template verglichen"
+// ist damit ueberfluessig geworden -- ersetzt durch einen ECHTEN
+// Verhaltenstest gegen `thunderThresholdLevelsFromCatalog()` in
+// thunderThresholdLevels.test.ts (Adversary M9). Was bleibt: das Template
+// muss ueberhaupt diese Funktion aufrufen (Verdrahtungs-Nachweis) und der
+// Lade-/Fehler-Guard muss weiterhin greifen (AC-7).
 //
 // Spec: docs/specs/modules/thunder_threshold_katalog.md AC-3, AC-7.
 //
@@ -110,51 +121,8 @@ function findThunderThresholdRow(fragment: unknown): {
 	return hit;
 }
 
-/**
- * Sucht im Subtree nach einem `<catalog>.find((e) => e.<field> === '<literalValue>')`-
- * Aufruf (Adversary-Finding F001: der bisherige Test prueft nur, DASS `levels` ein
- * Funktionsaufruf ist, nicht WELCHER Katalog-Schluessel als Argument hineingeht --
- * ein Katalog-Eintrag ohne `ordinalLabels`, z.B. `wind_max_kmh`, liefert eine leere
- * Schwellenliste, ohne dass ein bestehender Test rot wird). Liefert den gefundenen
- * `find(...)`-CallExpression-Knoten oder `null`.
- */
-function findCatalogLookupComparingTo(node: unknown, literalValue: string): any {
-	let found: any = null;
-	function visit(n: unknown): void {
-		if (found || n === null || typeof n !== 'object') return;
-		if (Array.isArray(n)) {
-			n.forEach(visit);
-			return;
-		}
-		const rec = n as Record<string, any>;
-		if (
-			rec.type === 'CallExpression' &&
-			rec.callee?.type === 'MemberExpression' &&
-			rec.callee.property?.name === 'find'
-		) {
-			const arrowArg = (rec.arguments ?? [])[0];
-			const body = arrowArg?.body;
-			const comparesToLiteral =
-				body?.type === 'BinaryExpression' &&
-				(body.operator === '===' || body.operator === '==') &&
-				((body.left?.type === 'Literal' && body.left.value === literalValue) ||
-					(body.right?.type === 'Literal' && body.right.value === literalValue));
-			if (comparesToLiteral) {
-				found = rec;
-				return;
-			}
-		}
-		for (const key of Object.keys(rec)) {
-			if (key === 'parent') continue;
-			visit(rec[key]);
-		}
-	}
-	visit(node);
-	return found;
-}
-
-describe('#1911 AC-3 (Verdrahtung): die Gewitter-Zeile bezieht `levels` aus deriveThunderThresholdLevels(...)', () => {
-	test('`levels`-Attribut ist ein Aufruf von deriveThunderThresholdLevels, kein Array-Literal', () => {
+describe('#1911 AC-3 (Verdrahtung): die Gewitter-Zeile bezieht `levels` aus thunderThresholdLevelsFromCatalog(...)', () => {
+	test('`levels`-Attribut ist ein Aufruf von thunderThresholdLevelsFromCatalog(compareCatalog), kein Array-Literal', () => {
 		const ast = parseComponent();
 		const hit = findThunderThresholdRow(ast.fragment);
 		assert.ok(
@@ -163,7 +131,9 @@ describe('#1911 AC-3 (Verdrahtung): die Gewitter-Zeile bezieht `levels` aus deri
 				'Struktur zu weit veraendert, um den Block zu finden.'
 		);
 
-		const levelsExpr = attrValue(hit!.component, 'levels') as { type?: string; callee?: { name?: string } } | undefined;
+		const levelsExpr = attrValue(hit!.component, 'levels') as
+			| { type?: string; callee?: { name?: string }; arguments?: any[] }
+			| undefined;
 		assert.equal(
 			levelsExpr?.type,
 			'CallExpression',
@@ -173,31 +143,18 @@ describe('#1911 AC-3 (Verdrahtung): die Gewitter-Zeile bezieht `levels` aus deri
 		);
 		assert.equal(
 			levelsExpr?.callee?.name,
-			'deriveThunderThresholdLevels',
+			'thunderThresholdLevelsFromCatalog',
 			`AC-3 FAIL: \`levels\` ruft nicht `+
-				`\`deriveThunderThresholdLevels\` auf, sondern \`${levelsExpr?.callee?.name}\`.`
+				`\`thunderThresholdLevelsFromCatalog\` auf, sondern \`${levelsExpr?.callee?.name}\`. ` +
+				'Die Katalog-Suche nach "thunder_level_max" gehoert seit #1911 Runde 2 in die ' +
+				'geteilte Funktion (compareMetricCatalogLoader.ts), nicht ins Template.'
 		);
-	});
-
-	test('das Argument von deriveThunderThresholdLevels stammt aus dem Katalog-Eintrag "thunder_level_max" (Adversary F001)', () => {
-		const ast = parseComponent();
-		const hit = findThunderThresholdRow(ast.fragment);
-		assert.ok(hit, 'Keine <ThresholdMetricRow metricId="thunder" .../> im Template gefunden.');
-
-		const levelsExpr = attrValue(hit!.component, 'levels') as { type?: string; arguments?: unknown } | undefined;
-		assert.equal(
-			levelsExpr?.type,
-			'CallExpression',
-			'Vorbedingung (s. vorheriger Test) nicht erfuellt -- `levels` ist kein Funktionsaufruf.'
-		);
-
-		const lookupCall = findCatalogLookupComparingTo(levelsExpr!.arguments, 'thunder_level_max');
-		assert.ok(
-			lookupCall,
-			'AC-3 FAIL: das Argument von `deriveThunderThresholdLevels(...)` enthaelt keinen ' +
-				'`....find((e) => e.metric === \'thunder_level_max\')`-Aufruf -- die Ableitung liest ' +
-				'moeglicherweise den falschen Katalog-Eintrag (z.B. einen Range-Eintrag ohne ' +
-				'`ordinalLabels`), was still eine leere Schwellenliste liefert.'
+		const argNames = (levelsExpr?.arguments ?? []).map((a: any) => a?.name);
+		assert.deepEqual(
+			argNames,
+			['compareCatalog'],
+			`AC-3 FAIL: thunderThresholdLevelsFromCatalog(...) wird nicht mit \`compareCatalog\` ` +
+				`aufgerufen (Argumente: ${JSON.stringify(argNames)}).`
 		);
 	});
 });
@@ -359,6 +316,27 @@ describe('#1911 AC-7 Richtung (Adversary F002): der Guard-Test waehlt den echten
 			alternateHasPlaceholder && !consequentHasPlaceholder,
 			'AC-7 FAIL: der Platzhalter steht nicht (ausschliesslich) im {:else}-Zweig des Guard-Blocks ' +
 				`(consequent: ${consequentHasPlaceholder}, alternate: ${alternateHasPlaceholder}).`
+		);
+	});
+
+	// Adversary-Runde 2, Finding F003: die bisherigen Guard-Tests werten nur die
+	// DREI konkreten Kombinationen von compareCatalogLoaded/compareCatalogError
+	// aus -- ein angehaengtes `|| userTouched` (eine reale $state-Variable im
+	// selben Component-Scope) veraendert keine dieser drei Ergebnisse und bliebe
+	// unentdeckt. Zusicherung "nichts anderes darf hier mit hineinspielen" ist
+	// eine legitime, endliche Strukturpruefung: die Menge der im Test-Ausdruck
+	// vorkommenden Bezeichner muss GENAU {compareCatalogLoaded, compareCatalogError}
+	// sein, keine dritte Variable.
+	test('im Guard-Test-Ausdruck kommen ausschliesslich compareCatalogLoaded/compareCatalogError vor (Adversary F003)', () => {
+		const guardBlock = findGuardBlock();
+		const usedIdentifiers = identifiers(guardBlock.test);
+		assert.deepEqual(
+			[...usedIdentifiers].sort(),
+			['compareCatalogError', 'compareCatalogLoaded'],
+			'AC-7 FAIL: der Guard-Test-Ausdruck verwendet weitere Bezeichner neben ' +
+				`compareCatalogLoaded/compareCatalogError (gefunden: ${JSON.stringify([...usedIdentifiers].sort())}) -- ` +
+				'eine zusaetzliche Bedingung (z.B. `|| userTouched`) koennte den Guard umgehen, ' +
+				'ohne dass die drei Kombinations-Tests oben etwas bemerken.'
 		);
 	});
 });

--- a/frontend/src/lib/components/shared/weather-metrics-tab/__tests__/thunderThresholdCatalogGuard.test.ts
+++ b/frontend/src/lib/components/shared/weather-metrics-tab/__tests__/thunderThresholdCatalogGuard.test.ts
@@ -1,0 +1,174 @@
+// Issue #1911 AC-3 (Verdrahtung) / AC-7 (Ladezustand): die Gewitter-
+// Schwellenzeile in WeatherMetricsTab.svelte muss (a) ihre `levels` ueber
+// `deriveThunderThresholdLevels(...)` beziehen statt ueber das alte
+// Array-Literal, und (b) darf keinen kaputten/leeren Zustand rendern,
+// solange `compareCatalog` noch nicht geladen ist (`compareCatalogLoaded
+// === false`) oder das Laden fehlschlug (`compareCatalogError` gesetzt).
+//
+// Struktur-/AST-Test mit dem echten Svelte-Compiler (dieses Repo hat kein
+// vitest/jsdom, kein Runtime-Rendering-Harness fuer Svelte-5-Runen in
+// node:test) -- Vorbild: shared/__tests__/weather_metrics_tab_compare_catalog_fetch.test.ts,
+// das denselben Ancestor-IfBlock-Nachweis fuer ganze Sections liefert. Diese
+// Datei uebertraegt das Muster von "Section" auf eine einzelne
+// <ThresholdMetricRow metricId="thunder" .../>-Komponente.
+//
+// Spec: docs/specs/modules/thunder_threshold_katalog.md AC-3, AC-7.
+//
+// Ausfuehrung:
+//   cd frontend && node --import ./test-lib-loader.mjs --experimental-strip-types \
+//     --test src/lib/components/shared/weather-metrics-tab/__tests__/thunderThresholdCatalogGuard.test.ts
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parse } from 'svelte/compiler';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const COMPONENT = join(here, '..', '..', 'WeatherMetricsTab.svelte');
+
+function parseComponent(): any {
+	return parse(readFileSync(COMPONENT, 'utf-8'), { modern: true });
+}
+
+/** Alle Identifier-Namen eines Subtrees. */
+function identifiers(subtree: unknown): Set<string> {
+	const found = new Set<string>();
+	function visit(node: unknown): void {
+		if (node === null || typeof node !== 'object') return;
+		if (Array.isArray(node)) {
+			node.forEach(visit);
+			return;
+		}
+		const n = node as Record<string, any>;
+		if (n.type === 'Identifier' && typeof n.name === 'string') found.add(n.name);
+		for (const key of Object.keys(n)) {
+			if (key === 'parent') continue;
+			visit(n[key]);
+		}
+	}
+	visit(subtree);
+	return found;
+}
+
+/** Der (Ausdrucks-)Wert eines Attributs: String bei Text-Attributen (z.B.
+ *  `metricId="thunder"`), Ausdrucks-AST-Knoten bei `{...}`-Attributen (z.B.
+ *  `levels={...}`). */
+function attrValue(node: any, name: string): unknown {
+	const attr = (node.attributes ?? []).find(
+		(a: any) => a.type === 'Attribute' && a.name === name
+	);
+	if (!attr) return undefined;
+	if (Array.isArray(attr.value)) {
+		return attr.value.map((v: any) => v.data ?? '').join('');
+	}
+	if (attr.value?.type === 'ExpressionTag') {
+		return attr.value.expression;
+	}
+	return attr.value;
+}
+
+/**
+ * Findet die `<ThresholdMetricRow metricId="thunder" .../>`-Komponente
+ * mitsamt der Kette ihrer IfBlock-Vorfahren (Test-Ausdruck jedes
+ * umschliessenden `{#if ...}`) -- Vorbild:
+ * weather_metrics_tab_compare_catalog_fetch.test.ts::findSectionBlockWithAncestors,
+ * hier auf eine einzelne Komponente statt einen benannten Section-Block
+ * uebertragen. Liefert zusaetzlich den NAECHSTEN (innersten) umschliessenden
+ * IfBlock als `innermostIf` -- das ist der Block, dessen `{:else}`-Zweig
+ * (falls vorhanden) den in AC-7 geforderten Platzhalter-/Fehlerzustand
+ * tragen muesste.
+ */
+function findThunderThresholdRow(fragment: unknown): {
+	component: any;
+	ancestorIfBlocks: any[];
+} | null {
+	let hit: { component: any; ancestorIfBlocks: any[] } | null = null;
+	function visit(node: unknown, ifAncestors: any[]): void {
+		if (hit) return;
+		if (node === null || typeof node !== 'object') return;
+		if (Array.isArray(node)) {
+			node.forEach((c) => visit(c, ifAncestors));
+			return;
+		}
+		const n = node as Record<string, any>;
+		if (n.type === 'Component' && n.name === 'ThresholdMetricRow' && attrValue(n, 'metricId') === 'thunder') {
+			hit = { component: n, ancestorIfBlocks: ifAncestors };
+			return;
+		}
+		let nextAncestors = ifAncestors;
+		if (n.type === 'IfBlock') {
+			nextAncestors = [...ifAncestors, n];
+		}
+		for (const key of Object.keys(n)) {
+			if (key === 'parent') continue;
+			visit(n[key], nextAncestors);
+		}
+	}
+	visit(fragment, []);
+	return hit;
+}
+
+describe('#1911 AC-3 (Verdrahtung): die Gewitter-Zeile bezieht `levels` aus deriveThunderThresholdLevels(...)', () => {
+	test('`levels`-Attribut ist ein Aufruf von deriveThunderThresholdLevels, kein Array-Literal', () => {
+		const ast = parseComponent();
+		const hit = findThunderThresholdRow(ast.fragment);
+		assert.ok(
+			hit,
+			'Keine <ThresholdMetricRow metricId="thunder" .../> im Template gefunden -- ' +
+				'Struktur zu weit veraendert, um den Block zu finden.'
+		);
+
+		const levelsExpr = attrValue(hit!.component, 'levels') as { type?: string; callee?: { name?: string } } | undefined;
+		assert.equal(
+			levelsExpr?.type,
+			'CallExpression',
+			'AC-3 FAIL: `levels` an der Gewitter-Zeile ist (noch) kein Funktionsaufruf ' +
+				`(gefundener Ausdruckstyp: ${levelsExpr?.type ?? 'Array-Literal/undefined'}) -- ` +
+				'vermutlich noch das alte hart codierte Level-Array.'
+		);
+		assert.equal(
+			levelsExpr?.callee?.name,
+			'deriveThunderThresholdLevels',
+			`AC-3 FAIL: \`levels\` ruft nicht `+
+				`\`deriveThunderThresholdLevels\` auf, sondern \`${levelsExpr?.callee?.name}\`.`
+		);
+	});
+});
+
+describe('#1911 AC-7: definierter Lade-/Fehlerzustand statt kaputter/leerer Optionsliste', () => {
+	test('die Gewitter-Zeile ist an compareCatalogLoaded/compareCatalogError gekoppelt (kein ungeschuetztes Rendern vor dem Laden)', () => {
+		const ast = parseComponent();
+		const hit = findThunderThresholdRow(ast.fragment);
+		assert.ok(hit, 'Keine <ThresholdMetricRow metricId="thunder" .../> im Template gefunden.');
+
+		const guardBlock = hit!.ancestorIfBlocks.find(
+			(block) => identifiers(block.test).has('compareCatalogLoaded') || identifiers(block.test).has('compareCatalogError')
+		);
+		assert.ok(
+			guardBlock,
+			'AC-7 FAIL: kein umschliessender `{#if compareCatalogLoaded/compareCatalogError ...}`-Block ' +
+				'um die Gewitter-Schwellenzeile gefunden -- die Zeile kann rendern, bevor der Katalog ' +
+				'geladen ist bzw. obwohl das Laden fehlschlug (leere/kaputte Optionsliste statt eines ' +
+				'definierten Zustands).'
+		);
+	});
+
+	test('der Guard-Block hat einen {:else}-Zweig -- ein definierter Platzhalter-/Fehlerzustand existiert', () => {
+		const ast = parseComponent();
+		const hit = findThunderThresholdRow(ast.fragment);
+		assert.ok(hit, 'Keine <ThresholdMetricRow metricId="thunder" .../> im Template gefunden.');
+
+		const guardBlock = hit!.ancestorIfBlocks.find(
+			(block) => identifiers(block.test).has('compareCatalogLoaded') || identifiers(block.test).has('compareCatalogError')
+		);
+		assert.ok(guardBlock, 'Vorbedingung (s. vorheriger Test) nicht erfuellt -- kein Guard-Block gefunden.');
+		assert.ok(
+			guardBlock.alternate,
+			'AC-7 FAIL: der Guard-Block um die Gewitter-Schwellenzeile hat keinen `{:else}`-Zweig -- ' +
+				'ohne geladenen Katalog gibt es keinen definierten Platzhalter-/Fehlerzustand, nur ein ' +
+				'stilles Nichts-Rendern (das Template zeigt dann weder die Zeile noch einen Hinweis).'
+		);
+	});
+});

--- a/frontend/src/lib/components/shared/weather-metrics-tab/__tests__/thunderThresholdLevels.test.ts
+++ b/frontend/src/lib/components/shared/weather-metrics-tab/__tests__/thunderThresholdLevels.test.ts
@@ -55,6 +55,33 @@ async function loadDerive(): Promise<DeriveFn> {
 	return fn as DeriveFn;
 }
 
+interface CatalogEntry {
+	metric: string;
+	label: string;
+	ordinalLabels?: string[];
+}
+
+type FromCatalogFn = (entries: CatalogEntry[]) => Level[];
+
+/**
+ * Laedt `thunderThresholdLevelsFromCatalog` (Adversary-Runde 2, Findings
+ * F003/F004: die Naht Katalog-Suche + Ableitung ist aus dem Template in
+ * diese eine, direkt aufrufbare Funktion gewandert -- Vorbild `loadDerive`
+ * oben).
+ */
+async function loadFromCatalog(): Promise<FromCatalogFn> {
+	const mod = await import(MODULE_SPECIFIER);
+	const fn = (mod as Record<string, unknown>).thunderThresholdLevelsFromCatalog;
+	if (typeof fn !== 'function') {
+		assert.fail(
+			'#1911 Runde-2-FAIL: `thunderThresholdLevelsFromCatalog` ist in ' +
+				'shared/corridor-editor/compareMetricCatalogLoader.ts nicht exportiert -- ' +
+				'die Naht Katalog-Suche + Ableitung fehlt noch.'
+		);
+	}
+	return fn as FromCatalogFn;
+}
+
 // Live-Read gegen den ECHTEN Backend-Katalog UND die kanonische Stufenquelle
 // (kein Fixture -- Issue #1424 F001 Praezedenz: eine hartkodierte
 // Erwartungsliste ist kein Drift-Waechter).
@@ -205,5 +232,77 @@ describe('#1911 AC-7 (Funktionsebene): kein Absturz bei fehlendem/leerem Katalog
 		const derive = await loadDerive();
 		assert.doesNotThrow(() => derive(undefined));
 		assert.deepEqual(derive(undefined), []);
+	});
+});
+
+describe('#1911 Adversary-Runde-2 F004 (HIGH): thunderThresholdLevelsFromCatalog kapselt Katalog-Suche + Ableitung', () => {
+	test('findet "thunder_level_max" in einem mehrteiligen Katalog (Range-Metriken ohne ordinalLabels daneben) -> exakt leicht/mittel/hoch, 1.0/2.0/3.0', async () => {
+		const fromCatalog = await loadFromCatalog();
+		const live = fetchLive();
+		// Realistischer Katalog: mehrere Range-Metriken ohne `ordinalLabels`
+		// (wie sie echte Katalog-Eintraege liefern) UND der echte
+		// thunder_level_max-Eintrag, NICHT an erster Stelle.
+		const catalog: CatalogEntry[] = [
+			{ metric: 'wind_max_kmh', label: 'Wind (km/h)' },
+			{ metric: 'precipitation', label: 'Niederschlag (mm)' },
+			{ metric: 'thunder_level_max', label: 'Gewitter', ordinalLabels: live.ordinalLabels },
+			{ metric: 'temperature_max', label: 'Temperatur (°C)' }
+		];
+
+		const levels = fromCatalog(catalog);
+
+		// Feldweise, nicht nur Laenge -- ein angehaengtes `.slice(1)` auf die
+		// Labels wuerfe "leicht" raus und verschoebe "mittel"->1.0, "hoch"->2.0,
+		// ohne dass ein reiner Laengen-Check das bemerkt (Mutation M9).
+		assert.deepEqual(
+			levels.map((l) => l.label.toLowerCase()),
+			['leicht', 'mittel', 'hoch'],
+			`F004 FAIL: Labels weichen von leicht/mittel/hoch ab: ${JSON.stringify(levels)}`
+		);
+		assert.deepEqual(
+			levels.map((l) => l.float),
+			[1.0, 2.0, 3.0],
+			`F004 FAIL: floats weichen von 1.0/2.0/3.0 ab (Bestandsdaten-Risiko!): ${JSON.stringify(levels)}`
+		);
+	});
+
+	test('kein thunder_level_max-Eintrag im Katalog -> leere Liste, kein Wurf', async () => {
+		const fromCatalog = await loadFromCatalog();
+		const catalog: CatalogEntry[] = [{ metric: 'wind_max_kmh', label: 'Wind (km/h)' }];
+		assert.doesNotThrow(() => fromCatalog(catalog));
+		assert.deepEqual(fromCatalog(catalog), []);
+	});
+
+	test('leerer Katalog -> leere Liste, kein Wurf', async () => {
+		const fromCatalog = await loadFromCatalog();
+		assert.doesNotThrow(() => fromCatalog([]));
+		assert.deepEqual(fromCatalog([]), []);
+	});
+});
+
+describe('#1911 Adversary-Runde-2 F005 (MEDIUM): das id-Feld ist konsistent zu float/label', () => {
+	test('Nachschlagen ueber float liefert dieselbe id; id == kleingeschriebenes Label', async () => {
+		const derive = await loadDerive();
+		const levels = derive(['kein', 'leicht', 'mittel', 'hoch']);
+
+		// Mutation M10: `id` gegen `float`/`label` vertauscht/verschoben bliebe
+		// unentdeckt, solange nur `.label`/`.float` isoliert geprueft werden --
+		// ThresholdMetricRow.svelte:28 loest den aktiven Button ueber
+		// `levels.find(l => l.float === currentFloat)?.id` auf. Ein
+		// Bestandstrip mit float=3.0 muss ueber diesen Weg auf id "hoch" landen.
+		levels.forEach((l) => {
+			const byFloat = levels.find((x) => x.float === l.float);
+			assert.equal(
+				byFloat?.id,
+				l.id,
+				`F005 FAIL: Nachschlagen ueber float=${l.float} liefert eine andere id ` +
+					`("${byFloat?.id}") als das Level selbst ("${l.id}").`
+			);
+			assert.equal(
+				l.id,
+				l.label.toLowerCase(),
+				`F005 FAIL: id ("${l.id}") entspricht nicht dem kleingeschriebenen Label ("${l.label.toLowerCase()}").`
+			);
+		});
 	});
 });

--- a/frontend/src/lib/components/shared/weather-metrics-tab/__tests__/thunderThresholdLevels.test.ts
+++ b/frontend/src/lib/components/shared/weather-metrics-tab/__tests__/thunderThresholdLevels.test.ts
@@ -1,24 +1,14 @@
-// Issue #1474 Nachtrag (PO-Freigabe 2026-08-03/04): Die Gewitter-Erwaehnungs-
-// schwelle im Schwellwerte-Reiter (WeatherMetricsTab.svelte, ThresholdMetricRow
-// fuer metricId="thunder") bot bislang nur zwei Knoepfe (MED/HIGH, Werte 1.0/2.0)
-// -- ein Rest aus der alten Dreier-Skala (NONE/MED/HIGH). Seit #1474 hat
-// ThunderLevel vier Stufen (NONE/LOW/MED/HIGH), Ordinal 1 ist jetzt LOW, nicht
-// mehr MED. "MED" stellte also seither faelschlich "ab leicht" ein, "HIGH"
-// "ab mittel" -- "ab hoch" war gar nicht mehr erreichbar.
+// Issue #1911 (Ableitung statt Doppel-Kopie): dieser Test parste bisher
+// (#1474 Nachtrag) das hart codierte `levels={[...]}`-Literal in
+// WeatherMetricsTab.svelte per Regex. Nach der Umstellung auf
+// `deriveThunderThresholdLevels(...)` findet die Regex nichts mehr -- der
+// Test verliert seine Zusicherung nicht, sondern prueft jetzt die ECHTE
+// Ableitungsfunktion gegen echte Backend-Daten (Vorbild:
+// corridor-editor/__tests__/compareMetricCatalogParity.test.ts, Live-Read
+// per `execFileSync('uv', ...)`).
 //
-// Zielzustand: drei Knoepfe "Leicht"/"Mittel"/"Hoch" mit float 1.0/2.0/3.0
-// (passend zu thunder_ordinal() in src/output/metric_format.py).
-//
-// Kein Rendering-Harness fuer Svelte-5-Runen im node:test-Setup -- daher
-// source-inspizierender Test (Praezedenz: day_window_card.test.ts), der aber
-// NICHT nur auf String-Praesenz prueft, sondern dieselbe Zuordnungslogik wie
-// ThresholdMetricRow.svelte (levels.find(l => l.float === currentFloat)) real
-// gegen die aus dem Quelltext extrahierten Level-Objekte ausfuehrt -- eine
-// vertauschte Zuordnung (z.B. "Leicht" -> 2.0) wird dadurch rot, nicht nur eine
-// fehlende Beschriftung.
-//
-// Spec: docs/specs/modules/... (Bugfix, keine eigene Spec-Datei; PO-Auftrag
-// direkt in der Slice fix-1474-gewitterschwelle-cockpit)
+// Spec: docs/specs/modules/thunder_threshold_katalog.md AC-1, AC-2, AC-3,
+// AC-6, AC-7 (Funktionsebene).
 //
 // Ausfuehrung:
 //   cd frontend && node --import ./test-lib-loader.mjs --experimental-strip-types \
@@ -27,12 +17,16 @@
 import { test, describe } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
-import { dirname, join } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 
 const here = dirname(fileURLToPath(import.meta.url));
 // __tests__ -> weather-metrics-tab -> shared
 const WEATHER_METRICS_TAB = join(here, '..', '..', 'WeatherMetricsTab.svelte');
+// __tests__ -> weather-metrics-tab -> shared -> corridor-editor
+const MODULE_SPECIFIER = '../../corridor-editor/compareMetricCatalogLoader.ts';
+const REPO_ROOT = resolve(here, ...Array(7).fill('..'));
 
 interface Level {
 	id: string;
@@ -40,88 +34,176 @@ interface Level {
 	float: number;
 }
 
+type DeriveFn = (ordinalLabels: string[] | undefined) => Level[];
+
 /**
- * Extrahiert die `levels={[...]}` Liste aus dem ThresholdMetricRow-Block mit
- * `metricId="thunder"`. Bricht bewusst hart (kein Fallback), wenn die Struktur
- * sich so weit aendert, dass der Block nicht mehr auffindbar ist -- ein
- * stiller Leerlisten-Fallback wuerde den Test faelschlich gruen lassen.
+ * Laedt `deriveThunderThresholdLevels` aus compareMetricCatalogLoader.ts.
+ * Bricht sprechend (kein rohes ENOENT/undefined-Crash), solange die
+ * Funktion noch nicht existiert -- Vorbild:
+ * compareMetricCatalogParity.test.ts::loadDeriveActiveAlertMetricsForTrip.
  */
-function extractThunderLevels(source: string): Level[] {
-	const blockStart = source.indexOf('metricId="thunder"');
-	assert.ok(blockStart >= 0, 'ThresholdMetricRow mit metricId="thunder" nicht gefunden.');
-
-	const levelsStart = source.indexOf('levels={[', blockStart);
-	assert.ok(levelsStart >= 0, 'Kein levels={[...]}-Block nach metricId="thunder" gefunden.');
-
-	const levelsEnd = source.indexOf(']}', levelsStart);
-	assert.ok(levelsEnd >= 0, 'levels={[...]}-Block wird nie geschlossen (]} fehlt).');
-
-	const block = source.slice(levelsStart, levelsEnd);
-
-	// Jeder Eintrag: { id: 'xyz', label: 'Xyz', float: N }
-	const entryRe = /\{\s*id:\s*'([^']+)',\s*label:\s*'([^']+)',\s*float:\s*([0-9.]+)\s*\}/g;
-	const levels: Level[] = [];
-	let m: RegExpExecArray | null;
-	while ((m = entryRe.exec(block)) !== null) {
-		levels.push({ id: m[1], label: m[2], float: Number(m[3]) });
+async function loadDerive(): Promise<DeriveFn> {
+	const mod = await import(MODULE_SPECIFIER);
+	const fn = (mod as Record<string, unknown>).deriveThunderThresholdLevels;
+	if (typeof fn !== 'function') {
+		assert.fail(
+			'#1911 FAIL: `deriveThunderThresholdLevels` ist in ' +
+				'shared/corridor-editor/compareMetricCatalogLoader.ts nicht exportiert -- ' +
+				'die Ableitungsfunktion (Spec Implementation Details Punkt 3) fehlt noch.'
+		);
 	}
-	assert.ok(levels.length > 0, `Keine Level-Eintraege im Block extrahierbar: ${block}`);
-	return levels;
+	return fn as DeriveFn;
 }
 
-// Repliziert ThresholdMetricRow.svelte Zeile 27f. (levels.find(l => l.float
-// === currentFloat)?.id) -- die tatsaechliche Lauflogik, gegen die extrahierte
-// Liste angewandt.
-function activeLabelFor(levels: Level[], currentFloat: number): string | undefined {
-	return levels.find((l) => l.float === currentFloat)?.label;
-}
+// Live-Read gegen den ECHTEN Backend-Katalog UND die kanonische Stufenquelle
+// (kein Fixture -- Issue #1424 F001 Praezedenz: eine hartkodierte
+// Erwartungsliste ist kein Drift-Waechter).
+const PY_SCRIPT =
+	'import sys, json\n' +
+	"sys.path.insert(0, 'src')\n" +
+	'from output.renderers.compare_metric_catalog import get_compare_metric_catalog\n' +
+	'from output.metric_format import THUNDER_LABEL_DE, thunder_ordinal\n' +
+	'from app.models import ThunderLevel\n' +
+	"catalog = get_compare_metric_catalog()\n" +
+	"thunder = next(e for e in catalog if e['key'] == 'thunder_level_max')\n" +
+	'ordered = sorted(ThunderLevel, key=thunder_ordinal)\n' +
+	'canonical = [THUNDER_LABEL_DE[l] for l in ordered]\n' +
+	"print(json.dumps({'ordinalLabels': thunder['ordinalLabels'], 'canonical': canonical}))\n";
 
-describe('Gewitter-Schwellwert-Knoepfe (#1474 Nachtrag): drei Stufen, korrekte Werte', () => {
-	const source = readFileSync(WEATHER_METRICS_TAB, 'utf-8');
-	const levels = extractThunderLevels(source);
-
-	test('genau drei Stufen (nicht mehr die alten zwei)', () => {
-		assert.equal(levels.length, 3, `Erwartet 3 Stufen, gefunden: ${JSON.stringify(levels)}`);
+function fetchLive(): { ordinalLabels: string[]; canonical: string[] } {
+	const stdout = execFileSync('uv', ['run', 'python3', '-c', PY_SCRIPT], {
+		cwd: REPO_ROOT,
+		encoding: 'utf-8'
 	});
+	return JSON.parse(stdout.trim());
+}
 
-	test('"leicht" setzt float 1.0', () => {
-		const label = activeLabelFor(levels, 1.0);
-		assert.ok(label, 'Kein Level mit float 1.0 gefunden.');
+describe('#1911 AC-1/AC-2 (KRITISCH): deriveThunderThresholdLevels(Live-Katalog) -> 3 Stufen, korrekte floats', () => {
+	test('genau 3 Stufen, "kein" nicht dabei, float 1.0/2.0/3.0 -> leicht/mittel/hoch', async () => {
+		const derive = await loadDerive();
+		const live = fetchLive();
+		assert.deepEqual(
+			live.ordinalLabels,
+			['kein', 'leicht', 'mittel', 'hoch'],
+			`Vorbedingung verletzt: der Backend-Katalog liefert nicht die erwarteten vier ` +
+				`Stufen (ueberraschende Baseline-Aenderung?): ${JSON.stringify(live.ordinalLabels)}`
+		);
+
+		const levels = derive(live.ordinalLabels);
+
 		assert.equal(
-			label!.toLowerCase(),
+			levels.length,
+			3,
+			`AC-1 FAIL: erwartet genau 3 waehlbare Stufen, erhalten ${JSON.stringify(levels)}`
+		);
+		assert.ok(
+			!levels.some((l) => l.id === 'kein' || l.label.toLowerCase() === 'kein'),
+			`AC-1 FAIL: die Nullstufe "kein" darf keine waehlbare Alarmschwelle sein: ${JSON.stringify(levels)}`
+		);
+
+		// AC-2 (KRITISCH, Bestandsdaten-Risiko): Feld fuer Feld, nicht nur Laenge.
+		// Ein Offset um eins wuerde still bei der falschen Stufe alarmieren.
+		assert.deepEqual(
+			levels.map((l) => l.float),
+			[1.0, 2.0, 3.0],
+			`AC-2 FAIL: float-Werte weichen von 1.0/2.0/3.0 ab (Bestandsdaten-Risiko!): ${JSON.stringify(levels)}`
+		);
+		assert.equal(
+			levels[0].label.toLowerCase(),
 			'leicht',
-			`float 1.0 muss auf "leicht" zeigen, zeigt aber auf "${label}".`
+			`AC-2 FAIL: float 1.0 zeigt nicht auf "leicht", sondern auf "${levels[0].label}"`
 		);
-	});
-
-	test('"mittel" setzt float 2.0', () => {
-		const label = activeLabelFor(levels, 2.0);
-		assert.ok(label, 'Kein Level mit float 2.0 gefunden.');
 		assert.equal(
-			label!.toLowerCase(),
+			levels[1].label.toLowerCase(),
 			'mittel',
-			`float 2.0 muss auf "mittel" zeigen, zeigt aber auf "${label}".`
+			`AC-2 FAIL: float 2.0 zeigt nicht auf "mittel", sondern auf "${levels[1].label}"`
 		);
-	});
-
-	test('"hoch" setzt float 3.0 (bisher gar nicht erreichbar)', () => {
-		const label = activeLabelFor(levels, 3.0);
-		assert.ok(label, 'Kein Level mit float 3.0 gefunden -- "ab hoch" ist nicht waehlbar.');
 		assert.equal(
-			label!.toLowerCase(),
+			levels[2].label.toLowerCase(),
 			'hoch',
-			`float 3.0 muss auf "hoch" zeigen, zeigt aber auf "${label}".`
+			`AC-2 FAIL: float 3.0 zeigt nicht auf "hoch", sondern auf "${levels[2].label}"`
 		);
 	});
 
-	test('Bestandswert 1.0 wird nach der Aenderung weiterhin korrekt als "leicht" angezeigt', () => {
-		// ThresholdMetricRow.svelte:28 -- levels.find(l => l.float === currentFloat).
-		// Bestandstrips speichern nur den Zahlenwert (onChange gibt l.float weiter,
-		// nie l.id) -- 1.0/2.0 aus alten Trips muessen weiterhin einen Treffer haben.
-		assert.equal(activeLabelFor(levels, 1.0)?.toLowerCase(), 'leicht');
+	test('Bestandswert 1.0 bleibt "leicht", 2.0 bleibt "mittel" (Reverse-Mapping wie ThresholdMetricRow.svelte:28)', async () => {
+		const derive = await loadDerive();
+		const levels = derive(['kein', 'leicht', 'mittel', 'hoch']);
+		const activeLabelFor = (float: number) => levels.find((l) => l.float === float)?.label;
+		assert.equal(activeLabelFor(1.0)?.toLowerCase(), 'leicht');
+		assert.equal(activeLabelFor(2.0)?.toLowerCase(), 'mittel');
+		assert.equal(activeLabelFor(3.0)?.toLowerCase(), 'hoch');
+	});
+});
+
+describe('#1911 AC-3: Labels stammen aus THUNDER_LABEL_DE, einzig zulaessige Abweichung ist der Anfangsbuchstabe', () => {
+	test('deriveThunderThresholdLevels-Labels == THUNDER_LABEL_DE (Live-Read), nur Grossschreibung weicht ab', async () => {
+		const derive = await loadDerive();
+		const live = fetchLive();
+		const levels = derive(live.ordinalLabels);
+		const canonicalWithoutNone = live.canonical.slice(1); // Index 0 = NONE/"kein", verworfen
+
+		levels.forEach((l, i) => {
+			assert.equal(
+				l.label.toLowerCase(),
+				canonicalWithoutNone[i].toLowerCase(),
+				`AC-3 FAIL: Level[${i}] ("${l.label}") weicht inhaltlich von THUNDER_LABEL_DE ` +
+					`("${canonicalWithoutNone[i]}") ab -- jede Abweichung ausser der ` +
+					'Anfangsbuchstaben-Grossschreibung ist ein Verstoss.'
+			);
+			assert.equal(
+				l.label[0],
+				l.label[0].toUpperCase(),
+				`AC-3 FAIL: Level[${i}] ("${l.label}") beginnt nicht mit einem Grossbuchstaben.`
+			);
+		});
 	});
 
-	test('Bestandswert 2.0 wird nach der Aenderung weiterhin korrekt als "mittel" angezeigt', () => {
-		assert.equal(activeLabelFor(levels, 2.0)?.toLowerCase(), 'mittel');
+	// doc-compliance-test: Abwesenheits-Nachweis ist per Verhalten nicht
+	// pruefbar, nur per Dateiinhalt (CLAUDE.md-Ausnahme).
+	test('# doc-compliance-test: das alte hart codierte Level-Literal steht nicht mehr in WeatherMetricsTab.svelte', () => {
+		const source = readFileSync(WEATHER_METRICS_TAB, 'utf-8');
+		const oldLiteral =
+			/\{\s*id:\s*'leicht',\s*label:\s*'Leicht',\s*float:\s*1\.0\s*\}/;
+		assert.equal(
+			oldLiteral.test(source),
+			false,
+			'AC-3 FAIL: das hart codierte Level-Literal ' +
+				"{ id: 'leicht', label: 'Leicht', float: 1.0 } steht weiterhin in " +
+				'WeatherMetricsTab.svelte -- die Gewitter-Schwellenliste muss aus dem ' +
+				'Backend-Katalog abgeleitet werden (deriveThunderThresholdLevels), nicht ' +
+				'lokal getippt sein.'
+		);
+	});
+});
+
+describe('#1911 AC-6: eine synthetische fuenfte Stufe erscheint ohne Aenderung an der Funktion selbst', () => {
+	test('5-Stufen-Fixture ["kein","leicht","mittel","hoch","extrem"] -> 4 Eintraege, floats 1.0..4.0', async () => {
+		const derive = await loadDerive();
+		const levels = derive(['kein', 'leicht', 'mittel', 'hoch', 'extrem']);
+		assert.equal(
+			levels.length,
+			4,
+			`AC-6 FAIL: erwartet 4 Eintraege (5 Katalog-Stufen minus Nullstufe), erhalten ${JSON.stringify(levels)}`
+		);
+		assert.deepEqual(
+			levels.map((l) => l.float),
+			[1, 2, 3, 4],
+			`AC-6 FAIL: floats weichen von 1..4 ab: ${JSON.stringify(levels)}`
+		);
+		assert.equal(levels[3].label.toLowerCase(), 'extrem', 'AC-6 FAIL: die fuenfte Stufe fehlt/ist falsch benannt.');
+	});
+});
+
+describe('#1911 AC-7 (Funktionsebene): kein Absturz bei fehlendem/leerem Katalog', () => {
+	test('leeres Array -> leere Liste, kein Wurf', async () => {
+		const derive = await loadDerive();
+		assert.doesNotThrow(() => derive([]));
+		assert.deepEqual(derive([]), []);
+	});
+
+	test('undefined (Katalog noch nicht geladen) -> leere Liste, kein Wurf', async () => {
+		const derive = await loadDerive();
+		assert.doesNotThrow(() => derive(undefined));
+		assert.deepEqual(derive(undefined), []);
 	});
 });

--- a/frontend/src/lib/components/shared/weather-metrics-tab/compareMetricSelection.ts
+++ b/frontend/src/lib/components/shared/weather-metrics-tab/compareMetricSelection.ts
@@ -27,6 +27,9 @@ export interface CompareSelectionEntry {
 	hourlyDefault?: boolean;
 	hourlyMergeOnly?: boolean;
 	hourly_legacy_keys?: string[];
+	// Issue #1911: Ordinal-Beschriftungen (z.B. Gewitter "kein"/"leicht"/
+	// "mittel"/"hoch"), unveraendert aus der Katalogantwort durchgereicht.
+	ordinalLabels?: string[];
 }
 
 /**
@@ -68,7 +71,8 @@ export function toCompareSelectionEntries(
 		...(m.hourlyMergeOnly !== undefined ? { hourlyMergeOnly: m.hourlyMergeOnly } : {}),
 		...(m.hourly_legacy_keys !== undefined
 			? { hourly_legacy_keys: m.hourly_legacy_keys }
-			: {})
+			: {}),
+		...(m.ordinalLabels !== undefined ? { ordinalLabels: m.ordinalLabels } : {})
 	}));
 	// Issue #1373 (S2 Scheibe B): dieselbe geladene Katalogantwort ist die
 	// EINZIGE Quelle für die Übersetzung Auswahl-Schlüssel <-> Größe+Auswertung

--- a/src/output/renderers/compare_metric_catalog.py
+++ b/src/output/renderers/compare_metric_catalog.py
@@ -49,12 +49,23 @@ im Resolver, schlaegt der Import fehl.
 from __future__ import annotations
 
 from app.metric_catalog import aggregation_label_de, alert_metric_for, get_metric
+from app.models import ThunderLevel
+from output.metric_format import THUNDER_LABEL_DE, thunder_ordinal
 from output.renderers.compare_hourly_metric_ids import (
     HOURLY_DEFAULT_METRIC_IDS, HOURLY_EXCLUDED_METRIC_IDS, HOURLY_EXCLUSION_REASON,
     HOURLY_LEGACY_KEYS_BY_METRIC_ID, HOURLY_MERGE_ONLY_METRIC_IDS,
 )
 from output.renderers.compare_metric_ids import FRONTEND_TO_RENDERER_METRIC_ID
 from services.compare_alert import _SUMMARY_KEY_TO_CATALOG_ID
+
+# #1911 (Befund B2): ordinalLabels war ein handgepflegtes Literal, das seit
+# der Ordinalverschiebung schon einmal driftete (#1474 F001). Ableitung aus
+# der kanonischen Quelle THUNDER_LABEL_DE, sortiert ueber thunder_ordinal()
+# (NICHT ueber die Dict-Einfuegereihenfolge) -- Ergebnis bleibt wertgleich
+# zum vorherigen Literal ["kein", "leicht", "mittel", "hoch"].
+_THUNDER_ORDINAL_LABELS: list[str] = [
+    THUNDER_LABEL_DE[level] for level in sorted(ThunderLevel, key=thunder_ordinal)
+]
 
 # #1401 A1: deutsche Beschriftung der Auswertung -- eigenes Anzeige-Element
 # neben dem Namen, nicht Teil des Namens.
@@ -108,7 +119,7 @@ COMPARE_METRIC_CATALOG: list[dict] = [
      # Schieberegler-Bereich im Frontend wird aus len(ordinalLabels) abgeleitet
      # (compareMetricCatalogLoader.ts::buildCompareMetricDefs), eine dritte
      # Stelle hier war seit der Ordinalverschiebung um eine Stufe zu kurz.
-     "ordinalLabels": ["kein", "leicht", "mittel", "hoch"],
+     "ordinalLabels": _THUNDER_ORDINAL_LABELS,
      "metric_id": "thunder", "aggregation": "max"},
     {"key": "temp_min_c", "unit": "°C", "decimals": 0,
      "higherIsBetter": True, "kind": "range", "rangeMin": -30, "rangeMax": 30, "step": 1,

--- a/tests/tdd/test_thunder_ordinal_labels_derivation.py
+++ b/tests/tdd/test_thunder_ordinal_labels_derivation.py
@@ -1,0 +1,127 @@
+"""RED-Tests fuer #1911 (Gewitter-Schwellenliste: Ableitung statt Doppel-Kopie),
+Backend-Haelfte AC-4/AC-5.
+
+Spec: docs/specs/modules/thunder_threshold_katalog.md (AC-4, AC-5)
+
+Befund B2 (docs/context/fix-1911-thunder-katalog.md): der Compare-Katalog
+(`compare_metric_catalog.py:104-112`) traegt `ordinalLabels` heute als
+Literal-Liste `["kein", "leicht", "mittel", "hoch"]` -- die Datei importiert
+`THUNDER_LABEL_DE`/`thunder_ordinal` (`output/metric_format.py:283-288`,
+`app/thunder_scale.py:47-57`) NICHT. `compareMetricCatalogParity.test.ts`
+vergleicht nur den *Wert* der Endpoint-Antwort, nie ihre *Herkunft* -- ein
+Rueckfall auf ein Literal bliebe dort unentdeckt.
+
+Mutations-Technik statt Mock (CLAUDE.md, "Mutations-Gegenprobe ist PFLICHT"):
+`THUNDER_LABEL_DE` wird zur Laufzeit MUTIERT (dasselbe Dict-Objekt, in place)
+und `output.renderers.compare_metric_catalog` per `importlib.reload()` neu
+ausgefuehrt. Eine Ableitung liest die mutierten Werte bei jedem Reload frisch
+ein (egal ob sie als Modul-Konstante beim Import oder erst beim Aufruf von
+`get_compare_metric_catalog()` berechnet wird) -- ein Literal bleibt in
+JEDEM Fall unveraendert. Das ist der Unterschied, den die zwei Tests unten
+messen.
+
+Beide Tests kombinieren absichtlich Wert-AENDERUNG und Reihenfolge-VERTAUSCHUNG
+in einem Zug (test_ac5_...): eine reine Reihenfolge-Vertauschung OHNE
+Wertaenderung waere gegen das heutige Literal ["kein","leicht","mittel","hoch"]
+zufaellig identisch mit der erwarteten (korrekten) Ausgabe -- ein
+"Null-ohne-Varianz"-Scheingruen. Erst mit unterscheidbaren Markerwerten wird
+der Test heute nachweisbar ROT.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+import output.metric_format as metric_format
+import output.renderers.compare_metric_catalog as compare_metric_catalog
+from app.models import ThunderLevel
+
+_ORIGINAL_LABELS = dict(metric_format.THUNDER_LABEL_DE)
+
+
+def _restore_and_reload() -> None:
+    """Stellt THUNDER_LABEL_DE (Inhalt UND Einfuegereihenfolge) wieder her und
+    laedt compare_metric_catalog neu, damit andere Tests im selben Prozess den
+    unveraenderten Katalog sehen."""
+    metric_format.THUNDER_LABEL_DE.clear()
+    for level, label in _ORIGINAL_LABELS.items():
+        metric_format.THUNDER_LABEL_DE[level] = label
+    importlib.reload(compare_metric_catalog)
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_thunder_label_de():
+    yield
+    _restore_and_reload()
+
+
+def _thunder_entry(catalog: list[dict]) -> dict:
+    return next(e for e in catalog if e["key"] == "thunder_level_max")
+
+
+def test_ac4_ordinal_labels_reflect_a_mutated_source_label() -> None:
+    """AC-4 (Herkunfts-Nachweis): aendert sich EIN Eintrag in THUNDER_LABEL_DE,
+    muss sich das in COMPARE_METRIC_CATALOG['thunder_level_max']['ordinalLabels']
+    niederschlagen -- sonst ist ordinalLabels ein Literal, keine Ableitung.
+
+    RED heute: compare_metric_catalog.py:111 ignoriert THUNDER_LABEL_DE
+    vollstaendig -- die Mutation bleibt wirkungslos, das Reload liefert
+    weiterhin die alte Wortliste ["kein","leicht","mittel","hoch"].
+    """
+    metric_format.THUNDER_LABEL_DE[ThunderLevel.MED] = "GZ_MARKER_MED"
+    importlib.reload(compare_metric_catalog)
+
+    thunder = _thunder_entry(compare_metric_catalog.get_compare_metric_catalog())
+
+    assert "GZ_MARKER_MED" in thunder["ordinalLabels"], (
+        "Eine Aenderung an THUNDER_LABEL_DE[MED] schlaegt sich nicht in "
+        f"ordinalLabels nieder ({thunder['ordinalLabels']!r}) -- ordinalLabels "
+        "ist (noch) ein Literal, keine Ableitung aus THUNDER_LABEL_DE (AC-4)."
+    )
+    assert thunder["ordinalLabels"][2] == "GZ_MARKER_MED", (
+        "Das mutierte Label erscheint nicht an der ordinal-korrekten Position "
+        f"(Index 2 = MED, thunder_ordinal()==2): {thunder['ordinalLabels']!r}"
+    )
+
+
+def test_ac5_ordinal_labels_follow_thunder_ordinal_not_dict_insertion_order() -> None:
+    """AC-5: die Reihenfolge der abgeleiteten ordinalLabels entsteht ueber
+    thunder_ordinal() (NONE=0 < LOW=1 < MED=2 < HIGH=3), NICHT ueber die
+    Einfuegereihenfolge von THUNDER_LABEL_DE.
+
+    THUNDER_LABEL_DE wird komplett geleert und in VERTAUSCHTER Reihenfolge
+    (HIGH, MED, LOW, NONE) mit unterscheidbaren Markerwerten neu befuellt.
+    Eine Ableitung ueber `list(THUNDER_LABEL_DE.values())` (Dict-
+    Einfuegereihenfolge) wuerde ["GZ_HIGH","GZ_MED","GZ_LOW","GZ_NONE"]
+    liefern -- eine Ableitung ueber thunder_ordinal() liefert unabhaengig von
+    der Einfuegereihenfolge ["GZ_NONE","GZ_LOW","GZ_MED","GZ_HIGH"].
+
+    RED heute: aus demselben Grund wie oben -- das Literal ignoriert
+    THUNDER_LABEL_DE komplett, unabhaengig von seiner Reihenfolge; die
+    erwarteten Marker-Werte erscheinen nirgends in der Antwort.
+    """
+    metric_format.THUNDER_LABEL_DE.clear()
+    metric_format.THUNDER_LABEL_DE[ThunderLevel.HIGH] = "GZ_HIGH"
+    metric_format.THUNDER_LABEL_DE[ThunderLevel.MED] = "GZ_MED"
+    metric_format.THUNDER_LABEL_DE[ThunderLevel.LOW] = "GZ_LOW"
+    metric_format.THUNDER_LABEL_DE[ThunderLevel.NONE] = "GZ_NONE"
+    importlib.reload(compare_metric_catalog)
+
+    thunder = _thunder_entry(compare_metric_catalog.get_compare_metric_catalog())
+
+    assert thunder["ordinalLabels"] == ["GZ_NONE", "GZ_LOW", "GZ_MED", "GZ_HIGH"], (
+        "ordinalLabels folgt nicht thunder_ordinal() (NONE<LOW<MED<HIGH), "
+        f"erhalten: {thunder['ordinalLabels']!r} -- entweder unveraendertes "
+        "Literal oder Ableitung ueber Dict-Einfuegereihenfolge "
+        "(HIGH,MED,LOW,NONE) statt thunder_ordinal()."
+    )
+
+
+def test_real_catalog_unaffected_after_cleanup() -> None:
+    """Gegenprobe: nach der (autouse) Wiederherstellung liefert der echte,
+    unveraenderte Katalog wieder die heutigen vier Woerter -- reines
+    Prozess-Hygiene-Netz, kein AC-Nachweis fuer sich."""
+    importlib.reload(compare_metric_catalog)
+    thunder = _thunder_entry(compare_metric_catalog.get_compare_metric_catalog())
+    assert thunder["ordinalLabels"] == ["kein", "leicht", "mittel", "hoch"]


### PR DESCRIPTION
Schliesst #1911 (#1488 Scheibe A2).

## Was sich aendert

Die Gewitter-Schwellenliste im Wetter-Metriken-Reiter war ein hart codiertes Frontend-Literal. Sie wird jetzt aus dem Backend-Katalog abgeleitet — **und der Backend-Katalog leitet seine Stufenbeschriftungen seinerseits aus `THUNDER_LABEL_DE` ab, statt sie als Literal zu fuehren.**

Der zweite Teil war noetig, weil `compare_metric_catalog.py` nichts aus `metric_format.py` importierte: Haette man nur das Frontend umgestellt, waere die handgepflegte Kopie lediglich ins Backend gewandert. Der Kommentar an der Stelle dokumentierte die bereits eingetretene Drift selbst („eine dritte Stelle hier war seit der Ordinalverschiebung um eine Stufe zu kurz").

## Drei Befunde, die die Ticket-Praemisse korrigiert haben

1. Der Block ist ein **Alarm-Schwellenwaehler mit drei** Eintraegen, keine vierstufige Anzeige-Skala — „ab Stufe *kein* alarmieren" gibt es bewusst nicht. Also **ableiten** (Katalog ohne Nullstufe), nicht ersetzen.
2. `GET /api/metrics` fuehrt keine `ordinalLabels`; nur `GET /api/compare/metrics` tut es. Der Trip-Kontext laedt diesen Katalog aber bereits.
3. `toCompareSelectionEntries()` reichte `ordinalLabels` gar nicht durch — die Rohinfo stand im Trip-Kontext noch nicht bereit.

## Hauptrisiko und wie es abgesichert ist

Der gewaehlte Wert wird als `sms_threshold` gespeichert und backendseitig als **Zahl** verglichen (`src/output/tokens/metrics.py:52`). Ein Offset um eins haette still bei der falschen Stufe alarmiert — wer „hoch" eingestellt hat, haette ab da schon „mittel" bekommen. AC-2 prueft die Werte feldweise; die Mutation „Offset um 1" und die Mutation „`.slice(1)` nach der Katalog-Suche" werden beide gefangen.

## Adversary

Drei Runden, fuenf Findings (F001–F005) — **keines betraf den Produktivcode**, alle waren Abdeckungsluecken, alle geschlossen. Statt sie mit weiteren AST-Formpruefungen zu flicken, wurde auf PO-Entscheid die **Naht verschoben**: Die Katalog-Suche wanderte aus dem Template in `thunderThresholdLevelsFromCatalog()`. Dadurch wurden zwei Zusicherungen von Formpruefungen zu echten Verhaltenstests, und eine AST-Kruecke entfiel ersatzlos.

Die drei zugehoerigen Mutationen wurden von einem **unabhaengigen** Agenten nachgestellt und jeweils mit der vorhergesagten Fehlermeldung als gefangen belegt.

## Teststand

- Frontend: **2711 passed / 0 failed**
- Python-Kern: **10292 gelaufen** (von 11046 gesammelt, 754 per Standard-Marker abgewaehlt), **9973 passed**. Die 198 Roten sind zu 195 ein Artefakt von `--disable-socket` (blockt auch legitime lokale Test-Server) und zu 3 vorbestehend (Kalenderzufall auf 2026-08-20, Umgebungs-Guard) — keiner erwaehnt `compare_metric_catalog`, `ordinalLabels` oder `THUNDER_LABEL_DE`. Alle 19 katalog-konsumierenden Testdateien gruen.
- Endpoint-Antwort nachweislich **wertgleich** zu vorher.

## Umfang

Produktivcode 4 Dateien, +74/-8 — deutlich unter dem LoC-Limit.

## Abgestimmt

`session:1848` fasst `WeatherMetricsTab.svelte` in ihrer Scheibe A3 an und rebast auf diesen Merge. Die sechs anderen Schwellenlisten und die Temperatur-Kuerzel (#1848 A1) sind unveraendert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)