### PR TITLE
fix(#2004): Diskriminierungs-Anker gegen eingefrorene Systemuhr statt echter Uhr

### DIFF
--- a/tests/tdd/conftest.py
+++ b/tests/tdd/conftest.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from zoneinfo import ZoneInfo
 
 import pytest
+from freezegun import freeze_time
 
 # .claude/hooks muss auf sys.path liegen, damit Hooks die importieren
 # (z.B. staging_gate, prod_selftest) `import _e2e_paths` auflösen können —
@@ -103,6 +104,21 @@ def _anker(now_utc: datetime, zone: str, erwarteter_ortstag: _date) -> None:
     DIESEM Zeitpunkt wirklich auseinanderfallen. Ohne ihn koennte die
     Hauptzusicherung strukturell nie fehlschlagen (Fehlerklasse #1726 F002).
     Der Sollwert wird aus der Zone gebildet, nicht aus dem Prueflingsweg.
+
+    Die dritte Zusicherung (Servertag) wird UNTER ``freeze_time(now_utc)``
+    ausgewertet statt gegen die echte, ungemockte Systemuhr (Issue #2004):
+    jeder Aufrufer dieses Ankers fuehrt den Pruefling anschliessend selbst
+    innerhalb von ``with freeze_time(now_utc): ...`` aus (Beleg: alle
+    Nutzer in ``tests/tdd/test_*_folgen_ortszone.py`` /
+    ``test_import_und_fremdquellen_folgen_ortstag.py``) -- ``date.today()``
+    liefert dem Pruefling in diesem Moment also GENAU den hier gefrorenen
+    Wert, nicht das reale Kalenderdatum des CI-Laufs. Ein Pruefling, der die
+    uebergebene Zeit ignoriert und stattdessen die Systemuhr abfraegt,
+    bekaeme exakt diesen (gegenueber ``erwarteter_ortstag`` bewusst
+    abweichenden) Wert und wuerde an der Hauptzusicherung scheitern. Vorher
+    verglich diese Zeile gegen das ECHTE, ungefrorene Tagesdatum -- an genau
+    einem Kalendertag im Jahr faelschlich blockierend, wenn Ortstag und
+    reales Serverdatum zufaellig zusammenfielen (#2004).
     """
     ortstag = now_utc.astimezone(ZoneInfo(zone)).date()
     assert ortstag == erwarteter_ortstag, (
@@ -113,9 +129,11 @@ def _anker(now_utc: datetime, zone: str, erwarteter_ortstag: _date) -> None:
         f"Testaufbau nicht diskriminierend: Ortstag ({ortstag}) und "
         f"Weltzeit-Tag ({now_utc.date()}) sind gleich (#1726 F002)"
     )
-    assert ortstag != _date.today(), (
+    with freeze_time(now_utc):
+        servertag = _date.today()
+    assert ortstag != servertag, (
         f"Testaufbau nicht diskriminierend: Ortstag ({ortstag}) und Servertag "
-        f"date.today() ({_date.today()}) sind gleich (#1726 F002)"
+        f"date.today() ({servertag}) sind gleich (#1726 F002)"
     )
 
 


### PR DESCRIPTION
## Ursache

Der CI-Job `test` war heute (2026-08-20) fuer JEDEN PR im Repo rot, unabhaengig vom Aenderungsinhalt, und blockierte damit die Branch-Protection fuer alle Merges.

`tests/tdd/conftest.py:116-119` (`_anker()`) prueft:

```python
assert ortstag != _date.today(), (...)
```

`tests/tdd/test_import_und_fremdquellen_folgen_ortstag.py` verankert zwei Tests hart auf `now_utc = 2026-08-19 20:00 UTC` und erwartet Ortstag Kiritimati `2026-08-20`. Heute ist real der `2026-08-20` — `ortstag == _date.today()` faellt also zufaellig zusammen, und die Selbstpruefung schlaegt fehl, bevor die eigentliche Hauptzusicherung ueberhaupt laeuft. Kippkante: ab 2026-08-21 waere es ohne jede Codeaenderung wieder gruen.

## Fix

Zeile 116 bleibt bestehen — sie ist nicht redundant zur Zeile 112 (die gegen den Weltzeit-Tag `now_utc.date()` prueft), sondern faengt eigenstaendig die Fehlerklasse #1726 F002 (Pruefling ignoriert den uebergebenen Zeitpunkt und fragt stattdessen die Systemuhr ab).

Die dritte Zusicherung liest `date.today()` jetzt unter `freeze_time(now_utc)` statt gegen die echte, ungemockte Uhr:

```python
with freeze_time(now_utc):
    servertag = _date.today()
assert ortstag != servertag, (...)
```

Begruendung: jeder Aufrufer des geteilten Ankers fuehrt den Pruefling anschliessend selbst innerhalb von `with freeze_time(now_utc): ...` aus (Beleg: alle sechs Nutzer in `tests/tdd/`). `date.today()` liefert dem Pruefling zur Laufzeit also exakt den hier gefrorenen Wert, nicht das reale Kalenderdatum des CI-Laufs — die Diskriminierung wird dadurch deterministisch und datumsunabhaengig, ohne die Zusicherung selbst zu schwaechen oder zu loeschen.

## Mutationsbeleg (PFLICHT laut CLAUDE.md)

`src/services/gpx_processing.py::gpx_to_stage_data` wurde per String-Ersetzung (externe Sicherungskopie im Scratchpad, kein `git checkout`) auf die Vor-#1727-S5d-Fassung zurueckgesetzt:

```python
d = stage_date or date.today()  # ignoriert now_utc/Ortszone
```

Ergebnis: `test_ac1_gpx_rueckfalltag_folgt_der_zone_des_ersten_wegpunkts` wird rot:

```
AssertionError: gpx_to_stage_data() lieferte date='2026-08-19' -- erwartet
den ORTSTAG von Kiritimati (2026-08-20), nicht den Servertag (2026-08-19)
assert '2026-08-19' == '2026-08-20'
```

Nach Rueckbau der Mutation (Datei-Diff gegen die Sicherungskopie bestaetigt: identisch) wieder gruen. Der Anker faengt die urspruengliche Fehlerklasse also nach wie vor.

## Testergebnis — alle Nutzer des geteilten Ankers (Issue #1795)

`TZ=UTC uv run pytest ... --allow-unix-socket`, benannte Dateien:

- `tests/tdd/test_import_und_fremdquellen_folgen_ortstag.py` — 6 passed (vorher 2 failed)
- `tests/tdd/test_vorschau_anzeige_folgen_ortszone.py`
- `tests/tdd/test_befehlspfade_folgen_ortszone.py`
- `tests/tdd/test_versandpfade_folgen_ortszone.py`
- `tests/tdd/test_massif_sperrcache_folgt_kalendertag.py`
- `tests/tdd/test_timeline_folgt_der_ortszeit.py`

Zusammen mit den weiteren `_anker`-Erwaehnungen (eigene, unabhaengige lokale Funktionen, nicht der geteilte Anker): **220 passed**.

## Auswirkung

Entblockt die Branch-Protection fuer alle offenen PRs im Repo (mindestens drei Sitzungen haengen aktuell daran).

Fixes #2004

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>