### PR TITLE
fix(#1848 A1): Ausblick liest das Gehzeit-Fenster + Schraegstrich-Spannenzelle

### DIFF
--- a/docs/context/feat-1848-a1-tagesfenster-kennungen.md
+++ b/docs/context/feat-1848-a1-tagesfenster-kennungen.md
@@ -272,3 +272,84 @@ Wert im Ausblick erscheint — und wenn es der Gehzeit-Wert sein soll (PO-Entsch
 wie die SMS"), muss der Weg dorthin gebaut werden. **Vor der Umsetzung ist auszumessen, in
 wie vielen Faellen die beiden Werte ueberhaupt auseinanderliegen** — sonst ist jeder
 Gleichheitsbefund trivial wahr.
+
+---
+
+# 🔴 IST-ZUSTAND GEMESSEN (2026-08-20) — die Anzeige-Praemisse von A1 traegt nicht
+
+Alles unten per **echtem Funktionsaufruf** belegt, nicht aus dem Code abgeleitet.
+
+## Es gibt ZWEI Ausblick-Formen, beide in Trip UND Ortsvergleich
+
+| Form | Wann | Temperatur-Darstellung |
+|---|---|---|
+| **A) Feste 7-Spalten-Form** (Altbestand, `metrics=None`) | keine Auswahl gespeichert | HTML: **zwei** Spalten `N`/`D`, je eine Zahl (`outlook.py:258-259`). Klartext: **ein Spannen-Token** `8–16°C` (`helpers.py:940-947`) |
+| **B) Konfigurierbare Spaltenauswahl** (#1361/#1368/#1373) | `metrics` gesetzt | jede Spalte **immer genau ein Wert**, nie eine Spanne |
+
+Form B ist der Pfad, den das Frontend-Bedienteil bedient (`CompareOutlookLayoutControls.svelte`,
+eingebunden ueber das geteilte `WeatherMetricsTab.svelte`). Trip via
+`resolve_trip_outlook_metrics()` (`trip_report.py:209`), Compare via `resolve_outlook_metrics()`
+(`report_config_resolver.py:249/291`).
+
+## 🔴 Tief und Hoch sind im Ausblick HEUTE SCHON getrennt waehlbar
+
+```
+outlook_columns([{"metric_id":"temperature","aggregation":"max"},
+                 {"metric_id":"temperature","aggregation":"min"}])
+→ [{'label': 'Temperatur Maximum', 'field': 'temp_max_c', 'unit': '°C', 'decimals': 0},
+   {'label': 'Temperatur Minimum', 'field': 'temp_min_c', 'unit': '°C', 'decimals': 0}]
+format_outlook_value(27.3, max) → '27 °C'   ·   format_outlook_value(8.9, min) → '9 °C'
+```
+
+Label-Kollisionsaufloesung haengt „Minimum"/„Maximum" an (`compare_outlook_metric_ids.py:144-148`).
+Frontend bestaetigt es woertlich: „Groessen mit mehreren Auswertungen (Temperatur, gefuehlte
+Temperatur) bekommen je Auswertung ein unabhaengiges Kaestchen"
+(`CompareOutlookLayoutControls.svelte:146-148`).
+
+**Folge fuer den Zuschnitt:** Die Begruendung „getrennte Waehlbarkeit braucht eigene Kennungen"
+gilt **nicht fuer die Anzeige** — die kann es schon. Sie gilt nur fuer die **Speicherform**,
+weil das Kanal-Modul ausschliesslich Kennungen kennt und keine Paare aus Kennung+Auswertung.
+Das ist exakt die Naht zu **Scheibe A2**, nicht zu A1.
+
+## Praezedenzfall Spannen-Zelle
+
+Der einzige Beleg im Ausblick ist der Klartext der **Alt-Form**: `f"{tl}–{th}°C"`
+(`helpers.py:943`, Halbgeviertstrich, EIN Einheiten-Suffix). Tests mit echten Zahlen:
+`test_compare_outlook.py:205` (`"9–20°C"`), `test_compare_outlook_metric_selection.py:265-267`
+(nennt es „festen Temperatur-Spannen-Token").
+
+🔴 **Zwei verschiedene Ist-Schreibweisen fuer dieselbe Sache:** SMS nutzt den **Schraegstrich**
+(`D13/27`, minusfest), der Ausblick-Klartext den **Halbgeviertstrich** (`8–16°C`). „Exakt wie
+die SMS" muss entscheiden, welche im Ausblick gilt — im HTML gibt es heute **gar keine**
+Spannen-Zelle.
+
+## `summary_fields` → Spalte, und warum die Gehzeit-Kennungen rausfallen
+
+Weg: `MetricDefinition.summary_fields` (`metric_catalog.py:42`) → `summary_field_for()`
+(`metric_catalog.py:899-910`, liefert `None` bei `selectable=False` oder fehlendem Key) →
+`_summary_field()` (`compare_outlook_metric_ids.py:34-42`) → Drop-Bedingungen Zeile **62**
+und **133**.
+
+**Bestaetigt per Ausfuehrung** — die vier Gehzeit-Kennungen werden ersatzlos verworfen:
+```
+resolve_outlook_metrics([{"metric_id":"temperature_day_low",  "aggregation":"min"},
+                         {"metric_id":"wind_chill_day_high", "aggregation":"max"}])
+WARNING: ... ohne Katalog-Entsprechung — Eintrag wird verworfen (vgl. #1361 Befund 3)
+→ []
+```
+Mehrfach-`summary_fields` gibt es: `temperature` traegt **drei** (`min`/`max`/`avg`,
+`metric_catalog.py:119`), `wind_chill` zwei (`:218`). Das erzeugt aber **keine** Spannen-Zelle,
+sondern mehrere separate waehlbare Spalten.
+
+## `avg` ist im Ausblick heute NICHT waehlbar
+
+Zentral vorhanden, im Compare-Katalog fehlend — `COMPARE_METRIC_CATALOG`
+(`compare_metric_catalog.py:76-162`) hat fuer `temperature` nur `temp_max_c` (`:101-103`) und
+`temp_min_c` (`:113-115`), **keine** `avg`-Zeile:
+```
+summary_field_for("temperature", "avg")                            → 'temp_avg_c'
+resolve_outlook_metrics([{"metric_id":"temperature","aggregation":"avg"}])  → []
+```
+Die Picker-Liste zeigt fuer Temperatur daher nur zwei Kaestchen. **Die Open Question
+„faellt avg weg oder kommt er dazu?" ist damit falsch gestellt** — er ist heute schon nicht da;
+die Frage lautet, ob er neu dazukommen soll.

--- a/docs/context/feat-1848-a1-tagesfenster-kennungen.md
+++ b/docs/context/feat-1848-a1-tagesfenster-kennungen.md
@@ -427,3 +427,46 @@ werden muss** — sonst stehen zwei Schreibweisen fuer dieselbe Sache nebeneinan
 7-Spalten-Altform**. Ob deren Klartext mit angeglichen wird oder nur der konfigurierbare Pfad,
 haengt an den Golden-Fixtures (`test_compare_outlook.py:205` erwartet `"9–20°C"`) — technischer
 Zuschnitt, keine PO-Frage.
+
+## Reichweite des falschen Werts (belegt)
+
+**Der Ausblick zeigt NIE den heutigen Tag.** `get_future_stages()` filtert `s.date > from_date`
+(`trip.py:275-280`), aufgerufen als `trip.get_future_stages(target_date)` und auf
+`future_stages[:3]` begrenzt (`trip_report_scheduler.py:2236, 2249`). Die Kachelzeile/
+Zusammenfassung derselben Mail deckt `target_date` ab (`trip_report_scheduler.py:1239`).
+
+⇒ **Der Widerspruch ist NICHT innerhalb einer Mail sichtbar** — die Tagesmengen sind strukturell
+disjunkt (`>`, nicht `>=`). Er zeigt sich **zeitversetzt**: die heutige Mail nennt im Ausblick
+fuer morgen `27`, die morgige Mail nennt fuer denselben Kalendertag in der Kachelzeile `28`.
+Das ist fuer die AC-Formulierung entscheidend — ein AC, das „in derselben Mail" prueft, waere
+strukturell nie erfuellbar.
+
+| Ausblick-Spalte | Von #1417 betroffen? | Beleg |
+|---|---|---|
+| Temperatur (`N`/`D` fix **und** gewaehlt) | **JA** | `outlook.py:503-504`, Messung oben |
+| Gefuehlte Temperatur (`wind_chill`, nur wenn gewaehlt) | **JA**, strukturell derselbe Fehler | `metric_catalog.py:213-218` → `outlook.py:647` liest dasselbe Etappenaggregat; SMS `FL`/`FD` nutzt `hiking_field_min_max(..., "wind_chill_c")` (`sms_trip.py:240`) |
+| Wind / Boeen | **NEIN** | `W`/`G` kommen aus dem geteilten **Tagesfenster 04-19** (`day_window.py:210-213`, Epic #1319/#1317), nicht aus der Gehzeit — andere Baustelle |
+
+🔸 **Nebenbefund (→ #1199, nicht in dieser Scheibe):** Die Boeen-Spalte des Ausblicks liest eine
+**dritte** Quelle — `hourly_gust` aus `_flat_points`, also rohe **ungefensterte** Zeitreihen
+aller Segmente (`trip_report_scheduler.py:2306-2309`), waehrend Wind daneben das Etappenaggregat
+nutzt. Zwei Spalten derselben Tabelle mit verschiedener Fensterung. Eigene Baustelle.
+
+---
+
+# 🟢 ZUSCHNITT A1 (final, Stand 2026-08-20)
+
+| # | Inhalt |
+|---|---|
+| **1** | Der Trip-Ausblick liest Temperatur **und** gefuehlte Temperatur aus dem **Gehzeit-Fenster** statt aus dem Etappenaggregat — Nachzug zu #1417, fail-soft zurueck auf `summary.temp_*` |
+| **2** | Sind Tief **und** Hoch gewaehlt: **eine** Zelle `{min}/{max}` (Schraegstrich, minusfest); nur eine gewaehlt ⇒ Einzelwert wie heute. Gilt HTML **und** Klartext, Trip **und** Ortsvergleich |
+| **3** | Der Ausblick-Klartext der Altform wird auf denselben Trenner gezogen (Golden-Anpassung) |
+
+**Nicht in A1:** neue Registerkennungen (reine Speicherform-Frage ⇒ **A2**) · `avg` (⇒ **A3**) ·
+Wind/Boeen-Fensterung (⇒ #1199) · Kanal-Modul im Ausblick (⇒ **A3**).
+
+**Ortsvergleich:** hat keine Gehzeit — dort bleibt das Tagesfenster richtig
+(`comparison_engine.py:43-86`). Nur Punkt 2 gilt dort, nicht Punkt 1.
+
+**Waechter aus Scheibe C bleibt unberuehrt:** A1 fasst die vier Gehzeit-**Kennungen** nicht an,
+sondern nur den **Wert**, den die bestehende Kennung `temperature` im Ausblick liefert.

--- a/docs/context/feat-1848-a1-tagesfenster-kennungen.md
+++ b/docs/context/feat-1848-a1-tagesfenster-kennungen.md
@@ -207,3 +207,68 @@ Die Kennung transportiert sie nicht — das ist bestehende, dokumentierte Bauart
       in den ACs mit abdecken.
 - [ ] **`avg` bei `temperature`** — der Mittelwert ist heute als eigenes Paar waehlbar.
       Faellt er im Ausblick weg, oder erscheint er zusaetzlich? **Braucht PO-Entscheid.**
+
+---
+
+# 🔴 KORREKTUR des Zuschnitts (PO, 2026-08-20)
+
+**Der Abschnitt „Analysis" oben ist in seiner Schlussfolgerung ueberholt. Scheibe A1
+entfaellt NICHT.** Grund: Die Entscheidungsvorlage, auf der „A1 entfaellt" beruhte, hat das
+SMS-Ist-Verhalten falsch wiedergegeben. Der PO hat richtiggestellt: „exakt so wie
+Temperatur bei SMS heute."
+
+## Das SMS-Ist-Verhalten, nachgelesen (Issue #1824, `docs/reference/sms_format.md:67, 136-139`)
+
+| Fall | Ausgabe |
+|---|---|
+| Tief **und** Hoch gewaehlt | **ein** Bereichs-Token unter dem Hoch-Kuerzel: `D13/27` |
+| nur Tief gewaehlt | `L13` |
+| nur Hoch gewaehlt | `D27` |
+
+🔴 **Trennzeichen ist ein Schraegstrich, NICHT ein Bindestrich.** Begruendung im Doku-Text:
+bei Minusgraden waere der Bindestrich zugleich Trenner und Vorzeichen (nicht eindeutig
+parsbar); der Schraegstrich ist GSM-7-sicher. Beispiele aus der Doku: `D13/27`, `D-12/-4`,
+`D13/-`. Jede Haelfte kann unabhaengig Wert, Null-Form oder Lueckenform sein.
+
+**Die frueher hier vorgeschlagene Schreibweise mit Bindestrich und Gradzeichen ist damit
+falsch** und darf nicht in die ACs.
+
+## Was das fuer den Zuschnitt heisst
+
+Getrennte Waehlbarkeit von Tief und Hoch braucht **eigene Kennungen** — das Kanal-Modul
+kennt nur Kennungen, keine Paare aus Kennung und Auswertung. Also lebt A1.
+
+Das frueher als Blocker notierte **Doppelspalten-Problem ist keiner**: #1728 hat es fuer die
+SMS bereits geloest, indem die Kuerzel zu den neuen Kennungen wanderten und
+`temperature`/`wind_chill` „nur noch den Stundenwert fuer Stundentabelle und Telegram-Zelle"
+liefern (`sms_format.md:94`). Dasselbe Muster traegt hier.
+
+## 🟢 PO-Entscheid 2026-08-20 — welche Groessen der Trip-Ausblick benutzt
+
+> **Der Trip-Ausblick benutzt dieselben Groessen wie die SMS** — die vier bestehenden
+> Gehzeit-Kennungen. Eine Groesse, ein Wert, kanaluebergreifend gleich.
+> Fuer den Ortsvergleich (keine Route, keine Gehzeit) kommen eigene Tief/Hoch-Groessen
+> ueber das Tagesfenster dazu.
+
+Damit bleibt der Waechter aus Scheibe C unveraendert gueltig: die Gehzeit-Groessen bleiben
+trip-exklusiv, die neuen Tagesfenster-Groessen sind ein **separates** Paar.
+
+## 🔴 Offener technischer Kernpunkt fuer die A1-Spec
+
+Die vier Gehzeit-Kennungen tragen heute **keine** `summary_fields` — im Ausblick entsteht
+fuer sie deshalb **keine Spalte** (`compare_outlook_metric_ids.py:56-68, 128-134` verwerfen
+sie ersatzlos, `summary_field_for()` hat keinen Fallback). Ein Tabellenwert muss erst
+nutzbar gemacht werden.
+
+⚠️ **Dabei nicht annehmen, dass `temp_min_c` der gesuchte Wert ist.** Gemessen:
+
+| Wert | Fensterung | Quelle |
+|---|---|---|
+| `SegmentWeatherSummary.temp_min_c` | **Etappengrenzen** (Segment-Start bis -Ende) | `segment_weather.py:266-276` → `weather_metrics.py:525-540` |
+| SMS-Token `L`/`D` | **Gehzeit** — enger als die Etappengrenzen | `collect_hiking_window_points()` → `hiking_field_min_max()`, `sms_trip.py:238-258` |
+
+Beide sind aehnlich, aber **nicht nachweislich gleich**. Die Spec muss festlegen, welcher
+Wert im Ausblick erscheint — und wenn es der Gehzeit-Wert sein soll (PO-Entscheid: „dieselben
+wie die SMS"), muss der Weg dorthin gebaut werden. **Vor der Umsetzung ist auszumessen, in
+wie vielen Faellen die beiden Werte ueberhaupt auseinanderliegen** — sonst ist jeder
+Gleichheitsbefund trivial wahr.

--- a/docs/context/feat-1848-a1-tagesfenster-kennungen.md
+++ b/docs/context/feat-1848-a1-tagesfenster-kennungen.md
@@ -2,6 +2,13 @@
 
 Scheibe A1 von #1848 Teil A. Erstellt 2026-08-19, Phase 1.
 
+> 🔴 **ZUSCHNITT GEAENDERT nach der Analyse (PO-Entscheid 2026-08-19, Phase 2).**
+> **Scheibe A1 entfaellt ersatzlos — es kommen KEINE neuen Registerkennungen.**
+> Workflow-Name und Dateiname bleiben aus technischen Gruenden stehen (aktiver
+> Workflow-State); der Branch heisst `feat-1848-a-ausblick-kanal-modul`.
+> Was stattdessen gilt, steht unten unter „Analysis". Alles ab „Related Files" bis
+> „Risks" ist als **Recherche-Fundus** weiter gueltig, die Zielsetzung nicht.
+
 ## Request Summary
 
 Tages-Tief und Tages-Hoch sollen im 3-Tages-Ausblick **getrennte, einzeln waehlbare
@@ -121,3 +128,82 @@ Eintrag plus Pflege von `CENTRAL_METRICS_COVERED_ELSEWHERE`
 Auf Produktion und Staging ist keine einzige `outlook_metrics`-Auswahl gespeichert
 (Messung 2026-08-18). Die `None`/`[]`/gefuellt-Semantik traegt trotzdem weiter und darf
 nicht durch unbedachtes Schreiben kippen (BUG-DATALOSS-GR221, #102).
+
+---
+
+# Analysis (Phase 2, 2026-08-19)
+
+## Type
+
+Feature.
+
+## 🟢 PO-Entscheid, der den Zuschnitt festlegt
+
+Vorgelegt wurde die Frage, ob Tief und Hoch im Ausblick einzeln **waehlbar** sein sollen
+oder nur gemeinsam **angezeigt**. Entscheid: **gemeinsam angezeigt, eine Zeile.**
+
+> Der Nutzer waehlt im Ausblick „Temperatur" — eine Zeile, wie bei den Kanaelen — und
+> sieht Tief UND Hoch als Spanne (`8–19°`). Nur-das-Hoch-Zeigen entfaellt.
+
+**Folge: Scheibe A1 (neue Registerkennungen) entfaellt vollstaendig.** Damit fallen auch
+alle daran haengenden Probleme weg:
+
+| Problem aus der Analyse | Status |
+|---|---|
+| Doppelte Spalten — neue Kennung und `temperature` zeigen dasselbe Feld; **keine Dedup-Logik** in `resolve_metric_col_order()` (`email/helpers.py:311-324`), nur `col_key`-Eindeutigkeit je Kennung | entfaellt |
+| Namensverwechslung „Tages-Hoch" vs. „Tages-Hoch (Gehzeit)" | entfaellt |
+| 54 register-abhaengige Listen im Repo, davon **2 mechanisch erzwungen** (`METRIC_PRIORITY` via `soll_vollstaendig`; `COMPARE_METRIC_CATALOG`/`CENTRAL_METRICS_COVERED_ELSEWHERE` via `test_every_selectable_central_metric_has_a_compare_entry`) und ~15 „kommt drauf an" | entfaellt |
+| Bruch von `test_kaskade_ac9_fixture_carries_full_catalog_width` (`tests/tdd/test_channel_metric_matrix.py:1088-1106`) — eingefrorene Fixture gegen dynamisch gezaehlte Katalogbreite | entfaellt |
+| R-A1-1 (Waechter aus Scheibe C wird faelschlich rot) und R-A1-4 | entfallen |
+
+**Weiter gueltig bleiben** R-A1-3 (ohne `summary_fields` kein Ausblick-Wert — betrifft jetzt
+die Frage, wie eine Kennung ohne Paar ihre Spalte bekommt) und R-A1-6 (Drei-Werte-Semantik).
+
+## Was stattdessen zu tun ist
+
+| Scheibe | Inhalt |
+|---|---|
+| **A2 — Backend** | `outlook_metrics` speichert **reine Kennungen** statt `{metric_id, aggregation}`-Paare · Bestandsableitung Paar→Kennung, **dedupliziert** (`{temperature,min}` + `{temperature,max}` ⇒ ein `temperature`) · `outlook_columns()` rendert fuer eine Kennung mit mehreren Auswertungen **eine Spalte als Spanne** statt zwei Spalten |
+| **A3 — Frontend** | `CompareOutlookLayoutControls.svelte` bekommt das Kanal-Modul-Verhalten: **nur abwaehlbar** aus der Grundauswahl statt freier Katalog-Checkbox-Liste · sichtbare „Aus"-Gruppe mit Zurueckholen · gleiche Beschriftungsquelle wie die Kanaele · **beide Flaechen** (Trip + Ortsvergleich) |
+
+## Affected Files (Scheibe A2)
+
+| Datei | Change | Beschreibung |
+|---|---|---|
+| `src/app/models.py:844` | MODIFY | `outlook_metrics: Optional[list[dict]]` → Kennungsliste |
+| `src/app/loader.py:948, 1558-1561` | MODIFY | Lese-/Schreibpfad; Paar→Kennung ableiten, Drei-Werte-Semantik (`None`/`[]`/gefuellt) erhalten |
+| `src/output/renderers/compare_outlook_metric_ids.py:45-149` | MODIFY | `resolve_outlook_metrics()` auf Kennungen; `outlook_columns()` Spanne statt Doppelspalte |
+| `src/services/report_config_resolver.py:249, 291` | MODIFY | Aufrufer nachziehen |
+| `frontend/src/lib/types.ts:299` | MODIFY | Typ auf Kennungsliste |
+| Tests | CREATE/MODIFY | u.a. `tests/tdd/test_compare_outlook_metric_selection.py`, `test_trip_outlook_metrics_persistence.py`, `test_trip_outlook_metric_selection.py` |
+
+## Scope Assessment
+
+- Dateien: ~8 (A2), ~6 (A3)
+- Risk Level: **MEDIUM** — nutzersichtbare Ausgabe aendert sich (zwei Spalten → eine Spanne)
+- Erleichterung: **keine Bestandsdaten** — auf Produktion und Staging ist keine einzige
+  `outlook_metrics`-Auswahl gespeichert (Messung 2026-08-18, positive Gegenprobe ueber
+  `display_config`). Die Ableitung ist trotzdem zu bauen (Drei-Werte-Semantik, kuenftige
+  Bestaende), aber ohne Migrationsdruck.
+
+## Technical Approach
+
+Der Ausblick verliert sein eigenes Vokabular und wird eine **weitere Flaeche derselben
+Metrik-Kaskade** — Grundauswahl als Maximum, die Flaeche darf nur abwaehlen und ordnen.
+Die Kaskadenregel dafuer existiert bereits an genau einer Stelle
+(`allowed_metric_ids_for_report_type()`, seit #1848 Scheibe A) und muss nicht erweitert
+werden — `resolve_trip_outlook_metrics()` ruft sie schon auf.
+
+Die Fensterung bleibt flaechen-eigen (Trip: Etappengrenzen, Ortsvergleich: Tagesfenster).
+Die Kennung transportiert sie nicht — das ist bestehende, dokumentierte Bauart
+(„bedeutungsgleich, nicht wertgleich", `test_compare_catalog_derives_from_central_catalog.py:62-71`).
+
+## Open Questions (gehen mit der Spec an den PO)
+
+- [ ] **Schreibweise der Spanne** — `8–19°` in einer Zelle? Der PO hat diesen Entwurf in
+      der Entscheidungsvorlage gesehen und gewaehlt; Trennzeichen und Einheiten-Wiederholung
+      gehoeren als AC festgeschrieben.
+- [ ] **`wind_chill`** verhaelt sich wie `temperature` (min/max) — gleiche Behandlung,
+      in den ACs mit abdecken.
+- [ ] **`avg` bei `temperature`** — der Mittelwert ist heute als eigenes Paar waehlbar.
+      Faellt er im Ausblick weg, oder erscheint er zusaetzlich? **Braucht PO-Entscheid.**

--- a/docs/context/feat-1848-a1-tagesfenster-kennungen.md
+++ b/docs/context/feat-1848-a1-tagesfenster-kennungen.md
@@ -352,4 +352,78 @@ resolve_outlook_metrics([{"metric_id":"temperature","aggregation":"avg"}])  → 
 ```
 Die Picker-Liste zeigt fuer Temperatur daher nur zwei Kaestchen. **Die Open Question
 „faellt avg weg oder kommt er dazu?" ist damit falsch gestellt** — er ist heute schon nicht da;
-die Frage lautet, ob er neu dazukommen soll.
+die Frage lautet, ob er neu dazukommen soll. → **Nicht in A1.** Das Zielbild „Grundauswahl ist
+das MAXIMUM, der Kanal darf nur abwaehlen" macht das zu einem Punkt fuer **A3** (Kanal-Modul
+im Ausblick), nicht zu einer A1-Aenderung am Katalog.
+
+---
+
+# 🔴 WERT-MESSUNG (2026-08-20): Etappenwert vs. Gehzeit-Wert
+
+Messkript (Wegwerf, Scratchpad): `measure_ausblick_vs_gehzeit.py`.
+
+## Mechanik der Abweichung
+
+| Pfad | Fensterung | Fundstelle |
+|---|---|---|
+| Ausblick heute | `[start_floor, end_floor)` je Segment — **Endstunde EXKLUSIV** | `segment_weather.py:266-273`, gelesen ueber `aggregate_stage()` in `trip_report_scheduler.py:2286` → `outlook.py:503-504` |
+| SMS `L`/`D` | wie oben, **ausser beim letzten Segment: Ankunftsstunde INKLUSIV** | `day_window.py:210-229` → `hiking_field_min_max()`, `sms_trip.py:238-239` |
+
+Die Abweichung ist also die **Randbehandlung der Ankunftsstunde**, kein Rundungs- oder
+Aggregationsunterschied.
+
+## Messwerte (Varianz ausgewiesen, nicht nur Trefferzahl)
+
+| Block | Fenster verschieden | Werte verschieden | Δ |
+|---|---|---|---|
+| 6 bestehende #1417-Konstellationen (`tests/tdd/_hiking_window_fixtures.py`) | **3/6** | 3 | bis **-9,0 °C** (adversarisch konstruiert) |
+| Sweep 60 Kombis (Segmente 1-3 × Start 6-9 × Ankunft 13-20, glatter Tagesgang) | **60/60** strukturell | **24/60** | Median **1,23 °C**, Max **1,66 °C** |
+
+Die 36 deckungsgleichen Faelle sind **zufaellig** gleich (Ankunftsstunde traegt dort nicht das
+Extremum) — nicht Beleg fuer Gleichheit.
+
+**Gerichtet:** `Etappe - Gehzeit <= 0` in **allen 84** Faellen. Die Etappen-Fensterung kann der
+Gehzeit-Fensterung nur einen Datenpunkt VORENTHALTEN, nie einen hinzugewinnen. ⇒ **Der Ausblick
+zeigt systematisch ein zu kuehles Hoch.** Beim Tief 0/84 — die Ankunft liegt in realistischen
+Etappenzeiten nie am Tagestiefpunkt (strukturell moeglich, praktisch selten).
+
+## 🔴 Das ist ein Nachzug zu #1417, keine Feature-Luecke
+
+**#1417 („Mail und Kurznachricht zeigen fuer dieselbe Etappe verschiedene Temperaturen") ist
+CLOSED.** Der Fix hat SMS, Telegram-Kurzuebersicht und E-Mail-Kurzzusammenfassung auf
+`collect_hiking_window_points()` umgestellt — **der 3-Tages-Ausblick war nicht dabei** und liest
+weiter `summary.temp_min_c`/`temp_max_c`. Dieselbe Ursache (exklusive Ankunftsstunde), dieselbe
+Richtung, eine uebersehene Flaeche.
+
+`segment_weather.py` bleibt dabei bewusst unveraendert (#1329: rein pro Segment, darf nicht
+wissen, an welcher Stelle des Berichts es steht) — deshalb wurde schon #1146 nicht dort behoben.
+
+## Naht fuer den Fix (~20-25 LoC)
+
+`trip_report_scheduler.py:2286-2338` hat `seg_weather` bereits vorliegen — dort zusaetzlich
+`collect_hiking_window_points()` + `hiking_field_min_max(..., "t2m_c")` aufrufen (dieselben
+Funktionen, die `sms_trip.py` nutzt) und als optionale Parameter an `build_outlook_row()`
+durchreichen; in `outlook.py:503-504` `temp_lo`/`temp_hi` daraus ableiten, **fail-soft** zurueck
+auf `summary.temp_*`. Diskriminator `trip_display_config is not None`, analog dem bestehenden
+#1841-Muster fuer die Gewitterspalte (`outlook.py:~612-639`).
+
+---
+
+# 🟢 PO-ENTSCHEID 2026-08-20 — Darstellung im Ausblick
+
+**Gewaehlt: EINE Zelle mit SCHRAEGSTRICH** (die SMS-Schreibweise), wenn Tief und Hoch beide
+gewaehlt sind.
+
+```
+Temperatur          Minusgrade eindeutig      nur eine Haelfte
+9/27                -12/-4                    13/-
+```
+
+Der PO hat mit dem ausdruecklichen Hinweis gewaehlt, dass der Ausblick-**Klartext** heute die
+andere Schreibweise fuehrt (`9–20°C`, Halbgeviertstrich, `helpers.py:943`) und **mit angeglichen
+werden muss** — sonst stehen zwei Schreibweisen fuer dieselbe Sache nebeneinander.
+
+⚠️ Zu klaeren beim Zuschnitt: die Halbgeviertstrich-Schreibweise sitzt in der **festen
+7-Spalten-Altform**. Ob deren Klartext mit angeglichen wird oder nur der konfigurierbare Pfad,
+haengt an den Golden-Fixtures (`test_compare_outlook.py:205` erwartet `"9–20°C"`) — technischer
+Zuschnitt, keine PO-Frage.

--- a/docs/context/feat-1848-a1-tagesfenster-kennungen.md
+++ b/docs/context/feat-1848-a1-tagesfenster-kennungen.md
@@ -1,0 +1,123 @@
+# Context: feat-1848-a1-tagesfenster-kennungen
+
+Scheibe A1 von #1848 Teil A. Erstellt 2026-08-19, Phase 1.
+
+## Request Summary
+
+Tages-Tief und Tages-Hoch sollen im 3-Tages-Ausblick **getrennte, einzeln waehlbare
+Zeilen** werden — als reine Register-Kennungen, nicht als `{metric_id, aggregation}`-Paare.
+PO-Vorgabe 2026-08-19: „Temperatur und Gefuehlte Temperatur wird doch heute schon in der
+SMS als Hoch/Tief angezeigt. Genauso soll es hier auch ausgegeben werden."
+
+A1 legt dafuer das Fundament im Zentralregister. A2 stellt das Speicherformat um,
+A3 gibt dem Ausblick das geteilte Kanal-Modul.
+
+## 🔴 Befund, der den Zuschnitt aendert
+
+Die urspruengliche Annahme war: der Ortsvergleich braucht **eigene Tagesfenster-Kennungen**,
+weil ihm die Gehzeit fehlt. **Am Code gemessen ist das nicht noetig** — die Fensterung
+haengt gar nicht an der Kennung, sondern an der Flaeche:
+
+| Flaeche | wer fenstert | Beleg |
+|---|---|---|
+| Trip | `segment_weather.py:266-276` schneidet auf die **Etappengrenzen** (Gehzeiten), bevor `weather_metrics.py` rechnet | `segment_weather.py:300-301` sagt das ausdruecklich |
+| Ortsvergleich | `comparison_engine._filter_by_target_date_and_window()` schneidet auf **`target_date` + Tagesfenster** | `comparison_engine.py:43-86`, Werte ab `:199-211` |
+
+Beide fuellen anschliessend **dieselben Feldnamen** (`temp_min_c`, `temp_max_c`,
+`wind_chill_min_c`, `wind_chill_max_c`) — mit flaechen-eigener Bedeutung. Genau das ist
+die im Repo schon benannte Regel **„bedeutungsgleich, nicht wertgleich"**
+(`tests/unit/test_compare_catalog_derives_from_central_catalog.py:62-71`, Adversary-Nachtrag
+in Commit `c18f8eb7`).
+
+**Folge:** Zwei neue Kennungen mit `summary_fields={"min": "temp_min_c"}` bzw.
+`{"max": "temp_max_c"}` funktionieren in **beiden** Flaechen automatisch richtig — jede
+Flaeche liefert ihre eigene Fensterung. Es braucht **kein** Ortsvergleich-Sonderpaar.
+
+⚠️ Offene Designfrage fuer Phase 2: Im Trip existierten dann
+`temperature_day_high` (Gehzeit, nur SMS-Token) **und** eine neue Tabellen-Kennung fuer
+Tages-Hoch. Zwei aehnlich benannte Dinge — exakt die Verwechslungsgefahr, vor der
+`metric_catalog.py:180-183` warnt. Namensgebung und Abgrenzung sind zu klaeren.
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `src/app/metric_catalog.py:111-688` | Zentralregister `_METRICS`, 32 Eintraege / 29 waehlbar. Hier entstehen die neuen Kennungen |
+| `src/app/metric_catalog.py:775-783` | `SMS_MULTI_SYMBOLS_BY_METRIC` — abgeleitet, nicht danebengepflegt |
+| `src/app/metric_catalog.py:899-910` | `summary_field_for()` — liefert `None` ohne `summary_fields`, **kein Fallback** |
+| `src/app/loader.py:751-767` | `_DERIVED_METRIC_RULES` + `_append_derived_metrics()` — Muster fuer Bestandsableitung (`derived=True`) |
+| `src/app/loader.py:854, 895, 931` | Ableitung wirkt auch auf Kanal- und Report-Ebene (DEC-6b aus #1728) |
+| `src/output/renderers/compare_outlook_metric_ids.py:56-68, 128-134` | Ausblick **verwirft** jeden Eintrag ohne `summary_fields` — zentrale Einschraenkung |
+| `src/output/renderers/compare_metric_catalog.py:76-162` | Compare-Katalog ist **kuratierte Literal-Liste** (26 Eintraege), nur Anzeigenamen kommen live aus dem Register |
+| `src/output/renderers/channel_layout.py:72-78` | `VISIBILITY_GATE_IDS` — Liste, die bei neuen Sichtbarkeits-Gates nachzuziehen ist |
+| `src/output/renderers/compare_hourly_metric_ids.py:59-65` | `HOURLY_EXCLUDED_METRIC_IDS` — dito |
+| `src/services/comparison_engine.py:43-86, 199-211` | Tagesfenster-Fensterung im Ortsvergleich |
+| `src/services/segment_weather.py:266-276, 300-301` | Etappen-Fensterung im Trip |
+| `src/services/weather_metrics.py:474-476, 525-540, 944-946, 1024-1037` | Befuellung der `temp_*`/`wind_chill_*`-Felder |
+| `src/app/day_window.py:20-21, 24-54` | `DAY_WINDOW_START_HOUR=4`, `END=19`, `resolve_configured_window()` |
+
+## Existing Patterns
+
+**Das Vorbild ist #1728 Scheibe 1** (`c18f8eb7`, Nachzuege `e0b279ff`, `ac8501f5`,
+`5c4e435d`) — es hat exakt diese Aufgabe schon einmal geloest, fuer die Gehzeit-Groessen.
+Aenderungs-Checkliste daraus:
+
+1. Registereintraege in `metric_catalog.py` (+ `trip_default_rank`, falls Anlege-Standard)
+2. `SMS_MULTI_SYMBOLS_BY_METRIC` — Symbole wandern von der Elterngroesse zur neuen Kennung
+3. `loader.py`: `_DERIVED_METRIC_RULES` fuer Bestandsableitung, **auf allen drei Ebenen**
+   (global, `per_channel_layouts`, `per_report_layouts`)
+4. Serialisierungsfilter `if not getattr(mc, "derived", False)` beim Speichern
+5. `VISIBILITY_GATE_IDS` und `HOURLY_EXCLUDED_METRIC_IDS` nachziehen
+6. Renderer-Pillen / MetricSpec-Gates
+7. Doku: `sms_format.md`, `api_contract.md`, `metric_output_matrix.md`
+8. Tests: eigene TDD-Datei je Verhalten + Bestandsableitungs-Test
+
+🔴 **Lehre aus #1856 E7 (`5c4e435d`):** #1728 S1 hatte **drei Listen nicht nachgezogen**
+(`_DERIVED_METRIC_RULES[0]/[1]`, `VISIBILITY_GATE_IDS`, `METRIC_PRIORITY`). Ein
+Listen-Waechter fing das erst nachtraeglich. Diese Listen sind die bekannte Fehlerquelle.
+
+## Dependencies
+
+- **Upstream:** `metric_catalog` (Register), `day_window` (Fensterung), `SegmentWeatherSummary`-Felder
+- **Downstream:** Ausblick-Renderer, Compare-Katalog, SMS-Token-Builder, Loader/Persistenz,
+  Frontend `WeatherMetricsTab.svelte` + `CompareOutlookLayoutControls.svelte`
+
+## Existing Specs
+
+- `docs/specs/modules/feat_1848_a_kaskade_eine_quelle.md` — Haelfte 1 von Teil A (geliefert)
+- `docs/context/feat-1848-ausblick-vokabular.md` — Analyse 2026-08-18, Risiken R1-R6, PO-Entscheid
+- `docs/specs/modules/feat_1848_c_waechter_gehzeit_trip_exklusiv.md` — Scheibe C
+- `docs/specs/modules/issue_1361_1368_ausblick_konfigurierbar.md` — Ursprung des Paar-Vokabulars
+- `docs/specs/modules/feat_1720_s1_trip_ausblick_metriken.md` — AC-14/15/16 zur Kaskade
+
+## Risks & Considerations
+
+**R-A1-1 — Waechter aus Scheibe C wird faelschlich rot.**
+`tests/unit/test_gehzeit_metriken_bleiben_trip_exklusiv.py:415-416` sammelt alle
+Registereintraege, deren `label_de` den Substring `"(Gehzeit)"` traegt, und verlangt
+Mengengleichheit mit dem Literal `GEHZEIT_METRIC_IDS` (Zeile 53-56). Zusaetzlich prueft
+`:519-526` die Endpoint-Antwort auf `"(Gehzeit)"` im `label`.
+**Mitigation:** Die neuen Labels duerfen den Zusatz `"(Gehzeit)"` **nicht** tragen.
+
+**R-A1-2 — Derselbe Waechter ist blind fuer Werte-Semantik.**
+Er prueft ausschliesslich Katalog-/Endpoint-**Mitgliedschaft**, nie **Werte**. Wuerde A1
+die Bedeutung der bestehenden vier Kennungen verschieben (oder fuer die neuen doch
+`collect_hiking_window_points()` verwenden), faellt das nicht auf. Der einzige Vermerk
+dazu ist ein Doku-Kommentar, kein Test.
+
+**R-A1-3 — Ohne `summary_fields` gibt es im Ausblick keinen Wert.**
+`compare_outlook_metric_ids.py:56-68, 128-134` verwirft solche Eintraege ersatzlos; einen
+Ausweichweg wie bei SMS (hart verdrahtete Symbol→Feld-Bindung, `builder.py:324-330`) gibt
+es im Ausblick nicht. Die neuen Kennungen **muessen** `summary_fields` tragen.
+
+**R-A1-4 — Namensverwechslung im Trip.** Siehe offene Designfrage oben.
+
+**R-A1-5 — Der Compare-Katalog ist Handarbeit.** `compare_metric_catalog.py:76-162` ist
+eine kuratierte Literal-Liste. Neue Kennungen erscheinen dort **nicht automatisch** —
+Eintrag plus Pflege von `CENTRAL_METRICS_COVERED_ELSEWHERE`
+(`tests/unit/test_compare_catalog_derives_from_central_catalog.py:44-88`) noetig.
+
+**R-A1-6 — Keine Bestandsdaten, aber Drei-Werte-Semantik bleibt heikel.**
+Auf Produktion und Staging ist keine einzige `outlook_metrics`-Auswahl gespeichert
+(Messung 2026-08-18). Die `None`/`[]`/gefuellt-Semantik traegt trotzdem weiter und darf
+nicht durch unbedachtes Schreiben kippen (BUG-DATALOSS-GR221, #102).

--- a/docs/specs/modules/outlook_gehzeit_und_spanne.md
+++ b/docs/specs/modules/outlook_gehzeit_und_spanne.md
@@ -229,6 +229,46 @@ prüft).
   — beide Tagesmengen sind disjunkt. Der Bug-Nachweis (AC-1) läuft deshalb auf Funktionsebene,
   nicht als Mail-interner Widerspruch.
 
+## 🔴 Abgelöste Entscheidung: die Paar-basierte Spalten-Sollmenge aus #1703 Scheibe 2
+
+Beim Umsetzen von AC-4..AC-8 kollidierte der Merge mit einer bestehenden, testbewachten
+Zusicherung — hier festgehalten, damit die Ablösung **nicht still** passiert.
+
+**Vorher (Epic #1703 S2, PO-Entscheidung 2026-07-27 „keine zwei gleich beschrifteten Spalten"):**
+`tests/tdd/test_channel_metric_matrix.py` baute die Soll-Spaltenmenge aus **Paaren**
+(`metric_id` + `aggregation`). Wählte der Nutzer alles, erschienen `temperature:min` und
+`temperature:max` als **zwei** Spalten mit den disambiguierten Überschriften „Temp Minimum" /
+„Temp Maximum" (`compare_outlook_metric_ids.py:144-148`). 26 parametrisierte Tests bewachten das.
+
+**Jetzt (PO-Entscheid 2026-08-20, diese Spec):** min+max desselben `metric_id` werden zu **einer**
+Zelle zusammengeführt. Damit fällt die Paar-basierte Sollmenge.
+
+**Warum das keine Aufweichung ist:** Der Testname lautet „jede wählbare **Größe** ergibt genau
+eine Spalte" — die Sollmenge war aber über **Paare** gebaut. Nach dem Merge ergibt die Größe
+`temperature` weiterhin genau **eine** Spalte; die Invariante im Sinne ihres Namens gilt
+unverändert. Angepasst wurde die Soll**menge** (`tests/helpers/outlook_columns.py`), **nicht** die
+Zusicherung — beide S2-Tests bleiben in Kraft, inklusive der Gegenrichtung
+(`html_und_klartext_zeigen_dieselbe_spaltenmenge`).
+
+**Was ausdrücklich BESTEHEN bleibt:**
+
+- Die Disambiguierungs-Logik (`compare_outlook_metric_ids.py:144-148`) wird **nicht**
+  zurückgebaut, obwohl sie durch den Merge vorerst ins Leere läuft (heute haben genau 2 von 29
+  wählbaren Größen mehr als eine Auswertung). Kommt mit **A3** `avg` bei Temperatur dazu, hat die
+  Größe drei Auswertungen: min+max mergen zur Spanne, `avg` bleibt eine eigene Spalte und braucht
+  das Suffix wieder. Ein Rückbau müsste in der nächsten Scheibe zurückgedreht werden.
+- Deshalb prüft die Vakuum-Gegenprobe in `test_ac_s2_3_*` seither einen **synthetischen**
+  Katalog-Ausschnitt (dritte Auswertung simuliert) statt des realen Katalogs. Am realen Katalog
+  wäre sie nach dem Merge **trivial wahr** geworden — der Ausschluss hätte die Bedingung erzeugt,
+  mit der er begründet wird, und die Disambiguierung wäre totes, ungetestetes Recht. Der
+  synthetische Ausschnitt ist **absichtlich** synthetisch und darf nicht auf den realen Katalog
+  „zurückkorrigiert" werden.
+- Die Anti-Vertauschungs-Prüfung (AC-S2-6/AC-S2-8) wurde **umgebaut, nicht abgeschwächt**: Die
+  Zelle wird an `/` geteilt und **jede Seite** gegen ihren eigenen gerechneten Sollwert geprüft.
+  Ohne diesen Umbau hätte die Prüfung nur noch die führende Zahl gelesen und wäre für eine
+  Vertauschung strukturell **blind** geworden — ein Wächter, der dasteht und nichts mehr fängt.
+  Wirksamkeit per Mutation belegt (vertauschte Zuweisungen ⇒ beide Tests rot).
+
 ## Architektur-Entscheidung (ADR)
 
 - **ADR-Nr.:** keine
@@ -243,3 +283,11 @@ prüft).
 ## Changelog
 
 - 2026-08-20: Initial spec created (#1848 Scheibe A1)
+- 2026-08-20: Ablösung der Paar-basierten Spalten-Sollmenge aus #1703 S2 dokumentiert; Umbau der
+  Anti-Vertauschungs-Prüfung und der Vakuum-Gegenprobe festgehalten (beide wirksam belegt).
+- 2026-08-20: Nach Adversary-Verdict VERIFIED eine Wache für die Scheduler-Verdrahtung ergänzt
+  (`tests/tdd/test_outlook_scheduler_wires_hiking_window.py`). Grund: die Mutation
+  `segments=seg_weather` → `None` blieb bei 625 Tests **grün** — die Zusicherung war dort geprüft,
+  wo der Code steht, nicht dort, wo sie wirkt. Genau die Fehlerform, die A1 nötig machte (#1417
+  stellte drei Kanäle um und übersah den Ausblick). Divergenz gemessen: Etappenaggregat 15,0 °C
+  gegen Gehzeit-Fenster 22,0 °C; Mutation macht die Wache nachweislich rot.

--- a/docs/specs/modules/outlook_gehzeit_und_spanne.md
+++ b/docs/specs/modules/outlook_gehzeit_und_spanne.md
@@ -3,7 +3,7 @@ entity_id: outlook_gehzeit_und_spanne
 type: bugfix
 created: 2026-08-20
 updated: 2026-08-20
-status: draft
+status: approved
 version: "1.0"
 tags: [outlook, trip, compare, gehzeit, "#1848"]
 ---
@@ -12,7 +12,8 @@ tags: [outlook, trip, compare, gehzeit, "#1848"]
 
 ## Approval
 
-- [ ] Approved
+- [x] Approved — PO, 2026-08-20 („go"). Freigegeben wurden alle 10 ACs inklusive AC-9
+      (Altform-Klartext wechselt auf den Schrägstrich; sichtbar auch ohne jede Nutzereinstellung).
 
 ## Purpose
 

--- a/docs/specs/modules/outlook_gehzeit_und_spanne.md
+++ b/docs/specs/modules/outlook_gehzeit_und_spanne.md
@@ -1,0 +1,244 @@
+---
+entity_id: outlook_gehzeit_und_spanne
+type: bugfix
+created: 2026-08-20
+updated: 2026-08-20
+status: draft
+version: "1.0"
+tags: [outlook, trip, compare, gehzeit, "#1848"]
+---
+
+# Outlook: Gehzeit-Fenster und Spannen-Zelle (#1848 Scheibe A1)
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Der 3-Tages-Ausblick (Trip UND Ortsvergleich) liest Temperatur und gefühlte Temperatur heute
+aus dem Etappenaggregat statt aus dem Gehzeit-Fenster — derselbe Randbehandlungsfehler
+(exklusive Ankunftsstunde), der #1417 für SMS/Telegram/Kachelzeile bereits behoben hat, nur
+für den Ausblick übersehen. Zusätzlich zeigt der Ausblick Tief und Hoch bei gemeinsamer Auswahl
+als zwei getrennte Spalten statt einer Spanne, und der Klartext der festen Altform nutzt einen
+anderen Trenner als die SMS. A1 zieht alle drei Punkte auf den SMS-Ist-Zustand nach.
+
+## Source
+
+- **File:** `src/output/renderers/email/outlook.py`
+- **Identifier:** `def build_outlook_row(...)` — geteilter Zeilenbauer für Trip UND Compare
+  (Epic #1301 B4), Ansatzpunkt für Punkt 1 (Gehzeit-Wert) und Punkt 2 (Spannen-Zelle).
+
+> **Schicht-Hinweis:** Reines Python-Core (`src/output/`, `src/services/`, `src/app/`) — kein
+> Go-API-, kein Frontend-Code betroffen. Der Ausblick ist reine Server-Rendering-Logik.
+
+## Estimated Scope
+
+- **LoC:** ~180-220 (Produktivcode ~70-100, Golden-Fixture-Anpassungen ~10, neue Tests ~90-110)
+  — **passt** unter das 250-LoC-Limit, aber knapp; bei Überschreitung
+  `workflow.py set-field loc_limit_override 300` erwägen statt Test-Umfang zu kürzen.
+- **Files:** 4 Produktivdateien (MODIFY), 2 Bestandstest-Dateien (MODIFY, Golden-Fixture), 1-2
+  neue Testdateien (CREATE).
+- **Effort:** medium (drei fachlich unabhängige Teiländerungen an einer gemeinsam genutzten
+  Baustelle).
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `collect_hiking_window_points()` | function, `src/output/renderers/day_window.py:186` | Gehzeit-gefensterte Rohpunkte (Ankunftsstunde beim letzten Segment inklusiv), einzige Quelle seit #1417 für SMS/Telegram/Kachelzeile |
+| `hiking_field_min_max()` | function, `src/output/renderers/day_window.py:232` | Min/Max eines Feldes (`t2m_c`/`wind_chill_c`) aus den Gehzeit-Punkten; liefert `None` bei leerem Fenster (Fail-soft-Signal an den Aufrufer) |
+| `build_outlook_row()` | function, `src/output/renderers/email/outlook.py` | Geteilter Zeilenbauer, aufgerufen von `trip_report_scheduler.py` (Trip) und `email/compare_html.py` (Ortsvergleich) |
+| `outlook_columns()` / `format_outlook_value()` | functions, `src/output/renderers/compare_outlook_metric_ids.py:112`/`152` | Spalten-/Zellenaufbau für den konfigurierbaren Ausblick-Pfad (`metrics is not None`) — Ansatzpunkt für die Spannen-Zelle, wirkt geteilt auf Trip und Compare |
+| `format_trend_tokens()` | function, `src/output/renderers/email/helpers.py` | Baut `temp_str` der festen Altform (Zeile 943, `f"{tl}–{th}°C"`) für den unkonfigurierten Pfad (`metrics is None`) |
+| `#1841`-Diskriminator-Muster | Vorbild, `outlook.py:~612-639` | `trip_display_config is not None` als Unterscheidung Trip vs. Compare — dasselbe Muster gilt für Punkt 1 |
+
+## Implementation Details
+
+**Zwei Render-Pfade, in beiden muss der Wert stimmen.** `build_outlook_row()` liefert je nach
+`metrics`-Parameter zwei unabhängige Wertequellen:
+
+- **Fester Altform-Pfad** (`metrics is None`): `temp_lo`/`temp_hi` (Zeilen 503-504, aus
+  `summary.temp_min_c`/`temp_max_c`) landen im Row-Dict und speisen über
+  `format_trend_tokens()` den Klartext-Token `temp_str` (`helpers.py:943`).
+- **Konfigurierbarer Pfad** (`metrics is not None`, aktiv sobald ein Trip eine
+  `display_config` hat ODER der Ortsvergleich `outlook_metrics` gesetzt hat): die `cells`-Liste
+  (Zeilen 643-655) liest **direkt** `getattr(summary, col["field"], None)` — für Temperatur
+  `temp_min_c`/`temp_max_c`, für gefühlte Temperatur `wind_chill_min_c`/`wind_chill_max_c`
+  (`metric_catalog.py:218`). `temp_lo`/`temp_hi` werden hier **nicht** gelesen. Dieser Pfad
+  rendert sowohl die HTML-Tabelle (`outlook.py:128-155`) als auch den Klartext
+  (`outlook.py:333-341`) aus derselben `cells`-Liste — eine Quelle für beide Formate.
+
+  Gefühlte Temperatur hat **keinen** Altform-Weg — sie existiert nur im konfigurierbaren Pfad.
+  Ein Fix, der nur `temp_lo`/`temp_hi` überschreibt, träfe daher Punkt 1 nur zur Hälfte
+  (Temperatur ja, gefühlte Temperatur nein) und den in der Praxis überwiegend aktiven
+  konfigurierbaren Pfad gar nicht.
+
+**Punkt 1 — Ansatz:** `trip_report_scheduler.py` hat `seg_weather` (mit Zeitreihen) bereits
+vorliegen (Zeile ~2270-2286, vor `aggregate_stage()`). Dort zusätzlich
+`collect_hiking_window_points(seg_weather)` + `hiking_field_min_max(punkte, "t2m_c")` bzw.
+`"wind_chill_c")` aufrufen (dieselben Funktionen, die `sms_trip.py:238-240` bereits nutzt) und
+das Ergebnis als optionalen Overrides-Parameter an `build_outlook_row()` durchreichen.
+`build_outlook_row()` wendet den Override an **beiden** Stellen an: bei der Ableitung von
+`temp_lo`/`temp_hi` UND beim `getattr(summary, col["field"])`-Zugriff der `cells`-Schleife
+(Felder `temp_min_c`/`temp_max_c`/`wind_chill_min_c`/`wind_chill_max_c`). Liefert
+`hiking_field_min_max()` `None` (leeres Fenster), bleibt das jeweilige Feld beim
+Etappenaggregat (Fail-soft, kein Override gesetzt). Diskriminator wie beim #1841-Vorbild:
+`trip_display_config is not None` — der Ortsvergleich (`email/compare_html.py`) übergibt keine
+Overrides und bleibt unverändert (er hat keine Gehzeit, vgl. `comparison_engine.py:43-86`).
+
+**Punkt 2 — Ansatz:** Wenn `outlook_columns(metrics)` für dieselbe Größe sowohl eine
+`min`- als auch eine `max`-Spalte enthält, werden die beiden Spalten zu einer zusammengeführt
+(ein Spaltenkopf, ein `field`-Paar) und die zugehörigen zwei Werte beim Zellentext zu
+`{min}/{max}` verbunden (Schrägstrich, kein Leerzeichen, vorhandenes Minuszeichen bleibt
+unangetastet — `"-12/-4"`, nicht `"-1", "2/-4"`). Ist nur eine der beiden Auswertungen
+ausgewählt, bleibt die bestehende Ein-Spalten-Logik unverändert (kein Merge, kein Schrägstrich).
+Fehlt bei **beiden ausgewählten** Auswertungen einer der beiden Werte (Datenlücke, z. B. wenn
+`hiking_field_min_max()` nur eine Seite liefert oder das Aggregat nur eine Seite trägt), zeigt
+die Zelle die vorhandene Seite und `-` für die fehlende (`"13/-"`) — das ist ein anderer Fall
+als „nur eine Auswertung gewählt" und darf nicht damit verwechselt werden. Die Umsetzung sitzt
+in `outlook_columns()`/`format_outlook_value()` bzw. in der `cells`-Schleife von
+`build_outlook_row()` — geteilt zwischen Trip und Compare, keine zweite Kopie (Trip/Compare-
+Teilungsgebot, CLAUDE.md).
+
+**Punkt 3 — Ansatz:** `helpers.py:943` (`f"{tl}–{th}°C"`) wird auf denselben Schrägstrich
+gezogen. Betrifft ausschließlich den festen Altform-Pfad — dort verwendet sowohl Trip
+(unkonfigurierte Fälle) als auch Ortsvergleich (`outlook_metrics` nicht gesetzt) dieselbe
+Funktion. Golden-Fixtures mit dem alten Halbgeviertstrich müssen mitgezogen werden:
+`tests/tdd/test_compare_outlook.py:205-206` (positiv, `"9–20°C"`/`"21–33°C"`) und `:397-398`
+(positiv `"9–20°C" in text_on`), `tests/tdd/test_compare_outlook_metric_selection.py:265-267`
+(negative Assertion, bleibt nach Trennerwechsel weiterhin wahr, sollte aber den neuen Trenner
+im Kommentar/String führen, damit die Negativprobe nicht versehentlich gegen den alten Trenner
+prüft).
+
+## Expected Behavior
+
+- **Input:** Trip mit Segmenten inkl. Zeitreihen; `display_config.outlook_metrics` wählt
+  Temperatur min und/oder max (und optional gefühlte Temperatur min/max). Ortsvergleich analog
+  über `outlook_metrics`, ohne Gehzeit.
+- **Output:**
+  - Trip-Ausblick zeigt für Temperatur/gefühlte Temperatur den Wert aus dem Gehzeit-Fenster
+    (inkl. Ankunftsstunde), nicht mehr aus dem vollen Etappenfenster.
+  - Sind bei einer Größe Tief und Hoch beide gewählt: eine Zelle `{min}/{max}` mit Schrägstrich,
+    identisch in HTML und Klartext, in Trip und Ortsvergleich.
+  - Ist nur eine Auswertung gewählt: unveränderter Einzelwert.
+  - Der Klartext der festen Altform (Trip unkonfiguriert, Ortsvergleich ohne `outlook_metrics`)
+    nutzt denselben Schrägstrich statt des Halbgeviertstrichs.
+- **Side effects:** keine — reine Lesepfad-/Formatierungsänderung, kein Schreibzugriff auf
+  Trip-/User-Daten, keine neuen Persistenzfelder.
+
+## Acceptance Criteria
+
+- **AC-1:** Given eine Etappe, deren Ankunftsstunde im vollen Etappenfenster nicht das
+  Tageshoch trägt, aber im Gehzeit-Fenster schon (Sweep-Konstellation, Median-Differenz
+  1,23 °C, gemessen) / When der Trip-Ausblick für diese Etappe gerendert wird / Then zeigt die
+  Temperatur-Hoch-Spalte denselben Wert wie `hiking_field_min_max(collect_hiking_window_points(seg_weather), "t2m_c")` — und nicht mehr `summary.temp_max_c` des vollen Etappenfensters.
+  - Test: Funktionsebene — `build_outlook_row()` mit denselben Segment-Daten aufrufen, die
+    `sms_trip.py` für den `D`-Token derselben Etappe verwendet, und die Zahlen vergleichen
+    (nicht „gleiche Mail", da Ausblick und Kachelzeile strukturell disjunkte Tagesmengen zeigen
+    — `get_future_stages()` filtert `>`, Kachelzeile zeigt `target_date`).
+
+- **AC-2:** Given ein Segment, dessen Gehzeit-Fenster keinen einzigen Datenpunkt mit
+  `t2m_c` trägt (Provider-Lücke) / When der Trip-Ausblick für diese Etappe gerendert wird /
+  Then fällt die Temperatur-Zelle fail-soft auf `summary.temp_min_c`/`temp_max_c` zurück statt
+  „–" zu zeigen oder abzustürzen.
+  - Test: `hiking_field_min_max()` liefert `None` (leere Punktliste) simulieren, prüfen dass
+    `build_outlook_row()` denselben Wert wie vor dieser Änderung liefert.
+
+- **AC-3:** Given `display_config.outlook_metrics` wählt `wind_chill` min und max / When der
+  Trip-Ausblick gerendert wird / Then liest die gefühlte-Temperatur-Zelle ebenfalls aus
+  `hiking_field_min_max(punkte, "wind_chill_c")` statt aus `summary.wind_chill_min_c`/
+  `wind_chill_max_c` des vollen Etappenfensters — strukturell derselbe Fehler wie bei der
+  gemessenen Temperatur (AC-1), eigener Test wegen eigenem Datenfeld und eigenem SMS-Token
+  (`FK`/`FD`, `sms_trip.py:240`).
+  - Test: analog AC-1, mit `wind_chill_c`-Feld statt `t2m_c`.
+
+- **AC-4:** Given `outlook_metrics` wählt Temperatur min UND max für eine Etappe mit Werten
+  -12 °C und -4 °C / When die Ausblick-Zelle gerendert wird / Then zeigt sie genau eine Zelle
+  mit dem Text `-12/-4` — nicht zwei Spalten, kein verlorenes Minuszeichen an der Trennstelle.
+  - Test: `outlook_columns()`/Zellentext mit negativen Min- und Max-Werten aufrufen, exakten
+    String prüfen.
+
+- **AC-5:** Given `outlook_metrics` wählt für Temperatur ausschließlich max (min nicht
+  gewählt) / When die Ausblick-Zelle gerendert wird / Then zeigt sie weiterhin einen
+  Einzelwert ohne Schrägstrich (z. B. `13`), identisch zum Verhalten vor dieser Änderung —
+  eine reine Konfigurationsauswahl darf nicht mit einer Datenlücke verwechselt werden (AC-6).
+  - Test: nur eine Aggregation in `outlook_metrics`, prüfen dass genau eine Spalte mit
+    unverändertem Format entsteht.
+
+- **AC-6:** Given `outlook_metrics` wählt Temperatur min UND max, aber für eine Etappe liegt
+  nur der Hoch-Wert vor (z. B. Fail-soft-Rückfall liefert nur eine Seite) / When die
+  Ausblick-Zelle gerendert wird / Then zeigt sie den vorhandenen Wert und einen Strich für die
+  fehlende Seite, z. B. `13/-` — unterscheidbar vom Einzelwert-Fall aus AC-5 dadurch, dass hier
+  beide Auswertungen ausgewählt waren.
+  - Test: eine Seite auf `None` setzen, beide Aggregationen weiterhin in `outlook_metrics`,
+    exakten Zellentext prüfen.
+
+- **AC-7:** Given eine Trip-Mail mit gewählter Temperatur-Spanne / When HTML- und
+  Klartext-Teil derselben Mail verglichen werden / Then zeigen beide dieselbe
+  Schrägstrich-Zelle für dieselbe Etappe — keine Abweichung zwischen den Formaten (Muster
+  `test_plain_outlook_shows_same_selection_as_html`, #1366-Fehlerklasse).
+  - Test: HTML-Zelle und Klartext-Zeile derselben gerenderten Mail extrahieren, Zellentext
+    vergleichen.
+
+- **AC-8:** Given ein Ortsvergleich mit `outlook_metrics`, die Temperatur min UND max wählen,
+  ohne Gehzeit (kein Trip, keine Segmente) / When der Ausblick für einen Ort gerendert wird /
+  Then zeigt auch dort eine Zelle die Schrägstrich-Spanne — Punkt 2 gilt geräteübergreifend,
+  Punkt 1 (Gehzeit) gilt dort nicht, weil der Ortsvergleich strukturell keine Gehzeit hat.
+  - Test: `email/compare_html.py`-Pfad mit `outlook_metrics` min+max aufrufen, Zellentext
+    prüfen; separat sicherstellen, dass keine Gehzeit-Funktion aufgerufen wird (kein Absturz
+    mangels Segmenten).
+
+- **AC-9:** Given ein Trip ohne `display_config` (Altform) oder ein Ortsvergleich ohne
+  `outlook_metrics` mit Temperatur 9 °C bis 20 °C / When der Klartext-Ausblick gerendert wird /
+  Then enthält er `9/20°C` statt `9–20°C` — Golden-Fixtures
+  `tests/tdd/test_compare_outlook.py:205-206,397-398` sind auf den neuen Trenner gezogen.
+  - Test: bestehende Golden-Fixture-Tests mit angepasstem Erwartungsstring, weiterhin grün.
+
+- **AC-10:** Given der Wächtertest `tests/unit/test_gehzeit_metriken_bleiben_trip_exklusiv.py`
+  aus Scheibe C / When diese Änderung eingespielt ist / Then bleibt er unverändert grün — A1
+  führt keine neuen Registerkennungen ein und hängt der Kennung `temperature` keinen
+  „(Gehzeit)"-Zusatz an; nur der Wert hinter der bestehenden Kennung ändert sich.
+  - Test: bestehenden Wächtertest unverändert mitlaufen lassen, kein neuer Test nötig.
+
+### Abdeckungstabelle (Zuschnitt A1 gegen ACs)
+
+| Zuschnitt-Punkt | Abgedeckt durch |
+|---|---|
+| 1. Gehzeit-Fenster für Temperatur/gefühlte Temperatur | AC-1, AC-2, AC-3 |
+| 2. Spannen-Zelle mit Schrägstrich (HTML+Klartext, Trip+Compare) | AC-4, AC-5, AC-6, AC-7, AC-8 |
+| 3. Altform-Klartext auf denselben Trenner ziehen | AC-9 |
+| Nicht-Ziel-Guard (Scheibe-C-Wächter unberührt) | AC-10 |
+
+## Known Limitations
+
+- **`avg` bleibt außen vor** (⇒ A3): der Compare-Katalog kennt für Temperatur nur `min`/`max`,
+  keine `avg`-Spalte — diese Spec ändert daran nichts.
+- **Neue Registerkennungen bleiben außen vor** (⇒ A2): die vier Gehzeit-Kennungen
+  (`temperature_day_low` u. a.) werden weiterhin vom Compare-Katalog verworfen
+  (`compare_outlook_metric_ids.py:62`); A1 ändert nur den Wert hinter der bestehenden Kennung
+  `temperature`.
+- **Wind/Böen-Fensterung bleibt unangetastet** (⇒ Sammel-Issue #1199): beide lesen weiterhin
+  aus dem konfigurierten Tagesfenster bzw. den ungefensterten `_flat_points` — beides eigene
+  Baustellen, keine Gehzeit-Fensterung.
+- **Kanal-Modul im Ausblick bleibt außen vor** (⇒ A3): diese Spec ändert nicht, welche Größen
+  wählbar sind, nur wie ein bereits gewähltes Paar dargestellt wird.
+- **Kein Nachweis „in derselben Mail"**: der Ausblick zeigt strukturell nie den heutigen Tag
+  (`get_future_stages()` filtert `s.date > from_date`), die Kachelzeile deckt `target_date` ab
+  — beide Tagesmengen sind disjunkt. Der Bug-Nachweis (AC-1) läuft deshalb auf Funktionsebene,
+  nicht als Mail-interner Widerspruch.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Kein neues Entscheidungsfeld (Kanal, Provider, Datenmodell, Auth,
+  Editor-Paradigma, Test-/Deploy-Strategie) — reine Fortsetzung des mit #1417 bereits
+  getroffenen Musters (Gehzeit-Fenster statt Etappenaggregat) auf eine bis dahin übersehene
+  Fläche, plus eine Formatangleichung an einen bereits bestehenden SMS-Trenner. Der geteilte
+  Baustein `build_outlook_row()`/`outlook_columns()` bleibt architektonisch unverändert
+  (weiterhin EIN Zeilenbauer für Trip und Compare, Epic #1301 B4) — keine neue
+  Architekturentscheidung, nur deren konsequente Anwendung.
+
+## Changelog
+
+- 2026-08-20: Initial spec created (#1848 Scheibe A1)

--- a/src/output/renderers/compare_outlook_metric_ids.py
+++ b/src/output/renderers/compare_outlook_metric_ids.py
@@ -135,18 +135,69 @@ def outlook_columns(metrics: object) -> list[dict]:
         columns.append({
             "label": catalog["label"],
             "metric_id": metric_id,
+            "aggregation": aggregation,
             "field": field,
             "unit": catalog.get("unit", ""),
             "decimals": catalog.get("decimals", 0),
             "kind": catalog.get("kind", "range"),
             "aggregation_label": catalog.get("aggregation_label", ""),
         })
+    columns = _merge_min_max_pairs(columns)
     mehrfach = {c["label"] for c in columns
                 if sum(1 for other in columns if other["label"] == c["label"]) > 1}
     for column in columns:
-        if column["label"] in mehrfach and column["aggregation_label"]:
+        if column["label"] in mehrfach and column.get("aggregation_label"):
             column["label"] = f"{column['label']} {column['aggregation_label']}"
     return columns
+
+
+def _merge_min_max_pairs(columns: list[dict]) -> list[dict]:
+    """#1848 A1 (PO-Entscheid 2026-08-20, AC-4..AC-8): sind fuer dieselbe
+    Groesse Tief UND Hoch gewaehlt (``kind == "range"``), werden die beiden
+    Spalten zu EINER Spannen-Spalte (``field_min``/``field_max`` statt
+    ``field``) zusammengefuehrt -- Schraegstrich-Zelle statt zweier Spalten
+    mit Minimum-/Maximum-Suffix. Loest fuer diesen Fall die rein paarbasierte
+    Soll-Menge aus Epic #1703 Scheibe 2 ab (Gegenzahl:
+    ``tests/helpers/outlook_columns.py::_merge_min_max_soll``, dieselbe
+    Regel). Alles andere bleibt additiv unveraendert: nur eine Auswertung
+    gewaehlt (AC-5), ordinal/enum-Groessen, oder mehr als zwei Auswertungen
+    einer Groesse (z. B. kuenftiges ``avg`` bei Temperatur, A3) -- dann
+    greift weiterhin die bestehende Minimum-/Maximum-Disambiguierung
+    unveraendert."""
+    by_metric: dict[str, dict[str, int]] = {}
+    for i, col in enumerate(columns):
+        if col.get("kind") == "range" and col.get("aggregation") in ("min", "max"):
+            by_metric.setdefault(col["metric_id"], {})[col["aggregation"]] = i
+
+    merge_at: dict[int, int] = {}
+    consumed: set[int] = set()
+    for aggs in by_metric.values():
+        if "min" in aggs and "max" in aggs:
+            first_idx, second_idx = sorted((aggs["min"], aggs["max"]))
+            merge_at[first_idx] = second_idx
+            consumed.add(second_idx)
+
+    merged: list[dict] = []
+    for i, col in enumerate(columns):
+        if i in consumed:
+            continue
+        if i not in merge_at:
+            merged.append(col)
+            continue
+        partner = columns[merge_at[i]]
+        lo = col if col["aggregation"] == "min" else partner
+        hi = col if col["aggregation"] == "max" else partner
+        merged.append({
+            "label": col["label"],
+            "metric_id": col["metric_id"],
+            "field_min": lo["field"],
+            "field_max": hi["field"],
+            "unit": col.get("unit", ""),
+            "decimals": col.get("decimals", 0),
+            "kind": "range",
+            "aggregation_label": "",
+        })
+    return merged
 
 
 def format_outlook_value(value: object, column: dict) -> str:
@@ -184,9 +235,44 @@ def format_outlook_value(value: object, column: dict) -> str:
     return f"{text} {unit}".strip()
 
 
+def format_outlook_range_cell(raw_min: object, raw_max: object, column: dict) -> str:
+    """Tief/Hoch-Zelle einer zusammengefuehrten Spannen-Spalte (#1848 A1,
+    AC-4/AC-6/AC-7/AC-8) -- ASCII-Schraegstrich, kein Leerzeichen,
+    vorhandenes Minuszeichen bleibt an der Trennstelle erhalten
+    (``"-12/-4"``). Kein Einheiten-Suffix in der Zelle selbst (anders als
+    die feste Altform, AC-9).
+
+    Sind BEIDE Seiten vorhanden, ist die Reihenfolge Tief/Hoch (``"9/27"``).
+    Fehlt EINE Seite (Datenluecke, nicht Konfigurationsauswahl -- die bleibt
+    Einzelwert, AC-5), zeigt die Zelle PO-Vorgabe-konform die vorhandene
+    Seite zuerst und ``"-"`` fuer die fehlende (``"13/-"``, spec-woertlich
+    "zeigt die Zelle die vorhandene Seite und '-' fuer die fehlende") --
+    NICHT die feste Tief/Hoch-Position mit einer Luecke."""
+    decimals = column.get("decimals") or 0
+
+    def _num(value: object) -> str | None:
+        if value is None:
+            return None
+        try:
+            number = float(value)
+        except (TypeError, ValueError):
+            return str(value)
+        return f"{number:.{int(decimals)}f}"
+
+    min_str, max_str = _num(raw_min), _num(raw_max)
+    if min_str is not None and max_str is not None:
+        return f"{min_str}/{max_str}"
+    if min_str is not None:
+        return f"{min_str}/-"
+    if max_str is not None:
+        return f"{max_str}/-"
+    return "-/-"
+
+
 __all__ = [
     "resolve_outlook_metrics",
     "resolve_trip_outlook_metrics",
     "outlook_columns",
     "format_outlook_value",
+    "format_outlook_range_cell",
 ]

--- a/src/output/renderers/email/helpers.py
+++ b/src/output/renderers/email/helpers.py
@@ -940,7 +940,11 @@ def format_trend_tokens(stage: dict) -> dict:
     tl = stage.get("temp_lo")
     th = stage.get("temp_hi")
     if tl is not None and th is not None:
-        temp_str = f"{tl}–{th}°C"
+        # #1848 A1 AC-9: Schraegstrich statt Halbgeviertstrich -- derselbe
+        # Trenner wie die SMS-Schreibweise (Punkt 2 dieser Spec), betrifft nur
+        # den festen Altform-Pfad (unkonfigurierter Trip/Compare ohne
+        # outlook_metrics).
+        temp_str = f"{tl}/{th}°C"
     elif th is not None:
         temp_str = f"{th}°C"
     else:

--- a/src/output/renderers/email/outlook.py
+++ b/src/output/renderers/email/outlook.py
@@ -444,6 +444,68 @@ def _metric_column_bg(col: dict, raw: object) -> str:
     return f"background:{tone_css(band)[0]};"
 
 
+
+# #1848 A1 (AC-1/AC-2/AC-3): Gehzeit-Fenster-Override je Summary-Feld.
+# `hiking_extrema` ist ein bereits fertiges hiking_field_min_max()-Mapping
+# (Vorbild sms_thresholds) -- dieselben Funktionen, die sms_trip.py fuer
+# D/FD nutzt (Issue #1417). Fail-soft: fehlt der Key oder ist
+# `hiking_extrema` None, bleibt das Etappenaggregat (AC-2). Berechnet wird
+# es entweder vom Aufrufer selbst UEBERGEBEN oder HIER aus `segments`
+# abgeleitet (s. `_resolve_hiking_extrema`) -- `trip_report_scheduler.py`
+# darf `output.renderers.day_window` nicht selbst importieren
+# (Architektur-Wache `test_scheduler_has_no_output_imports`), reicht daher
+# die rohen Segmente durch statt das Ergebnis vorzurechnen.
+_HIKING_FIELD_MAP = {
+    "temp_min_c": ("t2m_c", 0),
+    "temp_max_c": ("t2m_c", 1),
+    "wind_chill_min_c": ("wind_chill_c", 0),
+    "wind_chill_max_c": ("wind_chill_c", 1),
+}
+
+
+def _hiking_or_summary(
+    summary: "SegmentWeatherSummary", field: Optional[str], hiking_extrema: Optional[dict],
+) -> object:
+    """Wert fuer ``field`` aus dem Gehzeit-Fenster, wenn ein Override vorliegt
+    -- sonst faellt es fail-soft auf das Etappenaggregat zurueck (AC-2)."""
+    if field is None:
+        return None
+    hit = _HIKING_FIELD_MAP.get(field)
+    if hit is not None and hiking_extrema is not None:
+        extrema = hiking_extrema.get(hit[0])
+        if extrema is not None:
+            return extrema[hit[1]]
+    return getattr(summary, field, None)
+
+
+def _resolve_hiking_extrema(
+    hiking_extrema: Optional[dict], segments: Optional[list],
+) -> Optional[dict]:
+    """``hiking_extrema`` hat Vorrang; ohne es aber mit ``segments`` wird das
+    Gehzeit-Fenster HIER berechnet (``output.renderers.day_window`` ist ein
+    Renderer-Modul, der Import gehoert deshalb in diese Schicht, nicht in den
+    Zeitplaner). Segmentlose Teile (kein ``.segment``, nur Zeitreihe --
+    Test-Doubles) bleiben aussen vor statt die Berechnung abstuerzen zu
+    lassen."""
+    if hiking_extrema is not None or not segments:
+        return hiking_extrema
+    from output.renderers.day_window import (
+        collect_hiking_window_points, hiking_field_min_max,
+    )
+
+    usable = [s for s in segments if getattr(s, "segment", None) is not None]
+    hiking_points = collect_hiking_window_points(usable)
+    resolved = {
+        field: extrema
+        for field, extrema in (
+            ("t2m_c", hiking_field_min_max(hiking_points, "t2m_c")),
+            ("wind_chill_c", hiking_field_min_max(hiking_points, "wind_chill_c")),
+        )
+        if extrema is not None
+    }
+    return resolved or None
+
+
 def build_outlook_row(
     summary: "SegmentWeatherSummary",
     points: list["ForecastDataPoint"],
@@ -456,6 +518,8 @@ def build_outlook_row(
     report_type: Optional[str] = None,
     day_window_start_hour: Optional[int] = None,
     day_window_end_hour: Optional[int] = None,
+    hiking_extrema: Optional[dict] = None,
+    segments: Optional[list] = None,
 ) -> dict:
     """Baut ein Ausblick-Row-Dict aus einer SegmentWeatherSummary + Punktliste.
 
@@ -489,7 +553,25 @@ def build_outlook_row(
     Zellen dieser Zeile koennen nicht nach einer anderen Regel entstehen als
     die Ueberschriften darueber. Ein ausdrueckliches ``metrics`` hat Vorrang
     (Compare-Pfad unveraendert).
+
+    ``hiking_extrema`` (#1848 A1, AC-1/AC-2/AC-3): optionales Mapping
+    ``{"t2m_c": (min, max, max_ts), "wind_chill_c": (...)}`` --
+    ``hiking_field_min_max()``-Ergebnisse aus dem Gehzeit-Fenster
+    (``collect_hiking_window_points()``), das der Aufrufer SELBST berechnet
+    (er kennt Segmente, diese Funktion nicht). Wirkt an BEIDEN Wertequellen:
+    ``temp_lo``/``temp_hi`` des festen Altform-Pfads UND ``getattr(summary,
+    col["field"])`` der ``cells``-Schleife des konfigurierbaren Pfads.
+    Fehlender Key/``None`` faellt fail-soft auf das Etappenaggregat zurueck.
+
+    ``segments`` (#1848 A1, Alternative zu ``hiking_extrema``): der Aufrufer
+    (``trip_report_scheduler.py``) hat ``seg_weather`` bereits vorliegen,
+    darf aber ``output.renderers.day_window`` selbst nicht importieren
+    (Architektur-Wache ``test_scheduler_has_no_output_imports``) -- reicht
+    daher die rohen Segmente durch, die Ableitung passiert HIER
+    (``_resolve_hiking_extrema``). Ein explizites ``hiking_extrema`` hat
+    Vorrang vor ``segments``.
     """
+    hiking_extrema = _resolve_hiking_extrema(hiking_extrema, segments)
     if metrics is None and trip_display_config is not None:
         from output.renderers.compare_outlook_metric_ids import (
             resolve_trip_outlook_metrics,
@@ -500,8 +582,10 @@ def build_outlook_row(
     from output.tokens.dto import HourlyValue
     from utils.timezone import local_hour as _lh
 
-    temp_lo = int(summary.temp_min_c) if summary.temp_min_c is not None else None
-    temp_hi = int(summary.temp_max_c) if summary.temp_max_c is not None else None
+    _temp_lo_raw = _hiking_or_summary(summary, "temp_min_c", hiking_extrema)
+    _temp_hi_raw = _hiking_or_summary(summary, "temp_max_c", hiking_extrema)
+    temp_lo = int(_temp_lo_raw) if _temp_lo_raw is not None else None
+    temp_hi = int(_temp_hi_raw) if _temp_hi_raw is not None else None
     precip_mm = float(summary.precip_sum_mm or 0.0)
     wind_kmh = int(summary.wind_max_kmh or 0)
     wind_dir = degrees_to_compass(getattr(summary, "wind_direction_avg_deg", None))
@@ -644,7 +728,10 @@ def build_outlook_row(
         cell_bg: list[str] = []
         for col in outlook_columns(metrics):
             ordinal = col.get("kind") == "ordinal"
-            raw = _thunder_value if ordinal else getattr(summary, col["field"], None)
+            raw = (
+                _thunder_value if ordinal
+                else _hiking_or_summary(summary, col.get("field"), hiking_extrema)
+            )
             cells.append(format_outlook_value(
                 raw,
                 {**col, "hail": _hail,

--- a/src/output/renderers/email/outlook.py
+++ b/src/output/renderers/email/outlook.py
@@ -678,7 +678,7 @@ def build_outlook_row(
 
     if metrics is not None:
         from output.renderers.compare_outlook_metric_ids import (
-            format_outlook_value, outlook_columns,
+            format_outlook_range_cell, format_outlook_value, outlook_columns,
         )
 
         # Issue #1475 Nachbesserung (Punkt 5b, Aufrufstelle 4): der Hagel-Wert
@@ -728,6 +728,16 @@ def build_outlook_row(
         cell_bg: list[str] = []
         for col in outlook_columns(metrics):
             ordinal = col.get("kind") == "ordinal"
+            # #1848 A1 (AC-4..AC-8): eine zusammengefuehrte Spannen-Spalte
+            # traegt `field_min`/`field_max` statt `field` -- BEIDE Seiten
+            # gehen (mit demselben Gehzeit-Fenster-Override wie der
+            # Einzelwert-Fall) in EINE Zelle "{min}/{max}".
+            if "field_min" in col or "field_max" in col:
+                raw_min = _hiking_or_summary(summary, col.get("field_min"), hiking_extrema)
+                raw_max = _hiking_or_summary(summary, col.get("field_max"), hiking_extrema)
+                cells.append(format_outlook_range_cell(raw_min, raw_max, col))
+                cell_bg.append(_metric_column_bg(col, raw_max))
+                continue
             raw = (
                 _thunder_value if ordinal
                 else _hiking_or_summary(summary, col.get("field"), hiking_extrema)

--- a/src/services/trip_report_scheduler.py
+++ b/src/services/trip_report_scheduler.py
@@ -2335,6 +2335,17 @@ class TripReportSchedulerService:
                     trip_display_config=dc, report_type=report_type,
                     day_window_start_hour=_win_start,
                     day_window_end_hour=_win_end,
+                    # #1848 A1 (AC-1/AC-2/AC-3): Gehzeit-Fenster statt
+                    # Etappenaggregat fuer Temperatur/gefuehlte Temperatur --
+                    # derselbe Randbehandlungsfehler (exklusive
+                    # Ankunftsstunde), den #1417 bereits fuer SMS/Telegram/
+                    # Kachelzeile behoben hat. `seg_weather` liegt hier
+                    # bereits vor; die Ableitung (collect_hiking_window_points
+                    # + hiking_field_min_max, output.renderers.day_window)
+                    # passiert INNERHALB von build_outlook_row -- der
+                    # Zeitplaner darf dieses Renderer-Modul nicht selbst
+                    # importieren (test_scheduler_has_no_output_imports).
+                    segments=seg_weather,
                 )
                 # Issue #1275: explicit calendar date so the thunder forecast
                 # can reuse this row (matched by date, gap-safe) instead of

--- a/tests/fixtures/outlook_trip_parity/README.md
+++ b/tests/fixtures/outlook_trip_parity/README.md
@@ -24,6 +24,7 @@ Default-Parameter abgeschirmte Erweiterungen.
 | 2026-08-10 | `...txt` | Zeile "Di", Gewitter-Feld | `⚡–` | `⚡mittel` | #1653/F004 |
 | 2026-08-14 | `...html` | alle Zellen mit gelber/oranger Ampel-Toenung (Regenwahrsch./Gewitter, Zeilen "Mo"/"Di") | `#fbeeb8`/`#fad6b8` | `#fdf4cd`/`#fbe3cc` | #1801 S2 (design_tokens.tone_css() ist die geteilte Farbquelle von `render_outlook_table()`; `.txt`-Gegenstueck traegt keine Farben, unveraendert) |
 | 2026-08-18 | `...txt` | Zeilen "Mo" und "Di", Gewitter-Feld | `⚡mittel` | `⚡mittel@16` | #1493 (AC-3: der Klartext-Ausblick fuehrt die Onset-Stunde wie HTML-Zelle, Telegram und SMS; `...html` traegt `mittel @16` bereits seit #1653 und ist unveraendert) |
+| 2026-08-20 | `...txt` | Zeilen "Mo" und "Di", Temperatur-Feld | `9–21°C`/`11–19°C` | `9/21°C`/`11/19°C` | #1848 A1 AC-9 (Altform-Klartext auf denselben Schraegstrich-Trenner wie die SMS-Schreibweise gezogen; `...html` traegt keinen Trenner in dieser Zelle, unveraendert) |
 
 Beide Eingabezeilen tragen `hourly_thunder` mit "mittel" um 16 Uhr — im
 Tagesfenster 4-19 —, waehrend das Aggregat `thunder` einmal `MED` und einmal

--- a/tests/fixtures/outlook_trip_parity/trip_outlook_show_acc_true.txt
+++ b/tests/fixtures/outlook_trip_parity/trip_outlook_show_acc_true.txt
@@ -1,5 +1,5 @@
 
 Nächste Etappen
-Mo  Etappe A                   9–21°C   2.5mm W18   ⚡mittel@16
+Mo  Etappe A                   9/21°C   2.5mm W18   ⚡mittel@16
     ↳ Hütte geschlossen
-Di  Etappe B                   11–19°C  –     W25   ⚡mittel@16
+Di  Etappe B                   11/19°C  –     W25   ⚡mittel@16

--- a/tests/fixtures/trip_outlook_reference/README.md
+++ b/tests/fixtures/trip_outlook_reference/README.md
@@ -37,6 +37,7 @@ Abweichung steht zitierbar im Testcode statt still in der Fixture.
 | Datum | Datei | Zelle | Alt | Neu | Grund |
 |---|---|---|---|---|---|
 | 2026-08-18 | `outlook_block.txt` | Zeilen "Mo"/"Mi", Gewitter-Feld | `⚡mittel` / `⚡hoch` | `⚡mittel@10` / `⚡hoch@10` | #1493 AC-3 (freigegebene Spec `feat_1493_gewitter_onset_sichtbar.md`): der Klartext-Ausblick fuehrt die Onset-Stunde, wie HTML-Zelle, Telegram und SMS es laengst tun. `outlook_table.html` und `outlook_legend.html` sind unveraendert; die Di-Zeile (`⚡–`, kein Tagesgewitter) ebenfalls |
+| 2026-08-20 | `outlook_block.txt`/`compact_block.txt`/`telegram_bubble.txt` | alle Temperatur-Zellen | `9–21°C`/`9-21C`/`9–21°C` u.a. | `9/21°C`/`9/21C`/`9/21°C` u.a. | #1848 A1 AC-9 (Altform-Klartext auf denselben Schraegstrich-Trenner wie die SMS-Schreibweise gezogen -- betrifft `format_trend_tokens()`, `temp_str`, `helpers.py:943`, wirkt in alle drei Klartext-Renderer durch; `outlook_table.html`/`outlook_legend.html` sind unveraendert, das HTML rendert N/D als getrennte Spalten ohne Trennzeichen) |
 
 ## Diese Dateien werden NICHT nachgezogen
 

--- a/tests/fixtures/trip_outlook_reference/compact_block.txt
+++ b/tests/fixtures/trip_outlook_reference/compact_block.txt
@@ -1,4 +1,4 @@
 Naechste Etappen
-XX  Tag 2                      9-21C   2.5mm 25    Tmittel
-XX  Tag 3                      11-19C  -     31    T-
-XX  Tag 4                      6-24C   7.1mm 18    Thoch
+XX  Tag 2                      9/21C   2.5mm 25    Tmittel
+XX  Tag 3                      11/19C  -     31    T-
+XX  Tag 4                      6/24C   7.1mm 18    Thoch

--- a/tests/fixtures/trip_outlook_reference/outlook_block.txt
+++ b/tests/fixtures/trip_outlook_reference/outlook_block.txt
@@ -1,5 +1,5 @@
 Nächste Etappen
-Mo  Obstanserseehütte          9–21°C   2.5mm 25    ⚡mittel@10
+Mo  Obstanserseehütte          9/21°C   2.5mm 25    ⚡mittel@10
     ↳ Hütte geschlossen
-Di  Filmoor-Standschützenhütte 11–19°C  –     31    ⚡–
-Mi  Sillianer Hütte            6–24°C   7.1mm 18    ⚡hoch@10
+Di  Filmoor-Standschützenhütte 11/19°C  –     31    ⚡–
+Mi  Sillianer Hütte            6/24°C   7.1mm 18    ⚡hoch@10

--- a/tests/fixtures/trip_outlook_reference/telegram_bubble.txt
+++ b/tests/fixtures/trip_outlook_reference/telegram_bubble.txt
@@ -1,6 +1,6 @@
 Ausblick
-XX  9–21°C  2.5mm  25  ⚡mittel
+XX  9/21°C  2.5mm  25  ⚡mittel
     ↳ Gewitter möglich
-XX  11–19°C  R–  31  ⚡–
-XX  6–24°C  7.1mm  18  ⚡hoch
+XX  11/19°C  R–  31  ⚡–
+XX  6/24°C  7.1mm  18  ⚡hoch
     ↳ Gewitter möglich · Regen 7 mm

--- a/tests/golden/email/outlook-thunder-day-night.txt
+++ b/tests/golden/email/outlook-thunder-day-night.txt
@@ -2,6 +2,6 @@
 ---
 
 Nächste Etappen
-Mo  Fall A – nur Nacht         12–24°C  1.2mm W18   ⚡– · nachts hoch @0
-Di  Fall B – Tag + Nacht       12–24°C  1.2mm W18   ⚡mittel@14 · nachts hoch @0
-Mi  Fall C – Tag stärker       12–24°C  1.2mm W18   ⚡hoch@14 · nachts mittel @22
+Mo  Fall A – nur Nacht         12/24°C  1.2mm W18   ⚡– · nachts hoch @0
+Di  Fall B – Tag + Nacht       12/24°C  1.2mm W18   ⚡mittel@14 · nachts hoch @0
+Mi  Fall C – Tag stärker       12/24°C  1.2mm W18   ⚡hoch@14 · nachts mittel @22

--- a/tests/helpers/outlook_columns.py
+++ b/tests/helpers/outlook_columns.py
@@ -49,7 +49,9 @@ def nicht_waehlbare_compare_keys(entries: list[dict] | None = None) -> list[str]
 
 
 def compare_outlook_soll_spalten(entries: list[dict] | None = None) -> list[dict]:
-    """Je ausgeliefertem Katalog-Paar ein Soll-Eintrag, in Katalog-Reihenfolge.
+    """Je ausgeliefertem Katalog-Paar ein Soll-Eintrag, in Katalog-Reihenfolge
+    -- MIT Ausnahme: min+max derselben Groesse ergeben EINE zusammengefuehrte
+    Spalte (``_merge_min_max_soll``, s. dort).
 
     ``entries`` injiziert eine Testkopie der Katalogzeilen (Vorbild
     ``get_compare_metric_catalog(entries=...)``), damit die
@@ -58,12 +60,12 @@ def compare_outlook_soll_spalten(entries: list[dict] | None = None) -> list[dict
     """
     geliefert = get_compare_metric_catalog(entries)
     haeufigkeit = Counter(e["label"] for e in geliefert)
-    soll: list[dict] = []
+    roh: list[dict] = []
     for eintrag in geliefert:
         label = eintrag["label"]
         auswertung_label = eintrag.get("aggregation_label", "")
         mehrdeutig = haeufigkeit[label] > 1 and bool(auswertung_label)
-        soll.append({
+        roh.append({
             "key": eintrag["key"],
             "metric_id": eintrag["metric_id"],
             "aggregation": eintrag["aggregation"],
@@ -73,17 +75,77 @@ def compare_outlook_soll_spalten(entries: list[dict] | None = None) -> list[dict
                 eintrag["metric_id"], eintrag["aggregation"],
             ),
             "kind": eintrag.get("kind", "range"),
+            # Die Paare, die dieser Soll-Eintrag repraesentiert -- fuer
+            # unveraenderte Eintraege genau eines, fuer Merges (s.u.) zwei.
+            "paare": [{"metric_id": eintrag["metric_id"], "aggregation": eintrag["aggregation"]}],
         })
-    return soll
+    return _merge_min_max_soll(roh)
+
+
+def _merge_min_max_soll(roh: list[dict]) -> list[dict]:
+    """#1848 A1 (PO-Entscheid 2026-08-20): min+max derselben Groesse ergeben
+    in der Produktivauswahl EINE Spalte (Schraegstrich-Zelle), nicht mehr
+    zwei mit Minimum-/Maximum-Suffix -- loest fuer diesen Fall die rein
+    paarbasierte Soll-Menge aus Epic #1703 Scheibe 2 ab (dieselbe Merge-
+    Regel wie die Produktivfunktion
+    ``compare_outlook_metric_ids._merge_min_max_pairs()``).
+
+    „Jede waehlbare GROESSE ergibt genau eine Spalte" (AC-S2-1) bleibt dabei
+    wahr -- nur die Menge der Paare, die eine Groesse ausmacht, aendert
+    sich. Die Disambiguierungs-Logik (Minimum-/Maximum-Suffix bei
+    mehrdeutigem Label) bleibt fuer den Fall bestehen, dass eine Groesse
+    KUENFTIG mehr als zwei Auswertungen traegt (z. B. ``avg`` bei
+    Temperatur, Scheibe A3): dann mergen min+max weiterhin zur Spanne, aber
+    die dritte Auswertung bleibt eine eigene, disambiguierte Spalte.
+    """
+    by_metric: dict[str, dict[str, int]] = {}
+    for i, s in enumerate(roh):
+        if s["kind"] == "range" and s["aggregation"] in ("min", "max"):
+            by_metric.setdefault(s["metric_id"], {})[s["aggregation"]] = i
+
+    merge_at: dict[int, int] = {}
+    consumed: set[int] = set()
+    for aggs in by_metric.values():
+        if "min" in aggs and "max" in aggs:
+            first_idx, second_idx = sorted((aggs["min"], aggs["max"]))
+            merge_at[first_idx] = second_idx
+            consumed.add(second_idx)
+
+    merged: list[dict] = []
+    for i, s in enumerate(roh):
+        if i in consumed:
+            continue
+        if i not in merge_at:
+            merged.append(s)
+            continue
+        partner = roh[merge_at[i]]
+        lo = s if s["aggregation"] == "min" else partner
+        hi = s if s["aggregation"] == "max" else partner
+        merged.append({
+            "key": f"{s['key']}+{partner['key']}",
+            "metric_id": s["metric_id"],
+            "aggregation": None,
+            "label": s["label"],
+            "ueberschrift": s["label"],
+            # Truthy UND informativ (statt None): ein Tupel beider Felder --
+            # der Vakuum-Schutz `ohne_feld` in
+            # `assert_soll_menge_ist_plausibel()` prueft nur auf Wahrheits-
+            # wert, ein `None` wuerde den Merge selbst faelschlich als
+            # "kein SegmentWeatherSummary-Feld" melden.
+            "summary_field": (lo["summary_field"], hi["summary_field"]),
+            "kind": "range",
+            "paare": s["paare"] + partner["paare"],
+        })
+    return merged
 
 
 def compare_outlook_soll_paare(entries: list[dict] | None = None) -> list[dict]:
     """Die Auswahl im Speicherformat der Bedienflaeche (#1373-Vokabular) —
-    genau das, was ein Nutzer waehlt, der alles waehlt."""
-    return [
-        {"metric_id": s["metric_id"], "aggregation": s["aggregation"]}
-        for s in compare_outlook_soll_spalten(entries)
-    ]
+    genau das, was ein Nutzer waehlt, der alles waehlt. Bleibt die FLACHE
+    Paar-Menge (ein Eintrag je Katalog-Paar) auch nach dem Merge in
+    ``compare_outlook_soll_spalten()`` -- die Auswahl selbst aendert sich
+    nicht, nur wie viele SPALTEN daraus entstehen."""
+    return [p for s in compare_outlook_soll_spalten(entries) for p in s["paare"]]
 
 
 def assert_soll_menge_ist_plausibel(entries: list[dict] | None = None) -> list[dict]:
@@ -110,9 +172,14 @@ def assert_soll_menge_ist_plausibel(entries: list[dict] | None = None) -> list[d
         f"- {len(zurueckgehalten)} nicht waehlbare ({zurueckgehalten}) "
         f"!= {len(geliefert)} ausgelieferte"
     )
-    assert len(soll) == len(geliefert), (
-        f"Soll-Menge ({len(soll)}) und ausgelieferter Katalog "
-        f"({len(geliefert)}) sind auseinandergelaufen"
+    # #1848 A1: min+max derselben Groesse ergeben EINEN Soll-Eintrag mit
+    # ZWEI Paaren (``paare``) -- "ein Eintrag je geliefertem Paar" gilt
+    # seither nur noch auf PAAR-Ebene (jedes gelieferte Paar erscheint in
+    # genau einem Soll-Eintrag), nicht mehr 1:1 auf Spalten-Ebene.
+    paare_gesamt = sum(len(s["paare"]) for s in soll)
+    assert paare_gesamt == len(geliefert), (
+        f"Paar-Menge ueber alle Soll-Eintraege ({paare_gesamt}) und "
+        f"ausgelieferter Katalog ({len(geliefert)}) sind auseinandergelaufen"
     )
     assert zurueckgehalten, (
         "Der Compare-Katalog haelt keine einzige Zeile mehr wegen "

--- a/tests/integration/test_multi_day_trend.py
+++ b/tests/integration/test_multi_day_trend.py
@@ -496,7 +496,8 @@ class TestTrendRendering:
 
         assert "Nächste Etappen" in report.email_plain
         assert "Tossals Verds" in report.email_plain
-        assert "6–14°C" in report.email_plain
+        # #1848 A1 AC-9: Schraegstrich statt Halbgeviertstrich (SMS-Trenner).
+        assert "6/14°C" in report.email_plain
 
     def test_trend_no_future_stages(self):
         """No trend block when multi_day_trend is None.

--- a/tests/tdd/test_channel_metric_matrix.py
+++ b/tests/tdd/test_channel_metric_matrix.py
@@ -2602,7 +2602,15 @@ def test_ac_s2_3_keine_zwei_spalten_mit_gleicher_beschriftung():
     Auswertung derselben Groesse (Vorbild fuer ein kuenftiges ``avg`` bei
     Temperatur, Scheibe A3): min+max mergen weiterhin, die dritte bleibt
     eine eigene, disambiguierte Spalte -- GENAU der Zweig, den dieser Test
-    bewacht."""
+    bewacht.
+
+    🔴 Der synthetische Ausschnitt ist ABSICHTLICH synthetisch, keine
+    Verlegenheitsloesung: liefe die Vakuum-Gegenprobe stattdessen ueber den
+    REALEN Katalog, bewiese sie ab jetzt nur noch, dass der Merge wirkt --
+    der Ausschluss wuerde die Bedingung erzeugen, mit der er begruendet
+    ist, und die Disambiguierung waere totes, ungetestetes Recht (bis A3
+    tatsaechlich eine dritte Auswertung einfuehrt). NICHT auf den realen
+    Katalog "vereinfachen"."""
     _temp_max_zeile = next(e for e in COMPARE_METRIC_CATALOG if e["key"] == "temp_max_c")
     _synthetische_dritte_auswertung = {
         **_temp_max_zeile, "key": "temp_avg_c_ac_s2_3_synthetisch", "aggregation": "avg",

--- a/tests/tdd/test_channel_metric_matrix.py
+++ b/tests/tdd/test_channel_metric_matrix.py
@@ -94,7 +94,7 @@ from bs4 import BeautifulSoup
 from app.loader import _parse_display_config
 from app.metric_catalog import (
     _METRICS, build_default_display_config, format_metric_value, get_all_metrics,
-    get_alert_label, get_cmp, get_metric, get_sms_code,
+    get_alert_label, get_cmp, get_metric, get_sms_code, summary_field_for,
 )
 from app.models import (
     AlertMetric, ForecastDataPoint, ForecastMeta, MetricConfig, NormalizedTimeseries,
@@ -2354,9 +2354,12 @@ _S2_TAGE = ((6.0, 18.0), (9.0, 27.0), (11.0, 23.0))
 # Klartext, an jedem der drei Tage) -- der ROTE Anteil von AC-S2-4. Die Liste
 # bleibt nach dem Fix stehen: sie begrenzt die Charakterisierung in AC-S2-6 auf
 # die 20 bereits gefuellten Zellen und bleibt der Beleg des roten Anteils.
+# #1848 A1: wind_chill_min_c/wind_chill_max_c teilen sich seit dem Merge
+# ebenfalls EINEN Soll-Eintrag -- dasselbe Tupel-Prinzip wie bei
+# _S2_UNVERAENDERTE_ZELLEN oben.
 _S2_DEFEKTE_FELDER = frozenset({
     "snow_depth_cm", "snow_new_sum_cm", "wind_direction_avg_deg",
-    "wind_chill_min_c", "wind_chill_max_c",
+    ("wind_chill_min_c", "wind_chill_max_c"),
 })
 
 
@@ -2776,10 +2779,17 @@ def test_ac_s2_5_beide_tagesaggregationen_fuellen_dieselben_felder():
 # 2026-08-11 am ersten Ausblickstag der Mail aus ``_s2_mail()``. Schluessel ist
 # der ``SegmentWeatherSummary``-Feldname (stabiler als die Beschriftung, die
 # AC-S2-1 ohnehin bewacht).
+#
+# #1848 A1: temp_min_c/temp_max_c teilen sich seit dem Merge EINEN
+# Soll-Eintrag mit ``summary_field`` als Tupel ``(min_feld, max_feld)``
+# (``_merge_min_max_soll``) -- der Schluessel hier zieht das nach, sonst
+# ginge die Mengen-Gleichheit unten NICHT auf (kein Zufallstreffer: ein
+# fehlender/verschwundener Soll-Eintrag faellt weiterhin auf, weil dann
+# GENAU dieses Tupel auf der einen Seite fehlt).
 _S2_UNVERAENDERTE_ZELLEN = {
     "sunny_hours": "4.0 h", "wind_max_kmh": "15 km/h", "cloud_avg_pct": "50 %",
     "visibility_min_m": "20000 m", "precip_sum_mm": "4.4 mm", "uv_index_max": "4",
-    "temp_max_c": "18 °C", "thunder_level_max": "mittel", "temp_min_c": "6 °C",
+    ("temp_min_c", "temp_max_c"): "6/18", "thunder_level_max": "mittel",
     "gust_max_kmh": "25 km/h", "freezing_level_m": "3000 m", "pop_max_pct": "55 %",
     "humidity_avg_pct": "70 %", "dewpoint_avg_c": "5 °C",
     "snowfall_limit_m": "2200 m", "precip_type_dominant": "Regen",
@@ -2999,16 +3009,115 @@ def _s2_zellenzahl(zelle: str) -> float:
     return float(treffer.group().replace(",", "."))
 
 
+def _s2_zellenseiten(zelle: str) -> tuple[str, str]:
+    """#1848 A1: zerlegt eine zusammengefuehrte Spannen-Zelle (``"min/max"``)
+    in ``(min_teil, max_teil)`` -- GENAU EIN Trenn-Schraegstrich erwartet,
+    sonst ``AssertionError`` statt stillem Vorbeigehen (haelt insbesondere
+    negative Werte wie ``"-12/-4"`` aus, ohne am fuehrenden Minuszeichen zu
+    splitten). Die fehlende Seite (``"13/-"``) bleibt als String ``"-"``
+    erhalten -- die Zahl-Interpretation ist Sache des Aufrufers, ein
+    stilles Ueberspringen hier waere selbst wieder ein verstummter
+    Schutz."""
+    teile = zelle.strip().split("/")
+    assert len(teile) == 2, (
+        f"Erwartet genau EINEN Trenner '/' in der Spannen-Zelle {zelle!r}, "
+        f"gefunden: {len(teile) - 1}"
+    )
+    return teile[0], teile[1]
+
+
+def test_s2_zellenseiten_haelt_negative_werte_aus():
+    """#1848 A1: ``-12/-4`` (AC-4) darf NICHT am fuehrenden Minuszeichen
+    splitten -- ein spaeterer Trennerwechsel oder eine naive
+    Split-Implementierung faellt hier auf, nicht erst live in AC-S2-8."""
+    assert _s2_zellenseiten("-12/-4") == ("-12", "-4")
+
+
+def test_s2_zellenseiten_fehlende_seite_bleibt_als_strich_sichtbar():
+    """#1848 A1 (AC-6): ``13/-`` -- die fehlende Seite bleibt der String
+    ``"-"``, wird NICHT stillschweigend uebersprungen oder als Zahl
+    interpretiert. ``_s2_seiten_wert`` MUSS an dieser Seite laut
+    scheitern (kein ``except``/``continue``, der den Fall verstummt) --
+    genau das ist die Zusicherung, kein Nebeneffekt."""
+    min_teil, max_teil = _s2_zellenseiten("13/-")
+    assert min_teil == "13"
+    assert max_teil == "-"
+    with pytest.raises(AssertionError):
+        _s2_seiten_wert("13/-", "max")
+
+
+def _s2_seite_von_feld(spalte: dict, feld: str) -> str:
+    """#1848 A1: ``"min"``/``"max"`` -- welche Seite der zusammengefuehrten
+    Spannen-Spalte ``spalte`` das Rohfeld ``feld`` besetzt. ``None``, wenn
+    ``spalte`` gar keine Spannen-Spalte ist (``summary_field`` kein Tupel)."""
+    if not isinstance(spalte["summary_field"], tuple):
+        return None
+    lo_feld, hi_feld = spalte["summary_field"]
+    if feld == lo_feld:
+        return "min"
+    if feld == hi_feld:
+        return "max"
+    raise AssertionError(
+        f"Feld {feld!r} gehoert nicht zur Spannen-Spalte {spalte['key']!r} "
+        f"({spalte['summary_field']!r})"
+    )
+
+
+def _s2_seiten_wert(zelle: str, seite: str) -> float:
+    """#1848 A1: der numerische Wert EINER Seite (``"min"``/``"max"``) einer
+    Spannen-Zelle -- fuer den Anti-Vertauschungs-Schutz AC-S2-8, der pro
+    Feld die EIGENE Seite prueft statt nur die fuehrende Zahl der Zelle
+    (die waere bei einer Spannen-Zelle immer die Min-Seite, egal welches
+    der beiden Felder gerade geprueft wird -- der Vertauschungs-Schutz
+    waere strukturell blind fuer die Max-Seite)."""
+    min_teil, max_teil = _s2_zellenseiten(zelle)
+    roh = {"min": min_teil, "max": max_teil}[seite]
+    treffer = _S2_ZELLENZAHL.match(roh.strip())
+    assert treffer is not None, (
+        f"AC-S2-8: die {seite}-Seite der Spannen-Zelle {zelle!r} traegt "
+        f"keine Zahl ({roh!r}) -- ohne Zahl ist der Wert nicht pruefbar"
+    )
+    return float(treffer.group().replace(",", "."))
+
+
 def test_ac_s2_8_ausblick_zelle_zeigt_den_gerechneten_wert():
     """AC-S2-8 (Wirkort): derselbe gerechnete Tageswert steht in der Zelle der
     ECHTEN Vergleichs-Mail -- HTML UND Klartext, an jedem der drei Tage. Der
     Nachweis an ``summarize_points()`` allein zeigte nur, dass das Aggregat
     stimmt, nicht dass der Nutzer den richtigen Wert sieht (Pruefort =
-    Wirkort)."""
+    Wirkort).
+
+    #1848 A1: wind_chill_min_c/wind_chill_max_c teilen sich seit dem Merge
+    EINE Spannen-Zelle (``"min/max"``) statt zweier eigener Spalten. Der
+    Anti-Vertauschungs-Schutz (Adversary-Finding F001) prueft deshalb NICHT
+    mehr nur die fuehrende Zahl der Zelle (die waere fuer beide Felder
+    identisch -- die Min-Seite -- und liesse eine Vertauschung von
+    Min/Max unsichtbar), sondern splittet die Zelle und prueft JEDE Seite
+    gegen ihren EIGENEN gerechneten Wert (``_s2_seiten_wert``). Mutations-
+    Gegenprobe (String-Ersetzung in weather_metrics.py, Sicherungskopie,
+    kein git-checkout/-stash/-reset): mit vertauschten wind_chill_min_c/
+    wind_chill_max_c-Zuweisungen wird dieser Test ROT -- Protokoll in der
+    Commit-Message."""
     erwartungen = _s2_erwartungen_je_ausblickstag()
     _s2_erwartungen_sind_unterscheidbar(erwartungen)
-    nach_feld = {s["summary_field"]: s for s in _S2_SOLL}
-    dezimalen = {e["key"]: e.get("decimals") or 0 for e in get_compare_metric_catalog()}
+    # #1848 A1: `summary_field` ist fuer gemergte Spalten ein Tupel beider
+    # Rohfelder -- BEIDE muessen auf dieselbe Spalte zeigen, damit
+    # `_S2_NEUE_FELDER_REGEL["wind_chill_min_c"]` UND
+    # `_S2_NEUE_FELDER_REGEL["wind_chill_max_c"]` dieselbe Zelle finden.
+    nach_feld: dict[str, dict] = {}
+    for s in _S2_SOLL:
+        felder = s["summary_field"] if isinstance(s["summary_field"], tuple) else (s["summary_field"],)
+        for f in felder:
+            nach_feld[f] = s
+    # #1848 A1: Schluessel MUSS der SegmentWeatherSummary-Feldname sein (wie
+    # `feld` unten aus `_S2_NEUE_FELDER_REGEL`) -- der Katalog-``key`` weicht
+    # fuer wind_direction_avg_deg vom Feldnamen ab (``key`` "wind_direction_
+    # deg"), und ein gemergter Soll-Eintrag hat gar keinen einzelnen ``key``
+    # mehr, der beide Seiten trueg.
+    dezimalen = {
+        summary_field_for(e["metric_id"], e["aggregation"]): e.get("decimals") or 0
+        for e in get_compare_metric_catalog()
+    }
 
     html, text = _s2_mail()
     kopf, zeilen = _s2_html_ausblick(html)
@@ -3022,17 +3131,21 @@ def test_ac_s2_8_ausblick_zelle_zeigt_den_gerechneten_wert():
     for nummer, (tag, soll) in enumerate(erwartungen):
         for feld, regel in _S2_NEUE_FELDER_REGEL.items():
             spalte = nach_feld[feld]
-            erwartet = round(soll[feld], dezimalen[spalte["key"]])
+            erwartet = round(soll[feld], dezimalen[feld])
+            seite = _s2_seite_von_feld(spalte, feld)
             for form, zelle in (
                 ("HTML", zeilen[nummer][kopf.index(spalte["ueberschrift"])]),
                 ("KLARTEXT", klartext[nummer][spalte["ueberschrift"]]),
             ):
-                assert _s2_zellenzahl(zelle) == erwartet, (
+                ist = _s2_seiten_wert(zelle, seite) if seite else _s2_zellenzahl(zelle)
+                assert ist == erwartet, (
                     f"AC-S2-8: die {form}-Zelle der Spalte "
                     f"{spalte['ueberschrift']!r} ({spalte['key']} -> "
-                    f"SegmentWeatherSummary.{feld}) zeigt am Ausblickstag {tag} "
-                    f"{zelle!r}; aus den Stundenwerten gerechnet ({regel}) "
-                    f"gehoert dort {erwartet!r} hin.\nSoll des Tages: {soll}\n"
+                    f"SegmentWeatherSummary.{feld}"
+                    f"{f', Seite {seite}' if seite else ''}) zeigt am "
+                    f"Ausblickstag {tag} {ist!r} (Zelle {zelle!r}); aus den "
+                    f"Stundenwerten gerechnet ({regel}) gehoert dort "
+                    f"{erwartet!r} hin.\nSoll des Tages: {soll}\n"
                     "Haeufigster Grund: vertauschte Zuweisungen in "
                     "summarize_points() -- bei Gefuehlter Temperatur "
                     "Minimum/Maximum zeigen dann beide Spalten einen "

--- a/tests/tdd/test_channel_metric_matrix.py
+++ b/tests/tdd/test_channel_metric_matrix.py
@@ -2561,9 +2561,13 @@ def test_ac_s2_2_soll_menge_wird_gerechnet_und_ist_plausibel():
     from output.renderers.compare_outlook_metric_ids import resolve_outlook_metrics
 
     aufgeloest = resolve_outlook_metrics(list(_S2_SOLL_PAARE))
-    assert aufgeloest is not None and len(aufgeloest) == len(_S2_SOLL), (
+    # #1848 A1: ``resolve_outlook_metrics()`` arbeitet auf PAAR-Ebene (vor
+    # dem Spalten-Merge) -- Massstab ist deshalb die flache Paar-Menge
+    # ``_S2_SOLL_PAARE``, nicht mehr die (seither kleinere) Spalten-Menge
+    # ``_S2_SOLL``.
+    assert aufgeloest is not None and len(aufgeloest) == len(_S2_SOLL_PAARE), (
         f"AC-S2-2: ``resolve_outlook_metrics()`` verwirft "
-        f"{len(_S2_SOLL) - len(aufgeloest or [])} der {len(_S2_SOLL)} "
+        f"{len(_S2_SOLL_PAARE) - len(aufgeloest or [])} der {len(_S2_SOLL_PAARE)} "
         "Katalog-Paare -- Katalog-Zugehoerigkeit und Feld-Aufloesung sind "
         "auseinandergelaufen, die verworfenen Groessen haetten gar keine Spalte"
     )
@@ -2583,13 +2587,31 @@ def test_ac_s2_3_keine_zwei_spalten_mit_gleicher_beschriftung():
     Beschriftung. Die Unterscheidung entsteht dadurch, dass die Auswertung
     angehaengt wird, sobald derselbe Name mehrfach vorkommt -- die
     Vakuum-Gegenprobe stellt sicher, dass dieser Zweig ueberhaupt greift
-    (sonst prueft der Test eine Regel, die nie zur Anwendung kommt)."""
-    mehrfach = [n for n, anzahl in Counter(s["label"] for s in _S2_SOLL).items()
+    (sonst prueft der Test eine Regel, die nie zur Anwendung kommt).
+
+    #1848 A1 (PO-Entscheid 2026-08-20): die frueher EINZIGEN zwei mehrfach
+    vorkommenden Groessen (Temperatur, Gefuehlte Temperatur -- beide
+    min+max) werden seither zu je EINER Spannen-Spalte zusammengefuehrt
+    (``_merge_min_max_soll``) und loesen die Minimum-/Maximum-
+    Disambiguierung damit nicht mehr aus -- der reale Katalog liefert
+    heute keine Mehrfach-Beschriftung mehr. Die Vakuum-Gegenprobe braucht
+    deshalb einen synthetischen Katalog-Ausschnitt mit einer DRITTEN
+    Auswertung derselben Groesse (Vorbild fuer ein kuenftiges ``avg`` bei
+    Temperatur, Scheibe A3): min+max mergen weiterhin, die dritte bleibt
+    eine eigene, disambiguierte Spalte -- GENAU der Zweig, den dieser Test
+    bewacht."""
+    _temp_max_zeile = next(e for e in COMPARE_METRIC_CATALOG if e["key"] == "temp_max_c")
+    _synthetische_dritte_auswertung = {
+        **_temp_max_zeile, "key": "temp_avg_c_ac_s2_3_synthetisch", "aggregation": "avg",
+    }
+    synthetisch = list(COMPARE_METRIC_CATALOG) + [_synthetische_dritte_auswertung]
+    soll_synthetisch = compare_outlook_soll_spalten(entries=synthetisch)
+    mehrfach = [n for n, anzahl in Counter(s["label"] for s in soll_synthetisch).items()
                 if anzahl > 1]
     assert mehrfach, (
-        "Vakuum: keine Groesse kommt im Ausblick-Katalog mehrfach vor -- die "
-        "Auswertungs-Unterscheidung waere nie aktiv und dieser Test bewachte "
-        "nichts (gemessen 2026-08-11: 'Temperatur' und 'Gefuehlte Temperatur')"
+        "Vakuum: auch mit einer synthetischen dritten Auswertung derselben "
+        "Groesse kommt kein Label mehrfach vor -- die Auswertungs-"
+        "Unterscheidung waere nie aktiv und dieser Test bewachte nichts"
     )
 
     html, _ = _s2_mail()

--- a/tests/tdd/test_compare_outlook.py
+++ b/tests/tdd/test_compare_outlook.py
@@ -202,8 +202,10 @@ def test_compare_plain_shows_outlook_per_location():
 
     text = render_comparison_text(result, outlook_enabled=True)
 
-    assert "9–20°C" in text, "Innsbruck-Ausblick (Tag 2: 9-20°C) fehlt im Klartext"
-    assert "21–33°C" in text, "Fréjus-Ausblick (Tag 2: 21-33°C) fehlt im Klartext"
+    # #1848 A1 AC-9: Trenner auf den SMS-Schraegstrich gezogen (vorher Halb-
+    # geviertstrich "9–20°C") -- RED bis der Altform-Klartext mitgezogen ist.
+    assert "9/20°C" in text, "Innsbruck-Ausblick (Tag 2: 9/20°C) fehlt im Klartext"
+    assert "21/33°C" in text, "Fréjus-Ausblick (Tag 2: 21/33°C) fehlt im Klartext"
 
 
 # ---------------------------------------------------------------------------
@@ -394,8 +396,9 @@ def test_outlook_enabled_false_suppresses_both_formats(compare_env, tmp_path):
         "Ausblick-Tabelle sichtbar trotz outlook_enabled=False"
     )
     assert _OUTLOOK_TABLE_MARKER in html_on, "Ausblick-Tabelle fehlt trotz outlook_enabled=True"
-    assert "9–20°C" not in text_off, "Klartext-Ausblick sichtbar trotz outlook_enabled=False"
-    assert "9–20°C" in text_on, "Klartext-Ausblick fehlt trotz outlook_enabled=True"
+    # #1848 A1 AC-9: neuer Trenner "/" statt "–" (s. Kommentar oben).
+    assert "9/20°C" not in text_off, "Klartext-Ausblick sichtbar trotz outlook_enabled=False"
+    assert "9/20°C" in text_on, "Klartext-Ausblick fehlt trotz outlook_enabled=True"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tdd/test_compare_outlook_metric_selection.py
+++ b/tests/tdd/test_compare_outlook_metric_selection.py
@@ -262,7 +262,10 @@ def test_plain_outlook_shows_same_selection_as_html():
     )
 
     joined = "\n".join(body)
-    assert "9–27°C" not in joined, (
+    # #1848 A1 AC-9: neuer Trenner "/" statt "–" -- Negativprobe muss gegen
+    # den AKTUELLEN Altform-Trenner pruefen, sonst waere sie gegen einen
+    # bereits abgeloesten Trenner trivial wahr.
+    assert "9/27°C" not in joined, (
         "Der Klartext-Ausblick zeigt weiterhin den festen Temperatur-Spannen-Token "
         f"der abgewaehlten Sieben-Spalten-Form: {day2_line!r} (AC-2)"
     )

--- a/tests/tdd/test_kompaktmail_ausblick_tagesfenster.py
+++ b/tests/tdd/test_kompaktmail_ausblick_tagesfenster.py
@@ -361,7 +361,15 @@ def test_unzerlegbarer_tagestoken_faellt_auf_kein_gewitter_zurueck():
 # Issue #1488 Scheibe B: Sollwert neu aufgezeichnet -- das Aggregatwort kommt
 # jetzt aus THUNDER_LABEL_DE ("mittel" statt "MED"). Geprueft bleibt die
 # Zweigwahl (Rueckfall auf `thunder_plain` ohne Stundenreihe), nicht das Vokabular.
-_AC5_ALT_ZEILE_SOLL = "Mi  Alte Etappe                9-21C   1.5mm NW22  Tmittel"
+# Issue #1848 Scheibe A1: Sollwert erneut aufgezeichnet -- der Temperatur-Spannen-
+# Trenner ist vom Bindestrich auf den Schraegstrich gewechselt ("9-21C" -> "9/21C").
+# Grund: PO-Entscheid 2026-08-20, EIN Trenner ueber alle Klartext-Flaechen; der
+# Bindestrich ist bei Minusgraden zugleich Trenner und Vorzeichen und damit nicht
+# eindeutig lesbar. Gleiche Lage wie bei #1488 oben (MED -> mittel): geaendert hat
+# sich das VOKABULAR, nicht die hier bewachte Zweigwahl -- der Rueckfall auf
+# `thunder_plain` ohne Stundenreihe bleibt am abschliessenden "Tmittel" ablesbar
+# und unveraendert geprueft.
+_AC5_ALT_ZEILE_SOLL = "Mi  Alte Etappe                9/21C   1.5mm NW22  Tmittel"
 
 _AC5_ALT_ZEILE = dict(
     weekday="Mi", name="Alte Etappe", note=None,

--- a/tests/tdd/test_outlook_range_cell.py
+++ b/tests/tdd/test_outlook_range_cell.py
@@ -1,0 +1,161 @@
+"""RED — #1848 Scheibe A1: Ausblick-Zelle fasst Tief+Hoch als EINE Zelle mit
+Schraegstrich zusammen (SMS-Schreibweise), Trip UND Ortsvergleich, HTML UND
+Klartext.
+
+SPEC: docs/specs/modules/outlook_gehzeit_und_spanne.md AC-4..AC-9
+PO-Entscheid 2026-08-20: "9/27", "-12/-4", "13/-" -- KEIN Leerzeichen um den
+Schraegstrich, vorhandenes Minuszeichen bleibt an der Trennstelle erhalten,
+kein Einheiten-Suffix in der Zelle selbst (anders als die feste Altform,
+s. AC-9-Aenderungen in test_compare_outlook.py/test_compare_outlook_metric_
+selection.py -- dort bleibt das °C-Suffix, nur der Trenner wechselt).
+
+Getestet wird ausschliesslich das BEOBACHTBARE Ergebnis (``row["cells"]``
+bzw. der gerenderte HTML-/Klartext-Zellentext), nicht die interne Aufteilung
+zwischen ``outlook_columns()``/``format_outlook_value()`` und der
+``cells``-Schleife von ``build_outlook_row()`` -- die Spec laesst dem
+GREEN-Schritt hier ausdruecklich die Wahl ("geteilt zwischen Trip und
+Compare, keine zweite Kopie").
+
+Kern-Schicht: keine Mocks, kein Netz. Pfadregel #1409: Aufloesung relativ zu
+dieser Testdatei.
+"""
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+
+from bs4 import BeautifulSoup
+
+from app.models import SegmentWeatherSummary
+from output.renderers.email.outlook import (
+    build_outlook_row, render_outlook_plain, render_outlook_table,
+)
+
+_UTC = timezone.utc
+_TEMP_BOTH = [
+    {"metric_id": "temperature", "aggregation": "max"},
+    {"metric_id": "temperature", "aggregation": "min"},
+]
+_TEMP_MAX_ONLY = [{"metric_id": "temperature", "aggregation": "max"}]
+
+
+def _row(summary, metrics):
+    return build_outlook_row(summary, points=[], weekday="Mo", tz=_UTC, metrics=metrics)
+
+
+# ---------------------------------------------------------------------------
+# AC-4 -- negative Werte, Minuszeichen bleibt an der Trennstelle erhalten
+# ---------------------------------------------------------------------------
+
+def test_ac4_negative_min_and_max_form_one_cell_with_slash():
+    """AC-4: Given Temperatur min UND max gewaehlt, Werte -12 C / -4 C / When
+    die Ausblick-Zelle gerendert wird / Then zeigt sie genau EINE Zelle mit
+    dem Text ``-12/-4`` -- nicht zwei Spalten, kein verlorenes Minuszeichen."""
+    summary = SegmentWeatherSummary(temp_min_c=-12.0, temp_max_c=-4.0)
+    row = _row(summary, _TEMP_BOTH)
+    assert row["cells"] == ["-12/-4"], (
+        f"Erwartet genau EINE Zelle '-12/-4', erhalten: {row['cells']} -- "
+        "Tief und Hoch werden weiterhin als zwei getrennte Spalten gerendert."
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-5 -- nur eine Auswertung gewaehlt bleibt Einzelwert (Regressionsschutz)
+# ---------------------------------------------------------------------------
+
+def test_ac5_single_selected_aggregation_stays_a_single_value():
+    """AC-5: Given nur Temperatur-Max gewaehlt (min NICHT gewaehlt) / When
+    die Ausblick-Zelle gerendert wird / Then zeigt sie weiterhin einen
+    Einzelwert ohne Schraegstrich -- eine reine Konfigurationsauswahl darf
+    nicht mit einer Datenluecke (AC-6) verwechselt werden.
+
+    GRUEN erwartet -- Bestandsverhalten, das erhalten bleiben MUSS."""
+    summary = SegmentWeatherSummary(temp_min_c=-12.0, temp_max_c=13.0)
+    row = _row(summary, _TEMP_MAX_ONLY)
+    assert len(row["cells"]) == 1 and "/" not in row["cells"][0], (
+        f"Einzelauswahl zeigt einen Schraegstrich oder mehrere Zellen: {row['cells']}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-6 -- beide gewaehlt, aber eine Seite fehlt (Datenluecke, nicht Auswahl)
+# ---------------------------------------------------------------------------
+
+def test_ac6_missing_side_shows_dash_not_two_columns():
+    """AC-6: Given Temperatur min UND max gewaehlt, aber fuer diese Etappe
+    liegt nur der Hoch-Wert vor (Fail-soft-Rueckfall liefert nur eine Seite)
+    / When die Ausblick-Zelle gerendert wird / Then zeigt sie den
+    vorhandenen Wert und einen Strich fuer die fehlende Seite: ``13/-`` --
+    unterscheidbar von AC-5 dadurch, dass hier BEIDE Auswertungen gewaehlt
+    waren."""
+    summary = SegmentWeatherSummary(temp_min_c=None, temp_max_c=13.0)
+    row = _row(summary, _TEMP_BOTH)
+    assert row["cells"] == ["13/-"], (
+        f"Erwartet genau EINE Zelle '13/-' (Hoch vorhanden, Tief fehlt), "
+        f"erhalten: {row['cells']}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-7 -- HTML und Klartext derselben Mail zeigen dieselbe Zelle
+# ---------------------------------------------------------------------------
+
+def test_ac7_html_and_plain_show_the_same_range_cell():
+    """AC-7: Given eine Trip-Mail mit gewaehlter Temperatur-Spanne / When
+    HTML- und Klartext-Teil derselben Mail verglichen werden / Then zeigen
+    beide dieselbe Schraegstrich-Zelle fuer dieselbe Etappe (Muster
+    ``test_plain_outlook_shows_same_selection_as_html``, #1366-Fehlerklasse)."""
+    summary = SegmentWeatherSummary(temp_min_c=9.0, temp_max_c=27.0)
+    row = _row(summary, _TEMP_BOTH)
+
+    html = render_outlook_table([row], show_acc=False, metrics=_TEMP_BOTH)
+    plain = render_outlook_plain(
+        [row], show_acc=False, metrics=_TEMP_BOTH, heading="Ausblick", show_name=False,
+    )
+
+    soup = BeautifulSoup(html, "html.parser")
+    tds = soup.find_all("td")
+    assert len(tds) >= 2, f"HTML-Tabelle hat keine Datenzelle: {html}"
+    html_cell = tds[1].get_text(strip=True)
+
+    zahlen = re.findall(r"-?\d+/-?\d+|-?\d+/-", plain)
+    assert zahlen, f"Klartext enthaelt keine Spannen-Zelle: {plain!r}"
+    plain_cell = zahlen[0]
+
+    assert html_cell == plain_cell == "9/27", (
+        f"HTML zeigt {html_cell!r}, Klartext zeigt {plain_cell!r} -- beide "
+        "muessen '9/27' zeigen (#1366-Fehlerklasse: HTML und Klartext laufen "
+        "auseinander)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-8 -- Ortsvergleich ohne Gehzeit: Spannen-Zelle gilt trotzdem
+# ---------------------------------------------------------------------------
+
+def test_ac8_compare_range_cell_without_hiking_shows_slash_too():
+    """AC-8: Given ein Ortsvergleich mit ``outlook_metrics``, die Temperatur
+    min UND max waehlen, ohne Gehzeit (kein Trip, keine Segmente) / When der
+    Ausblick fuer einen Ort gerendert wird / Then zeigt auch dort eine Zelle
+    die Schraegstrich-Spanne -- Punkt 2 gilt geraeteuebergreifend. Aufruf
+    exakt wie ``email/compare_html.py::_build_location_outlook_rows()``:
+    ``summarize_points()`` statt ``aggregate_stage()``, KEIN
+    ``trip_display_config``, KEINE Segmente -- darf nicht abstuerzen."""
+    from app.models import ForecastDataPoint, ThunderLevel
+    from services.weather_metrics import summarize_points
+
+    day_points = [
+        ForecastDataPoint(
+            ts=datetime(2026, 7, 20, h, 0, tzinfo=_UTC), t2m_c=t,
+            thunder_level=ThunderLevel.NONE,
+        )
+        for h, t in ((2, 9.0), (14, 27.0), (20, 15.0))
+    ]
+    summary = summarize_points(day_points)
+    assert summary is not None, "Testaufbau: summarize_points() liefert kein Aggregat"
+
+    row = build_outlook_row(summary, day_points, "Mo", _UTC, metrics=_TEMP_BOTH)
+
+    assert row["cells"] == ["9/27"], (
+        f"Ortsvergleich-Ausblick ohne Gehzeit zeigt keine Spannen-Zelle: {row['cells']}"
+    )

--- a/tests/tdd/test_outlook_scheduler_wires_hiking_window.py
+++ b/tests/tdd/test_outlook_scheduler_wires_hiking_window.py
@@ -1,0 +1,141 @@
+"""#1848 A1, Adversary-Nachzug (implementation-validator, 2026-08-20):
+`_build_stage_trend()` muss das Gehzeit-Fenster (AC-1) bis in die
+gerenderte Ausblick-Zeile durchreichen -- nicht nur `build_outlook_row()`
+isoliert.
+
+**Warum dieser Test noetig ist.** AC-1..AC-3 riefen bisher ausschliesslich
+`build_outlook_row()` DIREKT auf, mit von Hand gebautem
+`hiking_extrema={"t2m_c": hiking}` (`test_outlook_uses_hiking_window.py`).
+Das beweist, dass `build_outlook_row()` einen Override RICHTIG anwendet --
+nicht, dass der Scheduler ihn tatsaechlich UEBERGIBT. Die Zusicherung war
+dort geprueft, wo der Code STEHT (`outlook.py`), nicht wo er WIRKT
+(`trip_report_scheduler.py::_build_stage_trend()`, Zeile ~2348
+`segments=seg_weather`). Der Adversary hat das per Mutation belegt: mit
+`segments=None` blieben ALLE 625 Tests gruen -- exakt die Fehlerklasse,
+die #1417 schon einmal ausgeloest hat (SMS/Telegram/Kurzzusammenfassung
+umgestellt, Ausblick vergessen, monatelang unbemerkt, weil keine Wache an
+der Naht sass).
+
+Dieser Test ruft `_build_stage_trend()` -- den ECHTEN Scheduler-Pfad --
+auf einer echten `TripReportSchedulerService`-Unterklasse, die nur die
+drei Netz-/Fetch-Schritte ersetzt (Vorbild
+`test_outlook_day_night_thunder_split.py::_TrendSchedulerWithFixedWeather`,
+Muster fuer #1653 Adversary-Finding F001 -- dieselbe Fehlerklasse: eine
+Fenster-/Override-Uebergabe, die nur an der Aufrufstelle geprueft wird,
+nicht an der Verdrahtung dahinter).
+
+Kern-Schicht: keine Mocks, kein Netz, echte Segmente aus dem
+Produktivpfad (`_hiking_window_fixtures.build_segments()` ->
+`SegmentWeatherService._aggregate_for_segment()`).
+"""
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
+
+from tests.tdd import _hiking_window_fixtures as F
+
+
+class _SchedulerWithFixedSegments:
+    """Echter Scheduler -- `_build_stage_trend()` laeuft UNVERAENDERT --,
+    nur die drei Netz-/Fetch-Schritte durch feste Werte ersetzt."""
+
+    @staticmethod
+    def build(segments):
+        from services.trip_report_scheduler import TripReportSchedulerService
+
+        class _Fixed(TripReportSchedulerService):
+            def _convert_trip_to_segments(self, trip, target_date):
+                # Rueckgabewert ist irrelevant -- _fetch_weather() unten
+                # ignoriert ihn und liefert die festen Segmente.
+                return ["ein-segment"]
+
+            def _fetch_weather(self, seg, provider=None):
+                return segments
+
+            def _enrich_ensemble_for_trip(self, trip, weather_data):
+                return None
+
+        return _Fixed()
+
+
+def _trip_with_stage(stage_date: date):
+    from app.trip import Stage, Trip, Waypoint
+
+    return Trip(
+        id="i1848-a1-wiring", name="Wiring-Test",
+        stages=[Stage(
+            id="S1", name="E7", date=stage_date,
+            waypoints=[Waypoint(id="W1", name="Ort", lat=42.0, lon=9.0, elevation_m=500)],
+        )],
+    )
+
+
+def test_ac1_vorbedingung_stage_aggregat_und_gehzeit_fenster_divergieren():
+    """Kein AC, Testaufbau-Beleg (Muster #1841/#1848-A1-Vorlage): die
+    Konstellation ``extremwert_an_der_ankunftsstunde`` muss ueberhaupt
+    divergieren, sonst prueft der Wiring-Test unten nichts.
+
+    GEMESSEN (nicht von Hand geschaetzt): ``aggregate_stage()`` liefert
+    ``temp_max_c=15.0`` (Segment 2s EXKLUSIVES Fenster [10,12) schliesst
+    die Ankunftsstunde 12 Uhr aus -- keine andere Stunde im Etappenfenster
+    traegt einen Extremwert, die Basis-Temperatur 15.0 C bleibt Maximum).
+    ``hiking_field_min_max()`` liefert ``22.0`` (das Gehzeit-Fenster
+    schliesst die Ankunftsstunde beim LETZTEN Segment INKLUSIVE ein --
+    genau dort liegt mit 22.0 C die waermste Stunde des Tages)."""
+    from output.renderers.day_window import (
+        collect_hiking_window_points, hiking_field_min_max,
+    )
+    from services.weather_metrics import aggregate_stage
+
+    segments = F.CONSTELLATIONS_BY_NAME["extremwert_an_der_ankunftsstunde"].segments()
+    agg = aggregate_stage(segments)
+    hiking = hiking_field_min_max(collect_hiking_window_points(segments), "t2m_c")
+
+    assert agg.temp_max_c == 15.0, (
+        f"Vorbedingung verletzt: Etappenaggregat-Hoch ist {agg.temp_max_c}, "
+        "erwartet 15.0 -- die Konstellation liefert nicht mehr das gemessene "
+        "Ausgangs-Setup, der Wiring-Test unten koennte nichts pruefen."
+    )
+    assert hiking is not None and hiking[1] == 22.0, (
+        f"Vorbedingung verletzt: Gehzeit-Hoch ist {hiking}, erwartet 22.0."
+    )
+    assert int(agg.temp_max_c) != int(hiking[1]), (
+        f"Vorbedingung verletzt: Etappenaggregat ({agg.temp_max_c}) und "
+        f"Gehzeit-Hoch ({hiking[1]}) sind (gerundet) gleich -- der Wiring-"
+        "Test koennte eine kaputte Verdrahtung nicht von einer intakten "
+        "unterscheiden."
+    )
+
+
+def test_ac1_scheduler_wiring_carries_hiking_window_into_the_outlook_row():
+    """AC-1 (Wirkort): der ECHTE Scheduler-Pfad (``_build_stage_trend()``,
+    NICHT ``build_outlook_row()`` direkt) muss das Gehzeit-Fenster bis in
+    die gerenderte Ausblick-Zeile durchreichen -- die Ankunftsstunde traegt
+    hier das Tageshoch (22.0 C), das volle Etappenfenster sieht dagegen nur
+    15.0 C (Vorbedingung oben gemessen und belegt).
+
+    Positivkontrolle per Mutation (Pflicht-Nachweis, s. Commit-Message):
+    ``segments=seg_weather`` -> ``segments=None`` in
+    ``trip_report_scheduler.py::_build_stage_trend()`` macht GENAU diesen
+    Test rot -- der Ausblick faellt dann fail-soft auf das
+    Etappenaggregat (15) zurueck, dieser Test erwartet aber 22."""
+    segments = F.CONSTELLATIONS_BY_NAME["extremwert_an_der_ankunftsstunde"].segments()
+
+    stage_date = date.today() + timedelta(days=1)
+    trip = _trip_with_stage(stage_date)
+    service = _SchedulerWithFixedSegments.build(segments)
+
+    result = service._build_stage_trend(
+        trip, date.today(), now_utc=datetime.now(timezone.utc), tz=ZoneInfo("UTC"),
+    )
+
+    assert result.rows, f"Kein Ausblick gebaut (state={result.state}) -- der Test misst sonst nichts."
+    row = result.rows[0]
+    assert row["temp_hi"] == 22, (
+        f"Der ECHTE Scheduler-Pfad zeigt {row['temp_hi']!r} statt 22 (Gehzeit-"
+        "Hoch) -- entweder faellt er auf das Etappenaggregat (15) zurueck "
+        "(die Uebergabe `segments=seg_weather` an build_outlook_row() fehlt "
+        "oder wurde entfernt), oder ein anderer Wert wird geliefert. "
+        f"row={row}"
+    )

--- a/tests/tdd/test_outlook_uses_hiking_window.py
+++ b/tests/tdd/test_outlook_uses_hiking_window.py
@@ -1,0 +1,199 @@
+"""RED — #1848 Scheibe A1: Ausblick liest Temperatur/gefuehlte Temperatur aus
+dem Etappenaggregat statt aus dem Gehzeit-Fenster (Nachzug zu #1417).
+
+SPEC: docs/specs/modules/outlook_gehzeit_und_spanne.md AC-1, AC-2, AC-3
+KONTEXT: docs/context/feat-1848-a1-tagesfenster-kennungen.md, Abschnitt
+"WERT-MESSUNG" (gemessene Sweep-Konstellation, Median-Differenz 1,23 C).
+
+**Nachweisform Funktionsebene, NICHT "in derselben Mail".** Der Ausblick
+zeigt strukturell nie den heutigen Tag (``get_future_stages()`` filtert
+``>``, Spec "Known Limitations") -- ein Vergleich "gleiche Mail" waere nie
+erfuellbar. AC-1/AC-3 rufen ``build_outlook_row()`` mit DENSELBEN
+Segment-Daten auf, die ``sms_trip.py`` fuer den D-/FD-Token derselben Etappe
+verwendet (``collect_hiking_window_points()`` + ``hiking_field_min_max()``,
+Vorbild ``tests/tdd/_hiking_window_fixtures.py``, Issue #1417).
+
+**Angenommene Schnittstelle (RED definiert den Vertrag).** Zum Zeitpunkt
+dieses Tests existiert noch kein Weg, das Gehzeit-Fenster an
+``build_outlook_row()`` zu uebergeben -- die Funktion kennt keine Segmente,
+nur ``summary``+``points`` (flache, ungefensterte Stundenliste ueber ALLE
+Segmente, s. Docstring). Der "Naht"-Abschnitt des Kontexts sagt: der
+Aufrufer (``trip_report_scheduler.py``, hat ``seg_weather`` bereits vorliegen)
+berechnet ``hiking_field_min_max()`` SELBST und reicht das ERGEBNIS als
+optionalen Parameter durch (Vorbild ``sms_thresholds``). Diese Tests nehmen
+dafuer den Parameter ``hiking_extrema: dict[str, tuple] | None`` an -- Keys
+sind die ``ForecastDataPoint``-Feldnamen (``"t2m_c"``/``"wind_chill_c"``,
+identisch zum ``field``-Argument von ``hiking_field_min_max()``), Werte das
+3-Tupel ``(min, max, max_ts)``, wie die Funktion es liefert. Fehlt ein Key
+(oder ist ``hiking_extrema`` ganz ``None``), bleibt der Fail-soft-Rueckfall
+aufs Etappenaggregat unveraendert (AC-2). Der genaue Parametername ist eine
+Implementierungsentscheidung des GREEN-Schritts -- entscheidend ist die
+Zusicherung "Ausblick-Wert == hiking_field_min_max()-Wert bei gesetztem
+Override", nicht der Name selbst.
+
+RED heute: ``TypeError: unexpected keyword argument 'hiking_extrema'`` fuer
+AC-1/AC-3 (Parameter existiert nicht) -- ehrlich rot aus dem richtigen
+Grund, nicht aus einem Tippfehler.
+
+Kern-Schicht: keine Mocks, kein Netz. Segmente/Aggregate kommen aus dem
+ECHTEN Produktivpfad (``SegmentWeatherService._aggregate_for_segment()``
+ueber ``_hiking_window_fixtures.build_segments()``). Pfadregel #1409:
+Aufloesung relativ zu dieser Testdatei (``from tests.tdd import ...``).
+"""
+from __future__ import annotations
+
+from app.models import SegmentWeatherSummary
+from tests.tdd import _hiking_window_fixtures as F
+
+
+def _summary_and_segments(name: str):
+    """Etappenaggregat (wie build_outlook_row es heute liest) UND die
+    zugrundeliegenden Segmente derselben Sweep-Konstellation."""
+    from services.weather_metrics import aggregate_stage
+
+    segments = F.CONSTELLATIONS_BY_NAME[name].segments()
+    return aggregate_stage(segments), segments
+
+
+def _hiking(segments, field: str):
+    from output.renderers.day_window import (
+        collect_hiking_window_points, hiking_field_min_max,
+    )
+
+    return hiking_field_min_max(collect_hiking_window_points(segments), field)
+
+
+# ---------------------------------------------------------------------------
+# AC-1 -- Temperatur, fester Altform-Pfad (metrics=None): temp_hi/temp_lo
+# ---------------------------------------------------------------------------
+
+def test_ac1_vorbedingung_etappenaggregat_und_gehzeit_liefern_verschiedene_werte():
+    """Kein AC, Testaufbau-Beleg: die gewaehlte Konstellation muss ueberhaupt
+    divergieren, sonst pruefte AC-1 nichts (Muster #1841-Vorlage)."""
+    summary, segments = _summary_and_segments("extremwert_an_der_ankunftsstunde")
+    hiking = _hiking(segments, "t2m_c")
+    assert hiking is not None, "Sweep-Konstellation liefert kein Gehzeit-Fenster"
+    assert int(summary.temp_max_c) != int(hiking[1]), (
+        f"Vorbedingung verletzt: Etappenaggregat ({summary.temp_max_c}) und "
+        f"Gehzeit-Hoch ({hiking[1]}) sind gleich -- AC-1 koennte nichts pruefen."
+    )
+
+
+def test_ac1_altform_temp_hi_matches_hiking_window_not_stage_aggregate():
+    """AC-1: Given eine Etappe, deren Ankunftsstunde im Gehzeit-Fenster das
+    Tageshoch traegt, im vollen Etappenfenster aber nicht / When der
+    Trip-Ausblick (feste Altform) fuer diese Etappe gerendert wird / Then
+    zeigt die Temperatur-Hoch-Spalte denselben Wert wie
+    ``hiking_field_min_max(collect_hiking_window_points(seg_weather), "t2m_c")``
+    -- nicht mehr ``summary.temp_max_c`` des vollen Etappenfensters."""
+    from output.renderers.email.outlook import build_outlook_row
+
+    summary, segments = _summary_and_segments("extremwert_an_der_ankunftsstunde")
+    hiking = _hiking(segments, "t2m_c")
+
+    row = build_outlook_row(
+        summary, points=[], weekday="Mo", tz=F.TZ,
+        hiking_extrema={"t2m_c": hiking},
+    )
+
+    assert row["temp_hi"] == int(hiking[1]), (
+        f"Ausblick-Hoch {row['temp_hi']} weicht vom Gehzeit-Hoch {int(hiking[1])} "
+        f"ab (zeigt weiterhin das Etappenaggregat {summary.temp_max_c})."
+    )
+    assert row["temp_lo"] == int(hiking[0]), (
+        f"Ausblick-Tief {row['temp_lo']} weicht vom Gehzeit-Tief {int(hiking[0])} ab."
+    )
+
+
+def test_ac1_configurable_path_temp_cell_matches_hiking_window():
+    """AC-1, zweite Haelfte (Spec "Implementation Details"): derselbe Fehler
+    besteht auch im konfigurierbaren ``cells``-Pfad (``metrics`` gesetzt) --
+    ein Fix, der nur ``temp_lo``/``temp_hi`` ueberschreibt, traefe den in der
+    Praxis ueberwiegend aktiven Pfad NICHT."""
+    from output.renderers.email.outlook import build_outlook_row
+
+    summary, segments = _summary_and_segments("extremwert_an_der_ankunftsstunde")
+    hiking = _hiking(segments, "t2m_c")
+    metrics = [{"metric_id": "temperature", "aggregation": "max"}]
+
+    row = build_outlook_row(
+        summary, points=[], weekday="Mo", tz=F.TZ, metrics=metrics,
+        hiking_extrema={"t2m_c": hiking},
+    )
+
+    cell = row["cells"][0]
+    zahl = cell.split()[0]
+    assert int(float(zahl)) == int(hiking[1]), (
+        f"Konfigurierbare Ausblick-Zelle {cell!r} zeigt nicht das Gehzeit-Hoch "
+        f"{int(hiking[1])} (Etappenaggregat: {summary.temp_max_c})."
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-2 -- leeres Gehzeit-Fenster: Fail-soft-Rueckfall (GRUEN, Regressionsschutz)
+# ---------------------------------------------------------------------------
+
+def test_ac2_fail_soft_keeps_stage_aggregate_when_no_hiking_extrema_supplied():
+    """AC-2: Given ein Segment, dessen Gehzeit-Fenster keinen einzigen
+    Datenpunkt mit ``t2m_c`` traegt (Provider-Luecke) / When der
+    Trip-Ausblick gerendert wird / Then faellt die Temperatur-Zelle
+    fail-soft auf ``summary.temp_min_c``/``temp_max_c`` zurueck statt "-" zu
+    zeigen oder abzustuerzen.
+
+    GRUEN erwartet -- Regressionsschutz, kein Bug-Nachweis: kein Aufrufer
+    liefert fuer diesen Fall einen ``hiking_extrema``-Eintrag (analog zu
+    einem ``hiking_field_min_max()``-Ergebnis von ``None``), der Aufruf
+    entspricht exakt dem heutigen Signaturstand -- muss vor UND nach dieser
+    Aenderung gleich bleiben."""
+    from output.renderers.email.outlook import build_outlook_row
+
+    summary = SegmentWeatherSummary(temp_min_c=3.0, temp_max_c=11.0)
+    row = build_outlook_row(summary, points=[], weekday="Mo", tz=F.TZ)
+
+    assert row["temp_lo"] == 3 and row["temp_hi"] == 11, (
+        f"Fail-soft-Rueckfall gebrochen: temp_lo/temp_hi={row['temp_lo']}/"
+        f"{row['temp_hi']} statt des Etappenaggregats 3/11."
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-3 -- gefuehlte Temperatur, NUR konfigurierbarer Pfad (kein Altform-Weg)
+# ---------------------------------------------------------------------------
+
+def test_ac3_vorbedingung_etappenaggregat_und_gehzeit_liefern_verschiedene_werte():
+    """Kein AC, Testaufbau-Beleg fuer die gefuehlte Temperatur."""
+    summary, segments = _summary_and_segments("extremwert_an_der_ankunftsstunde")
+    hiking = _hiking(segments, "wind_chill_c")
+    assert hiking is not None, "Sweep-Konstellation liefert kein Gehzeit-Fenster (gefuehlt)"
+    assert int(summary.wind_chill_max_c) != int(hiking[1]), (
+        f"Vorbedingung verletzt: Etappenaggregat ({summary.wind_chill_max_c}) und "
+        f"Gehzeit-Hoch ({hiking[1]}) sind gleich -- AC-3 koennte nichts pruefen."
+    )
+
+
+def test_ac3_configurable_path_wind_chill_cell_matches_hiking_window():
+    """AC-3: Given ``outlook_metrics`` waehlt gefuehlte Temperatur max / When
+    der Trip-Ausblick gerendert wird / Then liest die Zelle aus
+    ``hiking_field_min_max(punkte, "wind_chill_c")`` statt aus
+    ``summary.wind_chill_max_c`` des vollen Etappenfensters -- strukturell
+    derselbe Fehler wie AC-1, eigener Test wegen eigenem Datenfeld/Token
+    (``FK``/``FD``, ``sms_trip.py:240``). Gefuehlte Temperatur hat keinen
+    Altform-Weg (Spec "Implementation Details") -- nur der ``cells``-Pfad
+    ist hier zu pruefen."""
+    from output.renderers.email.outlook import build_outlook_row
+
+    summary, segments = _summary_and_segments("extremwert_an_der_ankunftsstunde")
+    hiking = _hiking(segments, "wind_chill_c")
+    metrics = [{"metric_id": "wind_chill", "aggregation": "max"}]
+
+    row = build_outlook_row(
+        summary, points=[], weekday="Mo", tz=F.TZ, metrics=metrics,
+        hiking_extrema={"wind_chill_c": hiking},
+    )
+
+    cell = row["cells"][0]
+    zahl = cell.split()[0]
+    assert int(float(zahl)) == int(hiking[1]), (
+        f"Konfigurierbare Ausblick-Zelle {cell!r} zeigt nicht das gefuehlte "
+        f"Gehzeit-Hoch {int(hiking[1])} (Etappenaggregat: {summary.wind_chill_max_c})."
+    )

--- a/tests/tdd/test_trip_outlook_metric_selection.py
+++ b/tests/tdd/test_trip_outlook_metric_selection.py
@@ -350,8 +350,11 @@ def test_ac11_jede_angebotene_groesse_erscheint_auch_als_spalte():
         f"Nur {len(soll)} Soll-Spalten -- Vakuum-Schutz: ein Waechter ueber "
         "einer geschrumpften Menge ist immer gruen."
     )
-    auswahl = [{"metric_id": e["metric_id"], "aggregation": e["aggregation"]}
-               for e in soll]
+    # #1848 A1: min+max derselben Groesse ergeben EINEN Soll-Eintrag mit
+    # ZWEI Paaren (``paare``) -- die AUSWAHL (was der Picker an den
+    # Renderer schickt) bleibt die FLACHE Paar-Menge, nur die Zahl der
+    # daraus entstehenden SPALTEN (``soll``) sinkt.
+    auswahl = [p for e in soll for p in e["paare"]]
     dc = display_config(enabled_ids={e["metric_id"] for e in soll},
                         outlook_metrics=auswahl)
     kopf = html_outlook_headers(render_trip_mail(dc, outlook_rows(metrics=auswahl))[0])

--- a/tests/tdd/test_trip_outlook_parity.py
+++ b/tests/tdd/test_trip_outlook_parity.py
@@ -27,6 +27,11 @@ in `tests/fixtures/outlook_trip_parity/README.md`:
   * F004, Klartext, Zeile "Mo": "⚡MED" -> "⚡mittel"
   * F004, Klartext, Zeile "Di": "⚡–"   -> "⚡mittel"
 
+NACHGEFUEHRT (#1848 A1 AC-9, 2026-08-20): Klartext, Zeilen "Mo"/"Di", Temperatur-
+Feld: "9–21°C"/"11–19°C" -> "9/21°C"/"11/19°C" -- Altform-Klartext auf denselben
+Schraegstrich-Trenner wie die SMS-Schreibweise gezogen (vollstaendige Begruendung
+in ``tests/fixtures/outlook_trip_parity/README.md``).
+
 Beide Eingabezeilen tragen `hourly_thunder` mit "mittel" um 16 Uhr (im
 Tagesfenster 4-19), waehrend das Aggregat `thunder` einmal "MED" und einmal
 "NONE" sagt — zwei gegenlaeufige Quellen. Die alten Werte "–"/"⚡–" sind genau


### PR DESCRIPTION
## Worum es geht

Der 3-Tages-Ausblick war die **letzte Fläche, die #1417 übersehen hat**. Jenes Ticket stellte SMS, Telegram-Kurzübersicht und E-Mail-Kurzzusammenfassung auf das **Gehzeit-Fenster** um — der Ausblick blieb beim **Etappenaggregat** und zeigt seither ein systematisch **zu kühles Tageshoch**.

**Ursache:** Randbehandlung der Ankunftsstunde. `segment_weather.py:266-273` fenstert `[start_floor, end_floor)` — Endstunde **exklusiv**. `collect_hiking_window_points()` (`day_window.py:210-229`) schließt sie beim **letzten** Segment **ein**. Genau diese eine Stunde ist der Unterschied.

**Gemessen** (Sweep über 60 Konstellationen): 60/60 Fenster strukturell verschieden, **24/60 mit echter Wert-Differenz**, Median **1,23 °C**, Max **1,66 °C**. Gerichtet: `Etappe - Gehzeit <= 0` in **allen 84** geprüften Fällen — die Etappen-Fensterung kann der Gehzeit-Fensterung nur einen Datenpunkt vorenthalten, nie einen hinzugewinnen.

**Warum es nie auffiel:** Der Ausblick zeigt **nie den heutigen Tag** (`get_future_stages()` filtert `s.date > from_date`), die Kachelzeile zeigt `target_date`. Disjunkte Tagesmengen — der Widerspruch ist innerhalb einer Mail strukturell unsichtbar, nur zeitversetzt über zwei Briefings.

## Was sich ändert

| # | Änderung |
|---|---|
| 1 | Trip-Ausblick liest Temperatur **und** gefühlte Temperatur aus dem Gehzeit-Fenster; fail-soft zurück auf `summary.temp_*` |
| 2 | Beide Auswertungen gewählt ⇒ **eine** Zelle `{min}/{max}` mit Schrägstrich (minusfest: `-12/-4`, halbe Datenlage: `13/-`). HTML **und** Klartext, Trip **und** Ortsvergleich |
| 3 | Altform-Klartext auf denselben Trenner gezogen (vorher `9–20°C`, jetzt `9/20°C`) |

PO-Entscheid 2026-08-20: „exakt so wie Temperatur bei SMS heute" — die SMS führt beide Werte als ein Bereichs-Token unter dem Hoch-Kürzel; der Schrägstrich ist minusfest, wo der Halbgeviertstrich zugleich Vorzeichen wäre.

⚠️ **Sichtbar auch ohne Nutzereinstellung:** Punkt 3 betrifft die feste Standard-Ansicht. Vom PO ausdrücklich mit diesem Hinweis freigegeben.

## Abgelöste Entscheidung

Die **paar-basierte Spalten-Sollmenge aus Epic #1703 S2** fällt (26 bewachte Tests). Der Testname lautet „jede wählbare **Größe** ergibt genau eine Spalte", die Sollmenge war aber über **Paare** (`metric_id`+`aggregation`) gebaut — nach dem Merge gilt die Invariante im Sinne ihres Namens unverändert. Angepasst wurde die Soll**menge**, **nicht** die Zusicherung; beide S2-Tests bleiben in Kraft inklusive Gegenrichtung. Dokumentiert in der Spec, Abschnitt „Abgelöste Entscheidung".

**Bewusst stehen geblieben:** die Disambiguierungs-Logik (`compare_outlook_metric_ids.py:144-148`), obwohl sie durch den Merge ins Leere läuft — mit `avg` in A3 hat Temperatur drei Auswertungen und braucht das Suffix wieder. Die Vakuum-Gegenprobe prüft deshalb einen **synthetischen** Katalog-Ausschnitt: am realen wäre sie nach dem Merge **trivial wahr** geworden.

## Nachweise

| Prüfung | Ergebnis |
|---|---|
| Feature- + Matrix-Suite (volles CI-Flag-Set) | **542 passed, 1 dokumentierter Skip, Exit 0** |
| Scheibe-C-Wächter (AC-10) | 21/21 grün, Datei nicht im Diff |
| Adversary | **VERIFIED**, 2 Runden, 14 Punkte belegt |
| Mutationen | 7 geprüft — 6 in Runde 1 gefangen, die 7. durch Auflage geschlossen |
| Produktivcode | **198 / 250 Zeilen**, exakt die 4 in der Spec genannten Dateien |
| Nicht-Ziele | `metric_catalog.py`, `compare_metric_catalog.py`, `segment_weather.py` **nicht im Diff** |

### Das Finding, das nicht abgebucht wurde

Die Mutation `segments=seg_weather` → `segments=None` ließ **625/625 Tests grün**: Der Gehzeit-Wert hätte die Mail nie erreicht, ohne dass es auffällt. Die AC-Tests riefen `build_outlook_row()` **direkt** auf — die Zusicherung war dort geprüft, **wo der Code steht**, nicht dort, **wo sie wirkt**.

Der Adversary schlug einen Sammel-Eintrag vor. Abgelehnt: **Genau diese Fehlerform hat dieses Ticket erzeugt** — #1417 stellte drei Kanäle um und übersah den Ausblick, monatelang unbemerkt, weil an der Naht keine Wache saß.

Nachgezogen: `tests/tdd/test_outlook_scheduler_wires_hiking_window.py` geht den **echten** `_build_stage_trend()`-Pfad. Divergenz **gemessen**, nicht behauptet: Etappenaggregat **15,0 °C** gegen Gehzeit-Fenster **22,0 °C**; ein Vorbedingungstest bricht ab, falls die Fixture die Divergenz je verliert. Positivkontrolle: die Mutation macht die Wache nachweislich rot.

## Nicht enthalten

neue Registerkennungen (⇒ A2) · `avg` bei Temperatur (⇒ A3, heute im Ausblick gar nicht wählbar) · Kanal-Modul im Ausblick (⇒ A3) · Wind-/Böen-Fensterung (⇒ #1199, dort als **ungemessen** gebucht)

Teil von #1848 Scheibe A1. Schließt das Issue **nicht** — A2 und A3 bleiben offen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
