### PR TITLE
fix(#1987): kanalscharfer rollierender Alarm-Anker (S1)

### DIFF
--- a/docs/adr/0056-rollierender-alarm-anker-statt-briefing-only-snapshot.md
+++ b/docs/adr/0056-rollierender-alarm-anker-statt-briefing-only-snapshot.md
@@ -75,3 +75,38 @@ gewählte Umsetzung.
   nur den Briefing-Anker annehmen. Die Trend-Erkennungs-Invariante (AC-9 in
   `docs/specs/modules/trip_alert.md`) ist bei jeder künftigen Änderung an der Schreiblogik als
   Regressionstest zu erhalten.
+
+## Amendment 2026-08-19 (Issue #1987 S1): Kanal-Dimension, Trigger (b) entfällt
+
+Der rollierende Anker aus der Entscheidung oben war **kanalagnostisch** — genau EIN Stand für
+alle vier Kanäle. Damit trug er einen stillen Ausfall in sich: rückte er nach einem Alarm vor,
+der nur auf einem Teil der Kanäle zustellbar war, verlor der nicht bediente Kanal die Änderung
+dauerhaft. Er wurde gegen einen Stand verglichen, den sein Empfänger nie erhalten hat. Auf dem
+Karnischen Höhenweg trifft das den Regelfall, nicht den Ausnahmefall: auf der Hütte kommt nur
+Premium-SMS an, auf dem Pass nur E-Mail und Telegram.
+
+**Ergänzung:** Der rollierende Anker (Tier 2) wird ab #1987 S1 **je Kanal** geführt —
+eine Datei `{trip_id}_alarm_anchor_{channel}.json` je Kanal. Fortgeschrieben wird ein
+Kanal-Merker ausschließlich, wenn dieser Kanal im selben Lauf tatsächlich **zugestellt** hat
+(`NotificationResult.delivered_channels`).
+
+**Ablösung von Trigger (b):** Der opportunistische Auffrisch-Schreibvorgang aus der
+Entscheidung oben entfällt für den kanalscharfen Tier-2-Merker **ersatzlos**. Er lief im Zweig
+„kein Alarm gefeuert" — dort wurde nichts versendet, es gibt also keine Zustellinformation, und
+ein dort geschriebener Merker wäre genau das, was S1 verbietet: ein Stand, den kein Empfänger je
+bekam. Die Schutzwirkung gegen eine veraltete Vergleichsbasis bleibt vollständig erhalten, sie
+wandert vom Schreib- in den **Lesepfad**: ein Kanal-Merker jenseits der Alterungs-Ceiling (4h)
+wird als Kandidat nicht mehr herangezogen, und die Kette fällt für diesen Kanal auf den
+taggleichen Tier-1-Briefing-Anker zurück — ausdrücklich **nicht** auf den Merker eines anderen
+Kanals (Kontaminationsverbot).
+
+**Unverändert:** Trigger (a) (Fortschreibung bei tatsächlichem Versand), der Tier-1-Briefing-
+Anker (`save()`/`save_dated()`, weiterhin unbedingt und kanalagnostisch — die #1629-Garantie),
+die #823-Tagesgrenze (gilt jetzt je Kanal), die Radar-Unterdrückung über die datierte
+Briefing-Datei, und die Auslöse-Entscheidung selbst: `DeviationAlertEngine.evaluate()` bleibt
+EIN gemeinsamer Lauf (ADR-0021). Er bekommt weiterhin genau eine Vergleichsbasis — den
+**ältesten** gültigen Kandidaten unter den effektiven Kanälen, damit keinem Kanal eine Änderung
+verlorengeht; gegen Wiederholungen schützt weiterhin das Melde-Gedächtnis (`alert_state`).
+
+Details und Akzeptanzkriterien: `docs/specs/modules/fix_1987_kanal_anker.md`.
+Der Ortsvergleichs-Δ-Anker bleibt kanalagnostisch (Scheibe S2, zurückgestellt).

--- a/docs/context/fix-1987-kanal-anker.md
+++ b/docs/context/fix-1987-kanal-anker.md
@@ -257,3 +257,19 @@ eigenen Test und ist ein Pflicht-Punkt der Mutations-Gegenprobe.
    Auslöse-Entscheidung.
 3. **Scope-Grenze:** Der Briefing-Anker bleibt kanalagnostisch. Ein Kanal ohne eigenen Tier-2-Eintrag
    vergleicht gegen den Tagesstand, den er möglicherweise selbst nie erhalten hat.
+
+### PO-Entscheide 2026-08-19 (Phase 2, Abschluss)
+
+**E1 — AC-2 gilt nur für Ebene 2 (rollierender Alarm-Anker).**
+Der Briefing-Anker (Tier 1) bleibt unbedingt und kanalagnostisch; #1629 wird nicht zurückgedreht,
+die Radar-Unterdrückungs-Referenz bleibt unangetastet. Ein Kanal ohne eigenen Tier-2-Eintrag fällt
+auf den Tagesstand zurück und bekommt weiterhin Alarme, nur mit gröberer Vergleichsbasis.
+
+**E2 — Ein gemeinsamer Auswertungslauf, getrennte Merker.**
+Die Auslöse-Entscheidung bleibt gemeinsam. Kanalgetrennt sind ausschließlich: (1) welcher Kanal seinen
+Merker fortschreibt, (2) welcher Vergleichsstand im Text ausgewiesen wird (`reference_at`, #1916 AC-1..5).
+Der geteilte `DeviationAlertEngine`-Pfad (ADR-0021), den auch amtliche Warnungen nutzen, wird nicht
+angefasst. Eine getrennte Auswertung je Kanal wäre eine eigene Scheibe.
+
+Damit sind die offenen Fragen 1 und 2 geschlossen; Frage 3 (Scope-Grenze) ist die dokumentierte Folge
+von E1 und geht als solche in die Spec.

--- a/docs/context/fix-1987-kanal-anker.md
+++ b/docs/context/fix-1987-kanal-anker.md
@@ -157,3 +157,103 @@ Die Migration muss also ohne vorherige Bestandsaufnahme sicher sein — Read-Mod
 3. Definition „frischester verfügbarer Stand" für AC-3. (R3)
 4. Behandlung schwellengefilterter Kanäle. (R4)
 5. Bekommt der Briefing-Pfad überhaupt eine Kanal-Dimension, oder nur der rollierende Anker? (R2)
+
+---
+
+## Analysis (Phase 2)
+
+### Type
+Bug mit Umbaucharakter (Label `type:bug`, `triage:a` — nutzersichtbares Fehlverhalten), umgesetzt als
+Erweiterung eines bestehenden Mechanismus (ADR-0056), nicht als Neubau.
+
+### Der Schlüsselbefund: die #1629-Garantie hängt gar nicht am rollierenden Anker
+
+Selbst nachgeprüft (`trip_report_scheduler.py:1543` und `:1651`): `_anchor_and_reset()` — und damit
+`save()` + `save_dated()` — wird **zweimal unbedingt** aufgerufen: einmal im `except`-Zweig um den
+Versandaufruf, einmal im regulären Weg außerhalb jeder `sent`-Verzweigung.
+
+Daraus folgt die Auflösung des Zielkonflikts aus R1:
+
+- **Tier 1** (datierter Briefing-Anker) trägt die #1629-Garantie gegen die stille Wache. Er bleibt
+  unbedingt und kanalagnostisch — ohnehin zwingend, weil er zugleich die Radar-Unterdrückungs-Referenz
+  ist (ADR-0056 AC-11).
+- **Tier 2** (rollierender Alarm-Anker) kann daher **vollständig** kanalscharf und zustellungsgebunden
+  werden, ohne die stille Wache zurückzuholen: fehlt einem Kanal sein Tier-2-Eintrag, fällt die Kette
+  auf Tier 1 zurück, der taggleich immer vorhanden ist.
+
+Das macht Variante (ii) aus der Vorüberlegung — ein zusätzlicher „technischer" kanalloser Anker —
+überflüssig. Er existiert bereits.
+
+### Gewählte Umsetzungsvariante: eine Datei je Kanal
+
+`{trip_id}_alarm_anchor_{channel}.json` statt verschachteltem JSON.
+
+Begründung: `weather_snapshot.py` führt seine drei Rollen bereits als drei separate Dateien
+(`:104`, `:131`, `:215`), jede Methode überschreibt vollständig — es gibt **keinen** Merge-Pfad im Modul.
+Verschachteltes JSON bräuchte einen neuen Read-Modify-Write-Mechanismus, weil die vier Kanäle nie
+gleichzeitig geschrieben werden. Variante (a) verlängert das etablierte Muster um eine Achse.
+Unterverzeichnis je Kanal bringt keinen Zusatznutzen.
+
+Der vervierfachte Platzbedarf (der Anker hält vollständige Stundenreihen aller Etappen) ist **nicht**
+vermeidbar und auch nicht durch verschachteltes JSON zu umgehen: divergierende Zustellung bedeutet
+fachlich verschiedene Wetterstände je Kanal — genau der Zweck des Tickets. Deduplizierung wäre falsch.
+
+### AC-4 (Bestandsdaten) — Korrektur zur Agenten-Empfehlung
+
+Die strategische Bewertung schlug vor, die alte kanallose `{trip_id}_alarm_anchor.json` verwaisen zu
+lassen (reiner Ableitungs-Cache). **Das widerspricht AC-4.** Richtig ist:
+`load_alarm_anchor(trip_id, channel)` fällt auf die kanallose Altdatei zurück, wenn die kanalspezifische
+fehlt — damit dient der Bestand beim ersten Lauf allen Kanälen als Ausgangsbasis, ohne Migrationsskript
+und ohne Datenverlust. Der Rückfall ist zugleich der natürliche Zustand für jeden Kanal, der noch nie
+zugestellt hat.
+
+### Schwellengefilterte Kanäle (R4) — geklärt, keine Sonderregel nötig
+
+Ein von `split_by_threshold()` entfernter Kanal (`trip_alert.py:1508-1511`) erscheint weder in
+`sent_channels` noch in `failed_channels`, also nie in `delivered_channels`
+(`notification_service.py:142-144`). Unter der zustellungsgebundenen Regel bekommt er damit von selbst
+keinen frischen Merker — fachlich richtig, denn der Empfänger hat auf diesem Kanal nichts bekommen.
+
+Die Fehlerquelle liegt in der Umsetzung, nicht im Konzept: iteriert der Schreibpfad versehentlich über
+`effective_channels` statt `delivered_channels`, bricht die Zusicherung **still**. Das braucht einen
+eigenen Test und ist ein Pflicht-Punkt der Mutations-Gegenprobe.
+
+### AC-3 „frischester verfügbarer Stand" — Empfehlung (c)
+
+| Option | Folge |
+|---|---|
+| (a) jüngster Merker eines **anderen** Kanals | Kontamination: SMS vergliche gegen einen Stand, den nur die E-Mail erhalten hat — unterläuft den Ticket-Zweck |
+| (b) der aktuelle `fresh_weather` | Vergleich gegen sich selbst ⇒ strukturell Nulldifferenz ⇒ der Kanal meldet dauerhaft „keine Änderung": ein stiller Ausfall anderer Bauart |
+| **(c) der taggleiche Tier-1-Briefing-Anker** | **empfohlen** — behauptet keine Zustellung, ist immer vorhanden, ist bereits Teil der bestehenden Kette; keine neue Logik |
+
+### Affected Files
+
+| Datei | Änderung | Beschreibung |
+|---|---|---|
+| `src/services/weather_snapshot.py` | MODIFY | `save_alarm_anchor` / `load_alarm_anchor` / `alarm_anchor_target_date` um `channel` erweitern; Dateinamensschema; Rückfall auf kanallose Altdatei (AC-4) |
+| `src/services/trip_alert.py` | MODIFY | `_write_rolling_alarm_anchor` über `delivered_channels` schleifen; Tier-2-Schritt der Kette kanalscharf; `_effective_anchor_age` je Kanal |
+| 5 Bestandstests (Dateiname/JSON direkt) | MODIFY | `test_alert_rolling_anchor.py`, `test_alert_anchor_day_guard.py`, `test_onset_anchor_fresh_window_symmetry.py`, `test_onset_shift_alert.py`, `test_compare_alert_anchor_unaffected.py` |
+| 4 Bestandstests (nur API) | ggf. unverändert | überleben, wenn `channel` einen Default bekommt |
+| neue Tests | CREATE | AC-1 bis AC-4 + Schwellenfilter-Fall |
+| `docs/adr/ADR-0056` | MODIFY | Amendment (Weiterentwicklung desselben Mechanismus, keine Ablösung, kein neues ADR) |
+
+**Refactoring-Oberfläche im Produktivcode ist klein:** außerhalb von `weather_snapshot.py` kennt nur
+`trip_alert.py` den Anker (`:343`, `:432`, `:688`, `:796`, `:804`, `:819`).
+
+### Scope Assessment
+- Produktivdateien: 2
+- Geschätzte LoC: +100 bis +160 (Limit 250; Tests und `docs/` zählen nicht)
+- Risiko: **MITTEL** für Speicher- und Gating-Änderung (etabliertes Muster, dichtes Testnetz)
+
+### Open Questions — PO-Entscheid nötig
+
+1. **AC-2 wörtlich würde #1629 brechen.** AC-2 verweist auf den Briefing-Anker
+   (`trip_report_scheduler.py:1527-1531`). Genau dieser unbedingte Write ist die #1629-Absicherung.
+   Vorschlag: AC-2 gilt für den **rollierenden** Anker (Tier 2), Tier 1 bleibt unbedingt.
+2. **Ein Evaluierungslauf oder einer je Kanal?** Heute wertet die Engine **einmal** gegen **einen**
+   `cached`-Stand aus (`trip_alert.py:311-329`), das Ergebnis geht an alle Kanäle. Kanalscharfe Anker
+   werfen die Frage auf, ob je Kanal getrennt ausgewertet wird. Vorschlag für S1: ein gemeinsamer Lauf;
+   die Kanal-Präzision wirkt auf Schreib-/Lesepfad und die Nachweiszeile, nicht auf die
+   Auslöse-Entscheidung.
+3. **Scope-Grenze:** Der Briefing-Anker bleibt kanalagnostisch. Ein Kanal ohne eigenen Tier-2-Eintrag
+   vergleicht gegen den Tagesstand, den er möglicherweise selbst nie erhalten hat.

--- a/docs/context/fix-1987-kanal-anker.md
+++ b/docs/context/fix-1987-kanal-anker.md
@@ -1,0 +1,159 @@
+# Context: fix-1987-kanal-anker
+
+**Issue:** #1987 — Alarm-Vergleichsbasis: ein Merker je Kanal, nur bei tatsächlicher Zustellung
+**Scope dieser Session:** ausschließlich **Scheibe S1 (Trip)**. Scheibe S2 (Ortsvergleich) bleibt PO-zurückgestellt.
+**Track:** Full Process (Intake-Score 5/6)
+**Erstellt:** 2026-08-19
+
+## Request Summary
+
+Die Vergleichsbasis eines Abweichungsalarms soll fachlich das sein, was der Empfänger **auf diesem Kanal
+zuletzt tatsächlich zugestellt bekommen hat** (PO-Entscheid 2026-08-19). Heute gibt es genau einen
+kanallosen Merker je Trip, und er wird auch dann fortgeschrieben, wenn nichts zugestellt wurde.
+
+## Ist-Zustand: drei Snapshot-Dateien, nicht zwei
+
+Das Ticket spricht von „Alarm-Anker und Briefing-Anker". Tatsächlich existieren **drei** Dateien mit
+unterschiedlichen Rollen — alle unter `data/users/<user_id>/weather_snapshots/`
+(`src/app/loader.py:1171-1173`, produktiv `GZ_DATA_DIR=/var/lib/gregor`):
+
+| Datei | Geschrieben von | Rolle |
+|---|---|---|
+| `{trip_id}_{YYYY-MM-DD}.json` | `save_dated()`, `weather_snapshot.py:110-138` | **Priorität 1** der Anker-Kette **und** eingefrorene Briefing-Referenz der Radar-Unterdrückung (#818/#1667) |
+| `{trip_id}_alarm_anchor.json` | `save_alarm_anchor()`, `weather_snapshot.py:190-219` | rollierender Alarm-Anker (#1916 / ADR-0056) |
+| `{trip_id}.json` | `save()`, `weather_snapshot.py:72-108` | undatierter Rückfall; trägt als einzige Datei `briefing_backed` |
+
+**Korrektur zu einer Zwischenannahme:** `save_alarm_anchor()` schreibt **kein** `briefing_backed`-Feld
+(`weather_snapshot.py:204-212` — nachgelesen, nicht vermutet). Nur `save()` tut das. Das ist für die
+Migration relevant: die drei Dateien haben nicht dasselbe Schema.
+
+Die **doppelte Rolle der datierten Datei** ist der wichtigste Befund dieser Phase: `save_dated()` ist
+zugleich Vergleichsbasis und Radar-Unterdrückungs-Referenz. ADR-0056 hält ausdrücklich fest, dass ein
+rollierender Schreibvorgang sie **niemals** verändern darf (`weather_snapshot.py:194-199`, AC-11,
+abgesichert durch `tests/tdd/test_alert_anchor_radar_isolation.py`). Eine Kanal-Auffächerung darf diese
+zweite Aufgabe nicht mitreißen.
+
+### Anker-Prioritätskette (`trip_alert.py:672-763`)
+
+1. `load_dated(trip.id, heute)` → sofort zurück, **ohne** weitere Prüfung (`trip_alert.py:676-678`)
+2. `load_alarm_anchor(trip.id)` → nur wenn `alarm_anchor_target_date() == heute`
+   (Tagesgrenze #823, AC-10; `trip_alert.py:688-697`)
+3. `load(trip.id)` undatiert → Herkunftsprüfung `briefing_backed` (#1699), dann Datum,
+   ersatzweise Altersnetz ≤ `_MAX_UNDATED_ANCHOR_AGE` (`trip_alert.py:700-763`)
+
+Verwerfen heißt `None` — und `None` bedeutet **kein Alarm**, nicht „ungenauer Alarm".
+
+### Schreibpfade
+
+| Auslöser | Ort | Bedingung |
+|---|---|---|
+| Alarm zugestellt | `trip_alert.py:429-434` | `delivered = notif_result.sent` (`trip_alert.py:403`) — **aggregiertes Bool über alle Kanäle** |
+| Alterungs-Ceiling | `trip_alert.py:334-345` | kein Alarm gefeuert **und** `_effective_anchor_age > _ALARM_ANCHOR_CEILING` |
+| Briefing | `trip_report_scheduler.py:1505-1512` (`_write_briefing_anchor`) | schreibt **beide** Briefing-Dateien; aufgerufen über `_anchor_and_reset()`, `trip_report_scheduler.py:1651` — **unbedingt** |
+
+Grenzwerte: `_ALARM_ANCHOR_CEILING = timedelta(hours=4)` (`trip_alert.py:80`),
+`_MAX_UNDATED_ANCHOR_AGE = timedelta(hours=26)` (`trip_alert.py:70`).
+`_effective_anchor_age()` (`trip_alert.py:808-826`) nimmt das **jüngere** von Briefing- und rollierendem Anker.
+
+## Das Rohsignal je Kanal liegt bereits vor
+
+`NotificationResult` (`notification_service.py:114-144`):
+
+| Feld | Bedeutung |
+|---|---|
+| `sent: bool` | mindestens ein konfigurierter Kanal war erreichbar |
+| `sent_channels: list[str]` | Kanäle, die **betreten** wurden (Best-Effort, auch bei Transportfehler) |
+| `failed_channels: list[str]` | Teilmenge davon, die technisch nicht angekommen ist |
+| `blocked_channels` / `blocked_reason_codes` | bewusst nicht betretene Kanäle mit Grund |
+| **`delivered_channels`** (Property, Z. 142-144) | `[c for c in sent_channels if c not in failed_channels]` |
+
+`delivered_channels` wird **heute schon** benutzt — aber nur fürs Protokoll
+(`trip_alert.py:397` → `alert_log.append_entry(sent_channels=…)`), nicht für den Anker-Write daneben
+(`trip_alert.py:429-434`). Der Umbau verwendet vorhandene Daten an einer zweiten Stelle.
+
+Kanal-Bezeichner sind projektweit einheitlich, ohne Enum:
+`_ALL_CHANNELS = ("email", "telegram", "sms", "premium_sms")` (`alert_log.py:70`).
+Keine Varianten wie `mail` oder `garmin`.
+
+Kanal-Auflösung für Trip-Alarme: `TripAlertService._effective_alert_channels()` (`trip_alert.py:1810`).
+Danach filtert `alert_channel_threshold.split_by_threshold()` (`trip_alert.py:1508-1511`) nach
+Dringlichkeitsschwelle — der Notification-Service sieht nur die gefilterte Menge.
+
+## Dependencies
+
+- **Upstream:** `WeatherSnapshotService`, `NotificationResult`, `trip_local_today()`/`anchor_tz()` (Ortszeit, ADR-0051), `alert_log`
+- **Downstream:** `DeviationAlertEngine.evaluate()` bekommt `cached=` aus `_get_cached_weather()`; amtliche Warnungen (`check_official_alert_triggers`) nutzen dieselbe Funktion mit `tagesgleicher_anker_noetig=False`
+
+## Existing Specs & ADRs
+
+- **ADR-0056** (Akzeptiert, 2026-08-16) — rollierender Anker, Hybrid-Trigger (a) Alarmversand / (b) 4h-Ceiling. Nicht abgelöst.
+- **ADR-0009** — Alerts als Abweichungs-Wächter; Snapshot nur beim Briefing. Durch ADR-0056 in der Persistenz ausgeweitet.
+- **ADR-0051** (Vorgeschlagen) — Ortszeit statt Server-Zone; gilt für die Tagesgrenzen-Prüfung.
+- **ADR-0021** — geteilte `DeviationAlertEngine`, location-generisch.
+- `docs/specs/modules/trip_alert.md` (v3.0) — drei Snapshot-Typen, Hybrid-Trigger, AC-Gruppen A/B
+- `docs/specs/modules/weather_snapshot.md` (v1.0) — Persistierungs-API
+- `docs/specs/modules/fix_1661_anker_vom_falschen_tag.md` — Tagesgrenzen-Guard
+
+## Bestehende Tests am Anker (9 Dateien)
+
+`tests/tdd/`: `test_alert_rolling_anchor.py`, `test_alert_anchor_no_memory_reset.py`,
+`test_alert_anchor_day_guard.py`, `test_alert_anchor_day_boundary.py`,
+`test_alert_anchor_radar_isolation.py`, `test_alert_trend_detection_regression.py`,
+`test_onset_anchor_fresh_window_symmetry.py`, `test_onset_shift_alert.py`,
+`test_compare_alert_anchor_unaffected.py`
+
+Eine Recherche-Einschätzung besagt, die ersten vier würden bei einer zusätzlichen Kanal-Ebene brechen.
+**Das ist noch nicht verifiziert** und hängt von der gewählten Umsetzungsvariante ab (Dateiname je Kanal
+vs. verschachteltes JSON vs. Default-Parameter). In Phase 2 gegenzuprüfen, nicht zu übernehmen.
+
+## Risks & Considerations
+
+### R1 — Zielkonflikt mit #1629 (der zentrale Punkt)
+
+AC-2 verlangt: kein Kanal zugestellt ⇒ kein Merker. Genau das Gegenteil wurde in **#1629** bewusst
+eingeführt (`trip_report_scheduler.py:1527-1531`, Kommentar): ein nicht zustellbares Briefing schreibt
+den Anker „seit jeher", weil am 08.08.2026 ein gescheiterter Versand einen **ganzen Tag** Abweichungsalarm
+gekostet hat.
+
+Die Schärfe liegt in der Kette: existiert kein tagesgleicher Anker, liefert `_get_cached_weather()` `None`
+— die Wache ist dann **still**, nicht bloß ungenau. AC-2 wörtlich umgesetzt kann also einen stillen Ausfall
+zurückbringen, den ein früheres Ticket beseitigt hat. Die Spec muss das explizit auflösen; ein Rückfall in
+#1629 wäre eine Regression, kein Nebeneffekt.
+
+### R2 — Doppelrolle der datierten Datei
+
+Kanal-Auffächerung von `save_dated()` würde die Radar-Unterdrückungs-Referenz (#818/#1667) mit verändern.
+Muss getrennt bleiben (ADR-0056 AC-11).
+
+### R3 — Alterung je Kanal (AC-3)
+
+`_effective_anchor_age()` nimmt heute das Maximum zweier Zeitstempel. Je Kanal gerechnet braucht es eine
+prüfbare Definition von „frischester verfügbarer Stand": jüngster Anker eines anderen Kanals, oder der
+aktuelle Wetterstand? Entscheidungsvorlage für die Spec.
+
+### R4 — Schwellenfilter vor dem Versand
+
+`split_by_threshold()` entfernt Kanäle **unterhalb** der Dringlichkeitsschwelle vor dem Versand
+(`trip_alert.py:1508-1511`). Ein so gefilterter Kanal ist weder „zugestellt" noch „fehlgeschlagen".
+Was passiert mit seinem Merker? Ungeklärt, muss in die Spec.
+
+### R5 — Bestandsdaten ohne Inspektionsmöglichkeit
+
+Das produktive Datenverzeichnis `/var/lib/gregor` ist für diese Session nicht lesbar (Rechte).
+Die Migration muss also ohne vorherige Bestandsaufnahme sicher sein — Read-Modify-Write, kein Replace
+(CLAUDE.md „Daten-Schema-Reworks"). AC-4 fordert genau das.
+
+### R6 — Berührungspunkte anderer Sessions (abgefragt 2026-08-19)
+
+- `gregor-zwanzig-15` (#1971): erweitert `AlertEvaluationConfig` in `point_weather.py` und
+  `expand_per_metric_levels()` in `deviation_alert_engine.py`, beides additiv mit Default `False`.
+  Textkollision möglich, falls wir dieselben Signaturen anfassen.
+- `#1948 S4`: nur Alarm-**Renderer** (`src/output/renderers/alert/`), keine Überschneidung.
+
+## Offene Fragen für Phase 2
+
+1. Wie wird der #1629-Zielkonflikt aufgelöst, ohne die stille Wache zurückzuholen? (R1)
+2. Umsetzungsvariante der Kanal-Dimension: eigene Datei je Kanal, verschachteltes JSON, oder Verzeichnisebene? Welche hält die 9 Bestandstests am Leben?
+3. Definition „frischester verfügbarer Stand" für AC-3. (R3)
+4. Behandlung schwellengefilterter Kanäle. (R4)
+5. Bekommt der Briefing-Pfad überhaupt eine Kanal-Dimension, oder nur der rollierende Anker? (R2)

--- a/docs/specs/modules/fix_1987_kanal_anker.md
+++ b/docs/specs/modules/fix_1987_kanal_anker.md
@@ -3,7 +3,7 @@ entity_id: fix_1987_kanal_anker
 type: bugfix
 created: 2026-08-19
 updated: 2026-08-19
-status: draft
+status: approved
 workflow: fix-1987-kanal-anker
 version: "1.1"
 tags: [alerts, trip, channels, anchor, issue-1987, notification]
@@ -13,7 +13,7 @@ tags: [alerts, trip, channels, anchor, issue-1987, notification]
 
 ## Approval
 
-- [ ] Approved
+- [x] Approved — PO (Henning) am 2026-08-19, Freigabe der 11 Akzeptanzkriterien mit „go"
 
 ## Purpose
 

--- a/docs/specs/modules/fix_1987_kanal_anker.md
+++ b/docs/specs/modules/fix_1987_kanal_anker.md
@@ -1,0 +1,518 @@
+---
+entity_id: fix_1987_kanal_anker
+type: bugfix
+created: 2026-08-19
+updated: 2026-08-19
+status: draft
+workflow: fix-1987-kanal-anker
+version: "1.1"
+tags: [alerts, trip, channels, anchor, issue-1987, notification]
+---
+
+# Alarm-Vergleichsbasis wird je Kanal geführt — nur bei tatsächlicher Zustellung (Issue #1987, Scheibe S1)
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Der Abweichungs-Alarm eines Trips vergleicht die aktuelle Vorhersage gegen
+einen gespeicherten Referenz-Wert ("Anker"). Heute gibt es genau **einen**
+rollierenden Alarm-Anker je Trip, kanallos — er wird auch dann
+fortgeschrieben, wenn ein Kanal den Alarm nie erreicht hat. Fachlich richtig
+ist: die Vergleichsbasis eines Empfängers ist das, was dieser Empfänger auf
+**diesem konkreten Kanal zuletzt tatsächlich zugestellt bekommen hat**
+(PO-Entscheid 2026-08-19). Diese Scheibe fächert den rollierenden Alarm-Anker
+über die vier Kanäle `("email", "telegram", "sms", "premium_sms")`
+(`alert_log.py:70`) auf und bindet ihn an tatsächliche Zustellung —
+ausschließlich für **Trips**, nicht für den Ortsvergleich (Scheibe S2,
+zurückgestellt).
+
+Vollständige Herleitung, Ist-Zustand, Risiken und PO-Entscheidungen E1/E2:
+`docs/context/fix-1987-kanal-anker.md`. Diese Spec wiederholt die Analyse
+nicht, sondern zieht Scope und Acceptance Criteria daraus.
+
+## Source
+
+- **File:** `src/services/trip_alert.py`
+- **Identifier:** `TripAlertService._get_cached_weather` (Anker-Priori\
+tätskette, Zeile 608-763), `TripAlertService._write_rolling_alarm_anchor`
+  (Zeile 796-806), einzige verbleibende Schreib-Aufrufstelle Zeile 429-434
+  (Zustellungs-Trigger). Der bisherige Ceiling-Schreib-Trigger Zeile 334-344
+  (`_effective_anchor_age`-Aufruf Zeile 340 + Refresh-Write bei
+  Ceiling-Überschreitung) entfällt für den kanalscharfen Tier-2-Merker
+  ersatzlos (s. Implementation Details, „Schreibpfad — EIN Trigger")
+- Nebendatei: `src/services/weather_snapshot.py` — `WeatherSnapshotService
+  .save_alarm_anchor` (Zeile 190-219), `.load_alarm_anchor` (Zeile 221-251),
+  `.alarm_anchor_target_date` (Zeile 253-263)
+
+> **Schicht-Hinweis:** ausschließlich Python-Core (`src/services/`) —
+> Persistenz-Schema des rollierenden Alarm-Ankers und die Lese-/Schreiblogik
+> im Trip-Alarm-Pfad. Kein Frontend-Code, keine Go-API-Änderung.
+
+## Estimated Scope
+
+- **LoC:** ~100-160 Produktivcode (Kernänderung in `weather_snapshot.py` und
+  `trip_alert.py`), Tests zusätzlich. Workflow-Limit 250 (Standard, keine
+  Anhebung beantragt).
+- **Files:** 2 Produktivdateien, 5 bestehende Testdateien (Dateiname/JSON-\
+  Zugriff direkt), mindestens 3 neue Testdateien.
+- **Effort:** medium — etabliertes Muster (`weather_snapshot.py` führt
+  bereits drei Rollen als drei separate Dateien), additive Erweiterung ohne
+  neuen Merge-Mechanismus.
+
+### Affected Files
+
+| Datei | Änderungstyp | Beschreibung |
+|---|---|---|
+| `src/services/weather_snapshot.py` | MODIFY | `save_alarm_anchor`, `load_alarm_anchor`, `alarm_anchor_target_date` bekommen einen Pflicht-Parameter `channel: str`. Dateinamensschema wechselt von `{trip_id}_alarm_anchor.json` auf `{trip_id}_alarm_anchor_{channel}.json`. `load_alarm_anchor`/`alarm_anchor_target_date` fallen auf die kanallose Altdatei zurück, wenn die kanalspezifische Datei fehlt (AC-5) |
+| `src/services/trip_alert.py` | MODIFY | `_write_rolling_alarm_anchor` iteriert über `notif_result.delivered_channels` und schreibt je Kanal einen eigenen Merker (AC-1, AC-2) — einziger verbleibender Schreib-Trigger; der bisherige Ceiling-Schreib-Trigger (Zeile 334-344) entfällt ersatzlos. Neue Kandidaten-Auflösung je Kanal in `_get_cached_weather` (AC-4/AC-7/AC-8); `_effective_anchor_age` wird durch eine reine Lese-Alterungsprüfung je Kanal-Kandidat ersetzt (kein Schreibeffekt mehr). Neue Aggregation über `effective_channels`: der EINE gemeinsame Auswertungslauf vergleicht gegen den ÄLTESTEN gültigen Kandidaten (AC-11) |
+| `tests/tdd/test_alert_rolling_anchor.py` | MODIFY | Dateiname-/API-Zugriffe bekommen den neuen `channel`-Parameter |
+| `tests/tdd/test_alert_anchor_day_guard.py` | MODIFY | dito |
+| `tests/tdd/test_onset_anchor_fresh_window_symmetry.py` | MODIFY | dito |
+| `tests/tdd/test_onset_shift_alert.py` | MODIFY | dito |
+| `tests/tdd/test_compare_alert_anchor_unaffected.py` | MODIFY | dito — beweist zusätzlich, dass der Ortsvergleichs-Anker (eigene Datei, eigener Code) von der Kanal-Auffächerung unberührt bleibt |
+| `tests/tdd/test_alert_channel_anchor_delivery.py` | CREATE | AC-1, AC-2, AC-5, AC-6 (Teilzustellung, keine Zustellung, Bestandsdaten-Rückfall, Schwellenfilter) |
+| `tests/tdd/test_alert_channel_anchor_ceiling_fallback.py` | CREATE | AC-4, AC-7, AC-8 (Alterungsgrenze je Kandidat, fehlender Merker, Tagesgrenze) |
+| `tests/tdd/test_alert_channel_anchor_shared_comparison.py` | CREATE | AC-11 (Auswahl des ältesten Kandidaten für den EINEN gemeinsamen Auswertungslauf) |
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `NotificationResult.delivered_channels` (`notification_service.py:142-144`) | property | Quelle der Wahrheit für „zugestellt" — `[c for c in sent_channels if c not in failed_channels]`. NICHT `sent` (aggregiertes Bool), NICHT `effective_channels` (nur konfiguriert, nicht zugestellt) |
+| `alert_log._ALL_CHANNELS` (`alert_log.py:70`) | const | verbindliche Kanal-Bezeichner `("email", "telegram", "sms", "premium_sms")`, projektweit einheitlich ohne Enum |
+| `alert_channel_threshold.split_by_threshold` (`trip_alert.py:1508-1511`) | function | filtert Kanäle unterhalb der Dringlichkeitsschwelle VOR dem Versand — ein so entfernter Kanal erscheint nie in `sent_channels`/`delivered_channels` und bekommt dadurch von selbst keinen frischen Merker (AC-6); die verbleibenden Kanäle bilden zugleich die Menge, aus der AC-11 den ältesten Kandidaten wählt |
+| `WeatherSnapshotService.save`/`save_dated` (Tier 1, Briefing-Anker) | function | unverändert weiterverwendet — bleibt unbedingt und kanalagnostisch (E1) |
+| `write_anchor_and_reset_memory`/`_anchor_and_reset()` (`trip_report_scheduler.py:1514-1525`, `:1543`, `:1651`) | function | unverändert — trägt die #1629-Garantie, wird von dieser Scheibe nicht angefasst |
+| `DeviationAlertEngine.evaluate()` (ADR-0021) | function | unverändert — bleibt EIN gemeinsamer Auswertungslauf (E2), keine Signaturänderung; bekommt weiterhin genau einen `cached`-Wert, jetzt aus der AC-11-Aggregation |
+| `alert_state` (Melde-Gedächtnis, ADR-0056 AC-12) | store | schützt bereits gegen Wiederholungs-Alarme für Kanäle, die schon einen aktuelleren Stand kennen — Grundlage der AC-11-Begründung, warum „ältester Kandidat" keine Doppel-Alarme erzeugt |
+| `docs/adr/ADR-0056` | doc | führte den rollierenden Alarm-Anker ein (Hybrid-Trigger a/b) — diese Scheibe erweitert den Mechanismus additiv und löst Trigger (b) für den kanalscharfen Merker ab (Amendment, kein neues ADR) |
+| `docs/specs/modules/fix_1661_anker_vom_falschen_tag.md` | doc | Tagesgrenzen-Guard (#823/#1916 AC-10) — gilt weiterhin je Kanal (AC-8) |
+
+## Nicht in dieser Scheibe
+
+- **Scheibe S2 (Ortsvergleich).** Der Compare-Δ-Anker (`compare_alert.py`,
+  `compare_weather_snapshot.py`) bleibt vollständig unverändert. PO-\
+  zurückgestellt.
+- **Getrennte Auswertung je Kanal.** Die Auslöse-Entscheidung
+  (`DeviationAlertEngine.evaluate`) bleibt EIN gemeinsamer Lauf (E2) — ob ein
+  Alarm ausgelöst wird, hängt weiterhin nicht vom Kanal ab. Kanalscharf sind
+  ausschließlich (1) welcher Kanal seinen Merker fortschreibt und (2) welcher
+  Kandidat in die AC-11-Aggregation eingeht.
+- **Kanalgenaue Ausweisung des Vergleichsstands im Alarmtext.** `reference_at`
+  (`trip_alert.py:359-371`, an `_send_alert` übergeben `:373-378`) bleibt EIN
+  gemeinsamer Wert für den gesamten Alarm — der Stand, gegen den tatsächlich
+  verglichen wurde (AC-11, der gewählte älteste Kandidat). Eine je-Kanal
+  getrennte Ausweisung im Text bräuchte einen Umbau der Versandschnittstelle
+  und gehört, falls gewünscht, zu #1948 S6 (Telegram-Parität), wo die
+  kanalweise Ausweisung ohnehin behandelt wird.
+- **Kanal-Dimension am Briefing-Anker (Tier 1).** `save()`/`save_dated()`
+  bleiben unbedingt und kanalagnostisch (E1) — s. Abschnitt „Bewusste Abkehr
+  von Alt-Verhalten" unten.
+- **Migrationsskript für Bestandsdaten.** Die kanallose Altdatei bleibt
+  liegen und dient als Rückfall (AC-5); kein aktives Umschreiben.
+- **Neue Kalibrierung von `_ALARM_ANCHOR_CEILING` (4h) oder
+  `_MAX_UNDATED_ANCHOR_AGE` (26h).** Beide Werte bleiben unverändert.
+
+## Implementation Details
+
+### Kanal-Dimension am rollierenden Anker (Tier 2)
+
+Umsetzungsvariante: **eine Datei je Kanal**,
+`{trip_id}_alarm_anchor_{channel}.json`, statt verschachteltem JSON.
+Begründung: `weather_snapshot.py` führt seine drei bestehenden Rollen bereits
+als drei separate Dateien (`:104`, `:131`, `:215`), jede Schreibmethode
+überschreibt vollständig — es existiert **kein** Merge-Pfad im Modul.
+Verschachteltes JSON bräuchte einen neuen Read-Modify-Write-Mechanismus, weil
+die vier Kanäle nie gleichzeitig geschrieben werden (unterschiedliche
+Zustellbilanzen je Lauf). Der vervielfachte Platzbedarf (der Anker hält
+vollständige Stundenreihen aller Etappen) ist bewusst nicht vermeidbar:
+divergierende Zustellung bedeutet fachlich verschiedene Wetterstände je
+Kanal — genau der Zweck dieses Tickets.
+
+`save_alarm_anchor(trip_id, target_date, segments, channel)`,
+`load_alarm_anchor(trip_id, channel)`, `alarm_anchor_target_date(trip_id,
+channel)` (alle `weather_snapshot.py`) bekommen `channel` als Pflicht-\
+Parameter ohne Default — dasselbe Muster wie der bereits pflichtige
+`tagesgleicher_anker_noetig`-Parameter aus #1661: ein vergessenes Argument
+mit stillschweigendem Default würde eine Kanal-Verwechslung erzeugen, die
+kein Test fängt, solange nur ein Kanal konfiguriert ist.
+
+### Schreibpfad: nur zugestellte Kanäle rücken vor — EIN Trigger
+
+`_write_rolling_alarm_anchor` (`trip_alert.py:796-806`) iteriert über eine
+Liste von Kanälen statt einen einzelnen Schreibvorgang auszuführen:
+
+```
+def _write_rolling_alarm_anchor(
+    self, trip_id: str, target_date: date,
+    weather: List[SegmentWeatherData], channels: Iterable[str],
+) -> None:
+    svc = WeatherSnapshotService(user_id=self._user_id)
+    for channel in channels:
+        svc.save_alarm_anchor(trip_id, target_date, weather, channel)
+```
+
+Es bleibt genau EINE Aufrufstelle: der **Zustellungs-Trigger**
+(`trip_alert.py:429-434`, nach `notif_result = self._send_alert(...)`):
+`channels=notif_result.delivered_channels`. Ein Kanal, der nicht in
+`delivered_channels` steht — sei es, weil er fehlgeschlagen ist, blockiert
+wurde, oder von `split_by_threshold()` vorab entfernt wurde — bekommt
+**keinen** frischen Merker (AC-1, AC-2, AC-6). Bewusst `delivered_channels`,
+NICHT `effective_channels` (konfiguriert, aber nicht notwendig zugestellt)
+und NICHT `sent_channels` (nur „betreten", enthält auch fehlgeschlagene
+Transporte, Anti-Pattern #656).
+
+**Der bisherige Ceiling-Schreib-Trigger entfällt für den kanalscharfen
+Tier-2-Merker ersatzlos.** Der Block `trip_alert.py:334-344` (Kommentar +
+`_effective_anchor_age`-Aufruf Zeile 340 + Refresh-Write bei
+Ceiling-Überschreitung Zeile 341-344) lief bislang im Zweig „kein Alarm
+gefeuert" (`eval_result.triggered == False`) — dort wurde NICHTS versendet,
+es gibt keine `delivered_channels`. Ein dort geschriebener Merker wäre exakt
+das, was diese Scheibe verbietet: ein Stand, den kein Empfänger je
+zugestellt bekam. Die Schutzwirkung gegen eine veraltete Vergleichsbasis
+geht dadurch nicht verloren — sie wandert vom Schreib- in den Lesepfad (s.
+u. „Alterungs-Obergrenze je Kanal"): ein gealterter Kanal-Merker wird beim
+Lesen einfach nicht mehr als Kandidat herangezogen, die Kette fällt für
+diesen Kanal auf Tier 1 zurück, statt ihn beim Schreiben künstlich
+aufzufrischen. Dies ist eine bewusste Ablösung von ADR-0056 Trigger (b) für
+den kanalscharfen Merker — s. „Bewusste Abkehr von Alt-Verhalten" und das
+ADR-Amendment.
+
+### Lesepfad: kanalscharfe Kandidaten, EIN gemeinsamer Vergleich
+
+Die bestehende Kette in `_get_cached_weather` (`trip_alert.py:671-763`)
+bleibt strukturell erhalten (`load_dated` → rollierender Anker →
+undatierter Rückfall). Sie wird um eine **Kandidaten-Auflösung je Kanal**
+erweitert: für jeden Kanal aus `effective_channels` (nach Schwellenfilter,
+s. AC-6) wird sein eigener Kandidaten-Merker bestimmt —
+`load_alarm_anchor(trip.id, channel)`, mit Tagesgrenzen-Prüfung (AC-8) und
+Alterungsgrenze (AC-4); fehlt er ganz (weder kanalspezifisch noch kanallose
+Altdatei), fällt der Kandidat direkt auf den taggleichen Tier-1-\
+Briefing-Anker zurück (AC-7). `load_alarm_anchor` selbst fällt zusätzlich
+auf die kanallose Altdatei `{trip_id}_alarm_anchor.json` zurück, wenn nur
+die kanalspezifische Datei fehlt (AC-5).
+
+Da die Auslöse-Entscheidung (`DeviationAlertEngine.evaluate`) EIN
+gemeinsamer Lauf bleibt (E2, ADR-0021 unangetastet), braucht sie GENAU EINEN
+`cached`-Stand. Dieser wird aus den Kanal-Kandidaten wie folgt gewählt
+(AC-11): **der ÄLTESTE gültige Kandidat unter den effektiven Kanälen.**
+Begründung: nur so geht keinem Kanal eine Änderung verloren — ein Kanal, der
+auf einem älteren Stand steht, muss die Änderungen sehen, die er noch nicht
+kennt; ein bereits aktueller Kanal bekommt dadurch höchstens eine
+Wiederholung im Vergleich, wovor bereits das Melde-Gedächtnis (`alert_state`,
+ADR-0056 AC-12) schützt.
+
+Ausdrücklich verworfen:
+
+- **der JÜNGSTE Kandidat** — würde für schlechter versorgte Kanäle
+  Änderungen unterschlagen, die diese Kanäle noch gar nicht gesehen haben:
+  ein stiller Ausfall anderer Bauart, genau das, was diese Scheibe beheben
+  soll.
+- **ein fester Kanal-Vorrang** (z. B. immer E-Mail zuerst) — willkürlich,
+  ohne fachliche Rechtfertigung, und würde bei abgeschaltetem
+  Vorrangs-Kanal überraschend versagen.
+
+Der im Alarmtext ausgewiesene `reference_at` (`trip_alert.py:359-371`,
+`:373-378`) bleibt dabei EIN gemeinsamer Wert für den gesamten Alarm — der
+Stand, gegen den tatsächlich verglichen wurde (also der gewählte älteste
+Kandidat). Eine kanalgenaue Ausweisung im Text ist NICHT Teil dieser Scheibe
+(s. „Nicht in dieser Scheibe").
+
+### Alterungs-Obergrenze je Kanal (AC-4) — nur beim Lesen wirksam
+
+Überschreitet der Tier-2-Merker EINES Kanals `_ALARM_ANCHOR_CEILING` (4h,
+`trip_alert.py:80`), wird er als Kandidat für diesen Kanal NICHT
+herangezogen — der Kandidat dieses Kanals ist dann der taggleiche Tier-1-\
+Briefing-Anker, nicht der veraltete Kanal-Merker und ausdrücklich NICHT der
+(möglicherweise frischere) Merker eines anderen Kanals (Kontaminationsverbot,
+s. Kontext-Dokument, Bewertungstabelle „AC-3 frischester verfügbarer Stand",
+Option (c) gewählt, Option (a) verworfen). Diese Prüfung ersetzt die frühere
+`_effective_anchor_age`-Methode (Zeile 808-826), die bislang „das jüngere
+von Briefing- und rollierendem Anker" für einen Schreib-Trigger berechnete —
+mit dem Entfall des Ceiling-Schreib-Triggers (s. o.) wird sie durch eine
+reine Lese-Alterungsprüfung je Kanal-Kandidat ersetzt, ohne eigenen
+Schreibeffekt.
+
+## Expected Behavior
+
+- **Input:** ein Alarm-Lauf für einen Trip mit mehreren konfigurierten
+  Kanälen, dessen Zustellbilanz je Kanal unterschiedlich ausfällt
+  (z. B. E-Mail zugestellt, SMS gescheitert), und deren Tier-2-Merker
+  unterschiedlich alt sind.
+- **Output:** nur die tatsächlich zugestellten Kanäle bekommen einen
+  frischen rollierenden Anker-Merker; nicht zugestellte, blockierte oder
+  schwellengefilterte Kanäle behalten ihren alten Stand (oder den
+  kanallosen Alt-Rückfall) unverändert. Der EINE gemeinsame Auswertungslauf
+  vergleicht gegen den ältesten gültigen Kandidaten unter den effektiven
+  Kanälen (AC-11). Die Auslöse-Entscheidung selbst (ob überhaupt ein Alarm
+  gefeuert wird) ändert sich nicht.
+- **Side effects:** bis zu vier Anker-Dateien je Trip statt einer
+  (`{trip_id}_alarm_anchor_{channel}.json`), die alte kanallose Datei bleibt
+  als Rückfall bestehen und wird nicht mehr aktiv fortgeschrieben, sobald
+  mindestens ein Kanal seine eigene Datei besitzt. Kein neuer HTTP-Endpunkt,
+  kein Schema-Bruch am Briefing-Anker. Kein opportunistischer
+  Ceiling-Refresh-Write mehr (entfällt ersatzlos für Tier 2).
+
+## Acceptance Criteria
+
+- **AC-1:** Given ein Trip mit den Alarmkanälen E-Mail und SMS, bei dem ein
+  Alarm nur per E-Mail zugestellt wird (SMS scheitert am Transport), When
+  der Alarm-Versand abgeschlossen ist und `_write_rolling_alarm_anchor`
+  läuft, Then wird ausschließlich der E-Mail-Anker (`{trip_id}_alarm_anchor
+  _email.json`) auf den neuen Stand geschrieben, während der SMS-Anker
+  (`{trip_id}_alarm_anchor_sms.json`) unverändert stehen bleibt.
+  - Test: Kern. `notification_service` so präparieren, dass
+    `delivered_channels == ["email"]` (SMS in `failed_channels`); vor und
+    nach dem Lauf `load_alarm_anchor(trip_id, "sms")` vergleichen
+    (identisch) und `load_alarm_anchor(trip_id, "email")` prüfen (neuer
+    `fetched_at`-Zeitstempel).
+
+- **AC-2:** Given ein Alarm wird auf keinem einzigen konfigurierten Kanal
+  zugestellt (alle scheitern oder sind blockiert), When
+  `_write_rolling_alarm_anchor` für diesen Lauf aufgerufen wird, Then
+  entsteht für KEINEN Kanal ein frischer rollierender Merker.
+  - Test: Kern. `delivered_channels == []` präparieren, alle vier
+    Kanal-Dateien vor/nach dem Lauf vergleichen — keine wird neu
+    geschrieben (Zeitstempel-Vergleich, kein Dateiinhalt-String-Check).
+
+- **AC-3 (Regressionsschutz #1629, Gegenprobe):** Given ein
+  Briefing-Lauf, bei dem auf keinem Kanal etwas zugestellt wird (z. B. der
+  Versandaufruf wirft eine Ausnahme, `trip_report_scheduler.py:1543`,
+  oder `result.sent == False` im regulären Pfad, `:1651`), When der
+  Briefing-Lauf abgeschlossen ist, Then wird der Tier-1-Briefing-Anker
+  (`save()` + `save_dated()`) TROTZDEM geschrieben, UND ein anschließender
+  Abweichungs-Alarm-Check für denselben Trip findet über den Rückfall (AC-4)
+  eine gültige Vergleichsbasis statt `None`.
+  - Test: Kern. `send_trip_report` einen Fehler werfen lassen bzw.
+    `result.sent = False` zurückgeben, `_anchor_and_reset()` durchlaufen
+    lassen (bestehendes #1629-Muster), danach `_get_cached_weather()` für
+    einen beliebigen Kanal aufrufen — Rückgabe ist NICHT `None`.
+  - Mutations-Gegenprobe: koppelt eine Verfälschung den Tier-1-Write
+    fälschlich an eine Zustellbedingung, MUSS dieser Test rot werden.
+
+- **AC-4:** Given der rollierende Tier-2-Merker eines Kanals existiert,
+  ist aber älter als `_ALARM_ANCHOR_CEILING` (4h, `trip_alert.py:80`),
+  While ein taggleicher Tier-1-Briefing-Anker vorhanden ist, When der
+  Kandidaten-Merker dieses Kanals aufgelöst wird, Then wird gegen den
+  Tier-1-Briefing-Anker verglichen — NICHT gegen den veralteten
+  Kanal-Merker und NICHT gegen den (ggf. frischeren) Merker eines anderen
+  Kanals.
+  - Test: Kern. Kanal-Anker `email` mit `fetched_at` = jetzt minus 5h
+    anlegen, Kanal-Anker `telegram` frisch anlegen (jetzt), Tier-1-\
+    Briefing-Anker für heute anlegen. Kandidaten-Auflösung für Kanal
+    `email` aufrufen — Assert: Kandidat ist der Tier-1-Anker, NICHT der
+    frische `telegram`-Anker und NICHT der eigene, zu alte `email`-Anker.
+  - Mutations-Gegenprobe: griffe der Ceiling-Rückfall versehentlich auf
+    den Merker eines anderen Kanals zu, MUSS dieser Test rot werden.
+
+- **AC-5:** Given ein Trip besitzt ausschließlich die kanallose Altdatei
+  `{trip_id}_alarm_anchor.json` (Bestand vor dieser Scheibe), When nach dem
+  Deploy der erste Alarm-Lesevorgang für einen beliebigen Kanal (z. B.
+  `premium_sms`) läuft, Then liefert `load_alarm_anchor(trip_id,
+  "premium_sms")` den Inhalt der Altdatei als Vergleichsbasis — kein
+  Datenverlust, kein Migrationsskript nötig.
+  - Test: Kern. Altdatei manuell anlegen (Dateiname ohne Kanal-Suffix),
+    `load_alarm_anchor()` für zwei verschiedene Kanäle aufrufen — beide
+    liefern denselben Inhalt.
+
+- **AC-6:** Given ein Kanal wird von `split_by_threshold()`
+  (`trip_alert.py:1508-1511`) vor dem Versand unterhalb der
+  Dringlichkeitsschwelle entfernt (er landet weder in `sent_channels` noch
+  in `failed_channels`), When `_write_rolling_alarm_anchor` läuft, Then
+  bekommt dieser Kanal KEINEN frischen Merker — er hat nichts empfangen.
+  - Test: Kern. `notif_result.sent_channels` ohne den schwellengefilterten
+    Kanal präparieren (er taucht in keiner der beiden Listen auf), Anker-\
+    Datei dieses Kanals vor/nach dem Lauf vergleichen (unverändert).
+  - Mutations-Gegenprobe: iteriert der Schreibpfad versehentlich über
+    `effective_channels` (konfiguriert) statt `delivered_channels`
+    (zugestellt), MUSS dieser Test rot werden — genau der Fehler, der die
+    Zusicherung still bricht.
+
+- **AC-7:** Given ein Kanal hat noch nie einen eigenen Tier-2-Merker
+  geschrieben bekommen UND keine kanallose Altdatei existiert, When sein
+  Kandidaten-Merker aufgelöst wird, Then fällt er auf den
+  Tier-1-Briefing-Anker zurück und bekommt weiterhin Alarme — dies ist die
+  dokumentierte Präzisionsgrenze von S1 (gröbere, aber gültige
+  Vergleichsbasis), kein Fehler.
+  - Test: Kern. Weder kanalspezifische noch kanallose Alarm-Anker-Datei
+    anlegen, nur einen Tier-1-Briefing-Anker — Assert: Kandidat ist NICHT
+    `None`, sondern der Tier-1-Anker.
+
+- **AC-8:** Given ein rollierender Kanal-Anker trägt ein `target_date`
+  ungleich heute (falscher Tag, #823/#1916 AC-10), When sein
+  Kandidaten-Merker aufgelöst wird, Then wird er verworfen (analog zur
+  bestehenden Tagesgrenzen-Prüfung für den kanallosen Anker) und die Kette
+  fällt für diesen Kanal weiter auf den nächsten gültigen Stand zurück —
+  die Tagesgrenze gilt weiterhin je Kanal, nicht global.
+  - Test: Kern. Kanal-Anker mit `target_date` = gestern anlegen,
+    `alarm_anchor_target_date(trip_id, channel)` prüfen — Rückgabe ≠ heute,
+    Anker wird als Kandidat verworfen.
+
+- **AC-9:** Given ein Trip-Alarm wird ausgelöst und mindestens ein Kanal
+  zugestellt (Regelfall wie vor dieser Scheibe), When
+  `DeviationAlertEngine.evaluate()` innerhalb desselben Alarm-Laufs
+  aufgerufen wird, Then feuert derselbe Alarm bei gleicher Wetterlage wie
+  vor dem Umbau — die Kanal-Trennung wirkt ausschließlich auf Merker und
+  Kandidaten-Auswahl (AC-11), NICHT auf die Auslöse-Entscheidung.
+  - Test: Kern. Bestehendes Szenario aus `test_alert_rolling_anchor.py`
+    (Signale, die vor der Scheibe einen Alarm auslösen) nach der Migration
+    unverändert grün laufen lassen — keine neue Assertion nötig, reiner
+    Regressionsnachweis.
+
+- **AC-10:** Given Radar-Unterdrückung basiert auf der eingefrorenen,
+  datierten Briefing-Datei (ADR-0056 AC-11), When ein kanalscharfer
+  Schreibvorgang des rollierenden Alarm-Ankers läuft (egal für welchen
+  Kanal), Then bleibt die datierte Briefing-Datei (`{trip_id}_{YYYY-MM-\
+  DD}.json`) davon vollständig unberührt.
+  - Test: Kern. Bestehender `tests/tdd/test_alert_anchor_radar_isolation
+    .py` unverändert grün nach der Migration der Kanal-Dimension.
+
+- **AC-11:** Given zwei Alarmkanäle mit unterschiedlich alten gültigen
+  Kandidaten-Merkern (E-Mail-Merker von 09:00, SMS-Merker von 06:00), When
+  der EINE gemeinsame Auswertungslauf die Vergleichsbasis für diesen Alarm
+  auflöst, Then wird gegen den SMS-Merker von 06:00 verglichen (der ältere
+  der beiden Kandidaten) — damit auch die Änderung zwischen 06:00 und 09:00
+  gemeldet wird, die der SMS-Kanal noch nicht kennt.
+  - Test: Kern. Zwei Kanal-Merker mit unterschiedlichen `fetched_at`-\
+    Zeitstempeln anlegen, `effective_channels = {"email", "sms"}`, den
+    gemeinsamen Auswertungslauf aufrufen — Assert: der an
+    `DeviationAlertEngine.evaluate()` übergebene `cached`-Stand entspricht
+    dem SMS-Merker (06:00), nicht dem E-Mail-Merker (09:00).
+  - Mutations-Gegenprobe: greift die Auflösung auf den JÜNGSTEN statt den
+    ÄLTESTEN Kandidaten zu, MUSS dieser Test rot werden — genau der
+    Fehler, der Änderungen für schlechter versorgte Kanäle stillschweigend
+    unterschlägt.
+
+## Bewusste Abkehr von Alt-Verhalten
+
+**Erste bewusste Abkehr — der unbedingte Tier-1-Write bleibt bestehen.**
+Der Kommentar `trip_report_scheduler.py:1527-1531` beschreibt den
+unbedingten Anker-Write als bewusstes #1629-Verhalten: „Ein bloß nicht
+zustellbares Briefing schreibt ihn seit jeher; hier wird nur
+Gleichbehandlung hergestellt." Diese Scheibe hält fest: dieses Verhalten
+bleibt für Tier 1 (Briefing-Anker, `save()`/`save_dated()`) **unverändert
+bestehen** (E1, AC-3) — die Zustellungsbindung dieser Spec betrifft
+ausschließlich Tier 2 (rollierender Alarm-Anker). Wer künftig den
+unbedingten Tier-1-Write als Widerspruch zu #1987 liest, irrt: beide
+Regeln gelten gleichzeitig, auf verschiedenen Ebenen der Anker-\
+Prioritätskette.
+
+**Zweite bewusste Abkehr — Ceiling-Schreib-Trigger (ADR-0056 Trigger b)
+entfällt für den kanalscharfen Merker.** ADR-0056 führte zwei Schreib-\
+Trigger ein: (a) tatsächlicher Alarmversand, (b) opportunistische
+Auffrischung bei Überschreiten der 4h-Ceiling, unabhängig von einem
+ausgelösten Alarm. Trigger (b) ist mit der Zustellungsbindung dieser
+Scheibe für den kanalscharfen Tier-2-Merker begrifflich unmöglich
+geworden: er lief im Zweig „kein Alarm gefeuert", also ohne jede
+`delivered_channels`-Information — ein dort geschriebener Merker wäre eine
+Zustellung, die nie stattgefunden hat. Die Schutzwirkung gegen eine
+veraltete Vergleichsbasis bleibt erhalten, wandert aber vom Schreib- in den
+Lesepfad: ein gealterter Kanal-Merker wird beim Lesen als Kandidat
+ausgeschlossen (AC-4) und die Kette fällt für diesen Kanal auf den
+taggleichen Tier-1-Anker zurück, statt ihn beim Schreiben künstlich
+aufzufrischen.
+
+## Testplan
+
+Alle Tests laufen in der **Kern-Schicht** (deterministisch, kein Netz, kein
+Live-Versand) — kein AC dieser Scheibe braucht Staging.
+
+| AC | Testdatei | Ansatz |
+|---|---|---|
+| AC-1, AC-2, AC-6 | `test_alert_channel_anchor_delivery.py` (CREATE) | echte `WeatherSnapshotService`-Fixtures in isoliertem `get_data_dir()`, präparierte `NotificationResult` (Teilzustellung/Nullzustellung/Schwellenfilter) über den echten `_write_rolling_alarm_anchor`-Aufruf |
+| AC-3 | `test_alert_channel_anchor_delivery.py` (CREATE) | echter `_anchor_and_reset()`-Pfad mit fehlgeschlagenem Versand (Muster #1629), anschließender `_get_cached_weather()`-Aufruf |
+| AC-4, AC-7, AC-8 | `test_alert_channel_anchor_ceiling_fallback.py` (CREATE) | Fixture-Anker mit präparierten `fetched_at`/`target_date`-Werten je Kanal, Tier-1-Anker als Referenz |
+| AC-5 | `test_alert_channel_anchor_delivery.py` (CREATE) | kanallose Altdatei manuell anlegen, zwei Kanäle lesen |
+| AC-9 | `test_alert_rolling_anchor.py` (MODIFY) | bestehendes Auslöse-Szenario, Regressionsnachweis nach API-Anpassung |
+| AC-10 | `test_alert_anchor_radar_isolation.py` (unverändert, muss grün bleiben) | Bestandstest, keine inhaltliche Änderung nötig |
+| AC-11 | `test_alert_channel_anchor_shared_comparison.py` (CREATE) | zwei Kanal-Kandidaten unterschiedlichen Alters, geteilter Auswertungslauf, Spionage auf den an `DeviationAlertEngine.evaluate()` übergebenen `cached`-Wert |
+
+Kein Mock-Theater: alle Tests laufen über echte Dateien und den echten
+Trip-Alarm-Pfad (keine `Mock()`/`patch()`/`MagicMock`, die nur die eigene
+Annahme zurückspiegeln), keine Dateiinhalt-String-Checks als
+Verhaltensnachweis.
+
+## Mutations-Gegenprobe
+
+Mindestens diese vier Verfälschungen MUSS je ein Test fangen (Pflicht, nicht
+Kür — eine grüne Testsuite beweist nur, dass sie durchläuft, nicht dass sie
+etwas bewacht):
+
+1. **Schreibpfad iteriert über `effective_channels` statt
+   `delivered_channels`.** Bricht die Zusicherung still — ein
+   schwellengefilterter oder fehlgeschlagener Kanal bekäme trotzdem einen
+   frischen Merker. Muss AC-6 (und AC-1) rot machen.
+2. **Tier-1-Write wird an die Zustellung gekoppelt.** Bringt die #1629-\
+   Regression zurück — ein Briefing ohne jede Zustellung schriebe dann
+   keinen Briefing-Anker mehr, die Abweichungs-Wache würde erneut
+   strukturell blind. Muss AC-3 rot machen.
+3. **Ceiling-Rückfall greift auf den Merker eines anderen Kanals zu**
+   statt auf den Tier-1-Briefing-Anker. Kontaminiert die Vergleichsbasis
+   eines Kanals mit einem Stand, den dieser Empfänger nie erhalten hat.
+   Muss AC-4 rot machen.
+4. **Die AC-11-Aggregation wählt den JÜNGSTEN statt den ÄLTESTEN
+   Kandidaten.** Unterschlägt Änderungen für schlechter versorgte Kanäle —
+   ein stiller Ausfall anderer Bauart als der ursprüngliche Bug. Muss
+   AC-11 rot machen.
+
+## Known Limitations
+
+- **Kein Migrationsskript, aktives Auslaufen der Altdatei.** Die kanallose
+  `{trip_id}_alarm_anchor.json` wird nach dem Deploy nicht mehr aktiv
+  fortgeschrieben (jeder Schreibvorgang trägt jetzt einen Kanal-Suffix),
+  bleibt aber als Rückfall bestehen, solange ein Kanal noch keine eigene
+  Datei besitzt (AC-5, AC-7).
+- **Ein Kanal ohne eigenen Merker vergleicht gegen den gröberen
+  Tier-1-Stand** (AC-7) — bewusste Präzisionsgrenze von S1, kein Fehler.
+  Eine Auflösung, die stattdessen den Merker eines anderen Kanals nutzt,
+  wurde als Kontamination verworfen (s. Kontext-Dokument).
+- **Vervierfachter Speicherbedarf für den rollierenden Alarm-Anker** je
+  Trip (bis zu vier vollständige Segment-Schnappschüsse statt einem) —
+  fachlich notwendig, nicht optimierbar ohne den Ticket-Zweck zu
+  unterlaufen.
+- **Kein opportunistischer Ceiling-Refresh mehr für Tier 2** — ein Kanal,
+  dessen Merker altert, ohne dass ein neuer Alarm zugestellt wird, bleibt
+  auf dem alten Merker sitzen, bis entweder ein neuer Alarm zugestellt wird
+  oder die Kette beim Lesen auf Tier 1 zurückfällt (AC-4). Bewusst in Kauf
+  genommen — s. „Bewusste Abkehr von Alt-Verhalten".
+- **Scheibe S2 (Ortsvergleich) bleibt vollständig unangetastet** — der
+  Compare-Δ-Anker hat weiterhin genau eine Vergleichsbasis je Preset/Ort,
+  unabhängig vom Zustellkanal.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine neue — Amendment zu ADR-0056.
+- **Rationale:** ADR-0056 führte den rollierenden Alarm-Anker mit
+  Hybrid-Trigger (a) Alarmversand / (b) 4h-Ceiling ein, aber kanallos.
+  Diese Scheibe erweitert denselben Mechanismus additiv um eine
+  Kanal-Dimension und löst dabei Trigger (b) für den kanalscharfen
+  Tier-2-Merker ab: die Alterungsprüfung wandert vom Schreib- in den
+  Lesepfad (s. Implementation Details, „Schreibpfad — EIN Trigger"), weil
+  ein zustellungsfreier Schreibvorgang unter der neuen Zustellungsbindung
+  begrifflich unmöglich ist. Trigger (a) und die Tagesgrenzen-Prüfung
+  (#823/#1916 AC-10) sowie die Radar-Isolation (AC-11 des ADR, nicht zu
+  verwechseln mit AC-11 dieser Spec) bleiben unverändert — kein neues ADR
+  nötig, ein Amendment-Absatz in `docs/adr/ADR-0056` genügt zur
+  Dokumentation. ADR-0021 (geteilte `DeviationAlertEngine`) bleibt
+  unangetastet: die Auslöse-Entscheidung ist weiterhin EIN gemeinsamer Lauf
+  (E2), der genau einen `cached`-Wert erhält (jetzt aus der
+  AC-11-Aggregation).
+
+## Changelog
+
+- 2026-08-19: Initiale Spec. Scope aus
+  `docs/context/fix-1987-kanal-anker.md` (PO-Entscheidungen E1/E2, gewählte
+  Umsetzungsvariante „eine Datei je Kanal") übernommen, ohne Abweichung.
+- 2026-08-19 (Nachschärfung, Team-Lead-Review): (A) Ceiling-Schreib-\
+  Trigger entfällt für den kanalscharfen Tier-2-Merker ersatzlos — Widerspruch
+  zwischen Schreibpfad-Beschreibung und AC-4 aufgelöst, Alterungsprüfung
+  wandert vom Schreib- in den Lesepfad. (B) Neues AC-11: der EINE gemeinsame
+  Auswertungslauf vergleicht gegen den ÄLTESTEN gültigen Kandidaten unter den
+  effektiven Kanälen, nicht „Implementierungsdetail der GREEN-Phase". (C)
+  `reference_at` bleibt EIN gemeinsamer Wert (Korrektur einer früheren
+  Fehlvorgabe); kanalgenaue Ausweisung nach „Nicht in dieser Scheibe"
+  verschoben, Verweis auf #1948 S6. AC-4/AC-7 entdoppelt (AC-4 nur
+  Alterungsfall, AC-7 nur „nie geschrieben"-Fall).

--- a/docs/specs/modules/fix_1987_kanal_anker.md
+++ b/docs/specs/modules/fix_1987_kanal_anker.md
@@ -186,8 +186,8 @@ ADR-Amendment.
 Die bestehende Kette in `_get_cached_weather` (`trip_alert.py:671-763`)
 bleibt strukturell erhalten (`load_dated` → rollierender Anker →
 undatierter Rückfall). Sie wird um eine **Kandidaten-Auflösung je Kanal**
-erweitert: für jeden Kanal aus `effective_channels` (nach Schwellenfilter,
-s. AC-6) wird sein eigener Kandidaten-Merker bestimmt —
+erweitert: für jeden Kanal aus `effective_channels` wird sein eigener
+Kandidaten-Merker bestimmt —
 `load_alarm_anchor(trip.id, channel)`, mit Tagesgrenzen-Prüfung (AC-8) und
 Alterungsgrenze (AC-4); fehlt er ganz (weder kanalspezifisch noch kanallose
 Altdatei), fällt der Kandidat direkt auf den taggleichen Tier-1-\
@@ -214,6 +214,20 @@ Ausdrücklich verworfen:
 - **ein fester Kanal-Vorrang** (z. B. immer E-Mail zuerst) — willkürlich,
   ohne fachliche Rechtfertigung, und würde bei abgeschaltetem
   Vorrangs-Kanal überraschend versagen.
+
+**Klarstellung zum Schwellenfilter im Lesepfad (Präzisierung während der
+RED-Phase, keine AC-Änderung).** In die AC-11-Aggregation geht das **rohe**
+`effective_channels` ein — also OHNE Vorab-Anwendung von
+`split_by_threshold()`. Grund: der Schwellenfilter braucht die
+Dringlichkeitsstufe, und die steht erst nach der Change-Detection fest — also
+NACH dem Zeitpunkt, zu dem der `cached`-Stand gebraucht wird. Eine
+Filterung wäre dort schlicht nicht berechenbar. Fachlich ist das die
+konservative Richtung: ein schwellengefilterter Kanal kann die
+Vergleichsbasis nur nach HINTEN ziehen (älterer Kandidat) — es geht dadurch
+keine Änderung verloren, und gegen Wiederholungen schützt weiterhin
+`alert_state`. AC-6 bleibt davon unberührt: es betrifft ausschließlich den
+**Schreibpfad**, wo `delivered_channels` den gefilterten Kanal von selbst
+nicht enthält.
 
 Der im Alarmtext ausgewiesene `reference_at` (`trip_alert.py:359-371`,
 `:373-378`) bleibt dabei EIN gemeinsamer Wert für den gesamten Alarm — der

--- a/src/services/trip_alert.py
+++ b/src/services/trip_alert.py
@@ -12,7 +12,7 @@ import logging
 import time
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta, timezone
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, Iterable, List, Optional
 
 from app.config import Settings
 from app.models import SegmentWeatherData, WeatherChange
@@ -332,17 +332,16 @@ class TripAlertService:
             logger.debug(
                 f"No changes for trip {trip.id}: {eval_result.suppressed_reason}"
             )
-            # Issue #1916 Trigger (b): opportunistische Auffrischung, wenn der
-            # wirksame Anker (Briefing- ODER rollierender Anker, der juengere
-            # von beiden) die Alterungs-Ceiling ueberschreitet — auch ohne
-            # ausgeloesten Alarm (AC-7/AC-8). Die Vergleichsbasis selbst bleibt
-            # dabei UNVERAENDERT, solange die Ceiling nicht ueberschritten ist
-            # (Trend-Erkennungs-Invariante, AC-9).
-            age = self._effective_anchor_age(trip.id, cached_weather)
-            if age is not None and age > _ALARM_ANCHOR_CEILING:
-                self._write_rolling_alarm_anchor(
-                    trip.id, trip_local_today(trip, now_utc), fresh_weather,
-                )
+            # Issue #1987 (S1): der frueher hier stehende opportunistische
+            # Ceiling-Schreibtrigger (ADR-0056 Trigger b) entfaellt ersatzlos.
+            # Er lief in genau diesem Zweig — "kein Alarm gefeuert", also ohne
+            # jede Zustellung — und schrieb damit einen Stand fort, den kein
+            # Empfaenger je bekommen hat: exakt das, was diese Scheibe
+            # verbietet. Die Schutzwirkung gegen eine veraltete
+            # Vergleichsbasis geht nicht verloren, sie wandert in den
+            # LESEPFAD (`_kanal_anker_kandidat`): ein gealterter Kanal-Merker
+            # wird dort nicht mehr als Kandidat herangezogen, statt ihn hier
+            # kuenstlich aufzufrischen.
             return False
 
         logger.info(
@@ -428,9 +427,12 @@ class TripAlertService:
 
         # Issue #1916 Trigger (a): jeder TATSAECHLICH versendete Alarm
         # schreibt einen frischen rollierenden Anker (AC-6), unabhaengig von
-        # einem vorherigen Briefing.
+        # einem vorherigen Briefing. Issue #1987 (S1): und zwar NUR fuer die
+        # Kanaele, die ihn wirklich zugestellt bekommen haben — der einzige
+        # verbleibende Schreibtrigger.
         self._write_rolling_alarm_anchor(
             trip.id, trip_local_today(trip, now_utc), fresh_weather,
+            notif_result.delivered_channels,
         )
 
         return True
@@ -685,16 +687,23 @@ class TripAlertService:
             # falschen Tag wird verworfen, NICHT zurueckgegeben; die Funktion
             # faellt dann auf den bestehenden undatierten Rueckfall weiter
             # unten zurueck.
-            rolling = svc.load_alarm_anchor(trip.id)
-            if rolling is not None:
-                if not tagesgleicher_anker_noetig:
+            # Issue #1987 (S1): der Anker wird je Kanal gefuehrt, die Auswahl
+            # deshalb je Kanal aufgeloest und danach zu EINEM Stand
+            # zusammengefuehrt (s. `_rollierender_anker_kandidat`).
+            kanaele = self._effective_alert_channels(trip)
+            if not tagesgleicher_anker_noetig:
+                # Amtliche Warnungen brauchen aus dem Anker NUR die
+                # Routen-Geometrie (s. Docstring) — die ist in jedem
+                # Kanal-Merker dieselbe. Erster gefundener genuegt, keine
+                # Tages- oder Alterspruefung (unveraendertes Verhalten).
+                for channel in sorted(kanaele):
+                    rolling = svc.load_alarm_anchor(trip.id, channel)
+                    if rolling is not None:
+                        return rolling
+            else:
+                rolling = self._rollierender_anker_kandidat(svc, trip, today, kanaele)
+                if rolling is not None:
                     return rolling
-                if svc.alarm_anchor_target_date(trip.id) == today:
-                    return rolling
-                logger.debug(
-                    "Rollierender Alarm-Anker fuer Trip %s verworfen "
-                    "(falscher Tag).", trip.id,
-                )
 
             # Fallback: undated snapshot (may be stale after evening briefing)
             undated = svc.load(trip.id)
@@ -762,6 +771,85 @@ class TripAlertService:
         )
         return None
 
+    def _kanal_anker_kandidat(
+        self, svc, trip_id: str, today: date, channel: str,
+    ) -> Optional[tuple[datetime, List[SegmentWeatherData]]]:
+        """Der GUELTIGE rollierende Merker eines Kanals mit seinem Alter —
+        oder `None` (Issue #1987, AC-4/AC-7/AC-8).
+
+        Drei Ausschlussgruende, alle rein LESEND (kein Schreibeffekt, anders
+        als der entfallene Trigger b):
+
+        * kein eigener Merker und keine kanallose Altdatei (AC-7),
+        * `target_date` ungleich heute — die #823/#1916-Tagesgrenze gilt je
+          Kanal, nicht global (AC-8),
+        * aelter als `_ALARM_ANCHOR_CEILING` (AC-4).
+
+        Ausgeschlossen heisst IMMER: dieser Kanal faellt auf den
+        Tier-1-Briefing-Anker zurueck — nie auf den Merker eines ANDEREN
+        Kanals. Das waere eine Vergleichsbasis, die dieser Empfaenger nie
+        erhalten hat (Kontaminationsverbot).
+        """
+        merker = svc.load_alarm_anchor(trip_id, channel)
+        if merker is None:
+            return None
+        if svc.alarm_anchor_target_date(trip_id, channel) != today:
+            logger.debug(
+                "Rollierender Alarm-Anker fuer Trip %s (%s) verworfen "
+                "(falscher Tag).", trip_id, channel,
+            )
+            return None
+        fetched_at = _as_aware_utc(merker[0].fetched_at)
+        if fetched_at is None:
+            return None
+        alter = datetime.now(timezone.utc) - fetched_at
+        if alter > _ALARM_ANCHOR_CEILING:
+            logger.debug(
+                "Rollierender Alarm-Anker fuer Trip %s (%s) verworfen "
+                "(%.1f h alt, Grenze %.0f h).", trip_id, channel,
+                alter.total_seconds() / 3600,
+                _ALARM_ANCHOR_CEILING.total_seconds() / 3600,
+            )
+            return None
+        return fetched_at, merker
+
+    def _rollierender_anker_kandidat(
+        self, svc, trip: "Trip", today: date, channels: set,
+    ) -> Optional[List[SegmentWeatherData]]:
+        """Die EINE gemeinsame Vergleichsbasis aus den Kanal-Kandidaten
+        (Issue #1987, AC-11) — oder `None` fuer den Tier-1-Rueckfall.
+
+        Die Ausloese-Entscheidung bleibt EIN gemeinsamer
+        `DeviationAlertEngine.evaluate()`-Lauf (E2, ADR-0021) und braucht
+        deshalb genau EINEN `cached`-Stand. Gewaehlt wird der AELTESTE
+        gueltige Kandidat: nur so geht keinem Kanal eine Aenderung verloren,
+        die er noch nicht kennt. Ein bereits aktuellerer Kanal bekommt
+        hoechstens eine Wiederholung im Vergleich — davor schuetzt das
+        Melde-Gedaechtnis (`alert_state`, ADR-0056 AC-12).
+
+        `channels` ist das ROHE `effective_channels` ohne
+        `split_by_threshold()`: der Schwellenfilter braucht die
+        Dringlichkeitsstufe, die erst NACH der Change-Detection feststeht —
+        hier waere sie nicht berechenbar (Spec, "Klarstellung zum
+        Schwellenfilter im Lesepfad").
+
+        Hat auch nur EIN Kanal keinen gueltigen eigenen Merker, faellt die
+        Auswahl auf den Tier-1-Briefing-Anker durch (`None`): dieser Kanal
+        kennt den Tier-1-Stand als letzten, und der ist auf diesem Pfad
+        immer der aeltere — lief naemlich ein Briefing, hat bereits
+        `load_dated()` weiter oben zurueckgegeben und diese Methode wird gar
+        nicht erreicht.
+        """
+        if not channels:
+            return None
+        kandidaten: List[tuple[datetime, List[SegmentWeatherData]]] = []
+        for channel in sorted(channels):
+            kandidat = self._kanal_anker_kandidat(svc, trip.id, today, channel)
+            if kandidat is None:
+                return None
+            kandidaten.append(kandidat)
+        return min(kandidaten, key=lambda paar: paar[0])[1]
+
     def _report_missing_anchor(self, trip: "Trip", today: date) -> None:
         """Issue #1661 (Teil C, C2): „gar kein Anker" ist zwei verschiedene Dinge.
 
@@ -795,35 +883,26 @@ class TripAlertService:
 
     def _write_rolling_alarm_anchor(
         self, trip_id: str, target_date: date, weather: List[SegmentWeatherData],
+        channels: Iterable[str],
     ) -> None:
         """Schreibt NUR den rollierenden Alarm-Anker (Issue #1916, ADR-0056)
         — bewusst OHNE `write_anchor_and_reset_memory()`: dieser Schreibpfad
-        darf das Melde-Gedaechtnis NICHT zuruecksetzen (AC-12)."""
+        darf das Melde-Gedaechtnis NICHT zuruecksetzen (AC-12).
+
+        Issue #1987 (S1): je Kanal ein eigener Merker, und `channels` MUSS
+        `NotificationResult.delivered_channels` sein — NICHT `sent_channels`
+        (nur "betreten", enthaelt auch gescheiterte Transporte, Anti-Pattern
+        #656) und NICHT `effective_channels` (konfiguriert, aber nicht
+        notwendig zugestellt). Die Vergleichsbasis eines Empfaengers ist das,
+        was dieser Empfaenger auf DIESEM Kanal zuletzt tatsaechlich
+        zugestellt bekommen hat; ein leeres `channels` schreibt folgerichtig
+        gar nichts (AC-1, AC-2, AC-6).
+        """
         from services.weather_snapshot import WeatherSnapshotService
 
-        WeatherSnapshotService(user_id=self._user_id).save_alarm_anchor(
-            trip_id, target_date, weather,
-        )
-
-    def _effective_anchor_age(
-        self, trip_id: str, cached_weather: List[SegmentWeatherData],
-    ) -> Optional[timedelta]:
-        """Alter des juengeren der beiden Anker (Briefing- ODER rollierender
-        Anker) — Trigger (b), Issue #1916 AC-7/AC-8."""
-        from services.weather_snapshot import WeatherSnapshotService
-
-        candidates: List[datetime] = []
-        cached_fetched = _as_aware_utc(cached_weather[0].fetched_at) if cached_weather else None
-        if cached_fetched is not None:
-            candidates.append(cached_fetched)
-        rolling = WeatherSnapshotService(user_id=self._user_id).load_alarm_anchor(trip_id)
-        if rolling:
-            rolling_fetched = _as_aware_utc(rolling[0].fetched_at)
-            if rolling_fetched is not None:
-                candidates.append(rolling_fetched)
-        if not candidates:
-            return None
-        return datetime.now(timezone.utc) - max(candidates)
+        svc = WeatherSnapshotService(user_id=self._user_id)
+        for channel in channels:
+            svc.save_alarm_anchor(trip_id, target_date, weather, channel)
 
     def _is_quiet_hours(self, trip: "Trip", now: datetime) -> bool:
         """Check if current time falls within the trip's configured quiet hours.

--- a/src/services/weather_snapshot.py
+++ b/src/services/weather_snapshot.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from datetime import date, datetime, timezone
 from enum import Enum
 from pathlib import Path
@@ -56,6 +57,11 @@ _HOURLY_ENUM_FIELDS: dict[str, type] = {
     "thunder_level": ThunderLevel,
     "precip_type": PrecipType,
 }
+
+# Issue #1987: erkennt den DATIERTEN Snapshot `{trip_id}_{YYYY-MM-DD}.json` —
+# und nur ihn. Trennt die Aufraeumung von den Nachbardateien desselben Trips
+# (rollierende Alarm-Anker), s. `_prune_dated_snapshots`.
+_DATED_SUFFIX = re.compile(r"_\d{4}-\d{2}-\d{2}\.json$")
 
 # Provider string → Provider enum mapping
 _PROVIDER_MAP: dict[str, Provider] = {p.value.lower(): p for p in Provider}
@@ -174,10 +180,24 @@ class WeatherSnapshotService:
             return None
 
     def _prune_dated_snapshots(self, trip_id: str) -> None:
-        """Delete oldest dated snapshots for trip_id, keeping max 7."""
-        pattern = f"{trip_id}_*.json"
+        """Delete oldest dated snapshots for trip_id, keeping max 7.
+
+        Issue #1987: Das Glob-Muster `{trip_id}_*.json` erfasst NICHT nur die
+        datierten Snapshots, sondern jede Nachbardatei desselben Trips — also
+        auch die rollierenden Alarm-Anker. Gemessen: von vier kanalscharfen
+        Ankern (`{trip_id}_alarm_anchor_{channel}.json`) ueberlebten nach acht
+        Briefing-Laeufen genau EINER; die uebrigen drei fuellten das
+        7er-Kontingent und wurden als "aelteste" geloescht. Getroffen haette
+        es bevorzugt die Kanaele, die laenger nichts zugestellt bekommen haben
+        (aeltester mtime) — exakt jene, deren eigenen Stand dieses Ticket
+        erhalten soll. Deshalb greift die Aufraeumung jetzt ausschliesslich
+        auf Dateien mit echtem Datums-Suffix.
+        """
         dated_files = sorted(
-            self._snapshots_dir.glob(pattern),
+            (
+                p for p in self._snapshots_dir.glob(f"{trip_id}_*.json")
+                if _DATED_SUFFIX.search(p.name)
+            ),
             key=lambda p: (p.stat().st_mtime, p.name),
         )
         for old_file in dated_files[:-7]:
@@ -187,17 +207,42 @@ class WeatherSnapshotService:
             except OSError as e:
                 logger.warning(f"Failed to prune dated snapshot {old_file}: {e}")
 
+    def _alarm_anchor_path(self, trip_id: str, channel: str) -> Path:
+        """Ablageort des rollierenden Alarm-Ankers dieses Kanals (Issue #1987).
+
+        Faellt auf die KANALLOSE Altdatei `{trip_id}_alarm_anchor.json`
+        zurueck, solange der Kanal noch keine eigene besitzt (AC-5): der
+        Bestand vor dieser Scheibe bleibt damit ohne Migrationsskript als
+        Vergleichsbasis lesbar. Die Ableitung sitzt bewusst hier statt in den
+        drei Methoden — sonst faelle der Rueckfall in einer von ihnen
+        irgendwann auseinander.
+        """
+        kanalscharf = self._snapshots_dir / f"{trip_id}_alarm_anchor_{channel}.json"
+        if kanalscharf.exists():
+            return kanalscharf
+        return self._snapshots_dir / f"{trip_id}_alarm_anchor.json"
+
     def save_alarm_anchor(
         self,
         trip_id: str,
         target_date: date,
         segments: List[SegmentWeatherData],
+        channel: str,
     ) -> None:
         """Rollierender Alarm-Anker (Issue #1916, ADR-0056) — EIGENER,
-        undatierter Speicherort (EIN File je Trip, ueberschrieben statt
-        aufgehaeuft), getrennt von `save_dated()`/`load_dated()`: ein
+        undatierter Speicherort (EIN File je Trip UND Kanal, ueberschrieben
+        statt aufgehaeuft), getrennt von `save_dated()`/`load_dated()`: ein
         rollierender Schreibvorgang darf die eingefrorene Briefing-Referenz
-        der Radar-Unterdrueckung (#818/#1667) niemals veraendern (AC-11)."""
+        der Radar-Unterdrueckung (#818/#1667) niemals veraendern (AC-11).
+
+        Issue #1987 (S1): `channel` ist PFLICHT und hat bewusst KEINEN
+        Vorgabewert — dasselbe Muster wie `tagesgleicher_anker_noetig` aus
+        #1661. Ein vergessenes Argument mit stillschweigendem Default
+        erzeugte eine Kanal-Verwechslung, die kein Test faengt, solange nur
+        EIN Kanal konfiguriert ist. Geschrieben wird ausschliesslich die
+        kanalscharfe Datei; die kanallose Altdatei bleibt liegen und
+        veraltet (sie dient nur noch als Lese-Rueckfall).
+        """
         try:
             self._snapshots_dir.mkdir(parents=True, exist_ok=True)
 
@@ -212,18 +257,22 @@ class WeatherSnapshotService:
                 ],
             }
 
-            filepath = self._snapshots_dir / f"{trip_id}_alarm_anchor.json"
+            filepath = self._snapshots_dir / f"{trip_id}_alarm_anchor_{channel}.json"
             filepath.write_text(json.dumps(snapshot, indent=2))
-            logger.info(f"Alarm anchor saved: {trip_id}")
+            logger.info(f"Alarm anchor saved: {trip_id} ({channel})")
         except Exception as e:
-            logger.warning(f"Failed to save alarm anchor {trip_id}: {e}")
+            logger.warning(f"Failed to save alarm anchor {trip_id} ({channel}): {e}")
 
-    def load_alarm_anchor(self, trip_id: str) -> Optional[List[SegmentWeatherData]]:
-        """Rollierenden Alarm-Anker laden (Issue #1916) — s. `save_alarm_anchor`."""
-        filepath = self._snapshots_dir / f"{trip_id}_alarm_anchor.json"
+    def load_alarm_anchor(
+        self, trip_id: str, channel: str,
+    ) -> Optional[List[SegmentWeatherData]]:
+        """Rollierenden Alarm-Anker DIESES Kanals laden (Issue #1916/#1987)
+        — s. `save_alarm_anchor` und `_alarm_anchor_path` (Rueckfall auf die
+        kanallose Altdatei, AC-5)."""
+        filepath = self._alarm_anchor_path(trip_id, channel)
 
         if not filepath.exists():
-            logger.debug(f"No alarm anchor for {trip_id}")
+            logger.debug(f"No alarm anchor for {trip_id} ({channel})")
             return None
 
         try:
@@ -247,19 +296,24 @@ class WeatherSnapshotService:
                 )
             return result
         except (json.JSONDecodeError, ValueError, KeyError, OSError) as e:
-            logger.warning(f"Corrupt alarm anchor {trip_id}: {e}")
+            logger.warning(f"Corrupt alarm anchor {trip_id} ({channel}): {e}")
             return None
 
-    def alarm_anchor_target_date(self, trip_id: str) -> Optional[date]:
-        """Gespeicherten Tagesbezug des rollierenden Alarm-Ankers lesen
-        (Issue #1916, AC-10) — analog `load_target_date()` fuer den
-        undatierten Rueckfall."""
-        filepath = self._snapshots_dir / f"{trip_id}_alarm_anchor.json"
+    def alarm_anchor_target_date(self, trip_id: str, channel: str) -> Optional[date]:
+        """Gespeicherten Tagesbezug des rollierenden Alarm-Ankers DIESES
+        Kanals lesen (Issue #1916, AC-10; Issue #1987) — analog
+        `load_target_date()` fuer den undatierten Rueckfall. Liest dieselbe
+        Datei wie `load_alarm_anchor()` (inkl. Altdatei-Rueckfall), sonst
+        koennte die Tagesgrenze einen anderen Anker pruefen als den, der
+        tatsaechlich verwendet wird."""
+        filepath = self._alarm_anchor_path(trip_id, channel)
         try:
             data = json.loads(filepath.read_text())
             return date.fromisoformat(str(data["target_date"]))
         except (json.JSONDecodeError, ValueError, KeyError, TypeError, OSError) as e:
-            logger.debug(f"No readable target_date in alarm anchor {trip_id}: {e}")
+            logger.debug(
+                f"No readable target_date in alarm anchor {trip_id} ({channel}): {e}"
+            )
             return None
 
     def load_target_date(self, trip_id: str) -> Optional[date]:

--- a/tests/tdd/test_alert_anchor_day_boundary.py
+++ b/tests/tdd/test_alert_anchor_day_boundary.py
@@ -8,7 +8,7 @@ Anker (Issue #823/#1661): ein rollierender Anker vom FALSCHEN Kalendertag
 (Ortszeit) darf nicht als "heute" durchgehen.
 
 Angenommene API (Spec Zeile 69, "z.B."): ``WeatherSnapshotService.
-save_alarm_anchor(trip_id, target_date, segments)``/``load_alarm_anchor()``,
+save_alarm_anchor(trip_id, target_date, segments, channel)``/``load_alarm_anchor()``,
 Signatur analog ``save_dated()``/``load_dated()`` -- der einzige Weg, diesen
 neuen Anker-Typ ueberhaupt mit einem Tagesbezug zu erzeugen.
 """
@@ -34,7 +34,7 @@ def test_ac10_rollierender_anker_vom_falschen_tag_wird_verworfen(caplog):
     trip = gust_alert_trip(trip_id)
     gestern = date.today() - timedelta(days=1)
     WeatherSnapshotService(user_id=user_id).save_alarm_anchor(
-        trip_id, gestern, [weather(1, gust_max_kmh=10.0)],
+        trip_id, gestern, [weather(1, gust_max_kmh=10.0)], "email",
     )
 
     with caplog.at_level(logging.DEBUG):
@@ -62,7 +62,7 @@ def test_ac10_regression_rollierender_anker_vom_heutigen_tag_bleibt_gueltig():
     trip = gust_alert_trip(trip_id)
     heute = date.today()
     WeatherSnapshotService(user_id=user_id).save_alarm_anchor(
-        trip_id, heute, [weather(1, gust_max_kmh=17.0)],
+        trip_id, heute, [weather(1, gust_max_kmh=17.0)], "email",
     )
 
     ergebnis = TripAlertService(

--- a/tests/tdd/test_alert_anchor_day_guard.py
+++ b/tests/tdd/test_alert_anchor_day_guard.py
@@ -1066,9 +1066,9 @@ def test_ac3_amtliche_warnung_ueberlebt_auch_die_stufe_2_weiche():
     trip.official_alert_triggers_enabled = True
     save_trip(trip, user_id=user_id)
     svc = WeatherSnapshotService(user_id=user_id)
-    svc.save_alarm_anchor(trip_id, date.today(), [_wetter(ANKER_BOE_KMH)])
+    svc.save_alarm_anchor(trip_id, date.today(), [_wetter(ANKER_BOE_KMH)], "email")
 
-    assert svc.alarm_anchor_target_date(trip_id) == date.today(), (
+    assert svc.alarm_anchor_target_date(trip_id, "email") == date.today(), (
         "Fixtur-Schutz: nur ein TAGESGLEICHER rollierender Anker laesst die "
         "Kette ueberhaupt in die Stufe-2-Weiche laufen."
     )
@@ -1264,7 +1264,7 @@ def test_ac7_regulaeres_briefing_heilt_den_abfrage_anker(caplog):
 # Anker-Schreiber (200 km/h) statt der echten Abfrage: nur so ergaebe die
 # verworfene Basis ueberhaupt ein Delta, das Trigger (a) ausloesen WUERDE.
 def rollierender_anker_pfad(user_id: str, trip_id: str) -> Path:
-    return get_snapshots_dir(user_id) / f"{trip_id}_alarm_anchor.json"
+    return get_snapshots_dir(user_id) / f"{trip_id}_alarm_anchor_email.json"
 
 
 def _ac10_lauf(user_id: str, trip_id: str, *, herkunft):
@@ -1313,7 +1313,7 @@ def test_ac10_verworfene_basis_erzeugt_keinen_rollierenden_alarm_anker():
 
     ergebnis, mails = _ac10_lauf(user_id, trip_id, herkunft=False)
 
-    assert WeatherSnapshotService(user_id=user_id).load_alarm_anchor(trip_id) is None, (
+    assert WeatherSnapshotService(user_id=user_id).load_alarm_anchor(trip_id, "email") is None, (
         "AC-10: Aus einer wegen fehlenden Briefings verworfenen Basis darf kein "
         "rollierender Alarm-Anker entstehen."
     )
@@ -1439,6 +1439,7 @@ def test_ac10_abgelaufener_rollierender_anker_bleibt_unveraendert():
     save_trip(boeen_trip(trip_id, [date.today()]), user_id=user_id)
     WeatherSnapshotService(user_id=user_id).save_alarm_anchor(
         trip_id, date.today() - timedelta(days=1), [_wetter(ANKER_BOE_KMH)],
+        "email",
     )
     pfad = rollierender_anker_pfad(user_id, trip_id)
     vorher = pfad.read_text()
@@ -1539,7 +1540,7 @@ def test_torbedingung_matrix_basis_mal_amtliche_warnung(basis_gueltig, amtlich):
         f"{lage}: genau {1 if versand else 0} Versand erwartet, gezaehlt "
         f"{ergebnis.alerts_sent}, zugestellt {[s for s, _ in mails]}"
     )
-    rollierend = WeatherSnapshotService(user_id=user_id).load_alarm_anchor(trip_id)
+    rollierend = WeatherSnapshotService(user_id=user_id).load_alarm_anchor(trip_id, "email")
     assert (rollierend is not None) is basis_gueltig, (
         f"{lage}: ein rollierender Alarm-Anker darf NUR aus gueltiger Basis "
         f"entstehen (#1916 Trigger (a)) — ein amtlicher Alleinversand keinen."

--- a/tests/tdd/test_alert_anchor_no_memory_reset.py
+++ b/tests/tdd/test_alert_anchor_no_memory_reset.py
@@ -39,7 +39,15 @@ def test_ac12_rollierender_schreibpfad_setzt_melde_gedaechtnis_nicht_zurueck():
     state_svc.save(trip_id, {"gust:99": unberuehrter_eintrag})
 
     trip = gust_alert_trip(trip_id)
-    svc = TripAlertService(settings=settings_email_only(), user_id=user_id)
+    # Issue #1987 (S1): der rollierende Anker rueckt seither NUR fuer
+    # tatsaechlich ZUGESTELLTE Kanaele vor. Ohne die `mail_sink`-Naht
+    # scheitert der E-Mail-Versand am Egress-Waechter, `delivered_channels`
+    # bliebe leer und der Fixtur-Schutz unten haette nichts zu finden --
+    # kein Mock, dieselbe Transportnaht wie in `test_alert_anchor_day_guard`.
+    svc = TripAlertService(
+        settings=settings_email_only(), user_id=user_id,
+        mail_sink=lambda subject, body: None,
+    )
     ausgeloest = svc.check_and_send_alerts(
         trip, [weather(1, gust_max_kmh=10.0)],
         fresh_weather=[weather(1, gust_max_kmh=150.0)],
@@ -48,7 +56,7 @@ def test_ac12_rollierender_schreibpfad_setzt_melde_gedaechtnis_nicht_zurueck():
     assert ausgeloest, "Fixtur-Schutz: der Alarm muss ausgeloest haben."
     # HEUTE ROT: load_alarm_anchor() existiert nicht -> AttributeError,
     # ein direkter Beleg, dass der neue Schreibpfad (Trigger a) fehlt.
-    anker = WeatherSnapshotService(user_id=user_id).load_alarm_anchor(trip_id)
+    anker = WeatherSnapshotService(user_id=user_id).load_alarm_anchor(trip_id, "email")
     assert anker, "Fixtur-Schutz: Trigger (a) muss einen rollierenden Anker erzeugt haben."
 
     nachher = state_svc.load(trip_id)

--- a/tests/tdd/test_alert_anchor_radar_isolation.py
+++ b/tests/tdd/test_alert_anchor_radar_isolation.py
@@ -37,15 +37,22 @@ def test_ac11_briefing_anker_datei_bleibt_unberuehrt_von_rollierenden_schreibvor
     vor_mtime = briefing_pfad.stat().st_mtime_ns
 
     trip = gust_alert_trip(trip_id)
-    svc = TripAlertService(settings=settings_email_only(), user_id=user_id)
-    now = datetime.now(timezone.utc)
+    # Issue #1987 (S1): der rollierende Anker rueckt seither NUR fuer
+    # tatsaechlich ZUGESTELLTE Kanaele vor. Ohne die `mail_sink`-Naht
+    # scheitert der E-Mail-Versand am Egress-Waechter, `delivered_channels`
+    # bliebe leer und der Fixtur-Schutz unten haette nichts zu finden --
+    # kein Mock, dieselbe Transportnaht wie in `test_alert_anchor_day_guard`.
+    svc = TripAlertService(
+        settings=settings_email_only(), user_id=user_id,
+        mail_sink=lambda subject, body: None,
+    )
     ausgeloest = svc.check_and_send_alerts(
         trip, [weather(1, gust_max_kmh=10.0)],
         fresh_weather=[weather(1, gust_max_kmh=150.0)],
     )
 
     assert ausgeloest, "Fixtur-Schutz: der Alarm (Trigger a) muss ausgeloest haben."
-    anker = snap_svc.load_alarm_anchor(trip_id)
+    anker = snap_svc.load_alarm_anchor(trip_id, "email")
     assert anker, "Fixtur-Schutz: der rollierende Anker muss geschrieben worden sein."
     assert briefing_pfad.read_bytes() == vor_inhalt, (
         "AC-11: die Briefing-Anker-Datei darf durch den rollierenden "

--- a/tests/tdd/test_alert_channel_anchor_ceiling_fallback.py
+++ b/tests/tdd/test_alert_channel_anchor_ceiling_fallback.py
@@ -1,0 +1,293 @@
+"""TDD RED — Issue #1987 Scheibe S1: Kandidaten-Aufloesung je Kanal.
+
+SPEC: ``docs/specs/modules/fix_1987_kanal_anker.md`` (AC-4, AC-7, AC-8).
+
+Gepruefte Zusicherung in einem Satz: der rollierende Tier-2-Merker EINES
+Kanals entscheidet ausschliesslich ueber die Vergleichsbasis DIESES Kanals —
+ist er zu alt (AC-4), gar nicht vorhanden (AC-7) oder vom falschen Tag
+(AC-8), faellt die Kette fuer diesen Kanal auf den taggleichen
+Tier-1-Briefing-Anker zurueck und ausdruecklich NICHT auf den (ggf.
+frischeren) Merker eines ANDEREN Kanals (Kontaminationsverbot).
+
+Angenommene API (die Spec legt den Pflicht-Parameter fest, nicht die
+Aufrufform): ``WeatherSnapshotService.save_alarm_anchor(...)``/
+``.load_alarm_anchor(...)``/``.alarm_anchor_target_date(...)`` bekommen
+``channel`` als Pflicht-Parameter; die Kanal-Aufloesung selbst passiert
+INNERHALB von ``TripAlertService._get_cached_weather()`` ueber die effektiven
+Alarmkanaele des Trips. Deshalb konfigurieren die Tests hier eine Tour mit
+GENAU EINEM effektiven Kanal (``alert_channels={"email": True}``) — damit ist
+die AC-11-Aggregation (aeltester Kandidat) trivial und der Rueckgabewert von
+``_get_cached_weather()`` ist exakt der Kandidat dieses einen Kanals. Aendert
+die Umsetzung die Aufrufform, betrifft das die Aufrufstellen hier, nicht die
+Zusicherungen.
+
+Test-Politik (kein Mock-Theater): echte ``WeatherSnapshotService``-Dateien in
+der pytest-isolierten ``get_data_dir()``-Basis (#1133), echter
+``_get_cached_weather()``-Pfad, Vergleich ueber GELADENE Objekte
+(``aggregated.gust_max_kmh``), nie ueber einen Dateiinhalt-String. Die
+Rueckdatierung eines Merkers ist reine Testdaten-Manipulation der Persistenz
+(Vorbild: ``test_alert_rolling_anchor.py``, F002-Test), kein Patch des
+Prueflings.
+
+Pfadregel #1409: alle Prueflinge werden ueber ``app.loader`` bzw. relativ zur
+Testdatei aufgeloest, nie ueber einen festen Hauptrepo-Pfad.
+"""
+from __future__ import annotations
+
+import dataclasses
+import json
+import uuid
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from tests.helpers.alert_log_fixtures import gust_alert_trip, settings_email_only, weather
+
+# Unverwechselbare Boeen-Werte — sie sagen, WELCHER Stand als Vergleichsbasis
+# gewaehlt wurde. Ein Zeitstempel allein koennte das nicht: alle drei Anker
+# werden im selben Testlauf geschrieben.
+TIER1_BOE = 11.0        # taggleicher Briefing-Anker (der erwartete Rueckfall)
+EMAIL_MERKER_BOE = 22.0  # Tier-2-Merker des geprueften Kanals (ungueltig)
+FREMDER_MERKER_BOE = 33.0  # Tier-2-Merker eines ANDEREN Kanals (Kontamination)
+
+
+def _nutzer(prefix: str) -> str:
+    return f"tdd-1987-{prefix}-{uuid.uuid4().hex[:6]}"
+
+
+def _wetter(gust_kmh: float):
+    return dataclasses.replace(
+        weather(1, gust_max_kmh=gust_kmh), fetched_at=datetime.now(timezone.utc),
+    )
+
+
+def _ortstag(trip) -> date:
+    """Der Tag, den der Alarm-Pfad selbst benutzt (``trip_local_today``) —
+    nicht ``date.today()`` des Servers, sonst prueft der Test an der
+    Tagesgrenze einen anderen Tag als der Pruefling."""
+    from services.trip_day import trip_local_today
+
+    return trip_local_today(trip, datetime.now(timezone.utc))
+
+
+def _anker_pfad(user_id: str, trip_id: str, channel: str) -> Path:
+    """Ablageort des kanalscharfen Tier-2-Merkers (Spec, Implementation
+    Details: ``{trip_id}_alarm_anchor_{channel}.json``)."""
+    from app.loader import get_snapshots_dir
+
+    return get_snapshots_dir(user_id) / f"{trip_id}_alarm_anchor_{channel}.json"
+
+
+def _zurueckdatieren(user_id: str, trip_id: str, channel: str, alter: timedelta) -> None:
+    """Laesst einen bereits geschriebenen Kanal-Merker ``alter`` alt aussehen.
+
+    ``save_alarm_anchor()`` schreibt bewusst immer die SCHREIBZEIT als
+    ``snapshot_at`` (aus ihr leitet ``load_alarm_anchor()`` das ``fetched_at``
+    ab) — ein alter Merker laesst sich deshalb nur so herstellen.
+    """
+    pfad = _anker_pfad(user_id, trip_id, channel)
+    assert pfad.exists(), (
+        f"Fixtur-Schutz: der kanalscharfe Merker muss unter {pfad.name!r} "
+        "liegen (Spec: '{trip_id}_alarm_anchor_{channel}.json'). Fehlt er, "
+        "misst dieser Test nichts."
+    )
+    daten = json.loads(pfad.read_text())
+    daten["snapshot_at"] = (datetime.now(timezone.utc) - alter).isoformat()
+    pfad.write_text(json.dumps(daten, indent=2))
+
+
+def _vergleichsbasis(user_id: str, trip):
+    """Die Vergleichsbasis, die der Abweichungs-Alarm tatsaechlich benutzt.
+
+    ``_get_cached_weather(..., tagesgleicher_anker_noetig=True)`` ist genau
+    der Wert, den ``check_all_trips()`` als ``cached`` an
+    ``check_and_send_alerts()`` und damit an ``DeviationAlertEngine.evaluate()``
+    weiterreicht — Pruefort = Wirkort.
+    """
+    from services.trip_alert import TripAlertService
+
+    return TripAlertService(
+        settings=settings_email_only(), user_id=user_id,
+    )._get_cached_weather(trip, tagesgleicher_anker_noetig=True)
+
+
+def _nur_email_trip(trip_id: str):
+    """Tour mit GENAU EINEM effektiven Alarmkanal (E-Mail) — s. Modul-Docstring."""
+    return gust_alert_trip(trip_id, alert_channels={"email": True})
+
+
+def _tier1_briefing_anker(user_id: str, trip_id: str, tag: date) -> None:
+    """Taggleicher Tier-1-Briefing-Anker, UNDATIERT abgelegt.
+
+    Bewusst ohne ``save_dated()``: die Kette in ``_get_cached_weather()``
+    steigt bei einem vorhandenen DATIERTEN Anker sofort aus
+    (``load_dated`` -> return), der rollierende Zweig kaeme dann nie zum Zug
+    und diese Tests waeren trivial wahr. Der undatierte Anker mit
+    ``target_date = heute`` und ``briefing_backed=True`` ist ebenfalls ein
+    taggleicher Briefing-Anker (AC-4 „While ein taggleicher Tier-1-\
+    Briefing-Anker vorhanden ist"), erzwingt aber, dass die Kanal-Aufloesung
+    tatsaechlich durchlaufen wird.
+    """
+    from services.weather_snapshot import WeatherSnapshotService
+
+    WeatherSnapshotService(user_id=user_id).save(trip_id, [_wetter(TIER1_BOE)], tag)
+
+
+# ═════════════════════════════════ AC-4 ══════════════════════════════════════
+
+
+def test_ac4_zu_alter_kanal_merker_faellt_auf_tier1_nicht_auf_fremden_kanal():
+    """AC-4.
+
+    GIVEN der rollierende Tier-2-Merker des Kanals ``email`` ist 5 h alt (die
+          Alterungs-Obergrenze ``_ALARM_ANCHOR_CEILING`` betraegt 4 h), ein
+          taggleicher Tier-1-Briefing-Anker liegt vor, und der Kanal
+          ``telegram`` hat einen FRISCHEN eigenen Merker.
+    WHEN  die Vergleichsbasis fuer die Tour aufgeloest wird, deren einziger
+          effektiver Alarmkanal ``email`` ist.
+    THEN  wird gegen den Tier-1-Briefing-Anker verglichen — weder gegen den
+          eigenen, zu alten Merker noch gegen den frischeren Merker des
+          fremden Kanals (Kontaminationsverbot).
+
+    HEUTE ROT: ``save_alarm_anchor()`` kennt keinen ``channel``-Parameter
+    (TypeError) — es gibt gar keine kanalscharfen Merker.
+
+    Mutations-Gegenprobe (Spec Nr. 3): greift der Ceiling-Rueckfall auf den
+    Merker eines anderen Kanals zu, liefert dieser Test
+    ``FREMDER_MERKER_BOE`` statt ``TIER1_BOE`` und wird rot.
+    """
+    from services.weather_snapshot import WeatherSnapshotService
+
+    user_id, trip_id = _nutzer("ac4"), "trip-1987-ac4"
+    trip = _nur_email_trip(trip_id)
+    heute = _ortstag(trip)
+    svc = WeatherSnapshotService(user_id=user_id)
+
+    _tier1_briefing_anker(user_id, trip_id, heute)
+    svc.save_alarm_anchor(trip_id, heute, [_wetter(EMAIL_MERKER_BOE)], channel="email")
+    _zurueckdatieren(user_id, trip_id, "email", timedelta(hours=5))
+    svc.save_alarm_anchor(trip_id, heute, [_wetter(FREMDER_MERKER_BOE)], channel="telegram")
+
+    basis = _vergleichsbasis(user_id, trip)
+
+    assert basis, (
+        "AC-4: ein zu alter Kanal-Merker darf die Wache nicht blind machen — "
+        "es liegt ein gueltiger, taggleicher Tier-1-Briefing-Anker vor."
+    )
+    assert basis[0].aggregated.gust_max_kmh == pytest.approx(TIER1_BOE), (
+        f"AC-4: die Vergleichsbasis des Kanals 'email' muss der "
+        f"Tier-1-Briefing-Anker ({TIER1_BOE} km/h) sein. Erhalten: "
+        f"{basis[0].aggregated.gust_max_kmh} km/h — "
+        f"{EMAIL_MERKER_BOE} hiesse: die 4h-Ceiling wird beim LESEN nicht "
+        f"geprueft; {FREMDER_MERKER_BOE} hiesse: der Rueckfall greift auf den "
+        "Merker eines ANDEREN Kanals zu und kontaminiert die Vergleichsbasis "
+        "mit einem Stand, den dieser Empfaenger nie erhalten hat."
+    )
+
+
+# ═════════════════════════════════ AC-7 ══════════════════════════════════════
+
+
+def test_ac7_kanal_ohne_eigenen_merker_faellt_auf_tier1_und_bleibt_alarmfaehig():
+    """AC-7.
+
+    GIVEN der Kanal ``email`` hat noch NIE einen eigenen Tier-2-Merker
+          bekommen und es existiert auch keine kanallose Altdatei; ein
+          taggleicher Tier-1-Briefing-Anker liegt vor, und der Kanal
+          ``telegram`` hat einen eigenen, frischen Merker.
+    WHEN  die Vergleichsbasis fuer die Tour aufgeloest wird, deren einziger
+          effektiver Alarmkanal ``email`` ist.
+    THEN  faellt sie auf den Tier-1-Briefing-Anker zurueck (NICHT ``None``,
+          die Tour bleibt alarmfaehig) und uebernimmt NICHT den Merker des
+          fremden Kanals — die groebere, aber gueltige Vergleichsbasis ist die
+          dokumentierte Praezisionsgrenze von S1, kein Fehler.
+
+    HEUTE ROT: ``save_alarm_anchor()`` kennt keinen ``channel``-Parameter
+    (TypeError). Der Rueckfall auf Tier 1 an sich ist Bestandsverhalten —
+    NEU und ab GREEN bewacht ist, dass ein fremder Kanal-Merker ihn nicht
+    verdraengt.
+    """
+    from services.weather_snapshot import WeatherSnapshotService
+
+    user_id, trip_id = _nutzer("ac7"), "trip-1987-ac7"
+    trip = _nur_email_trip(trip_id)
+    heute = _ortstag(trip)
+
+    _tier1_briefing_anker(user_id, trip_id, heute)
+    WeatherSnapshotService(user_id=user_id).save_alarm_anchor(
+        trip_id, heute, [_wetter(FREMDER_MERKER_BOE)], channel="telegram",
+    )
+    assert not _anker_pfad(user_id, trip_id, "email").exists(), (
+        "Fixtur-Schutz: der geprueft Kanal darf keinen eigenen Merker haben."
+    )
+
+    basis = _vergleichsbasis(user_id, trip)
+
+    assert basis, (
+        "AC-7: ein Kanal ohne eigenen Merker muss weiterhin Alarme bekommen — "
+        "der Rueckfall auf den Tier-1-Briefing-Anker ist die dokumentierte "
+        "Praezisionsgrenze, kein Grund fuer eine blinde Wache."
+    )
+    assert basis[0].aggregated.gust_max_kmh == pytest.approx(TIER1_BOE), (
+        f"AC-7: erwartet wird der Tier-1-Briefing-Anker ({TIER1_BOE} km/h), "
+        f"erhalten: {basis[0].aggregated.gust_max_kmh} km/h — "
+        f"{FREMDER_MERKER_BOE} hiesse: ein Kanal ohne eigenen Merker erbt den "
+        "Stand eines fremden Kanals (als Kontamination verworfen, s. Spec "
+        "'Known Limitations')."
+    )
+
+
+# ═════════════════════════════════ AC-8 ══════════════════════════════════════
+
+
+def test_ac8_kanal_merker_vom_falschen_tag_wird_je_kanal_verworfen():
+    """AC-8.
+
+    GIVEN der Tier-2-Merker des Kanals ``email`` traegt ``target_date =
+          gestern`` (#823/#1916 AC-10), der Merker des Kanals ``telegram``
+          traegt korrekt HEUTE, und ein taggleicher Tier-1-Briefing-Anker
+          liegt vor.
+    WHEN  die Vergleichsbasis fuer die Tour aufgeloest wird, deren einziger
+          effektiver Alarmkanal ``email`` ist.
+    THEN  wird der Merker vom falschen Tag verworfen und die Kette faellt fuer
+          DIESEN Kanal auf den Tier-1-Briefing-Anker zurueck — die
+          Tagesgrenze gilt je Kanal, und der taggleiche Merker des anderen
+          Kanals springt nicht ein.
+
+    HEUTE ROT: ``save_alarm_anchor()``/``alarm_anchor_target_date()`` kennen
+    keinen ``channel``-Parameter (TypeError).
+    """
+    from services.weather_snapshot import WeatherSnapshotService
+
+    user_id, trip_id = _nutzer("ac8"), "trip-1987-ac8"
+    trip = _nur_email_trip(trip_id)
+    heute = _ortstag(trip)
+    gestern = heute - timedelta(days=1)
+    svc = WeatherSnapshotService(user_id=user_id)
+
+    _tier1_briefing_anker(user_id, trip_id, heute)
+    svc.save_alarm_anchor(trip_id, gestern, [_wetter(EMAIL_MERKER_BOE)], channel="email")
+    svc.save_alarm_anchor(trip_id, heute, [_wetter(FREMDER_MERKER_BOE)], channel="telegram")
+
+    assert svc.alarm_anchor_target_date(trip_id, channel="email") == gestern, (
+        "AC-8: der Tagesbezug muss JE KANAL lesbar sein — sonst kann die "
+        "Tagesgrenze nicht je Kanal greifen."
+    )
+    assert svc.alarm_anchor_target_date(trip_id, channel="telegram") == heute, (
+        "AC-8: der Tagesbezug des anderen Kanals darf davon unberuehrt sein."
+    )
+
+    basis = _vergleichsbasis(user_id, trip)
+
+    assert basis, (
+        "AC-8: ein Merker vom falschen Tag darf die Wache nicht blind machen — "
+        "es liegt ein gueltiger, taggleicher Tier-1-Briefing-Anker vor."
+    )
+    assert basis[0].aggregated.gust_max_kmh == pytest.approx(TIER1_BOE), (
+        f"AC-8: erwartet wird der Tier-1-Briefing-Anker ({TIER1_BOE} km/h), "
+        f"erhalten: {basis[0].aggregated.gust_max_kmh} km/h — "
+        f"{EMAIL_MERKER_BOE} hiesse: die Tagesgrenze greift fuer den "
+        f"kanalscharfen Merker gar nicht; {FREMDER_MERKER_BOE} hiesse: der "
+        "taggleiche Merker eines ANDEREN Kanals springt ein."
+    )

--- a/tests/tdd/test_alert_channel_anchor_delivery.py
+++ b/tests/tdd/test_alert_channel_anchor_delivery.py
@@ -1,0 +1,434 @@
+"""TDD RED — Issue #1987 Scheibe S1: nur ZUGESTELLTE Kanaele ruecken vor.
+
+SPEC: ``docs/specs/modules/fix_1987_kanal_anker.md`` (AC-1, AC-2, AC-3, AC-5,
+AC-6).
+
+Gepruefte Zusicherung in einem Satz: der rollierende Tier-2-Alarm-Anker wird
+je Kanal gefuehrt und ausschliesslich fuer die Kanaele fortgeschrieben, die
+den Alarm TATSAECHLICH zugestellt bekommen haben
+(``NotificationResult.delivered_channels``) — ein gescheiterter (AC-1),
+gar nicht zustellender (AC-2) oder von der Kanal-Schwelle vorab entfernter
+Kanal (AC-6) behaelt seinen alten Stand. Der unbedingte Tier-1-Write des
+Briefings (#1629) bleibt davon unberuehrt (AC-3), Bestandsdaten ohne
+Kanal-Suffix bleiben als Rueckfall lesbar (AC-5).
+
+Angenommene API: ``WeatherSnapshotService.save_alarm_anchor()``/
+``.load_alarm_anchor()`` bekommen ``channel`` als Pflicht-Parameter, die
+kanalscharfe Ablage ist ``{trip_id}_alarm_anchor_{channel}.json``
+(Spec, Implementation Details).
+
+Test-Politik (kein Mock-Theater): echte ``WeatherSnapshotService``-Dateien in
+der pytest-isolierten ``get_data_dir()``-Basis (#1133); die Zustellbilanz
+entsteht am ECHTEN Transportrand — E-Mail ueber die ``mail_sink``-Naht (kein
+SMTP, kein Netz), Telegram ueber den echten ``TelegramOutput``-Guard (#1363),
+der bei Testlauf-Herkunft VOR jedem Netzaufruf wirft. Geprueft wird der
+GELADENE Anker-Inhalt (``aggregated.gust_max_kmh``), nie ein
+Dateiinhalt-String. Jede Zusicherung hat einen Fixtur-Schutz, der die
+tatsaechliche Zustellbilanz des Laufs aus dem Alarm-Protokoll nachweist —
+ohne ihn waeren die Erwartungen auch dann erfuellt, wenn ein Kanal gar nicht
+erst betreten worden waere.
+
+Pfadregel #1409: alle Prueflinge werden ueber ``app.loader`` bzw. relativ zur
+Testdatei aufgeloest, nie ueber einen festen Hauptrepo-Pfad.
+"""
+from __future__ import annotations
+
+import dataclasses
+import uuid
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from tests.helpers.alert_log_fixtures import (
+    gust_alert_trip,
+    read_log,
+    settings_email_and_failing_telegram,
+    weather,
+)
+
+# Unverwechselbare Boeen-Werte je Anker — sie sagen, WELCHER Stand in der
+# Datei steht. Zwei im selben Lauf geschriebene Anker unterscheiden sich im
+# Zeitstempel nur um Mikrosekunden; der Inhalt ist eindeutig.
+EMAIL_ALTSTAND = 22.0
+TELEGRAM_ALTSTAND = 33.0
+SMS_ALTSTAND = 44.0
+PREMIUM_ALTSTAND = 55.0
+ALTBESTAND_BOE = 77.0   # Inhalt der kanallosen Altdatei (AC-5)
+TIER1_BOE = 11.0
+
+ANKER_BOE = 10.0        # Vergleichsbasis, gegen die gemeldet wird
+FRISCH_HOCH_BOE = 150.0  # Δ 140 km/h -> Dringlichkeit HIGH
+FRISCH_NIEDRIG_BOE = 35.0  # Δ 25 km/h -> ausloesend, aber nur LOW (AC-6)
+
+ALLE_KANAELE = ("email", "telegram", "sms", "premium_sms")
+
+
+def _nutzer(prefix: str) -> str:
+    return f"tdd-1987-{prefix}-{uuid.uuid4().hex[:6]}"
+
+
+def _wetter(gust_kmh: float, *, alter: timedelta = timedelta(0)):
+    return dataclasses.replace(
+        weather(1, gust_max_kmh=gust_kmh),
+        fetched_at=datetime.now(timezone.utc) - alter,
+    )
+
+
+def _ortstag(trip) -> date:
+    """Der Tag, den der Alarm-Pfad selbst benutzt (``trip_local_today``)."""
+    from services.trip_day import trip_local_today
+
+    return trip_local_today(trip, datetime.now(timezone.utc))
+
+
+def _anker_pfad(user_id: str, trip_id: str, channel: str) -> Path:
+    from app.loader import get_snapshots_dir
+
+    return get_snapshots_dir(user_id) / f"{trip_id}_alarm_anchor_{channel}.json"
+
+
+def _kanal_anker_boe(user_id: str, trip_id: str, channel: str):
+    """Boeenwert im Tier-2-Merker dieses Kanals — ``None``, wenn es ihn nicht gibt."""
+    from services.weather_snapshot import WeatherSnapshotService
+
+    geladen = WeatherSnapshotService(user_id=user_id).load_alarm_anchor(
+        trip_id, channel=channel,
+    )
+    return geladen[0].aggregated.gust_max_kmh if geladen else None
+
+
+def _altstaende_anlegen(user_id: str, trip_id: str, tag: date) -> dict[str, float]:
+    """Fuer JEDEN der vier Kanaele einen unterscheidbaren Tier-2-Merker."""
+    from services.weather_snapshot import WeatherSnapshotService
+
+    svc = WeatherSnapshotService(user_id=user_id)
+    staende = dict(zip(
+        ALLE_KANAELE,
+        (EMAIL_ALTSTAND, TELEGRAM_ALTSTAND, SMS_ALTSTAND, PREMIUM_ALTSTAND),
+    ))
+    for channel, boe in staende.items():
+        svc.save_alarm_anchor(trip_id, tag, [_wetter(boe)], channel=channel)
+    return staende
+
+
+def _letzter_protokoll_eintrag(user_id: str) -> dict:
+    """Die Zustellbilanz des Laufs, wie das Alarm-Protokoll sie festhaelt.
+
+    ``channels_sent`` traegt exakt ``NotificationResult.delivered_channels``
+    (``alert_log.py:362``) — der unabhaengige Nachweis, welcher Kanal in
+    diesem Lauf wirklich zugestellt hat.
+    """
+    eintraege = read_log(user_id)["entries"]
+    assert eintraege, (
+        "Fixtur-Schutz: der Lauf hat keinen Protokoll-Eintrag hinterlassen — "
+        "dann ist der Versand gar nicht erst versucht worden und die "
+        "Anker-Erwartungen unten waeren trivial wahr."
+    )
+    return eintraege[-1]
+
+
+def _alarm_service(user_id: str, mails: list):
+    from services.trip_alert import TripAlertService
+
+    settings = settings_email_and_failing_telegram()
+    assert settings.can_send_email() is True, (
+        "Fixtur-Schutz: ohne sendefaehigen E-Mail-Kanal gaebe es keine "
+        "erfolgreiche Zustellung, gegen die sich der Fehlschlag abheben kann."
+    )
+    assert settings.can_send_telegram() is True, (
+        "Fixtur-Schutz: Telegram MUSS betreten werden und dort scheitern — "
+        "ein gar nicht erst betretener Kanal wuerde die Zusicherung "
+        "trivial erfuellen (kein Varianz-Nachweis)."
+    )
+    return TripAlertService(
+        settings=settings, user_id=user_id,
+        mail_sink=lambda subject, body: mails.append(subject),
+    )
+
+
+# ═════════════════════════════════ AC-1 ══════════════════════════════════════
+
+
+def test_ac1_nur_der_zugestellte_kanal_bekommt_einen_frischen_merker():
+    """AC-1.
+
+    GIVEN eine Tour mit den Alarmkanaelen E-Mail und Telegram, beide mit einem
+          eigenen, unterscheidbaren Tier-2-Merker.
+    WHEN  ein Alarm laeuft, den nur E-Mail zustellt (Telegram scheitert am
+          echten Transport-Guard).
+    THEN  traegt der E-Mail-Merker den neuen Stand, waehrend der
+          Telegram-Merker unveraendert auf seinem Altstand stehen bleibt.
+
+    HEUTE ROT: ``save_alarm_anchor()`` kennt keinen ``channel``-Parameter
+    (TypeError) — es gibt genau EINEN kanallosen Merker je Tour, der nach
+    jedem versendeten Alarm vorrueckt, gleichgueltig wer ihn bekommen hat.
+
+    Mutations-Gegenprobe (Spec Nr. 1): iteriert der Schreibpfad ueber
+    ``effective_channels`` statt ``delivered_channels``, bekaeme auch der
+    gescheiterte Telegram-Kanal den frischen Stand — dieser Test wird rot.
+    """
+    user_id, trip_id = _nutzer("ac1"), "trip-1987-ac1"
+    trip = gust_alert_trip(trip_id, alert_channels={"email": True, "telegram": True})
+    heute = _ortstag(trip)
+    staende = _altstaende_anlegen(user_id, trip_id, heute)
+
+    mails: list = []
+    ausgeloest = _alarm_service(user_id, mails).check_and_send_alerts(
+        trip, [_wetter(ANKER_BOE, alter=timedelta(hours=1))],
+        fresh_weather=[_wetter(FRISCH_HOCH_BOE)],
+    )
+
+    assert ausgeloest, "Fixtur-Schutz: das Delta 10 -> 150 km/h muss ausloesen."
+    assert mails, "Fixtur-Schutz: die E-Mail muss tatsaechlich zugestellt sein."
+    bilanz = _letzter_protokoll_eintrag(user_id)["channels_sent"]
+    assert bilanz == ["email"], (
+        "Fixtur-Schutz: die Zustellbilanz dieses Laufs muss genau 'E-Mail "
+        f"zugestellt, Telegram nicht' lauten, erhalten: {bilanz!r}."
+    )
+
+    assert _kanal_anker_boe(user_id, trip_id, "email") == pytest.approx(FRISCH_HOCH_BOE), (
+        "AC-1: der zugestellte Kanal MUSS auf den neuen Stand vorruecken "
+        f"({FRISCH_HOCH_BOE} km/h), erhalten: "
+        f"{_kanal_anker_boe(user_id, trip_id, 'email')}."
+    )
+    assert _kanal_anker_boe(user_id, trip_id, "telegram") == pytest.approx(
+        staende["telegram"]
+    ), (
+        "AC-1: der NICHT zugestellte Kanal muss auf seinem Altstand "
+        f"({staende['telegram']} km/h) stehen bleiben — sonst vergleicht der "
+        "naechste Lauf gegen einen Stand, den dieser Empfaenger nie bekommen "
+        f"hat. Erhalten: {_kanal_anker_boe(user_id, trip_id, 'telegram')}."
+    )
+
+
+# ═════════════════════════════════ AC-2 ══════════════════════════════════════
+
+
+def test_ac2_ohne_jede_zustellung_rueckt_kein_einziger_kanal_vor():
+    """AC-2.
+
+    GIVEN eine Tour, deren einziger Alarmkanal Telegram ist, mit vorbelegten
+          Tier-2-Merkern fuer ALLE vier Kanaele.
+    WHEN  ein Alarm laeuft, den kein einziger Kanal zustellt (Telegram
+          scheitert am echten Transport-Guard).
+    THEN  bleibt JEDER der vier Merker unveraendert — es entsteht nirgends
+          ein frischer Stand.
+
+    HEUTE ROT: ``save_alarm_anchor()`` kennt keinen ``channel``-Parameter
+    (TypeError). Fachlich schreibt der Bestand hier sogar einen frischen
+    (kanallosen) Merker, obwohl niemand etwas bekommen hat — genau der Bug
+    aus #1987.
+    """
+    user_id, trip_id = _nutzer("ac2"), "trip-1987-ac2"
+    trip = gust_alert_trip(trip_id, alert_channels={"telegram": True})
+    heute = _ortstag(trip)
+    staende = _altstaende_anlegen(user_id, trip_id, heute)
+
+    mails: list = []
+    ausgeloest = _alarm_service(user_id, mails).check_and_send_alerts(
+        trip, [_wetter(ANKER_BOE, alter=timedelta(hours=1))],
+        fresh_weather=[_wetter(FRISCH_HOCH_BOE)],
+    )
+
+    assert ausgeloest, (
+        "Fixtur-Schutz: der Lauf muss bis zum Schreibpfad kommen — Telegram "
+        "war erreichbar (nur der Transport scheiterte), der Bestand wertet "
+        "das als 'gesendet'."
+    )
+    assert not mails, "Fixtur-Schutz: E-Mail ist hier gar nicht konfiguriert."
+    bilanz = _letzter_protokoll_eintrag(user_id)["channels_sent"]
+    assert bilanz == [], (
+        f"Fixtur-Schutz: kein Kanal darf zugestellt haben, erhalten: {bilanz!r}."
+    )
+
+    for channel, alt in staende.items():
+        assert _kanal_anker_boe(user_id, trip_id, channel) == pytest.approx(alt), (
+            f"AC-2: ohne jede Zustellung darf KEIN Kanal vorruecken — "
+            f"{channel!r} steht auf "
+            f"{_kanal_anker_boe(user_id, trip_id, channel)} statt {alt} km/h."
+        )
+
+
+# ═════════════════════════════════ AC-6 ══════════════════════════════════════
+
+
+def test_ac6_schwellengefilterter_kanal_bekommt_keinen_frischen_merker():
+    """AC-6.
+
+    GIVEN eine Tour mit den Alarmkanaelen E-Mail und Telegram, bei der
+          Telegram erst ab Dringlichkeit MODERATE gemeldet wird, und beide
+          Kanaele haben einen eigenen Tier-2-Merker.
+    WHEN  ein Alarm der Dringlichkeit LOW laeuft — ``split_by_threshold()``
+          entfernt Telegram VOR dem Versand, er landet also weder in
+          ``sent_channels`` noch in ``failed_channels``.
+    THEN  bekommt Telegram KEINEN frischen Merker (er hat nichts empfangen),
+          waehrend der E-Mail-Merker vorrueckt.
+
+    HEUTE ROT: ``save_alarm_anchor()`` kennt keinen ``channel``-Parameter
+    (TypeError).
+
+    Mutations-Gegenprobe (Spec Nr. 1): iteriert der Schreibpfad ueber
+    ``effective_channels`` (rohes Opt-in, enthaelt Telegram) statt ueber
+    ``delivered_channels``, wird dieser Test rot — genau der Fehler, der die
+    Zusicherung still bricht.
+    """
+    user_id, trip_id = _nutzer("ac6"), "trip-1987-ac6"
+    trip = gust_alert_trip(trip_id, alert_channels={"email": True, "telegram": True})
+    trip.alert_channel_thresholds = {"telegram": "MODERATE"}
+    heute = _ortstag(trip)
+    staende = _altstaende_anlegen(user_id, trip_id, heute)
+
+    mails: list = []
+    svc = _alarm_service(user_id, mails)
+    ausgeloest = svc.check_and_send_alerts(
+        trip, [_wetter(ANKER_BOE, alter=timedelta(hours=1))],
+        fresh_weather=[_wetter(FRISCH_NIEDRIG_BOE)],
+    )
+
+    assert ausgeloest, "Fixtur-Schutz: das Delta 10 -> 35 km/h muss ausloesen."
+    assert svc._last_below_threshold_channels == {"telegram"}, (
+        "Fixtur-Schutz: genau Telegram muss an der Kanal-Schwelle "
+        "haengenbleiben, erhalten: "
+        f"{svc._last_below_threshold_channels!r} — sonst misst dieser Test "
+        "den Schwellenfall gar nicht."
+    )
+    bilanz = _letzter_protokoll_eintrag(user_id)["channels_sent"]
+    assert bilanz == ["email"], (
+        f"Fixtur-Schutz: nur E-Mail darf zugestellt haben, erhalten: {bilanz!r}."
+    )
+
+    assert _kanal_anker_boe(user_id, trip_id, "email") == pytest.approx(
+        FRISCH_NIEDRIG_BOE
+    ), (
+        "AC-6: der zugestellte Kanal muss vorruecken, erhalten: "
+        f"{_kanal_anker_boe(user_id, trip_id, 'email')}."
+    )
+    assert _kanal_anker_boe(user_id, trip_id, "telegram") == pytest.approx(
+        staende["telegram"]
+    ), (
+        "AC-6: ein unterhalb der Dringlichkeitsschwelle entfernter Kanal hat "
+        "nichts empfangen und darf deshalb keinen frischen Merker bekommen — "
+        f"erhalten: {_kanal_anker_boe(user_id, trip_id, 'telegram')} statt "
+        f"{staende['telegram']} km/h."
+    )
+
+
+# ═════════════════════════════════ AC-5 ══════════════════════════════════════
+
+
+def test_ac5_kanallose_altdatei_dient_jedem_kanal_als_rueckfall():
+    """AC-5.
+
+    GIVEN eine Tour besitzt ausschliesslich die kanallose Altdatei
+          ``{trip_id}_alarm_anchor.json`` (Bestand vor dieser Scheibe) und
+          KEINE kanalspezifische Datei.
+    WHEN  der erste Lesevorgang fuer beliebige Kanaele laeuft (hier
+          ``premium_sms`` und ``email``).
+    THEN  liefern beide den Inhalt der Altdatei als Vergleichsbasis — kein
+          Datenverlust, kein Migrationsskript noetig.
+
+    HEUTE ROT: ``load_alarm_anchor()`` kennt keinen ``channel``-Parameter
+    (TypeError).
+
+    Die Altdatei entsteht ueber den echten Serialisierer (``save()`` schreibt
+    dasselbe Schema) und wird anschliessend unter den kanallosen Namen
+    kopiert — reines Setup der Ausgangslage, keine Zusicherung ueber
+    Dateiinhalte. Der undatierte Anker wird danach mit einem ANDEREN Wert
+    ueberschrieben: liest die Kette versehentlich die falsche Datei, faellt
+    das sofort auf.
+    """
+    from app.loader import get_snapshots_dir
+    from services.weather_snapshot import WeatherSnapshotService
+
+    user_id, trip_id = _nutzer("ac5"), "trip-1987-ac5"
+    trip = gust_alert_trip(trip_id, alert_channels={"email": True})
+    heute = _ortstag(trip)
+    svc = WeatherSnapshotService(user_id=user_id)
+
+    svc.save(trip_id, [_wetter(ALTBESTAND_BOE)], heute)
+    quelle = get_snapshots_dir(user_id) / f"{trip_id}.json"
+    (get_snapshots_dir(user_id) / f"{trip_id}_alarm_anchor.json").write_text(
+        quelle.read_text()
+    )
+    svc.save(trip_id, [_wetter(TIER1_BOE)], heute)
+
+    for channel in ("premium_sms", "email"):
+        assert not _anker_pfad(user_id, trip_id, channel).exists(), (
+            f"Fixtur-Schutz: fuer {channel!r} darf es KEINE kanalspezifische "
+            "Datei geben, sonst prueft dieser Test den Rueckfall nicht."
+        )
+        geladen = svc.load_alarm_anchor(trip_id, channel=channel)
+        assert geladen, (
+            f"AC-5: die kanallose Altdatei muss fuer {channel!r} weiterhin als "
+            "Vergleichsbasis dienen — sonst verlieren alle Bestandstouren beim "
+            "Deploy ihren rollierenden Anker."
+        )
+        assert geladen[0].aggregated.gust_max_kmh == pytest.approx(ALTBESTAND_BOE), (
+            f"AC-5: {channel!r} muss den Inhalt der Altdatei "
+            f"({ALTBESTAND_BOE} km/h) sehen, erhalten: "
+            f"{geladen[0].aggregated.gust_max_kmh} km/h."
+        )
+
+
+# ═════════════════ AC-3 (Regressionsschutz #1629, Gegenprobe) ════════════════
+
+
+def test_ac3_briefing_ohne_jede_zustellung_schreibt_tier1_aber_keinen_kanal_merker():
+    """AC-3.
+
+    GIVEN ein Briefing-Lauf, dessen Versand mit einer Ausnahme scheitert — auf
+          keinem Kanal wird etwas zugestellt (das gemessene #1629-Muster).
+    WHEN  der Briefing-Lauf abgeschlossen ist.
+    THEN  ist der Tier-1-Briefing-Anker TROTZDEM geschrieben und ein
+          anschliessender Abweichungs-Alarm-Check findet eine gueltige
+          Vergleichsbasis (nicht ``None``) — gleichzeitig ist fuer KEINEN der
+          vier Kanaele ein Tier-2-Merker entstanden: die Zustellungsbindung
+          dieser Scheibe gilt fuer Tier 2, der unbedingte Tier-1-Write
+          bleibt unveraendert bestehen (E1).
+
+    HEUTE ROT: ``load_alarm_anchor()`` kennt keinen ``channel``-Parameter
+    (TypeError). Der Tier-1-Teil dieser Zusicherung ist Bestandsverhalten und
+    MUSS es bleiben.
+
+    Mutations-Gegenprobe (Spec Nr. 2): koppelt eine Verfaelschung den
+    Tier-1-Write an eine Zustellbedingung, kehrt die #1629-Regression zurueck
+    (Vergleichsbasis ``None``, Abweichungs-Wache strukturell blind) und
+    dieser Test wird rot.
+
+    Der gescheiterte Briefing-Lauf wird nicht nachgebaut, sondern ueber die
+    erprobten, mockfreien Helfer des #1629-Tests gefahren (echter
+    Konfigurations-Guard des echten E-Mail-Kanals, echter Scheduler mit
+    Fixture-Wetterquelle) — ein zweiter Nachbau wuerde nur eine zweite
+    Fehlerquelle schaffen.
+    """
+    from services.trip_alert import TripAlertService
+    from services.weather_snapshot import WeatherSnapshotService
+    from tests.helpers.alert_log_fixtures import settings_email_only
+    from tests.tdd.test_briefing_anchor_survives_dispatch_failure import (
+        _run_failing_briefing,
+        _trip as _briefing_trip,
+    )
+
+    user_id = _nutzer("ac3")
+    trip = _briefing_trip(f"trip-1987-ac3-{uuid.uuid4().hex[:6]}", with_levels=True)
+
+    _run_failing_briefing(user_id, trip, gust=25.0)
+
+    basis = TripAlertService(
+        settings=settings_email_only(), user_id=user_id,
+    )._get_cached_weather(trip, tagesgleicher_anker_noetig=True)
+    assert basis, (
+        "AC-3: nach einem Briefing ohne jede Zustellung muss der "
+        "Tier-1-Briefing-Anker trotzdem geschrieben sein und eine gueltige "
+        "Vergleichsbasis liefern — sonst ist die Abweichungs-Wache den "
+        "ganzen Tag blind (#1629)."
+    )
+
+    svc = WeatherSnapshotService(user_id=user_id)
+    for channel in ALLE_KANAELE:
+        assert svc.load_alarm_anchor(trip.id, channel=channel) is None, (
+            f"AC-3: ein Briefing ohne jede Zustellung darf fuer {channel!r} "
+            "KEINEN rollierenden Tier-2-Merker anlegen — dieser Empfaenger "
+            "hat nichts bekommen. Nur Tier 1 bleibt unbedingt (E1)."
+        )

--- a/tests/tdd/test_alert_channel_anchor_delivery.py
+++ b/tests/tdd/test_alert_channel_anchor_delivery.py
@@ -372,13 +372,84 @@ def test_ac5_kanallose_altdatei_dient_jedem_kanal_als_rueckfall():
 
 
 # ═════════════════ AC-3 (Regressionsschutz #1629, Gegenprobe) ════════════════
+#
+# AC-3 nennt ZWEI gleichwertige #1629-Szenarien, und der Scheduler bedient sie
+# an ZWEI verschiedenen Stellen. Beide muessen bewacht sein: eine Kopplung des
+# Tier-1-Writes an eine Zustellbedingung waere an jeder von ihnen einzeln
+# moeglich, und je Naht faellt nur der Test, der genau sie durchlaeuft
+# (Adversary-Befund F001).
+#
+# Die Briefing-Laeufe werden nicht nachgebaut, sondern ueber die erprobten,
+# mockfreien Helfer des #1629-Tests gefahren (echte Kanal-Guards, echter
+# Scheduler mit Fixture-Wetterquelle) — ein zweiter Nachbau wuerde nur eine
+# zweite Fehlerquelle schaffen.
 
 
-def test_ac3_briefing_ohne_jede_zustellung_schreibt_tier1_aber_keinen_kanal_merker():
+def _briefing_lauf_mit_ausnahme(user_id: str):
+    """Naht 1 (`trip_report_scheduler.py:1543`): der Versandaufruf WIRFT.
+
+    Der Fehler entsteht am echten Konfigurations-Guard des echten
+    E-Mail-Kanals — dieselbe Ausnahmeklasse, aus demselben Modul, wie im
+    Produktivfall vom 08.08.2026.
+    """
+    from tests.tdd.test_briefing_anchor_survives_dispatch_failure import (
+        _run_failing_briefing,
+        _trip as _briefing_trip,
+    )
+
+    trip = _briefing_trip(f"trip-1987-ac3a-{uuid.uuid4().hex[:6]}", with_levels=True)
+    _run_failing_briefing(user_id, trip, gust=25.0)
+    return trip
+
+
+def _briefing_lauf_ohne_zustellung(user_id: str):
+    """Naht 2 (`trip_report_scheduler.py:1651`): KEIN Kanal erreichbar, aber
+    auch KEINE Ausnahme — der regulaere Pfad laeuft bis zum Ende durch und
+    endet mit ``result.sent == False``.
+
+    Aufbau: E-Mail ist fuer die Tour aus, Telegram an und garantiert
+    scheiternd (echter ``TelegramOutput``-Guard #1363, wirft VOR jedem
+    Netzaufruf). Telegram ist fail-soft, die Ausnahme kommt also nie beim
+    Scheduler an — genau der Unterschied zu Naht 1.
+    """
+    from tests.tdd.test_briefing_anchor_survives_dispatch_failure import (
+        _fixture_scheduler,
+        _trip as _briefing_trip,
+    )
+
+    trip = _briefing_trip(
+        f"trip-1987-ac3b-{uuid.uuid4().hex[:6]}", with_levels=True,
+        send_email=False, send_telegram=True,
+    )
+    ergebnis = _fixture_scheduler(25.0)(
+        settings=settings_email_and_failing_telegram(), user_id=user_id,
+    )._send_trip_report_outcome(trip, "morning", on_demand=False)
+    assert ergebnis == "channels_unreachable", (
+        "Fixtur-Schutz: dieser Lauf muss OHNE Ausnahme enden und ehrlich als "
+        f"nicht zugestellt gelten, erhalten: {ergebnis!r} — sonst prueft er "
+        "dieselbe Naht wie die Ausnahme-Variante und der zweite Fall bleibt "
+        "unbewacht."
+    )
+    return trip
+
+
+@pytest.mark.parametrize(
+    "briefing_lauf, naht",
+    [
+        (_briefing_lauf_mit_ausnahme, "Ausnahme aus dem Versandaufruf (:1543)"),
+        (_briefing_lauf_ohne_zustellung, "kein Kanal erreichbar, ohne Ausnahme (:1651)"),
+    ],
+    ids=["naht_ausnahme", "naht_unerreichbar"],
+)
+def test_ac3_briefing_ohne_jede_zustellung_schreibt_tier1_aber_keinen_kanal_merker(
+    briefing_lauf, naht,
+):
     """AC-3.
 
-    GIVEN ein Briefing-Lauf, dessen Versand mit einer Ausnahme scheitert — auf
-          keinem Kanal wird etwas zugestellt (das gemessene #1629-Muster).
+    GIVEN ein Briefing-Lauf, bei dem auf keinem Kanal etwas zugestellt wird —
+          einmal, weil der Versandaufruf mit einer Ausnahme abbricht, einmal,
+          weil der regulaere Pfad mit ``result.sent == False`` endet. Die Spec
+          nennt beide Faelle ausdruecklich gleichwertig.
     WHEN  der Briefing-Lauf abgeschlossen ist.
     THEN  ist der Tier-1-Briefing-Anker TROTZDEM geschrieben und ein
           anschliessender Abweichungs-Alarm-Check findet eine gueltige
@@ -387,39 +458,36 @@ def test_ac3_briefing_ohne_jede_zustellung_schreibt_tier1_aber_keinen_kanal_merk
           dieser Scheibe gilt fuer Tier 2, der unbedingte Tier-1-Write
           bleibt unveraendert bestehen (E1).
 
-    HEUTE ROT: ``load_alarm_anchor()`` kennt keinen ``channel``-Parameter
-    (TypeError). Der Tier-1-Teil dieser Zusicherung ist Bestandsverhalten und
-    MUSS es bleiben.
+    Der Tier-1-Teil dieser Zusicherung ist Bestandsverhalten und MUSS es
+    bleiben.
 
     Mutations-Gegenprobe (Spec Nr. 2): koppelt eine Verfaelschung den
     Tier-1-Write an eine Zustellbedingung, kehrt die #1629-Regression zurueck
     (Vergleichsbasis ``None``, Abweichungs-Wache strukturell blind) und
-    dieser Test wird rot.
-
-    Der gescheiterte Briefing-Lauf wird nicht nachgebaut, sondern ueber die
-    erprobten, mockfreien Helfer des #1629-Tests gefahren (echter
-    Konfigurations-Guard des echten E-Mail-Kanals, echter Scheduler mit
-    Fixture-Wetterquelle) — ein zweiter Nachbau wuerde nur eine zweite
-    Fehlerquelle schaffen.
+    dieser Test wird rot. Beide Parameter sind noetig: die Mutation ist an
+    jeder der beiden Nahtstellen EINZELN moeglich, und je Naht faellt nur der
+    Fall, der genau sie durchlaeuft (Adversary-Befund F001).
     """
+    from app.loader import get_data_dir
     from services.trip_alert import TripAlertService
     from services.weather_snapshot import WeatherSnapshotService
     from tests.helpers.alert_log_fixtures import settings_email_only
-    from tests.tdd.test_briefing_anchor_survives_dispatch_failure import (
-        _run_failing_briefing,
-        _trip as _briefing_trip,
-    )
 
     user_id = _nutzer("ac3")
-    trip = _briefing_trip(f"trip-1987-ac3-{uuid.uuid4().hex[:6]}", with_levels=True)
-
-    _run_failing_briefing(user_id, trip, gust=25.0)
+    # Im Betrieb existiert die Nutzerablage laengst (der Nutzer hat Touren).
+    # Hier legt sie sonst erst der Anker-Write selbst an — und dann scheitert
+    # bei einer Mutation, die genau ihn ausschaltet, der nachfolgende
+    # Nachliefer-Vermerk mit einem FileNotFoundError. Der Test waere zwar rot,
+    # aber am falschen Grund: er wuerde die Reihenfolge zweier Schreibvorgaenge
+    # messen statt der Vergleichsbasis. Deshalb Vorbedingung statt Zufall.
+    get_data_dir(user_id).mkdir(parents=True, exist_ok=True)
+    trip = briefing_lauf(user_id)
 
     basis = TripAlertService(
         settings=settings_email_only(), user_id=user_id,
     )._get_cached_weather(trip, tagesgleicher_anker_noetig=True)
     assert basis, (
-        "AC-3: nach einem Briefing ohne jede Zustellung muss der "
+        f"AC-3 ({naht}): nach einem Briefing ohne jede Zustellung muss der "
         "Tier-1-Briefing-Anker trotzdem geschrieben sein und eine gueltige "
         "Vergleichsbasis liefern — sonst ist die Abweichungs-Wache den "
         "ganzen Tag blind (#1629)."
@@ -428,7 +496,7 @@ def test_ac3_briefing_ohne_jede_zustellung_schreibt_tier1_aber_keinen_kanal_merk
     svc = WeatherSnapshotService(user_id=user_id)
     for channel in ALLE_KANAELE:
         assert svc.load_alarm_anchor(trip.id, channel=channel) is None, (
-            f"AC-3: ein Briefing ohne jede Zustellung darf fuer {channel!r} "
-            "KEINEN rollierenden Tier-2-Merker anlegen — dieser Empfaenger "
-            "hat nichts bekommen. Nur Tier 1 bleibt unbedingt (E1)."
+            f"AC-3 ({naht}): ein Briefing ohne jede Zustellung darf fuer "
+            f"{channel!r} KEINEN rollierenden Tier-2-Merker anlegen — dieser "
+            "Empfaenger hat nichts bekommen. Nur Tier 1 bleibt unbedingt (E1)."
         )

--- a/tests/tdd/test_alert_channel_anchor_retention.py
+++ b/tests/tdd/test_alert_channel_anchor_retention.py
@@ -1,0 +1,70 @@
+"""Issue #1987 (S1), Nebenbefund aus der GREEN-Phase: die Aufraeumung der
+datierten Snapshots darf die kanalscharfen Alarm-Anker nicht mitreissen.
+
+`_prune_dated_snapshots()` (`weather_snapshot.py`) haelt maximal sieben
+datierte Snapshots je Tour und loescht den Rest. Es sammelte sie ueber
+`{trip_id}_*.json` ein — ein Muster, das jede Nachbardatei derselben Tour
+mitnimmt, also auch `{trip_id}_alarm_anchor_{channel}.json`.
+
+Gemessen VOR dem Fix (vier Kanal-Anker, danach acht Briefing-Laeufe): von
+den vier Ankern ueberlebte genau EINER, und zwei der acht datierten
+Snapshots fielen zusaetzlich weg, weil die Anker das 7er-Kontingent
+mitfuellten. Getroffen haette es bevorzugt die Kanaele mit dem aeltesten
+Schreibzeitpunkt — also genau jene, die laenger nichts zugestellt bekommen
+haben. Das sind die Kanaele, deren eigenen Stand #1987 ueberhaupt erst
+erhalten will: die Zusicherung waere in Produktion still ausgehoehlt worden,
+ohne dass ein Test es bemerkt.
+
+Kern-Schicht, kein Mock: echte Dateien in der pytest-isolierten
+`get_data_dir()`-Basis (#1133), geprueft wird der Bestand nach dem echten
+`save_dated()`-Pfad.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import date, timedelta
+
+from tests.helpers.alert_log_fixtures import weather
+
+ALLE_KANAELE = ("email", "telegram", "sms", "premium_sms")
+
+
+def test_aufraeumung_der_datierten_snapshots_laesst_kanal_anker_stehen():
+    """GIVEN eine Tour mit einem rollierenden Alarm-Anker je Kanal.
+    WHEN  acht Briefing-Laeufe datierte Snapshots schreiben und die
+          Aufraeumung auf sieben zurueckschneidet.
+    THEN  stehen ALLE VIER Kanal-Anker unveraendert da, und es bleiben
+          trotzdem sieben datierte Snapshots uebrig — die Aufraeumung zaehlt
+          die Anker also weder mit noch loescht sie sie.
+    """
+    from app.loader import get_snapshots_dir
+    from services.weather_snapshot import WeatherSnapshotService
+
+    user_id, trip_id = f"tdd-1987-prune-{uuid.uuid4().hex[:6]}", "trip-1987-prune"
+    svc = WeatherSnapshotService(user_id=user_id)
+    heute = date.today()
+
+    for channel in ALLE_KANAELE:
+        svc.save_alarm_anchor(trip_id, heute, [weather(1, gust_max_kmh=10.0)], channel)
+    for tag in range(8):
+        svc.save_dated(
+            trip_id, heute - timedelta(days=tag), [weather(1, gust_max_kmh=20.0)],
+        )
+
+    for channel in ALLE_KANAELE:
+        assert svc.load_alarm_anchor(trip_id, channel), (
+            f"Der rollierende Alarm-Anker des Kanals {channel!r} wurde von der "
+            "Aufraeumung der datierten Snapshots mitgeloescht — betroffen sind "
+            "bevorzugt die Kanaele, die am laengsten nichts zugestellt bekamen, "
+            "also genau die, deren Stand #1987 erhalten soll."
+        )
+
+    datiert = sorted(
+        p.name for p in get_snapshots_dir(user_id).glob(f"{trip_id}_*.json")
+        if "alarm_anchor" not in p.name
+    )
+    assert len(datiert) == 7, (
+        "Die Aufraeumung muss weiterhin genau sieben datierte Snapshots halten "
+        "— zaehlt sie die Anker mit, fallen zusaetzlich echte Snapshots weg. "
+        f"Vorhanden: {datiert}"
+    )

--- a/tests/tdd/test_alert_channel_anchor_shared_comparison.py
+++ b/tests/tdd/test_alert_channel_anchor_shared_comparison.py
@@ -1,0 +1,233 @@
+"""TDD RED — Issue #1987 Scheibe S1, AC-11: EIN gemeinsamer Auswertungslauf,
+verglichen gegen den AELTESTEN gueltigen Kandidaten.
+
+SPEC: ``docs/specs/modules/fix_1987_kanal_anker.md`` (AC-11).
+
+Die Auslöse-Entscheidung bleibt EIN gemeinsamer
+``DeviationAlertEngine.evaluate()``-Lauf (E2, ADR-0021 unangetastet) und
+braucht deshalb GENAU EINEN ``cached``-Stand. Gewaehlt wird der AELTESTE
+gueltige Kandidat unter den effektiven Kanaelen: nur so geht keinem Kanal
+eine Aenderung verloren, die er noch nicht kennt. Gegen Wiederholungs-Alarme
+fuer bereits aktuellere Kanaele schuetzt weiterhin das Melde-Gedaechtnis
+(``alert_state``, ADR-0056 AC-12).
+
+Test-Politik (kein Mock-Theater): echte ``WeatherSnapshotService``-Dateien in
+der pytest-isolierten ``get_data_dir()``-Basis (#1133). Der zweite Test misst
+die WIRKUNG ueber den echten Produktivpfad ``check_all_trips()`` — ersetzt
+wird ausschliesslich der Provider-Abruf durch eine echte, netzfreie
+Implementierung der vorhandenen Abruf-Naht (Haus-Muster
+``_FixedSegmentWeatherService`` aus ``test_briefing_anchor_survives_dispatch\
+_failure.py``), nicht der Prüfling. Statt auf den an ``evaluate()``
+uebergebenen Wert zu spionieren, sind die drei moeglichen Vergleichsbasen so
+gewaehlt, dass NUR die richtige (der aelteste Kandidat) einen Alarm ergibt —
+der Alarm selbst ist damit der Nachweis.
+
+Pfadregel #1409: alle Prueflinge werden ueber ``app.loader`` bzw. relativ zur
+Testdatei aufgeloest, nie ueber einen festen Hauptrepo-Pfad.
+"""
+from __future__ import annotations
+
+import dataclasses
+import json
+import uuid
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from tests.helpers.alert_log_fixtures import gust_alert_trip, settings_email_only, weather
+
+# Die drei moeglichen Vergleichsbasen — bewusst so gelegt, dass gegen den
+# frischen Stand von 50 km/h NUR der AELTESTE Kandidat ein meldepflichtiges
+# Delta (>= 20 km/h) ergibt:
+#   SMS  (aeltester, 3 h)  10 -> 50 = Δ40  -> Alarm      (richtig)
+#   MAIL (juengster, neu)  45 -> 50 = Δ5   -> kein Alarm (Mutation "juengster")
+#   TIER1 (Rueckfall)      48 -> 50 = Δ2   -> kein Alarm (Mutation "Tier 1")
+SMS_MERKER_BOE = 10.0
+EMAIL_MERKER_BOE = 45.0
+TIER1_BOE = 48.0
+FRISCH_BOE = 50.0
+
+SMS_MERKER_ALTER = timedelta(hours=3)  # innerhalb der 4h-Ceiling: gueltig
+
+
+def _nutzer(prefix: str) -> str:
+    return f"tdd-1987-{prefix}-{uuid.uuid4().hex[:6]}"
+
+
+def _wetter(gust_kmh: float, segment=None):
+    daten = dataclasses.replace(
+        weather(1, gust_max_kmh=gust_kmh), fetched_at=datetime.now(timezone.utc),
+    )
+    return dataclasses.replace(daten, segment=segment) if segment is not None else daten
+
+
+def _ortstag(trip) -> date:
+    from services.trip_day import trip_local_today
+
+    return trip_local_today(trip, datetime.now(timezone.utc))
+
+
+def _anker_pfad(user_id: str, trip_id: str, channel: str) -> Path:
+    from app.loader import get_snapshots_dir
+
+    return get_snapshots_dir(user_id) / f"{trip_id}_alarm_anchor_{channel}.json"
+
+
+def _zurueckdatieren(user_id: str, trip_id: str, channel: str, alter: timedelta) -> None:
+    """Laesst einen Kanal-Merker ``alter`` alt aussehen — ``save_alarm_anchor()``
+    schreibt immer die Schreibzeit als ``snapshot_at``."""
+    pfad = _anker_pfad(user_id, trip_id, channel)
+    assert pfad.exists(), (
+        f"Fixtur-Schutz: der kanalscharfe Merker muss unter {pfad.name!r} "
+        "liegen (Spec: '{trip_id}_alarm_anchor_{channel}.json')."
+    )
+    daten = json.loads(pfad.read_text())
+    daten["snapshot_at"] = (datetime.now(timezone.utc) - alter).isoformat()
+    pfad.write_text(json.dumps(daten, indent=2))
+
+
+def _sms_kanal_freischalten(user_id: str) -> None:
+    """SMS haengt am Nutzerlevel (``services/user_tier.py``) — ohne
+    ``tier >= standard`` faellt der Kanal aus ``_effective_alert_channels()``
+    heraus und der Test haette nur EINEN Kandidaten."""
+    from app.loader import get_data_dir
+
+    verzeichnis = get_data_dir(user_id)
+    verzeichnis.mkdir(parents=True, exist_ok=True)
+    (verzeichnis / "user.json").write_text(
+        json.dumps({"id": user_id, "tier": "premium"}), encoding="utf-8",
+    )
+
+
+def _zwei_kandidaten_anlegen(user_id: str, trip, heute: date) -> None:
+    """Ausgangslage beider Tests: SMS-Merker von "06:00", E-Mail-Merker von
+    "09:00", dazu ein taggleicher Tier-1-Briefing-Anker als Rueckfall.
+
+    Der Tier-1-Anker wird bewusst UNDATIERT abgelegt: bei einem vorhandenen
+    DATIERTEN Anker steigt ``_get_cached_weather()`` sofort aus und die
+    Kanal-Aufloesung kaeme nie zum Zug (der Test waere trivial wahr).
+    """
+    from services.weather_snapshot import WeatherSnapshotService
+
+    svc = WeatherSnapshotService(user_id=user_id)
+    svc.save(trip.id, [_wetter(TIER1_BOE)], heute)
+    svc.save_alarm_anchor(trip.id, heute, [_wetter(SMS_MERKER_BOE)], channel="sms")
+    _zurueckdatieren(user_id, trip.id, "sms", SMS_MERKER_ALTER)
+    svc.save_alarm_anchor(trip.id, heute, [_wetter(EMAIL_MERKER_BOE)], channel="email")
+
+
+def _zwei_kanal_trip(trip_id: str):
+    return gust_alert_trip(trip_id, alert_channels={"email": True, "sms": True})
+
+
+# ═════════════════════════════════ AC-11 ═════════════════════════════════════
+
+
+def test_ac11_gemeinsame_vergleichsbasis_ist_der_aelteste_gueltige_kandidat():
+    """AC-11 (Auswahl).
+
+    GIVEN zwei Alarmkanaele mit unterschiedlich alten, beide gueltigen
+          Kandidaten-Merkern (E-Mail von "09:00", SMS von "06:00") und einem
+          taggleichen Tier-1-Briefing-Anker.
+    WHEN  der EINE gemeinsame Auswertungslauf seine Vergleichsbasis aufloest.
+    THEN  ist es der SMS-Merker von "06:00" — der AELTERE der beiden
+          Kandidaten —, damit auch die Aenderung zwischen "06:00" und "09:00"
+          gemeldet wird, die der SMS-Kanal noch nicht kennt.
+
+    HEUTE ROT: ``save_alarm_anchor()`` kennt keinen ``channel``-Parameter
+    (TypeError) — es gibt nur einen kanallosen Merker, also gar keine Auswahl.
+
+    Mutations-Gegenprobe (Spec Nr. 4): waehlt die Aufloesung den JUENGSTEN
+    statt den AELTESTEN Kandidaten, liefert sie ``EMAIL_MERKER_BOE`` und
+    dieser Test wird rot.
+    """
+    user_id, trip_id = _nutzer("ac11"), "trip-1987-ac11"
+    _sms_kanal_freischalten(user_id)
+    trip = _zwei_kanal_trip(trip_id)
+    _zwei_kandidaten_anlegen(user_id, trip, _ortstag(trip))
+
+    from services.trip_alert import TripAlertService
+
+    svc = TripAlertService(settings=settings_email_only(), user_id=user_id)
+    assert svc._effective_alert_channels(trip) == {"email", "sms"}, (
+        "Fixtur-Schutz: es muessen ZWEI effektive Alarmkanaele vorliegen, "
+        f"erhalten: {svc._effective_alert_channels(trip)!r} — mit nur einem "
+        "Kanal gaebe es nichts auszuwaehlen."
+    )
+
+    basis = svc._get_cached_weather(trip, tagesgleicher_anker_noetig=True)
+
+    assert basis, "AC-11: beide Kandidaten sind gueltig, es MUSS eine Basis geben."
+    assert basis[0].aggregated.gust_max_kmh == pytest.approx(SMS_MERKER_BOE), (
+        f"AC-11: verglichen werden muss gegen den AELTESTEN gueltigen "
+        f"Kandidaten ({SMS_MERKER_BOE} km/h, SMS-Merker von '06:00'). "
+        f"Erhalten: {basis[0].aggregated.gust_max_kmh} km/h — "
+        f"{EMAIL_MERKER_BOE} hiesse: der JUENGSTE Kandidat gewinnt und dem "
+        f"schlechter versorgten Kanal wird eine Aenderung unterschlagen; "
+        f"{TIER1_BOE} hiesse: die Kanal-Kandidaten werden gar nicht erst "
+        "herangezogen."
+    )
+
+
+def test_ac11_wirkung_aenderung_die_nur_der_aeltere_kanal_kennt_wird_gemeldet(monkeypatch):
+    """AC-11 (Wirkung am Produktivpfad).
+
+    GIVEN dieselbe Ausgangslage wie oben, und die frische Vorhersage liegt bei
+          50 km/h.
+    WHEN  der regulaere Alarm-Lauf ``check_all_trips()`` fuer diese Tour
+          durchlaeuft.
+    THEN  geht ein Alarm raus — denn gegen den SMS-Merker von "06:00"
+          (10 km/h) betraegt das Delta 40 km/h. Gegen den E-Mail-Merker
+          (45 km/h, Δ5) oder den Tier-1-Anker (48 km/h, Δ2) bliebe es still.
+          Der Alarm ist damit selbst der Nachweis, WELCHE Basis in den EINEN
+          gemeinsamen Auswertungslauf gegangen ist.
+
+    HEUTE ROT: ``save_alarm_anchor()`` kennt keinen ``channel``-Parameter
+    (TypeError).
+
+    Mutations-Gegenprobe (Spec Nr. 4): waehlt die Aufloesung den JUENGSTEN
+    Kandidaten, bleibt der Lauf still (``alerts_sent == 0``, keine Mail) und
+    dieser Test wird rot — genau der stille Ausfall, den die Scheibe fuer
+    schlechter versorgte Kanaele verhindern soll.
+    """
+    import services.segment_weather as sw_mod
+    from app.loader import save_trip
+    from services.trip_alert import TripAlertService
+
+    user_id, trip_id = _nutzer("ac11w"), "trip-1987-ac11w"
+    _sms_kanal_freischalten(user_id)
+    trip = _zwei_kanal_trip(trip_id)
+    save_trip(trip, user_id=user_id)
+    _zwei_kandidaten_anlegen(user_id, trip, _ortstag(trip))
+
+    class _FesteWetterquelle:
+        """Echte, netzfreie Implementierung der Abruf-Naht von
+        ``_fetch_fresh_weather()`` — der Zeitfilter dort laeuft unveraendert."""
+
+        def __init__(self, provider=None) -> None:
+            self._provider = provider
+
+        def fetch_segment_weather(self, segment, **kwargs):
+            return _wetter(FRISCH_BOE, segment=segment)
+
+    monkeypatch.setattr(sw_mod, "SegmentWeatherService", _FesteWetterquelle)
+
+    mails: list = []
+    ergebnis = TripAlertService(
+        settings=settings_email_only(), user_id=user_id,
+        mail_sink=lambda subject, body: mails.append(subject),
+    ).check_all_trips()
+
+    assert ergebnis.alerts_sent == 1, (
+        "AC-11 (Wirkung): der Lauf muss die Aenderung melden, die nur der "
+        f"aeltere SMS-Kandidat noch nicht kennt ({SMS_MERKER_BOE} -> "
+        f"{FRISCH_BOE} km/h). Erhalten: alerts_sent="
+        f"{ergebnis.alerts_sent} — still bleibt der Lauf genau dann, wenn "
+        f"gegen den juengeren E-Mail-Merker ({EMAIL_MERKER_BOE}) oder den "
+        f"Tier-1-Anker ({TIER1_BOE}) verglichen wurde."
+    )
+    assert mails, (
+        "AC-11 (Wirkung): es muss tatsaechlich eine Meldung rausgehen — sonst "
+        "ist die Auswertung nur formal gelaufen."
+    )

--- a/tests/tdd/test_alert_rolling_anchor.py
+++ b/tests/tdd/test_alert_rolling_anchor.py
@@ -1,22 +1,37 @@
-"""TDD RED — Issue #1916, AC-Gruppe B ("Rollierende Basis"), AC-6..AC-8.
+"""TDD RED — Issue #1916, AC-Gruppe B ("Rollierende Basis"), AC-6.
 
-SPEC: docs/specs/modules/trip_alert.md v3.0, ADR-0056.
+SPEC: docs/specs/modules/trip_alert.md v3.0, ADR-0056;
+docs/specs/modules/fix_1987_kanal_anker.md (S1).
 
-Dritter, rollierender Anker-Typ mit Hybrid-Schreibtrigger: (a) bei jedem
-tatsaechlich versendeten Alarm, (b) opportunistisch beim Ueberschreiten der
-4h-Alterungs-Ceiling. Kern-Schicht, deterministisch: ``cached_weather``/
-``fresh_weather`` werden DIREKT an ``check_and_send_alerts()`` uebergeben
-(Vorbild ``test_alert_channel_threshold.py:409-412``) -- der Schreibpfad ist
-Teil dieser Methode selbst (Spec-Tabelle: "trip_alert.py MODIFY ... neuer
-Schreibpfad nach jedem Check-Lauf"), unabhaengig davon, wie ``cached``
-zustande kam.
+Dritter, rollierender Anker-Typ. Kern-Schicht, deterministisch:
+``cached_weather``/``fresh_weather`` werden DIREKT an
+``check_and_send_alerts()`` uebergeben (Vorbild
+``test_alert_channel_threshold.py:409-412``) -- der Schreibpfad ist Teil
+dieser Methode selbst, unabhaengig davon, wie ``cached`` zustande kam.
 
-Angenommene API (Spec Zeile 69, "z.B."): ``WeatherSnapshotService.
-save_alarm_anchor()``/``load_alarm_anchor()``, Rueckgabetyp wie die
-Geschwistermethoden ``load()``/``load_dated()``
-(``Optional[list[SegmentWeatherData]]``). Aendert die Implementierung die
-Namen, betrifft das nur die Aufrufstellen hier, nicht die Zusicherungen
-selbst.
+**Issue #1987 (S1) hat den Hybrid-Trigger halbiert.** ADR-0056 kannte zwei
+Schreibtrigger: (a) tatsaechlicher Alarmversand, (b) opportunistische
+Auffrischung beim Ueberschreiten der 4h-Ceiling, auch ohne Alarm. Trigger
+(b) ist mit der Zustellungsbindung von #1987 begrifflich unmoeglich geworden
+-- er lief im Zweig "kein Alarm gefeuert", also ohne jede
+``delivered_channels``-Information, und schrieb damit einen Stand fort, den
+kein Empfaenger je bekommen hat (Spec #1987, "Bewusste Abkehr von
+Alt-Verhalten", zweite Abkehr). Die frueheren AC-7/AC-8-Tests dieser Datei
+haben genau diesen Trigger geprueft und sind deshalb ERSETZT durch
+``test_ohne_alarm_wird_kein_rollierender_anker_mehr_geschrieben`` unten --
+die Umkehrung derselben Naht. Dasselbe gilt fuer den frueheren
+``_effective_anchor_age()``-Regressionstest: die Methode existiert nicht
+mehr, sie hatte nur den entfallenen Schreibtrigger zu bedienen.
+
+Die Schutzwirkung gegen eine veraltete Vergleichsbasis ist NICHT entfallen,
+sie wandert in den Lesepfad: ein gealterter Kanal-Merker wird dort nicht
+mehr als Kandidat herangezogen, die Kette faellt fuer diesen Kanal auf den
+Tier-1-Briefing-Anker zurueck. Bewacht in
+``test_alert_channel_anchor_ceiling_fallback.py`` (#1987 AC-4).
+
+API seit #1987: ``save_alarm_anchor()``/``load_alarm_anchor()`` tragen
+``channel`` als PFLICHT-Parameter, je Kanal eine eigene Datei
+``{trip_id}_alarm_anchor_{channel}.json``.
 """
 from __future__ import annotations
 
@@ -35,18 +50,35 @@ def _aware(dt: datetime) -> datetime:
     return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
 
 
+def _dienst(user_id: str):
+    """Alarm-Dienst mit gesetzter Transportnaht.
+
+    Issue #1987 (S1): der rollierende Anker rueckt seither NUR fuer
+    tatsaechlich ZUGESTELLTE Kanaele vor. Ohne die ``mail_sink``-Naht
+    scheitert der E-Mail-Versand am Egress-Waechter, ``delivered_channels``
+    bliebe leer und es entstuende gar kein Anker -- kein Mock, dieselbe
+    Naht wie in ``test_alert_anchor_day_guard``.
+    """
+    from services.trip_alert import TripAlertService
+
+    return TripAlertService(
+        settings=settings_email_only(), user_id=user_id,
+        mail_sink=lambda subject, body: None,
+    )
+
+
 def test_ac6_erfolgreicher_alarmversand_schreibt_rollierenden_anker():
     """AC-6: Trigger (a) -- ein tatsaechlich versendeter Alarm schreibt einen
     frischen rollierenden Anker, unabhaengig von einem vorherigen Briefing.
 
-    HEUTE ROT: ``load_alarm_anchor()`` existiert nicht -> AttributeError.
+    Seit #1987 kanalscharf: geschrieben wird der Merker des Kanals, der den
+    Alarm zugestellt bekommen hat (hier E-Mail).
     """
-    from services.trip_alert import TripAlertService
     from services.weather_snapshot import WeatherSnapshotService
 
     user_id, trip_id = f"tdd-1916-ac6-{uuid.uuid4().hex[:8]}", "trip-ac6"
     trip = gust_alert_trip(trip_id)
-    svc = TripAlertService(settings=settings_email_only(), user_id=user_id)
+    svc = _dienst(user_id)
     vor_lauf = datetime.now(timezone.utc)
 
     ausgeloest = svc.check_and_send_alerts(
@@ -55,7 +87,7 @@ def test_ac6_erfolgreicher_alarmversand_schreibt_rollierenden_anker():
     )
 
     assert ausgeloest, "Fixtur-Schutz: das massive Delta muss ausloesen."
-    anker = WeatherSnapshotService(user_id=user_id).load_alarm_anchor(trip_id)
+    anker = WeatherSnapshotService(user_id=user_id).load_alarm_anchor(trip_id, "email")
     assert anker, (
         "AC-6: nach einem tatsaechlich versendeten Alarm MUSS ein "
         "rollierender Anker existieren -- unabhaengig von einem Briefing."
@@ -66,133 +98,55 @@ def test_ac6_erfolgreicher_alarmversand_schreibt_rollierenden_anker():
     )
 
 
-def test_ac7_ueberschrittene_ceiling_schreibt_opportunistisch_ohne_alarm():
-    """AC-7: Trigger (b) -- 5h alter Anker + unterschwelliges Δ: trotz
-    ausbleibendem Alarm wird opportunistisch ein frischer Anker geschrieben.
+def test_ohne_alarm_wird_kein_rollierender_anker_mehr_geschrieben():
+    """Nachfolger der frueheren AC-7/AC-8 (#1916 Trigger b), Issue #1987 S1.
 
-    HEUTE ROT: ``load_alarm_anchor()`` existiert nicht -> AttributeError.
-    """
-    from services.trip_alert import TripAlertService
-    from services.weather_snapshot import WeatherSnapshotService
+    GIVEN einen 5 h alten rollierenden Merker (weit ausserhalb der
+          4h-Ceiling) und ein unterschwelliges Delta.
+    WHEN  der Check-Lauf ohne ausgeloesten Alarm endet.
+    THEN  bleibt der Merker UNVERAENDERT -- der opportunistische
+          Ceiling-Schreibtrigger ist ersatzlos entfallen. In diesem Zweig
+          wurde nichts versendet, es gibt also keine ``delivered_channels``;
+          ein hier geschriebener Merker waere ein Stand, den kein Empfaenger
+          je zugestellt bekam (#1987, E1/AC-2).
 
-    user_id, trip_id = f"tdd-1916-ac7-{uuid.uuid4().hex[:8]}", "trip-ac7"
-    trip = gust_alert_trip(trip_id)
-    svc = TripAlertService(settings=settings_email_only(), user_id=user_id)
-    vor_lauf = datetime.now(timezone.utc)
-    alter_anker = vor_lauf - timedelta(hours=5)
+    Diese Zusicherung ist die Umkehrung der frueheren AC-7/AC-8 an derselben
+    Naht: eine Mutation, die den Ceiling-Schreibtrigger wieder einbaut, wird
+    hier rot. Dass die Alterung dadurch nicht wirkungslos wird, sondern beim
+    LESEN greift, bewacht ``test_alert_channel_anchor_ceiling_fallback.py``
+    (#1987 AC-4).
 
-    ausgeloest = svc.check_and_send_alerts(
-        trip, [_wetter(10.0, alter_anker)],
-        fresh_weather=[_wetter(12.0, vor_lauf)],
-    )
-
-    assert not ausgeloest, "Fixtur-Schutz: das Delta (2 km/h) darf NICHT ausloesen."
-    anker = WeatherSnapshotService(user_id=user_id).load_alarm_anchor(trip_id)
-    assert anker, (
-        "AC-7: trotz fehlendem Alarm muss die Ueberschreitung der 4h-Ceiling "
-        "opportunistisch einen frischen rollierenden Anker schreiben."
-    )
-    assert _aware(anker[0].fetched_at) >= vor_lauf, (
-        "AC-7: der opportunistisch geschriebene Anker muss den AKTUELLEN "
-        f"Wetterstand tragen (fetched_at={anker[0].fetched_at})."
-    )
-
-
-def test_ac8_lange_ausfallserie_wird_automatisch_binnen_ceiling_aufgefrischt():
-    """AC-8 (End-to-End-Symptomnachweis): mehrere Check-Laeufe in Folge, JEDER
-    MIT DEMSELBEN ~28h alten (nie erneuerten) Briefing-Anker als ``cached`` --
-    simuliert einen ueber Stunden ausgefallenen Briefing-Versand (#1897).
-    Nach spaetestens einem Lauf liegt das rollierende Anker-Alter innerhalb
-    der 4h-Ceiling -- das urspruengliche #1916-Symptom (~24h alte Basis)
-    tritt nicht mehr auf.
-
-    HEUTE ROT: ``load_alarm_anchor()`` existiert nicht -> AttributeError.
-    """
-    from services.trip_alert import TripAlertService
-    from services.weather_snapshot import WeatherSnapshotService
-
-    user_id, trip_id = f"tdd-1916-ac8-{uuid.uuid4().hex[:8]}", "trip-ac8"
-    trip = gust_alert_trip(trip_id)
-    svc = TripAlertService(settings=settings_email_only(), user_id=user_id)
-    snap_svc = WeatherSnapshotService(user_id=user_id)
-    uralter_anker = datetime.now(timezone.utc) - timedelta(hours=28)
-
-    for _ in range(3):
-        svc.check_and_send_alerts(
-            trip, [_wetter(10.0, uralter_anker)],
-            fresh_weather=[_wetter(12.0, datetime.now(timezone.utc))],
-        )
-
-    anker = snap_svc.load_alarm_anchor(trip_id)
-    assert anker, "AC-8: nach mehreren Laeufen MUSS ein rollierender Anker existieren."
-    alter = datetime.now(timezone.utc) - _aware(anker[0].fetched_at)
-    assert alter <= timedelta(hours=4, minutes=5), (
-        f"AC-8: die 4h-Ceiling muss eingehalten sein (gemessen: "
-        f"{alter.total_seconds() / 3600:.2f} h) -- sonst besteht das "
-        f"urspruengliche #1916-Symptom (~24h alte Basis) weiter."
-    )
-
-
-def test_effective_anchor_age_waehlt_den_juengeren_anker_nicht_den_aelteren():
-    """Regressionstest (Fix-Loop F002 zu #1916): `_effective_anchor_age()`
-    MUSS den JUENGEREN der beiden Anker (Briefing- ODER rollierender Anker)
-    waehlen -- nicht den aelteren. Sonst wuerde eine frische Vergleichsbasis
-    faelschlich als "veraltet" behandelt und der rollierende Anker
-    unnoetig ueberschrieben.
-
-    Mutations-Gegenprobe (Fix-Loop-Befund): `max(candidates)` -> `min(candidates)`
-    in `_effective_anchor_age()` wurde von KEINEM der bestehenden AC-6..AC-9-
-    Tests gefangen, weil kein Test beide Anker gleichzeitig mit
-    unterschiedlichem Alter am Aufrufpunkt konstruiert. Dieser Test tut genau
-    das: ein ALTER rollierender Anker (5h, ausserhalb der Ceiling) UND eine
-    FRISCHE `cached_weather`-Vergleichsbasis (30 Min, innerhalb der Ceiling)
-    gleichzeitig -- der juengere (30 Min) muss den Ausschlag geben.
-
-    `save_alarm_anchor()` schreibt bewusst IMMER die Schreibzeit als
-    `snapshot_at` (nicht das uebergebene `fetched_at` der Segmente, s.
-    AC-6/AC-7: "der Anker muss den AKTUELLEN Wetterstand tragen"). Um einen
-    5h ALTEN rollierenden Anker zu simulieren, wird `snapshot_at` deshalb NACH
-    dem Schreiben direkt in der Datei zurueckdatiert -- reine Testdaten-
-    Manipulation der Persistenz (Vorbild: `test_alert_anchor_radar_isolation.py`
-    liest/prueft dieselbe Art von Datei direkt), kein Mock/Patch des Prueflings.
+    Die Rueckdatierung von ``snapshot_at`` ist reine Testdaten-Manipulation
+    der Persistenz (``save_alarm_anchor()`` schreibt immer die Schreibzeit),
+    kein Mock/Patch des Prueflings.
     """
     import json
 
     from app.loader import get_snapshots_dir
-    from services.trip_alert import TripAlertService
     from services.weather_snapshot import WeatherSnapshotService
 
-    user_id, trip_id = f"tdd-1916-f002-{uuid.uuid4().hex[:8]}", "trip-f002"
+    user_id, trip_id = f"tdd-1987-kein-b-{uuid.uuid4().hex[:8]}", "trip-kein-b"
     trip = gust_alert_trip(trip_id)
-    svc = TripAlertService(settings=settings_email_only(), user_id=user_id)
     snap_svc = WeatherSnapshotService(user_id=user_id)
+    alt = datetime.now(timezone.utc) - timedelta(hours=5)
+    snap_svc.save_alarm_anchor(trip_id, date.today(), [_wetter(10.0, alt)], "email")
+    pfad = get_snapshots_dir(user_id) / f"{trip_id}_alarm_anchor_email.json"
+    daten = json.loads(pfad.read_text())
+    daten["snapshot_at"] = alt.isoformat()
+    pfad.write_text(json.dumps(daten, indent=2))
+    vorher = snap_svc.load_alarm_anchor(trip_id, "email")[0].fetched_at
+    assert vorher == alt, "Fixtur-Schutz: die Rueckdatierung muss greifen."
 
-    # ALTER rollierender Anker (5h) -- ausserhalb der 4h-Ceiling fuer sich allein.
-    alter_rollierender_anker_zeit = datetime.now(timezone.utc) - timedelta(hours=5)
-    snap_svc.save_alarm_anchor(trip_id, date.today(), [_wetter(10.0, alter_rollierender_anker_zeit)])
-    anchor_path = get_snapshots_dir(user_id) / f"{trip_id}_alarm_anchor.json"
-    anchor_data = json.loads(anchor_path.read_text())
-    anchor_data["snapshot_at"] = alter_rollierender_anker_zeit.isoformat()
-    anchor_path.write_text(json.dumps(anchor_data))
-    vor_lauf = snap_svc.load_alarm_anchor(trip_id)[0].fetched_at
-    assert vor_lauf == alter_rollierender_anker_zeit, "Fixtur-Schutz: Rueckdatierung muss greifen."
-
-    # FRISCHE Vergleichsbasis (30 Min) als `cached_weather` -- der juengere
-    # der beiden Anker, MUSS die Ceiling-Entscheidung tragen.
-    frischer_anker_zeit = datetime.now(timezone.utc) - timedelta(minutes=30)
-    ausgeloest = svc.check_and_send_alerts(
-        trip, [_wetter(10.0, frischer_anker_zeit)],
-        fresh_weather=[_wetter(12.0, datetime.now(timezone.utc))],  # 2 km/h, unterschwellig
+    ausgeloest = _dienst(user_id).check_and_send_alerts(
+        trip, [_wetter(10.0, datetime.now(timezone.utc) - timedelta(minutes=30))],
+        fresh_weather=[_wetter(12.0, datetime.now(timezone.utc))],
     )
 
     assert not ausgeloest, "Fixtur-Schutz: das Delta (2 km/h) darf NICHT ausloesen."
-    nach_lauf = snap_svc.load_alarm_anchor(trip_id)[0].fetched_at
-    assert nach_lauf == vor_lauf, (
-        "F002: der rollierende Anker darf NICHT ueberschrieben werden, wenn "
-        "der JUENGERE der beiden Anker (hier: der 30 Min alte "
-        "cached_weather-Anker) noch innerhalb der 4h-Ceiling liegt -- "
-        "unabhaengig vom Alter des ALTEN rollierenden Ankers. Ein `min()` "
-        "statt `max()` in `_effective_anchor_age()` waehlt faelschlich den "
-        f"AELTEREN Anker und macht diesen Test rot (vorher: {vor_lauf}, "
-        f"nachher: {nach_lauf})."
+    nachher = snap_svc.load_alarm_anchor(trip_id, "email")[0].fetched_at
+    assert nachher == vorher, (
+        "Ohne Alarmversand darf KEIN rollierender Anker fortgeschrieben "
+        "werden -- auch nicht, wenn der bestehende Merker die 4h-Ceiling "
+        f"ueberschreitet (#1987: Trigger (b) entfaellt ersatzlos). Vorher: "
+        f"{vorher}, nachher: {nachher}."
     )

--- a/tests/tdd/test_alert_trend_detection_regression.py
+++ b/tests/tdd/test_alert_trend_detection_regression.py
@@ -63,7 +63,7 @@ def test_ac9_kumulativer_trend_ueber_mehrere_laeufe_loest_dennoch_aus():
         fresh = [_wetter(wert, datetime.now(timezone.utc))]
         ausgeloest = svc.check_and_send_alerts(trip, aktueller_anker, fresh_weather=fresh)
         ausgeloest_je_lauf.append(ausgeloest)
-        rollierend = snap_svc.load_alarm_anchor(trip_id)
+        rollierend = snap_svc.load_alarm_anchor(trip_id, "email")
         if rollierend:
             aktueller_anker = rollierend
 

--- a/tests/tdd/test_onset_anchor_fresh_window_symmetry.py
+++ b/tests/tdd/test_onset_anchor_fresh_window_symmetry.py
@@ -274,9 +274,9 @@ def test_gespeicherter_anker_behaelt_das_fenster_seines_segments():
     """
     dienst = WeatherSnapshotService(user_id="onset-fenster-anker")
     segment = _segmente(*ENG)[0]
-    dienst.save_alarm_anchor("fenster-trip", _tag(), [_aggregiert(segment)])
+    dienst.save_alarm_anchor("fenster-trip", _tag(), [_aggregiert(segment)], "email")
 
-    geladen = dienst.load_alarm_anchor("fenster-trip")
+    geladen = dienst.load_alarm_anchor("fenster-trip", "email")
     assert geladen, "Anker liess sich nicht laden"
     zurueck = geladen[0].segment
     assert (zurueck.day_window_start_hour, zurueck.day_window_end_hour) == ENG, (
@@ -301,16 +301,16 @@ def test_alt_anker_ohne_fensterfelder_laedt_unveraendert():
 
     dienst = WeatherSnapshotService(user_id="onset-fenster-altanker")
     segment = _segmente(*ENG)[0]
-    dienst.save_alarm_anchor("alt-trip", _tag(), [_aggregiert(segment)])
+    dienst.save_alarm_anchor("alt-trip", _tag(), [_aggregiert(segment)], "email")
 
-    pfad = dienst._snapshots_dir / "alt-trip_alarm_anchor.json"
+    pfad = dienst._snapshots_dir / "alt-trip_alarm_anchor_email.json"
     daten = json.loads(pfad.read_text())
     for eintrag in daten["segments"]:
         eintrag.pop("day_window_start_hour", None)
         eintrag.pop("day_window_end_hour", None)
     pfad.write_text(json.dumps(daten, indent=2))
 
-    geladen = dienst.load_alarm_anchor("alt-trip")
+    geladen = dienst.load_alarm_anchor("alt-trip", "email")
     assert geladen, "Alt-Anker ohne die Fensterfelder liess sich nicht laden"
     zurueck = geladen[0].segment
     assert zurueck.day_window_start_hour is None, (

--- a/tests/tdd/test_onset_shift_alert.py
+++ b/tests/tdd/test_onset_shift_alert.py
@@ -528,7 +528,7 @@ def test_ac5_bestandsanker_ohne_onset_felder_laedt_und_alarmiert_nicht():
         json.dumps(_ALT_ANKER, indent=2)
     )
 
-    geladen = dienst.load_alarm_anchor("trip-alt")
+    geladen = dienst.load_alarm_anchor("trip-alt", "email")
     assert geladen is not None and len(geladen) == 1, (
         f"AC-5: Bestandsanker liess sich nicht laden: {geladen!r}"
     )
@@ -551,8 +551,8 @@ def test_ac5_bestandsanker_ohne_onset_felder_laedt_und_alarmiert_nicht():
         f"Beginn-Alarm aus einem Anker ohne Onset-Wert: {changes!r}"
     )
 
-    dienst.save_alarm_anchor("trip-neu", TAG, [frisch])
-    zurueck = dienst.load_alarm_anchor("trip-neu")
+    dienst.save_alarm_anchor("trip-neu", TAG, [frisch], "email")
+    zurueck = dienst.load_alarm_anchor("trip-neu", "email")
     assert zurueck is not None, (
         "AC-5: ein Anker MIT Onset-Wert liess sich nicht speichern/laden -- "
         "`save_alarm_anchor` verschluckt Serialisierungsfehler still."


### PR DESCRIPTION
Schließt Schritt S1 von #1987.

## Problem

Der rollierende Alarm-Anker war **ein** Merker pro Trip, obwohl vier Kanäle unabhängig
voneinander zugestellt werden. Ein Versand über E-Mail rückte den Anker auch für
Telegram, SMS und Premium-SMS vor — die Vergleichsbasis der anderen Kanäle sprang
also weiter, ohne dass dort je etwas ankam. Auf dem Karnischen Höhenweg trifft das
genau den Fall, für den der Anker gedacht ist: auf der Hütte kommt nur Premium-SMS
an, und deren Anker wurde von einem E-Mail-Versand am Pass stillschweigend
mitgezogen.

## Lösung

Der Anker bekommt eine Kanal-Dimension. `save_alarm_anchor` / `load_alarm_anchor` /
`alarm_anchor_target_date` tragen einen Pflicht-Parameter `channel`; das
Dateinamensschema wechselt von `{trip_id}_alarm_anchor.json` auf
`{trip_id}_alarm_anchor_{channel}.json`. Geschrieben wird nur noch für die
tatsächlich zugestellten Kanäle (`delivered_channels`) — der bisherige
Ceiling-Schreib-Trigger entfällt ersatzlos.

Die Auswertung bleibt **ein** gemeinsamer Lauf: verglichen wird gegen den ältesten
gültigen Kanal-Kandidaten (AC-11). So meldet der Lauf auch eine Änderung, die nur
der zurückliegende Kanal noch nicht kennt.

Bestandsdaten bleiben lesbar: fehlt die kanalspezifische Datei, fällt der Lesepfad
auf die kanallose Altdatei zurück (AC-5).

## Nachweis

- **11/11 ACs**, jeder mit Code-Stelle und bewachendem Test
- **Adversary VERIFIED** — 3 Runden, 5 Mutationen alle gefangen; F001 geschlossen,
  F002 (LOW, Mehrkanal-Kombinatorik) als Nebenbefund in #1199
- **Zielfläche 68/68 grün**; volle Suite über 9.099 Tests ohne Regression
- ADR-0056 um die Kanal-Dimension ergänzt

### Zur roten CI-Historie auf älteren Ständen

Der Branch ist auf `31e5d304` rebast und enthält damit den #2004-Fix (`437c46e9`).
Ein voller lokaler Suite-Lauf mit `--disable-socket` zeigt ~195 `SocketBlockedError`
— das ist ein Artefakt der lokalen Socket-Sperre (Tests mit echtem lokalem
`ThreadingHTTPServer`), nicht dieses Diffs. Namentlich ohne Sperre laufen dieselben
Dateien grün. Die CI läuft ohne die Sperre.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
