### PR TITLE
docs(#1848 A1): sms_format.md — Ausblick war von der #1417-Vereinheitlichung ausgenommen

### DIFF
--- a/docs/reference/sms_format.md
+++ b/docs/reference/sms_format.md
@@ -166,6 +166,26 @@ letzten verwertbaren Teils inklusiv, innere Segmentgrenzen genau einmal.**
 Ausgefallene Etappenteile werden bei der Bestimmung des „letzten" Teils
 uebersprungen.
 
+> **Nachtrag 2026-08-20 (#1848 Scheibe A1):** Die Aussage „eine Berechnung fuer alle
+> Kanaele" galt bis dahin **nicht vollstaendig** — #1417 hat SMS, Telegram-Kurzuebersicht
+> und E-Mail-Kurzzusammenfassung umgestellt, den **3-Tages-Ausblick** aber uebersehen. Der
+> las weiter das Etappenaggregat (`SegmentWeatherSummary.temp_min_c`/`temp_max_c`,
+> Endstunde exklusiv) und zeigte dadurch ein **systematisch zu kuehles Hoch**: gemessen
+> ueber 60 Konstellationen wichen 24 ab, Median 1,23 °C, Maximum 1,66 °C, und die Richtung
+> war immer dieselbe (die Etappen-Fensterung kann der Gehzeit-Fensterung nur einen
+> Datenpunkt vorenthalten, nie einen hinzugewinnen). Unbemerkt blieb das, weil der Ausblick
+> **nie den heutigen Tag** zeigt (`get_future_stages()` filtert `s.date > from_date`) —
+> der Widerspruch war innerhalb einer Mail strukturell unsichtbar.
+>
+> Seit #1848 A1 liest auch der Ausblick `collect_hiking_window_points()` +
+> `hiking_field_min_max()`, fuer Temperatur **und** gefuehlte Temperatur. Bewacht wird die
+> Verdrahtung jetzt am **Wirkort** (`tests/tdd/test_outlook_scheduler_wires_hiking_window.py`,
+> echter `_build_stage_trend()`-Pfad) — vorher blieben 625 Tests gruen, wenn man die
+> Datenquelle im Scheduler abschaltete.
+>
+> **Wind und Boeen (`W`/`G`) sind davon nicht betroffen** — sie stammen aus dem geteilten
+> Tagesfenster 04–19 (Epic #1319/#1317), nicht aus der Gehzeit.
+
 **`D` ist NICHT das Tagesmaximum.** Trotz des Namens „Tag-Max" bezieht sich `D`
 — wie `L`/`FL`/`FD` — ausschliesslich auf die **Gehzeit**. Die tatsaechliche
 Tageshoechsttemperatur am Ziel kann deutlich hoeher liegen (belegtes Beispiel:


### PR DESCRIPTION
Reine Doku-Ergaenzung, kein Code.

`docs/reference/sms_format.md` beschreibt seit #1417 die Gehzeit-Fensterung als **eine Berechnung fuer alle Kanaele**. Das galt bis 2026-08-20 **nicht vollstaendig**: Der 3-Tages-Ausblick war beim damaligen Fix uebersehen worden.

Der Nachtrag haelt fest:
- **was falsch war** — Ausblick las das Etappenaggregat (Endstunde exklusiv), systematisch zu kuehles Hoch: 24 von 60 Konstellationen abweichend, Median 1,23 °C, Max 1,66 °C, Richtung immer gleich
- **warum es niemand sah** — der Ausblick zeigt nie den heutigen Tag, der Widerspruch war innerhalb einer Mail strukturell unsichtbar
- **was jetzt gilt** — seit #1848 A1 liest auch der Ausblick `collect_hiking_window_points()`, fuer Temperatur und gefuehlte Temperatur; die Verdrahtung ist am **Wirkort** bewacht (vorher blieben 625 Tests gruen, wenn man die Datenquelle im Scheduler abschaltete)
- **was bewusst NICHT betroffen ist** — Wind/Boeen stammen aus dem Tagesfenster 04-19 (Epic #1319/#1317)

Ergaenzt die Auslieferung von #1848 A1 (Prod `d4764b92`, PR #2006).

🤖 Generated with [Claude Code](https://claude.com/claude-code)