### PR TITLE
fix(#2017 A): Nowcast-Messpunkt — geteilter Baustein position_at_time

### DIFF
--- a/docs/context/fix-2017-nowcast-messpunkt.md
+++ b/docs/context/fix-2017-nowcast-messpunkt.md
@@ -1,0 +1,290 @@
+# Context: fix-2017-nowcast-messpunkt
+
+Issue: [#2017](https://github.com/henemm/gregor_zwanzig/issues/2017) · Track: Full Process · Phase 1 (Kontext)
+
+## Request Summary
+
+Der Radar-/Nowcast-Alarm fragt das Wetter am **Startpunkt des aktiven Segments** ab — dem Wegpunkt, den der Wanderer bereits passiert hat. Gemeldet wird damit Wetter für einen Ort, an dem der Nutzer zum genannten Zeitpunkt nicht mehr steht. Gemessen (Issue-Kommentar, echte KHW-Tour): Median 2,68 km Versatz **während der Gehphasen**, in 68 % der Geh-Minuten liegt der Onset gar nicht mehr im abgefragten Segment.
+
+## 🔴 Zentraler Befund: die Sollformulierung ist mit einem Abruf nicht erreichbar
+
+Das Issue nennt als fachlich richtig „die **Position zum Onset-Zeitpunkt**". Der Code-Ablauf macht das mit einem einzigen Abruf **prinzipiell unmöglich** — es ist ein Zirkelschluss:
+
+| Schritt | Code | Konsequenz |
+|---|---|---|
+| 1 | `lat/lon = active.start_point` (`trip_alert.py:1257-1259`) | Ort steht fest, **bevor** irgendetwas über das Wetter bekannt ist |
+| 2 | `radar_svc.get_nowcast(lat, lon, priority="polling")` (`:1265`) | Abruf erfolgt |
+| 3 | `onset_minutes` entsteht in `_derive_result()` (`radar_service.py:543-599`) | erster Frame im 180-Min-Fenster über der Niederschlagsschwelle |
+| 4 | `_onset_dt = now_utc + timedelta(minutes=result.onset_minutes)` (`:1282`) | **Erst hier** ist der Onset-Zeitpunkt bekannt — der Abruf ist längst gelaufen |
+
+**Man kann die Position zum Onset-Zeitpunkt nicht abfragen, ohne den Onset zu kennen, und man kennt den Onset erst nach der Abfrage.** Jede Lösung muss diesen Zirkel brechen. Die Optionen:
+
+- **Onset-frei schätzen** (Issue-Variante 1): Position zu einem *festen* Zeitpunkt im Vorwarnfenster (z. B. Mitte) — braucht den Onset nicht, ein Abruf, deterministisch.
+- **Zweistufig/iterativ**: erst abfragen, Onset lesen, dann an der Onset-Position erneut abfragen — zwei Abrufe, und das Ergebnis kann zwischen den Stufen widersprüchlich werden (anderer Ort ⇒ anderer Onset ⇒ andere Position …).
+- **Trajektorie** (Variante 3): pro Vorhersage-Zeitschritt die zugehörige Position auswerten — löst den Zirkel sauber auf, weil jeder Zeitschritt seine eigene Position mitbringt; teuerste Variante.
+
+Das ist **keine** Ablehnung des Issue-Ziels, sondern die Feststellung, dass „Position zum Onset-Zeitpunkt" bei einem Abruf nur als *Näherung* zu haben ist. Die Spec muss die Näherung benennen, statt exakte Onset-Treue zu versprechen.
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `src/services/trip_alert.py:1257-1260` | **Der Fehler.** `lat/lon` fix aus `active.start_point`, Kommentar sagt „Genau EIN get_nowcast-Call pro Trip an Segment-Startpunkt" |
+| `src/services/trip_alert.py:1265` | `radar_svc.get_nowcast(lat, lon, priority="polling")` |
+| `src/services/trip_alert.py:1270` | `radar_alert_due(result, threshold_min=20)` — **Inline-Literal**, keine Konstante (#2009 macht daraus `RADAR_ONSET_THRESHOLD_MIN=55`) |
+| `src/services/trip_alert.py:1282` | `_onset_dt` — erst hier ist der Onset-Zeitpunkt bekannt |
+| `src/services/trip_alert.py:126-129` | `radar_alert_due()` — `onset is not None and onset <= threshold_min` |
+| `src/services/trip_alert.py:1155` | `resolve_current_segment(trip, now_utc, today)` |
+| `src/services/trip_alert.py:1357-1362` | `RadarAlertRequest` bekommt `segment_id`, `km_from`, `km_to` aus `active` |
+| `src/services/trip_segments.py:363-413` | `resolve_current_segment()` — Vorrangkette heute → gestern → Vorschau → None; schaut **nie vorwärts** |
+| `src/services/trip_segments.py:345-360` | `select_active_segment()` — `None`, wenn alle Segmente vorbei |
+| `src/services/trip_segments.py:108-342` | `convert_trip_to_segments()` — genau **ein** Kalendertag |
+| `src/services/radar_service.py:170` | `get_nowcast(self, lat, lon, priority="user_briefing")` — kein `elevation_m`, kein Positions-/Zeitfenster |
+| `src/services/radar_service.py:543-599` | `_derive_result()` — Onset rein zeitbasiert für den EINEN Punkt |
+| `src/services/radar_cache.py:72-75` | Cache-Schlüssel `f"{round(lat,4)}_{round(lon,4)}_{region}"`, TTL 300s |
+| `src/app/models.py:407-430` | `TripSegment` — trägt `start_time`/`end_time` (UTC), `duration_hours`, `distance_km` |
+| `src/app/models.py:360-365` | `GPXPoint` — `lat`, `lon`, `elevation_m`, **kein Name** |
+| `src/app/trip.py:61-86` | `Waypoint` — `name: str` Pflichtfeld, `elevation_m: int` ohne Optional |
+| `src/utils/geo.py:19-29` | `haversine_km()` — einziger vorhandener Geo-Baustein (SSoT, #1027) |
+| `src/core/naismith.py:81-127` | Gehzeit **kumulativ mit Steigung**, nicht linear nach Distanz |
+
+## Existing Patterns
+
+- **Segmente sind zeitlich lückenlos und aufsteigend**: `end_time` von Segment *i* ist bitgenau `start_time` von Segment *i+1* (`trip_segments.py:172-253`), das Ziel-Segment schließt genauso an. Zu einem Zeitpunkt T gilt normalerweise genau ein Segment. Ausnahme: der Guard `end_dt <= start_dt` (`:200-218`) **überspringt** ein Wegpunktpaar bei nicht vorwärtslaufender Zeit — dann fehlt ein Segment ersatzlos, keine synthetische Füllung.
+- **Ortsfestes Ziel-Segment ohne Flag**: erkennbar an `segment_id == "Ziel"` (String statt int), `start_point == end_point`, `distance_km == 0.0`. Sauberster Filter für „bewegt sich": `isinstance(segment.segment_id, int)` bzw. `distance_km > 0`.
+- **Gehzeit über Naismith** (`src/core/naismith.py`): `dist_km/speed_flat + ascent_m/speed_ascent + descent_m/speed_descent`, Wanderer 4 km/h flach, 300 m/h Aufstieg, 500 m/h Abstieg. Die Segment-Start-/Endzeiten tragen dieses Ergebnis bereits — **innerhalb** eines Segments (= ein Wegpunktpaar) gibt es keine Zwischenpunkte, dort ist lineare Interpolation nach Zeitanteil die einzig verfügbare Auflösung.
+- **Ortsangabe im Alarm** (`output/renderers/alert/segments.py:91-111`): `format_alert_location()` → `location_label` (nur Ortsvergleich) → „Etappe N" → Fallback „km von–bis". Der Text nennt **keinen Wegpunktnamen**, ist also von einer Positionsverlegung nicht automatisch betroffen.
+- **Fenster-Konvention aus #1417/#1146** (`output/renderers/day_window.py:186-229`): inklusiver Start, exklusives Ende, Sonderfall letztes Segment inklusiv.
+
+## Dependencies
+
+**Upstream (was wir nutzen):** `resolve_current_segment()` · `convert_trip_to_segments()` · `TripSegment` · `GPXPoint` · `haversine_km()` · `RadarNowcastService.get_nowcast()` · `ForecastBudgetGate`
+
+**Downstream (was auf uns aufsetzt):** `RadarAlertRequest` → `notification_service` → Renderer aller vier Kanäle · Alarm-Logging/Metriken · Throttle-/Kanal-Gates
+
+## 🔴 Keine wiederverwendbare Interpolation vorhanden
+
+Breite Suche (`interpolate`, `lerp`, `fraction`, `progress`, `position_at`, `along_route`, `bearing`) in `src/`, `internal/`, `api/`: **keine Funktion interpoliert eine Position entlang einer Strecke.** `_interpolate_missing_times()` (`trip_segments.py:59-105`) interpoliert nur **Zeiten**, keine Geo-Position. Die räumliche Interpolation ist neu zu bauen; `haversine_km()` taugt nur zur Distanzprüfung, nicht zur Positionsberechnung.
+
+## API-Budget: Variante 1 ist praktisch kostenneutral (geprüft)
+
+Das Issue vermutet Kostenneutralität für den einfachen Mittelweg. Der Code bestätigt das für den tragenden Verbrauchsstrom:
+
+| Größe | Wert | Fundstelle |
+|---|---|---|
+| Open-Meteo-Tageslimit | 10.000 | — |
+| Intern gesetztes Budget | **9.000** | `services/forecast_budget.py:40-42` |
+| `polling` wird abgewiesen ab | 80 % | `forecast_budget.py` (`POLLING_THRESHOLD`) |
+| nur noch `user_briefing` ab | 95 % | `forecast_budget.py` (`BRIEFING_ONLY_THRESHOLD`) |
+| Radar-Alarm-Takt | `7,22,37,52 * * * *` = 96×/Tag je Job | `internal/scheduler/scheduler.go:199,202` |
+| Cache-TTL | 300 s | `radar_cache.py` |
+
+**Kernargument:** Der Alarm läuft alle 900 s, der Cache lebt 300 s — zwischen zwei Läufen ist der Eintrag **immer** abgelaufen. Der Trip-Poll profitiert schon heute nie von seinem eigenen Vorlauf-Cache. Eine wandernde Koordinate ändert die **Zahl** der Abrufe dieses Stroms daher nicht.
+
+**Zwei Randverluste, beide klein:**
+- *Trip↔Compare-Dedup*: Compare misst an **festen Preset-Orten** (`compare_radar_alert.py:126-129,342`, Docstring `:13-16` — „keine Etappen/Segmente"). Ein gemeinsamer Cache-Treffer setzt exakte Koordinatengleichheit auf 4 Nachkommastellen voraus — Zufall, kein Regelfall.
+- */jetzt-Nutzerbefehl* (`trip_command_processor.py:1369,1375`) fragt `stage.waypoints[0]` ab, oft identisch mit dem Segment-Startpunkt. Innerhalb von 300 s um einen Poll-Tick spart das heute einen echten Fetch; bei wandernder Koordinate trifft es seltener. Ohne Nutzungsdaten nicht quantifizierbar, aber keine 96×/Tag-Größenordnung.
+
+**Zählweise geklärt:** `record_cache_hit()`/`record_cache_miss()` (`forecast_budget.py:83-91`) sind reine Beobachtungszähler und schreiben **nicht** in `calls_today`. Nur `record_call()` (`:76-81`) zählt, und zwar unmittelbar vor dem echten HTTP-Request (`radar_service.py:464`). Ein Koordinatenwechsel für sich kostet also **nichts** — nur ein dadurch zusätzlich ausgelöster realer Fetch kostet.
+
+## 🔴 Der Fehler steht an ZWEI Stellen — die zweite wiegt schwerer
+
+Alle fünf `get_nowcast()`-Aufrufer des Repos, vollständig geprüft:
+
+| Datei:Zeile | Zweck | Positionsquelle | Vom #2017-Muster betroffen? |
+|---|---|---|---|
+| `src/services/trip_alert.py:1265` | Trip-Radar-Alarm, Onset-Schwelle 20 (nach #2009: 55) Min | `active.start_point` via `resolve_current_segment()` | **Ja — der im Issue beschriebene Kernbug** |
+| `src/services/trip_report_scheduler.py:1815` | `_build_starkregen_hint()` — Starkregen-Kurzfristhinweis im planmäßigen Briefing, Horizont bis **180 Min** | `active.start_point`, **eigene lokale Segmentwahl** (`:1780-1789`) statt des geteilten Bausteins | **Ja — gleicher Mechanismus, größeres Fehlerfenster** |
+| `src/services/trip_command_processor.py:1375` | `/jetzt`-Inbound-Kommando | `stage.waypoints[0]` — **erster Wegpunkt des Tages**, nicht einmal das aktive Segment | Andere Fehlerklasse (Sofort-Abfrage, kein Onset-Zirkel) — **eigenständiger Befund**, siehe Risiko 12 |
+| `src/services/compare_radar_alert.py:342` | Ortsvergleich-Radar-Alarm | `loc.lat/lon` eines festen Presets | Nein — ortsfest per Definition |
+| `src/providers/thunder_enrichment.py:255` | `_apply_radar_override()`, Fenster ±90 Min um jetzt | `location.lat/lon` der Reihe | Nein — Teil der akzeptierten Aggregations-Vereinfachung „ein Ort deckt die Reihe", kein Onset-Zirkel |
+
+**Warum die zweite Stelle schwerer wiegt:** Der Alarmpfad begrenzt auf `onset_minutes <= 20` (nach #2009: 55). Der Starkregen-Hinweis kennt **keinen Minuten-Grenzwert auf den Onset** — er filtert nur auf `intensity_label == HEAVY` (`:1820`) und akzeptiert damit jeden Onset im vollen **180-Minuten**-Fenster (`NOWCAST_HORIZON_MIN = 180`, `radar_service.py:70`). Bei drei Stunden Vorlauf ist der Wanderer regelmäßig ein bis zwei Segmente weiter — der Hinweis nennt Starkregen für einen Ort, an dem er zum genannten Zeitpunkt längst nicht mehr ist, teils für einen, den die Route gar nicht mehr berührt.
+
+**Abgrenzung gilt an beiden Stellen gleich:** nur Geh-Segmente; das ortsfeste Ziel-Segment wird von der lokalen Auswahlschleife wie jedes andere behandelt, ist dann aber der tatsächliche Standort — kein Versatz.
+
+**Konsequenz für den Zuschnitt:** Beide Stellen teilen denselben Mechanismus und sollten über **einen gemeinsamen Baustein** korrigiert werden, statt zweimal getrennt — entspricht der Code-Teilungs-Konvention des Projekts. Dass `trip_report_scheduler.py` heute eine eigene Segmentwahl mitbringt (bewusst ohne Vortags-Rückgriff, Docstring `:1761-1771`, #1667 S3), ist dabei zu respektieren: geteilt wird die **Positionsberechnung**, nicht die Segmentwahl.
+
+## Existing Specs
+
+- `docs/specs/modules/fix_1329_c2_radar_nowcast_cache.md` — Radar-Cache + Anbindung an `ForecastBudgetGate` (ADR-0033: „ein Kontingent, ein Zähler")
+- `docs/specs/modules/fix_2009_nowcast_vorlauf.md` — **nur auf `origin/fix-2009-nowcast-vorlauf`**, noch nicht auf `main` (lesbar per `git show origin/fix-2009-nowcast-vorlauf:<pfad>`). Status approved (PO-Freigabe 2026-08-20). Hebt `RADAR_ONSET_THRESHOLD_MIN` 20 → **55** als **eine geteilte Konstante** in `radar_service.py` (Muster `NOWCAST_HORIZON_MIN`, #1439) und ersetzt damit die heute doppelt gepflegten Literale in `trip_alert.py:1270` und `compare_radar_alert.py:53`. ACs: AC-1 geteilte Konstante treibt beide Pfade · AC-2/AC-3 Auslöseraster 8/23/38/53 für Trip und Compare · AC-4 Tagesbezug bei Mitternachts-Überlauf (E-Mail/Telegram) · AC-5 Tages-Suffix `TH@0:23+1` für SMS/Premium-SMS · **AC-6 Segment-Ende-Guard** (nur Trip; Compare kennt keine Segmente) — unterdrückt Alarme, deren Onset nach dem Segmentende liegt, mit Unterdrückungs-Log
+- `radar_nowcast*.md` (mehrere) — Quellen-/Provider-Basis-Specs
+- `docs/specs/modules/fix_1752_radar_folgt_alarm_kanaelen.md` · `fix_1914_radar_telegram_style.md` — nachgelagerte Kanal-/Darstellungsfragen
+
+## Risks & Considerations
+
+1. **🔴 Tagesgrenze.** `convert_trip_to_segments()` deckt **nur einen Kalendertag** ab, `resolve_current_segment()` schaut nur rückwärts. Bei 55 Min Vorlauf kann der Zielzeitpunkt über das Ende des Ziel-Segments hinauslaufen ⇒ `select_active_segment()` liefert `None`. Entweder Folgetag selbst nachladen (`target_date + 1 day`) oder bewusst am Tagesende klemmen. Fail-Soft nötig: Ruhetag ohne Stage oder < 2 Wegpunkte ⇒ leere Liste.
+2. **🔴 Höhe muss mitwandern** (Abstimmung #1991, Session `gregor-zwanzig-ad`, Commit `892e0631`). Nach deren Merge trägt `get_nowcast` ein `elevation_m`; verlegt man die Koordinate ohne die Höhe, fragt man den neuen Ort mit alter Höhe ab. Gemessen an 3300 m: bis 2,4 mm Niederschlagsdifferenz, Wettercode in 11 von 48 Stunden abweichend — im Gebirge entscheidet das über Regen oder Schnee. Höhe ist verlässlich vorhanden (`Waypoint.elevation_m: int` ohne Optional, GPX-Import erzwingt sie über `gpx_parser.py:178-181`), muss aber **interpoliert** werden wie die Koordinate.
+3. **🔴 Segment-Ende-Guard aus #2009 ist mit unserem Merge ersatzlos zu entfernen** — inklusive AC-6 und `tests/tdd/test_radar_alert_segment_end_guard.py`. Der Guard gleicht den falschen Messpunkt aus, statt ihn zu beheben; nach der Korrektur würde er **richtige** Alarme verwerfen. Dokumentiert in Commit `87644e6a` (Known Limitations der #2009-Spec) — dadurch vorgesehener Rückbau, kein stiller Spec-Widerruf.
+4. **🔴 Zwei bestehende Tests schreiben den Bug fest.** `tests/tdd/test_issue_822_radar_nowcast_segment.py`: **AC-3** prüft exakte Gleichheit mit `active.start_point` (reißt sicher), **AC-2** (`test_ac2_segment_selection_by_time`) prüft dieselbe Koordinate mit Toleranz `< 0.01°` ≈ 1,1 km (reißt bei realistischem Versatz ebenfalls). Beide bewusst und begründet anpassen, nicht beiläufig.
+5. **Nur Geh-Segmente betroffen.** Das ortsfeste Ziel-Segment macht 65,5 % der überwachten Zeit aus, der Ortsfehler ist dort exakt null. Wer über das ganze Tagesfenster mittelt, misst Median 0 km und hält den Befund für harmlos. Die Beispiel-Mail aus #2009 („🏁 Ziel · Gewitter in 8 Min") stammt aus diesem Segment und ist **kein** Beleg für den Bug.
+6. **Reihenfolge.** `src/services/trip_alert.py` ist dreifach belegt: #1991 (`:1265`, committet, geht zuerst) → #2009 (`:1270` + Guard, Scheibe 1 grün `977c774f`, Scheibe 2 wartet) → #2017 (`:1257-1259`). Vereinbart und von beiden Sessions bestätigt.
+7. **Drosselung ist nicht unterscheidbar — aber dokumentiert.** `radar_alert_due()` behandelt `onset_minutes=None` bei Drosselung wie „echt trocken". Bewusster Trade-off („a missed poll beats a quota outage", `radar_service.py:94-98`), festgehalten in den Known Limitations von `fix_1329_c2_radar_nowcast_cache.md:529-534`. **Kein blinder Fleck, nicht Teil dieses Tickets.**
+8. **Kein Ortsname für den Zwischenpunkt.** `GPXPoint` trägt keinen Namen; ein interpolierter Punkt liegt namenlos zwischen zwei Wegpunkten. Da der Alarmtext ohnehin „Etappe N" / „km von–bis" nutzt, entsteht daraus kein Zwang — aber die Frage, ob `km_from`/`km_to` nach der Verlegung noch die richtige Aussage machen, gehört in die Spec.
+10. 🔴 **Zweite Fundstelle bestätigt** (`trip_report_scheduler.py:1809-1810`, Horizont 180 Min, kein Onset-Grenzwert). Das Issue sagt „betrifft nur den Trip-Pfad" — beide Stellen *sind* Trip-Pfad. Die zweite ist im Issue nicht genannt, teilt aber Mechanismus und Lösung. **Zuschnitt-Entscheidung für die Spec:** beide gemeinsam über einen geteilten Baustein, oder #2017 auf den Alarmpfad begrenzen und die zweite Stelle als Folge-Issue führen. Empfehlung: gemeinsam — getrennte Lösungen desselben Problems sind laut Projektkonvention ein Verstoß, und die zweite Stelle wiegt schwerer.
+11. **LoC-Budget — entschärft.** Mit dem Schnitt in zwei Scheiben (siehe Analyse) bleibt jede Scheibe unter 250 LoC; **kein Override nötig**.
+12. **Nebenbefund `/jetzt`** (`trip_command_processor.py:1375`): fragt `stage.waypoints[0]` ab — den **ersten Wegpunkt des Tages**, nicht das aktive Segment. Wer nachmittags „jetzt" fragt, bekommt das Wetter vom Tagesstart, potenziell zweistellige Kilometer entfernt. Andere Fehlerklasse als #2017 (kein Onset-Zirkel, sondern falscher Bezugspunkt für eine Sofortabfrage), aber nutzersichtbar. **In der Analyse bewerten, ob eigenes Issue** — nicht stillschweigend in #2017 mitnehmen.
+13. **AST-Wächter aus #1480** (Session `gregor-zwanzig-15`): nach dessen Merge wird jeder PR rot, der eine lokale ThunderLevel-Zuordnung anlegt. Vorgabe `thunder_ordinal()` / `THUNDER_LABEL_DE` / `thunder_ampel_band()`. Für #2017 voraussichtlich nicht einschlägig (Geometrie, keine Stufenlogik).
+
+---
+
+# Analysis
+
+## Type
+
+**Bug** — nutzersichtbares Fehlverhalten, PO-Einstufung „kritisch, höchste Priorität". Zugleich (siehe Framing unten) die **dritte Stufe einer dokumentierten Verfeinerungskette**, nicht die Korrektur einer Nachlässigkeit.
+
+## Framing: #2017 ist Stufe 3, nicht Stufe 1
+
+| Stufe | Issue | Abfragepunkt | Beleg |
+|---|---|---|---|
+| 1 | #656 | `waypoints[0]` — erster Wegpunkt des Tages | `docs/specs/modules/radar_nowcast.md:69` |
+| 2 | #822 | `active.start_point` — Start des aktiven Segments | `tests/tdd/test_issue_822_radar_nowcast_segment.py:7-8,384-469` |
+| **3** | **#2017** | **Position zum relevanten Zeitpunkt (interpoliert)** | dieses Ticket |
+
+Die Ursprungs-Spec benennt die Näherung ausdrücklich als bekannte Grenze: **„'Aktuelle Position' = repräsentativer Punkt der heutigen Etappe, kein Live-GPS"** (`radar_nowcast.md:110`). Der Kommentar `trip_alert.py:1257` („Genau EIN get_nowcast-Call…") ist eine bewusste Budget-Entscheidung aus #1329, keine Schlamperei.
+
+**Konsequenz:** Die neue Spec **aktualisiert diese Known Limitation**, statt sie neu zu erfinden — und liefert damit zugleich die saubere Begründung für die Anpassung der beiden bugfestschreibenden Tests (Risiko 4) und für den Guard-Rückbau (Risiko 3).
+
+## Der Zirkelschluss ist beweisbar, nicht nur plausibel
+
+Ein Abruf liefert eine Zeitreihe (`frames`) über bis zu 180 Min — aber **`RadarFrame` trägt überhaupt kein lat/lon**: die Felder sind `timestamp`, `precip_mm_h`, `is_convective` (`src/providers/brightsky.py:32-37`). Alle Frames stammen aus **einem** `_fetch_frames_with_fallback(lat, lon)` für **eine** fixe Koordinate (`radar_service.py:170-241`); `_derive_result()` filtert nur nach `f.timestamp`, nie nach Ort (`:543-599`). Auch die Provider-Ebene liefert bewusst Punkt-, keine Flächenabfragen (`geosphere.py:69`: „using timeseries for point queries (grid requires bbox)").
+
+⇒ Eine Trajektorie (Position × Zeit) ist mit einem Abruf **strukturell unmöglich** — der Datentyp kann sie nicht tragen. Variante 3 kostet zwingend n Abrufe.
+
+## Der Ortsfehler liegt außerhalb der Modellauflösung
+
+| Quelle | Zellgröße | Fundstelle |
+|---|---|---|
+| GeoSphere INCA | **1 km** | `geosphere.py:71` (`nowcast-v1-15min-1km`) |
+| AROME-FR | **1,3 km** | `openmeteo.py:127`, `meteofrance.py:794` |
+| ICON-D2 | **2 km** | `openmeteo.py:132-135` |
+| ARPAE ICON-2I | **2 km** | `radar_service.py:250` |
+
+Der gemessene Median-Versatz von **2,68 km** entspricht dem **1,3- bis 2,7-Fachen** der Zellgröße der für den KHW relevanten Quellen (Abdeckung über die Bbox-Konstanten `radar_service.py:37-61`). Der Fehler liegt strukturell **außerhalb einer einzelnen Gitterzelle** — er verschwindet nicht im Modellrauschen. Das ist ein eigenständiges Argument für die fachliche Relevanz und gehört in die Spec.
+
+## Präzisionsgrenze (PO-bestätigt, gehört als Known Limitation in die Spec)
+
+Das System kennt die Ist-Position nicht und wird sie nie kennen — der Wanderer ist offline oder auf Satellit. **Das ist der Daseinszweck des Produkts, kein Mangel**: Online-Warnsysteme mit Live-Position existieren zahllos und helfen im Gebirge nicht (PO-Entscheid 2026-08-20). Kein GPS/Check-in vorschlagen.
+
+Was die Korrektur leistet und was nicht, quantifiziert:
+
+- Sei `p_plan` der geplante Fortschrittsanteil im Segment, `p_real` der tatsächliche.
+- Fehler Startpunkt = `p_real` · Fehler Interpolation = `|p_plan − p_real|`
+- **Die Interpolation ist mindestens so gut wie der Startpunkt, solange `p_real >= p_plan/2`** — also solange der Wanderer wenigstens die Hälfte des planmäßig erwarteten Fortschritts erreicht hat.
+- Erst bei über 50 % Rückstand kann der Startpunkt zufällig näher liegen — dann aber „näher an falsch", nie richtig.
+
+⇒ Die Korrektur beseitigt den **systematischen** Bias (der Startpunkt liegt *immer* zurück, nie voraus), nicht die **stochastische** Abweichung vom Plan. Genau so formulieren, statt „korrekte Position" zu versprechen.
+
+**Randfall Vorschau-Zweig:** Liegt `now_utc` noch vor dem ersten Segment des Tages (Wanderer auf der Hütte), liefert `resolve_current_segment()` das erste Segment als Vorschau (`trip_segments.py:412`). Dort ist Fortschritt **0** die richtige Antwort. Der Fortschrittsanteil ist auf `[0,1]` zu klemmen und der Vorschau-Fall (`p_plan = 0`) vom aktiven Fall (`p_plan = elapsed/duration`) zu unterscheiden — sonst entsteht am Tagesbeginn ein Scheinfehler, wo keiner ist.
+
+## Zweite Fundstelle — Formulierung präzisiert
+
+`trip_report_scheduler.py:1809-1810` teilt den Mechanismus, Horizont 180 Min ohne Onset-Grenzwert. **Aber der gerenderte Text nennt gar keinen Ort:** `format_starkregen_hint()` (`output/renderers/email/starkregen_hint.py:18-27`) gibt nur `"{intensity_label} ab ca. {time_str} (in ~{onset_minutes} Min)."` aus — kein Etappenname, kein km-Bereich.
+
+Der Schaden ist damit **nicht** „falscher Ortsbezug", sondern: **kein Ortsbezug ⇒ der Leser bezieht die Aussage selbstverständlich auf sich selbst, obwohl sie an einem Ort berechnet wurde, an dem er nicht ist.** Das verschärft die Fehlinterpretation, statt sie zu entschärfen.
+
+## Affected Files
+
+### Scheibe A — Baustein (sofort startbar, unabhängig von #1991/#2009)
+
+| Datei | Änderung | Beschreibung |
+|---|---|---|
+| `src/services/trip_segments.py` | MODIFY | `position_at_time(trip, active, segment_date, at) -> GPXPoint` — lineare Interpolation von lat/lon/**elevation_m** nach Zeitanteil; Vorwärtssuche über Segment- und Tagesgrenze; Ziel-Segment stationär; Fortschritt auf `[0,1]` geklemmt; fail-soft auf letzten `end_point` |
+| `tests/tdd/test_position_at_time.py` | CREATE | Within-Segment · Segmentgrenze · **Tagesgrenze** · Ziel-Segment stationär · Vorschau-Zweig (`p=0`) · Höhen-Interpolation · Fail-soft-Klemme |
+
+### Scheibe B — Wiring (blockiert bis #1991 **und** #2009 auf `main`)
+
+| Datei | Änderung | Beschreibung |
+|---|---|---|
+| `src/services/trip_alert.py` | MODIFY | `:1257-1265` — Abrufpunkt `position_at_time(at = now + RADAR_ONSET_THRESHOLD_MIN//2)`, Höhe mitgeben |
+| `src/services/trip_report_scheduler.py` | MODIFY | `:1809-1815` — analog mit `NOWCAST_HORIZON_MIN//2`; **eigene Segmentwahl bleibt unangetastet** (#1667 S3) |
+| `src/services/trip_alert.py` | MODIFY | Segment-Ende-Guard aus #2009 **ersatzlos entfernen** |
+| `tests/tdd/test_radar_alert_segment_end_guard.py` | DELETE | zusammen mit AC-6 der #2009-Spec |
+| `tests/tdd/test_issue_822_radar_nowcast_segment.py` | MODIFY | **AC-2 und AC-3** auf den interpolierten Punkt umschreiben, mit Begründung aus der Verfeinerungskette |
+| `docs/specs/modules/radar_nowcast.md` | MODIFY | Known Limitation `:110` fortschreiben |
+
+## Scope Assessment
+
+| Scheibe | Dateien | LoC (geschätzt) | Risiko |
+|---|---|---|---|
+| A | 2 | +180…220 | **LOW** — reiner Zusatzcode, keine Berührung mit fremden Branches |
+| B | 6 | +60…100 saldiert (Guard-Rückbau zieht ab) | **MEDIUM** — kritischer Alarmpfad, zwei Fundstellen, Testanpassung |
+
+**Kein `loc_limit_override` nötig.** Beide Scheiben bleiben unter 250 LoC.
+
+## Technical Approach (Empfehlung)
+
+**Variante 1 — Position zur Mitte des Vorwarnfensters, ein Abruf, Baustein in `src/services/trip_segments.py`.**
+
+- **Warum nicht Variante 3 (Trajektorie):** strukturell unmöglich ohne n Abrufe (`RadarFrame` trägt keine Position). Für ein 55-Minuten-Fenster mit linearer Bewegung wäre der Aufwand ohnehin unverhältnismäßig.
+- **Warum nicht Variante 2 (zwei Abrufe):** fachlich *schlechter*, nicht nur teurer — anderer Ort ⇒ anderer Onset ⇒ andere Position, das Ergebnis kann in sich widersprüchlich werden. Zudem doppeltes Budget.
+- **Warum `trip_segments.py` und nicht `geo.py`:** `geo.py` ist Distanz-/Kompass-SSoT ohne Trip-Kenntnis (#1027). Die Interpolation braucht Segment- und Tagesgrenzen-Logik, die `trip_segments.py` bereits hält — dessen Docstring nennt es „SSoT for segment conversion, shared between briefing and radar alert" (`:4-5`). Dieselbe lineare Näherung wie die bestehende Zeit-Interpolation.
+- **Geteilt wird die Positionsberechnung, nicht die Segmentwahl.** Beide Aufrufer übergeben ihr eigenes `(active, segment_date)`; der Baustein weiß nicht, woher es stammt.
+- **Offset-Quelle:** je Aufrufer die halbe **bereits vorhandene** Konstante — `RADAR_ONSET_THRESHOLD_MIN//2` (Alarm) bzw. `NOWCAST_HORIZON_MIN//2` (Starkregen-Hinweis). Keine neue Konstante.
+
+## Dependencies
+
+- **Scheibe A:** keine. Sofort startbar.
+- **Scheibe B:** #1991 (`elevation_m` an `get_nowcast`) **und** #2009 (geteilte Schwelle + der zu entfernende Guard) müssen auf `main` sein. Beide sind es **noch nicht** (`git merge-base --is-ancestor` gegen `892e0631` und `977c774f`: beide nein). Vor Beginn von Scheibe B am Code verifizieren, dass der Guard tatsächlich existiert — nicht aus der Doku annehmen.
+
+## Open Questions
+
+- [ ] Keine offenen **technischen** Fragen. Die Variantenwahl wird durch die laufende Messung (Restfehler je Variante) quantitativ untermauert; fällt sie unerwartet aus, wird die Empfehlung angepasst.
+- [ ] **Zuschnitt-Bestätigung durch die Spec-Freigabe:** beide Fundstellen gemeinsam (Empfehlung) vs. nur der Alarmpfad.
+
+## Nebenbefunde (nicht Teil dieses Tickets)
+
+| Befund | Einordnung |
+|---|---|
+| `/jetzt` fragt `stage.waypoints[0]` ab — den Tagesstartpunkt (`trip_command_processor.py:1375`) | nutzersichtbar, andere Fehlerklasse ⇒ **eigenes Issue** prüfen |
+| `starkregen_hint.py:4-5` Docstring nennt „60-Minuten-Nowcast-Fenster", real sind es seit #1945 **180** | stale Doku ⇒ Sammel-Issue **#1199** |
+| Interpolierter Punkt kann theoretisch eine andere **Region** treffen (`_region_bucket()`) und damit eine andere Datenquelle | seltener Grenzfall an Modellgrenzen ⇒ **#1199**, kein Blocker |
+| Drosselung ununterscheidbar von „trocken" | bereits dokumentiert (`fix_1329_c2…:529-534`), kein Handlungsbedarf |
+
+## Wirksamkeitsmessung der Varianten (eigene Messung, 2026-08-20)
+
+**Grundlage:** Trip `5f534011` „KHW 403", 13 Etappen, 51 Geh-Segmente, 3.595 Geh-Minuten, gelesen über `GET /api/_internal/trip/{id}/loaded`; Segmente über den echten `convert_trip_to_segments()`. Nur gelesen und gerechnet. Skript und Rohergebnis im Session-Scratchpad.
+**Sanity-Check:** V0 bei H=55/worst case (Median 2,73 km) deckt sich mit der Vorgänger-Messung im Issue (H=53, Median 2,68 km) — Methodik konsistent.
+
+**H = 55 min (Alarmpfad nach #2009), gleichverteilter Onset, n = 43.140**
+
+| Variante | Median | p75 | p90 | Max | > 2 km | richtiges Segment |
+|---|---|---|---|---|---|---|
+| **V0 (heute)** | 1,99 | 2,89 | 3,68 | 6,53 | **49,7 %** | 63,9 % |
+| **V1 (Mitte)** | **0,37** | 0,67 | 0,92 | 1,82 | **0,0 %** | 79,6 % |
+| V1b (Fensterende) | 0,65 | 1,20 | 1,70 | 3,64 | 4,8 % | 64,0 % |
+| V2 (zwei Abrufe) | 0,30 | 0,55 | 0,81 | 1,65 | 0,0 % | 97,5 % |
+| V3 (Trajektorie) | 0,00 | — | — | — | 0 % | 100 % |
+
+**H = 180 min (Starkregen-Kurzfristhinweis), gleichverteilter Onset, n = 133.015**
+
+| Variante | Median | p75 | p90 | Max | > 2 km | richtiges Segment |
+|---|---|---|---|---|---|---|
+| **V0 (heute)** | 3,22 | 4,77 | 6,33 | 9,08 | **75,4 %** | 23,8 % |
+| **V1 (Mitte)** | **0,73** | 1,64 | 2,45 | 5,31 | 17,6 % | 54,5 % |
+| V1b (Fensterende) | 1,03 | 2,81 | 4,29 | 7,56 | 35,7 % | 41,1 % |
+| V2 (zwei Abrufe) | 0,46 | 1,33 | 2,11 | 3,80 | 11,6 % | 65,0 % |
+| V3 (Trajektorie) | 0,00 | — | — | — | 0 % | 100 % |
+
+Worst case (Onset = H): H=55 → V0 2,73 / V1 0,82 · H=180 → V0 5,23 / V1 1,42. Kein Tages-Überlauf in irgendeiner Kombination (0 übersprungene Onset-Punkte) — Risiko 1 ist real, aber auf dieser Tour nicht getroffen.
+
+### Ableitungen
+
+1. **V1 holt den Löwenanteil:** Median-Verbesserung **Faktor 5,4×** bei H=55 (−81 %), Faktor 4,4× bei H=180 (−77 %). Bei H=55 fällt der Anteil grober Fehler (> 2 km) von **49,7 % auf 0,0 %**.
+2. **V2 lohnt den doppelten Verbrauch nicht:** Zugewinn gegenüber V1 nur **70 m** im Median bei H=55 (p90: 110 m). Der große Sprung liegt bei V0→V1, nicht bei V1→V2.
+   ⚠️ **Und die Messung ist zu V2 wohlwollend:** Sie setzt den Fehler auf das *Minimum* beider Abrufe — als wüsste man hinterher, welcher der richtige war. Genau das weiß man nicht; die Auswahl wäre derselbe Zirkelschluss. Real ist V2 also **schlechter** als hier ausgewiesen.
+3. **Restfehler V1 bei H=55 unbedenklich:** Median 370 m, p90 920 m — deutlich unter der Zellgröße der Radarquellen (1–2 km) und weit unter der Ausdehnung einer Gewitterzelle.
+4. **Restfehler V1 bei H=180 real spürbar:** p90 2,45 km, 17,6 % über 2 km (worst case 39,6 %). Das erreicht die Zellgröße. **Der 180-Minuten-Pfad bleibt auch nach der Korrektur ungenauer** — das ist offen zu benennen.
+
+### Entscheidung: V1 für **beide** Pfade
+
+Die Messung legt für den 180-Minuten-Pfad V2 nahe. Dagegen und für **V1 überall**:
+
+- **V2 ist nicht sauber entscheidbar.** Zwei Abrufe liefern zwei Onsets; welcher gilt, ist genau die Frage, die man ohne Onset nicht beantworten kann. Die Messung umgeht das per `min()` — im Betrieb gibt es dieses Wissen nicht.
+- **Ein Mechanismus, ein Baustein.** Zwei verschiedene Bauformen für dieselbe Fehlerursache widersprechen der Code-Teilungs-Konvention.
+- **V1 holt auch bei H=180 noch 77 %** des Fehlers — von „völlig falsch verortet" (75,4 % über 2 km) auf „meist brauchbar" (17,6 %).
+- **Der eigentliche Schaden des 180-Minuten-Pfads ist ein anderer:** Sein Text nennt **gar keinen Ort** (`starkregen_hint.py:18-27`), weshalb der Leser die Aussage auf sich bezieht. Dagegen hilft kein zweiter Abruf, sondern eine Ortsangabe im Text. Das ist die wirksamere Folgearbeit — **eigenes Issue**, weil es Mail-Inhalt ändert (Renderer-Gate) und damit einen anderen Zuschnitt hat.
+
+⇒ **Restfehler bei H=180 wird als Known Limitation in die Spec geschrieben**, mit den Zahlen aus dieser Messung, plus Verweis auf das Folge-Issue zur Ortsangabe.

--- a/docs/specs/modules/fix_2017_nowcast_messpunkt.md
+++ b/docs/specs/modules/fix_2017_nowcast_messpunkt.md
@@ -1,0 +1,394 @@
+---
+entity_id: fix_2017_nowcast_messpunkt
+type: bugfix
+created: 2026-08-20
+updated: 2026-08-20
+status: approved
+version: "1.0"
+tags: [alerts, radar, nowcast, trip, geometry]
+---
+
+# Nowcast-Messpunkt: interpolierte Position statt Segment-Startpunkt (Issue #2017)
+
+## Approval
+
+- [x] Approved — PO-Freigabe 2026-08-20 (Henning), 12 ACs
+
+## Purpose
+
+Der Radar-/Nowcast-Alarm (`trip_alert.py`) und der Starkregen-Kurzfristhinweis
+(`trip_report_scheduler.py`) fragen das Wetter am **Startpunkt des aktiven Segments** ab — dem
+Wegpunkt, den der Wanderer bereits verlassen hat. Gemessen: Median 2,68 km Versatz während der
+Gehphasen (Issue-Kommentar), bestätigt durch eigene Messung (Median 1,99 km bei H=55, 3,22 km bei
+H=180, siehe Known Limitations). Diese Spec führt einen geteilten Baustein ein, der die Position
+**zur Mitte des jeweiligen Vorwarnfensters** aus der Gehzeit-Planung interpoliert (lat, lon **und
+Höhe**), und verdrahtet ihn an beiden Fundstellen — ohne zusätzliches API-Budget. Sie ist Stufe 3
+einer dokumentierten Verfeinerungskette (#656 → #822 → #2017, siehe Framing unten) und schreibt
+die zugehörige Known Limitation in `radar_nowcast.md:110` fort statt sie neu zu erfinden.
+
+## Framing: Stufe 3 einer Verfeinerungskette
+
+| Stufe | Issue | Abfragepunkt |
+|---|---|---|
+| 1 | #656 | `waypoints[0]` — erster Wegpunkt des Tages |
+| 2 | #822 | `active.start_point` — Start des aktiven Segments |
+| **3** | **#2017** | **Position zum Onset-Zeitpunkt, angenähert über Interpolation zur Fenstermitte** |
+
+`docs/specs/modules/radar_nowcast.md:110` benennt die Näherung seit #656 ausdrücklich als
+bekannte Grenze: „'Aktuelle Position' = repräsentativer Punkt der heutigen Etappe, kein
+Live-GPS." Der Kommentar `trip_alert.py:1257` ist eine bewusste Budget-Entscheidung aus #1329,
+keine Schlamperei — diese Spec verschärft die Näherung, sie hebt sie nicht auf.
+
+## Der Zirkelschluss — warum "Position zum Onset-Zeitpunkt" nicht exakt erreichbar ist
+
+Der Onset-Zeitpunkt entsteht **aus** dem Nowcast-Ergebnis (`radar_service.py:543-599`,
+`_onset_dt = now_utc + timedelta(minutes=result.onset_minutes)`, `trip_alert.py:1282`) — er ist
+erst bekannt, *nachdem* die Abfrage mit einer festen Koordinate bereits gelaufen ist. Die exakte
+Onset-Position kann mit einem Abruf nicht abgefragt werden, ohne den Onset schon zu kennen. Diese
+Spec löst den Zirkel **onset-frei** auf: Position zu einem *festen* Zeitpunkt in der Mitte des
+Vorwarnfensters (`now + Fenster//2`), unabhängig vom (noch unbekannten) Onset — ein Abruf,
+deterministisch. Zwei Alternativen wurden geprüft und verworfen, siehe Known Limitations 3 und 4.
+
+## Source
+
+- **File:** `src/services/trip_segments.py`, `src/services/trip_alert.py`,
+  `src/services/trip_report_scheduler.py`
+- **Identifier:** `position_at_time()` (neu), `TripAlertService.check_radar_alerts()`,
+  `TripReportSchedulerService._starkregen_hint_data()` (Methode, die
+  `trip_report_scheduler.py:1809-1815` enthält)
+- **Schicht:** Python-Core (`src/services/`) — kein Go, kein Frontend.
+
+## Estimated Scope
+
+- **LoC:** Scheibe A ~180–220 (Baustein + eigene Tests), Scheibe B ~60–100 saldiert
+  (Wiring an zwei Stellen minus Guard-Rückbau minus gelöschte Testdatei).
+  Kein `loc_limit_override` nötig — beide Scheiben bleiben unter 250 LoC.
+- **Files:** Scheibe A: 2 (1 modifiziert, 1 neu). Scheibe B: 6 (4 modifiziert, 1 gelöscht, 1
+  Doku).
+- **Effort:** medium
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `services.trip_segments.resolve_current_segment` | function | Liefert `(active, segment_date)` — Segmentwahl bleibt bei den Aufrufern, unverändert |
+| `services.trip_segments.convert_trip_to_segments` | function | Wird vom neuen Baustein selbst genutzt, um Folgesegmente/-tage nachzuladen |
+| `services.trip_segments.TripSegment` | model | Trägt `start_time`/`end_time`, `start_point`, `end_point` — Grundlage der Interpolation |
+| `app.models.GPXPoint` | model | Rückgabetyp — `lat`, `lon`, `elevation_m` |
+| `services.radar_service.RADAR_ONSET_THRESHOLD_MIN` | constant | Aus #2009 — Offset-Quelle für `trip_alert.py` (`//2`); **Voraussetzung: #2009 auf `main`** |
+| `services.radar_service.NOWCAST_HORIZON_MIN` | constant | Offset-Quelle für `trip_report_scheduler.py` (`//2`), bereits auf `main` (#1439) |
+| `services.radar_service.RadarNowcastService.get_nowcast` | function | Erhält ab Scheibe B die interpolierte Koordinate statt `active.start_point`; trägt seit #1991 `elevation_m` — **Voraussetzung: #1991 auf `main`** |
+
+## Implementation Details
+
+### Scheibe A — geteilter Baustein (sofort startbar, unabhängig von #1991/#2009)
+
+Neue Funktion in `src/services/trip_segments.py` (dieselbe Datei wie
+`resolve_current_segment()`/`convert_trip_to_segments()` — Docstring dort nennt sie bereits
+„SSoT for segment conversion, shared between briefing and radar alert"):
+
+```python
+def position_at_time(
+    trip: "Trip", active: TripSegment, segment_date: date, at: datetime,
+) -> GPXPoint:
+    """Interpolierte Position innerhalb/nach dem aktiven Segment zum Zeitpunkt `at`.
+
+    Onset-frei (#2017): `at` ist ein FESTER Zeitpunkt (Fenstermitte), kein aus
+    dem Nowcast-Ergebnis abgeleiteter — sonst Zirkelschluss (siehe Spec).
+    """
+```
+
+Ablauf:
+
+1. **Ortsfestes Ziel-Segment** (`isinstance(active.segment_id, int)` ist `False`, bzw.
+   `active.distance_km == 0.0` — etablierter Filter, siehe `trip_segments.py`
+   Existing-Patterns): sofort `active.start_point` zurückgeben. Keine Interpolation — der
+   Wanderer bewegt sich dort nicht.
+2. **Vorschau-Zweig** (`at` bzw. `now_utc` liegt noch vor `active.start_time` — der Fall, in dem
+   `resolve_current_segment()` das erste Segment des Tages als Vorschau liefert,
+   `trip_segments.py:412`): Fortschritt = 0, `active.start_point` zurückgeben. Der Wanderer ist
+   noch nicht losgelaufen, das ist die richtige Antwort, kein Sonderfall im negativen Sinn.
+3. **`at` liegt innerhalb `[active.start_time, active.end_time]`:** Fortschrittsanteil
+   `p = (at - active.start_time) / (active.end_time - active.start_time)`, geklemmt auf `[0,1]`.
+   Lineare Interpolation von `lat`, `lon` **und `elevation_m`** zwischen `active.start_point` und
+   `active.end_point` nach `p`. Dieselbe Näherung wie die bestehende Zeit-Interpolation
+   `_interpolate_missing_times()` (`trip_segments.py:59-105`) — dort nur für Zeiten, hier
+   erstmals für Geometrie.
+4. **`at` liegt nach `active.end_time`:** Vorwärtssuche. `convert_trip_to_segments(trip,
+   segment_date)` liefert die volle Tagesliste; das Nachfolgesegment von `active` (per
+   `segment_id`-Reihenfolge bzw. Listenindex) wird geprüft; liegt `at` auch darüber hinaus,
+   iterativ weiter. Reicht der Tag nicht aus (letztes Segment des Tages endet vor `at`), wird
+   `convert_trip_to_segments(trip, segment_date + timedelta(days=1))` nachgeladen und die Suche
+   dort fortgesetzt.
+5. **Fail-soft** (kein Folgetag vorhanden — Tour zu Ende, Ruhetag ohne Stage, < 2 Wegpunkte,
+   oder eine durch den bestehenden Zeitlücken-Guard übersprungene Segmentkette,
+   `trip_segments.py:200-218`): auf den letzten bekannten `end_point` klemmen, ein
+   `logger.debug`/`logger.warning`-Eintrag mit erkennbarem Grund, **keine Exception nach
+   außen**. Der Aufrufer bekommt in jedem Fall einen `GPXPoint` zurück.
+
+`tests/tdd/test_position_at_time.py` (neu) deckt: Interpolation innerhalb eines Segments ·
+Höhen-Interpolation · Segmentgrenzen-Überschreitung (Folgesegment) · Tagesgrenzen-Überschreitung
+(Folgetag nachgeladen) · Ziel-Segment bleibt stationär · Vorschau-Zweig liefert Fortschritt 0 ·
+Fail-soft-Klemme bei fehlendem Folgetag/Ruhetag/Zeitlücke.
+
+### Scheibe B — Wiring (blockiert bis #1991 UND #2009 auf `main`)
+
+**`trip_alert.py:1257-1265`:**
+
+```python
+_at = now_utc + timedelta(minutes=RADAR_ONSET_THRESHOLD_MIN // 2)
+_pos = position_at_time(trip, active, segment_date, _at)
+lat, lon = _pos.lat, _pos.lon
+...
+result = radar_svc.get_nowcast(lat, lon, elevation_m=_pos.elevation_m, priority="polling")
+```
+
+**`trip_report_scheduler.py:1809-1815`:** analog, mit `NOWCAST_HORIZON_MIN // 2` als Offset.
+Die **eigene lokale Segmentwahl** dieser Methode (`:1780-1789`, bewusst ohne Vortags-Rückgriff,
+#1667 S3) bleibt unangetastet — `position_at_time()` erhält deren `(active, segment_date)` als
+Parameter, ohne sie zu beeinflussen. **Geteilt wird ausschließlich die Positionsberechnung.**
+
+**Segment-Ende-Guard-Rückbau (#2009 AC-6):** Der in #2009 eingeführte Guard in `trip_alert.py`
+(unterdrückt Alarme, deren Onset nach `active.end_time` liegt) wird **ersatzlos entfernt**,
+zusammen mit `tests/tdd/test_radar_alert_segment_end_guard.py`. Der Guard war eine
+Ausgleichsmaßnahme für den falschen Messpunkt (dokumentiert als Known Limitation mit
+Verfallsdatum in `fix_2009_nowcast_vorlauf.md`, Commit `87644e6a`) — nach dieser Korrektur läge
+der Onset systematisch dort, wo der Wanderer zu diesem Zeitpunkt sein wird, und der Guard würde
+**richtige** Alarme verwerfen. Das ist der dokumentierte, vorgesehene Rückbau, kein stiller
+Spec-Widerruf.
+
+**Bugfestschreibende Tests:** `tests/tdd/test_issue_822_radar_nowcast_segment.py` — **AC-2**
+(`test_ac2_segment_selection_by_time`, Zeile 249) und **AC-3**
+(`test_ac3_nowcast_called_at_segment_coordinates`, Zeile 388) prüfen heute exakte Gleichheit
+(Toleranz `< 0.01°`) mit `active.start_point`. Beide werden auf den interpolierten Punkt
+umgeschrieben — begründet über die Verfeinerungskette #656 → #822 → #2017: AC-3 aus #822 wollte
+„nicht mehr `waypoints[0]`, sondern der Segment-Startpunkt" beweisen; das bleibt durch #2017
+unberührt für den *Vorschau*-Fall (dort ist Fortschritt 0 weiterhin `start_point`), ändert sich
+aber für den *aktiven* Fall, wo #2017 einen genaueren Punkt liefert. Beide Tests werden bewusst
+und einzeln angepasst, nicht pauschal überschrieben.
+
+**Known-Limitation-Nachzug:** `docs/specs/modules/radar_nowcast.md:110` — „'Aktuelle Position' =
+repräsentativer Punkt der heutigen Etappe, kein Live-GPS" wird um die Präzisierung ergänzt: der
+repräsentative Punkt ist seit #2017 die zur Fenstermitte interpolierte Position, nicht mehr der
+Segment-Startpunkt.
+
+## Expected Behavior
+
+- **Input:** `TripSegment` mit `start_point`/`end_point`/`start_time`/`end_time` aus
+  `resolve_current_segment()` bzw. der lokalen Segmentwahl in `trip_report_scheduler.py`; fester
+  Zieloffset (`RADAR_ONSET_THRESHOLD_MIN // 2` bzw. `NOWCAST_HORIZON_MIN // 2`).
+- **Output:** `GPXPoint` mit interpolierten `lat`/`lon`/`elevation_m`; bei ortsfestem Ziel-Segment
+  oder Vorschau-Zweig identisch zum bisherigen `start_point`. `get_nowcast()` wird an beiden
+  Fundstellen mit dieser Position statt dem Segment-Startpunkt aufgerufen, inklusive Höhe.
+- **Side effects:** Keine zusätzlichen `get_nowcast()`-Aufrufe (weiterhin genau ein Abruf je
+  Lauf und Fundstelle). Kein neues Persistenzfeld, keine Migration — `position_at_time()` ist
+  eine reine Berechnung, nichts wird gespeichert.
+
+## Acceptance Criteria
+
+- **AC-1:** Given ein aktives Geh-Segment und ein Zeitpunkt `at` innerhalb `[start_time,
+  end_time]` / When `position_at_time(trip, active, segment_date, at)` aufgerufen wird / Then
+  liegt die zurückgegebene Position linear zwischen `start_point` und `end_point`, entsprechend
+  dem Zeitanteil `(at - start_time) / (end_time - start_time)`.
+  - Test: echter Aufruf mit konstruiertem Segment und `at` = Fenstermitte, Assert auf
+    `lat`/`lon` gegen den analytisch erwarteten interpolierten Wert (kein Mock).
+
+- **AC-2:** Given dasselbe Segment mit unterschiedlicher `elevation_m` an Start- und Endpunkt /
+  When `position_at_time()` für einen Zeitpunkt in der Segmentmitte aufgerufen wird / Then ist
+  auch `elevation_m` linear interpoliert, nicht die Höhe des Startpunkts.
+  - Test: echter Aufruf, Assert auf `elevation_m` gegen den erwarteten Zwischenwert.
+
+- **AC-3:** Given ein Zeitpunkt `at`, der auf ein ortsfestes Ziel-Segment fällt (`segment_id`
+  kein `int` bzw. `distance_km == 0.0`) / When `position_at_time()` aufgerufen wird / Then wird
+  unverändert `start_point` zurückgegeben, ohne Interpolation.
+  - Test: echter Aufruf mit konstruiertem Ziel-Segment, Assert auf Identität mit
+    `active.start_point` (nicht nur numerische Nähe).
+
+- **AC-4:** Given `now_utc` liegt noch vor dem ersten Segment des Tages (Vorschau-Zweig aus
+  `resolve_current_segment()`, Wanderer noch auf der Unterkunft) / When `position_at_time()`
+  aufgerufen wird / Then ist der Fortschrittsanteil 0 und die Rückgabe ist `active.start_point`
+  — kein Scheinfehler durch negativen oder verfrühten Zeitanteil.
+  - Test: echter Aufruf mit `at`/`now_utc` vor `active.start_time`, Assert auf
+    `start_point`-Identität.
+
+- **AC-5:** Given ein Zieloffset, dessen `at` über das Ende des aktiven Segments, aber nicht
+  über das Ende des Tages hinausläuft / When `position_at_time()` aufgerufen wird / Then wird
+  auf das zeitlich passende Folgesegment desselben Tages weitergesucht und die Position dort
+  interpoliert, statt am Ende des aktiven Segments zu klemmen.
+  - Test: echter Aufruf über zwei aufeinanderfolgende Segmente, `at` im zweiten Segment, Assert
+    auf einen Punkt, der nur aus dem zweiten Segment erreichbar ist.
+
+- **AC-6:** Given ein Zieloffset, dessen `at` über das Ende des letzten Segments des Tages
+  hinausläuft / When `position_at_time()` aufgerufen wird / Then wird
+  `convert_trip_to_segments(trip, segment_date + 1 Tag)` nachgeladen und die Position im
+  entsprechenden Segment des Folgetags interpoliert.
+  - Test: echter Aufruf mit `at` jenseits des letzten Tagessegments, Trip mit gültiger
+    Folgetags-Etappe, Assert auf einen Punkt aus dem Folgetag.
+
+- **AC-7:** Given `at` liegt jenseits des letzten verfügbaren Segments UND es existiert kein
+  Folgetag (Tour zu Ende, Ruhetag ohne Stage, oder eine durch den bestehenden Zeitlücken-Guard
+  entstandene Lücke) / When `position_at_time()` aufgerufen wird / Then wird auf den letzten
+  bekannten `end_point` geklemmt, ein Log-Eintrag mit erkennbarem Grund geschrieben, und es wird
+  **keine** Exception nach außen geworfen.
+  - Test: echter Aufruf mit Trip ohne Folgetags-Stage, Assert auf Rückgabewert
+    (`end_point`-Identität) und dass der Aufruf nicht wirft.
+
+- **AC-8:** Given `TripAlertService.check_radar_alerts()` mit einem aktiven Geh-Segment / When
+  der Radar-Alarm-Pfad läuft / Then wird `get_nowcast()` mit der über `position_at_time(...,
+  at=now + RADAR_ONSET_THRESHOLD_MIN // 2)` berechneten Position (inkl. Höhe) aufgerufen, nicht
+  mit `active.start_point`.
+  - Test: echter `check_radar_alerts()`-Lauf mit einem Segment, dessen `start_point` und
+    interpolierter Punkt sich nachweisbar unterscheiden; Assert auf die tatsächlich an
+    `get_nowcast()` übergebenen Koordinaten (DI-Seam / Capture, kein Mock der
+    Entscheidungslogik).
+
+- **AC-9:** Given der Starkregen-Kurzfristhinweis-Pfad in `trip_report_scheduler.py` mit seiner
+  eigenen (unveränderten) Segmentwahl / When er läuft / Then wird `get_nowcast()` mit der über
+  `position_at_time(..., at=now + NOWCAST_HORIZON_MIN // 2)` berechneten Position aufgerufen,
+  und die Segmentwahl selbst liefert weiterhin dasselbe Segment wie vor dieser Änderung
+  (Regressionsschutz für #1667 S3: kein Vortags-Rückgriff).
+  - Test: echter Aufruf mit einem Trip, bei dem Alarm- und Briefing-Pfad unterschiedliche
+    Segmente wählen würden (z. B. Segment endet genau `now_utc`); Assert, dass beide Pfade ihre
+    jeweils eigene, unveränderte Segmentwahl behalten UND beide `position_at_time()` mit ihrem
+    eigenen Offset aufrufen.
+
+- **AC-10:** Given der Segment-Ende-Guard aus #2009 (AC-6 jener Spec) ist entfernt / When ein
+  Onset-Zeitpunkt errechnet wird, der (nach altem Maßstab) nach `active.end_time` läge / Then
+  wird der Alarm **nicht** mehr durch diesen Guard unterdrückt — `check_radar_alerts()` sendet
+  ihn regulär, sofern kein anderer Gate ihn stoppt.
+  - Test: `tests/tdd/test_radar_alert_segment_end_guard.py` ist gelöscht; ein neuer oder
+    bestehender Test in `test_issue_822_radar_nowcast_segment.py` bzw.
+    `test_feature_656_radar_nowcast.py` belegt, dass ein später Onset nicht mehr pauschal
+    unterdrückt wird (Positivnachweis der Entfernung, nicht nur Abwesenheit des alten Tests).
+
+- **AC-11 (Kontrollfall/Regressionsschutz):** Given ein Segment, dessen Dauer kürzer ist als der
+  verwendete Zieloffset (`RADAR_ONSET_THRESHOLD_MIN // 2` bzw. `NOWCAST_HORIZON_MIN // 2`), und
+  bei dem die Vorwärtssuche kein weiteres Segment und keinen Folgetag findet / When
+  `position_at_time()` läuft / Then bleibt das Verhalten aus AC-7 (Klemmen auf `end_point`,
+  kein Crash) — UND ein Kontrollfall mit `at` exakt auf `start_time` liefert weiterhin exakt
+  `start_point` (Fortschritt 0 an der unteren Grenze, keine Verschiebung durch Klemmung).
+  - Test: zwei Aufrufe im selben Testlauf — Grenzfall unten (`at == start_time` →
+    `start_point`) und der bereits in AC-7 geprüfte Grenzfall oben, um beide Enden der
+    `[0,1]`-Klemmung nachzuweisen.
+
+- **AC-12 (Budget-Invariante):** Given ein Lauf von `check_radar_alerts()` für einen Trip mit
+  aktivem Geh-Segment / When der Radar-Alarm-Pfad vollständig durchläuft / Then erfolgt **genau
+  ein** `get_nowcast()`-Aufruf für diesen Trip — die Verlegung des Abrufpunkts erhöht die Zahl
+  der Abrufe nicht. Dasselbe gilt analog für den Starkregen-Hinweis-Pfad in
+  `trip_report_scheduler.py`. Der Kommentar `trip_alert.py:1257` („Genau EIN get_nowcast-Call
+  pro Trip an Segment-Startpunkt") hielt diese Zusicherung bislang nur als Prosa fest; da genau
+  diese Zeile durch Scheibe B angefasst wird, verliert der Kommentar seinen Anker — die
+  Invariante gehört ab jetzt in einen Test, nicht in einen Kommentar.
+  - Test: Aufruf-Zähler am `get_nowcast`-Seam (DI-Seam, kein Mock der Entscheidungslogik) über
+    einen vollständigen `check_radar_alerts()`-Lauf, Assert `== 1`. Analoger Zähler-Assert für
+    den Starkregen-Hinweis-Lauf in `trip_report_scheduler.py`.
+
+## AC-Test-Mapping (Test-Plan)
+
+| AC | Testdatei | Testfunktion (geplant) |
+|----|-----------|--------------|
+| AC-1 | `tests/tdd/test_position_at_time.py` | `test_ac1_interpolates_within_active_segment` |
+| AC-2 | `tests/tdd/test_position_at_time.py` | `test_ac2_elevation_interpolates_too` |
+| AC-3 | `tests/tdd/test_position_at_time.py` | `test_ac3_destination_segment_stays_stationary` |
+| AC-4 | `tests/tdd/test_position_at_time.py` | `test_ac4_preview_branch_returns_progress_zero` |
+| AC-5 | `tests/tdd/test_position_at_time.py` | `test_ac5_crosses_segment_boundary` |
+| AC-6 | `tests/tdd/test_position_at_time.py` | `test_ac6_crosses_day_boundary` |
+| AC-7 | `tests/tdd/test_position_at_time.py` | `test_ac7_fail_soft_clamps_without_exception` |
+| AC-8 | `tests/tdd/test_issue_822_radar_nowcast_segment.py` (MODIFY) | `test_ac2_segment_selection_by_time`, `test_ac3_nowcast_called_at_segment_coordinates` |
+| AC-9 | `tests/tdd/test_trip_report_scheduler_starkregen_hint.py` (bestehend, ergänzt) | neue Testfunktion zur Positions-Berechnung |
+| AC-10 | `tests/tdd/test_radar_alert_segment_end_guard.py` (DELETE) + Positivnachweis in `test_feature_656_radar_nowcast.py` | siehe oben |
+| AC-11 | `tests/tdd/test_position_at_time.py` | `test_ac11_boundary_clamp_regression` |
+| AC-12 | `tests/tdd/test_issue_822_radar_nowcast_segment.py` (MODIFY, DI-Seam-Zähler) + `tests/tdd/test_trip_report_scheduler_starkregen_hint.py` (ergänzt) | `test_ac12_single_get_nowcast_call_per_run` (je Pfad) |
+
+### Aufgabenpunkte des Issues → AC-Abdeckung
+
+| Aufgabenpunkt | AC |
+|---|---|
+| Interpolation im aktiven Segment (statt Startpunkt) | AC-1 |
+| Höhe muss mitwandern (#1991-Abhängigkeit) | AC-2 |
+| Ziel-Segment bleibt ortsfest | AC-3 |
+| Vorschau-Zweig liefert Fortschritt 0 | AC-4 |
+| Segmentgrenzen-Überschreitung | AC-5 |
+| Tagesgrenzen-Überschreitung | AC-6 |
+| Fail-soft, keine Exception | AC-7 |
+| Fundstelle 1 (`trip_alert.py`) nutzt den Baustein | AC-8 |
+| Fundstelle 2 (`trip_report_scheduler.py`) nutzt den Baustein, eigene Segmentwahl bleibt | AC-9 |
+| Segment-Ende-Guard-Rückbau (#2009 AC-6) | AC-10 |
+| Regressionsschutz Klemmung/Kontrollfall | AC-11 |
+| API-Budget-Neutralität (ein Abruf pro Trip/Lauf) | AC-12 |
+
+## Explizit AUSGESCHLOSSEN
+
+- **Variante 2 (zwei Abrufe, iterativ an der Onset-Position).** Fachlich schlechter, nicht nur
+  teurer: anderer Ort ⇒ anderer Onset ⇒ andere Position — das Ergebnis kann in sich
+  widersprüchlich werden, die Wahl zwischen den beiden Abrufen ist derselbe Zirkelschluss, den
+  diese Spec gerade auflöst. Gemessener Zugewinn gegenüber V1 nur 70 m im Median (H=55) — und
+  die Messung ist zu V2 wohlwollend, weil sie das Minimum beider Abrufe wertet, was im Betrieb
+  nicht bekannt ist. Doppeltes API-Budget für einen Zugewinn, der den Mechanismus verkompliziert.
+- **Variante 3 (Trajektorie — Position je Vorhersage-Zeitschritt).** Strukturell unmöglich mit
+  einem Abruf: `RadarFrame` (`src/providers/brightsky.py:32-37`) trägt kein `lat`/`lon`, alle
+  Frames stammen aus einer fixen Koordinate (`_fetch_frames_with_fallback(lat, lon)`,
+  `radar_service.py:170-241`). Bräuchte zwingend n Abrufe — unverhältnismäßig für ein
+  55–180-Minuten-Fenster mit linearer Näherung.
+- **GPS/Live-Check-in als Alternative.** Kein technischer, sondern ein Produktentscheid (PO
+  2026-08-20): Der Wanderer ist auf der Tour offline oder nur über Satellit erreichbar — das ist
+  der Daseinszweck des Produkts. Online-Warnsysteme mit Live-Position existieren zahlreich und
+  helfen im Gebirge nicht.
+- **`/jetzt`-Sofortabfrage (`trip_command_processor.py:1375`, `stage.waypoints[0]`).** Andere
+  Fehlerklasse (kein Onset-Zirkel, sondern falscher Bezugspunkt für eine Sofortabfrage) —
+  eigener Befund, nicht Teil dieses Tickets. Prüfung auf eigenes Issue empfohlen.
+- **Ortsangabe im Starkregen-Hinweistext** (`starkregen_hint.py:18-27` nennt heute keinen Ort).
+  Die wirksamere Folgearbeit für den 180-Minuten-Pfad, aber Mail-Inhalt und damit ein anderer
+  Zuschnitt (Renderer-Gate) — eigenes Issue.
+
+## Known Limitations
+
+1. 🔴 **Planposition, nicht Ist-Position.** Das System kennt die tatsächliche Position des
+   Wanderers nicht und wird sie nie kennen — er ist offline oder auf Satellit. Das ist der
+   Daseinszweck des Produkts, kein Mangel (PO-Entscheid 2026-08-20). Formal: Sei `p_plan` der
+   geplante Fortschrittsanteil im Segment zum Zeitpunkt der Abfrage, `p_real` der tatsächliche.
+   Fehler des bisherigen Startpunkts = `p_real`; Fehler der Interpolation = `|p_plan − p_real|`.
+   Die Interpolation ist mindestens so gut wie der Startpunkt, solange `p_real >= p_plan/2`. Erst
+   bei über 50 % Rückstand gegenüber dem Plan kann der Startpunkt zufällig näher an der Wahrheit
+   liegen — dann aber „näher an falsch", nie richtig. Diese Korrektur beseitigt den
+   **systematischen** Bias (der Startpunkt liegt immer zurück, nie voraus), nicht die
+   **stochastische** Abweichung vom Plan.
+
+2. **Restfehler beim 180-Minuten-Pfad (Starkregen-Kurzfristhinweis) bleibt spürbar.** Eigene
+   Messung (Trip `5f534011`, 51 Geh-Segmente, 3.595 Geh-Minuten, gleichverteilter Onset):
+   V1 bei H=180 senkt den Median von 3,22 km (V0) auf **0,73 km** (−77 %), aber p90 bleibt bei
+   **2,45 km**, **17,6 %** der Fälle liegen über 2 km (worst case: p90 3,14 km, 39,6 %). Der
+   Starkregen-Hinweis bleibt damit ungenauer als der Alarmpfad (dort bei H=55: Median 0,37 km,
+   0,0 % über 2 km). Die wirksamere Folgearbeit ist eine Ortsangabe im Hinweistext selbst — der
+   Text nennt heute überhaupt keinen Ort (`starkregen_hint.py:18-27`), weshalb der Leser die
+   Aussage unabhängig von der Positionsgenauigkeit auf sich bezieht. Eigenes Issue, weil
+   Mail-Inhalt und damit anderer Zuschnitt (Renderer-Gate).
+
+3. **Warum kein zweiter Abruf (V2):** siehe „Explizit AUSGESCHLOSSEN".
+
+4. **Warum keine Trajektorie (V3):** siehe „Explizit AUSGESCHLOSSEN".
+
+5. **Kein Ortsname für den Zwischenpunkt.** `GPXPoint` trägt keinen Namen; der interpolierte
+   Punkt liegt namenlos zwischen zwei Wegpunkten. Der Alarmtext nutzt bereits „Etappe N" /
+   „km von–bis" (`output/renderers/alert/segments.py:91-111`, `format_alert_location()`), nicht
+   den Wegpunktnamen — daraus entsteht kein neuer Zwang. `km_from`/`km_to` in
+   `RadarAlertRequest` bleiben unverändert die km-Spanne des **Segments**, nicht des
+   Interpolationspunkts (die Aussage „irgendwo in diesem Kilometerbereich" bleibt korrekt,
+   unabhängig davon, wo innerhalb der Spanne abgefragt wurde).
+
+6. **Kein Tages-Überlauf in der Messgrundlage getroffen.** Bei der Wirksamkeitsmessung (Trip
+   `5f534011`) trat in keiner Kombination aus Variante/Horizont ein Tagesüberlauf auf (0
+   übersprungene Onset-Punkte). AC-6 (Tagesgrenzen-Überschreitung) ist damit durch Konstruktion
+   getestet, nicht durch reale Beobachtung auf dieser Tour bestätigt.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Keine Entscheidungsfläche im Sinne von `docs/adr/README.md` (Kanäle, Provider,
+  Datenmodell/Persistenz, Auth, Editor-Paradigma, Test-/Deploy-Strategie) ist berührt. Die
+  Änderung ist eine Präzisierung einer bereits in der Ursprungs-Spec (`radar_nowcast.md:110`)
+  dokumentierten Known Limitation, keine neue Grundsatzentscheidung.
+
+## Changelog
+
+- 2026-08-20: Initial spec created (Issue #2017)

--- a/docs/specs/modules/fix_2017_nowcast_messpunkt.md
+++ b/docs/specs/modules/fix_2017_nowcast_messpunkt.md
@@ -268,8 +268,14 @@ Segment-Startpunkt.
   kein Crash) — UND ein Kontrollfall mit `at` exakt auf `start_time` liefert weiterhin exakt
   `start_point` (Fortschritt 0 an der unteren Grenze, keine Verschiebung durch Klemmung).
   - Test: zwei Aufrufe im selben Testlauf — Grenzfall unten (`at == start_time` →
-    `start_point`) und der bereits in AC-7 geprüfte Grenzfall oben, um beide Enden der
-    `[0,1]`-Klemmung nachzuweisen.
+    `start_point`) und der bereits in AC-7 geprüfte Grenzfall oben, um **beide Enden des
+    Grenzverhaltens von `position_at_time()`** nachzuweisen: unten greift der Vorschau-Zweig,
+    oben die Fail-soft-Klemmung. Nicht gemeint ist der Klemm-Ausdruck
+    `max(0.0, min(1.0, p))` in `_interpolate_point()` — der wird von diesen beiden Aufrufen
+    gar nicht erreicht (beide Aufrufstellen schließen `p` außerhalb `[0,1]` schon durch die
+    Verzweigung davor aus; er bleibt als defensive Absicherung für die in Scheibe B
+    hinzukommenden Aufrufer stehen). Die Zusicherung ist dadurch nicht schwächer, sondern
+    genauer benannt.
 
 - **AC-12 (Budget-Invariante):** Given ein Lauf von `check_radar_alerts()` für einen Trip mit
   aktivem Geh-Segment / When der Radar-Alarm-Pfad vollständig durchläuft / Then erfolgt **genau
@@ -392,3 +398,10 @@ Segment-Startpunkt.
 ## Changelog
 
 - 2026-08-20: Initial spec created (Issue #2017)
+- 2026-08-20: AC-11 präzisiert (Adversary-Finding F003, Scheibe A) — geprüft werden beide
+  Enden des **Grenzverhaltens von `position_at_time()`** (Vorschau-Zweig unten, Fail-soft-
+  Klemmung oben), nicht der von dort unerreichbare Klemm-Ausdruck in `_interpolate_point()`.
+  Zusicherung unverändert stark, nur genauer benannt. Zusätzlich abgedeckt seit demselben
+  Fix-Loop: Übernachtungslücke zwischen zwei Etappentagen (F002) und die Vorausschau-Grenze
+  von einem Folgetag (F004) — beide gehören zur AC-7-Familie „Fail-soft-Klemmung" und ändern
+  keine Zusicherung, sondern schließen Testlücken.

--- a/src/services/trip_segments.py
+++ b/src/services/trip_segments.py
@@ -411,3 +411,108 @@ def resolve_current_segment(
 
     preview = select_active_segment(segments_today, now_utc)
     return (preview, today) if preview is not None else None
+
+
+# Issue #2017: die Vorwaertssuche laedt hoechstens EINEN Folgetag nach. Die im
+# Betrieb verwendeten Zieloffsets sind <= 90 Minuten (NOWCAST_HORIZON_MIN // 2),
+# ein zweiter Tagessprung ist damit strukturell unerreichbar.
+_LOOKAHEAD_DAYS = 1
+
+
+def _interpolate_point(seg: TripSegment, at: datetime) -> GPXPoint:
+    """Linear zwischen ``seg.start_point`` und ``seg.end_point`` nach dem
+    Zeitanteil von ``at``, Fortschritt auf ``[0,1]`` geklemmt.
+
+    Dieselbe Naeherung wie die Zeit-Interpolation in
+    ``_interpolate_missing_times()`` — dort fuer Zeiten, hier fuer Geometrie.
+    """
+    span_s = (seg.end_time - seg.start_time).total_seconds()
+    p = 0.0 if span_s <= 0 else (at - seg.start_time).total_seconds() / span_s
+    p = max(0.0, min(1.0, p))
+
+    a, b = seg.start_point, seg.end_point
+    if a.elevation_m is None and b.elevation_m is None:
+        elev = None
+    else:
+        elev_a = a.elevation_m if a.elevation_m is not None else b.elevation_m
+        elev_b = b.elevation_m if b.elevation_m is not None else a.elevation_m
+        elev = elev_a + p * (elev_b - elev_a)
+
+    return GPXPoint(
+        lat=a.lat + p * (b.lat - a.lat),
+        lon=a.lon + p * (b.lon - a.lon),
+        elevation_m=elev,
+        distance_from_start_km=(
+            a.distance_from_start_km
+            + p * (b.distance_from_start_km - a.distance_from_start_km)
+        ),
+    )
+
+
+def position_at_time(
+    trip: "Trip", active: TripSegment, segment_date: date, at: datetime,
+) -> GPXPoint:
+    """Interpolierte Position innerhalb/nach dem aktiven Segment zum Zeitpunkt `at`.
+
+    Onset-frei (#2017): `at` ist ein FESTER Zeitpunkt (Fenstermitte), kein aus
+    dem Nowcast-Ergebnis abgeleiteter — sonst Zirkelschluss (siehe Spec).
+
+    Die Segmentwahl bleibt beim Aufrufer: ``active``/``segment_date`` kommen
+    unveraendert aus ``resolve_current_segment()`` bzw. der lokalen Auswahl in
+    ``trip_report_scheduler.py``. Geteilt wird ausschliesslich die
+    Positionsberechnung.
+
+    Fail-soft: der Aufrufer bekommt in JEDEM Fall einen ``GPXPoint`` — laeuft
+    ``at`` ueber alle bekannten Segmente hinaus, wird auf den zuletzt
+    erreichten ``end_point`` geklemmt und der Grund geloggt.
+
+    Die Hoehe wird roh interpoliert (keine Rundung) — die Normalisierung auf
+    ganze Meter fuer ``get_nowcast(elevation_m=...)`` wohnt an der Aufrufstelle.
+    """
+    # 1. Ortsfestes Ziel-Segment: dort bewegt sich der Wanderer nicht.
+    if not isinstance(active.segment_id, int) or active.distance_km == 0.0:
+        return active.start_point
+
+    # 2. Vorschau-Zweig: noch nicht losgelaufen → Fortschritt 0.
+    if at <= active.start_time:
+        return active.start_point
+
+    # 3. Innerhalb des aktiven Segments.
+    if at <= active.end_time:
+        return _interpolate_point(active, at)
+
+    # 4. Vorwaertssuche ueber Segment- und Tagesgrenze. Bereits durchlaufene
+    #    Segmente werden ueber ihr Ende erkannt, nicht ueber Objektidentitaet —
+    #    ``active`` stammt aus einer frueheren Konversion und ist mit den hier
+    #    frisch erzeugten Segmenten wertgleich, nicht identisch.
+    last_end_time = active.end_time
+    last_end_point = active.end_point
+    for day_offset in range(_LOOKAHEAD_DAYS + 1):
+        day = segment_date + timedelta(days=day_offset)
+        for seg in convert_trip_to_segments(trip, day):
+            if seg.end_time <= last_end_time:
+                continue  # liegt vollstaendig hinter uns
+            if at < seg.start_time:
+                # 5. Luecke zwischen zwei Segmenten (Tagesende/Unterkunft):
+                #    der Wanderer bleibt am zuletzt erreichten Punkt.
+                logger.debug(
+                    "position_at_time: %s liegt in der Luecke vor Segment %s "
+                    "(%s) — klemme auf letzten Endpunkt",
+                    at.isoformat(), seg.segment_id, day.isoformat(),
+                )
+                return last_end_point
+            if at <= seg.end_time:
+                return _interpolate_point(seg, at)
+            last_end_time = seg.end_time
+            last_end_point = seg.end_point
+
+    # 5. Fail-soft: kein Folgesegment, kein Folgetag (Tour zu Ende, Ruhetag
+    #    ohne Stage, uebersprungene Segmentkette) — klemmen statt werfen.
+    logger.warning(
+        "position_at_time: %s liegt hinter dem letzten bekannten Segment "
+        "(Trip %s, ab %s, %d Tag(e) vorausgeschaut) — klemme auf letzten "
+        "Endpunkt (%.4f, %.4f)",
+        at.isoformat(), getattr(trip, "id", "?"), segment_date.isoformat(),
+        _LOOKAHEAD_DAYS, last_end_point.lat, last_end_point.lon,
+    )
+    return last_end_point

--- a/src/services/trip_segments.py
+++ b/src/services/trip_segments.py
@@ -416,18 +416,35 @@ def resolve_current_segment(
 # Issue #2017: die Vorwaertssuche laedt hoechstens EINEN Folgetag nach. Die im
 # Betrieb verwendeten Zieloffsets sind <= 90 Minuten (NOWCAST_HORIZON_MIN // 2),
 # ein zweiter Tagessprung ist damit strukturell unerreichbar.
+#
+# Die Zahl ist eine OBERGRENZE, kein Richtwert: jeder zusaetzliche Tag kostet
+# eine weitere ``convert_trip_to_segments()``-Konversion pro Aufruf und wuerde
+# die Position eines Wanderers ueber eine ganze Nacht hinweg fortschreiben, statt
+# ihn an der Unterkunft zu belassen. Beide Enden sind bewacht:
+# ``test_ac6_crosses_day_boundary`` faellt bei 0, ``test_forward_search_stops_
+# after_one_lookahead_day`` bei >= 2. Wer die Zahl erhoeht, braucht dafuer einen
+# Aufrufer mit einem Zieloffset > 1 Tag — den gibt es heute nicht.
 _LOOKAHEAD_DAYS = 1
 
 
 def _interpolate_point(seg: TripSegment, at: datetime) -> GPXPoint:
     """Linear zwischen ``seg.start_point`` und ``seg.end_point`` nach dem
-    Zeitanteil von ``at``, Fortschritt auf ``[0,1]`` geklemmt.
+    Zeitanteil von ``at``.
 
     Dieselbe Naeherung wie die Zeit-Interpolation in
     ``_interpolate_missing_times()`` — dort fuer Zeiten, hier fuer Geometrie.
     """
     span_s = (seg.end_time - seg.start_time).total_seconds()
     p = 0.0 if span_s <= 0 else (at - seg.start_time).total_seconds() / span_s
+    # DEFENSIV, heute unerreichbar (Adversary F003): beide Aufrufstellen in
+    # ``position_at_time()`` schliessen ueber die Verzweigung davor bereits
+    # ``p < 0`` bzw. ``p > 1`` aus. Die Klemme bleibt trotzdem stehen, weil
+    # Scheibe B (#2017 Wiring) neue Aufrufer bringt und ein ungeklemmter
+    # Fortschritt dort still EXTRAPOLIEREN wuerde — eine Position weit vor oder
+    # hinter der Etappe, die kein Aufrufer als Fehler erkennen koennte.
+    # Das Grenzverhalten von ``position_at_time()`` selbst bewacht
+    # ``test_ac11_boundary_clamp_regression`` (Vorschau-Zweig unten,
+    # Fail-soft-Klemmung oben) — NICHT diese Zeile.
     p = max(0.0, min(1.0, p))
 
     a, b = seg.start_point, seg.end_point
@@ -490,6 +507,20 @@ def position_at_time(
     for day_offset in range(_LOOKAHEAD_DAYS + 1):
         day = segment_date + timedelta(days=day_offset)
         for seg in convert_trip_to_segments(trip, day):
+            # ``<=`` und nicht ``<``: der Gleichstand ist der Regelfall, denn
+            # beim ersten Durchlauf trifft die Liste ``active`` selbst wieder —
+            # dessen Ende IST ``last_end_time``. Mit ``<`` bliebe genau dieses
+            # Segment stehen; folgenlos waere das, weil ``at > last_end_time``
+            # gilt und es damit weder ``at`` enthalten (``at > seg.end_time``)
+            # noch nach ``at`` beginnen kann — es wuerde nur ``last_end_point``
+            # auf seinen eigenen, unveraenderten Wert setzen. Das ist kein
+            # Zufall, sondern erschoepfend: die Segmente EINES Tages haben
+            # strikt steigende Enden (jedes endet, wo das naechste beginnt;
+            # nicht vorwaerts laufende Paare fallen im Kollaps-Guard oben raus),
+            # und Segmente verschiedener Tage koennen zeitlich nicht
+            # zusammenfallen. Ein zweites Segment mit demselben Ende, aber einem
+            # ANDEREN Endpunkt — der einzige Fall, in dem die Wahl sichtbar
+            # wuerde — kann hier also nicht auftreten (Adversary F001).
             if seg.end_time <= last_end_time:
                 continue  # liegt vollstaendig hinter uns
             if at < seg.start_time:

--- a/tests/tdd/test_position_at_time.py
+++ b/tests/tdd/test_position_at_time.py
@@ -1,7 +1,10 @@
 """TDD RED — Issue #2017 Scheibe A: interpolierte Position statt Segment-Startpunkt.
 
-RED-Treiber (alle acht Tests): ``services.trip_segments.position_at_time``
-existiert noch nicht → ImportError beim Aufloesen des Prueflings.
+RED-Treiber — fuer JEDEN Test dieser Datei derselbe, ohne Ausnahme:
+``services.trip_segments.position_at_time`` existiert noch nicht → Fehler beim
+Aufloesen des Prueflings in ``_resolve_position_at_time()``. Wer hier einen Test
+ergaenzt, erbt das ueber denselben Helfer; eine Zahl steht bewusst nicht hier,
+sie waere beim naechsten Zuwachs still falsch.
 
 Kein Mock: Trip/Stage/Waypoint sind echte Modelle, die Segmente entstehen ueber
 den produktiven ``convert_trip_to_segments()``. Die erwarteten Werte sind von

--- a/tests/tdd/test_position_at_time.py
+++ b/tests/tdd/test_position_at_time.py
@@ -1,0 +1,343 @@
+"""TDD RED — Issue #2017 Scheibe A: interpolierte Position statt Segment-Startpunkt.
+
+RED-Treiber (alle acht Tests): ``services.trip_segments.position_at_time``
+existiert noch nicht → ImportError beim Aufloesen des Prueflings.
+
+Kein Mock: Trip/Stage/Waypoint sind echte Modelle, die Segmente entstehen ueber
+den produktiven ``convert_trip_to_segments()``. Die erwarteten Werte sind von
+Hand ausgerechnet (Kommentar an jeder Stelle), nicht aus dem Pruefling
+abgeleitet.
+
+Zeitbasis: fester Etappentag 2026-08-18, Koordinaten im suedenglischen
+Binnenland (Europe/London, BST = UTC+1) — dadurch sind die UTC-Segmentzeiten
+deterministisch und unabhaengig von Wanduhr und Prozess-TZ. Belegt gemessen:
+    Tag 1  Seg 1  08:00-10:00 UTC   A(51.00,-1.00,1000) -> B(51.10,-0.80,1400)
+    Tag 1  Seg 2  10:00-12:00 UTC   B                   -> C(51.20,-0.60,1800)
+    Tag 1  Ziel   12:00-19:00 UTC   C (ortsfest)
+    Tag 2  Seg 1  08:00-10:00 UTC   D(51.40,-0.40, 500) -> E(51.60, 0.00, 900)
+
+SPEC: docs/specs/modules/fix_2017_nowcast_messpunkt.md
+"""
+from __future__ import annotations
+
+import logging
+from datetime import date, timedelta
+from pathlib import Path
+
+import pytest
+
+from app.trip import Stage, Trip, Waypoint
+
+# Der Pruefling MUSS aus demselben Repo-Baum kommen wie diese Testdatei —
+# sonst liefert ein bereits implementierter Hauptrepo-Stand falsches Gruen.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+DAY1 = date(2026, 8, 18)
+DAY2 = DAY1 + timedelta(days=1)
+
+
+def _resolve_position_at_time():
+    """RED: ``position_at_time`` existiert noch nicht → ImportError."""
+    import services.trip_segments as mod
+
+    assert Path(mod.__file__).resolve().is_relative_to(_REPO_ROOT), (
+        f"Pruefling stammt aus fremdem Baum: {mod.__file__} (erwartet unter {_REPO_ROOT})"
+    )
+    return mod.position_at_time
+
+
+def _wp(uid: str, lat: float, lon: float, elev: int, hhmm: str) -> Waypoint:
+    return Waypoint(id=uid, name=uid, lat=lat, lon=lon, elevation_m=elev,
+                    arrival_calculated=hhmm)
+
+
+def _stage_day1() -> Stage:
+    return Stage(id="S1", name="Tag 1", date=DAY1, waypoints=[
+        _wp("A", 51.00, -1.00, 1000, "09:00"),
+        _wp("B", 51.10, -0.80, 1400, "11:00"),
+        _wp("C", 51.20, -0.60, 1800, "13:00"),
+    ])
+
+
+def _stage_day2() -> Stage:
+    return Stage(id="S2", name="Tag 2", date=DAY2, waypoints=[
+        _wp("D", 51.40, -0.40, 500, "09:00"),
+        _wp("E", 51.60, 0.00, 900, "11:00"),
+    ])
+
+
+def _trip(*stages: Stage) -> Trip:
+    return Trip(id="tdd-2017-trip", name="2017 Trip", stages=list(stages))
+
+
+def _segments(trip: Trip, day: date) -> list:
+    from services.trip_segments import convert_trip_to_segments
+    return convert_trip_to_segments(trip, day)
+
+
+# --------------------------------------------------------------------------
+# AC-1: Interpolation innerhalb des aktiven Segments
+# --------------------------------------------------------------------------
+
+def test_ac1_interpolates_within_active_segment():
+    """AC-1: `at` in der Mitte-Viertel des Segments → linear interpolierter Punkt.
+
+    Seg 1 laeuft 08:00-10:00 UTC (120 Min). `at` = 08:30 → p = 30/120 = 0.25.
+    Erwartet: lat = 51.00 + 0.25 * 0.10 = 51.025
+              lon = -1.00 + 0.25 * 0.20 = -0.95
+    Der bisherige Ist-Zustand (Segment-Startpunkt) waere 51.00 / -1.00.
+    """
+    position_at_time = _resolve_position_at_time()
+
+    trip = _trip(_stage_day1())
+    segs = _segments(trip, DAY1)
+    active = segs[0]
+
+    result = position_at_time(trip, active, DAY1, active.start_time + timedelta(minutes=30))
+
+    assert result.lat == pytest.approx(51.025, abs=1e-9), (
+        f"AC-1: lat={result.lat!r}; erwartet 51.025 (p=0.25 zwischen A und B). "
+        f"51.00 = ununterbrochener Startpunkt (Ist-Zustand vor #2017)."
+    )
+    assert result.lon == pytest.approx(-0.95, abs=1e-9), (
+        f"AC-1: lon={result.lon!r}; erwartet -0.95 (p=0.25 zwischen A und B)."
+    )
+
+
+# --------------------------------------------------------------------------
+# AC-2: Hoehe wandert mit
+# --------------------------------------------------------------------------
+
+def test_ac2_elevation_interpolates_too():
+    """AC-2: `elevation_m` wird mitinterpoliert, nicht vom Startpunkt uebernommen.
+
+    Seg 1: 1000 m -> 1400 m, `at` = 09:00 UTC → p = 0.5.
+    Erwartet: 1000 + 0.5 * 400 = 1200.0
+    """
+    position_at_time = _resolve_position_at_time()
+
+    trip = _trip(_stage_day1())
+    segs = _segments(trip, DAY1)
+    active = segs[0]
+
+    result = position_at_time(trip, active, DAY1, active.start_time + timedelta(minutes=60))
+
+    assert result.elevation_m == pytest.approx(1200.0, abs=1e-9), (
+        f"AC-2: elevation_m={result.elevation_m!r}; erwartet 1200.0 "
+        f"(Mitte zwischen 1000 und 1400). 1000.0 = Hoehe des Startpunkts."
+    )
+
+
+# --------------------------------------------------------------------------
+# AC-3: ortsfestes Ziel-Segment bleibt stehen
+# --------------------------------------------------------------------------
+
+def test_ac3_destination_segment_stays_stationary():
+    """AC-3: Ziel-Segment (`segment_id == "Ziel"`, `distance_km == 0.0`) liefert
+    unveraendert `start_point` — Identitaet, nicht nur numerische Naehe."""
+    position_at_time = _resolve_position_at_time()
+
+    trip = _trip(_stage_day1())
+    segs = _segments(trip, DAY1)
+    dest = segs[-1]
+    assert dest.segment_id == "Ziel" and dest.distance_km == 0.0, (
+        "Fixture-Fehler: letztes Segment ist nicht das Ziel-Segment"
+    )
+
+    result = position_at_time(trip, dest, DAY1, dest.start_time + timedelta(minutes=60))
+
+    assert result is dest.start_point, (
+        f"AC-3: Ziel-Segment muss `active.start_point` selbst zurueckgeben, "
+        f"nicht {result!r} — dort bewegt sich der Wanderer nicht."
+    )
+
+
+# --------------------------------------------------------------------------
+# AC-4: Vorschau-Zweig → Fortschritt 0
+# --------------------------------------------------------------------------
+
+def test_ac4_preview_branch_returns_progress_zero():
+    """AC-4: `at` vor `active.start_time` (Wanderer noch nicht losgelaufen)
+    → Fortschritt 0, Rueckgabe ist `start_point` (Identitaet), kein negativer
+    Zeitanteil, keine Extrapolation rueckwaerts."""
+    position_at_time = _resolve_position_at_time()
+
+    trip = _trip(_stage_day1())
+    segs = _segments(trip, DAY1)
+    active = segs[0]
+
+    result = position_at_time(trip, active, DAY1, active.start_time - timedelta(minutes=45))
+
+    assert result is active.start_point, (
+        f"AC-4: Vorschau-Zweig muss `active.start_point` selbst zurueckgeben, "
+        f"nicht {result!r} (lat={getattr(result, 'lat', None)!r})."
+    )
+
+
+# --------------------------------------------------------------------------
+# AC-5: Vorwaertssuche ueber die Segmentgrenze
+# --------------------------------------------------------------------------
+
+def test_ac5_crosses_segment_boundary():
+    """AC-5: `at` liegt hinter dem aktiven Segment, aber im Folgesegment des
+    Tages → dort interpolieren statt am Segmentende klemmen.
+
+    active = Seg 1 (08:00-10:00 UTC). `at` = 11:00 UTC liegt in Seg 2
+    (10:00-12:00 UTC) bei p = 0.5.
+    Erwartet: lat = (51.10 + 51.20) / 2 = 51.15
+              lon = (-0.80 + -0.60) / 2 = -0.70
+              elev = (1400 + 1800) / 2 = 1600.0
+    Dieser Punkt ist NUR aus Seg 2 erreichbar: ein Klemmen am Ende von Seg 1
+    ergaebe 51.10 / -0.80 (rund 7 km entfernt).
+    """
+    position_at_time = _resolve_position_at_time()
+
+    trip = _trip(_stage_day1())
+    segs = _segments(trip, DAY1)
+    active = segs[0]
+
+    result = position_at_time(trip, active, DAY1, active.end_time + timedelta(minutes=60))
+
+    assert result.lat == pytest.approx(51.15, abs=1e-9), (
+        f"AC-5: lat={result.lat!r}; erwartet 51.15 (Mitte von Seg 2). "
+        f"51.10 = am Ende von Seg 1 geklemmt, Vorwaertssuche fehlt."
+    )
+    assert result.lon == pytest.approx(-0.70, abs=1e-9), (
+        f"AC-5: lon={result.lon!r}; erwartet -0.70 (Mitte von Seg 2)."
+    )
+    assert result.elevation_m == pytest.approx(1600.0, abs=1e-9), (
+        f"AC-5: elevation_m={result.elevation_m!r}; erwartet 1600.0 (Mitte von Seg 2)."
+    )
+
+
+# --------------------------------------------------------------------------
+# AC-6: Vorwaertssuche ueber die Tagesgrenze
+# --------------------------------------------------------------------------
+
+def test_ac6_crosses_day_boundary():
+    """AC-6: `at` liegt hinter dem letzten Segment des Tages → Folgetag wird
+    nachgeladen und dort interpoliert.
+
+    active = Seg 2 von Tag 1, `segment_date` = 2026-08-18. `at` = 09:00 UTC am
+    2026-08-19 liegt in Tag-2-Seg-1 (08:00-10:00 UTC) bei p = 0.5.
+    Erwartet: lat = (51.40 + 51.60) / 2 = 51.50
+              lon = (-0.40 + 0.00) / 2 = -0.20
+              elev = (500 + 900) / 2 = 700.0
+    Jede Klemmung innerhalb von Tag 1 ergaebe 51.20 / -0.60 (Zielpunkt C).
+    """
+    position_at_time = _resolve_position_at_time()
+
+    trip = _trip(_stage_day1(), _stage_day2())
+    segs_day1 = _segments(trip, DAY1)
+    active = segs_day1[1]
+    at = _segments(trip, DAY2)[0].start_time + timedelta(minutes=60)
+
+    result = position_at_time(trip, active, DAY1, at)
+
+    assert result.lat == pytest.approx(51.50, abs=1e-9), (
+        f"AC-6: lat={result.lat!r}; erwartet 51.50 (Mitte des ersten Segments "
+        f"von Tag 2). 51.20 = auf Tag 1 geklemmt, Folgetag nicht nachgeladen."
+    )
+    assert result.lon == pytest.approx(-0.20, abs=1e-9), (
+        f"AC-6: lon={result.lon!r}; erwartet -0.20 (Mitte von Tag-2-Seg-1)."
+    )
+    assert result.elevation_m == pytest.approx(700.0, abs=1e-9), (
+        f"AC-6: elevation_m={result.elevation_m!r}; erwartet 700.0 (Mitte von Tag-2-Seg-1)."
+    )
+
+
+# --------------------------------------------------------------------------
+# AC-7: Fail-soft — klemmen statt werfen
+# --------------------------------------------------------------------------
+
+def test_ac7_fail_soft_clamps_without_exception(caplog):
+    """AC-7: kein Folgetag vorhanden → auf den letzten bekannten `end_point`
+    klemmen, Log-Eintrag schreiben, KEINE Exception nach aussen.
+
+    Trip hat nur Tag 1. `at` = 20:00 UTC liegt eine Stunde hinter dem Ende des
+    Ziel-Segments (19:00 UTC), Tag 2 existiert nicht.
+    Erwartet: letzter bekannter Endpunkt des Tages = C (51.20, -0.60, 1800).
+    Ein Klemmen auf `active.end_point` (Seg 1 → B, 51.10/-0.80) waere zu frueh:
+    die Vorwaertssuche muss den Tag zuerst ausschoepfen.
+
+    Positivkontrolle fuer den Log-Assert: `convert_trip_to_segments()` schreibt
+    fuer genau diesen Trip keine Eintraege (Tag 1 vollstaendig, Tag 2 ohne
+    Stage → stille leere Liste), jeder erfasste Record stammt also aus
+    `position_at_time()`.
+    """
+    position_at_time = _resolve_position_at_time()
+
+    trip = _trip(_stage_day1())
+    segs = _segments(trip, DAY1)
+    active = segs[0]
+    at = segs[-1].end_time + timedelta(minutes=60)
+
+    with caplog.at_level(logging.DEBUG, logger="trip_segments"):
+        caplog.clear()
+        result = position_at_time(trip, active, DAY1, at)  # darf nicht werfen
+
+    assert result.lat == pytest.approx(51.20, abs=1e-9), (
+        f"AC-7: lat={result.lat!r}; erwartet 51.20 (letzter bekannter Endpunkt C). "
+        f"51.10 = zu frueh auf das aktive Segment geklemmt."
+    )
+    assert result.lon == pytest.approx(-0.60, abs=1e-9), (
+        f"AC-7: lon={result.lon!r}; erwartet -0.60 (letzter bekannter Endpunkt C)."
+    )
+    assert result.elevation_m == pytest.approx(1800.0, abs=1e-9), (
+        f"AC-7: elevation_m={result.elevation_m!r}; erwartet 1800.0 (Endpunkt C)."
+    )
+    assert [r for r in caplog.records if r.name == "trip_segments"], (
+        "AC-7: Die Klemmung muss einen Log-Eintrag mit erkennbarem Grund "
+        "hinterlassen — es wurde keiner geschrieben."
+    )
+
+
+# --------------------------------------------------------------------------
+# AC-11: beide Enden der [0,1]-Klemmung
+# --------------------------------------------------------------------------
+
+def test_ac11_boundary_clamp_regression():
+    """AC-11: Segment kuerzer als der Zieloffset, kein Folgesegment/-tag.
+
+    Trip: ein Segment 18:30-18:50 UTC (20 Min) + Ziel-Segment bis 19:50 UTC
+    (Mindestfenster 1 h ab Ankunft). Der groesste im Betrieb verwendete Offset
+    ist NOWCAST_HORIZON_MIN // 2 = 90 Min — laenger als das Segment.
+
+    (a) untere Grenze: `at` == `start_time` → exakt `start_point` (51.00/-1.00,
+        1000 m), keine Verschiebung durch die Klemmung.
+    (b) obere Grenze: `at` = start + 90 Min = 20:00 UTC, hinter allem →
+        Klemmung auf den letzten Endpunkt Q (51.05/-0.90, 1200 m), kein Crash.
+    """
+    position_at_time = _resolve_position_at_time()
+
+    stage = Stage(id="S1", name="Kurz", date=DAY1, waypoints=[
+        _wp("P", 51.00, -1.00, 1000, "19:30"),
+        _wp("Q", 51.05, -0.90, 1200, "19:50"),
+    ])
+    trip = _trip(stage)
+    segs = _segments(trip, DAY1)
+    active = segs[0]
+
+    # (a) untere Grenze
+    lower = position_at_time(trip, active, DAY1, active.start_time)
+    assert lower.lat == pytest.approx(51.00, abs=1e-9), (
+        f"AC-11(a): lat={lower.lat!r}; bei `at == start_time` erwartet exakt 51.00."
+    )
+    assert lower.lon == pytest.approx(-1.00, abs=1e-9), (
+        f"AC-11(a): lon={lower.lon!r}; bei `at == start_time` erwartet exakt -1.00."
+    )
+    assert lower.elevation_m == pytest.approx(1000.0, abs=1e-9), (
+        f"AC-11(a): elevation_m={lower.elevation_m!r}; erwartet exakt 1000.0."
+    )
+
+    # (b) obere Grenze — Offset laenger als das Segment, nichts folgt
+    upper = position_at_time(trip, active, DAY1, active.start_time + timedelta(minutes=90))
+    assert upper.lat == pytest.approx(51.05, abs=1e-9), (
+        f"AC-11(b): lat={upper.lat!r}; erwartet Klemmung auf 51.05 (Endpunkt Q)."
+    )
+    assert upper.lon == pytest.approx(-0.90, abs=1e-9), (
+        f"AC-11(b): lon={upper.lon!r}; erwartet Klemmung auf -0.90 (Endpunkt Q)."
+    )
+    assert upper.elevation_m == pytest.approx(1200.0, abs=1e-9), (
+        f"AC-11(b): elevation_m={upper.elevation_m!r}; erwartet Klemmung auf 1200.0."
+    )

--- a/tests/tdd/test_position_at_time.py
+++ b/tests/tdd/test_position_at_time.py
@@ -66,6 +66,14 @@ def _stage_day2() -> Stage:
     ])
 
 
+def _stage_day4() -> Stage:
+    """Etappe zwei Tage NACH Tag 1 — hinter der Vorausschau-Grenze."""
+    return Stage(id="S4", name="Tag 4", date=DAY1 + timedelta(days=2), waypoints=[
+        _wp("F", 51.80, 0.40, 300, "09:00"),
+        _wp("G", 51.90, 0.60, 400, "11:00"),
+    ])
+
+
 def _trip(*stages: Stage) -> Trip:
     return Trip(id="tdd-2017-trip", name="2017 Trip", stages=list(stages))
 
@@ -101,6 +109,14 @@ def test_ac1_interpolates_within_active_segment():
     )
     assert result.lon == pytest.approx(-0.95, abs=1e-9), (
         f"AC-1: lon={result.lon!r}; erwartet -0.95 (p=0.25 zwischen A und B)."
+    )
+    # Adversary F005: `distance_from_start_km` wandert mit, statt still auf dem
+    # Default 0.0 stehen zu bleiben. Seg 1 spannt 0.0 -> 17.9 km (Haversine
+    # A->B, gemessen), p = 0.25 → 4.475.
+    assert result.distance_from_start_km == pytest.approx(4.475, abs=1e-9), (
+        f"AC-1: distance_from_start_km={result.distance_from_start_km!r}; "
+        f"erwartet 4.475 (p=0.25 der 17.9-km-Spanne). 0.0 = Default, nicht "
+        f"mitinterpoliert."
     )
 
 
@@ -293,11 +309,87 @@ def test_ac7_fail_soft_clamps_without_exception(caplog):
 
 
 # --------------------------------------------------------------------------
-# AC-11: beide Enden der [0,1]-Klemmung
+# AC-7 (Fortsetzung): Uebernachtungsluecke zwischen zwei Etappentagen
+# --------------------------------------------------------------------------
+
+def test_ac7b_overnight_gap_clamps_to_day_destination():
+    """AC-7-Familie: `at` faellt in die NACHT zwischen zwei Etappentagen.
+
+    Adversary F002: Dieser Zweig war von keinem Test erreicht. Die Mutation
+    `if False and at < seg.start_time:` liess alle acht Tests gruen und lieferte
+    statt des Tagesziels C den Startpunkt D des Folgetags — 26,2 km daneben.
+
+    Aufbau: Tag 1 endet mit dem Ziel-Segment um 19:00 UTC, Tag 2 beginnt erst
+    um 08:00 UTC. `at` = 21:00 UTC liegt dazwischen: der Wanderer ist auf der
+    Unterkunft am Tagesziel und laeuft nicht ueber Nacht weiter.
+    Erwartet: C (51.20, -0.60, 1800) — der zuletzt erreichte Endpunkt.
+    Falsch waere D (51.40, -0.40, 500), der Startpunkt des naechsten Morgens.
+    """
+    position_at_time = _resolve_position_at_time()
+
+    trip = _trip(_stage_day1(), _stage_day2())
+    segs_day1 = _segments(trip, DAY1)
+    active = segs_day1[1]
+    at = segs_day1[-1].end_time + timedelta(hours=2)
+    assert at < _segments(trip, DAY2)[0].start_time, (
+        "Fixture-Fehler: `at` liegt nicht in der Luecke, sondern schon im Folgetag"
+    )
+
+    result = position_at_time(trip, active, DAY1, at)
+
+    assert result.lat == pytest.approx(51.20, abs=1e-9), (
+        f"AC-7b: lat={result.lat!r}; erwartet 51.20 (Tagesziel C). "
+        f"51.40 = in den Folgetag vorgesprungen, Luecken-Zweig fehlt."
+    )
+    assert result.lon == pytest.approx(-0.60, abs=1e-9), (
+        f"AC-7b: lon={result.lon!r}; erwartet -0.60 (Tagesziel C)."
+    )
+    assert result.elevation_m == pytest.approx(1800.0, abs=1e-9), (
+        f"AC-7b: elevation_m={result.elevation_m!r}; erwartet 1800.0 (Tagesziel C). "
+        f"500.0 = Hoehe des Folgetags-Startpunkts."
+    )
+
+
+# --------------------------------------------------------------------------
+# Vorausschau-Grenze: hoechstens EIN Folgetag
+# --------------------------------------------------------------------------
+
+def test_forward_search_stops_after_one_lookahead_day():
+    """Adversary F004: `_LOOKAHEAD_DAYS` ist nach oben unbewacht.
+
+    Trip: Tag 1, dann eine Luecke (kein Ruhetags-Stage), dann eine Etappe zwei
+    Tage spaeter. `at` liegt in deren erstem Segment. Mit der dokumentierten
+    Grenze von einem Folgetag wird sie NICHT mehr erreicht → Klemmung auf das
+    Tagesziel C von Tag 1. Ab `_LOOKAHEAD_DAYS >= 2` kaeme 51.85 heraus.
+    """
+    position_at_time = _resolve_position_at_time()
+
+    trip = _trip(_stage_day1(), _stage_day4())
+    at = _segments(trip, DAY1 + timedelta(days=2))[0].start_time + timedelta(minutes=60)
+
+    result = position_at_time(trip, _segments(trip, DAY1)[1], DAY1, at)
+
+    assert result.lat == pytest.approx(51.20, abs=1e-9), (
+        f"Vorausschau-Grenze: lat={result.lat!r}; erwartet 51.20 (Tagesziel C von "
+        f"Tag 1). 51.85 = zwei Tage vorausgeschaut — die Position eines Wanderers "
+        f"ueber zwei Naechte fortzuschreiben ist keine Aussage, die dieser "
+        f"Baustein treffen kann."
+    )
+
+
+# --------------------------------------------------------------------------
+# AC-11: beide Enden des Grenzverhaltens
 # --------------------------------------------------------------------------
 
 def test_ac11_boundary_clamp_regression():
     """AC-11: Segment kuerzer als der Zieloffset, kein Folgesegment/-tag.
+
+    Geprueft wird das GRENZVERHALTEN VON ``position_at_time()`` an beiden
+    Enden — nicht der Klemm-Ausdruck in ``_interpolate_point()``, der von hier
+    aus gar nicht erreicht wird (Adversary F003, Docstring hier und AC-11 der
+    Spec entsprechend praezisiert). Unten greift der Vorschau-Zweig, oben die
+    Fail-soft-Klemmung; beides sind eigenstaendige Zusicherungen und keine
+    schwaechere Fassung der urspruenglichen.
 
     Trip: ein Segment 18:30-18:50 UTC (20 Min) + Ziel-Segment bis 19:50 UTC
     (Mindestfenster 1 h ab Ankunft). Der groesste im Betrieb verwendete Offset


### PR DESCRIPTION
Scheibe A von #2017: der geteilte Baustein, noch ohne Verdrahtung.

## Was das Ticket löst

Der Radar-/Nowcast-Alarm fragt das Wetter am **Startpunkt des aktiven Segments** ab — dem Wegpunkt, den der Wanderer bereits verlassen hat. Gemessen (Trip `5f534011`, n=43.140): Median **1,99 km** Versatz, **49,7 %** der Fälle über 2 km.

Diese Scheibe führt `position_at_time()` in `src/services/trip_segments.py` ein: die zur Mitte des Vorwarnfensters interpolierte Position (lat, lon **und Höhe**), onset-frei und ohne zusätzliches API-Budget. Erwartete Wirkung nach dem Verdrahten: Median **0,37 km**, **0,0 %** über 2 km.

**Diese Scheibe ändert noch kein Verhalten** — der Baustein wird von niemandem aufgerufen. Das Verdrahten an den beiden Fundstellen (`trip_alert.py`, `trip_report_scheduler.py`) ist Scheibe B und blockiert bis #2009 auf `main` ist.

## Umfang

- `src/services/trip_segments.py` — **+136 LoC, rein additiv**, kein Eingriff in Bestehendes
- `tests/tdd/test_position_at_time.py` — neu, 10 Tests, keine Mocks, keine Skips
- Spec + Kontextdokument

## Nachweise

- **AC-1 bis AC-7 und AC-11 erfüllt** (AC-8/9/10/12 gehören zu Scheibe B). Unabhängig gegengeprüft: Die Tests messen die geforderte Zusicherung, nicht nur etwas Ähnliches — AC-3/AC-4 auf Objektidentität, die übrigen gegen analytisch vorgerechnete Werte.
- **Adversary: BROKEN → VERIFIED** über zwei Runden. Runde 1 fand fünf Lücken, darunter einen Zweig, dessen Deaktivierung die Position um **26,2 km** verschob, ohne dass ein Test anschlug. Runde 2 prüfte die Fixes mit eigenen, teils schärferen Mutationen nach.
- **Kernsuite** 10 grün · **Nachbarschaft** (14 benannte Dateien) 167 grün · **Volle CI-Suite** `2 failed, 10129 passed` — beide Rotstellen vorbestehend und umgebungsbedingt (`test_issue_1014_live_optin.py`: Chat-ID aus der lokalen `.env`; `test_issue_937_staging_rolling_trip.py`: RED-Test für #937, dessen `skipif` auf diesem Host nicht griff). Keine der geänderten Dateien taucht in den Tracebacks auf.
- `ruff` sauber.

## Eine Erkenntnis, die über das Ticket hinausgeht

Der 26-km-Fehler sah wie ein plausibler Wegpunkt aus, **weil** eine defensive Klemmung ihn dazu machte. Ohne diese Absicherung wäre eine Position mit negativer Höhe und negativer Kilometrierung herausgekommen — offensichtlicher Unsinn. Die Klemmung bleibt deshalb im Code, aber die Stelle brauchte zwingend einen Test: Eine Absicherung, die Fehler in glaubwürdige Werte übersetzt, entzieht ihnen genau das Merkmal, an dem man sie sonst bemerkt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
