### PR TITLE
fix(#1992): Erreichbarkeits-Journal für GeoSphere-Datenpfade

### DIFF
--- a/docs/context/feat-1992-geosphere-health-journal.md
+++ b/docs/context/feat-1992-geosphere-health-journal.md
@@ -1,0 +1,105 @@
+# Context: feat-1992-geosphere-health-journal
+
+## Request Summary
+
+Issue #1992 (ursprünglich ein TLS-Befund, gemessen widerlegt — der Audit testete den
+falschen Host, der Code nutzt `dataset.api.hub.geosphere.at`, das mit gültigem
+Zertifikat 200 liefert) ist umgeschnitten auf den echten Rest-Befund: Fällt GeoSphere
+wirklich aus, laufen mehrere Pfade fail-soft still leer, ohne dass das nach außen sichtbar
+wird. Aufgabe: die noch unbeobachteten GeoSphere-Fehlerfälle beobachtbar machen.
+
+**Wichtigster Fund dieser Phase: Issue #1581 ist BEREITS GELIEFERT** (Spec
+`docs/specs/modules/fix_1581_enrichment_health.md`, Status `approved`, PO-Freigabe
+2026-08-19) und hat exakt dieses Muster für zwei der drei betroffenen Pfade schon gebaut
+— `MEMORY.md` ("🔴 #1581 LÄUFT") ist an dieser Stelle veraltet. #1992 baut also **kein
+neues Journal**, sondern schließt eine **Lücke innerhalb** des bestehenden.
+
+## Related Files
+
+| File | Relevance |
+|------|-----------|
+| `src/providers/geosphere.py:374-375` | `fetch_snowgrid` — `except httpx.HTTPStatusError: return None, None`, stumm, kein Log |
+| `src/providers/geosphere.py:391-426` | `fetch_thunder_signals_named` — `except (HTTPStatusError, TimeoutException, RequestError): return {"cape": {}, "cin": {}}`, stumm |
+| `src/providers/geosphere.py:486-489` | `fetch_nowcast` — `except httpx.HTTPStatusError: return None`, stumm |
+| `src/providers/thunder_enrichment.py:376-418` | `_hole_eintraege` ruft `provider.fetch_thunder_signals_named(...)` auf — bekommt bei echtem Ausfall `{"cape": {}, "cin": {}}` statt einer Exception |
+| `src/providers/thunder_enrichment.py:509-519` | Klassifiziert eine leere Antwort als **Erfolg** (`log_enrichment_call(PATH_THUNDER, OUTCOME_OK)`) — Kommentar: „kein Gewitter in Sicht". Ein echter GeoSphere-Ausfall sieht in dieser Kette **identisch** aus wie ruhiges Wetter |
+| `src/services/radar_service.py:337, 371-401` | `_fetch_geosphere_inca` — `except Exception: logger.warning(...); return []`. Nur echte, *nicht* von `fetch_nowcast` intern geschluckte Exceptions erreichen dieses Log; danach fällt die Aufrufkette (`_fetch_frames_with_fallback:326-355`) leise zum nächsten Radar-Quellenkandidaten durch |
+| `src/services/radar_service.py:225-240` | Journal-Schreibweg für `radar_nowcast` — klassifiziert `throttled`/`data_unavailable`/sonst `OK`; ob ein via `fetch_nowcast`-internem `except HTTPStatusError` verschluckter GeoSphere-Fehler hier korrekt als `data_unavailable` statt `OK` landet, ist ungeklärt (Folgefrage für Analyse) |
+| `src/providers/openmeteo.py:466-486` | `_enrich_snow` — SNOWGRID-Anreicherung, **zweite, eigene** Silent-Swallow-Schicht: `except Exception: pass`, **kein** `log_enrichment_call`, kein `PATH_SNOWGRID` existiert überhaupt |
+| `src/providers/openmeteo.py:1091-1096` | `at_direct`-Cross-Provider-Fallback (ADR-0047) — `except (ProviderNotImplementedError, ProviderRequestError, ProviderNotFoundError): pass`, dann `raise last_error` — Fallback-Fehlschlag komplett stumm |
+| `src/providers/enrichment_health.py` | Bestehendes Journal aus #1581: `PATH_THUNDER`, `PATH_RADAR_NOWCAST`, Outcomes `ok/fallback/unavailable/self_throttled`, `log_enrichment_call()` schreibt JSONL nach `<DataRoot>/diagnostics/enrichment_calls.jsonl` |
+| `src/providers/call_log.py:44` | Anderer, älterer Journal-Mechanismus (`briefing_health`/`openmeteo_calls.jsonl`) — kennt nur `("_fetch_openmeteo_clouds", "geosphere_clouds")`, protokolliert dort aber den Open-Meteo-Host, nicht GeoSphere |
+| `internal/scheduler/enrichment_health.go` | Go-Aggregator für `enrichment_calls.jsonl`, gruppiert nach `path` (geschlossenes Vokabular `PATH_THUNDER`/`PATH_RADAR_NOWCAST`), liefert `last_attempt_at`/`last_success_at`/`last_fallback_at`/`self_throttled` je Pfad, `journal_read_error`-Flag bei kaputter Datei |
+| `internal/scheduler/scheduler.go:830-833` | Einhängepunkt: `"enrichment_health": s.EnrichmentHealth()` als Top-Level-Schlüssel neben `briefing_health`/`warn_service_health`/`forecast_budget` in `/api/scheduler/status` |
+| `internal/scheduler/warn_service_health.go` | Schwesterpfad (ZAMG-Warnungen), analoges Muster, eigenes Journal (`warn_service_calls.jsonl`) — bewusst **kein** gemeinsames Journal mit `enrichment_health` |
+| `docs/adr/0018-provider-fallback-ohne-kaschieren.md` | Verlangt für jeden degradierbaren Pfad ein „wachsendes Health-Signal" — Referenz-ADR für #1581 UND für diesen Rest-Befund |
+| `docs/adr/0047-gewitter-vertretung-zwischen-direktquellen.md` | `at_direct`/Vertretungslogik — GeoSphere bekommt laut Spec-Scope-Abgrenzung **bewusst keinen** Vertretungs-Eintrag |
+| `docs/specs/modules/fix_1581_enrichment_health.md` | Vollständige Spec des bereits gelieferten Journals — Vorlage für Format/Struktur eines Amendments |
+
+## Existing Patterns
+
+- **Ein** gemeinsamer Schreibweg pro Journal-Familie: `log_warn_service_call` (ZAMG-Warnungen) bzw. `log_enrichment_call` (#1581, Gewitter-Direktquellen + Radar-Nowcast) — bewusst getrennte Journale, kein gemeinsames Format, aber gleiches Grundschema (`ts`, Pfad-Schlüssel, Outcome-Vokabular, `detail`/optional).
+- Go-Seite: reines Lesen/Aggregieren, **keine** Schwellenentscheidung im Code — „wächst mit der Ausfalldauer" ist Aufgabe des externen `check-gregor20.sh`, nicht des Aggregators.
+- Journalpfad wird bei **jedem** Aufruf frisch über `app.loader.get_data_root()` aufgelöst (Falle #1633: eine beim Import gebundene Konstante zeigt an Test-Isolationsfixtures vorbei).
+- Fehlklassifikation als Kernrisiko bereits im bestehenden Code erkannt und explizit kommentiert (`_fetch_primaerquelle:509-513`): „Als Ausfall gebucht meldete jede ruhige Wetterlage einen Dauerausfall" — das Spiegelbild dieses Risikos ist die hier gefundene Lücke: „Als Erfolg gebucht meldete jeder echte Ausfall ruhiges Wetter."
+
+## Dependencies
+
+- **Upstream:** `httpx`-Exceptions aus `GeoSphereProvider._request`/Direktaufrufen (`HTTPStatusError`, `TimeoutException`, `RequestError`, `ConnectError`) — heute an drei Stellen in `geosphere.py` gefangen, bevor sie den Aufrufer erreichen.
+- **Downstream:** `internal/scheduler/enrichment_health.go` (liest `path`-Werte aus einem geschlossenen Vokabular — jede neue Konstante braucht Go-Gegenstück), `/api/scheduler/status` (öffentlicher, auth-freier Endpoint — neues Feld ist ein additiver API-Vertrag), `check-gregor20.sh` (externes Monitoring, henemm-infra) — würde einen dritten Pfad `snowgrid` (falls hinzugefügt) automatisch mitlesen, sobald der Schlüssel im JSON auftaucht.
+
+## Existing Specs
+
+- `docs/specs/modules/fix_1581_enrichment_health.md` — direktes Vorbild, deckt `thunder`+`radar_nowcast` bereits ab. Diese Arbeit ist ein **Amendment/Nachfolge-Scheibe**, keine Neuanlage.
+
+## Risks & Considerations
+
+- **Scope-Frage für Analyse:** Zwei mögliche Schnitte — (a) nur die drei stummen `except`-Blöcke in `geosphere.py` so umbauen, dass ein echter Fehler eine Exception statt `None`/`{}` liefert (dann klassifizieren die *bestehenden* Aufrufer in `thunder_enrichment.py`/`radar_service.py` automatisch richtig — ggf. minimal-invasiv), vs. (b) zusätzlich `PATH_SNOWGRID` als dritten Journal-Pfad einführen (SNOWGRID hat aktuell **gar keine** Journalanbindung, doppelt stumm über zwei Dateien hinweg).
+- **`radar_nowcast` braucht Verifikation:** unklar, ob ein von `fetch_nowcast` (intern) verschluckter `HTTPStatusError` in der Aufrufkette am Ende korrekt `data_unavailable=True` setzt oder als stiller Fallback zur nächsten Radar-Quelle (`ARPAE`/`AROME`/`ICON-D2`/`minutely_15`) landet und dabei als `OK` erscheint.
+- **`at_direct` (ADR-0047) bewusst außerhalb des `enrichment_health`-Vokabulars** — die Spec zu #1581 grenzt das ausdrücklich aus („GeoSphere bekommt bewusst KEINEN Vertretungs-Eintrag"). Ob dieser Fallback-Fehlschlag (`openmeteo.py:1091-1093`) in den Scope von #1992 gehört oder ein eigenes, drittes Thema ist, ist eine offene Frage für die Analyse-Phase.
+- **`radar_service.py:458`** (`_fetch_openmeteo_15`) ist entgegen einem Hinweis der Parallelsession zu #1991 **kein** GeoSphere-Aufruf, sondern ein reiner Open-Meteo-Fallback (`api.open-meteo.com`) — Korrektur für die Analyse, damit dieser Pfad nicht fälschlich in den GeoSphere-Scope gezogen wird. Bleibt als benachbarte, aber separate Beobachtbarkeitslücke (nicht Teil dieses Tickets).
+- **LoC-Budget:** #1581 hatte ein angehobenes Limit (900 statt 250) für einen deutlich größeren Neubau (11 Dateien, 13 ACs). Dieses Amendment sollte kleiner sein — Umfang in der Analyse-Phase abschätzen, ggf. reicht das Standard-Limit von 250.
+- **Abgrenzung zu #1991** (Parallelsession, `_fetch_openmeteo_clouds`/`ForecastMeta.model_elevation_m`): bewusst getrennt geklärt — deren Feld beschreibt Parameter-Wirksamkeit, nicht Pfad-Ausfall, kein Konflikt mit `enrichment_health`.
+
+## Analysis
+
+### Type
+Feature (Amendment zu einem bestehenden Journal, kein Bugfix im engeren Sinn — kein Nutzer-Symptom, sondern eine Beobachtbarkeitslücke).
+
+### Kernergebnis der strategischen Bewertung
+
+Der ursprünglich erwogene minimal-invasive Schnitt ("nur die drei `except`-Blöcke in `geosphere.py` auf Exception umstellen") **erreicht das Ticket-Ziel für zwei der drei Pfade NICHT** und öffnet zusätzlich ein Regressionsrisiko:
+
+1. **SNOWGRID hat keinen Journal-Pfad.** Weder Exception-Werfen noch -Schlucken macht das sichtbar — es fehlt schlicht `PATH_SNOWGRID` in `enrichment_health.py`.
+2. **🔴 Regressionsrisiko:** `fetch_snowgrid` wird in `fetch_combined:597` **ungeschützt** aufgerufen (kein try/except). Würde `fetch_snowgrid` bei echtem HTTP-Fehler künftig eine Exception werfen statt `(None, None)`, propagiert sie durch `fetch_combined` bis in `fetch_forecast`s äußeres `except httpx.HTTPStatusError:268` — dort wird sie zu `ProviderRequestError`, und die **komplette Grundvorhersage** schlägt fehl, obwohl nur die optionale Schneeanreicherung betroffen war. Aus "Schneetiefe fehlt" würde "GeoSphere insgesamt nicht erreichbar". **`fetch_combined` braucht ein eigenes try/except um den `fetch_snowgrid`-Aufruf**, das den Fehler journalt und ohne Schnee weiterläuft.
+3. **Thunder-Pfad läuft für GeoSphere NIE über die "Primärquelle"-Klassifikation** (`_fetch_primaerquelle`/`thunder_enrichment.py:509-519`, der im Kontextdokument zitierte Kernfund). GeoSphere ist laut `thunder_routing.py:75` ausschließlich additive Zusatzquelle (`DE_ALPEN → ("geosphere",)`), läuft durch den additiven Zweig `thunder_enrichment.py:589-605`, der **überhaupt kein** `log_enrichment_call` schreibt — weder bei Erfolg noch bei Fehler (nur `logger.warning`). Eine Exception in `fetch_thunder_signals_named` allein ändert daran nichts (`except Exception: continue` bei 594 schluckt weiterhin ohne Journaleintrag). **Braucht eine `log_enrichment_call`-Anbindung direkt im additiven Zweig.**
+4. **`radar_nowcast` verifiziert falsch:** `_derive_result` (`radar_service.py:543-604`) berechnet `data_unavailable` ausschließlich aus `_openmeteo_unavailable_this_call` — einem Flag, das nur der *letzte* Fallback (Open-Meteo 15-Min) setzt. Ein INCA/GeoSphere-Fehlschlag, dem die Fallback-Kette danach eine funktionierende Ersatzquelle findet (wahrscheinlich, ICON-D2 deckt die INCA-Bbox meist mit ab), bleibt `data_unavailable=False` → Journal schreibt `OUTCOME_OK`. **Braucht ein eigenes Flag** (analog `_openmeteo_unavailable_this_call`) für INCA-spezifische Fehlschläge.
+5. **`at_direct`-Fallback (ADR-0047) bleibt außerhalb des Scopes**: Ein Fehlschlag dort eskaliert bereits sichtbar (`raise last_error` nach dem stummen `except`) — kein stiller Ausfall im Sinne des Tickets, nur fehlende Journal-Granularität. Zusätzlich hatte #1581 GeoSphere hier bewusst ausgeschlossen ("kein Vertretungs-Eintrag") — das wäre ein Rückgriff auf eine bereits getroffene Scope-Entscheidung, kein Bestandteil dieses Amendments.
+
+### Affected Files (with changes)
+
+| File | Change Type | Description |
+|------|-------------|--------------|
+| `src/providers/geosphere.py` | MODIFY | 3 stumme `except`-Blöcke (`fetch_snowgrid:374-375`, `fetch_thunder_signals_named:424-425`, `fetch_nowcast:488-489`) journalen statt schlucken |
+| `src/providers/geosphere.py::fetch_combined` | MODIFY | eigenes try/except um `fetch_snowgrid`-Aufruf (~597) — verhindert Eskalation zum Totalausfall der Grundvorhersage |
+| `src/providers/enrichment_health.py` | MODIFY | neue Konstante `PATH_SNOWGRID` |
+| `src/providers/openmeteo.py::_enrich_snow` | MODIFY | `except Exception: pass` (486-487) um `log_enrichment_call(PATH_SNOWGRID, ...)` ergänzen |
+| `src/providers/thunder_enrichment.py` | MODIFY | additiver Zweig (589-605) um `log_enrichment_call`-Anbindung ergänzen (Scope-Frage für Spec: unter `PATH_THUNDER` mit `detail=quelle`, oder neuer Pfad für additive Quellen) |
+| `src/services/radar_service.py` | MODIFY | `_fetch_geosphere_inca` (371-401) + `_derive_result` (543-604): eigenes Unavailable-Flag für INCA-spezifischen Fehlschlag |
+| `internal/scheduler/enrichment_health.go` | MODIFY | Go-Gegenstück für `PATH_SNOWGRID` (geschlossenes Vokabular) |
+| Tests (mehrere) | MODIFY/CREATE | `tests/tdd/test_snowgrid.py`, `test_geosphere_thunder_signals_fetch.py`, `test_issue_1161_inca_convective.py`, ggf. neue `test_*_enrichment_health_snowgrid.py` |
+
+### Scope Assessment
+- Files: ~8 (Python 6, Go 1, Tests mehrere)
+- Estimated LoC: +300/-20 (grobe Schätzung, inkl. Tests) — **Standard-Limit 250 reicht vermutlich knapp nicht**, ähnlich wie bei #1581 (dort auf 900 angehoben). In der Spec-Phase eher genau schätzen, `loc_limit_override` ggf. moderat anheben (z.B. 400-450), nicht pauschal auf 900.
+- Risk Level: **MEDIUM** (kein Absturzrisiko bei den geprüften Aufrufern außer dem beschriebenen `fetch_combined`-Fall, der aber explizit mitadressiert wird; Blast Radius touched den GeoSphere-Kernpfad `fetch_forecast`, deshalb Sorgfalt bei der `fetch_combined`-Änderung)
+
+### Geprüfte Aufrufer (kein blindes `None`/`{}`-Weiterrechnen gefunden außer `fetch_combined`)
+- `fetch_snowgrid`: `openmeteo.py:477` (bereits `except Exception` abgesichert), `geosphere.py::fetch_combined:597` (**ungeschützt — s.o.**), `src/validation/geosphere_validator.py:168` (Diagnosetool, unkritisch)
+- `fetch_nowcast`: einziger Aufrufer `radar_service.py:380`, bereits in `except Exception` — kein Absturzrisiko, aber Journal-Wirkung braucht Zusatzänderung (s. Punkt 4)
+- `fetch_thunder_signals_named`: einziger Aufrufer `thunder_enrichment.py:401` via `_hole_eintraege`, in zwei Kontexten (Primärquelle — für GeoSphere praktisch nie erreicht; additiv — kein Absturzrisiko, aber kein Journal-Log)
+
+### Open Questions (für Spec-Phase)
+- [ ] Additiver Thunder-Zweig: Journal unter bestehendem `PATH_THUNDER` mit `detail=quelle`, oder neuer eigener Pfad für additive Zusatzquellen?
+- [ ] LoC-Limit: genaue Schätzung nach TDD-RED, `loc_limit_override` voraussichtlich nötig
+

--- a/docs/specs/modules/feat_1992_geosphere_health_amendment.md
+++ b/docs/specs/modules/feat_1992_geosphere_health_amendment.md
@@ -1,0 +1,385 @@
+---
+entity_id: feat_1992_geosphere_health_amendment
+type: module
+created: 2026-08-20
+updated: 2026-08-20
+status: draft
+version: "1.0"
+tags: [observability, providers, health, geosphere]
+---
+
+# GeoSphere Health Journal Amendment (SNOWGRID, Gewitter-Zusatzquelle, Radar-Nowcast/INCA)
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Drei GeoSphere-Datenpfade fallen bei echtem Ausfall fail-soft still aus, ohne dass das
+im bestehenden `enrichment_health`-Journal (#1581, `docs/specs/modules/fix_1581_enrichment_health.md`,
+bereits geliefert und in `main`) sichtbar wird: SNOWGRID (Schneetiefe), die additive
+Gewitter-Zusatzquelle (cape/cin über `geosphere` in `DE_ALPEN`, #1758) und der
+INCA-spezifische Anteil des Radar-Nowcasts. Diese Spec ist ein **Amendment** — sie
+schließt drei Lücken **innerhalb** des bestehenden Journals, baut kein neues.
+
+## Source
+
+- **File:** `src/providers/geosphere.py` (MODIFY), `src/providers/enrichment_health.py`
+  (MODIFY), `src/providers/openmeteo.py` (unverändert — s. Architektur-Entscheidung 1),
+  `src/providers/thunder_enrichment.py` (MODIFY), `src/services/radar_service.py`
+  (MODIFY)
+- **Identifier:** `GeoSphereProvider.fetch_snowgrid`/`fetch_combined` (geosphere.py),
+  `providers.enrichment_health.PATH_SNOWGRID`/`PATH_THUNDER_ADDITIVE` (neu),
+  `thunder_enrichment._fetch_lightning_density` (additiver Zweig, ~589-608),
+  `radar_service.RadarService._fetch_geosphere_inca`/`get_nowcast`
+
+**Schicht:** ausschließlich Python-Core (`src/providers/`, `src/services/`).
+**Kein Go-Code betroffen** — s. Architektur-Entscheidung 3 (Korrektur der Analyse).
+Kein Frontend betroffen.
+
+## Estimated Scope
+
+- **LoC:** ~90-120 Produktionscode + ~320-420 Tests ≈ **~450 gesamt**. Kleiner als
+  #1581 (dort 900), aber über dem Standard-Limit 250 — `loc_limit_override` auf
+  **500** empfohlen.
+- **Files:** 5 Produktionsdateien (davon `openmeteo.py` NICHT geändert, s. u.) + 3-4
+  neue/erweiterte Testdateien
+- **Effort:** medium
+
+| Datei | Aktion | LoC (ca.) |
+|---|---|---|
+| `src/providers/enrichment_health.py` | MODIFY (2 neue Konstanten + Kommentar) | 10-15 |
+| `src/providers/geosphere.py` | MODIFY (`fetch_snowgrid` Except erweitern + journalen; `fetch_combined` eigenes try/except) | 25-35 |
+| `src/providers/thunder_enrichment.py` | MODIFY (additiver Zweig journalt) | 10-15 |
+| `src/services/radar_service.py` | MODIFY (neues Flag + Fallback-Unterscheidung in `get_nowcast`) | 10-15 |
+| `tests/tdd/test_snowgrid_enrichment_health.py` | CREATE | 100-140 |
+| `tests/tdd/test_thunder_additive_enrichment_health.py` | CREATE | 90-130 |
+| `tests/tdd/test_radar_inca_fallback_journal.py` | CREATE | 70-100 |
+| `internal/scheduler/enrichment_health_test.go` | KEINE Änderung nötig (s. AC-8) | 0 |
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `providers.enrichment_health.log_enrichment_call` | intern, bestehend (#1581) | Gemeinsamer, bereits fail-soft abgesicherter Schreibweg — wird nur mit neuen `path`-Werten aufgerufen, keine Änderung an der Funktion selbst |
+| `internal.scheduler.aggregateEnrichmentCalls`/`EnrichmentHealth` | intern, bestehend (#1581) | Gruppiert bereits generisch nach `entry.Path` als String — kein Enum, kein `switch` über erlaubte Pfadwerte (verifiziert, s. AC-8) |
+| `providers.thunder_routing.thunder_providers_for` | intern, bestehend | Liefert für `DE_ALPEN` `("de_direct", "geosphere")` — `geosphere` ist die einzige additive Quelle, nie Primärquelle |
+| ADR-0018 „Modell-Fallback ohne Kaschieren" | Architektur | Deckt bereits alle drei hier geschlossenen Lücken ab, keine neue Grundsatzentscheidung nötig |
+| `docs/specs/modules/fix_1581_enrichment_health.md` | Spec (Vorgänger) | Vorbild für Format, Outcome-Vokabular (`ok`/`fallback`/`unavailable`/`self_throttled`) und Choke-Point-Prinzip |
+
+## Implementation Details
+
+### 1. Neue Journal-Pfade (`src/providers/enrichment_health.py`)
+
+```python
+PATH_THUNDER = "thunder"
+PATH_THUNDER_ADDITIVE = "thunder_additive"   # neu
+PATH_RADAR_NOWCAST = "radar_nowcast"
+PATH_SNOWGRID = "snowgrid"                    # neu
+```
+
+`PATH_THUNDER_ADDITIVE` ist **absichtlich getrennt** von `PATH_THUNDER`, nicht
+`detail`-Varianten desselben Pfads — s. Architektur-Entscheidung 2.
+
+### 2. SNOWGRID (`src/providers/geosphere.py::fetch_snowgrid`, Zeilen 365-375)
+
+`fetch_snowgrid` ist der EINE Choke-Point für BEIDE Aufrufer (`fetch_combined` als
+GeoSphere-Primärpfad und `openmeteo.py::_enrich_snow` als Best-effort-Anreicherung,
+wenn Open-Meteo Primärquelle ist) — journalen genau hier deckt beide automatisch ab,
+ohne doppelte Einträge:
+
+```python
+try:
+    ...
+    return self._parse_snowgrid_response(data)
+except (httpx.HTTPStatusError, httpx.TimeoutException, httpx.RequestError) as e:
+    log_enrichment_call(PATH_SNOWGRID, OUTCOME_UNAVAILABLE, detail=str(e)[:200])
+    return None, None
+```
+
+Bei Erfolg (nach `return self._parse_snowgrid_response(data)`, aber vor dem
+`return`) `log_enrichment_call(PATH_SNOWGRID, OUTCOME_OK)`.
+
+Das Except wird von `httpx.HTTPStatusError` auf `(HTTPStatusError, TimeoutException,
+RequestError)` erweitert — dieselbe Klasse, die `fetch_thunder_signals_named` schon
+fängt (Zeile 424). Das bleibt **fail-soft** (kein Verhaltenswechsel: weiterhin
+`return None, None`), schließt aber eine echte, heute bestehende Lücke: ein Timeout
+oder Verbindungsfehler (nicht `HTTPStatusError`) propagiert HEUTE unverändert durch
+`fetch_snowgrid` hindurch (s. Punkt 3).
+
+### 3. Regressions-Leitplanke (`fetch_combined`, ~Zeile 597) — WICHTIGSTES AC
+
+`fetch_combined` ruft `fetch_snowgrid` heute **ungeschützt** auf. Selbst nach der
+Erweiterung in Punkt 2 bleibt ein Restrisiko: ein Fehler INNERHALB von
+`_parse_snowgrid_response` (z. B. `KeyError`/`ValueError` bei unerwarteter
+API-Antwortform) ist kein `httpx`-Fehler und wird von KEINEM der beiden Excepts
+gefangen — er propagiert durch `fetch_combined` bis in `fetch_forecast`s äußeres
+`except httpx.HTTPStatusError`/`except httpx.RequestError` (Zeilen 268-273), die ihn
+ebenfalls nicht fangen, und crasht damit die **komplette Grundvorhersage** wegen
+eines Fehlers in der optionalen Schneeanreicherung.
+
+```python
+if include_snow and ts.data:
+    try:
+        snow_depth_cm, swe_kgm2 = self.fetch_snowgrid(lat, lon)
+    except Exception as e:
+        log_enrichment_call(PATH_SNOWGRID, OUTCOME_UNAVAILABLE, detail=f"combined:{e}"[:200])
+        snow_depth_cm, swe_kgm2 = None, None
+    if snow_depth_cm is not None:
+        ...
+```
+
+Das ist ein bewusst **breiter** `except Exception` als zweite Verteidigungslinie
+(Defense-in-Depth) zusätzlich zum spezifischen `httpx`-Except in `fetch_snowgrid`
+selbst — die Grundvorhersage darf UNTER KEINEN Umständen an SNOWGRID scheitern, egal
+welche Fehlerklasse.
+
+### 4. Additive Gewitter-Zusatzquelle (`thunder_enrichment.py::_fetch_lightning_density`, ~589-608)
+
+Die `for quelle in zusatz:`-Schleife journalt heute NICHTS — weder Erfolg noch
+Fehlschlag. `PATH_THUNDER_ADDITIVE` mit `detail=quelle` (nicht `PATH_THUNDER`, s.
+Architektur-Entscheidung 2):
+
+```python
+for quelle in zusatz:
+    if quelle == bereits_befragt:
+        continue
+    try:
+        eintraege = _hole_eintraege(quelle, location, von, bis)
+    except Exception:
+        logger.warning("Zusatzquelle '%s' fehlgeschlagen", quelle, exc_info=True)
+        log_enrichment_call(PATH_THUNDER_ADDITIVE, OUTCOME_UNAVAILABLE, quelle)
+        continue
+    if not any(werte for _feld, werte in eintraege):
+        log_enrichment_call(PATH_THUNDER_ADDITIVE, OUTCOME_OK, quelle)
+        continue
+    gefuellt = _wende_eintraege_an(reihe, eintraege, basis)
+    log_enrichment_call(PATH_THUNDER_ADDITIVE, OUTCOME_OK, quelle)
+    if gefuellt:
+        logger.info(...)
+```
+
+`OUTCOME_OK` auch bei leerer-aber-gültiger Antwort — dieselbe Regel wie bei der
+Primärquelle (#1581, „kein Gewitter in Sicht" ist ein Erfolg).
+
+### 5. Radar-Nowcast — INCA-spezifischer Fehlschlag (`radar_service.py`)
+
+`_derive_result`s `data_unavailable`-Formel (Zeilen 583-593) bleibt **unverändert**
+(Architektur-Entscheidung 4 — sie treibt Alarm-Unterdrückung, s.
+`test_radar_upstream_failure.py`, und ist über `and not frames` bereits korrekt: sie
+darf nur True sein, wenn am Ende wirklich keine Frames vorliegen). Stattdessen ein
+neues, eigenes Flag, das den bestehenden Journal-Aufruf in `get_nowcast()`
+(bereits aus #1581 Scheibe 2 vorhanden, Zeilen ~225-241) erweitert:
+
+```python
+# Reset (an beiden bestehenden Reset-Stellen, Zeilen 138-139 und 186-187):
+self._inca_unavailable_this_call = False
+
+# In _fetch_geosphere_inca(), except-Zweig (Zeile ~399-400):
+except Exception as e:
+    logger.warning(f"GeoSphere INCA failed, falling back: {e}")
+    self._inca_unavailable_this_call = True
+    return []
+
+# In get_nowcast(), bestehender Journal-Block erweitert:
+if result.throttled:
+    log_enrichment_call(PATH_RADAR_NOWCAST, OUTCOME_SELF_THROTTLED)
+elif result.data_unavailable:
+    log_enrichment_call(PATH_RADAR_NOWCAST, OUTCOME_UNAVAILABLE)
+elif getattr(self, "_inca_unavailable_this_call", False):
+    log_enrichment_call(PATH_RADAR_NOWCAST, OUTCOME_FALLBACK, source)
+else:
+    log_enrichment_call(PATH_RADAR_NOWCAST, OUTCOME_OK)
+```
+
+`_within_inca(lat, lon)` = False (Ort außerhalb der INCA-Bbox) → `_fetch_geosphere_inca`
+wird nie aufgerufen, Flag bleibt `False`, unverändertes Verhalten.
+
+## Expected Behavior
+
+- **Input:** jeder Abruf von SNOWGRID (`fetch_snowgrid`, über beide Aufrufer), der
+  additiven Gewitter-Zusatzquelle (`geosphere` in `DE_ALPEN`) und des
+  INCA-Anteils des Radar-Nowcasts, unabhängig vom Ausgang.
+- **Output:** zusätzliche JSONL-Zeilen in `data/diagnostics/enrichment_calls.jsonl`
+  mit `path="snowgrid"` bzw. `path="thunder_additive"`; für `path="radar_nowcast"`
+  zusätzlich der Ausgang `outcome="fallback"` (bisher nie geschrieben). Beide neuen
+  `path`-Werte erscheinen automatisch als eigene Schlüssel unter
+  `enrichment_health` in `/api/scheduler/status`, OHNE Go-Code-Änderung (AC-8).
+- **Side effects:** keine auf den fachlichen Datenfluss — Schneetiefe,
+  Gewittersignale und Radar-Nowcast-Ergebnisse bleiben unverändert, auch bei
+  nicht beschreibbarem Journal (Fail-soft, geerbt von `log_enrichment_call`).
+  `PATH_THUNDER`/`PATH_RADAR_NOWCAST`-Einträge der Primärpfade bleiben unverändert
+  (außer dem neuen `fallback`-Ausgang bei Radar, AC-6).
+
+## Acceptance Criteria
+
+- **AC-1:** Given SNOWGRID antwortet mit einem echten Fehler (`httpx.HTTPStatusError`,
+  `TimeoutException` oder `RequestError`) / When `fetch_snowgrid()` durchläuft
+  (egal ob aufgerufen über `fetch_combined` oder `openmeteo.py::_enrich_snow`) /
+  Then wird eine Journalzeile mit `path="snowgrid"`, `outcome="unavailable"`
+  geschrieben, und die Funktion liefert weiterhin `(None, None)` (fail-soft,
+  unverändertes Rückgabeverhalten).
+  - Test: Fake-Provider/HTTP-Mock, der `fetch_snowgrid` mit je einer der drei
+    Exception-Klassen scheitern lässt (3 Fälle, auch `TimeoutException` — die
+    heute NICHT gefangen wird), danach Journal auf `path="snowgrid"`/`unavailable`
+    prüfen UND den Rückgabewert `(None, None)` verifizieren.
+
+- **AC-2:** Given SNOWGRID antwortet normal / When `fetch_snowgrid()` durchläuft /
+  Then wird eine Journalzeile mit `path="snowgrid"`, `outcome="ok"` geschrieben.
+  - Test: Erfolgreichen Abruf faken, Journal auf genau eine `ok`-Zeile für
+    `path="snowgrid"` prüfen, keine `unavailable`-Zeile.
+
+- **AC-3 (Regressions-Leitplanke, wichtigstes AC):** Given `fetch_snowgrid` wirft
+  eine beliebige Exception (auch eine NICHT-httpx-Exception, z. B. ein simulierter
+  Parsing-Fehler) / When `fetch_combined()` bzw. `fetch_forecast()` durchläuft /
+  Then liefert der Aufruf trotzdem ein `NormalizedTimeseries`-Ergebnis mit den
+  übrigen Wetterdaten (ohne Schneefelder), OHNE dass eine Exception propagiert —
+  die Grundvorhersage scheitert NIEMALS an einem SNOWGRID-Fehler.
+  - Test: `fetch_snowgrid` per Monkeypatch/Mock so präparieren, dass es eine
+    generische `Exception` wirft (nicht nur eine `httpx`-Klasse), `fetch_combined()`
+    UND `fetch_forecast()` aufrufen, beide liefern ein Ergebnis mit
+    `ts.data` befüllt und `snow_depth_cm is None` auf allen Punkten — kein
+    `ProviderRequestError`, keine unbehandelte Exception. Mutations-Gegenprobe:
+    das `try/except` um den `fetch_snowgrid`-Aufruf in `fetch_combined` entfernen
+    → genau dieser Test wird rot (Nachweis, dass er die Leitplanke tatsächlich
+    bewacht, nicht nur den bereits vorhandenen inneren Except von
+    `fetch_snowgrid`).
+
+- **AC-4:** Given die additive Gewitter-Zusatzquelle (`geosphere` in `DE_ALPEN`,
+  #1758) scheitert (`_hole_eintraege` wirft) / When
+  `_fetch_lightning_density()` die Zusatzquellen-Schleife durchläuft / Then wird
+  eine Journalzeile mit `path="thunder_additive"`, `outcome="unavailable"`,
+  `detail="geosphere"` geschrieben — getrennt von `path="thunder"` (Primärquelle).
+  Heute hinterlässt dieser Fall NICHTS außer einem `logger.warning`.
+  - Test: additive Quelle scheitern lassen (Primärquelle `de_direct` erfolgreich),
+    danach Journal auf die `thunder_additive`-Zeile prüfen UND verifizieren, dass
+    KEINE zusätzliche Zeile unter `path="thunder"` für dasselbe Ereignis entsteht
+    (Trennungsnachweis).
+
+- **AC-5:** Given die additive Gewitter-Zusatzquelle liefert (mit oder ohne
+  gefüllte Werte) / When die Zusatzquellen-Schleife durchläuft / Then wird eine
+  Journalzeile mit `path="thunder_additive"`, `outcome="ok"`, `detail="geosphere"`
+  geschrieben, und die Primärquelle (`path="thunder"`) bleibt in Anzahl und Inhalt
+  ihrer Journalzeilen unverändert zum Stand ohne diese Änderung.
+  - Test: additive Quelle erfolgreich (einmal mit gefüllten, einmal mit leeren
+    Werten) durchlaufen lassen, `thunder_additive`/`ok` in beiden Fällen prüfen;
+    Regressionsvergleich der `thunder`-Zeilenzahl vor/nach der Änderung.
+
+- **AC-6:** Given der Radar-Nowcast fällt für einen INCA-zuständigen Ort auf eine
+  andere Quelle zurück (INCA-Abruf scheitert, aber `_fetch_frames_with_fallback`
+  findet danach z. B. ICON-D2 mit Frames) / When `get_nowcast()` den Miss-Zweig
+  durchläuft / Then wird eine Journalzeile mit `path="radar_nowcast"`,
+  `outcome="fallback"`, `detail="ICON-D2"` geschrieben — NICHT `outcome="ok"`.
+  Heute erscheint dieser Fall identisch zu einem gesunden INCA-Abruf.
+  - Test: `_fetch_geosphere_inca` scheitern lassen (Exception in der internen
+    `fetch_nowcast`-Kette), `_fetch_icon_d2` erfolgreich faken, Journal auf
+    `fallback`/`detail="ICON-D2"` statt `ok` prüfen. Gegenprobe: ohne die
+    Änderung (Flag/`elif`-Zweig per String-Ersetzung entfernt) schreibt derselbe
+    Testaufbau `outcome="ok"` — der Test muss genau daran rot werden.
+
+- **AC-7:** Given INCA liefert selbst erfolgreich Frames (`source="INCA"`) / When
+  `get_nowcast()` durchläuft / Then bleibt die Journalzeile unverändert
+  `outcome="ok"` (Regressionsschutz für das #1581-Verhalten — dieses AC stellt
+  sicher, dass die neue `elif`-Verzweigung den bisherigen Erfolgsfall nicht
+  versehentlich in `fallback` verwandelt).
+  - Test: INCA erfolgreich faken (kein Fallback nötig), Journal auf `ok` prüfen,
+    `_inca_unavailable_this_call` bleibt `False`.
+
+- **AC-8:** Given zwei neue `path`-Werte (`snowgrid`, `thunder_additive`) tauchen
+  im Journal auf, OHNE dass `internal/scheduler/enrichment_health.go` geändert
+  wurde / When `/api/scheduler/status` abgefragt wird / Then erscheinen beide
+  automatisch als eigene Schlüssel unter `enrichment_health`, mit denselben
+  Rohdaten-Feldern (`last_attempt_at`/`last_success_at`/`last_fallback_at`/
+  `self_throttled`) wie `thunder`/`radar_nowcast`. Beweist, dass der bestehende
+  Go-Aggregator bereits generisch über `path` gruppiert (kein geschlossenes
+  Vokabular, kein `switch`) — korrigiert die ursprüngliche Analyse-Annahme, ein
+  Go-Gegenstück sei nötig.
+  - Test: Journal-Datei direkt mit synthetischen Zeilen für `path="snowgrid"`
+    und `path="thunder_additive"` befüllen (Python-Seite unverändert lassen),
+    bestehenden Go-Testaufbau (`enrichmentLine`/`enrichmentEntry` aus
+    `enrichment_health_test.go`) wiederverwenden und beide neuen Schlüssel im
+    Aggregat nachweisen — kein Code in `enrichment_health.go` wird dafür
+    angefasst.
+
+## Known Limitations
+
+- **`at_direct`-Fallback (ADR-0047, `openmeteo.py:1091-1096`) bleibt außerhalb des
+  Scopes.** Ein Fehlschlag dort eskaliert bereits sichtbar (`raise last_error`),
+  kein stiller Ausfall im Sinne dieses Tickets; #1581 hatte GeoSphere hier bewusst
+  ohne Vertretungs-Eintrag gelassen — das bleibt unverändert.
+- **Schwellenwert-Entscheidungen (wie lange gilt ein Ausfall als kritisch) bleiben
+  außerhalb des Codes**, wie bei #1581 — Aufgabe des externen Monitorings
+  (`henemm-infra/check-gregor20.sh`). `path="snowgrid"` und `path="thunder_additive"`
+  sind fachlich NICHT briefing-kritisch (analog `radar_nowcast`); Empfehlung fürs
+  externe Skript: langes Frischefenster, EXT-FAIL statt CORE.
+- **`fetch_thunder_signals_named` und `fetch_nowcast` in `geosphere.py` selbst
+  bekommen KEINE eigene Journal-Anbindung** (obwohl die ursprüngliche Analyse das
+  vorschlug) — ihre einzigen Aufrufer (`thunder_enrichment.py` und
+  `radar_service.py::get_nowcast()`) journalen bereits an einem gemeinsamen,
+  choke-point-nahen Ort (Primärquelle seit #1581, additiv und INCA-Fallback neu in
+  dieser Spec). Ein zweiter Journal-Aufruf auf Provider-Ebene würde für dasselbe
+  logische Ereignis eine doppelte Zeile erzeugen und `last_attempt_at` künstlich
+  verdoppeln, ohne zusätzliche Beobachtbarkeit zu gewinnen.
+- **`_derive_result()`s `data_unavailable`-Formel bleibt unangetastet.** Sie treibt
+  die Alarm-Unterdrückung (`trip_alert.py`, `test_radar_upstream_failure.py`) und
+  ist für den Fall „am Ende liegen wirklich keine Frames vor" bereits korrekt. Die
+  INCA-spezifische Beobachtbarkeit läuft bewusst über einen separaten Pfad
+  (`outcome="fallback"`), nicht über eine Änderung dieser Formel — eine Änderung
+  dort hätte das Risiko, den bestehenden, gut getesteten Alarm-Unterdrückungspfad
+  zu verändern, obwohl das fachlich nicht nötig ist (Fallback-Frames sind nutzbare
+  Daten, kein Ausfall im Sinne von `data_unavailable`).
+- **`enrichment_calls.jsonl` bleibt append-only ohne Rotation**, wie in #1581
+  festgelegt — unverändert.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine neue ADR — Amendment zu ADR-0018 (bestehender Grundsatz
+  „wachsendes Health-Signal für jeden degradierbaren Pfad" deckt alle drei Lücken
+  bereits ab) und faktische Fortsetzung der in #1581 getroffenen Entscheidungen
+  (kein eigenes ADR-Dokument für #1581 selbst — Amendment lief über ADR-0047).
+- **Rationale:**
+  1. **SNOWGRID journalt an EINEM Choke-Point (`fetch_snowgrid` selbst), nicht an
+     beiden Aufrufern.** `openmeteo.py::_enrich_snow` bleibt unverändert — sein
+     `except Exception: pass` fängt nach dieser Änderung realistisch nur noch
+     Bugs im Anreicherungs-Glue-Code (`_stamp_snow`), NICHT mehr echte
+     SNOWGRID-Fehlschläge (die journalen bereits vorher in `fetch_snowgrid`
+     selbst, ohne Exception zu propagieren). Das weicht von der ursprünglichen
+     Analyse ab (die eine zweite Journal-Stelle in `openmeteo.py` vorschlug) —
+     eine zweite Stelle hätte für denselben SNOWGRID-Abruf potenziell doppelt
+     journalt oder wäre inkonsistent leer geblieben, je nachdem welcher der
+     beiden `except`-Blöcke zuerst greift.
+  2. **`thunder_additive` ist ein EIGENER Pfad, nicht `detail` unter
+     `thunder`.** Der Go-Aggregator bildet pro `path` genau EIN
+     `last_success_at`. Würde die additive Quelle unter `path="thunder"`
+     mitschreiben, könnte ein Erfolg der PRIMÄRQUELLE (`de_direct`) einen
+     zeitgleichen Ausfall der additiven GeoSphere-Quelle im Aggregat
+     überdecken — genau die Vermengung, die dieses Ticket beheben soll. Ein
+     eigener Pfad macht GeoSphere-additive-Ausfälle unabhängig von der
+     Primärquelle sichtbar.
+  3. **Keine Änderung an `internal/scheduler/enrichment_health.go` nötig** —
+     verifiziert: `aggregateEnrichmentCalls()` gruppiert bereits generisch nach
+     `entry.Path` als freiem String (keine Konstanten-Liste, kein `switch` über
+     erlaubte Pfadwerte; die vorhandenen `enrichmentOutcome*`-Konstanten
+     beziehen sich auf `outcome`, nicht auf `path`). Ein neuer `path`-Wert
+     erscheint automatisch als zusätzlicher Schlüssel im
+     `EnrichmentHealth()`-Ergebnis. Die ursprüngliche Analyse ging von einem
+     „geschlossenen Vokabular" aus — das trifft für `outcome` zu (dort SIND es
+     feste Konstanten), aber nicht für `path`. AC-8 belegt das explizit.
+  4. **INCA-Fallback nutzt das bestehende `outcome="fallback"`-Vokabular**, statt
+     ein neues Flag in `NowcastResult`/`_derive_result` einzuführen. Das
+     vermeidet jede Berührung der bereits ausführlich getesteten
+     `data_unavailable`-Formel (Alarm-Unterdrückung) und ist konsistent mit dem
+     bereits für `PATH_THUNDER` etablierten Muster „Primärquelle fiel aus, eine
+     Ersatzquelle hat geliefert" = `fallback`.
+
+## Changelog
+
+- 2026-08-20: Initial spec created (Issue #1992, Analyse
+  `docs/context/feat-1992-geosphere-health-journal.md`). Drei Abweichungen von der
+  Analyse dokumentiert: (a) kein Go-Code nötig (Aggregator bereits generisch über
+  `path`), (b) `geosphere.py::fetch_thunder_signals_named`/`fetch_nowcast` bekommen
+  KEINE eigene Journal-Anbindung (Choke-Point liegt bereits beim jeweiligen
+  Aufrufer), (c) INCA-Beobachtbarkeit läuft über das bestehende
+  `outcome="fallback"`-Vokabular statt über eine Erweiterung von
+  `_derive_result()`s `data_unavailable`-Formel.

--- a/internal/scheduler/enrichment_health_test.go
+++ b/internal/scheduler/enrichment_health_test.go
@@ -401,3 +401,45 @@ func TestStatusEnthaeltEnrichmentHealthAlsGeschwisterVonBriefingHealth(t *testin
 		t.Errorf("warn_service_health ist aus dem Status verschwunden")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// AC-8 (#1992): neue path-Werte erscheinen automatisch, ohne diese Datei zu
+// aendern -- der Aggregator gruppiert bereits generisch ueber entry.Path.
+// ---------------------------------------------------------------------------
+
+// AC-8: zwei neue path-Werte (snowgrid, thunder_additive, #1992) tauchen im
+// Aggregat auf, obwohl enrichment_health.go sie an keiner Stelle kennt --
+// kein Enum, kein switch ueber erlaubte path-Werte. Belegt die Spec-
+// Architektur-Entscheidung 3 (aggregateEnrichmentCalls gruppiert generisch
+// nach Path, nicht nach einem geschlossenen Vokabular).
+func TestEnrichmentHealthNeuePathWerteErscheinenAutomatisch(t *testing.T) {
+	tmpDir := t.TempDir()
+	sched := newEnrichmentHealthTestScheduler(t, tmpDir)
+
+	now := time.Now().UTC()
+	snowgridErfolg := now.Add(-30 * time.Minute)
+	thunderAdditiveAusfall := now.Add(-10 * time.Minute)
+	writeEnrichmentJournal(t, tmpDir,
+		enrichmentLine(snowgridErfolg, "snowgrid", "ok", ""),
+		enrichmentLine(thunderAdditiveAusfall, "thunder_additive", "unavailable", "geosphere"),
+	)
+
+	health := sched.EnrichmentHealth()
+
+	snowgrid := enrichmentEntry(t, health, "snowgrid")
+	if got, want := snowgrid["last_success_at"], snowgridErfolg.Format(time.RFC3339); got != want {
+		t.Errorf("snowgrid.last_success_at: erwartet %v, bekommen %#v", want, got)
+	}
+	if _, ok := snowgrid["self_throttled"].(bool); !ok {
+		t.Errorf("snowgrid: erwartet dieselben Rohdaten-Felder wie thunder/radar_nowcast (self_throttled fehlt oder falscher Typ): %#v", snowgrid)
+	}
+
+	thunderAdditive := enrichmentEntry(t, health, "thunder_additive")
+	if got := thunderAdditive["last_success_at"]; got != nil {
+		t.Errorf("thunder_additive.last_success_at: erwartet nil (nur ein Ausfall im Journal), bekommen %#v", got)
+	}
+	attempt, ok := thunderAdditive["last_attempt_at"].(string)
+	if !ok || attempt != thunderAdditiveAusfall.Format(time.RFC3339) {
+		t.Errorf("thunder_additive.last_attempt_at: erwartet %v, bekommen %#v", thunderAdditiveAusfall.Format(time.RFC3339), thunderAdditive["last_attempt_at"])
+	}
+}

--- a/src/providers/enrichment_health.py
+++ b/src/providers/enrichment_health.py
@@ -19,10 +19,17 @@ import json
 from datetime import datetime, timezone
 from typing import Optional
 
-# Pfad-Vokabular: die beiden degradierbaren Anreicherungs-Pfade. Der
-# Go-Aggregator gruppiert nach genau diesen Werten.
+# Pfad-Vokabular: die degradierbaren Anreicherungs-Pfade. Der Go-Aggregator
+# gruppiert bereits generisch nach `path` als freiem String -- ein neuer Wert
+# hier erscheint automatisch als eigener Schluessel, ohne Aenderung an
+# `internal/scheduler/enrichment_health.go` (#1992 AC-8).
 PATH_THUNDER = "thunder"
+PATH_THUNDER_ADDITIVE = "thunder_additive"  # #1992: additive Zusatzquelle
+# (geosphere in DE_ALPEN, #1758) -- eigener Pfad statt `detail` unter
+# `thunder`, damit ein Ausfall der additiven Quelle nicht von einem
+# zeitgleichen Erfolg der Primaerquelle im Aggregat ueberdeckt wird.
 PATH_RADAR_NOWCAST = "radar_nowcast"
+PATH_SNOWGRID = "snowgrid"  # #1992: SNOWGRID-Schneetiefe
 
 # Ausgangs-Vokabular:
 #   ok             -- die Quelle hat regulaer geantwortet (auch leer:

--- a/src/providers/geosphere.py
+++ b/src/providers/geosphere.py
@@ -363,6 +363,9 @@ class GeoSphereProvider:
         Returns:
             Tuple of (snow_depth_cm, swe_kgm2) or (None, None) if unavailable
         """
+        from providers.enrichment_health import (
+            OUTCOME_OK, OUTCOME_UNAVAILABLE, PATH_SNOWGRID, log_enrichment_call,
+        )
         try:
             # SNOWGRID requires start/end dates - fetch last 7 days
             end = datetime.now(timezone.utc)
@@ -371,8 +374,11 @@ class GeoSphereProvider:
                 ENDPOINTS["snowgrid"], lat, lon, SNOWGRID_PARAMS,
                 start=start, end=end
             )
-            return self._parse_snowgrid_response(data)
-        except httpx.HTTPStatusError:
+            result = self._parse_snowgrid_response(data)
+            log_enrichment_call(PATH_SNOWGRID, OUTCOME_OK)
+            return result
+        except (httpx.HTTPStatusError, httpx.TimeoutException, httpx.RequestError) as e:
+            log_enrichment_call(PATH_SNOWGRID, OUTCOME_UNAVAILABLE, detail=str(e)[:200])
             return None, None
 
     def fetch_thunder_signals(
@@ -603,7 +609,16 @@ class GeoSphereProvider:
 
         # Enrich with snow data if requested
         if include_snow and ts.data:
-            snow_depth_cm, swe_kgm2 = self.fetch_snowgrid(lat, lon)
+            try:
+                snow_depth_cm, swe_kgm2 = self.fetch_snowgrid(lat, lon)
+            except Exception as e:
+                from providers.enrichment_health import (
+                    OUTCOME_UNAVAILABLE, PATH_SNOWGRID, log_enrichment_call,
+                )
+                log_enrichment_call(
+                    PATH_SNOWGRID, OUTCOME_UNAVAILABLE, detail=f"combined:{e}"[:200],
+                )
+                snow_depth_cm, swe_kgm2 = None, None
             if snow_depth_cm is not None:
                 # Add snow depth to all data points (it's a snapshot)
                 for dp in ts.data:

--- a/src/providers/thunder_enrichment.py
+++ b/src/providers/thunder_enrichment.py
@@ -587,6 +587,10 @@ def _fetch_lightning_density(
     # eine scheiternde Zusatzquelle weder die Primaerquelle noch andere
     # Zusatzquellen mitreisst. Keine Vertretung fuer Zusatzquellen (Scope-
     # Abgrenzung).
+    from providers.enrichment_health import (
+        OUTCOME_OK, OUTCOME_UNAVAILABLE, PATH_THUNDER_ADDITIVE, log_enrichment_call,
+    )
+
     for quelle in zusatz:
         if quelle == bereits_befragt:
             continue
@@ -594,10 +598,13 @@ def _fetch_lightning_density(
             eintraege = _hole_eintraege(quelle, location, von, bis)
         except Exception:
             logger.warning("Zusatzquelle '%s' fehlgeschlagen", quelle, exc_info=True)
+            log_enrichment_call(PATH_THUNDER_ADDITIVE, OUTCOME_UNAVAILABLE, quelle)
             continue
         if not any(werte for _feld, werte in eintraege):
+            log_enrichment_call(PATH_THUNDER_ADDITIVE, OUTCOME_OK, quelle)
             continue
         gefuellt = _wende_eintraege_an(reihe, eintraege, basis)
+        log_enrichment_call(PATH_THUNDER_ADDITIVE, OUTCOME_OK, quelle)
         if gefuellt:
             logger.info(
                 "Gewittersignale von Zusatzquelle '%s': %d Zeitpunkte gefuellt",

--- a/src/services/radar_service.py
+++ b/src/services/radar_service.py
@@ -138,6 +138,7 @@ class RadarNowcastService:
         self._cache = cache
         self._openmeteo_unavailable_this_call = False
         self._budget_throttled_this_call = False
+        self._inca_unavailable_this_call = False
         self._priority = "user_briefing"
         self._budget_gate = None
 
@@ -190,6 +191,7 @@ class RadarNowcastService:
         self._convective_checked = True
         self._openmeteo_unavailable_this_call = False
         self._budget_throttled_this_call = False
+        self._inca_unavailable_this_call = False
         self._priority = priority
         from services.forecast_budget import ForecastBudgetGate
         self._budget_gate = ForecastBudgetGate()
@@ -233,13 +235,15 @@ class RadarNowcastService:
         # Vermengung liesse das externe Auswertungsskript einen selbst
         # gewaehlten Rueckzug als Fremdausfall eskalieren (AC-8/AC-10).
         from providers.enrichment_health import (
-            OUTCOME_OK, OUTCOME_SELF_THROTTLED, OUTCOME_UNAVAILABLE,
-            PATH_RADAR_NOWCAST, log_enrichment_call,
+            OUTCOME_FALLBACK, OUTCOME_OK, OUTCOME_SELF_THROTTLED,
+            OUTCOME_UNAVAILABLE, PATH_RADAR_NOWCAST, log_enrichment_call,
         )
         if result.throttled:
             log_enrichment_call(PATH_RADAR_NOWCAST, OUTCOME_SELF_THROTTLED)
         elif result.data_unavailable:
             log_enrichment_call(PATH_RADAR_NOWCAST, OUTCOME_UNAVAILABLE)
+        elif self._inca_unavailable_this_call:
+            log_enrichment_call(PATH_RADAR_NOWCAST, OUTCOME_FALLBACK, source)
         else:
             log_enrichment_call(PATH_RADAR_NOWCAST, OUTCOME_OK)
         return result
@@ -404,6 +408,7 @@ class RadarNowcastService:
             return frames
         except Exception as e:
             logger.warning(f"GeoSphere INCA failed, falling back: {e}")
+            self._inca_unavailable_this_call = True
             return []
 
     def _merge_convective(self, inca_frames: list, sidecar_frames: list) -> None:

--- a/tests/tdd/test_radar_inca_fallback_journal.py
+++ b/tests/tdd/test_radar_inca_fallback_journal.py
@@ -1,0 +1,261 @@
+"""TDD RED -- Issue #1992 Amendment: Health-Journal des INCA-spezifischen
+Radar-Nowcast-Fallbacks.
+
+Spec: docs/specs/modules/feat_1992_geosphere_health_amendment.md (AC-6, AC-7).
+Vorbild: tests/tdd/test_radar_nowcast_health_journal.py (#1581 Scheibe 2).
+
+Deckt hier ab: AC-6 (INCA-Abruf scheitert, eine andere Quelle liefert danach
+Frames -> `path="radar_nowcast"`, `outcome="fallback"`, `detail="ICON-D2"` --
+NICHT `outcome="ok"`), AC-7 (INCA liefert selbst erfolgreich -> unveraendert
+`outcome="ok"`, Regressionsschutz fuer das #1581-Verhalten).
+
+===========================================================================
+Kein Mock-Theater
+===========================================================================
+Der Open-Meteo-Netzzugriff (ICON-D2-Fallback UND der INCA-Konvektions-
+Sidecar) wird durch eine Ersatzklasse fuer `httpx.Client` vertreten, die
+ECHTE `httpx.Response`-Objekte liefert (Muster `_ScriptedClient`,
+tests/unit/test_radar_upstream_failure.py) -- kein `Mock()`. Der
+GeoSphere-INCA-Abruf selbst wird gezielt ueber `GeoSphereProvider.
+fetch_nowcast` monkeygepatcht (so von der Spec als Testmethode benannt:
+"Exception in der internen fetch_nowcast-Kette") -- fuer AC-7 liefert der
+Fake ein ECHTES `NormalizedTimeseries`-Objekt statt eines Mock-Rueckgabewerts.
+Der Cache ist eine echte `RadarNowcastCacheService`-Instanz, das Journal wird
+ECHT geschrieben und als JSONL geparst gelesen.
+
+===========================================================================
+Erwartete Rotfaerbung
+===========================================================================
+AC-6 ist heute rot: `get_nowcast()` unterscheidet INCA-Fallback (Miss +
+andere Quelle liefert) heute NICHT von einem gesunden INCA-Abruf -- beide
+buchen `outcome="ok"`, weil weder `throttled` noch `data_unavailable`
+gesetzt sind. Der Test verlangt `outcome="fallback"`/`detail="ICON-D2"` und
+scheitert heute an der falschen `outcome`.
+
+AC-7 ist heute STRUKTURELL GRUEN (Regressionsschutz, bewusst): ein
+erfolgreicher INCA-Abruf bucht schon jetzt `outcome="ok"` (#1581). Er bleibt
+kein Blindtest -- er wird rot, sobald eine kuenftige Implementierung der
+neuen `elif`-Verzweigung (AC-6) den bestehenden Erfolgsfall versehentlich
+mit-faengt.
+
+Ausfuehrung:
+    uv run pytest tests/tdd/test_radar_inca_fallback_journal.py \
+        --disable-socket --allow-unix-socket -v
+"""
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import List
+
+import httpx
+
+_SRC = Path(__file__).resolve().parents[2] / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+import pytest  # noqa: E402
+
+from app.models import (  # noqa: E402
+    ForecastDataPoint,
+    ForecastMeta,
+    NormalizedTimeseries,
+    Provider,
+)
+from providers.geosphere import GeoSphereProvider  # noqa: E402
+from services.radar_cache import RadarNowcastCacheService  # noqa: E402
+from services.radar_service import RadarNowcastService  # noqa: E402
+
+# Wien: innerhalb INCA (46.3-49.1 lat, 9.5-17.2 lon) UND innerhalb ICON_D2
+# (44.0-58.0 lat, 2.0-19.0 lon), radar_service.py:32-61 -- AUSSERHALB von
+# RADOLAN (lon 16.37 > 15.1), Italien-Radar (lat 48.2 > 47.5) und AROME-FR
+# (lon 16.37 > 10.0): einzig INCA- und ICON-D2-Zweig sind erreichbar, genau
+# die Kette, die AC-6 braucht. Innsbruck (47.26/11.39) waere UNGEEIGNET --
+# liegt zusaetzlich in RADOLAN UND Italien-Radar, beide vor INCA/ICON-D2
+# geprueft (_fetch_frames_with_fallback-Reihenfolge).
+_LAT, _LON = 48.2, 16.37
+
+_JOURNAL_UNTERPFAD = ("diagnostics", "enrichment_calls.jsonl")
+
+
+# ---------------------------------------------------------------------------
+# Netz-Double fuer den Open-Meteo-Anteil (ICON-D2-Fallback + INCA-Sidecar)
+# -- echte httpx.Response-Objekte statt Mock/patch, uebernommen aus
+# tests/unit/test_radar_upstream_failure.py.
+# ---------------------------------------------------------------------------
+
+_CALL_URLS: List[str] = []
+_RESPONDER: list = [None]
+
+
+def _icon_d2_erfolg(url: str) -> httpx.Response:
+    jetzt = datetime.now(timezone.utc)
+    times = [
+        (jetzt + timedelta(minutes=m)).strftime("%Y-%m-%dT%H:%M")
+        for m in (15, 30, 45, 60)
+    ]
+    body = {
+        "minutely_15": {
+            "time": times,
+            "precipitation": [0.0, 0.0, 0.0, 0.0],
+            "weather_code": [0, 0, 0, 0],
+        }
+    }
+    return httpx.Response(200, request=httpx.Request("GET", url), json=body)
+
+
+class _ScriptedClient:
+    def __init__(self, *a, **kw) -> None:
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a) -> bool:
+        return False
+
+    def get(self, url, *a, **kw):
+        _CALL_URLS.append(url)
+        return _RESPONDER[0](url)
+
+
+@pytest.fixture(autouse=True)
+def _swap_http_client(monkeypatch):
+    """Netzsperre + Offline-Fixture aus dem Weg raeumen (Muster
+    test_radar_nowcast_health_journal.py)."""
+    _CALL_URLS.clear()
+    _RESPONDER[0] = _icon_d2_erfolg
+    monkeypatch.delenv("GZ_TEST_FIXTURE_DIR", raising=False)
+    monkeypatch.setattr(httpx, "Client", _ScriptedClient)
+    yield
+    _CALL_URLS.clear()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _journalpfad() -> Path:
+    from app.loader import get_data_root
+    return get_data_root().joinpath(*_JOURNAL_UNTERPFAD)
+
+
+def _zeilen() -> List[dict]:
+    pfad = _journalpfad()
+    if not pfad.is_file():
+        return []
+    return [json.loads(z) for z in pfad.read_text().splitlines() if z.strip()]
+
+
+def _radar_zeilen() -> List[dict]:
+    return [z for z in _zeilen() if z.get("path") == "radar_nowcast"]
+
+
+def _letzte_radar_zeile() -> dict:
+    zeilen = _radar_zeilen()
+    assert zeilen, (
+        f"Keine Journalzeile mit path='radar_nowcast' in {_journalpfad()} "
+        f"-- vorhandene Zeilen: {_zeilen()}."
+    )
+    return zeilen[-1]
+
+
+def _dienst() -> RadarNowcastService:
+    """Immer mit EIGENEM Cache -- der geteilte Prozess-Cache traegt sonst
+    Eintraege zwischen Tests weiter (Muster
+    test_radar_nowcast_health_journal.py::_dienst)."""
+    return RadarNowcastService(cache=RadarNowcastCacheService())
+
+
+def _inca_wirft(self, lat: float, lon: float):
+    """Ersetzt `GeoSphereProvider.fetch_nowcast` -- simuliert eine
+    Exception in der internen fetch_nowcast-Kette (Spec-Testmethode fuer
+    AC-6), z.B. ein GeoSphere-Ausfall."""
+    raise RuntimeError("GeoSphere INCA nicht erreichbar (simuliert)")
+
+
+def _inca_erfolgreich(self, lat: float, lon: float) -> NormalizedTimeseries:
+    """Ersetzt `GeoSphereProvider.fetch_nowcast` mit einem ECHTEN
+    Erfolgsergebnis (kein Mock-Rueckgabewert) fuer AC-7."""
+    jetzt = datetime.now(timezone.utc)
+    meta = ForecastMeta(provider=Provider.GEOSPHERE, model="NOWCAST", grid_res_km=1.0)
+    data = [
+        ForecastDataPoint(
+            ts=jetzt + timedelta(minutes=m), t2m_c=8.0, wind10m_kmh=6.0,
+            precip_1h_mm=0.0,
+        )
+        for m in (15, 30, 45, 60)
+    ]
+    return NormalizedTimeseries(meta=meta, data=data)
+
+
+# ---------------------------------------------------------------------------
+# AC-6: INCA-Fallback -> outcome="fallback", detail="ICON-D2" (NICHT "ok")
+# ---------------------------------------------------------------------------
+
+def test_ac6_inca_fallback_auf_icon_d2_schreibt_fallback_zeile(monkeypatch) -> None:
+    assert _radar_zeilen() == [], (
+        "Testaufbau: Journal muss vor dem Abruf leer sein."
+    )
+    monkeypatch.setattr(GeoSphereProvider, "fetch_nowcast", _inca_wirft)
+
+    dienst = _dienst()
+    ergebnis = dienst.get_nowcast(_LAT, _LON)
+
+    # Vorbedingung: der INCA-Ausfall hat wirklich zu ICON-D2 durchgereicht.
+    assert ergebnis.source == "ICON-D2", (
+        f"Testaufbau: erwartete Quelle 'ICON-D2' nach simuliertem "
+        f"INCA-Ausfall, bekommen {ergebnis.source!r} -- dann lief nicht "
+        f"der erwartete Fallback-Zweig und die Zusicherung unten prueft "
+        f"nichts Sinnvolles."
+    )
+    assert ergebnis.frames, (
+        "Testaufbau: der ICON-D2-Fallback lieferte keine Frames."
+    )
+
+    zeile = _letzte_radar_zeile()
+    assert zeile.get("outcome") == "fallback", (
+        f"AC-6: ein INCA-Ausfall mit erfolgreichem Ersatz muss "
+        f"outcome='fallback' hinterlassen (NICHT 'ok' -- heute erscheint "
+        f"dieser Fall identisch zu einem gesunden INCA-Abruf), bekommen "
+        f"{zeile.get('outcome')!r} (ganze Zeile: {zeile})"
+    )
+    assert zeile.get("detail") == "ICON-D2", (
+        f"AC-6: `detail` muss die tatsaechlich verwendete Ersatzquelle "
+        f"nennen ('ICON-D2'), bekommen {zeile.get('detail')!r} "
+        f"(ganze Zeile: {zeile})"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-7: INCA erfolgreich -> outcome bleibt "ok" (Regressionsschutz #1581)
+# ---------------------------------------------------------------------------
+
+def test_ac7_inca_erfolg_bleibt_ok(monkeypatch) -> None:
+    assert _radar_zeilen() == [], (
+        "Testaufbau: Journal muss vor dem Abruf leer sein."
+    )
+    monkeypatch.setattr(GeoSphereProvider, "fetch_nowcast", _inca_erfolgreich)
+
+    dienst = _dienst()
+    ergebnis = dienst.get_nowcast(_LAT, _LON)
+
+    # Vorbedingung: es war wirklich der gesunde INCA-Pfad, keine Vertretung.
+    assert ergebnis.source == "INCA", (
+        f"Testaufbau: erwartete Quelle 'INCA', bekommen {ergebnis.source!r} "
+        f"-- dann lief nicht der erwartete Erfolgs-Zweig."
+    )
+
+    zeile = _letzte_radar_zeile()
+    assert zeile.get("outcome") == "ok", (
+        f"AC-7: ein erfolgreicher INCA-Abruf muss weiterhin outcome='ok' "
+        f"hinterlassen (Regressionsschutz #1581 -- die neue elif-"
+        f"Verzweigung darf den bisherigen Erfolgsfall nicht mit-fangen), "
+        f"bekommen {zeile.get('outcome')!r} (ganze Zeile: {zeile})"
+    )
+    assert zeile.get("outcome") != "fallback", (
+        "AC-7: ein erfolgreicher INCA-Abruf darf NICHT als 'fallback' "
+        "gebucht werden."
+    )

--- a/tests/tdd/test_snowgrid_enrichment_health.py
+++ b/tests/tdd/test_snowgrid_enrichment_health.py
@@ -1,0 +1,307 @@
+"""TDD RED -- Issue #1992 Amendment: Health-Journal von SNOWGRID.
+
+Spec: docs/specs/modules/feat_1992_geosphere_health_amendment.md (AC-1..AC-3).
+Vorbild: tests/tdd/test_thunder_enrichment_health_journal.py (#1581).
+
+Deckt hier ab: AC-1 (echter Fehler in `fetch_snowgrid` -> `path="snowgrid"`,
+`outcome="unavailable"`, Rueckgabe bleibt `(None, None)`), AC-2 (regulaerer
+Abruf -> `outcome="ok"`), AC-3 (Regressions-Leitplanke, WICHTIGSTES AC:
+`fetch_combined`/`fetch_forecast` duerfen NIEMALS an einem SNOWGRID-Fehler
+scheitern -- auch nicht an einer generischen, NICHT-httpx Exception).
+
+===========================================================================
+Kein Mock-Theater
+===========================================================================
+Der Netzzugriff wird durch eine Ersatzklasse fuer `httpx.Client` vertreten,
+die ECHTE `httpx.Response`-Objekte liefert bzw. echte `httpx`-Exceptions
+wirft (Muster `_ScriptedClient`, tests/unit/test_radar_upstream_failure.py)
+-- kein `Mock()`, kein `patch()` von Rueckgabewerten. Fuer AC-3 wird gezielt
+`fetch_snowgrid` selbst per Monkeypatch zum Scheitern gebracht (so von der
+Spec als Testmethode benannt) -- das beobachtete Verhalten ist danach der
+ECHTE Rueckgabewert/die ECHTEN Datenpunkte von `fetch_combined()`/
+`fetch_forecast()`, kein interner Aufruf-Zaehler. Das Journal wird ECHT
+geschrieben und als JSONL geparst gelesen -- kein Substring-Test.
+
+===========================================================================
+Erwartete Rotfaerbung
+===========================================================================
+Alle Tests hier sind heute rot:
+* AC-1/AC-2: `path="snowgrid"` existiert im Journal ueberhaupt nicht (weder
+  `PATH_SNOWGRID` noch ein Aufruf von `log_enrichment_call` in
+  `fetch_snowgrid`) -- jede Journal-Zusicherung scheitert an "keine Zeile".
+* AC-3: `fetch_combined()` ruft `fetch_snowgrid()` heute UNGESCHUETZT auf
+  (kein try/except). Wirft `fetch_snowgrid` eine generische Exception (hier
+  `KeyError`, wie von der Spec als Beispiel genannt), propagiert sie durch
+  `fetch_combined()` und (da `fetch_forecast()`s aeusseres except nur
+  `httpx.HTTPStatusError`/`httpx.RequestError` faengt) auch durch
+  `fetch_forecast()` bis zum Testaufruf -- `pytest.fail()` macht diesen
+  Fehlschlag als klaren RED-Befund sichtbar statt eines unklaren Tracebacks.
+
+Ausfuehrung:
+    uv run pytest tests/tdd/test_snowgrid_enrichment_health.py \
+        --disable-socket --allow-unix-socket -v
+"""
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import List, Optional
+
+import httpx
+import pytest
+
+_SRC = Path(__file__).resolve().parents[2] / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from app.config import Location  # noqa: E402
+from providers.geosphere import GeoSphereProvider  # noqa: E402
+
+_JOURNAL_UNTERPFAD = ("diagnostics", "enrichment_calls.jsonl")
+
+_LAT, _LON = 46.40, 12.52  # innerhalb SNOWGRID_BOUNDS (Alpen)
+
+
+# ---------------------------------------------------------------------------
+# Fake-Client -- ersetzt den httpx.Client der GeoSphereProvider-Instanz,
+# liefert ECHTE httpx.Response-Objekte bzw. wirft ECHTE httpx-Exceptions.
+# ---------------------------------------------------------------------------
+
+class _FakeClient:
+    def __init__(self, antwort_fn) -> None:
+        self._antwort_fn = antwort_fn
+
+    def get(self, url: str, *a, **kw):
+        return self._antwort_fn(url)
+
+    def close(self) -> None:
+        pass
+
+
+def _antwort_404(url: str) -> httpx.Response:
+    """Nicht-retryable HTTP-Fehler (404 ist nicht in RETRY_STATUS_CODES
+    {502,503,504}) -- vermeidet tenacity-Retries mit Wartezeit im Test."""
+    return httpx.Response(
+        404, request=httpx.Request("GET", url), json={"error": "not found"},
+    )
+
+
+def _wirft_timeout(url: str):
+    """`httpx.TimeoutException` (Basisklasse, NICHT `ReadTimeout`) --
+    `_is_retryable_error` prueft explizit nur auf `ConnectError`/
+    `ReadTimeout`, die Basisklasse loest also KEINEN Retry aus."""
+    raise httpx.TimeoutException("Zeitueberschreitung im Test")
+
+
+def _wirft_request_error(url: str):
+    """`httpx.RequestError` (Basisklasse) -- ebenfalls kein Retry-Trigger."""
+    raise httpx.RequestError("Verbindungsfehler im Test")
+
+
+def _antwort_snowgrid_erfolg(url: str) -> httpx.Response:
+    body = {
+        "features": [{"properties": {"parameters": {
+            "snow_depth": {"data": [0.10, 0.15, 0.20]},
+            "swe_tot": {"data": [10.0, 15.0, 20.0]},
+        }}}],
+    }
+    return httpx.Response(200, request=httpx.Request("GET", url), json=body)
+
+
+def _antwort_nwp_erfolg(url: str) -> httpx.Response:
+    """Gueltige AROME-Antwort fuer `fetch_nwp_forecast` -- noetig, damit
+    `fetch_combined()`/`fetch_forecast()` in AC-3 ueberhaupt bis zum
+    SNOWGRID-Aufruf durchlaufen. Der Open-Meteo-Wolken-Zusatzabruf
+    (`_fetch_openmeteo_clouds`, laeuft bei `fetch_forecast()` IMMER mit)
+    ist selbst fail-soft -- ein Fehlschlag dort wird geschluckt und liefert
+    nur leere Wolkendaten, deshalb wirft dieser Fake fuer jede
+    open-meteo.com-URL bewusst einen (abgefangenen) Fehler."""
+    if "open-meteo.com" in url:
+        raise httpx.RequestError("Wolken-Zusatzabruf im Test nicht verkabelt")
+    jetzt = datetime.now(timezone.utc)
+    ts = [
+        (jetzt + timedelta(hours=h)).strftime("%Y-%m-%dT%H:%M+00:00")
+        for h in range(1, 4)
+    ]
+    body = {
+        "timestamps": ts,
+        "features": [{"properties": {"parameters": {
+            "t2m": {"data": [10.0, 10.5, 11.0]},
+            "u10m": {"data": [1.0, 1.0, 1.0]},
+            "v10m": {"data": [1.0, 1.0, 1.0]},
+            "ugust": {"data": [2.0, 2.0, 2.0]},
+            "vgust": {"data": [2.0, 2.0, 2.0]},
+            "rr_acc": {"data": [0.0, 0.0, 0.0]},
+            "snow_acc": {"data": [0.0, 0.0, 0.0]},
+            "snowlmt": {"data": [None, None, None]},
+            "tcc": {"data": [0.5, 0.5, 0.5]},
+            "rh2m": {"data": [50, 50, 50]},
+            "sp": {"data": [101300, 101300, 101300]},
+        }}}],
+    }
+    return httpx.Response(200, request=httpx.Request("GET", url), json=body)
+
+
+# ---------------------------------------------------------------------------
+# Journal-Helfer -- bewusst lokale Kopie (Testplumbing, kein geteilter
+# Prueflingsbaustein), s. Docstring test_thunder_enrichment_health_journal.py.
+# ---------------------------------------------------------------------------
+
+def _journalpfad() -> Path:
+    from app.loader import get_data_root
+    return get_data_root().joinpath(*_JOURNAL_UNTERPFAD)
+
+
+def _zeilen() -> List[dict]:
+    pfad = _journalpfad()
+    if not pfad.is_file():
+        return []
+    return [json.loads(z) for z in pfad.read_text().splitlines() if z.strip()]
+
+
+def _snowgrid_zeilen() -> List[dict]:
+    return [z for z in _zeilen() if z.get("path") == "snowgrid"]
+
+
+def _letzte_snowgrid_zeile() -> dict:
+    zeilen = _snowgrid_zeilen()
+    assert zeilen, (
+        f"Keine Journalzeile mit path='snowgrid' in {_journalpfad()} -- "
+        f"vorhandene Zeilen: {_zeilen()}. Ohne PATH_SNOWGRID/den Journal-"
+        f"Aufruf in fetch_snowgrid() entsteht die Datei gar nicht erst."
+    )
+    return zeilen[-1]
+
+
+# ---------------------------------------------------------------------------
+# AC-1: echter Fehler -> outcome="unavailable", Rueckgabe bleibt (None, None)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "bezeichnung,antwort_fn",
+    [
+        ("httpx.HTTPStatusError (404)", _antwort_404),
+        ("httpx.TimeoutException", _wirft_timeout),
+        ("httpx.RequestError", _wirft_request_error),
+    ],
+)
+def test_ac1_snowgrid_fehler_schreibt_unavailable_und_bleibt_fail_soft(
+    bezeichnung: str, antwort_fn,
+) -> None:
+    assert _snowgrid_zeilen() == [], (
+        f"Testaufbau ({bezeichnung}): Journal muss vor dem Abruf leer sein."
+    )
+    provider = GeoSphereProvider(client=_FakeClient(antwort_fn))
+
+    ergebnis = provider.fetch_snowgrid(_LAT, _LON)
+
+    assert ergebnis == (None, None), (
+        f"AC-1 ({bezeichnung}): fetch_snowgrid() muss bei einem Fehler "
+        f"weiterhin (None, None) liefern (fail-soft, unveraendertes "
+        f"Rueckgabeverhalten), bekommen {ergebnis!r}"
+    )
+
+    zeile = _letzte_snowgrid_zeile()
+    assert zeile.get("outcome") == "unavailable", (
+        f"AC-1 ({bezeichnung}): erwartet outcome='unavailable', bekommen "
+        f"{zeile.get('outcome')!r} (ganze Zeile: {zeile})"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-2: regulaerer Abruf -> outcome="ok"
+# ---------------------------------------------------------------------------
+
+def test_ac2_snowgrid_erfolg_schreibt_ok_zeile() -> None:
+    assert _snowgrid_zeilen() == [], (
+        "Testaufbau: Journal muss vor dem Abruf leer sein."
+    )
+    provider = GeoSphereProvider(client=_FakeClient(_antwort_snowgrid_erfolg))
+
+    ergebnis = provider.fetch_snowgrid(_LAT, _LON)
+
+    assert ergebnis == (20.0, 20.0), (
+        f"Testaufbau: unerwartetes Parse-Ergebnis {ergebnis!r} -- die "
+        f"Journalzeile unten wuerde einen anderen Ausgang beschreiben."
+    )
+
+    zeilen = _snowgrid_zeilen()
+    assert len(zeilen) == 1, (
+        f"AC-2: erwartet GENAU eine snowgrid-Zeile, bekommen {len(zeilen)}: "
+        f"{zeilen}"
+    )
+    assert zeilen[0].get("outcome") == "ok", (
+        f"AC-2: erwartet outcome='ok', bekommen {zeilen[0].get('outcome')!r} "
+        f"(ganze Zeile: {zeilen[0]})"
+    )
+    unverfuegbar = [z for z in zeilen if z.get("outcome") == "unavailable"]
+    assert unverfuegbar == [], (
+        f"AC-2: bei Erfolg darf keine 'unavailable'-Zeile entstehen, "
+        f"gefunden: {unverfuegbar}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-3 (Regressions-Leitplanke, wichtigstes AC): SNOWGRID-Fehler darf die
+# Grundvorhersage NIEMALS zum Scheitern bringen -- auch keine httpx-Klasse.
+# ---------------------------------------------------------------------------
+
+def _snowgrid_wirft_generisch(lat: float, lon: float):
+    """Simuliert einen Fehler INNERHALB von `_parse_snowgrid_response`
+    (z.B. unerwartete API-Antwortform) -- eine `KeyError`, wie von der Spec
+    selbst als Beispiel benannt. KEINE `httpx`-Klasse: der spezifische
+    Except in `fetch_snowgrid` selbst (Punkt 2 der Spec) faengt diese
+    Exception NICHT -- nur eine zusaetzliche, breitere Absicherung in
+    `fetch_combined` (Punkt 3) kann sie auffangen. Genau das ist die
+    Leitplanke, die dieser Test bewacht."""
+    raise KeyError("unerwartete SNOWGRID-Antwortform (simuliert)")
+
+
+def test_ac3_snowgrid_fehler_laesst_grundvorhersage_nicht_scheitern() -> None:
+    ort = Location(latitude=_LAT, longitude=_LON, name="Testort")
+
+    # -- fetch_combined() direkt --
+    provider = GeoSphereProvider(client=_FakeClient(_antwort_nwp_erfolg))
+    provider.fetch_snowgrid = _snowgrid_wirft_generisch  # type: ignore[method-assign]
+
+    try:
+        kombiniert = provider.fetch_combined(
+            lat=_LAT, lon=_LON, include_snow=True,
+        )
+    except Exception as e:  # noqa: BLE001 -- genau das ist die Zusicherung
+        pytest.fail(
+            f"AC-3: fetch_combined() darf NIEMALS an einem SNOWGRID-Fehler "
+            f"scheitern (Regressions-Leitplanke fehlt), bekommen "
+            f"{type(e).__name__}: {e}"
+        )
+
+    assert kombiniert.data, (
+        "Testaufbau: fetch_combined() lieferte keine Datenpunkte -- dann "
+        "prueft der Test unten nichts Sinnvolles."
+    )
+    assert all(dp.snow_depth_cm is None for dp in kombiniert.data), (
+        "AC-3: bei einem SNOWGRID-Fehler duerfen keine Schneefelder gesetzt "
+        "sein (die Grundvorhersage bleibt unbeschaedigt, aber ohne Schnee)."
+    )
+
+    # -- fetch_forecast() (der tatsaechliche Provider-Protokoll-Einstieg) --
+    provider2 = GeoSphereProvider(client=_FakeClient(_antwort_nwp_erfolg))
+    provider2.fetch_snowgrid = _snowgrid_wirft_generisch  # type: ignore[method-assign]
+
+    try:
+        vorhersage = provider2.fetch_forecast(ort)
+    except Exception as e:  # noqa: BLE001
+        pytest.fail(
+            f"AC-3: fetch_forecast() darf NIEMALS an einem SNOWGRID-Fehler "
+            f"scheitern, bekommen {type(e).__name__}: {e}"
+        )
+
+    assert vorhersage.data, (
+        "Testaufbau: fetch_forecast() lieferte keine Datenpunkte."
+    )
+    assert all(dp.snow_depth_cm is None for dp in vorhersage.data), (
+        "AC-3: auch ueber fetch_forecast() duerfen bei einem SNOWGRID-"
+        "Fehler keine Schneefelder gesetzt sein."
+    )

--- a/tests/tdd/test_snowgrid_enrichment_health.py
+++ b/tests/tdd/test_snowgrid_enrichment_health.py
@@ -47,7 +47,7 @@ import json
 import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import List, Optional
+from typing import List
 
 import httpx
 import pytest

--- a/tests/tdd/test_thunder_additive_enrichment_health.py
+++ b/tests/tdd/test_thunder_additive_enrichment_health.py
@@ -1,0 +1,292 @@
+"""TDD RED -- Issue #1992 Amendment: Health-Journal der additiven
+Gewitter-Zusatzquelle (`geosphere` in `DE_ALPEN`, #1758).
+
+Spec: docs/specs/modules/feat_1992_geosphere_health_amendment.md (AC-4, AC-5).
+Vorbild: tests/tdd/test_thunder_enrichment_health_journal.py (#1581).
+
+Deckt hier ab: AC-4 (additive Quelle scheitert -> `path="thunder_additive"`,
+`outcome="unavailable"`, `detail="geosphere"`, getrennt von `path="thunder"`),
+AC-5 (additive Quelle liefert, mit oder ohne gefuellte Werte ->
+`outcome="ok"`, Primaerquelle bleibt in Zeilenzahl/Inhalt unveraendert).
+
+===========================================================================
+Kein Mock-Theater
+===========================================================================
+Beide Quellen (Primaer- und Zusatzquelle) werden durch FAKE-Provider
+vertreten, die `providers.base.ThunderSignalProvider` strukturell erfuellen
+(Muster tests/unit/test_thunder_source_substitution.py) -- kein `Mock()`,
+kein `patch()`, kein `MagicMock`. Das Journal wird ECHT geschrieben (durch
+den Prueflingspfad `thunder_enrichment._fetch_lightning_density`) und ECHT
+gelesen (JSONL geparst, Felder geprueft).
+
+`providers.thunder_routing.thunder_providers_for` wird auf eine feste
+Quellenliste `("de_direct", "geosphere")` gezwungen (analog #1758 DE_ALPEN)
+-- so kann keine ECHTE Zusatzquelle unbemerkt mitfahren und eine im Test
+nicht erwartete Journalzeile erzeugen.
+
+===========================================================================
+Erwartete Rotfaerbung
+===========================================================================
+AC-4 und AC-5 sind heute rot: die Zusatzquellen-Schleife in
+`_fetch_lightning_density` (thunder_enrichment.py:589-604) journalt heute
+NICHTS -- weder Erfolg noch Fehlschlag, nur ein `logger.warning` beim
+Fehlschlag. `path="thunder_additive"` existiert im Journal ueberhaupt nicht
+(auch `PATH_THUNDER_ADDITIVE` fehlt noch in enrichment_health.py). Jede
+Journal-Zusicherung scheitert an "keine Zeile".
+
+Ausfuehrung:
+    uv run pytest tests/tdd/test_thunder_additive_enrichment_health.py \
+        --disable-socket --allow-unix-socket -v
+"""
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Dict, List, Optional
+
+_SRC = Path(__file__).resolve().parents[2] / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from app.config import Location  # noqa: E402
+from app.models import (  # noqa: E402
+    ForecastDataPoint,
+    ForecastMeta,
+    NormalizedTimeseries,
+    Provider,
+)
+from providers import base, thunder_enrichment, thunder_routing  # noqa: E402
+
+_ORT = Location(latitude=47.26, longitude=11.39, name="Testort DE_ALPEN")
+
+_JOURNAL_UNTERPFAD = ("diagnostics", "enrichment_calls.jsonl")
+
+
+# ---------------------------------------------------------------------------
+# Fakes -- erfuellen providers.base.ThunderSignalProvider strukturell
+# (uebernommen aus tests/unit/test_thunder_source_substitution.py)
+# ---------------------------------------------------------------------------
+
+class _FakeQuelle:
+    def __init__(
+        self, name: str, *, wirft: bool = False,
+        signale: Optional[Dict[str, Dict[int, float]]] = None,
+    ) -> None:
+        self._name = name
+        self._wirft = wirft
+        self._signale = signale or {}
+        self.call_count = 0
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def fetch_thunder_signals(self, location, start=None, end=None):
+        return {}
+
+    def fetch_thunder_signals_named(self, location, start=None, end=None):
+        self.call_count += 1
+        if self._wirft:
+            raise RuntimeError(f"Zusatzquelle '{self._name}' nicht erreichbar (simuliert)")
+        return self._signale
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _reihe(stunden: int = 4) -> NormalizedTimeseries:
+    start = datetime.now(timezone.utc).replace(minute=0, second=0, microsecond=0)
+    data = [
+        ForecastDataPoint(ts=start + timedelta(hours=h), t2m_c=9.5, wind10m_kmh=12.0)
+        for h in range(1, stunden + 1)
+    ]
+    meta = ForecastMeta(provider=Provider.DWD, model="TEST", grid_res_km=2.2)
+    return NormalizedTimeseries(meta=meta, data=data)
+
+
+def _patch_provider(monkeypatch, mapping: dict) -> None:
+    def _get(name):
+        if name not in mapping:
+            raise base.ProviderNotFoundError(name)
+        return mapping[name]
+    monkeypatch.setattr(base, "get_provider", _get, raising=True)
+
+
+def _patch_quellen_de_alpen(monkeypatch) -> None:
+    """Zwingt die Zustaendigkeitsaufloesung auf die #1758-DE_ALPEN-Kette
+    `("de_direct", "geosphere")` -- primaer + EINE additive Zusatzquelle."""
+    monkeypatch.setattr(
+        thunder_routing, "thunder_providers_for",
+        lambda lat, lon: ("de_direct", "geosphere"), raising=True,
+    )
+
+
+def _journalpfad() -> Path:
+    from app.loader import get_data_root
+    return get_data_root().joinpath(*_JOURNAL_UNTERPFAD)
+
+
+def _zeilen() -> List[dict]:
+    pfad = _journalpfad()
+    if not pfad.is_file():
+        return []
+    return [json.loads(z) for z in pfad.read_text().splitlines() if z.strip()]
+
+
+def _thunder_zeilen() -> List[dict]:
+    return [z for z in _zeilen() if z.get("path") == "thunder"]
+
+
+def _thunder_additive_zeilen() -> List[dict]:
+    return [z for z in _zeilen() if z.get("path") == "thunder_additive"]
+
+
+def _letzte_thunder_additive_zeile() -> dict:
+    zeilen = _thunder_additive_zeilen()
+    assert zeilen, (
+        f"Keine Journalzeile mit path='thunder_additive' in {_journalpfad()} "
+        f"-- vorhandene Zeilen: {_zeilen()}. Die Zusatzquellen-Schleife in "
+        f"_fetch_lightning_density journalt heute nichts."
+    )
+    return zeilen[-1]
+
+
+# ---------------------------------------------------------------------------
+# AC-4: additive Quelle scheitert -> outcome="unavailable", detail="geosphere"
+# ---------------------------------------------------------------------------
+
+def test_ac4_additive_quelle_scheitert_schreibt_unavailable_getrennt_von_thunder(
+    monkeypatch,
+) -> None:
+    assert _zeilen() == [], (
+        "Testaufbau: Journal muss vor dem Abruf leer sein."
+    )
+    reihe = _reihe()
+    primaer = _FakeQuelle(
+        "de_direct", signale={"lpi": {h: 3.0 for h in range(1, 5)}},
+    )
+    additiv = _FakeQuelle("geosphere", wirft=True)
+    _patch_quellen_de_alpen(monkeypatch)
+    _patch_provider(monkeypatch, {"de_direct": primaer, "geosphere": additiv})
+
+    thunder_enrichment._fetch_lightning_density(reihe, _ORT, None)
+
+    assert additiv.call_count == 1, (
+        f"Testaufbau: die additive Quelle wurde {additiv.call_count}x "
+        f"gerufen, erwartet genau einmal."
+    )
+
+    zeile = _letzte_thunder_additive_zeile()
+    assert zeile.get("outcome") == "unavailable", (
+        f"AC-4: eine scheiternde additive Quelle muss outcome='unavailable' "
+        f"hinterlassen, bekommen {zeile.get('outcome')!r} "
+        f"(ganze Zeile: {zeile})"
+    )
+    assert zeile.get("detail") == "geosphere", (
+        f"AC-4: `detail` muss die additive Quelle nennen ('geosphere'), "
+        f"bekommen {zeile.get('detail')!r} (ganze Zeile: {zeile})"
+    )
+
+    # Trennungsnachweis: die primaerquellen-Zeile (`path='thunder'`) darf
+    # durch den additiven Fehlschlag NICHT beruehrt werden -- genau EINE
+    # Zeile, aus dem erfolgreichen Primaerabruf.
+    thunder_zeilen = _thunder_zeilen()
+    assert len(thunder_zeilen) == 1, (
+        f"AC-4: erwartet GENAU eine 'thunder'-Zeile (Primaerquelle), "
+        f"bekommen {len(thunder_zeilen)}: {thunder_zeilen} -- der additive "
+        f"Fehlschlag darf keine zusaetzliche Zeile unter path='thunder' "
+        f"erzeugen (Trennungsnachweis)."
+    )
+    assert thunder_zeilen[0].get("outcome") == "ok", (
+        f"Testaufbau: die Primaerquelle hat geliefert -- erwartet "
+        f"outcome='ok' unter path='thunder', bekommen "
+        f"{thunder_zeilen[0].get('outcome')!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-5: additive Quelle liefert (gefuellt oder leer) -> outcome="ok"
+# ---------------------------------------------------------------------------
+
+def test_ac5_additive_quelle_erfolg_mit_werten_schreibt_ok(monkeypatch) -> None:
+    assert _zeilen() == [], "Testaufbau: Journal muss vor dem Abruf leer sein."
+    reihe = _reihe()
+    primaer = _FakeQuelle(
+        "de_direct", signale={"lpi": {h: 3.0 for h in range(1, 5)}},
+    )
+    additiv = _FakeQuelle(
+        "geosphere", signale={"cape": {h: 250.0 for h in range(1, 5)}},
+    )
+    _patch_quellen_de_alpen(monkeypatch)
+    _patch_provider(monkeypatch, {"de_direct": primaer, "geosphere": additiv})
+
+    thunder_enrichment._fetch_lightning_density(reihe, _ORT, None)
+
+    assert any(
+        getattr(dp, "cape_geosphere_jkg", None) == 250.0 for dp in reihe.data
+    ), (
+        "Testaufbau: die additive Quelle hat keine Werte in die Reihe "
+        "eingetragen -- der Test unten prueft dann den falschen Ausgang."
+    )
+
+    zeile = _letzte_thunder_additive_zeile()
+    assert zeile.get("outcome") == "ok", (
+        f"AC-5: eine erfolgreiche additive Quelle mit gefuellten Werten "
+        f"muss outcome='ok' hinterlassen, bekommen {zeile.get('outcome')!r} "
+        f"(ganze Zeile: {zeile})"
+    )
+    assert zeile.get("detail") == "geosphere", (
+        f"AC-5: `detail` muss die additive Quelle nennen ('geosphere'), "
+        f"bekommen {zeile.get('detail')!r} (ganze Zeile: {zeile})"
+    )
+
+    thunder_zeilen = _thunder_zeilen()
+    assert len(thunder_zeilen) == 1, (
+        f"AC-5: die Primaerquelle darf durch die additive Quelle nicht "
+        f"beeinflusst werden -- erwartet GENAU eine 'thunder'-Zeile, "
+        f"bekommen {len(thunder_zeilen)}: {thunder_zeilen}"
+    )
+
+
+def test_ac5_additive_quelle_erfolg_leer_schreibt_ebenfalls_ok(monkeypatch) -> None:
+    """AC-5, zweite Auspraegung: die additive Quelle antwortet gueltig, aber
+    ohne einen einzigen Wert -- auch das ist ein Erfolg ('kein Gewitter in
+    Sicht'), kein Ausfall (dieselbe Regel wie bei der Primaerquelle)."""
+    assert _zeilen() == [], "Testaufbau: Journal muss vor dem Abruf leer sein."
+    reihe = _reihe()
+    primaer = _FakeQuelle(
+        "de_direct", signale={"lpi": {h: 3.0 for h in range(1, 5)}},
+    )
+    additiv = _FakeQuelle("geosphere", signale={})
+    _patch_quellen_de_alpen(monkeypatch)
+    _patch_provider(monkeypatch, {"de_direct": primaer, "geosphere": additiv})
+
+    thunder_enrichment._fetch_lightning_density(reihe, _ORT, None)
+
+    assert additiv.call_count == 1, (
+        f"Testaufbau: die additive Quelle wurde {additiv.call_count}x "
+        f"gerufen, erwartet genau einmal."
+    )
+    assert all(
+        getattr(dp, "cape_geosphere_jkg", None) is None for dp in reihe.data
+    ), (
+        "Testaufbau: es wurde doch ein Wert gesetzt -- dann ist es nicht "
+        "der 'leere Antwort'-Ausgang."
+    )
+
+    zeile = _letzte_thunder_additive_zeile()
+    assert zeile.get("outcome") == "ok", (
+        f"AC-5: eine leere, aber gueltige Antwort der additiven Quelle muss "
+        f"ebenfalls outcome='ok' hinterlassen (sonst meldet jede ruhige "
+        f"Wetterlage einen Dauerausfall), bekommen "
+        f"{zeile.get('outcome')!r} (ganze Zeile: {zeile})"
+    )
+
+    thunder_zeilen = _thunder_zeilen()
+    assert len(thunder_zeilen) == 1, (
+        f"AC-5: erwartet GENAU eine 'thunder'-Zeile (Primaerquelle "
+        f"unveraendert), bekommen {len(thunder_zeilen)}: {thunder_zeilen}"
+    )


### PR DESCRIPTION
## Summary
- Ursprünglicher TLS-Befund (Audit B-02) widerlegt: Audit testete den falschen Host (`dataset.api.hub.zamg.ac.at` statt `dataset.api.hub.geosphere.at`) — kein CA-Problem im Code
- Ticket umgeschnitten auf Amendment zum `enrichment_health`-Journal (#1581): SNOWGRID, Gewitter-Zusatzquelle und Radar-INCA-Fallback fielen bisher fail-soft still aus, ohne Journal-Eintrag
- Regressions-Leitplanke: ein SNOWGRID-Fehler kann jetzt nie mehr die komplette Grundvorhersage zum Scheitern bringen (`fetch_combined` fängt das ab)
- AC-8 beweist: kein Go-Code-Change nötig, der bestehende Aggregator gruppiert bereits generisch über `path`

## Test plan
- [x] 10/10 Ziel-Tests grün (3 Testdateien, 8 ACs)
- [x] 10/10 Go-Tests grün (`internal/scheduler`)
- [x] Regressionsprobe: 58 passed, 1 xfailed (vorbestehend), 0 Regressionen
- [x] Adversary-Dialog VERIFIED (HOLDS): 8/8 ACs bewiesen, 4/4 Mutationsproben gefangen
- [x] Scope-Check: exakt die in der Spec vorgesehenen Dateien, +83/-7 LoC

Spec: `docs/specs/modules/feat_1992_geosphere_health_amendment.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>