### PR TITLE
fix(#1948 S6): Alarm spricht die Sprache des Briefings

### DIFF
--- a/docs/context/feat-1948-s6-telegram-paritaet.md
+++ b/docs/context/feat-1948-s6-telegram-paritaet.md
@@ -166,3 +166,110 @@ SMS seit S3 nicht mehr. Erzeugung `utils/timezone.py:146-162` `format_reference_
 
 Ersatz für die H1 (in Frage 2 mit vorgelegt): `Gewitter mittel → hoch seit dem Briefing`,
 `Niedersch 2,0 mm → 18,0 mm seit dem Briefing`.
+
+---
+
+# Analyse (Phase 2) — gemessene Befunde
+
+## 🔴 A. Positionen vs. Abstände — die Korrektur am PO-Entscheid
+
+In derselben Zeile stehen zwei Sorten Zahl, die gleich aussehen:
+
+```
+Gewitter · Schwelle 1 · 2 ↑ 3 · Änderung über
+             ^Abstand    ^Positionen
+```
+
+| Wert | Bedeutung | Fundstellen | Zielform |
+|---|---|---|---|
+| `value_from`, `value_to` | **Position** auf der Leiter | `render.py:491,505,524,562,713,722,817` | **Wort** |
+| `threshold` | **Abstand** („ab 1 Stufe alarmieren") | `render.py:523,540,567,712` | Zahl **+ „Stufe(n)"** |
+| `abs(value_to-value_from)` | **Abstand** („um 1 Stufe geändert") | `render.py:566,711` | Zahl **+ „Stufe(n)"** |
+| Korridor `bound`, `value` | **Positionen** | `render.py:185,192-193` | **Wort** |
+
+`Schwelle leicht` (mein ursprünglicher Vorschlag) wäre eine **sachlich falsche Aussage** —
+Abstand 1 ist nicht Stufe 1. Herkunft `threshold`: `default_change_threshold=1.0`
+(`metric_catalog.py:435`) → `project.py:298`. Begründung der Zeilenbauart: Docstring
+`render.py:550-556` (ADR-0013: `threshold` ist immer die Δ-Schwelle).
+
+## 🔴 B. Rückfall bei unbekanntem Stufenwert — Sicherheitsfrage
+
+- **Produktiv sind nur 0–3 erreichbar:** `thunder_scale.py:48-57` `_THUNDER_ORDER.get(level, 0)`,
+  aufgerufen in `weather_change_detection.py:742-745,919-923,946-948`. Immer `int` 0–3.
+- **Der Vorschau-/Validator-Pfad prüft KEINEN Wertebereich:** `validator_render_service.py:130-147`
+  baut `WeatherChange` direkt aus `body.changes`; `api/routers/validator.py` prüft nur die
+  Metrik-Kennung (422 bei unbekannt, `tests/tdd/test_alert_preview_input_validation.py:96-110`).
+  Bestandsfixtures nutzen faktisch 10/20/30/55/70/80/90 als „thunder"-Werte.
+- **Umkehrfunktion existiert:** `_THUNDER_JE_ORDINAL` (`metric_format.py:359`) = `{0:NONE,1:LOW,2:MED,3:HIGH}`.
+  Gemessen: `.get(4)` → `None`, `.get(90)` → `None`. `THUNDER_LABEL_DE` ist **enum**-, nicht int-geschlüsselt.
+- **Gemessene Altlast:** der SMS-Zweig fällt für 4 auf `'-'` zurück (`render.py:856-857`,
+  `LEVELS.get(int(round(v)), '-')`) — **derselbe Glyph wie Stufe 0**. Gemessen: `TH:M->-` für 2→4,
+  `TH:-->-` für 20→90.
+- ⇒ **Ein Wort-Rückfall auf `"kein"` wäre gefährlich** (meldet Entwarnung, wo Unbekanntes steht).
+  Der Rückfall muss als *unbekannt* erkennbar sein.
+
+## C. Rundung
+
+`get_decimals("thunder") == 0`; `_val`:50 und `_num`:68 nutzen `round(v, 0)`,
+`_sms_token`:856-863 `int(round(v))` — Python-Bankersrundung. Gemessen: `2.5` → `2` (nicht 3).
+
+## D. Telegram-Kurzstil zieht die Stand-Zeile NICHT mit
+
+`_dispatch_alert_message` rendert alle Kanäle vorab (`notification_service.py:1355-1360`);
+der Kurzstil-Zweig (`:1447-1463`) sendet **`sms_body`**, nicht `telegram_body`, und steht
+bewusst **vor** dem Fan-out (`:1464`). ⇒ Die Stand-Zeile darf ausschließlich in
+`render_telegram` entstehen. Wächter dagegen: `test_telegram_kurzstil_trip_alert.py:315`
+(`payload["text"] == sms_text`) — er würde melden, wenn sie in `render_sms` landete.
+
+## E. Escaping
+
+Telegram escapt **nur die fette Kopfzeile** (`render.py:786,791,799,821`); `_email_line`,
+`metric_line`, `_corridor_line` gehen **unescapt** mit `parse_mode="HTML"` raus. Die vier
+Stufenwörter und alle drei `reference_at`-Varianten sind reines ASCII ohne `& < >` — unkritisch,
+aber die neue Zeile landet im unescapten Bereich.
+
+## F. `_email_line` ist falsch benannt
+
+`render.py:521-526` heißt „email", wird aber **ausschließlich** von `render_telegram`
+(`:799`) aufgerufen (verifiziert: nur zwei Treffer im Repo). Die E-Mail nutzt sie nicht.
+
+## G. Legacy-Shim ist toter Code
+
+`render_deviation_alert` (`render.py:1047-1069`) hat **keinen** Aufrufer in `src/` — nur drei
+Bestandstests (`test_issue_816_alert_deviation.py:437`, `test_bundle_791_847_844_alerts.py:299`,
+`test_trip_alert_profile.py:106`). Er hat einen **eigenen** Footer (`:1030-1059`), daher sind
+diese drei Tests von S6 nicht betroffen. **Nicht anfassen.**
+
+## H. Ortsvergleich bringt keine eigene Stelle mit
+
+`to_multi_point_alert_message` (`project.py:256-308`) hat **keinen eigenen Renderer-Code** —
+läuft durch dieselben Zeilen. Einzige compare-eigene Zahlenstelle ist der SMS-Zweig
+`render.py:863` (`2:+TH3@16`). Bei genau einem Ort landet man im Ein-Event-Zweig.
+
+## I. Regressionsfläche — Basislinie verifiziert grün (50 passed)
+
+`tests/tdd/{test_978_deviation_line_readability,test_957_alert_mail_literal_structure,`
+`test_alert_multi_event_where_when,test_alert_change_amount_wording,test_alert_renderer_format_bugs}.py`
+
+**Wird ROT (bewusst nachzuziehen):**
+
+| Datei:Zeile | Auslöser | Art |
+|---|---|---|
+| `test_978_deviation_line_readability.py:224,240,273,292,358,368` | Stufenwort | Teilstring + Regex `(Gewitter) \d` |
+| `test_957_alert_mail_literal_structure.py:56,59` | Prozent | berechneter Teilstring, importiert `delta_pct` in `:51` |
+| `test_issue_1169_compare_alert_consumer.py:755-769` | Prozent (3 Fundstellen) | **byte-genau** |
+| `test_issue_1169_compare_alert_consumer.py:770-773` | Stand-Zeile | **byte-genau** |
+| `test_alert_multi_event_where_when.py:129-134` | Stand-Zeile (`splitlines()[-1]`) | Position |
+
+**🔴 MUSS GRÜN BLEIBEN — Trennlinie Einheit vs. Änderung:**
+`test_channel_metric_matrix.py:2202-2220` (`%` als Einheit am Zeilenende) · `:2174-2199` ·
+`test_alert_change_amount_wording.py:290-303` (`90%` Regenwahrscheinlichkeit) ·
+`test_952_alert_mail_design_fidelity.py:73`.
+
+**Scheinwächter:** `test_957_alert_mail_literal_structure.py:46` (`"%" in html`) ist faktisch
+durch `width="100%"` (`render.py:588`) erfüllt und bewacht die Trennlinie **nicht**.
+
+**Bleibt grün, obwohl es nah dranliegt:** `test_alert_bundle_958ff.py:147` (`tail` ist bereits
+konditional) · `test_alert_change_amount_wording.py:283` (`splitlines()[1]`, nicht `[-1]`) ·
+`test_alert_location_vocabulary.py:359,386` (nur Zeile 0) · `test_alert_sms_delta_notation.py:82-95`
+(SMS bleibt Buchstaben) · `test_channel_metric_matrix.py:2107-2160` (Fixture `0.0→2.0`, hatte nie Prozent).

--- a/docs/context/feat-1948-s6-telegram-paritaet.md
+++ b/docs/context/feat-1948-s6-telegram-paritaet.md
@@ -1,0 +1,168 @@
+# Context: #1948 S6 — Telegram-Parität (Alarm-Darstellung)
+
+**Workflow:** `feat-1948-s6-telegram-paritaet` · Branch `feat-1948-s6-telegram-paritaet`
+· Worktree `.claude/worktrees/intake-1948-s5` · Basis `origin/main` @ `b31acb40` (S5-Merge)
+· Track **Full Process** (Intake-Summe 4)
+
+## Request Summary
+
+Der Änderungs-Alarm gibt in den ausführlichen Kanälen die **interne Rohzahl** der
+Gewitterstufe aus (`2 ↑ 3`) und rechnet darauf eine **prozentuale Änderung**
+(`+50 %`). Beides widerspricht dem Rest des Produkts: das Briefing nennt die
+Gewitterstufe überall als deutsches Wort, und eine Prozentquote auf einer
+Ordinalskala ist bedeutungslos. Zusätzlich fehlt dem Telegram-Alarm die
+Stand-/Vergleichszeile, die die E-Mail führt.
+
+## 🔴 Alles Folgende ist GEMESSEN, nicht aus dem Quelltext abgeleitet
+
+Drei Messläufe am HEAD `b31acb40`, Renderer direkt aufgerufen (kein Versand).
+
+### Ist-Zustand Änderungs-Alarm, Gewitter Stufe 2 → 3
+
+```
+Betreff:   [TESTTRIP] km 0–4 · ↑ Gewitter: 2→3
+E-Mail:    Gewitter +50% seit dem Briefing
+           ↑ +50 % · Änderung über deiner Alarm-Schwelle (1)
+           Gewitter · : 2 ↑ 3 +50 %
+           Änderung 1: über Alarm-Schwelle 1 ✗
+           Wo & wann: km 0–4 · 15:00
+           Stand: heute 09:30 · verglichen mit dem letzten Briefing
+Telegram:  TESTTRIP · km 0–4 · ↑ Gewitter
+           Gewitter · Schwelle 1 · 2 ↑ 3 · Änderung über
+SMS:       km 0-4: TH:M->H@15
+```
+
+Mehr-Event-Fall (Gewitter 2→3 + Sicht 1400→280):
+```
+Telegram:  KHW 403 · 🏁 Ziel · 2 über Schwelle
+           Gewitter 🏁 Ziel · 16:00 2→3 · Sicht 🏁 Ziel · 14:00 1.400→280 m
+E-Mail:    Gewitter · 🏁 Ziel · 16:00 · Änderung 1 · Schwelle 1: 2 ↑ 3 über
+```
+
+### Ist-Vokabular der Gewitterstufe im übrigen Produkt
+
+**SSoT:** `src/output/metric_format.py:283-288`
+```python
+THUNDER_LABEL_DE = {NONE: "kein", LOW: "leicht", MED: "mittel", HIGH: "hoch"}
+```
+
+| Ort | Datei:Zeile | Darstellung |
+|---|---|---|
+| SMS (Briefing + Alarm) | `src/output/tokens/metrics.py:14` | `-` / `L` / `M` / `H` |
+| E-Mail Stundentabelle HTML | `email/helpers.py:773-776` | farbiger Ampelpunkt, **kein Text** |
+| E-Mail Stundentabelle Text | `email/helpers.py:762-772` | `kein`/`leicht`/`mittel`/`hoch` |
+| E-Mail Kurzzusammenfassung | `email/helpers.py:1784-1788` | `Gewitter mittel ab 16:00 · stärkste 18:00` |
+| E-Mail Ausblick „Gew" | `email/outlook.py:176-247` | `{Wort} @{H}` |
+| E-Mail Gewitter-Vorschau | `trip_report_scheduler.py:2607-2615` | `Starkes Gewitter erwartet ab 16:00` |
+| E-Mail Kompakt | `email/compact.py:97-116` | `⚡{Wort}@{H}` |
+| Telegram Briefing | `narrow.py:279-282`, `:538-543` | `⚡ {Wort}` |
+| Frontend Schwellen-UI | `compare_metric_catalog.py:66-68` | `Leicht`/`Mittel`/`Hoch` |
+| **Änderungs-Alarm** | `alert/render.py` | **Rohzahl 0–3** ← einziger Ausreißer |
+
+`thunder` ist die **einzige** Metrik mit `is_level=True` (`metric_catalog.py:446`).
+
+### Erreichbare Menge „berechnete Prozent-Änderung" (PO: entfällt grundsätzlich)
+
+**Genau eine Rechenstelle, genau zwei f-Strings, ein einziger Konsument.**
+
+- Rechnung: `alert/model.py:137-141` `delta_pct()` — `value_from == 0` → `None`
+- H1: `alert/render.py:515-517` `f" {d:+d}%"` (ohne Leerzeichen!)
+- Δ-Text: `alert/render.py:531-532` `f"{d:+d} %"` → Badge `:536-538`, Datenzeile `:558-563`
+- Import-Kante: `alert/render.py:23`
+- Einziger Konsument: `render_email()` `alert/render.py:646` → HTML `:766-776`, Plain `:742-746`
+
+**Nur im Ein-Event-Zweig** (`render.py:658` `single = len(evs) == 1`).
+
+**Entwarnungen (belegt, kein Prozent):** E-Mail-Betreff (`render_subject` `:466-509`
+ruft `delta_pct` nie) · Telegram (`:781-827`) · SMS (`:829-983`) · Radar-Alarm
+(`_render_email_onset`, `:647-651`) · amtlicher Alarm (`official_alerts.py`) ·
+Trip-Briefing (`day_comparison.py:76` = absolute Differenz; `narrow.py:373` nie `%`) ·
+Ortsvergleich (`comparison.py:72,84,112-114` = Einheit).
+
+**Grenzfall, Tech-Lead-Entscheid:** `email/helpers.py:1086-1100` `format_change_line()`
+erzeugt bei %-Einheiten Texte wie `+34 %` — das ist eine **vorzeichenbehaftete Differenz
+in Prozentpunkten**, dieselbe Sorte Zahl wie `+3 °C`, keine Quote. **Bleibt unverändert.**
+
+### Vergleichszeitpunkt (`reference_at`)
+
+Steht **ausschließlich** in der E-Mail: `alert/render.py:670-674` (Ein-Event),
+`:725-729` (Multi), `:1059` (Legacy-Shim #816). Telegram hat das Feld **nie** gelesen,
+SMS seit S3 nicht mehr. Erzeugung `utils/timezone.py:146-162` `format_reference_at()`
+(`"18:03"` / `"gestern 18:03 Uhr"` / `"vor N Tagen …"`), Durchreichung
+`trip_alert.py:361-376`, `compare_alert.py:286-308`, DTO `alert/model.py:122-126`.
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `src/output/renderers/alert/render.py` | **Kern.** `_h1`:511 · `_delta_text`:529 · `_verdict_single`:535 · `_datablock_single`:557 · `_email_line`:521 · `render_email`:646 · `render_telegram`:781 · `_num`:59 · `_val`:~40 · `_is_level_metric`:110 |
+| `src/output/renderers/alert/model.py` | `delta_pct`:137 · `reference_at`:122 |
+| `src/output/metric_format.py` | `THUNDER_LABEL_DE`:283 — Wort-SSoT, wird importiert statt kopiert |
+| `src/output/tokens/metrics.py` | `LEVELS`:14 — SMS-Buchstaben, **tabu** |
+| `src/app/metric_catalog.py` | `thunder`:428, `is_level=True`:446 |
+| `src/services/notification_service.py` | `:1355-1361` zentraler Renderpunkt; Telegram-Weiche `:1444-1520` |
+| `src/services/validator_render_service.py` | `:149-152` Alarm-Vorschau in der Oberfläche — dieselbe `AlertMessage` |
+
+## Existing Patterns
+
+- **Stufenleiter statt Messzahl** ist bereits gebaut: `_is_level_metric()` (`render.py:110`,
+  liest `MetricDefinition.is_level`) + `LEVELS`-Map — heute **nur** im SMS-Zweig
+  verdrahtet (`render.py:854-858`, Issue #1948 S3). Dasselbe Muster, andere Tabelle.
+- **Kanalabhängige Darstellung derselben Größe** ist etabliert und gewollt:
+  `Seg` (SMS) vs. `Segment` (Telegram/E-Mail) — S5 AC-13; führende Null nur in der SMS — S4 AC-11.
+- **Konditionales Weglassen** ist im Prozent-Pfad schon vorhanden: `tail`/`d_suffix` sind
+  bei `value_from == 0` bereits leer (`render.py:537-538`, `:558-559`) — der
+  „ohne Prozent"-Zustand ist also heute schon erreichbar und messbar.
+
+## Dependencies
+
+- **Upstream:** `metric_format.THUNDER_LABEL_DE` · `metric_catalog.get_metric().is_level`/`.unit`
+  · `alert/model.AlertEvent` · `utils/timezone.format_reference_at`
+- **Downstream:** `notification_service` (4 Versandwege: Trip-Δ, Compare-Δ einzeln,
+  Compare-Δ gebündelt, jeweils E-Mail + Telegram) · `validator_render_service` (Vorschau-API)
+
+## Existing Specs
+
+- `docs/specs/modules/fix_1948_s3_sms_sofortfix.md` — S3; `:207-210` merkt die S6-Frage vor
+- `docs/specs/modules/fix_1948_s5_amtliche_sms_zielbild.md` — S5; AC-13 = TABU-Wächter
+  für den ausführlichen Telegram-/E-Mail-Text des **amtlichen** Zweigs
+- `docs/analysis/alarm-format-konzept-2026-08.md` §8 — Scheiben-Tabelle, S6-Zuschnitt
+- `docs/reference/sms_format.md` §3.4c — `!`-Block, Stufenbuchstaben
+
+## Risks & Considerations
+
+1. **🔴 H1 verliert ohne Ersatz ihre Aussage.** Gemessen bei `value_from == 0`:
+   `Gewitter seit dem Briefing` — grammatisch defekt, kein Informationsträger mehr.
+   Prozent ist dort der **einzige** Träger (Von-/Bis-Werte stehen nicht in der H1).
+   Badge und Datenzeile vertragen den Wegfall dagegen ersatzlos (gemessen).
+2. **Byte-genaue Wächter werden rot** — bewusst nachzuziehen, nicht zu umgehen:
+   `tests/tdd/test_957_alert_mail_literal_structure.py:44-59` (fordert `%` im Verdikt,
+   importiert `delta_pct` in `:51`) · `tests/tdd/test_issue_1169_compare_alert_consumer.py:709,755-768`
+   (byte-genaue Plain-Gleichheit mit drei Prozent-Vorkommen).
+3. **🔴 Gegenprobe-Wächter muss GRÜN bleiben:** `tests/tdd/test_channel_metric_matrix.py:2202-2220`
+   fordert, dass `%` als **Einheit** erhalten bleibt. Ein pauschaler „%-Entfall" macht ihn rot —
+   er ist die Trennlinie zwischen (A) Einheit und (B) berechneter Änderung.
+4. **A/B stehen in einer Zeile nebeneinander.** Gemessen für `rain_probability` 60→90:
+   `Regen% · %: 60 % ↑ 90 % +50 %` — `60 %`/`90 %` Einheit, `+50 %` Quote, und in der
+   Folgezeile `Änderung 30 %` = Prozentpunkte. Nur das mittlere fällt weg.
+5. **Ortsvergleich zieht automatisch mit.** `render_email`/`render_telegram` bedienen Trip
+   **und** Ortsvergleich (`notification_service.py:628`/`:673`/`:695`). Das ist gewollte
+   Code-Teilung (CLAUDE.md), kein Ortsvergleich-Vorhaben — aber im Adversary zu prüfen.
+6. **Alarm-Vorschau in der Oberfläche ändert sich mit** (`validator_render_service.py:149-152`).
+7. **Nachbarsitzung #2009** (`gregor-zwanzig-26`, Branch `fix-2009-nowcast-vorlauf`) arbeitet
+   in derselben Datei an `render.py:371`, `:418`, `:435-463` (Onset-Tagesbezug, SMS + Telegram).
+   Abgestimmt: S6 fasst diese Zeilen **nicht** an und vereinheitlicht **keine** Zeitformatierung
+   (`local_fmt`, `%H:%M`). Wer zuerst auf `main` ist, der andere rebased.
+8. **Nebenbefund (nicht Teil des Zuschnitts, → #1199):** `Gewitter · :` — Trenner ins Leere,
+   weil die Stufen-Metrik keine Einheit hat (`render.py:557`, `:740`).
+
+## PO-Entscheide 2026-08-20 (Grundlage der Spec)
+
+| # | Frage | Entscheid |
+|---|---|---|
+| 1 | Gewitterstufe im Alarm | **Wort** aus `THUNDER_LABEL_DE` — `mittel ↑ hoch` statt `2 ↑ 3`; **Schwelle zieht mit** (`Schwelle leicht` statt `Schwelle 1`) |
+| 2 | Prozent-Änderung | **entfällt grundsätzlich** — Begründung wörtlich: „Das versteht niemand und stiftet keinen Nutzen" |
+| 3 | Stand-/Vergleichszeile in Telegram | **Variante (b)** — volle Zeile wie in der E-Mail: `Stand: heute 10:00 · verglichen mit 18:03` |
+
+Ersatz für die H1 (in Frage 2 mit vorgelegt): `Gewitter mittel → hoch seit dem Briefing`,
+`Niedersch 2,0 mm → 18,0 mm seit dem Briefing`.

--- a/docs/specs/modules/fix_1948_s6_alarm_stufenwort.md
+++ b/docs/specs/modules/fix_1948_s6_alarm_stufenwort.md
@@ -5,7 +5,9 @@ entity_id: alert_render
 issue: 1948
 slice: S6
 created: 2026-08-20
-status: draft
+status: approved
+approved_by: PO Henning
+approved_at: 2026-08-20
 workflow: feat-1948-s6-telegram-paritaet
 ```
 

--- a/docs/specs/modules/fix_1948_s6_alarm_stufenwort.md
+++ b/docs/specs/modules/fix_1948_s6_alarm_stufenwort.md
@@ -94,86 +94,86 @@ Diese Unterscheidung trägt die halbe Spec:
 
 ## Acceptance Criteria
 
-**AC-1:** Given ein Änderungs-Alarm mit einem einzelnen `thunder`-Ereignis von Stufe 2 auf
-Stufe 3, When die E-Mail gerendert wird, Then enthält die erste Datenzeile `mittel ↑ hoch`
-und an keiner Stelle der Zeile die Ziffernfolge `2 ↑ 3`.
+- **AC-1:** Given ein Änderungs-Alarm mit einem einzelnen `thunder`-Ereignis von Stufe 2 auf
+  Stufe 3, When die E-Mail gerendert wird, Then enthält die erste Datenzeile `mittel ↑ hoch`
+  und an keiner Stelle der Zeile die Ziffernfolge `2 ↑ 3`.
 
-**AC-2:** Given derselbe Alarm, When der ausführliche Telegram-Text gerendert wird, Then
-lautet die Metrik-Zeile `Gewitter · Schwelle 1 Stufe · mittel ↑ hoch · Änderung über`.
+- **AC-2:** Given derselbe Alarm, When der ausführliche Telegram-Text gerendert wird, Then
+  lautet die Metrik-Zeile `Gewitter · Schwelle 1 Stufe · mittel ↑ hoch · Änderung über`.
 
-**AC-3:** Given ein Änderungs-Alarm mit mehreren Ereignissen, darunter `thunder` von Stufe 2
-auf Stufe 3, When der ausführliche Telegram-Text gerendert wird, Then steht in der
-Metrik-Zeile `mittel→hoch` und nicht `2→3`, während Nicht-Stufen-Metriken unverändert ihre
-Messzahl mit Einheit behalten (z. B. `1.400→280 m`).
+- **AC-3:** Given ein Änderungs-Alarm mit mehreren Ereignissen, darunter `thunder` von Stufe 2
+  auf Stufe 3, When der ausführliche Telegram-Text gerendert wird, Then steht in der
+  Metrik-Zeile `mittel→hoch` und nicht `2→3`, während Nicht-Stufen-Metriken unverändert ihre
+  Messzahl mit Einheit behalten (z. B. `1.400→280 m`).
 
-**AC-4:** Given derselbe Mehr-Ereignis-Alarm, When die E-Mail gerendert wird, Then trägt die
-Gewitter-Zeile `mittel ↑ hoch` als Wertteil und `Änderung 1 Stufe · Schwelle 1 Stufe` im
-Labelteil.
+- **AC-4:** Given derselbe Mehr-Ereignis-Alarm, When die E-Mail gerendert wird, Then trägt die
+  Gewitter-Zeile `mittel ↑ hoch` als Wertteil und `Änderung 1 Stufe · Schwelle 1 Stufe` im
+  Labelteil.
 
-**AC-5:** Given ein Änderungs-Alarm mit `thunder`, When die Betreffzeile gerendert wird, Then
-erscheint die Stufe als Wort und niemals als nackte Ordinalzahl — bei **einem** Ereignis
-lautet der Betreff `[KHW 403] km 0–4 · ↑ Gewitter: mittel→hoch`, bei **mehreren** Ereignissen
-trägt die Aufzählung der Bis-Werte die Wörter, also
-`[KHW 403] Segment 1, 🏁 Ziel · ↑ 2 über Schwelle: Gewitter hoch, Gewitter mittel`.
+- **AC-5:** Given ein Änderungs-Alarm mit `thunder`, When die Betreffzeile gerendert wird, Then
+  erscheint die Stufe als Wort und niemals als nackte Ordinalzahl — bei **einem** Ereignis
+  lautet der Betreff `[KHW 403] km 0–4 · ↑ Gewitter: mittel→hoch`, bei **mehreren** Ereignissen
+  trägt die Aufzählung der Bis-Werte die Wörter, also
+  `[KHW 403] Segment 1, 🏁 Ziel · ↑ 2 über Schwelle: Gewitter hoch, Gewitter mittel`.
 
-**AC-6:** Given ein `thunder`-Alarm mit Änderungsschwelle 1, When irgendein Kanal gerendert
-wird, Then erscheinen Schwelle und Änderungsbetrag als Zahl mit der Einheit `Stufe` bzw.
-`Stufen` und **niemals** als Stufenwort — der Text `Schwelle leicht` darf in keiner Ausgabe
-vorkommen. Dieses Kriterium ist ein Wächter gegen die naheliegende Fehlumsetzung.
+- **AC-6:** Given ein `thunder`-Alarm mit Änderungsschwelle 1, When irgendein Kanal gerendert
+  wird, Then erscheinen Schwelle und Änderungsbetrag als Zahl mit der Einheit `Stufe` bzw.
+  `Stufen` und **niemals** als Stufenwort — der Text `Schwelle leicht` darf in keiner Ausgabe
+  vorkommen. Dieses Kriterium ist ein Wächter gegen die naheliegende Fehlumsetzung.
 
-**AC-7:** Given ein Grenzwert-/Korridor-Alarm auf `thunder` mit Grenze Stufe 1 und aktuellem
-Wert Stufe 3, When E-Mail oder Telegram gerendert werden, Then lautet die Zeile
-`Gewitter: deine Grenze leicht ist gerissen — jetzt hoch` — dort sind **beide** Werte
-Positionen und daher **beide** Wörter.
+- **AC-7:** Given ein Grenzwert-/Korridor-Alarm auf `thunder` mit Grenze Stufe 1 und aktuellem
+  Wert Stufe 3, When E-Mail oder Telegram gerendert werden, Then lautet die Zeile
+  `Gewitter: deine Grenze leicht ist gerissen — jetzt hoch` — dort sind **beide** Werte
+  Positionen und daher **beide** Wörter.
 
-**AC-8:** Given ein Änderungs-Alarm mit einem einzelnen Ereignis beliebiger Metrik, When
-E-Mail HTML und Klartext gerendert werden, Then enthält weder die Überschrift noch der Badge
-noch die Datenzeile eine berechnete prozentuale Änderung — die Zeichenfolgen `+50 %`,
-`+50%`, `-60 %` und ihresgleichen kommen nicht mehr vor.
+- **AC-8:** Given ein Änderungs-Alarm mit einem einzelnen Ereignis beliebiger Metrik, When
+  E-Mail HTML und Klartext gerendert werden, Then enthält weder die Überschrift noch der Badge
+  noch die Datenzeile eine berechnete prozentuale Änderung — die Zeichenfolgen `+50 %`,
+  `+50%`, `-60 %` und ihresgleichen kommen nicht mehr vor.
 
-**AC-9:** Given ein Änderungs-Alarm mit einem einzelnen Ereignis, When die E-Mail-Überschrift
-gerendert wird, Then nennt sie den Von- und den Bis-Wert statt der entfallenen Prozentzahl,
-also `Gewitter mittel → hoch seit dem Briefing` bzw. `Niedersch 2,0 mm → 18,0 mm seit dem
-Briefing`; die inhaltsleere Form `Gewitter seit dem Briefing` entsteht nicht mehr.
+- **AC-9:** Given ein Änderungs-Alarm mit einem einzelnen Ereignis, When die E-Mail-Überschrift
+  gerendert wird, Then nennt sie den Von- und den Bis-Wert statt der entfallenen Prozentzahl,
+  also `Gewitter mittel → hoch seit dem Briefing` bzw. `Niedersch 2,0 mm → 18,0 mm seit dem
+  Briefing`; die inhaltsleere Form `Gewitter seit dem Briefing` entsteht nicht mehr.
 
-**AC-10:** Given eine Metrik, deren Katalog-Einheit `%` ist (z. B. Regenwahrscheinlichkeit),
-When ein Alarm dafür in irgendeinem Kanal gerendert wird, Then bleibt das Prozentzeichen als
-**Einheit** am Messwert erhalten (`60 % ↑ 90 %`, Betreff `90%`) — der Wegfall betrifft
-ausschließlich die berechnete Änderung, niemals die Einheit.
+- **AC-10:** Given eine Metrik, deren Katalog-Einheit `%` ist (z. B. Regenwahrscheinlichkeit),
+  When ein Alarm dafür in irgendeinem Kanal gerendert wird, Then bleibt das Prozentzeichen als
+  **Einheit** am Messwert erhalten (`60 % ↑ 90 %`, Betreff `90%`) — der Wegfall betrifft
+  ausschließlich die berechnete Änderung, niemals die Einheit.
 
-**AC-11:** Given ein Änderungs-Alarm, When der ausführliche Telegram-Text gerendert wird,
-Then schließt er mit derselben Stand-Zeile, die die E-Mail führt — bei **bekanntem**
-Vergleichszeitpunkt `Stand: heute 10:00 · verglichen mit 18:03`, bei **fehlendem**
-(`reference_at is None`) `Stand: heute 10:00 · verglichen mit dem letzten Briefing`. Beide
-Fälle sind real erreichbar: der Ortsvergleich-Einzelpunkt und der Vorschau-Pfad reichen
-`reference_at` nie durch (`project.py:411-424`, `validator_render_service.py:144-147`).
+- **AC-11:** Given ein Änderungs-Alarm, When der ausführliche Telegram-Text gerendert wird,
+  Then schließt er mit derselben Stand-Zeile, die die E-Mail führt — bei **bekanntem**
+  Vergleichszeitpunkt `Stand: heute 10:00 · verglichen mit 18:03`, bei **fehlendem**
+  (`reference_at is None`) `Stand: heute 10:00 · verglichen mit dem letzten Briefing`. Beide
+  Fälle sind real erreichbar: der Ortsvergleich-Einzelpunkt und der Vorschau-Pfad reichen
+  `reference_at` nie durch (`project.py:411-424`, `validator_render_service.py:144-147`).
 
-**AC-12:** Given ein Trip mit Telegram-Kurzstil, When ein Änderungs-Alarm versendet wird,
-Then ist der gesendete Telegram-Text weiterhin **byte-identisch** mit dem SMS-Text und
-enthält **keine** Stand-Zeile — die neue Zeile entsteht ausschließlich in `render_telegram`,
-niemals in `render_sms`. Wächter gegen ein Auslaufen der Zeile in die Kurznachricht.
+- **AC-12:** Given ein Trip mit Telegram-Kurzstil, When ein Änderungs-Alarm versendet wird,
+  Then ist der gesendete Telegram-Text weiterhin **byte-identisch** mit dem SMS-Text und
+  enthält **keine** Stand-Zeile — die neue Zeile entsteht ausschließlich in `render_telegram`,
+  niemals in `render_sms`. Wächter gegen ein Auslaufen der Zeile in die Kurznachricht.
 
-**AC-13:** Given ein `thunder`-Ereignis mit einem Wert außerhalb 0–3 (über den Vorschau-Pfad
-erreichbar, der keinen Wertebereich prüft), When ein Kanal gerendert wird, Then fällt die
-Darstellung auf die bisherige Zahlform zurück und meldet **niemals** `kein` — eine
-Entwarnung für einen unbekannten Wert wäre eine sicherheitsrelevante Falschaussage.
+- **AC-13:** Given ein `thunder`-Ereignis mit einem Wert außerhalb 0–3 (über den Vorschau-Pfad
+  erreichbar, der keinen Wertebereich prüft), When ein Kanal gerendert wird, Then fällt die
+  Darstellung auf die bisherige Zahlform zurück und meldet **niemals** `kein` — eine
+  Entwarnung für einen unbekannten Wert wäre eine sicherheitsrelevante Falschaussage.
 
-**AC-14:** Given ein `thunder`-Alarm von Stufe 2 auf Stufe 3, When die SMS gerendert wird,
-Then lautet sie unverändert `km 0-4: TH:M->H@15` — S6 ändert an der Kurznachricht nichts.
+- **AC-14:** Given ein `thunder`-Alarm von Stufe 2 auf Stufe 3, When die SMS gerendert wird,
+  Then lautet sie unverändert `km 0-4: TH:M->H@15` — S6 ändert an der Kurznachricht nichts.
 
-**AC-15:** Given ein Alarm für eine Metrik ohne Stufencharakter (alle 31 übrigen
-Katalogeinträge), When irgendein Kanal gerendert wird, Then bleibt die Zahlformatierung
-einschließlich Einheit, Tausenderpunkt und Nachkommastellen unverändert gegenüber dem
-Prod-Stand `b31acb40`.
+- **AC-15:** Given ein Alarm für eine Metrik ohne Stufencharakter (alle 31 übrigen
+  Katalogeinträge), When irgendein Kanal gerendert wird, Then bleibt die Zahlformatierung
+  einschließlich Einheit, Tausenderpunkt und Nachkommastellen unverändert gegenüber dem
+  Prod-Stand `b31acb40`.
 
-**AC-16:** Given ein Ortsvergleich-Änderungsalarm mit einem `thunder`-Ereignis, When E-Mail
-und Telegram gerendert werden, Then erscheint die Stufe dort ebenso als Wort — die geteilten
-Renderer bedienen Trip und Ortsvergleich, ohne dass ortsvergleich-eigener Code entsteht.
+- **AC-16:** Given ein Ortsvergleich-Änderungsalarm mit einem `thunder`-Ereignis, When E-Mail
+  und Telegram gerendert werden, Then erscheint die Stufe dort ebenso als Wort — die geteilten
+  Renderer bedienen Trip und Ortsvergleich, ohne dass ortsvergleich-eigener Code entsteht.
 
-**AC-17:** Given ein `thunder`-Wert mit Nachkommaanteil, When er in ein Wort übersetzt wird,
-Then greift **exakt** die bisherige Rundung (`round(v, 0)`, kaufmännisch-gerade
-Bankersrundung), sodass 2,5 auf 2 rundet und damit `mittel` ergibt — **nicht** `hoch`. Die
-Wort-Darstellung darf an keinem Wert eine andere Stufe treffen als die heutige Zahlform.
+- **AC-17:** Given ein `thunder`-Wert mit Nachkommaanteil, When er in ein Wort übersetzt wird,
+  Then greift **exakt** die bisherige Rundung (`round(v, 0)`, kaufmännisch-gerade
+  Bankersrundung), sodass 2,5 auf 2 rundet und damit `mittel` ergibt — **nicht** `hoch`. Die
+  Wort-Darstellung darf an keinem Wert eine andere Stufe treffen als die heutige Zahlform.
 
 ## Betroffene Dateien (erwartet)
 

--- a/docs/specs/modules/fix_1948_s6_alarm_stufenwort.md
+++ b/docs/specs/modules/fix_1948_s6_alarm_stufenwort.md
@@ -1,0 +1,218 @@
+# Spec: #1948 S6 — Alarm spricht die Sprache des Briefings
+
+```yaml
+entity_id: alert_render
+issue: 1948
+slice: S6
+created: 2026-08-20
+status: draft
+workflow: feat-1948-s6-telegram-paritaet
+```
+
+## Problem
+
+Der **Änderungs-Alarm** ist die einzige Stelle im Produkt, die die interne Ordinalzahl der
+Gewitterstufe (0–3) nach außen gibt. Gemessen am Prod-Stand `b31acb40`, Gewitter Stufe 2 → 3:
+
+```
+Betreff:   [KHW 403] km 0–4 · ↑ Gewitter: 2→3
+E-Mail:    Gewitter +50% seit dem Briefing
+           ↑ +50 % · Änderung über deiner Alarm-Schwelle (1)
+           Gewitter · : 2 ↑ 3 +50 %
+           Änderung 1: über Alarm-Schwelle 1 ✗
+Telegram:  KHW 403 · km 0–4 · ↑ Gewitter
+           Gewitter · Schwelle 1 · 2 ↑ 3 · Änderung über
+SMS:       km 0-4: TH:M->H@15      ← spricht seit S3 sauber
+```
+
+Das Briefing nennt dieselbe Größe überall als deutsches Wort (`⚡ mittel`,
+`Gewitter mittel ab 16:00`, `Starkes Gewitter erwartet ab 16:00`), die SMS als Buchstaben
+(`TH:M`). Nur der Alarm zeigt `2`. Dazu rechnet er auf der Ordinalskala eine **prozentuale
+Änderung** (`+50 %`), die keinen Sachverhalt bezeichnet, und dem Telegram-Alarm fehlt die
+Stand-/Vergleichszeile, die die E-Mail führt.
+
+## Ziel
+
+Der Alarm spricht in **Betreff, E-Mail und Telegram** dasselbe Vokabular wie das Briefing.
+Die SMS bleibt bei ihren Buchstaben. Prozent als berechnete Änderung verschwindet
+vollständig; Prozent als **Einheit** bleibt unangetastet.
+
+| | heute | nach S6 |
+|---|---|---|
+| Betreff, eine Änderung | `[KHW 403] km 0–4 · ↑ Gewitter: 2→3` | `[KHW 403] km 0–4 · ↑ Gewitter: mittel→hoch` |
+| Betreff, mehrere | `… ↑ 2 über Schwelle: Gewitter 3, Gewitter 2` | `… ↑ 2 über Schwelle: Gewitter hoch, Gewitter mittel` |
+| E-Mail-Überschrift | `Gewitter +50% seit dem Briefing` | `Gewitter mittel → hoch seit dem Briefing` |
+| E-Mail-Badge | `↑ +50 % · Änderung über deiner Alarm-Schwelle (1)` | `↑ Änderung über deiner Alarm-Schwelle (1 Stufe)` |
+| E-Mail-Datenzeile | `Gewitter · : 2 ↑ 3 +50 %` | `Gewitter · : mittel ↑ hoch` |
+| E-Mail-Zeile 2 | `Änderung 1: über Alarm-Schwelle 1 ✗` | `Änderung 1 Stufe: über Alarm-Schwelle 1 Stufe ✗` |
+| Telegram, eine Änderung | `Gewitter · Schwelle 1 · 2 ↑ 3 · Änderung über` | `Gewitter · Schwelle 1 Stufe · mittel ↑ hoch · Änderung über` |
+| Telegram, mehrere | `Gewitter 🏁 Ziel · 16:00 2→3` | `Gewitter 🏁 Ziel · 16:00 mittel→hoch` |
+| Telegram, Schlusszeile | — fehlt — | `Stand: heute 10:00 · verglichen mit 18:03` |
+| Grenzwert-Alarm | `deine Grenze 1 ist gerissen — jetzt 3` | `deine Grenze leicht ist gerissen — jetzt hoch` |
+| SMS | `km 0-4: TH:M->H@15` | **unverändert** |
+
+## 🔴 Leitunterscheidung: Positionen vs. Abstände
+
+In derselben Zeile stehen zwei Sorten Zahl, die gleich aussehen und Verschiedenes bedeuten.
+Diese Unterscheidung trägt die halbe Spec:
+
+| Wert | Bedeutung | Zielform |
+|---|---|---|
+| `value_from`, `value_to` | **Position** auf der Leiter | **Wort** (`mittel`, `hoch`) |
+| Korridor `bound`, `value` | **Position** — `bound` ist die vom Nutzer gesetzte Bereichsgrenze auf der Skala selbst (`corridor.range[0]/[1]`, `corridor_threshold.py:104`), kein Abstand | **Wort** |
+| `threshold` (Δ-Alarm) | **Abstand** — „ab 1 Stufe Unterschied alarmieren" | Zahl **+ Einheit „Stufe(n)"** |
+| `abs(value_to − value_from)` | **Abstand** — „hat sich um 1 Stufe geändert" | Zahl **+ Einheit „Stufe(n)"** |
+
+`Schwelle leicht` wäre eine **sachlich falsche Aussage**: ein Abstand von 1 ist nicht Stufe 1.
+
+## Quellen der Wahrheit
+
+- **Wörter:** `THUNDER_LABEL_DE` (`src/output/metric_format.py:283-288`) —
+  `{NONE: "kein", LOW: "leicht", MED: "mittel", HIGH: "hoch"}`. **Importieren, nicht kopieren.**
+- **Zahl → Enum:** `_THUNDER_JE_ORDINAL` (`src/output/metric_format.py:359`) =
+  `{0: NONE, 1: LOW, 2: MED, 3: HIGH}`. Gemessen: `.get(4)` → `None`.
+- **Weiche:** `_is_level_metric()` (`src/output/renderers/alert/render.py:110-116`), liest
+  `MetricDefinition.is_level`. `thunder` ist die **einzige** Metrik mit `is_level=True`
+  (`src/app/metric_catalog.py:446`; über alle 32 Katalogeinträge gemessen).
+
+## Nicht-Ziele (ausdrücklich außerhalb dieser Scheibe)
+
+- **SMS** — bleibt bei `LEVELS` (`src/output/tokens/metrics.py:14`). S3/S4/S5-Ergebnis, tabu.
+- **Amtlicher Alarm** — eigener Renderer, S5 AC-13 hält seinen ausführlichen Text fest.
+- **Radar-/Onset-Alarm** — führt keine Stufenzahl (`_render_email_onset` u. a., geprüft).
+- **Trip-Briefing** — spricht bereits Wörter, rechnet nur absolute Differenzen.
+- **`format_change_line()`** (`src/output/renderers/email/helpers.py:1086-1100`) — erzeugt bei
+  %-Einheiten Texte wie `+34 %`. Das ist eine **Differenz in Prozentpunkten**, dieselbe Sorte
+  Zahl wie `+3 °C`, keine Quote. Bleibt unverändert (Tech-Lead-Entscheid, PO informiert).
+- **Legacy-Shim `render_deviation_alert`** (`render.py:1047-1069`) — kein Aufrufer in `src/`,
+  eigener Footer, nur von drei Bestandstests gerufen. Nicht anfassen.
+- **Ortsvergleich als Thema** — er zieht über die geteilten Renderer automatisch mit
+  (`project.py:256-308` hat keinen eigenen Renderer-Code); es wird dort nichts eigens gebaut.
+- **Zeitformatierung** (`local_fmt`, `%H:%M`) — mit Sitzung #2009 abgestimmt: nicht anfassen.
+
+## Acceptance Criteria
+
+**AC-1:** Given ein Änderungs-Alarm mit einem einzelnen `thunder`-Ereignis von Stufe 2 auf
+Stufe 3, When die E-Mail gerendert wird, Then enthält die erste Datenzeile `mittel ↑ hoch`
+und an keiner Stelle der Zeile die Ziffernfolge `2 ↑ 3`.
+
+**AC-2:** Given derselbe Alarm, When der ausführliche Telegram-Text gerendert wird, Then
+lautet die Metrik-Zeile `Gewitter · Schwelle 1 Stufe · mittel ↑ hoch · Änderung über`.
+
+**AC-3:** Given ein Änderungs-Alarm mit mehreren Ereignissen, darunter `thunder` von Stufe 2
+auf Stufe 3, When der ausführliche Telegram-Text gerendert wird, Then steht in der
+Metrik-Zeile `mittel→hoch` und nicht `2→3`, während Nicht-Stufen-Metriken unverändert ihre
+Messzahl mit Einheit behalten (z. B. `1.400→280 m`).
+
+**AC-4:** Given derselbe Mehr-Ereignis-Alarm, When die E-Mail gerendert wird, Then trägt die
+Gewitter-Zeile `mittel ↑ hoch` als Wertteil und `Änderung 1 Stufe · Schwelle 1 Stufe` im
+Labelteil.
+
+**AC-5:** Given ein Änderungs-Alarm mit `thunder`, When die Betreffzeile gerendert wird, Then
+erscheint die Stufe als Wort und niemals als nackte Ordinalzahl — bei **einem** Ereignis
+lautet der Betreff `[KHW 403] km 0–4 · ↑ Gewitter: mittel→hoch`, bei **mehreren** Ereignissen
+trägt die Aufzählung der Bis-Werte die Wörter, also
+`[KHW 403] Segment 1, 🏁 Ziel · ↑ 2 über Schwelle: Gewitter hoch, Gewitter mittel`.
+
+**AC-6:** Given ein `thunder`-Alarm mit Änderungsschwelle 1, When irgendein Kanal gerendert
+wird, Then erscheinen Schwelle und Änderungsbetrag als Zahl mit der Einheit `Stufe` bzw.
+`Stufen` und **niemals** als Stufenwort — der Text `Schwelle leicht` darf in keiner Ausgabe
+vorkommen. Dieses Kriterium ist ein Wächter gegen die naheliegende Fehlumsetzung.
+
+**AC-7:** Given ein Grenzwert-/Korridor-Alarm auf `thunder` mit Grenze Stufe 1 und aktuellem
+Wert Stufe 3, When E-Mail oder Telegram gerendert werden, Then lautet die Zeile
+`Gewitter: deine Grenze leicht ist gerissen — jetzt hoch` — dort sind **beide** Werte
+Positionen und daher **beide** Wörter.
+
+**AC-8:** Given ein Änderungs-Alarm mit einem einzelnen Ereignis beliebiger Metrik, When
+E-Mail HTML und Klartext gerendert werden, Then enthält weder die Überschrift noch der Badge
+noch die Datenzeile eine berechnete prozentuale Änderung — die Zeichenfolgen `+50 %`,
+`+50%`, `-60 %` und ihresgleichen kommen nicht mehr vor.
+
+**AC-9:** Given ein Änderungs-Alarm mit einem einzelnen Ereignis, When die E-Mail-Überschrift
+gerendert wird, Then nennt sie den Von- und den Bis-Wert statt der entfallenen Prozentzahl,
+also `Gewitter mittel → hoch seit dem Briefing` bzw. `Niedersch 2,0 mm → 18,0 mm seit dem
+Briefing`; die inhaltsleere Form `Gewitter seit dem Briefing` entsteht nicht mehr.
+
+**AC-10:** Given eine Metrik, deren Katalog-Einheit `%` ist (z. B. Regenwahrscheinlichkeit),
+When ein Alarm dafür in irgendeinem Kanal gerendert wird, Then bleibt das Prozentzeichen als
+**Einheit** am Messwert erhalten (`60 % ↑ 90 %`, Betreff `90%`) — der Wegfall betrifft
+ausschließlich die berechnete Änderung, niemals die Einheit.
+
+**AC-11:** Given ein Änderungs-Alarm, When der ausführliche Telegram-Text gerendert wird,
+Then schließt er mit derselben Stand-Zeile, die die E-Mail führt — bei **bekanntem**
+Vergleichszeitpunkt `Stand: heute 10:00 · verglichen mit 18:03`, bei **fehlendem**
+(`reference_at is None`) `Stand: heute 10:00 · verglichen mit dem letzten Briefing`. Beide
+Fälle sind real erreichbar: der Ortsvergleich-Einzelpunkt und der Vorschau-Pfad reichen
+`reference_at` nie durch (`project.py:411-424`, `validator_render_service.py:144-147`).
+
+**AC-12:** Given ein Trip mit Telegram-Kurzstil, When ein Änderungs-Alarm versendet wird,
+Then ist der gesendete Telegram-Text weiterhin **byte-identisch** mit dem SMS-Text und
+enthält **keine** Stand-Zeile — die neue Zeile entsteht ausschließlich in `render_telegram`,
+niemals in `render_sms`. Wächter gegen ein Auslaufen der Zeile in die Kurznachricht.
+
+**AC-13:** Given ein `thunder`-Ereignis mit einem Wert außerhalb 0–3 (über den Vorschau-Pfad
+erreichbar, der keinen Wertebereich prüft), When ein Kanal gerendert wird, Then fällt die
+Darstellung auf die bisherige Zahlform zurück und meldet **niemals** `kein` — eine
+Entwarnung für einen unbekannten Wert wäre eine sicherheitsrelevante Falschaussage.
+
+**AC-14:** Given ein `thunder`-Alarm von Stufe 2 auf Stufe 3, When die SMS gerendert wird,
+Then lautet sie unverändert `km 0-4: TH:M->H@15` — S6 ändert an der Kurznachricht nichts.
+
+**AC-15:** Given ein Alarm für eine Metrik ohne Stufencharakter (alle 31 übrigen
+Katalogeinträge), When irgendein Kanal gerendert wird, Then bleibt die Zahlformatierung
+einschließlich Einheit, Tausenderpunkt und Nachkommastellen unverändert gegenüber dem
+Prod-Stand `b31acb40`.
+
+**AC-16:** Given ein Ortsvergleich-Änderungsalarm mit einem `thunder`-Ereignis, When E-Mail
+und Telegram gerendert werden, Then erscheint die Stufe dort ebenso als Wort — die geteilten
+Renderer bedienen Trip und Ortsvergleich, ohne dass ortsvergleich-eigener Code entsteht.
+
+**AC-17:** Given ein `thunder`-Wert mit Nachkommaanteil, When er in ein Wort übersetzt wird,
+Then greift **exakt** die bisherige Rundung (`round(v, 0)`, kaufmännisch-gerade
+Bankersrundung), sodass 2,5 auf 2 rundet und damit `mittel` ergibt — **nicht** `hoch`. Die
+Wort-Darstellung darf an keinem Wert eine andere Stufe treffen als die heutige Zahlform.
+
+## Betroffene Dateien (erwartet)
+
+| Datei | Was |
+|---|---|
+| `src/output/renderers/alert/render.py` | Kern: Wort-Weiche in `_val`/`_num`-Aufrufern, `Stufe(n)`-Einheit für Abstände, `_h1`-Ersatz, Prozent-Entfall, Stand-Zeile in `render_telegram` |
+| `src/output/renderers/alert/model.py` | `delta_pct` entfällt (oder wird ungenutzt) |
+| Tests | siehe unten |
+
+## Regressionsfläche (Basislinie verifiziert grün: 50 passed)
+
+**Wird bewusst nachgezogen:**
+`test_978_deviation_line_readability.py:224,240,273,292,358,368` (Stufenwort; zwei Regexe
+`(Gewitter) \d`) · `test_957_alert_mail_literal_structure.py:56,59` (Prozent) ·
+`test_issue_1169_compare_alert_consumer.py:755-769` (byte-genau, Prozent) und `:770-773`
+(byte-genau, Stand-Zeile) · `test_alert_multi_event_where_when.py:129-134`
+(`splitlines()[-1]`).
+
+**🔴 Muss grün bleiben — Trennlinie Einheit vs. Änderung:**
+`test_channel_metric_matrix.py:2202-2220` und `:2174-2199` ·
+`test_alert_change_amount_wording.py:290-303` · `test_952_alert_mail_design_fidelity.py:73`.
+
+**Scheinwächter, nicht als Beweis verwenden:**
+`test_957_alert_mail_literal_structure.py:46` (`"%" in html`) ist faktisch durch
+`width="100%"` erfüllt (`render.py:588`) und bewacht die Trennlinie **nicht**.
+
+## Mutations-Gegenproben (Pflicht im Adversary)
+
+1. `THUNDER_LABEL_DE` durch eine lokale Kopie ersetzen → muss rot werden (SSoT-Bindung).
+2. Wort-Weiche auch auf `threshold` anwenden (`Schwelle leicht`) → **AC-6** muss rot werden.
+3. Rückfall für unbekannte Ordinalwerte auf `"kein"` setzen → **AC-13** muss rot werden.
+4. Stand-Zeile zusätzlich in `render_sms` erzeugen → **AC-12** muss rot werden.
+5. Prozent-Entfall auf die Einheit ausdehnen → **AC-10** muss rot werden.
+6. Wort-Weiche für alle Metriken statt nur `is_level` → **AC-15** muss rot werden.
+
+## Offene Punkte
+
+- **Nebenbefund → #1199:** `Gewitter · :` — hängender Trenner, weil die Stufen-Metrik keine
+  Einheit hat (`render.py:557`, `:740`). Nicht Teil dieser Scheibe.
+- **Nebenbefund → #1199:** Der SMS-Zweig fällt für Werte außerhalb 0–3 auf `-` zurück
+  (`render.py:856-857`) — **denselben Glyph wie Stufe 0**. Produktiv nicht erreichbar
+  (`thunder_scale.py:48-57` liefert immer 0–3), über den Vorschau-Pfad schon.
+- **Nebenbefund → #1199:** `_email_line` (`render.py:521-526`) ist falsch benannt — sie
+  bedient ausschließlich Telegram.

--- a/src/output/renderers/alert/render.py
+++ b/src/output/renderers/alert/render.py
@@ -12,6 +12,7 @@ from app.metric_catalog import (
     format_metric_value, get_alert_label, get_decimals, get_label_for_field,
     get_metric, get_sms_code,
 )
+from output.metric_format import THUNDER_LABEL_DE, _THUNDER_JE_ORDINAL
 from output.renderers.email.design_tokens import (
     FONT_DATA, FONT_UI, G_ACCENT, G_DANGER, G_INK, G_INK_MUTED, G_SUCCESS,
 )
@@ -20,7 +21,7 @@ from utils.ascii_fold import fold_ascii
 
 from .model import (
     AlertEvent, AlertMessage, CorridorEvent, OnsetEvent, OnsetShiftEvent,
-    arrow, delta_pct, km_span, over_thr, severity, side_label,
+    arrow, km_span, over_thr, severity, side_label,
 )
 from .project import COMPARE_RADAR_SOURCE
 from .segments import _renderable_segment_ids, format_alert_location
@@ -39,8 +40,29 @@ def _sorted(msg: AlertMessage) -> list[AlertEvent]:
 _HANDLED_UNITS = {"m", "km", "hPa", "%", "km/h", "°C", "mm"}
 
 
-def _val(e: AlertEvent, value: float) -> str:
-    """Wert MIT Einheit via Katalog (Email/Telegram/Betreff).
+def _thunder_word(value: float) -> str | None:
+    """Uebersetzt einen thunder-Ordinalwert (POSITION auf der Gewitter-
+    Leiter) in sein deutsches Wort (Issue #1948 S6). Rundung `round(v, 0)`
+    (kaufmaennisch-gerade Bankersrundung), exakt wie bisher (AC-17). Werte
+    ausserhalb 0-3 (nur ueber den Vorschau-Pfad erreichbar) liefern `None`
+    -- der Aufrufer faellt dann auf die bisherige Zahlform zurueck, NIEMALS
+    auf 'kein' (AC-13, `_THUNDER_JE_ORDINAL.get(4)` -> `None`)."""
+    ordinal = int(round(value, 0))
+    level = _THUNDER_JE_ORDINAL.get(ordinal)
+    return THUNDER_LABEL_DE[level] if level is not None else None
+
+
+def _stufe_unit(value: float) -> str:
+    """Deutsches Einheitswort fuer einen Stufen-ABSTAND (threshold, |Δ| einer
+    Stufenmetrik) -- Singular bei genau 1, sonst Plural (Issue #1948 S6,
+    AC-6-Waechter: ein Abstand ist NIE ein Stufenwort)."""
+    return "Stufe" if abs(round(value)) == 1 else "Stufen"
+
+
+def _val_raw(e: AlertEvent, value: float) -> str:
+    """Wert MIT Einheit via Katalog, OHNE Stufenwort-Weiche -- gemeinsamer
+    Zahlen-Fallback fuer `_val()` (Positionen) und `_val_delta()` (Abstaende,
+    Issue #1948 S6).
 
     format_metric_value() formatiert nur die o.g. Einheiten mit Suffix; fuer
     alle anderen (z.B. J/kg bei CAPE) baut dieser Renderer selbst einen
@@ -56,8 +78,33 @@ def _val(e: AlertEvent, value: float) -> str:
     return f"{formatted} {unit}".strip()
 
 
-def _num(e: AlertEvent, value: float) -> str:
-    """Zahl OHNE Einheit fuer die Multi-Metrik-Zeile (Issue #978).
+def _val(e: AlertEvent, value: float) -> str:
+    """Wert MIT Einheit fuer eine POSITION (value_from/value_to, Korridor-
+    bound/value) — Email/Telegram/Betreff. Bei Stufenmetriken (`is_level`)
+    das deutsche Stufenwort statt der Ordinalzahl (Issue #1948 S6, Leit-
+    unterscheidung Positionen vs. Abstaende); Werte ausserhalb 0-3 fallen auf
+    die bisherige Zahlform zurueck (AC-13)."""
+    if _is_level_metric(e.metric_id):
+        word = _thunder_word(value)
+        if word is not None:
+            return word
+    return _val_raw(e, value)
+
+
+def _val_delta(e: AlertEvent, value: float) -> str:
+    """Wert MIT Einheit fuer einen ABSTAND (threshold, |Δ|) -- bei
+    Stufenmetriken NIE ein Wort, sondern Zahl + 'Stufe(n)' (Issue #1948 S6,
+    AC-6-Waechter: 'Schwelle leicht' ist eine sachlich falsche Aussage)."""
+    if _is_level_metric(e.metric_id):
+        rounded = round(value, get_decimals(e.metric_id))
+        formatted = str(int(rounded)) if float(rounded).is_integer() else str(rounded)
+        return f"{formatted} {_stufe_unit(rounded)}"
+    return _val_raw(e, value)
+
+
+def _num_raw(value: float, decimals: int) -> str:
+    """Zahl OHNE Einheit, OHNE Stufenwort-Weiche -- gemeinsamer Zahlen-
+    Fallback fuer `_num()` (Positionen) und `_num_delta()` (Abstaende).
 
     Integer-Display bei glattem Rundungsergebnis (kein ',0'-Rauschen), sonst
     1 Nachkommastelle mit Komma -- Tausender-Punkt bleibt in beiden Zweigen
@@ -65,15 +112,32 @@ def _num(e: AlertEvent, value: float) -> str:
     aus metric_catalog lokal nach statt sie zu importieren, damit die
     geteilte Katalogfunktion fuer andere Aufrufer (format_change_line)
     unveraendert bleibt (Issue #952 Finding F001, analog zur Begruendung bei
-    _val() oben).
+    _val_raw() oben).
     """
-    decimals = get_decimals(e.metric_id)
     rounded = round(value, decimals)
     if float(rounded).is_integer():
         n = int(rounded)
         return f"{n:,}".replace(",", ".") if abs(n) >= 1000 else str(n)
     int_part, _, frac_part = f"{rounded:,.{decimals}f}".partition(".")
     return f"{int_part.replace(',', '.')},{frac_part}"
+
+
+def _num(e: AlertEvent, value: float) -> str:
+    """Zahl OHNE Einheit fuer eine POSITION in der Multi-Metrik-Zeile (Issue
+    #978) -- bei Stufenmetriken das deutsche Stufenwort statt der Ordinal-
+    zahl (Issue #1948 S6, AC-3/AC-4), sonst wie bisher."""
+    if _is_level_metric(e.metric_id):
+        word = _thunder_word(value)
+        if word is not None:
+            return word
+    return _num_raw(value, get_decimals(e.metric_id))
+
+
+def _num_delta(e: AlertEvent, value: float) -> str:
+    """Zahl OHNE Einheit fuer einen ABSTAND (threshold, |Δ|) in der Multi-
+    Metrik-Zeile -- NIE ein Wort, auch nicht bei Stufenmetriken (Issue #1948
+    S6, AC-6-Waechter)."""
+    return _num_raw(value, get_decimals(e.metric_id))
 
 
 def _unit_suffix(e: AlertEvent) -> str:
@@ -523,35 +587,32 @@ def render_subject(msg: AlertMessage) -> str:
 
 
 def _h1(msg: AlertMessage) -> str:
+    """Issue #1948 S6 (AC-9): nennt Von-/Bis-Wert statt der entfallenen
+    berechneten Prozent-Änderung -- die inhaltsleere Form 'Gewitter seit dem
+    Briefing' (frueherer value_from==0-Sonderfall) entsteht dadurch nicht
+    mehr, `_val()` liefert fuer Stufenmetriken ohnehin ein Wort statt '0'."""
     evs = _sorted(msg)
     if len(evs) == 1:
         e = evs[0]
-        d = delta_pct(e)
-        suffix = f" {d:+d}%" if d is not None else ""
-        return f"{_label(e)}{suffix} seit dem Briefing"
+        return f"{_label(e)} {_val(e, e.value_from)} → {_val(e, e.value_to)} seit dem Briefing"
     return f"{len(evs)} Werte über der Alarm-Schwelle"
 
 
 def _email_line(e: AlertEvent) -> str:
     return (
-        f"{_label(e)} · Schwelle {_val(e, e.threshold)} · "
+        f"{_label(e)} · Schwelle {_val_delta(e, e.threshold)} · "
         f"{_val(e, e.value_from)} {arrow(e)} {_val(e, e.value_to)} · "
         f"Änderung {side_label(e)}"
     )
 
 
-def _delta_text(e: AlertEvent) -> str:
-    """'-50 %'/'+12 %' — leer wenn value_from==0 (analog _h1-Sonderfall)."""
-    d = delta_pct(e)
-    return f"{d:+d} %" if d is not None else ""
-
-
 def _verdict_single(e: AlertEvent) -> str:
-    d = _delta_text(e)
-    tail = f"{d} · " if d else ""
+    """Issue #1948 S6 (AC-8): keine berechnete Prozent-Änderung mehr im
+    Badge -- nur noch Richtung, Über/Unter-Schwelle-Aussage und der
+    tatsaechliche Schwellenwert (Abstand, daher `_val_delta`)."""
     return (
-        f"{arrow(e)} {tail}Änderung {side_label(e)} deiner Alarm-Schwelle "
-        f"({_val(e, e.threshold)})"
+        f"{arrow(e)} Änderung {side_label(e)} deiner Alarm-Schwelle "
+        f"({_val_delta(e, e.threshold)})"
     )
 
 
@@ -569,16 +630,14 @@ def _datablock_single(e: AlertEvent, location_label: str | None = None) -> list[
     hoeher (AC-3). `over_thr()`/`side_label()` bleiben unveraendert.
     """
     unit = get_metric(e.metric_id).unit
-    d = _delta_text(e)
-    d_suffix = f" {d}" if d else ""
     row1 = (
         f"{_label(e)} · {unit}",
-        f"{_val(e, e.value_from)} {arrow(e)} {_val(e, e.value_to)}{d_suffix}",
+        f"{_val(e, e.value_from)} {arrow(e)} {_val(e, e.value_to)}",
     )
     mark = "✓" if not over_thr(e) else "✗"
     row2 = (
-        f"Änderung {_val(e, abs(e.value_to - e.value_from))}",
-        f"{side_label(e)} Alarm-Schwelle {_val(e, e.threshold)} {mark}",
+        f"Änderung {_val_delta(e, abs(e.value_to - e.value_from))}",
+        f"{side_label(e)} Alarm-Schwelle {_val_delta(e, e.threshold)} {mark}",
     )
     # Issue #1744 A1 (AC-6): DIESELBE Aufloesung wie im Betreff — vorher stand
     # hier ein dritter, eigener km-Bauer (`_km_str_events`), weshalb der
@@ -718,12 +777,18 @@ def render_email(msg: AlertMessage) -> tuple[str, str]:
                 # gebuendelten Fall -- Label nennt zusaetzlich zur Schwelle
                 # den tatsaechlichen Aenderungsbetrag (zwei unterscheidbare
                 # Zahlen in derselben Zeile, AC-4).
-                threshold_suffix = " %" if unit == "%" else ""
                 delta = abs(e.value_to - e.value_from)
+                if _is_level_metric(e.metric_id):
+                    # Issue #1948 S6 (AC-4/AC-6): Abstaende einer Stufen-
+                    # metrik sind Zahl + 'Stufe(n)', NIE ein Stufenwort.
+                    delta_suffix = f" {_stufe_unit(delta)}"
+                    schwelle_suffix = f" {_stufe_unit(e.threshold)}"
+                else:
+                    delta_suffix = schwelle_suffix = " %" if unit == "%" else ""
                 data_rows.append((
                     f"{loc_prefix}{_label(e)}{where_when} · "
-                    f"Änderung {_num(e, delta)}{threshold_suffix} · "
-                    f"Schwelle {_num(e, e.threshold)}{threshold_suffix}",
+                    f"Änderung {_num_delta(e, delta)}{delta_suffix} · "
+                    f"Schwelle {_num_delta(e, e.threshold)}{schwelle_suffix}",
                     f"{_num(e, e.value_from)} {arrow(e)} {_num(e, e.value_to)}"
                     f"{unit_suffix} {side_label(e)}",
                 ))
@@ -837,6 +902,15 @@ def render_telegram(msg: AlertMessage) -> str:
     # Treffer desselben Laufs anhaengen -- eine Nachricht, nicht drei.
     lines += [_onset_shift_line(oe) for oe in msg.onset_shift_events]
     lines += [_corridor_line(ce) for ce in msg.corridor_events]
+    # Issue #1948 S6 (AC-11): dieselbe Stand-/Vergleichszeile wie die E-Mail
+    # -- AUSSCHLIESSLICH hier, niemals in render_sms (AC-12, der Telegram-
+    # Kurzstil sendet render_sms()s Text unveraendert weiter).
+    footer = (
+        f"Stand: heute {msg.stand_at} · verglichen mit {msg.reference_at}"
+        if msg.reference_at
+        else f"Stand: heute {msg.stand_at} · verglichen mit dem letzten Briefing"
+    )
+    lines.append(footer)
     return "\n".join(lines)
 
 

--- a/tests/tdd/test_957_alert_mail_literal_structure.py
+++ b/tests/tdd/test_957_alert_mail_literal_structure.py
@@ -47,16 +47,20 @@ class TestSingleEventVerdictAndDatablock:
         assert "Schwelle" in html, f"'Schwelle'-Bezug fehlt im Verdikt: {html!r}"
 
     def test_verdict_delta_matches_computed_value(self):
-        """Δ% im Verdikt muss aus delta_pct() berechnet sein, kein Literal."""
-        from output.renderers.alert.model import delta_pct
+        """Issue #1948 S6 (AC-8): die berechnete Prozent-Änderung ist aus dem
+        Verdikt entfallen -- delta_pct() fliesst nicht mehr in render_email()
+        ein. Statt eines berechneten Δ% nennt der Badge den tatsaechlichen
+        Schwellenwert MIT Einheit (Abstand, keine berechnete Änderung)."""
+        from output.renderers.alert.model import side_label
         msg = _single_event_msg(value_from=1000.0, value_to=400.0, threshold=500.0)
         e = msg.events[0]
-        expected = delta_pct(e)
         html, plain = render_email(msg)
-        assert f"{expected:+d} %" in html, (
-            f"Berechnetes Δ% ({expected:+d} %) fehlt im HTML: {html!r}"
+        expected = f"Änderung {side_label(e)} deiner Alarm-Schwelle (500 J/kg)"
+        assert expected in html, f"Badge-Text weicht ab: {html!r}"
+        assert expected in plain, f"Badge-Text weicht ab: {plain!r}"
+        assert "-60 %" not in html, (
+            f"Berechnete Prozent-Änderung darf nicht mehr im Badge stehen: {html!r}"
         )
-        assert f"{expected:+d} %" in plain
 
     def test_datablock_has_three_rows(self):
         """3 separate Datenzeilen: Wert-Vergleich, Schwellwert-Status, Wo & wann."""

--- a/tests/tdd/test_978_deviation_line_readability.py
+++ b/tests/tdd/test_978_deviation_line_readability.py
@@ -341,9 +341,12 @@ class TestMixedOverUnderOrdering:
         _, plain = render_email(_mixed_over_under_msg())
         # Issue #980: unter-Schwelle-Zeilen tragen das Label "· unter Schwelle"
         # (ohne Schwellen-Zahl), über-Schwelle "· Änderung N · Schwelle N"
-        # (Issue #1935/#1779 E2) — beide erfassen.
+        # (Issue #1935/#1779 E2) — beide erfassen. Issue #1948 S6: bei der
+        # Stufenmetrik Gewitter traegt der Änderungsbetrag seither die
+        # Einheit "Stufe(n)" statt "%" (AC-6) -- Regex erfasst beide Suffixe.
         order = re.findall(
-            r"(Niedersch|Gewitter|Regen%|Böen) · (?:Änderung \S+(?: %)? · )?(?:unter )?Schwelle",
+            r"(Niedersch|Gewitter|Regen%|Böen) · "
+            r"(?:Änderung \S+(?: %| Stufen?)? · )?(?:unter )?Schwelle",
             plain,
         )
         assert order == ["Böen", "Gewitter", "Regen%", "Niedersch"], (

--- a/tests/tdd/test_alert_multi_event_where_when.py
+++ b/tests/tdd/test_alert_multi_event_where_when.py
@@ -126,7 +126,10 @@ def test_ac2_multi_event_telegram_rows_are_distinguishable_by_segment():
 
     msg = _three_thunder_events_trip_path()
     telegram_text = render_telegram(msg)
-    metric_line = telegram_text.split("\n")[-1]
+    # Issue #1948 S6 (AC-11): render_telegram() haengt seither eine Stand-
+    # Zeile als LETZTE Zeile an -- die Metrik-Zeile ist seither die
+    # zweitletzte Zeile, nicht mehr die letzte.
+    metric_line = telegram_text.split("\n")[-2]
 
     for segment in ("Segment 4", "Segment 5", "Segment 6"):
         assert segment in metric_line, (

--- a/tests/tdd/test_alert_prozent_entfall.py
+++ b/tests/tdd/test_alert_prozent_entfall.py
@@ -1,0 +1,135 @@
+"""TDD RED — Issue #1948 Scheibe S6: Die berechnete prozentuale Änderung
+(`delta_pct()`) verschwindet vollständig aus dem Änderungs-Alarm. Prozent
+als EINHEIT (z. B. Regenwahrscheinlichkeit) bleibt unangetastet — das ist
+die Trennlinie, die AC-10 bewacht.
+
+Spec: docs/specs/modules/fix_1948_s6_alarm_stufenwort.md (AC-8, AC-9, AC-10).
+Kontext: docs/context/feat-1948-s6-telegram-paritaet.md.
+
+PO-Begründung (wörtlich): "Das versteht niemand und stiftet keinen Nutzen."
+
+Alles echte Renderer-Aufrufe (render_email) mit echten AlertEvent/
+AlertMessage-Objekten. Kein Mock, keine Dateiinhalt-Checks.
+
+Alle Tests hier müssen vor der Implementierung ROT sein (kein
+Regressionswächter-Ausnahmefall in dieser Datei).
+"""
+from __future__ import annotations
+
+import re
+
+from output.renderers.alert.model import AlertEvent, AlertMessage
+from output.renderers.alert.render import render_email
+
+# Erfasst berechnete Prozent-Änderungen wie "+50 %", "+50%", "-60 %", "−60 %"
+# -- NICHT die reine Einheit ("90 %" ohne Vorzeichen).
+_COMPUTED_PERCENT_CHANGE = re.compile(r"[+\-−]\d+\s?%")
+
+
+def _single_event_msg(
+    metric_id: str, value_from: float, value_to: float, threshold: float,
+    *, cmp: str = "über", occurred_at: str | None = "09:00",
+    km_from: float = 0.0, km_to: float = 4.0,
+    trip_short: str = "KHW 403", stand_at: str = "09:30",
+) -> AlertMessage:
+    e = AlertEvent(
+        metric_id=metric_id, value_from=value_from, value_to=value_to,
+        threshold=threshold, cmp=cmp, occurred_at=occurred_at,
+        km_from=km_from, km_to=km_to,
+    )
+    return AlertMessage(trip_short=trip_short, stand_at=stand_at, events=(e,), source=None)
+
+
+def _first_plain_data_line(plain: str) -> str:
+    return plain.split("\n")[4]
+
+
+# ===========================================================================
+# AC-8: keine berechnete Prozent-Änderung mehr in H1/Badge/Datenzeile
+# ===========================================================================
+
+def test_ac8_email_enthaelt_keine_berechnete_prozentaenderung():
+    """AC-8: GIVEN ein Änderungs-Alarm mit einem einzelnen Ereignis
+    beliebiger Metrik (hier: Böen), WHEN E-Mail HTML und Klartext gerendert
+    werden, THEN enthält weder die Überschrift noch der Badge noch die
+    Datenzeile eine berechnete prozentuale Änderung -- Zeichenfolgen wie
+    '+50 %', '+50%', '-60 %' kommen nicht mehr vor."""
+    msg = _single_event_msg("gust", 20.0, 30.0, 5.0)
+    html, plain = render_email(msg)
+    for label, text in (("html", html), ("plain", plain)):
+        match = _COMPUTED_PERCENT_CHANGE.search(text)
+        assert match is None, (
+            f"Berechnete Prozent-Änderung in {label} gefunden: {match.group() if match else None!r} "
+            f"in {text!r}"
+        )
+
+
+# ===========================================================================
+# AC-9: H1 nennt Von-/Bis-Wert statt der entfallenen Prozentzahl
+# ===========================================================================
+
+def test_ac9_h1_nennt_von_bis_wert_stufenmetrik():
+    """AC-9 (Stufenmetrik): H1 lautet 'Gewitter mittel → hoch seit dem
+    Briefing'."""
+    from app.models import ThunderLevel
+    from output.metric_format import THUNDER_LABEL_DE
+
+    msg = _single_event_msg("thunder", 2.0, 3.0, 1.0)
+    _, plain = render_email(msg)
+    h1_line = plain.split("\n")[0]
+    expected = (
+        f"Gewitter {THUNDER_LABEL_DE[ThunderLevel.MED]} → "
+        f"{THUNDER_LABEL_DE[ThunderLevel.HIGH]} seit dem Briefing"
+    )
+    assert h1_line == expected, f"H1 weicht ab.\n  erwartet: {expected!r}\n  bekommen: {h1_line!r}"
+
+
+def test_ac9_h1_nennt_von_bis_wert_mengenmetrik():
+    """AC-9 (Mengenmetrik): H1 lautet
+    'Niedersch 2,0 mm → 18,0 mm seit dem Briefing'."""
+    msg = _single_event_msg("precipitation", 2.0, 18.0, 10.0)
+    _, plain = render_email(msg)
+    h1_line = plain.split("\n")[0]
+    expected = "Niedersch 2,0 mm → 18,0 mm seit dem Briefing"
+    assert h1_line == expected, f"H1 weicht ab.\n  erwartet: {expected!r}\n  bekommen: {h1_line!r}"
+
+
+def test_ac9_h1_bei_wertfrom_null_bleibt_nicht_inhaltsleer():
+    """AC-9 (Sonderfall value_from==0): die inhaltsleere Form 'Gewitter seit
+    dem Briefing' -- heute der einzige Prozent-Sonderfall -- entsteht nicht
+    mehr; H1 nennt weiterhin Von-/Bis-Wert."""
+    from app.models import ThunderLevel
+    from output.metric_format import THUNDER_LABEL_DE
+
+    msg = _single_event_msg("thunder", 0.0, 2.0, 1.0)
+    _, plain = render_email(msg)
+    h1_line = plain.split("\n")[0]
+    assert h1_line != "Gewitter seit dem Briefing", (
+        f"Inhaltsleere H1-Form darf nicht mehr entstehen: {h1_line!r}"
+    )
+    expected = (
+        f"Gewitter {THUNDER_LABEL_DE[ThunderLevel.NONE]} → "
+        f"{THUNDER_LABEL_DE[ThunderLevel.MED]} seit dem Briefing"
+    )
+    assert h1_line == expected, f"H1 weicht ab.\n  erwartet: {expected!r}\n  bekommen: {h1_line!r}"
+
+
+# ===========================================================================
+# AC-10: Prozent bleibt Einheit, nur die berechnete Änderung fällt weg
+# ===========================================================================
+
+def test_ac10_prozent_metrik_behaelt_einheit_verliert_aber_berechnete_aenderung():
+    """AC-10: GIVEN eine Metrik mit Katalog-Einheit '%' (Regenwahrschein-
+    lichkeit 60→90), WHEN die E-Mail-Datenzeile gerendert wird, THEN bleibt
+    das Prozentzeichen als Einheit am Messwert erhalten ('60 % ↑ 90 %'),
+    während die berechnete Änderung ('+50 %') verschwindet -- der Wegfall
+    betrifft ausschließlich die Änderung, niemals die Einheit."""
+    msg = _single_event_msg("rain_probability", 60.0, 90.0, 20.0)
+    _, plain = render_email(msg)
+    first_line = _first_plain_data_line(plain)
+    assert "60 % ↑ 90 %" in first_line, (
+        f"Einheit '%' am Messwert fehlt -- sie muss erhalten bleiben: {first_line!r}"
+    )
+    assert "+50 %" not in first_line, (
+        f"Berechnete Prozent-Änderung darf nicht mehr in der Datenzeile stehen: {first_line!r}"
+    )

--- a/tests/tdd/test_alert_stufenwort.py
+++ b/tests/tdd/test_alert_stufenwort.py
@@ -1,0 +1,352 @@
+"""TDD RED — Issue #1948 Scheibe S6: Der Änderungs-Alarm spricht die Stufe
+als Wort (`THUNDER_LABEL_DE`), nicht mehr als nackte Ordinalzahl (0-3).
+
+Spec: docs/specs/modules/fix_1948_s6_alarm_stufenwort.md (AC-1 bis AC-7,
+AC-13 bis AC-17). Kontext: docs/context/feat-1948-s6-telegram-paritaet.md.
+
+Leitunterscheidung der Spec: `value_from`/`value_to`/Korridor-`bound`/`value`
+sind POSITIONEN auf der Gewitter-Leiter -> Wort. `threshold` und
+`abs(value_to-value_from)` sind ABSTAENDE -> Zahl + Einheit "Stufe(n)"
+(AC-6 ist der Wächter dagegen, dass beide Sorten verwechselt werden).
+
+Alles echte Renderer-Aufrufe (render_subject/render_email/render_telegram/
+render_sms) mit echten AlertEvent/AlertMessage/CorridorEvent-Objekten. Kein
+Mock, keine Dateiinhalt-Checks. Wörter werden aus `THUNDER_LABEL_DE`
+(SSoT) abgeleitet, nicht als Literal kopiert (Mutations-Gegenprobe 1 der
+Spec zielt auf genau diese SSoT-Bindung).
+
+AC-14 und AC-15 sind Regressionswächter und dürfen bereits jetzt (ohne
+Implementierung) grün sein -- das ist beabsichtigt, s. jeweiligen Docstring.
+Alle übrigen Tests hier müssen vor der Implementierung ROT sein.
+"""
+from __future__ import annotations
+
+from app.models import ThunderLevel
+from output.metric_format import THUNDER_LABEL_DE
+from output.renderers.alert.model import AlertEvent, AlertMessage, CorridorEvent
+from output.renderers.alert.render import (
+    render_email, render_sms, render_subject, render_telegram,
+)
+
+W_NONE = THUNDER_LABEL_DE[ThunderLevel.NONE]
+W_LOW = THUNDER_LABEL_DE[ThunderLevel.LOW]
+W_MED = THUNDER_LABEL_DE[ThunderLevel.MED]
+W_HIGH = THUNDER_LABEL_DE[ThunderLevel.HIGH]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _single_thunder_msg(
+    *, value_from: float, value_to: float, threshold: float,
+    trip_short: str = "KHW 403", stand_at: str = "09:30",
+    occurred_at: str | None = "15:00", km_from: float = 0.0, km_to: float = 4.0,
+) -> AlertMessage:
+    e = AlertEvent(
+        metric_id="thunder", value_from=value_from, value_to=value_to,
+        threshold=threshold, cmp="über", occurred_at=occurred_at,
+        km_from=km_from, km_to=km_to,
+    )
+    return AlertMessage(trip_short=trip_short, stand_at=stand_at, events=(e,), source=None)
+
+
+def _multi_thunder_visibility_msg() -> AlertMessage:
+    """thunder (Stufen-Metrik) + visibility (Mess-Metrik) über Schwelle,
+    keine segment_id -> Multi-Metrik-Zeile ohne Ort-/Zeit-Zusatz."""
+    e_thunder = AlertEvent(
+        metric_id="thunder", value_from=2.0, value_to=3.0, threshold=1.0,
+        cmp="über", occurred_at=None, km_from=0.0, km_to=4.0,
+    )
+    e_vis = AlertEvent(
+        metric_id="visibility", value_from=1400.0, value_to=280.0, threshold=500.0,
+        cmp="unter", occurred_at=None, km_from=8.0, km_to=8.0,
+    )
+    return AlertMessage(trip_short="KHW 403", stand_at="09:00", events=(e_thunder, e_vis), source=None)
+
+
+def _first_plain_data_line(plain: str) -> str:
+    """Erste Datenzeile im Plain-Text des Ein-Event-Zweigs von render_email():
+    [h1, "", verdict, "", ROW1, row2, row3, ...] -> Index 4."""
+    return plain.split("\n")[4]
+
+
+# ===========================================================================
+# AC-1: E-Mail-Datenzeile, Einzelereignis
+# ===========================================================================
+
+def test_ac1_email_erste_datenzeile_zeigt_stufenwort_nicht_ordinalzahl():
+    """AC-1: GIVEN ein Änderungs-Alarm mit einem einzelnen thunder-Ereignis
+    von Stufe 2 auf Stufe 3, WHEN die E-Mail gerendert wird, THEN enthält die
+    erste Datenzeile 'mittel ↑ hoch' und an keiner Stelle der Zeile die
+    Ziffernfolge '2 ↑ 3'."""
+    msg = _single_thunder_msg(value_from=2.0, value_to=3.0, threshold=1.0)
+    html, plain = render_email(msg)
+    first_line = _first_plain_data_line(plain)
+    expected = f"{W_MED} ↑ {W_HIGH}"
+    assert expected in first_line, (
+        f"Stufenwort fehlt in der ersten Datenzeile: erwartet {expected!r} in {first_line!r}"
+    )
+    assert "2 ↑ 3" not in first_line, (
+        f"Rohe Ordinalzahl '2 ↑ 3' darf in der ersten Datenzeile nicht mehr vorkommen: {first_line!r}"
+    )
+    assert expected in html, f"Stufenwort fehlt im HTML: erwartet {expected!r} in {html!r}"
+    assert "2 ↑ 3" not in html, f"Rohe Ordinalzahl im HTML gefunden: {html!r}"
+
+
+# ===========================================================================
+# AC-2: Telegram-Metrikzeile, Einzelereignis
+# ===========================================================================
+
+def test_ac2_telegram_metrikzeile_einzelereignis_exaktes_literal():
+    """AC-2: GIVEN derselbe Alarm, WHEN der ausführliche Telegram-Text
+    gerendert wird, THEN lautet die Metrik-Zeile exakt
+    'Gewitter · Schwelle 1 Stufe · mittel ↑ hoch · Änderung über'."""
+    msg = _single_thunder_msg(value_from=2.0, value_to=3.0, threshold=1.0)
+    tg = render_telegram(msg)
+    metric_line = tg.split("\n")[1]
+    expected = f"Gewitter · Schwelle 1 Stufe · {W_MED} ↑ {W_HIGH} · Änderung über"
+    assert metric_line == expected, (
+        f"Telegram-Metrikzeile weicht ab.\n  erwartet: {expected!r}\n  bekommen: {metric_line!r}"
+    )
+
+
+# ===========================================================================
+# AC-3: Telegram-Metrikzeile, mehrere Ereignisse (Stufenwort vs. Messzahl)
+# ===========================================================================
+
+def test_ac3_telegram_multi_metrik_zeile_stufenwort_andere_metrik_unveraendert():
+    """AC-3: GIVEN ein Änderungs-Alarm mit mehreren Ereignissen, darunter
+    thunder von Stufe 2 auf Stufe 3, WHEN der ausführliche Telegram-Text
+    gerendert wird, THEN steht in der Metrik-Zeile 'mittel→hoch' und nicht
+    '2→3', während Nicht-Stufen-Metriken unverändert ihre Messzahl mit
+    Einheit behalten (hier: '1.400→280 m')."""
+    msg = _multi_thunder_visibility_msg()
+    tg = render_telegram(msg)
+    metric_line = tg.split("\n")[1]
+    assert f"{W_MED}→{W_HIGH}" in metric_line, (
+        f"Stufenwort fehlt in der Multi-Metrik-Zeile: {metric_line!r}"
+    )
+    assert "2→3" not in metric_line, (
+        f"Rohe Ordinalzahl '2→3' darf nicht mehr vorkommen: {metric_line!r}"
+    )
+    assert "1.400→280 m" in metric_line, (
+        f"Nicht-Stufen-Metrik 'Sicht' soll unveraendert ihre Messzahl mit Einheit zeigen: {metric_line!r}"
+    )
+
+
+# ===========================================================================
+# AC-4: E-Mail-Datenzeile, mehrere Ereignisse
+# ===========================================================================
+
+def test_ac4_email_multi_event_gewitterzeile_wort_und_stufen_einheit():
+    """AC-4: GIVEN denselben Mehr-Ereignis-Alarm, WHEN die E-Mail gerendert
+    wird, THEN trägt die Gewitter-Zeile 'mittel ↑ hoch' als Wertteil und
+    'Änderung 1 Stufe · Schwelle 1 Stufe' im Labelteil."""
+    msg = _multi_thunder_visibility_msg()
+    html, plain = render_email(msg)
+    assert "Änderung 1 Stufe · Schwelle 1 Stufe" in plain, (
+        f"Labelteil (Abstand als Zahl+Einheit) fehlt: {plain!r}"
+    )
+    assert f"{W_MED} ↑ {W_HIGH}" in plain, (
+        f"Wertteil (Position als Wort) fehlt: {plain!r}"
+    )
+    assert "2 ↑ 3" not in plain, f"Rohe Ordinalzahl darf nicht mehr vorkommen: {plain!r}"
+
+
+# ===========================================================================
+# AC-5: Betreff — ein Ereignis und mehrere Ereignisse
+# ===========================================================================
+
+def test_ac5_betreff_einzelereignis_stufenwort():
+    """AC-5 (Einzelereignis-Zweig): Betreff lautet
+    '[KHW 403] km 0–4 · ↑ Gewitter: mittel→hoch'."""
+    msg = _single_thunder_msg(value_from=2.0, value_to=3.0, threshold=1.0)
+    subject = render_subject(msg)
+    expected = f"[KHW 403] km 0–4 · ↑ Gewitter: {W_MED}→{W_HIGH}"
+    assert subject == expected, f"Betreff weicht ab.\n  erwartet: {expected!r}\n  bekommen: {subject!r}"
+
+
+def test_ac5_betreff_mehrere_ereignisse_top3_stufenwort():
+    """AC-5 (Mehr-Ereignis-Zweig): die Bis-Werte der Top-3-Aufzählung tragen
+    die Wörter -- '[KHW 403] Segment 1, 🏁 Ziel · ↑ 2 über Schwelle: Gewitter
+    hoch, Gewitter mittel'."""
+    e_a = AlertEvent(
+        metric_id="thunder", value_from=1.0, value_to=3.0, threshold=1.0,
+        cmp="über", occurred_at=None, km_from=0.0, km_to=0.0, segment_id="1",
+    )
+    e_b = AlertEvent(
+        metric_id="thunder", value_from=1.0, value_to=2.0, threshold=1.0,
+        cmp="über", occurred_at=None, km_from=0.0, km_to=0.0, segment_id="Ziel",
+    )
+    msg = AlertMessage(trip_short="KHW 403", stand_at="09:00", events=(e_a, e_b), source=None)
+    subject = render_subject(msg)
+    expected = (
+        f"[KHW 403] Segment 1, \U0001f3c1 Ziel · ↑ 2 über Schwelle: "
+        f"Gewitter {W_HIGH}, Gewitter {W_MED}"
+    )
+    assert subject == expected, f"Betreff weicht ab.\n  erwartet: {expected!r}\n  bekommen: {subject!r}"
+
+
+# ===========================================================================
+# AC-6: Wächter — Schwelle/Änderungsbetrag dürfen NIE als Stufenwort erscheinen
+# ===========================================================================
+
+def test_ac6_schwelle_erscheint_niemals_als_stufenwort_singular():
+    """AC-6 (Wächter, Singular): threshold=1 ('1 Stufe') darf niemals als
+    'Schwelle leicht' erscheinen — ein Abstand von 1 ist nicht Stufe 1."""
+    msg = _single_thunder_msg(value_from=2.0, value_to=3.0, threshold=1.0)
+    html, plain = render_email(msg)
+    tg = render_telegram(msg)
+    for label, text in (("html", html), ("plain", plain), ("telegram", tg)):
+        assert f"Schwelle {W_LOW}" not in text, (
+            f"Verbotene Fehlumsetzung 'Schwelle {W_LOW}' in {label} gefunden: {text!r}"
+        )
+    assert "Schwelle 1 Stufe" in tg, f"Korrekte Zahl+Einheit-Form fehlt in Telegram: {tg!r}"
+
+
+def test_ac6_schwelle_erscheint_niemals_als_stufenwort_plural():
+    """AC-6 (Wächter, Plural): threshold=2 ('2 Stufen') darf niemals als
+    'Schwelle mittel' erscheinen."""
+    e = AlertEvent(
+        metric_id="thunder", value_from=0.0, value_to=3.0, threshold=2.0,
+        cmp="über", occurred_at=None, km_from=0.0, km_to=4.0,
+    )
+    msg = AlertMessage(trip_short="KHW 403", stand_at="09:00", events=(e,), source=None)
+    html, plain = render_email(msg)
+    tg = render_telegram(msg)
+    for label, text in (("html", html), ("plain", plain), ("telegram", tg)):
+        assert f"Schwelle {W_MED}" not in text, (
+            f"Verbotene Fehlumsetzung 'Schwelle {W_MED}' in {label} gefunden: {text!r}"
+        )
+    assert "Schwelle 2 Stufen" in tg, f"Korrekte Zahl+Einheit-Form (Plural) fehlt in Telegram: {tg!r}"
+
+
+# ===========================================================================
+# AC-7: Grenzwert-/Korridor-Alarm
+# ===========================================================================
+
+def test_ac7_korridor_alarm_grenze_und_wert_beide_als_wort():
+    """AC-7: GIVEN ein Grenzwert-/Korridor-Alarm auf thunder mit Grenze
+    Stufe 1 und aktuellem Wert Stufe 3, WHEN E-Mail oder Telegram gerendert
+    werden, THEN lautet die Zeile 'Gewitter: deine Grenze leicht ist
+    gerissen — jetzt hoch' -- beide Werte sind Positionen, also beide Wörter."""
+    ce = CorridorEvent(
+        metric_id="thunder", value=3.0, bound=1.0, direction="above",
+        occurred_at=None, km_from=0.0, km_to=4.0,
+    )
+    msg = AlertMessage(trip_short="KHW 403", stand_at="10:00", events=(), corridor_events=(ce,))
+    html, plain = render_email(msg)
+    tg = render_telegram(msg)
+    expected_line = f"Gewitter: deine Grenze {W_LOW} ist gerissen — jetzt {W_HIGH} (km 0–4)"
+    assert expected_line in plain, f"Korridor-Zeile fehlt im E-Mail-Plaintext: {plain!r}"
+    assert expected_line in tg, f"Korridor-Zeile fehlt im Telegram-Text: {tg!r}"
+    assert f"Grenze {W_LOW} · jetzt {W_HIGH}" in html, f"Korridor-Wertzelle im HTML fehlt/falsch: {html!r}"
+
+
+# ===========================================================================
+# AC-13: Rückfall bei unbekanntem Stufenwert — niemals "kein"
+# ===========================================================================
+
+def test_ac13_unbekannter_stufenwert_faellt_auf_zahl_zurueck_nie_auf_kein():
+    """AC-13: GIVEN ein thunder-Ereignis mit einem Wert außerhalb 0–3
+    (value_to=90, über den Vorschau-Pfad erreichbar), WHEN ein Kanal
+    gerendert wird, THEN fällt die Darstellung auf die bisherige Zahlform
+    zurück und meldet niemals 'kein' -- eine Entwarnung für einen
+    unbekannten Wert wäre eine sicherheitsrelevante Falschaussage. Der
+    gültige Von-Wert (2 -> 'mittel') im selben Ereignis zeigt, dass die
+    Wort-Umsetzung an dieser Stelle aktiv ist."""
+    msg = _single_thunder_msg(value_from=2.0, value_to=90.0, threshold=1.0)
+    html, plain = render_email(msg)
+    first_line = _first_plain_data_line(plain)
+    assert W_MED in first_line, (
+        f"Gültiger Von-Wert (2) soll als Wort erscheinen: {first_line!r}"
+    )
+    assert "90" in first_line, (
+        f"Unbekannter Wert (90) soll numerisch zurückfallen: {first_line!r}"
+    )
+    assert "kein" not in first_line, (
+        f"Rückfall auf 'kein' wäre eine sicherheitsrelevante Falsch-Entwarnung: {first_line!r}"
+    )
+
+
+# ===========================================================================
+# AC-14: SMS bleibt unverändert (Regressionswächter, bereits grün)
+# ===========================================================================
+
+def test_ac14_sms_bleibt_unveraendert_regressionswaechter():
+    """AC-14 (bereits grün, Regressionswächter): GIVEN ein thunder-Alarm von
+    Stufe 2 auf Stufe 3, WHEN die SMS gerendert wird, THEN lautet sie
+    unverändert 'km 0-4: TH:M->H@15' -- S6 ändert an der Kurznachricht
+    nichts."""
+    msg = _single_thunder_msg(value_from=2.0, value_to=3.0, threshold=1.0)
+    sms = render_sms(msg)
+    assert sms == "km 0-4: TH:M->H@15", f"SMS weicht vom unveränderten Ist-Stand ab: {sms!r}"
+
+
+# ===========================================================================
+# AC-15: Nicht-Stufen-Metrik bleibt zahlenformatiert (Regressionswächter)
+# ===========================================================================
+
+def test_ac15_nicht_stufen_metrik_zahlformat_unveraendert_regressionswaechter():
+    """AC-15 (bereits grün, Regressionswächter): GIVEN ein Alarm für eine
+    Metrik ohne Stufencharakter (hier: Böen, km/h), WHEN irgendein Kanal
+    gerendert wird, THEN bleibt die Zahlformatierung inkl. Einheit
+    unverändert gegenüber dem Prod-Stand."""
+    e = AlertEvent(
+        metric_id="gust", value_from=20.0, value_to=80.0, threshold=40.0,
+        cmp="über", occurred_at="11:00", km_from=0.0, km_to=4.0,
+    )
+    msg = AlertMessage(trip_short="KHW 403", stand_at="09:30", events=(e,), source=None)
+    html, plain = render_email(msg)
+    first_line = _first_plain_data_line(plain)
+    assert "20 km/h ↑ 80 km/h" in first_line, (
+        f"Zahlformat der Nicht-Stufen-Metrik hat sich veraendert: {first_line!r}"
+    )
+    tg = render_telegram(msg)
+    metric_line = tg.split("\n")[1]
+    assert "Schwelle 40 km/h" in metric_line and "20 km/h ↑ 80 km/h" in metric_line, (
+        f"Telegram-Zahlformat der Nicht-Stufen-Metrik hat sich veraendert: {metric_line!r}"
+    )
+
+
+# ===========================================================================
+# AC-16: Ortsvergleich-Alarm zieht ohne eigenen Code mit
+# ===========================================================================
+
+def test_ac16_ortsvergleich_alarm_zeigt_ebenfalls_stufenwort():
+    """AC-16: GIVEN ein Ortsvergleich-Änderungsalarm (AlertMessage mit
+    gesetztem location_label statt segment_id) mit einem thunder-Ereignis,
+    WHEN E-Mail und Telegram gerendert werden, THEN erscheint die Stufe
+    ebenso als Wort -- die geteilten Renderer bedienen Trip und
+    Ortsvergleich ohne ortsvergleich-eigenen Code."""
+    e = AlertEvent(
+        metric_id="thunder", value_from=2.0, value_to=3.0, threshold=1.0,
+        cmp="über", occurred_at="15:00", km_from=0.0, km_to=0.0,
+    )
+    msg = AlertMessage(trip_short="Vergleich", stand_at="10:00", events=(e,), location_label="Sixt")
+    html, plain = render_email(msg)
+    tg = render_telegram(msg)
+    expected = f"{W_MED} ↑ {W_HIGH}"
+    assert expected in plain, f"Ortsvergleich-E-Mail zeigt kein Stufenwort: {plain!r}"
+    assert expected in tg, f"Ortsvergleich-Telegram zeigt kein Stufenwort: {tg!r}"
+
+
+# ===========================================================================
+# AC-17: Rundung — exakt die bisherige Bankersrundung
+# ===========================================================================
+
+def test_ac17_rundung_bankers_2_5_ergibt_mittel_nicht_hoch():
+    """AC-17: GIVEN ein thunder-Wert mit Nachkommaanteil (2,5), WHEN er in
+    ein Wort übersetzt wird, THEN greift exakt die bisherige Rundung
+    (round(v, 0), kaufmännisch-gerade Bankersrundung), sodass 2,5 auf 2
+    rundet und 'mittel' ergibt -- nicht 'hoch'."""
+    msg = _single_thunder_msg(value_from=1.0, value_to=2.5, threshold=1.0)
+    html, plain = render_email(msg)
+    first_line = _first_plain_data_line(plain)
+    assert W_MED in first_line, (
+        f"2,5 soll bankers-gerundet auf 2 ({W_MED}) fallen, nicht 3 ({W_HIGH}): {first_line!r}"
+    )
+    assert W_HIGH not in first_line, (
+        f"2,5 darf NICHT auf {W_HIGH} runden: {first_line!r}"
+    )

--- a/tests/tdd/test_alert_stufenwort.py
+++ b/tests/tdd/test_alert_stufenwort.py
@@ -350,3 +350,47 @@ def test_ac17_rundung_bankers_2_5_ergibt_mittel_nicht_hoch():
     assert W_HIGH not in first_line, (
         f"2,5 darf NICHT auf {W_HIGH} runden: {first_line!r}"
     )
+
+
+# ===========================================================================
+# Mutations-Gegenprobe 1 (Spec): SSoT-Bindung an THUNDER_LABEL_DE
+# ===========================================================================
+
+def test_mutation1_ssot_bindung_an_thunder_label_de():
+    """Mutations-Gegenprobe 1 der Spec: `render.py` MUSS `THUNDER_LABEL_DE`
+    (SSoT, `output/metric_format.py`) importieren, nicht eine wertgleiche
+    lokale Kopie halten. Ein Test, der sein Erwartungswort selbst aus
+    `THUNDER_LABEL_DE` ableitet (wie alle anderen Tests in dieser Datei via
+    `W_MED`/`W_HIGH` usw.), ist gegenueber genau dieser Bindung tautologisch
+    -- beide Seiten des Vergleichs kommen aus derselben Quelle. Dieser Test
+    mutiert daher den INHALT der echten SSoT-Tabelle zur Laufzeit und prueft,
+    dass der Renderer-Output den Marker zeigt.
+
+    Rebinding (`output.metric_format.THUNDER_LABEL_DE = {...neues Dict...}`)
+    wuerde NICHT durchschlagen: `render.py` bindet den Namen per
+    `from output.metric_format import THUNDER_LABEL_DE` an einen EIGENEN
+    Modul-Attribut-Namen, der weiterhin auf das ALTE Dict-Objekt zeigt. Nur
+    eine Mutation des Dict-INHALTS (`THUNDER_LABEL_DE[...] = ...`) ist fuer
+    beide Module sichtbar -- genau das ist die Bindung, die dieser Test
+    beweist. Wiederherstellung ZWINGEND per try/finally, sonst verseucht ein
+    haengengebliebener Marker jeden nachfolgenden Test im selben Lauf."""
+    marker = "MUTATIONS-MARKER-1948-S6"
+    original = THUNDER_LABEL_DE[ThunderLevel.MED]
+    THUNDER_LABEL_DE[ThunderLevel.MED] = marker
+    try:
+        msg = _single_thunder_msg(value_from=2.0, value_to=3.0, threshold=1.0)
+        html, plain = render_email(msg)
+        tg = render_telegram(msg)
+        assert marker in plain, (
+            f"E-Mail-Plaintext spiegelt die SSoT-Mutation nicht -- render.py "
+            f"haelt vermutlich eine lokale Kopie statt der importierten "
+            f"THUNDER_LABEL_DE-Tabelle: {plain!r}"
+        )
+        assert marker in html, (
+            f"E-Mail-HTML spiegelt die SSoT-Mutation nicht: {html!r}"
+        )
+        assert marker in tg, (
+            f"Telegram spiegelt die SSoT-Mutation nicht: {tg!r}"
+        )
+    finally:
+        THUNDER_LABEL_DE[ThunderLevel.MED] = original

--- a/tests/tdd/test_alert_telegram_stand_zeile.py
+++ b/tests/tdd/test_alert_telegram_stand_zeile.py
@@ -1,0 +1,96 @@
+"""TDD RED — Issue #1948 Scheibe S6: Der ausführliche Telegram-Alarm bekommt
+dieselbe Stand-/Vergleichszeile, die die E-Mail bereits führt. Sie entsteht
+ausschließlich in `render_telegram`, niemals in `render_sms` (Telegram-
+Kurzstil sendet den SMS-Text unverändert weiter).
+
+Spec: docs/specs/modules/fix_1948_s6_alarm_stufenwort.md (AC-11, AC-12).
+Kontext: docs/context/feat-1948-s6-telegram-paritaet.md, Abschnitt D.
+
+PO-Entscheid (Variante b): volle Zeile wie in der E-Mail,
+'Stand: heute 10:00 · verglichen mit 18:03'.
+
+Alles echte Renderer-Aufrufe (render_telegram/render_sms) mit echten
+AlertEvent/AlertMessage-Objekten. Kein Mock, keine Dateiinhalt-Checks.
+
+Alle Tests hier müssen vor der Implementierung ROT sein.
+"""
+from __future__ import annotations
+
+from output.renderers.alert.model import AlertEvent, AlertMessage
+from output.renderers.alert.render import render_sms, render_telegram
+
+
+def _single_thunder_msg(
+    value_from: float, value_to: float, threshold: float,
+    *, reference_at: str | None, stand_at: str = "10:00",
+    trip_short: str = "KHW 403", occurred_at: str | None = "15:00",
+    km_from: float = 0.0, km_to: float = 4.0,
+) -> AlertMessage:
+    e = AlertEvent(
+        metric_id="thunder", value_from=value_from, value_to=value_to,
+        threshold=threshold, cmp="über", occurred_at=occurred_at,
+        km_from=km_from, km_to=km_to,
+    )
+    return AlertMessage(
+        trip_short=trip_short, stand_at=stand_at, events=(e,), source=None,
+        reference_at=reference_at,
+    )
+
+
+# ===========================================================================
+# AC-11: Telegram-Stand-Zeile — bekannter und fehlender Vergleichszeitpunkt
+# ===========================================================================
+
+def test_ac11_telegram_stand_zeile_bei_bekanntem_referenzzeitpunkt():
+    """AC-11 (Fall 1, reference_at bekannt): GIVEN ein Änderungs-Alarm mit
+    gesetztem reference_at, WHEN der ausführliche Telegram-Text gerendert
+    wird, THEN schließt er mit derselben Stand-Zeile wie die E-Mail:
+    'Stand: heute 10:00 · verglichen mit 18:03'. Beide Fälle sind real
+    erreichbar: der Ortsvergleich-Einzelpunkt und der Vorschau-Pfad reichen
+    reference_at nie durch (project.py:411-424, validator_render_service.py:
+    144-147)."""
+    msg = _single_thunder_msg(2.0, 3.0, 1.0, reference_at="18:03", stand_at="10:00")
+    tg = render_telegram(msg)
+    last_line = tg.splitlines()[-1]
+    expected = "Stand: heute 10:00 · verglichen mit 18:03"
+    assert last_line == expected, (
+        f"Telegram-Stand-Zeile weicht ab.\n  erwartet: {expected!r}\n  bekommen: {last_line!r}"
+    )
+
+
+def test_ac11_telegram_stand_zeile_bei_fehlendem_referenzzeitpunkt():
+    """AC-11 (Fall 2, reference_at fehlt): GIVEN denselben Alarm-Typ ohne
+    reference_at, WHEN der ausführliche Telegram-Text gerendert wird, THEN
+    schließt er mit 'Stand: heute 10:00 · verglichen mit dem letzten
+    Briefing' -- derselbe Rückfalltext wie in der E-Mail."""
+    msg = _single_thunder_msg(2.0, 3.0, 1.0, reference_at=None, stand_at="10:00")
+    tg = render_telegram(msg)
+    last_line = tg.splitlines()[-1]
+    expected = "Stand: heute 10:00 · verglichen mit dem letzten Briefing"
+    assert last_line == expected, (
+        f"Telegram-Stand-Zeile (Rückfall) weicht ab.\n  erwartet: {expected!r}\n  "
+        f"bekommen: {last_line!r}"
+    )
+
+
+# ===========================================================================
+# AC-12: Stand-Zeile entsteht ausschließlich in render_telegram, nie in SMS
+# ===========================================================================
+
+def test_ac12_stand_zeile_entsteht_ausschliesslich_in_telegram_nie_in_sms():
+    """AC-12: GIVEN einen Trip mit Telegram-Kurzstil, WHEN ein Änderungs-
+    Alarm versendet wird, THEN bleibt der Kurzstil-Text byte-identisch mit
+    dem SMS-Text und enthält keine Stand-Zeile -- die neue Zeile entsteht
+    ausschließlich in render_telegram, niemals in render_sms. Wächter gegen
+    ein Auslaufen der Zeile in die Kurznachricht (Mutations-Gegenprobe 4 der
+    Spec: eine Stand-Zeile zusätzlich in render_sms muss dieses AC röten)."""
+    msg = _single_thunder_msg(2.0, 3.0, 1.0, reference_at="18:03", stand_at="10:00")
+    tg = render_telegram(msg)
+    sms = render_sms(msg)
+    assert "Stand:" in tg, (
+        f"Telegram (ausführlicher Text) soll die Stand-Zeile führen (AC-11): {tg!r}"
+    )
+    assert "Stand:" not in sms, (
+        f"Wächter AC-12: Die Stand-Zeile darf niemals in render_sms landen "
+        f"(sonst liefe sie über den Kurzstil-Pfad in die SMS aus): {sms!r}"
+    )

--- a/tests/tdd/test_issue_1169_compare_alert_consumer.py
+++ b/tests/tdd/test_issue_1169_compare_alert_consumer.py
@@ -754,9 +754,12 @@ def test_ac7_trip_alert_rendering_unchanged():
     # `location_label` nie — steht oben unveraendert und gilt weiter.
     assert subject == "[GR20] Segment 1 · ↑ Niedersch: 2,0 mm→18,0 mm", subject
     assert plain == (
-        "Niedersch +800% seit dem Briefing\n\n"
-        "↑ +800 % · Änderung über deiner Alarm-Schwelle (10,0 mm)\n\n"
-        "Niedersch · mm: 2,0 mm ↑ 18,0 mm +800 %\n"
+        # Issue #1948 S6 (AC-9): H1 nennt Von-/Bis-Wert statt der entfallenen
+        # berechneten Prozent-Änderung.
+        "Niedersch 2,0 mm → 18,0 mm seit dem Briefing\n\n"
+        # AC-8: kein berechnetes Δ% mehr im Verdikt-Badge.
+        "↑ Änderung über deiner Alarm-Schwelle (10,0 mm)\n\n"
+        "Niedersch · mm: 2,0 mm ↑ 18,0 mm\n"
         "Änderung 16,0 mm: über Alarm-Schwelle 10,0 mm ✗\n"
         "Wo & wann: Segment 1\n\n"
         "Stand: heute 14:00 · verglichen mit dem letzten Briefing"
@@ -770,7 +773,10 @@ def test_ac7_trip_alert_rendering_unchanged():
     ), plain
     assert telegram_text == (
         "<b>GR20 · Segment 1 · ↑ Niedersch</b>\n"
-        "Niedersch · Schwelle 10,0 mm · 2,0 mm ↑ 18,0 mm · Änderung über"
+        "Niedersch · Schwelle 10,0 mm · 2,0 mm ↑ 18,0 mm · Änderung über\n"
+        # Issue #1948 S6 (AC-11): Telegram fuehrt seither dieselbe Stand-
+        # Zeile wie die E-Mail (reference_at ist hier None -> Rueckfalltext).
+        "Stand: heute 14:00 · verglichen mit dem letzten Briefing"
     ), telegram_text
 
 


### PR DESCRIPTION
Scheibe S6 von #1948. Der Änderungs-Alarm war die einzige Stelle im Produkt, die die interne Ordinalzahl der Gewitterstufe nach außen gab — und dazu auf der Stufenskala eine prozentuale Änderung rechnete, die keinen Sachverhalt bezeichnet.

| | vorher | nachher |
|---|---|---|
| Betreff | `↑ Gewitter: 2→3` | `↑ Gewitter: mittel→hoch` |
| E-Mail-H1 | `Gewitter +50% seit dem Briefing` | `Gewitter mittel → hoch seit dem Briefing` |
| E-Mail-Datenzeile | `Gewitter · : 2 ↑ 3 +50 %` | `Gewitter · : mittel ↑ hoch` |
| Telegram | `Gewitter · Schwelle 1 · 2 ↑ 3` | `Gewitter · Schwelle 1 Stufe · mittel ↑ hoch` |
| Telegram-Schluss | — fehlte — | `Stand: heute 10:00 · verglichen mit 18:03` |
| Grenzwert-Alarm | `Grenze 1 gerissen — jetzt 3` | `Grenze leicht gerissen — jetzt hoch` |
| SMS | `km 0-4: TH:M->H@15` | **unverändert** |

## Positionen vs. Abstände

In derselben Zeile stehen zwei Sorten Zahl, die gleich aussehen:

- **Positionen** (`value_from`/`value_to`, Korridor-Grenze) → Wort aus `THUNDER_LABEL_DE`
- **Abstände** (`threshold`, `abs(Δ)`) → Zahl + Einheit `Stufe`/`Stufen`

`Schwelle leicht` wäre eine sachlich falsche Aussage — ein Abstand von 1 ist nicht Stufe 1. AC-6 ist der Wächter dagegen und prüft über alle Kanäle.

Werte außerhalb 0–3 (nur über den Vorschau-Pfad erreichbar) fallen auf die Zahlform zurück, **niemals** auf `kein` — eine Entwarnung für einen unbekannten Wert wäre sicherheitsrelevant falsch (AC-13).

Prozent als **Einheit** bleibt unangetastet (`60 % ↑ 90 %`); nur die berechnete Änderung entfällt (AC-10).

## Nachweise

- **17/17 ACs** erfüllt, Spec `docs/specs/modules/fix_1948_s6_alarm_stufenwort.md`
- **Adversary VERIFIED** — 5 Runden, alle 6 Pflicht-Mutationen gefangen
- Finding **F001** gefunden und geschlossen: Die Bindung an `THUNDER_LABEL_DE` war unbewacht — eine wertgleiche lokale Kopie ließ alle 560 Tests grün, weil jeder Test sein Erwartungswort aus derselben Tabelle ableitete. Neuer Laufzeit-Bindungstest schließt die Lücke.
- **575 passed, 1 skipped** gegen den finalen Stand (inkl. der Onset-Tests aus #2009)
- Radar-Alert-Mail-Validator Exit 0

## Nebenbefund → #1199

Bei `thunder`-Werten außerhalb 0–3 trägt der **Abstand** die Stufen-Einheit, obwohl die Positionen auf die Zahlform zurückfallen (`Änderung 45 Stufen` auf einer vierstufigen Leiter). Produktiv unerreichbar. Die Spec ordnet eine strukturgleiche SMS-Lücke bereits genauso ein.

🤖 Generated with [Claude Code](https://claude.com/claude-code)