### PR TITLE
fix(#1741): Telegram-Kappungshinweis + toten Detail-Pfad entfernen

### DIFF
--- a/docs/context/fix-1741-telegram-detailzeile.md
+++ b/docs/context/fix-1741-telegram-detailzeile.md
@@ -9,7 +9,11 @@ Für Telegram ausgewählte Metriken ab Slot 8 (sowie alle `secondary`-Größen) 
 der Telegram-Segment-Tabelle überhaupt nicht. Die Auswahl im Editor bleibt für diese
 Metriken wirkungslos.
 
-## Kernbefund: es ist eine Regression, kein liegengebliebener Altcode
+## Kernbefund: toter Pfad — Umsetzung eines PO-Entscheids, NICHT eine Regression
+
+> **Achtung, Lesereihenfolge:** Der erste Eindruck aus der Commit-Historie war „unbeabsichtigte
+> Regression". Die Analyse weiter unten widerlegt das: der Wegfall setzt die PO-Entscheidung
+> vom 2026-06-06 um. Dieser Abschnitt hält nur die Historie fest.
 
 `ChannelLayout.detail_metrics` wird berechnet (`channel_layout.py:127`) und **an keiner
 Stelle im Produktivcode gelesen**. Die zugehörige Renderfunktion `_detail_lines()`
@@ -33,8 +37,10 @@ Aus dem Diff von `6b27798f`:
 
 Die Spec des Redesigns (`docs/specs/modules/feat_1001_telegram_redesign.md:36-39`) nennt
 ausdrücklich nur die Entfernung von `_tg_extra_detail_line()` und reaktiviert
-`_narrow_table()`. Der Wegfall von `_detail_lines()` ist dort **nicht** als Entscheidung
-dokumentiert — er sieht nach Kollateralschaden des Rewrites aus.
+`_narrow_table()`. Der Wegfall von `_detail_lines()` ist dort **nicht** protokolliert —
+was den Eindruck eines Kollateralschadens erzeugt. Die Analyse zeigt: er folgt dem
+PO-Entscheid vom 2026-06-06 (#587), der die Detail-Zeile abgeschafft hat. Fehlend ist die
+Dokumentation, nicht die Entscheidung.
 
 **Seit 2026-07-03, also rund 7 Wochen, ist `detail_metrics` funktionslos.**
 
@@ -88,7 +94,8 @@ baut über `build_token_line` / `render_sms` aus
 | `src/output/renderers/narrow.py:111` | `_detail_lines()` — fertige Renderfunktion, null Aufrufstellen |
 | `src/output/renderers/narrow.py:700` | `render_for_channel("telegram", …)` — einziger Trip-Aufrufer |
 | `src/output/renderers/narrow.py:855-856` | einzige Nutzung von `layout.*` — nur `table_columns` |
-| `src/output/renderers/narrow.py:770-807` | Kurzübersicht-Bubble — liest `dc.get_enabled_metric_ids()`, also eine **andere Quelle** |
+| `src/output/renderers/narrow.py:770-807` | Kurzübersicht-Bubble — zeigt **alle** aktiven Telegram-Metriken als Tagesaussage |
+| `src/output/renderers/trip_report.py:275-292` | baut `_dc_telegram` (kanal-kaskadiert) — EINE Quelle für Tabelle + Kurzübersicht |
 | `src/output/renderers/channel_layout.py:86,127` | `detail_metrics` — Definition und einzige Befüllung |
 | `src/output/renderers/channel_layout.py:119-120` | SMS-Zweig `limit == 0`, unerreichbar |
 | `src/output/renderers/comparison.py:701,762,768-769` | Ortsvergleich — liest `table_columns` **und** `demoted_count` |
@@ -146,11 +153,12 @@ Kandidat und muss in der Spec ausdrücklich abgewogen werden.
    weil `grep` auf `WeatherMetricsTab.svelte` falsch-negative Treffer liefert). Wenn ja,
    ist das der eigentliche Beleg für „Bedienelement ohne Wirkung".
 
-4. **Zwei Quellen in einer Nachricht.** Die Kurzübersicht-Bubble liest
-   `dc.get_enabled_metric_ids()` (`narrow.py:780`), die Tabelle `layout.table_columns`.
-   Die Kurzübersicht ignoriert damit die **kanalspezifische** Auswahl. Vermutete
-   Konsequenz: eine für Telegram *abgewählte* Metrik erscheint dort trotzdem — das wäre
-   derselbe Fehler in der Gegenrichtung. Noch nicht verifiziert, gehört in `/20-analyse`.
+4. ~~**Zwei Quellen in einer Nachricht.**~~ **WIDERLEGT in der Analyse.** Die
+   Kurzübersicht liest zwar `dc.get_enabled_metric_ids()` (`narrow.py:780`), bekommt aber
+   ein bereits kanal-kaskadiertes `dc`: `trip_report.py:275-278` baut `_dc_telegram` aus
+   `get_metrics_for_channel("telegram", report_type)`. Der ausführliche Kommentar
+   `trip_report.py:280-292` hält fest, dass genau diese Falle als Adversary-Finding F004
+   (#1719 S2) gefangen wurde. Es gibt EINE Quelle für Tabelle, Kurzübersicht und Fußzeile.
 
 5. **Platzbudget ist real.** `_TG_TABLE_WIDTH` existiert, damit auf einem
    iPhone-Standardbildschirm kein Umbruch entsteht (`narrow.py:57-60`). Eine Detailzeile
@@ -165,3 +173,110 @@ Kandidat und muss in der Spec ausdrücklich abgewogen werden.
    Historie nicht mehr gleichwertig: Option 3 („ersatzlos entfernen") würde eine
    unbeabsichtigte Regression nachträglich zur Entscheidung erklären. Vorlage erfolgt mit
    der Spec.
+
+---
+
+## Analysis
+
+### Type
+
+Bug — aber mit deutlich kleinerem Schaden als das Ticket beschreibt, und teils auf einer
+falschen Prämisse.
+
+### Was wirklich passiert (Trip „KHW 403", 14 Telegram-Metriken)
+
+| Ort | Was erscheint |
+|---|---|
+| Kurzübersicht-Bubble (`narrow.py:780-807`) | **alle 14** Metriken, je eine Tagesaussage-Zeile |
+| Segment-Tabelle (`narrow.py:855-856`) | **7** Metriken, stündliche Werte |
+
+Verloren geht also **nicht die Metrik, sondern ihre stündliche Auflösung**. Die
+Ticket-Formulierung „verschwindet aus der Tabelle" trifft zu; „die Auswahl bleibt
+wirkungslos" trifft **nicht** zu.
+
+### Drei Ticket-Prämissen, die die Untersuchung nicht bestätigt
+
+1. **„ohne Hinweis" — falsch.** Der Editor warnt dreifach:
+   Chip `−N` am Kanalreiter (`LTChannelPicker.svelte:50-53`), gestrichelte Schnittlinie
+   „✂ ab hier Telegram-Limit (max 7)" (`LTCutLine.svelte:20`), warngefärbter Hinweis
+   „Telegram: N Metriken · zu breit — max 7, weiter vorne = sicherer"
+   (`ltChannels.ts:130-149`, gerendert `LTCapNote.svelte:47-49`). Der Versand-Reiter sagt
+   „Telegram die ersten 7" (`vtBriefingChannelsText.ts:34`).
+
+2. **„die dafür gebaute Detailzeile" — irreführend.** Es gibt eine dokumentierte
+   **PO-Entscheidung vom 2026-06-06**: „Kein ‚→ Detail'-Knopf, keine Detail-Zeile"
+   (`WeatherV2Reihenfolge.svelte:4`, Issue #587). Seither ist der `secondary`-Bucket
+   immer leer (`WeatherMetricsTab.svelte:220`, erzwungen `:436`/`:682`); die Design-Quelle
+   von #622 nennt den Editor-Screen ausdrücklich „(Roh/Einfach, kein Detail)".
+   ⇒ Der Wegfall in #1001 (`6b27798f`, 2026-07-03) setzt diesen Entscheid um. Er ist
+   **keine unbeabsichtigte Regression** — nur in der #1001-Spec nicht protokolliert.
+   Option 1 des Tickets („`_detail_lines()` aufrufen") widerspricht dem Entscheid direkt.
+
+3. **Tour-Relevanz — nicht gegeben.** `KHW 403` fährt `telegram_style = kurzform`
+   (siehe oben). Der Bubble-Renderer wird auf der Tour nicht ausgeliefert.
+
+### Die verbleibende echte Lücke
+
+**Die Telegram-Nachricht selbst trägt keinen Kappungshinweis.** Der Ortsvergleich hat auf
+demselben Kanal längst einen: `comparison.py:768-769` liest `demoted_count` und schreibt
+über `_telegram_metric_notice()` (`:854-867`) die Zeile „+N weitere Wettergrößen je Ort
+(Telegram-Limit)". Der Trip-Pfad hat kein Pendant, obwohl `demoted_count` dort berechnet
+wird und bereitliegt.
+
+Wer das Briefing liest, ohne den Editor offen zu haben — also unterwegs —, kann nicht
+wissen, dass die Tabelle beschnitten ist. Das ist der Rest von #1741, der Bestand hat.
+
+### Toter Code als Nebenwirkung
+
+`detail_metrics` (`channel_layout.py:127`) und `_detail_lines()` (`narrow.py:111`) sind
+seit `6b27798f` produziert-aber-nie-konsumiert. Genau diese Leiche hat das Ticket erzeugt:
+Sie sieht aus wie eine vorhandene, nur nicht verkabelte Fähigkeit, ist aber das Gegenteil —
+eine abgeschaffte. Solange sie steht, wird sie erneut als Bug gemeldet werden.
+
+Ebenfalls tot, gleiche Familie:
+- `applyChannel()`/`ChannelLayout` im Frontend (`metricsEditor.ts:379-405`) — nur Tests
+- SMS-Zweig `limit == 0` (`channel_layout.py:119-120`) — kein Renderer betritt ihn
+- `SavePresetDialog.svelte:205-213` zeigt dauerhaft „0 Detail" (`secondary` immer leer)
+
+### Affected Files (Vorschlag, abhängig von der PO-Richtung)
+
+| Datei | Change | Beschreibung |
+|---|---|---|
+| `src/output/renderers/narrow.py` | MODIFY | Kappungshinweis in der Segment-Bubble; `_detail_lines()` entfernen |
+| `src/output/renderers/comparison.py` | MODIFY | `_telegram_metric_notice()` zum geteilten Baustein heben |
+| `src/output/renderers/channel_layout.py` | MODIFY | `detail_metrics` entfernen; `demoted_count` bleibt |
+| `tests/tdd/test_issue_887_report_inkonsistenz.py:229` | MODIFY | prüft veraltetes Verhalten (trivial wahr) |
+| `tests/tdd/test_issue_360_channel_renderer.py`, `test_issue_429_channel_layouts.py`, `test_channel_metric_matrix.py`, `test_felt_night_catalog_exclusions.py`, `test_temp_tagesrichtung_aufloesung.py` | MODIFY | lesen `detail_metrics` |
+| `frontend/.../metricsEditor.ts` + `.test.ts` | MODIFY | tote `applyChannel()`/`ChannelLayout` |
+
+### Scope Assessment
+
+- Dateien: 4 Produktiv + ~7 Test (bei voller Aufräumung)
+- Geschätzte LoC: +40 / −90
+- Risiko: **LOW** — der Hinweistext ist additiv; das Entfernen betrifft ausschließlich
+  Code ohne Konsumenten. Einziges echtes Risiko: die Test-Anpassungen sind breit gestreut.
+
+### Technical Approach (Empfehlung)
+
+**Nicht Option 1.** Sie widerspricht dem PO-Entscheid vom 2026-06-06.
+
+Empfohlen ist die Kombination aus Option 2 und 3, in dieser Reihenfolge:
+
+1. **Kappungshinweis in der Trip-Telegram-Nachricht**, wortgleich zum Ortsvergleich, über
+   einen **geteilten Baustein** (`_telegram_metric_notice()` aus `comparison.py` heben).
+   Das erfüllt die Code-Teilungs-Vorgabe und schließt die einzige Lücke, die unterwegs
+   spürbar ist. Quelle ist `demoted_count`, das bereits berechnet wird.
+2. **`detail_metrics` + `_detail_lines()` ersatzlos entfernen**, damit der tote Pfad keine
+   abgeschaffte Fähigkeit mehr vortäuscht. Der Entscheid von 2026-06-06 wird dabei in der
+   Spec dokumentiert — das Versäumnis von #1001 wird nachgeholt.
+
+Nachweis-Pflicht: Der Test muss die **gerenderten Bubbles** prüfen, nicht das
+Layout-Ergebnis. Alle heutigen Tests prüfen die Berechnung (siehe Risiko 1) und würden
+eine erneute Entkopplung nicht bemerken.
+
+### Open Questions (PO)
+
+- [ ] Bestätigst du, dass die Detail-Zeile abgeschafft bleibt (Entscheid 2026-06-06)?
+- [ ] Soll die Telegram-Nachricht einen Kappungshinweis tragen — oder genügt die Warnung
+      im Editor, sodass #1741 als „so gewollt" geschlossen wird?
+- [ ] Bleibt #1741 im Milestone „Tour KHW 2026-08", obwohl der Tour-Trip im Kurzstil fährt?

--- a/docs/context/fix-1741-telegram-detailzeile.md
+++ b/docs/context/fix-1741-telegram-detailzeile.md
@@ -1,0 +1,167 @@
+# Context: fix-1741-telegram-detailzeile
+
+Issue: #1741 · Milestone „Tour KHW 2026-08" · `bug`, `priority:high`, `area:output`
+Stand: `origin/main` = `cba7ffa3`, Branch `fix-1741-telegram-detailzeile`
+
+## Request Summary
+
+Für Telegram ausgewählte Metriken ab Slot 8 (sowie alle `secondary`-Größen) erscheinen in
+der Telegram-Segment-Tabelle überhaupt nicht. Die Auswahl im Editor bleibt für diese
+Metriken wirkungslos.
+
+## Kernbefund: es ist eine Regression, kein liegengebliebener Altcode
+
+`ChannelLayout.detail_metrics` wird berechnet (`channel_layout.py:127`) und **an keiner
+Stelle im Produktivcode gelesen**. Die zugehörige Renderfunktion `_detail_lines()`
+(`narrow.py:111`) hat null Aufrufstellen.
+
+Das war nicht immer so — Historie über `git log -S "detail_metrics" -- src/`:
+
+| Commit | Datum | Wirkung |
+|---|---|---|
+| `5f9b57f9` | 2026-05-24 | #360 führt `detail_metrics` **und** `_detail_lines()` ein — **mit** Aufrufstelle |
+| `5f8abcb4` | 2026-06-26 | #887 ergänzt `_tg_extra_detail_line()`, liest `table_columns + detail_metrics` |
+| `6b27798f` | 2026-07-03 | **#1001 (Telegram-Redesign) entfernt beide Aufrufstellen** |
+
+Aus dem Diff von `6b27798f`:
+
+```
+-            if layout.detail_metrics and rows:
+-                    _detail_lines(layout.detail_metrics, rows[0], fkeys, width)
+-        mid for mid in layout.table_columns + layout.detail_metrics
+```
+
+Die Spec des Redesigns (`docs/specs/modules/feat_1001_telegram_redesign.md:36-39`) nennt
+ausdrücklich nur die Entfernung von `_tg_extra_detail_line()` und reaktiviert
+`_narrow_table()`. Der Wegfall von `_detail_lines()` ist dort **nicht** als Entscheidung
+dokumentiert — er sieht nach Kollateralschaden des Rewrites aus.
+
+**Seit 2026-07-03, also rund 7 Wochen, ist `detail_metrics` funktionslos.**
+
+## Wirkung auf echte Produktivdaten
+
+Gemessen an `/var/lib/gregor/users/*/briefings/*.json` (nur gelesen):
+
+**`henning/briefings/5f534011.json` — „KHW 403"**, `display_config.channel_layouts.telegram`:
+14 aktive `primary`-Metriken, davon erscheinen 7.
+
+| | Metriken |
+|---|---|
+| sichtbar (Slot 1–7) | `wind_chill`, `wind`, `wind_direction`, `precipitation`, `rain_probability`, `thunder`, `gust` |
+| **unsichtbar** (order 7–13) | `visibility`, `cloud_low`, `cloud_total`, `snowfall_limit`, `uv_index`, `humidity`, `freezing_level` |
+
+Der Bug trifft also die Hälfte einer sorgfältig sortierten Auswahl.
+
+## Einschränkung: der Tour-Trip erreicht diesen Renderer gar nicht
+
+`KHW 403` hat `report_config.telegram_style = "kurzform"`. Die Weiche in
+`notification_service.py:469-486` verwirft im Kurzstil die Bubbles und sendet
+`report.sms_text`. Der Bubble-Renderer läuft zwar immer (`format_email()` baut ihn
+unbedingt), sein Ergebnis wird im Kurzstil aber weggeworfen.
+
+Folgen:
+
+- Auf der Tour ist die **gesamte** 14-Metriken-Telegram-Auswahl ohne Wirkung, nicht nur
+  der Überlauf. Was ankommt, sind die 8 SMS-Metriken.
+- **#1741 hat keine nutzersichtbare Wirkung während der KHW-Tour** — das
+  Aufnahmekriterium des Milestones „Tour KHW 2026-08" trifft für dieses Ticket nicht zu.
+- Betroffen sind Trips im `rich`-Stil: `default/gr221-mallorca` (explizit `rich`) und alle
+  ohne gesetzten Stil (Default `rich`).
+
+Diese Einordnung ist eine PO-Entscheidung und wird hier nur festgehalten, nicht vollzogen.
+
+## Entwarnung: der SMS-Pfad ist nicht betroffen
+
+Naheliegende Sorge: für SMS gilt `max_table_cols = 0`, also landen dort **alle** Metriken
+in `detail_metrics` — bei totem `detail_metrics` wäre der SMS-Text metrikfrei.
+
+Das ist nicht der Fall. `sms_trip.py` importiert `channel_layout` überhaupt nicht, sondern
+baut über `build_token_line` / `render_sms` aus
+`get_metrics_for_channel("sms", report_type)` (`trip_report.py:335-347`, `:439-447`;
+`max_length=160` wird fest übergeben). Der Zweig `limit == 0` in
+`channel_layout.py:119-120` ist damit **struktureller Testcode** — kein Renderer betritt ihn.
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `src/output/renderers/narrow.py:111` | `_detail_lines()` — fertige Renderfunktion, null Aufrufstellen |
+| `src/output/renderers/narrow.py:700` | `render_for_channel("telegram", …)` — einziger Trip-Aufrufer |
+| `src/output/renderers/narrow.py:855-856` | einzige Nutzung von `layout.*` — nur `table_columns` |
+| `src/output/renderers/narrow.py:770-807` | Kurzübersicht-Bubble — liest `dc.get_enabled_metric_ids()`, also eine **andere Quelle** |
+| `src/output/renderers/channel_layout.py:86,127` | `detail_metrics` — Definition und einzige Befüllung |
+| `src/output/renderers/channel_layout.py:119-120` | SMS-Zweig `limit == 0`, unerreichbar |
+| `src/output/renderers/comparison.py:701,762,768-769` | Ortsvergleich — liest `table_columns` **und** `demoted_count` |
+| `src/output/renderers/comparison.py:854-867` | `_telegram_metric_notice()` — „+N weitere Wettergrößen je Ort (Telegram-Limit)" |
+| `src/services/notification_service.py:469-486` | Kurzstil-Weiche (verwirft Bubbles, sendet `sms_text`) |
+| `src/output/renderers/trip_report.py:293` | einzige produktive Aufrufstelle von `render_telegram_bubbles()` |
+| `frontend/src/lib/components/trip-detail/metricsEditor.ts:379-404` | Frontend-Nachbau `applyChannel()` mit `inTable`/`detail`/`demoted` |
+
+## Existing Patterns
+
+**Der Ortsvergleich löst dasselbe Problem bereits sichtbar.** `render_compare_telegram()`
+liest `demoted_count` und schreibt eine Hinweiszeile „+N weitere Wettergrößen je Ort
+(Telegram-Limit)" (`comparison.py:768-769`, `:854-867`). Der Trip-Pfad hat kein Pendant.
+
+Das ist relevant für die Code-Teilungs-Vorgabe aus `CLAUDE.md`: Trip und Ortsvergleich
+sollen möglichst viel teilen. Hier existiert eine gelöste Compare-Variante und eine
+kaputte Trip-Variante desselben Problems — ein geteilter Baustein ist ein ernsthafter
+Kandidat und muss in der Spec ausdrücklich abgewogen werden.
+
+## Dependencies
+
+- **Upstream:** `UnifiedWeatherDisplayConfig.get_metrics_for_channel()`,
+  `render_for_channel()`, `CHANNEL_LIMITS`, `_cell()`/`_compact_label()`/`_wrap()`
+- **Downstream:** `TripReport.telegram_bubbles` (`models.py:1078`) →
+  `notification_service.py:489-511` (Versand) und `preview_service.py:398` (Vorschau)
+
+## Existing Specs
+
+- `docs/specs/modules/feat_1001_telegram_redesign.md` — verursachende Spec; dokumentiert
+  den Wegfall von `_detail_lines()` **nicht**
+- `docs/specs/modules/feat_1260_telegram_kurzstil.md` — Kurzstil-Weiche
+- `docs/specs/modules/issue_365_channel_preview_mobile.md` — Frontend-Kanalvorschau
+- `docs/specs/_archive/modules/fix_887_report_inkonsistenz.md` — Ursprung der entfernten
+  `_tg_extra_detail_line()`
+
+## Risks & Considerations
+
+1. **Die Testschicht kennt den Bug und weicht ihm aus.** `tests/tdd/test_channel_metric_matrix.py:800-806`
+   hält im Klartext fest, dass `_detail_lines()` null Aufrufstellen hat und „überzählig"
+   deshalb „gar nicht sichtbar" bedeutet. Der Test wählt daraufhin bewusst
+   `freezing_level` (außerhalb des Budgets) und prüft es **nur** in der Kanal-Auswahl
+   `table_columns + detail_metrics`, nicht in der Ausgabe (`:1395`). Kein einziger Test
+   prüft eine gerenderte Telegram-Ausgabe auf eine `detail_metrics`-Metrik.
+   ⇒ Ein Fix muss den Nachweis **an der Wirkstelle** führen (gerenderte Bubbles), sonst
+   bewacht er nichts. Die vorhandenen Tests würden eine erneute Entkopplung nicht fangen.
+
+2. **Altlast-Test, der die Regression zementiert:** `tests/tdd/test_issue_887_report_inkonsistenz.py:229`
+   prüft, dass **keine** Detail-Zeile erscheint („Rain%" not in result) — seit dem Wegfall
+   trivial wahr. Bei einem Fix wird dieser Test rot; er prüft veraltetes Verhalten und ist
+   dann zu korrigieren oder zu löschen, nicht zu umgehen.
+
+3. **Frontend verspricht möglicherweise etwas, das nicht geliefert wird.** `applyChannel()`
+   berechnet `detail` und `demoted` für eine Nutzer-Vorschau. Ob diese Vorschau tatsächlich
+   gerendert wird, ist noch offen (Agent `fe-vorschau` läuft, mit Positivkontroll-Pflicht,
+   weil `grep` auf `WeatherMetricsTab.svelte` falsch-negative Treffer liefert). Wenn ja,
+   ist das der eigentliche Beleg für „Bedienelement ohne Wirkung".
+
+4. **Zwei Quellen in einer Nachricht.** Die Kurzübersicht-Bubble liest
+   `dc.get_enabled_metric_ids()` (`narrow.py:780`), die Tabelle `layout.table_columns`.
+   Die Kurzübersicht ignoriert damit die **kanalspezifische** Auswahl. Vermutete
+   Konsequenz: eine für Telegram *abgewählte* Metrik erscheint dort trotzdem — das wäre
+   derselbe Fehler in der Gegenrichtung. Noch nicht verifiziert, gehört in `/20-analyse`.
+
+5. **Platzbudget ist real.** `_TG_TABLE_WIDTH` existiert, damit auf einem
+   iPhone-Standardbildschirm kein Umbruch entsteht (`narrow.py:57-60`). Eine Detailzeile
+   darf dieses Versprechen nicht aufweichen; `_detail_lines()` bricht selbst um, die
+   Zielbreite ist aber zu wählen (`_TG_TABLE_WIDTH` vs. `_TG_PROSE_WIDTH`).
+
+6. **Wächter aus #1480:** In `narrow.py` liegen Duldungs-Marker gegen lokale Kopien der
+   Gewitter-Stufenskala. Stufenwerte nur über `THUNDER_LABEL_DE` aus
+   `src/output/metric_format.py`, nie lokal nachbauen.
+
+7. **Offene Richtungsentscheidung (PO).** Die drei Optionen des Tickets sind nach der
+   Historie nicht mehr gleichwertig: Option 3 („ersatzlos entfernen") würde eine
+   unbeabsichtigte Regression nachträglich zur Entscheidung erklären. Vorlage erfolgt mit
+   der Spec.

--- a/docs/reference/api_contract.md
+++ b/docs/reference/api_contract.md
@@ -686,7 +686,7 @@ Epochensekunden**; die lesbare Aufbereitung dort ist als Nebenbefund in #1199 no
 | alert_enabled       | bool             | Alert bei Änderung dieser Metrik? (default: false)     |
 | alert_threshold     | float \| None    | Schwellenwert für Alert (z.B. 5.0 für Temperatur)      |
 | horizons            | dict \| None     | Pro-Metrik-Zeithorizont-Filter (None = alle sichtbar)  |
-| bucket              | str              | Spalten-Gruppierung: `"primary"` (eigene Spalte) \| `"secondary"` (Detail-Zeile), default: `"primary"` |
+| bucket              | str              | Spalten-Gruppierung: `"primary"` (eigene Spalte) \| `"secondary"` (heute ohne eigene Ausgabe), default: `"primary"`. **Es gibt keine Detail-Zeile mehr** (PO-Entscheid 2026-06-06, #587); `secondary` bleibt nur aus Altdaten-Kompatibilität und wird seit #1741 nirgends gerendert. Was jenseits des Telegram-Spaltenbudgets liegt, erscheint in der Kurzübersicht als Tageswert plus Kappungshinweis — siehe `docs/specs/modules/fix_1741_telegram_kappungshinweis.md` |
 | order               | int              | Sortier-Reihenfolge innerhalb des Buckets (default: 0) |
 | sms_threshold       | float \| None    | **Neu Issue #624:** Schwellenwert für SMS-/Telegram-Kurzform (R/PR/W/G). None = Catalog/DEFAULTS-Fallback. Nur für threshold-fähige Metriken sichtbar (Niederschlag, Regenwahrscheinlichkeit, Wind, Böen) |
 

--- a/docs/specs/modules/fix_1741_telegram_kappungshinweis.md
+++ b/docs/specs/modules/fix_1741_telegram_kappungshinweis.md
@@ -1,0 +1,277 @@
+---
+entity_id: fix_1741_telegram_kappungshinweis
+type: bugfix
+created: 2026-08-21
+updated: 2026-08-21
+status: draft
+version: "1.0"
+tags: [telegram, channel_layout, kappungshinweis, dead-code]
+---
+
+# Telegram-Trip-Nachricht: Kappungshinweis + toten Detail-Pfad entfernen
+
+## Approval
+
+- [x] Approved (PO „go", 2026-08-21)
+
+## Purpose
+
+Wird eine Telegram-Trip-Auswahl auf mehr als 7 Wettergrößen konfiguriert, zeigt die
+Segment-Tabelle nur die ersten 7 (stündlich); die überzähligen erscheinen weiterhin als
+Tageswert in der Kurzübersicht-Bubble, verlieren aber ihre stündliche Auflösung — und die
+Telegram-Nachricht selbst sagt nirgends, dass gekappt wurde. Wer unterwegs liest, ohne den
+Editor offen zu haben, kann das nicht erkennen. Diese Spec schließt die Lücke über einen mit
+dem Ortsvergleich geteilten Hinweisbaustein und entfernt gleichzeitig den seit 2026-07-03
+toten `detail_metrics`/`_detail_lines()`-Pfad, der denselben Bug wiederholt vortäuschen
+würde, solange er im Code steht.
+
+## PO-Entscheide vom 2026-08-21 (bindend)
+
+1. Die Telegram-Trip-Nachricht bekommt einen Kappungshinweis, inhaltlich analog zum
+   Ortsvergleich, über einen geteilten Baustein.
+2. Der tote Pfad `ChannelLayout.detail_metrics` + `_detail_lines()` wird ersatzlos entfernt.
+3. **Die Detail-Zeile wird NICHT wieder gebaut.** Das widerspräche der PO-Entscheidung vom
+   2026-06-06 („Kein '→ Detail'-Knopf, keine Detail-Zeile", `WeatherV2Reihenfolge.svelte:4`,
+   Issue #587): Der `secondary`-Bucket im Editor ist seither immer leer
+   (`WeatherMetricsTab.svelte:220`, erzwungen `:436`/`:682`). Der Wegfall von
+   `_detail_lines()` in Commit `6b27798f` (#1001, 2026-07-03) hat diesen Entscheid
+   umgesetzt — nur die zugehörige Spec (`feat_1001_telegram_redesign.md`) hat ihn nicht
+   protokolliert, was #1741 als vermeintliche Regression erst erzeugt hat. Dieser Abschnitt
+   holt die fehlende Dokumentation nach.
+4. #1741 bleibt im Milestone „Tour KHW 2026-08" — unabhängig davon, dass der Tour-Trip
+   `KHW 403` im `telegram_style=kurzform` fährt und den Bubble-Renderer damit auf der Tour
+   selbst gar nicht durchläuft (siehe „Known Limitations").
+
+## Source
+
+- **File:** `src/output/renderers/narrow.py`
+- **Identifier:** `render_telegram_bubbles()` (Kurzübersicht-Bubble-Aufbau)
+- **File:** `src/output/renderers/channel_layout.py`
+- **Identifier:** `ChannelLayout`, `render_for_channel()`
+- **File:** `src/output/renderers/comparison.py`
+- **Identifier:** `_telegram_metric_notice()` — Vorbild und Umzugsziel
+
+## Estimated Scope
+
+- **LoC:** ~+45 / −95 (Netto-Abbau durch Entfernen von `_detail_lines()` und
+  `applyChannel()`/`ChannelLayout` im Frontend)
+- **Files:** 3 Produktiv-Backend, 1 Produktiv-Frontend, 6 Test-Backend, 1 Test-Frontend
+- **Effort:** low — additiver Hinweistext + Entfernen unerreichbaren Codes; kein neuer
+  Berechnungspfad, `demoted_count` liegt bereits vor.
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `channel_layout.render_for_channel()` | function | liefert `ChannelLayout.demoted_count`, unverändert wiederverwendet |
+| `comparison._telegram_metric_notice()` | function | Vorbild-Wortlaut, wird zum geteilten Baustein `channel_layout.telegram_metric_notice()` |
+| `trip_report.py:275-292` (`_dc_telegram`) | module | EINE kanal-kaskadierte Quelle für Tabelle + Kurzübersicht (#1719 S2 F004) — dieser Fix liest ausschließlich `layout.demoted_count`, keine neue Quelle |
+| `_TG_PROSE_WIDTH` (`narrow.py:55`) | constant | Breitenbudget für den Hinweistext (Prosa, nicht Tabelle) |
+
+## Implementation Details
+
+### 1. Geteilter Baustein: `channel_layout.telegram_metric_notice()`
+
+`_telegram_metric_notice()` (`comparison.py:854-869`) wandert unverändert im Verhalten,
+aber umbenannt und parametrisiert nach `channel_layout.py` (dort liegt bereits die
+`ChannelLayout`-Definition, und sowohl `narrow.py` als auch `comparison.py` importieren
+schon von dort — kein neuer Modul-Kopplungspunkt):
+
+```
+def telegram_metric_notice(demoted_count: int, *, context: str) -> str:
+    """context='vergleich' -> Ortsvergleich-Wortlaut (#1362, unveraendert).
+    context='route' -> Trip-Wortlaut (#1741, neu). Leer, wenn nichts verdraengt wurde.
+
+    Die beiden Wortlaute sind BEWUSST nicht ueber einen gemeinsamen Satzbau
+    gebildet: im Ortsvergleich fehlen die verdraengten Groessen in der
+    Telegram-Nachricht GANZ, im Trip stehen sie unmittelbar darueber in der
+    Kurzuebersicht als Tageswert. Ein gemeinsamer Text waere fuer eine der
+    beiden Flaechen sachlich falsch."""
+    if demoted_count <= 0:
+        return ""
+    if context == "vergleich":
+        return (
+            f"… +{demoted_count} weitere Wettergrößen je Ort (Telegram-Limit) "
+            "— vollständig per E-Mail"
+        )
+    return (
+        f"… +{demoted_count} weitere Wettergrößen nur als Tageswert "
+        "(Telegram-Limit)"
+    )
+```
+
+`comparison.py` importiert die Funktion und ruft `telegram_metric_notice(layout.demoted_count,
+context="vergleich")` — Wortlaut und Ausgabe bleiben für den Ortsvergleich bit-identisch zu
+heute (Regressionsschutz, kein neuer Test nötig, vorhandener `test_compare_kanal_metriken.py`
+bleibt grün).
+
+### 2. Wortlaut für den Trip-Pfad
+
+Der Ortsvergleich-Wortlaut „je Ort" ist für den Trip falsch — es gibt keine Orte, sondern
+Etappen-/Ziel-Tabellen, die alle **dieselbe** Kappung erben (`layout` wird in
+`render_telegram_bubbles()` EINMAL für den ganzen Trip berechnet, `narrow.py:700`, nicht je
+Segment). Gewählter Wortlaut: **„… +N weitere Wettergrößen nur als Tageswert
+(Telegram-Limit)"**. Begründung:
+
+- **Benennt, was tatsächlich fehlt.** Die verdrängten Größen sind nicht verschwunden — die
+  Kurzübersicht-Bubble zeigt jede aktive Telegram-Metrik als Tagesaussage
+  (`narrow.py:780-807`). Verloren geht ausschließlich die **stündliche Auflösung** in den
+  Etappentabellen. Ein Text, der die Größen als fehlend darstellt, wäre falsch.
+- **Kein Verweis auf E-Mail** — anders als im Ortsvergleich. Dort fehlen die Größen ganz,
+  dort trägt der Verweis. Beim Trip stünde er direkt unter den Werten, auf die er
+  verweist. Zudem gilt projektweit, dass kein Kanal einen anderen ersetzt: E-Mail kann für
+  diesen Trip abgeschaltet sein, dann ginge der Hinweis ins Leere.
+- **Steht an der richtigen Stelle:** am Ende der Kurzübersicht, unmittelbar nach den
+  Tageswerten, auf die sich „nur als Tageswert" bezieht.
+- Bleibt ohne HTML/Markup (reiner Text) und passt mit typischen `demoted_count`-Werten
+  (1-stellig) klar unter `_TG_PROSE_WIDTH = 56`.
+
+### 3. Position in der Nachricht
+
+Der Hinweis erscheint **einmal**, am Ende der **Kurzübersicht-Bubble**
+(`render_telegram_bubbles()`, `narrow.py:759-845`) — NICHT in den Segment-Bubbles. Begründung:
+
+- Segment-Bubbles wiederholen sich pro Etappe/Tag; `demoted_count` ist über den ganzen Trip
+  identisch (eine `layout`-Berechnung, s.o.) — ein Hinweis pro Segment wäre reiner Lärm
+  (mehrfach dieselbe Information).
+- Die Kurzübersicht-Bubble ist die einzige Stelle, die bereits GANZ am Ende eigene
+  Meta-Hinweiszeilen sammelt (Herkunfts-Vertretung `build_fallback_lines`, Vortags-Zeile
+  `_tg_vortag_line`) — der Kappungshinweis reiht sich dort als letzter Block ein, direkt vor
+  `bubbles.append(TelegramBubble(text="\n".join(overview_lines)))` (`narrow.py:845`), nach
+  dem `vortag_line`-Block. Gleiche Bauart (Leerzeile + `_wrap(_esc(...), _TG_PROSE_WIDTH)`).
+- Wer die Kurzübersicht liest, bekommt den Hinweis, BEVOR er auf die gekappten
+  Segment-Tabellen trifft (Bubble-Reihenfolge: Kopf, Kurzübersicht, dann Segmente).
+
+### 4. Datenquelle
+
+`layout = render_for_channel("telegram", dc, report_type)` (`narrow.py:700`) wird bereits
+berechnet; `layout.demoted_count` ist der einzige neue Lesezugriff. Keine neue Berechnung.
+
+### 5. Toter Pfad entfernen
+
+- `ChannelLayout.detail_metrics`-Feld (`channel_layout.py:86`) entfernen. `demoted_count`
+  bleibt (wird weiterhin aus `len(overflow)` berechnet, `channel_layout.py:128`); die
+  `overflow + secondary`-Zusammenstellung entfällt, weil niemand mehr liest.
+- `_detail_lines()` (`narrow.py:111-138`) ersatzlos entfernen — 0 Aufrufstellen.
+
+## Expected Behavior
+
+- **Input:** Eine `UnifiedWeatherDisplayConfig` mit mehr als 7 aktiven `primary`-Telegram-
+  Metriken (oder `secondary`-Metriken, die nie eine Tabellenspalte bekommen).
+- **Output:** `render_telegram_bubbles()` liefert eine Kurzübersicht-Bubble, deren Text am
+  Ende die Zeile „… +N weitere Wettergrößen nur als Tageswert (Telegram-Limit)"
+  trägt, mit `N == layout.demoted_count`. Bei `demoted_count == 0`
+  fehlt die Zeile vollständig (keine leere Zeile, kein „+0").
+- **Side effects:** keine. Pure function, wie der gesamte Modul-Kontrakt (`narrow.py:10-12`).
+
+## Acceptance Criteria
+
+- **AC-1:** Given eine Telegram-Auswahl mit mehr als 7 aktiven primary-Metriken (z. B. 9),
+  When `render_telegram_bubbles()` gerendert wird, Then enthält der Text der
+  Kurzübersicht-Bubble die Zeile „… +N weitere Wettergrößen nur als Tageswert
+  (Telegram-Limit)" mit korrektem `N`.
+  - Test: `tests/tdd/test_telegram_metric_notice.py` — Assertion auf `bubbles[i].text`
+    (Kurzübersicht-Bubble anhand des Präfix „Kurzübersicht" gefunden, nicht per festem
+    Index), nicht auf `ChannelLayout`.
+
+- **AC-2:** Given eine Telegram-Auswahl mit höchstens 7 aktiven primary-Metriken (kein
+  Überlauf), When `render_telegram_bubbles()` gerendert wird, Then fehlt die
+  Kappungshinweis-Zeile vollständig im Bubble-Text.
+  - Test: umgebauter `tests/tdd/test_issue_887_report_inkonsistenz.py::
+    test_ac5_telegram_no_detail_line_when_only_temp_and_wind` (Fixture hat bereits nur 2
+    Metriken, also `demoted_count == 0`) — Assertion wechselt von „keine Detail-Zeile" auf
+    „keine Kappungshinweis-Zeile".
+
+- **AC-3:** Given eine Telegram-Auswahl mit Überlauf UND mehreren Segmenten/Etappen, When
+  `render_telegram_bubbles()` gerendert wird, Then trägt GENAU EINE Bubble (die
+  Kurzübersicht) den Hinweistext; keine der Segment-Bubbles enthält ihn.
+  - Test: `tests/tdd/test_telegram_metric_notice.py` mit >=2 Segmenten — zählt Vorkommen
+    des Hinweistext-Fragments über alle `bubbles[i].text` hinweg, erwartet genau 1.
+
+- **AC-4:** Given `layout.demoted_count > 0` im Ortsvergleich-Pfad, When
+  `render_compare_telegram()` gerendert wird, Then bleibt der Wortlaut „… +N weitere
+  Wettergrößen je Ort (Telegram-Limit) — vollständig per E-Mail" unverändert gegenüber dem
+  Stand vor diesem Fix.
+  - Test: bestehender `tests/tdd/test_compare_kanal_metriken.py` bleibt ohne Änderung grün
+    (Regressionsschutz für den Umzug von `_telegram_metric_notice()` nach
+    `channel_layout.telegram_metric_notice()`).
+
+- **AC-5:** Given der SMS-Versandpfad (`sms_trip.py`, `build_token_line`/`render_sms`),
+  When ein Trip mit Telegram-Überlauf als SMS gerendert wird, Then enthält der SMS-Text
+  keine Kappungshinweis-Zeile und keinen Verweis auf `channel_layout`.
+  - Test: bestehende SMS-Tests bleiben unverändert grün (`sms_trip.py` importiert
+    `channel_layout` nicht — struktureller Nachweis per fehlendem Import, kein neuer Test
+    nötig).
+
+- **AC-6:** Given der Produktivcode nach diesem Fix, When `ChannelLayout`
+  (`channel_layout.py`) und das `narrow`-Modul (`narrow.py`) inspiziert werden, Then
+  besitzt `ChannelLayout` kein Feld `detail_metrics` mehr und `narrow` kein Attribut
+  `_detail_lines`.
+  - Test: `tests/tdd/test_telegram_metric_notice.py` — `'detail_metrics' not in
+    {f.name for f in dataclasses.fields(ChannelLayout)}` und
+    `not hasattr(narrow, '_detail_lines')`. Verhindert, dass derselbe tote Pfad erneut als
+    vermeintlicher Bug gemeldet wird (siehe Purpose).
+
+## Known Limitations
+
+- Der Kappungshinweis erreicht nur den `rich`-Telegram-Stil. Im `telegram_style=kurzform`
+  verwirft `notification_service.py:469-486` die Bubbles und sendet stattdessen
+  `report.sms_text`, das `render_telegram_bubbles()` gar nicht durchläuft. Der Tour-Trip
+  `KHW 403` fährt `kurzform` — auf der Tour selbst bleibt der Editor-Hinweis (Chip,
+  Schnittlinie, Warntext) die einzige Warnung vor dem Versand. Der PO hat #1741 trotzdem im
+  Milestone belassen (Entscheid 4, s. o.).
+- Der Hinweis nennt nur die Anzahl (`demoted_count`), nicht die betroffenen Metrik-IDs —
+  identisch zum Ortsvergleich-Vorbild; eine Auflistung würde das Prosa-Breitenbudget
+  (`_TG_PROSE_WIDTH = 56`) bei mehreren überzähligen Größen sprengen.
+
+## Invarianten (dürfen sich NICHT ändern)
+
+- Die 7-Spalten-Grenze der Segment-/Ziel-Tabelle bleibt unverändert
+  (`CHANNEL_LIMITS["telegram"]["max_table_cols"] = 8`, `channel_layout.py:47`).
+- Die Kurzübersicht-Bubble zeigt weiterhin ALLE aktiven Telegram-Metriken als Tagesaussage
+  (`narrow.py:780-807`, unverändert) — dieser Fix ergänzt nur eine zusätzliche Zeile am
+  Ende, entfernt keine bestehende.
+- Der SMS-Pfad bleibt vollständig unberührt (`sms_trip.py` nutzt `channel_layout` nicht,
+  s. AC-5).
+- Der Ortsvergleich-Hinweistext bleibt wortgleich zu heute (s. AC-4).
+- `buildBucketSummary`/`BucketSummary` (`metricsEditor.ts:407ff.`) bleiben unverändert —
+  sie basieren auf `Buckets` (primary/secondary/off), nicht auf dem entfernten
+  `applyChannel`/`ChannelLayout`, und werden produktiv von `SavePresetDialog.svelte`
+  genutzt.
+
+## Affected Files
+
+| Datei | Change | Beschreibung |
+|---|---|---|
+| `src/output/renderers/channel_layout.py` | MODIFY | `ChannelLayout.detail_metrics`-Feld entfernen; neue geteilte Funktion `telegram_metric_notice(demoted_count, *, context)` |
+| `src/output/renderers/comparison.py` | MODIFY | lokale `_telegram_metric_notice()` entfernen, Import + Aufruf mit `context="vergleich"` |
+| `src/output/renderers/narrow.py` | MODIFY | `_detail_lines()` entfernen (tot); Kappungshinweis am Ende der Kurzübersicht-Bubble einfügen (`context="route"`) |
+| `tests/tdd/test_telegram_metric_notice.py` | CREATE | AC-1, AC-3, AC-6 — Nachweis an der Wirkstelle (gerenderte Bubbles), nicht am `ChannelLayout` |
+| `tests/tdd/test_issue_887_report_inkonsistenz.py` | MODIFY | `test_ac5_telegram_no_detail_line_when_only_temp_and_wind` umgebaut auf AC-2 (kein Hinweis bei `demoted_count==0`) — bisherige Prämisse „keine Detail-Zeile" ist seit dem Wegfall trivial wahr |
+| `tests/tdd/test_issue_360_channel_renderer.py` | MODIFY | `layout.detail_metrics`-Assertionen (Z. 151, 189, 209-210) entfernen; `demoted_count`-Assertionen bleiben/ersetzen den Inhalt (AC-4-Test dort: `demoted_count == 9` statt Listen-Inhalt) |
+| `tests/tdd/test_issue_429_channel_layouts.py` | MODIFY | `layout.detail_metrics`-Assertionen (Z. 280, 306, 313, 318) entfernen/durch `demoted_count`-Prüfung ersetzen |
+| `tests/tdd/test_channel_metric_matrix.py` | MODIFY | `_telegram_cells()`/`_kaskade_telegram_cells()`-Helfer (Z. 262-264, 871-873, genutzt u. a. Z. 1392-1397) von `table_columns + detail_metrics` auf die tatsächliche Kanal-Auswahl (`dc.get_metrics_for_channel("telegram", report_type)`, gefiltert auf `enabled`) umstellen — der Test prüft Kaskaden-Auswahl, nicht Sichtbarkeit (das hält der Kommentar Z. 798-807 bereits fest) |
+| `tests/tdd/test_felt_night_catalog_exclusions.py` | MODIFY | `detail_metrics`-Hälfte der Assertion (Z. 122-126) entfernen; `table_columns`-Hälfte bleibt und beweist denselben Sachverhalt (Gate-Filter wirkt vor der Primary/Secondary-Aufteilung, `channel_layout.py:107`) |
+| `tests/tdd/test_temp_tagesrichtung_aufloesung.py` | MODIFY | `detail_metrics`-Hälfte der Assertionen (Z. 396, 421-425) entfernen, gleiche Begründung |
+| `frontend/src/lib/components/trip-detail/metricsEditor.ts` | MODIFY | `applyChannel()` (Z. 393-405) und lokale `ChannelLayout`-Schnittstelle (Z. 379-383) entfernen — 0 Produktiv-Aufrufer (geprüft gegen `WeatherMetricsTab.svelte`-Importliste); `buildBucketSummary`/`BucketSummary` unverändert, produktiv genutzt |
+| `frontend/src/lib/components/trip-detail/metricsEditor.test.ts` | MODIFY | AC-1/AC-2/AC-3-Testblöcke für `applyChannel` (Z. ~541-616) löschen; AC-4-Block (`buildBucketSummary`) unverändert |
+
+## Known Non-Changes (bewusst nicht angefasst)
+
+- `channel_layout.py:119-120` (SMS-Zweig `limit == 0`) bleibt strukturell unerreichbar
+  (kein Renderer betritt ihn, `sms_trip.py` importiert das Modul nicht) — Aufräumen ist ein
+  eigenes, kleineres Ticket, kein Bestandteil von #1741.
+- `SavePresetDialog.svelte:205-213` zeigt weiterhin dauerhaft „0 Detail" (weil `secondary`
+  seit 2026-06-06 immer leer ist) — das ist eine Folge des PO-Entscheids von #587, kein Bug
+  dieses Tickets.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Kein neuer Architektur-Entscheidungspunkt (Kanal, Provider, Datenmodell,
+  Auth, Editor-Paradigma) — reiner Bugfix + Code-Sharing zwischen zwei bestehenden
+  Renderern nach der bereits etablierten Trip/Compare-Teilungs-Vorgabe (`CLAUDE.md`).
+
+## Changelog
+
+- 2026-08-21: Initial spec created (Issue #1741)

--- a/frontend/src/lib/components/trip-detail/metricsEditor.test.ts
+++ b/frontend/src/lib/components/trip-detail/metricsEditor.test.ts
@@ -527,92 +527,15 @@ test('F002-fix: move off→primary (toggle active=true) — keine Metrik landet 
 });
 
 // =============================================================================
-// Issue #365 (Schritt C von #361) — 4-Kanal-Live-Vorschau (AC-1..AC-4)
+// Issue #365 (Schritt C von #361) — 4-Kanal-Live-Vorschau (AC-4)
 // =============================================================================
 //
 // Spec: docs/specs/modules/issue_365_channel_preview_mobile.md
 // Design: docs/design/epic_331_output_layout/screen-metrics-editor.jsx (Z. 555-667)
 //
-// applyChannel(primary, secondary, budget) und buildBucketSummary(buckets,
-// friendlyMap) existieren noch NICHT → in RED schlägt der Aufruf fehl (undefined
-// is not a function). AC-5 (responsive) + AC-6 (Marker-Politur) sind rein
-// visuell und werden NICHT hier erzwungen. KEINE Mocks (pure functions).
-
-// ---------- AC-1: applyChannel je Kanal --------------------------------------
-
-test('AC-1: applyChannel Email (Infinity) → inTable==primary, detail==secondary, demoted 0', () => {
-	const primary = ['temperature', 'wind', 'gust'];
-	const secondary = ['cloud_total', 'humidity'];
-	const r = editor.applyChannel(primary, secondary, editor.CHANNEL_COL_BUDGET.email);
-	assert.deepEqual(r.inTable, primary);
-	assert.deepEqual(r.detail, secondary);
-	assert.equal(r.demoted, 0);
-});
-
-test('F001: applyChannel Email gibt eine KOPIE von primary zurück (kein Alias)', () => {
-	const primary = ['temperature', 'wind'];
-	const r = editor.applyChannel(primary, [], editor.CHANNEL_COL_BUDGET.email);
-	assert.deepEqual(r.inTable, primary);
-	assert.notStrictEqual(r.inTable, primary, 'inTable darf nicht dieselbe Referenz wie primary sein');
-});
-
-test('AC-1: applyChannel SMS (0) → inTable==[], detail==alles, demoted==primary.length', () => {
-	const primary = ['temperature', 'wind', 'gust'];
-	const secondary = ['cloud_total'];
-	const r = editor.applyChannel(primary, secondary, editor.CHANNEL_COL_BUDGET.sms);
-	assert.deepEqual(r.inTable, []);
-	assert.deepEqual(r.detail, ['temperature', 'wind', 'gust', 'cloud_total']);
-	assert.equal(r.demoted, primary.length);
-});
-
-test('AC-1: applyChannel mit Budget 5 kappt inTable, demoted==overflow', () => {
-	const primary = ['temperature', 'wind', 'gust', 'rain_probability', 'precipitation', 'wind_chill'];
-	const secondary = ['cloud_total'];
-	const r = editor.applyChannel(primary, secondary, 5);
-	assert.equal(r.inTable.length, 5);
-	assert.deepEqual(r.inTable, ['temperature', 'wind', 'gust', 'rain_probability', 'precipitation']);
-	// Overflow (wind_chill) landet VORNE in detail, vor secondary.
-	assert.deepEqual(r.detail, ['wind_chill', 'cloud_total']);
-	assert.equal(r.demoted, 1);
-});
-
-// Issue #1719 S3 (GREEN, Bestandstest umgedreht): Budget=7 (von 8 korrigiert,
-// die 8. Telegram-Spalte war die Uhrzeit), daher passt genau 7 in inTable
-// ohne Demote.
-test('AC-1: applyChannel Telegram (7) kappt erst ab der 8. Spalte', () => {
-	const primary = ['a', 'b', 'c', 'd', 'e', 'f', 'g']; // genau 7
-	const r = editor.applyChannel(primary, [], editor.CHANNEL_COL_BUDGET.telegram);
-	assert.equal(r.inTable.length, 7);
-	assert.equal(r.demoted, 0);
-});
-
-// ---------- AC-2: 7 primary, Budget 5 → 2 demoted vorne in detail -------------
-
-test('AC-2: 7 primary bei Budget 5 → demoted==2, 2 überzählige vorne in detail', () => {
-	const primary = ['temperature', 'wind', 'gust', 'rain_probability', 'precipitation', 'wind_chill', 'cloud_total'];
-	const secondary = ['humidity'];
-	const r5 = editor.applyChannel(primary, secondary, 5);
-	assert.equal(r5.inTable.length, 5);
-	assert.equal(r5.demoted, 2);
-	// Die 2 überzähligen (wind_chill, cloud_total) stehen VOR secondary.
-	assert.deepEqual(r5.detail.slice(0, 2), ['wind_chill', 'cloud_total']);
-	assert.equal(r5.detail[2], 'humidity');
-
-	// Email zeigt alle 7 ohne Demote.
-	const mail = editor.applyChannel(primary, secondary, editor.CHANNEL_COL_BUDGET.email);
-	assert.equal(mail.inTable.length, 7);
-	assert.equal(mail.demoted, 0);
-});
-
-// ---------- AC-3: SMS keine Tabelle, alles flach in detail --------------------
-
-test('AC-3: SMS-Karte hat keine Tabelle (inTable==[]) — alles in detail', () => {
-	const primary = ['temperature', 'wind'];
-	const secondary = ['cloud_total', 'humidity'];
-	const r = editor.applyChannel(primary, secondary, editor.CHANNEL_COL_BUDGET.sms);
-	assert.deepEqual(r.inTable, []);
-	assert.deepEqual(r.detail, ['temperature', 'wind', 'cloud_total', 'humidity']);
-});
+// AC-1..AC-3 (applyChannel/ChannelLayout) sind mit #1741 entfallen: 0
+// Produktiv-Aufrufer (geprüft gegen WeatherMetricsTab.svelte-Importliste),
+// toter Pfad wie das Backend-Gegenstück ChannelLayout.detail_metrics.
 
 // ---------- AC-4: bucket-bewusste Preset-Summary ------------------------------
 

--- a/frontend/src/lib/components/trip-detail/metricsEditor.ts
+++ b/frontend/src/lib/components/trip-detail/metricsEditor.ts
@@ -376,34 +376,6 @@ export function buildWeatherConfigMetrics(
 // Spec: docs/specs/modules/issue_365_channel_preview_mobile.md
 // Design: docs/design/epic_331_output_layout/screen-metrics-editor.jsx (Z. 555-667)
 
-export interface ChannelLayout {
-	inTable: string[];
-	detail: string[];
-	demoted: number;
-}
-
-/**
- * AC-1..AC-3: Wendet das Spalten-Budget eines Kanals auf eine Bucket-Auswahl an.
- * Deckt sich mit Backend render_for_channel (#360):
- * - budget === Infinity (Email): alles als Spalte, kein Demote.
- * - budget === 0 (SMS): keine Tabelle, alles flach in detail, demoted == |primary|.
- * - sonst (Telegram 7): inTable gekappt; überzählige primary vorne
- *   in detail (vor secondary), demoted == overflow.
- */
-export function applyChannel(
-	primary: string[],
-	secondary: string[],
-	budget: number,
-): ChannelLayout {
-	if (budget === 0) {
-		return { inTable: [], detail: [...primary, ...secondary], demoted: primary.length };
-	}
-	// F001-Sauberkeit: Email-Pfad gibt eine KOPIE von primary zurück (kein Alias).
-	const inTable = budget === Infinity ? [...primary] : primary.slice(0, budget);
-	const overflow = budget === Infinity ? [] : primary.slice(budget);
-	return { inTable, detail: [...overflow, ...secondary], demoted: overflow.length };
-}
-
 export interface BucketSummary {
 	spalten: number;
 	detail: number;

--- a/src/output/renderers/channel_layout.py
+++ b/src/output/renderers/channel_layout.py
@@ -4,7 +4,8 @@ SPEC: docs/specs/modules/issue_360_signal_channel_renderer.md §2–§4.
 
 Pure functions: aus einer ``UnifiedWeatherDisplayConfig`` und einem Kanal
 wird berechnet, welche Metriken als eigene Tabellen-Spalte erscheinen und
-welche in die kompakte Detail-Zeile wandern. Keine I/O, keine Mocks.
+wie viele wegen der Kanal-Grenze verdraengt werden (``demoted_count``).
+Keine I/O, keine Mocks.
 """
 from __future__ import annotations
 
@@ -83,8 +84,29 @@ VISIBILITY_GATE_IDS: frozenset[str] = frozenset({
 class ChannelLayout:
     """Ergebnis der Layout-Berechnung fuer einen Kanal."""
     table_columns: list[str]   # metric_ids in Spalten-Reihenfolge (ohne Zeit)
-    detail_metrics: list[str]  # metric_ids fuer die Detail-Zeile
-    demoted_count: int         # aus primary in Detail verschoben (Logging/Badge)
+    demoted_count: int         # aus primary verdraengt (Logging/Badge/Hinweis)
+
+
+def telegram_metric_notice(demoted_count: int, *, context: str) -> str:
+    """context='vergleich' -> Ortsvergleich-Wortlaut (#1362, unveraendert).
+    context='route' -> Trip-Wortlaut (#1741, neu). Leer, wenn nichts verdraengt wurde.
+
+    Die beiden Wortlaute sind BEWUSST nicht ueber einen gemeinsamen Satzbau
+    gebildet: im Ortsvergleich fehlen die verdraengten Groessen in der
+    Telegram-Nachricht GANZ, im Trip stehen sie unmittelbar darueber in der
+    Kurzuebersicht als Tageswert. Ein gemeinsamer Text waere fuer eine der
+    beiden Flaechen sachlich falsch."""
+    if demoted_count <= 0:
+        return ""
+    if context == "vergleich":
+        return (
+            f"… +{demoted_count} weitere Wettergrößen je Ort (Telegram-Limit) "
+            "— vollständig per E-Mail"
+        )
+    return (
+        f"… +{demoted_count} weitere Wettergrößen nur als Tageswert "
+        "(Telegram-Limit)"
+    )
 
 
 def render_for_channel(
@@ -108,9 +130,6 @@ def render_for_channel(
     primary = sorted(
         [m for m in enabled if m.bucket == "primary"], key=lambda m: m.order,
     )
-    secondary = sorted(
-        [m for m in enabled if m.bucket == "secondary"], key=lambda m: m.order,
-    )
 
     channel_cfg = CHANNEL_LIMITS.get(channel, CHANNEL_LIMITS["telegram"])
     limit = channel_cfg["max_table_cols"]
@@ -124,7 +143,6 @@ def render_for_channel(
 
     return ChannelLayout(
         table_columns=[m.metric_id for m in table],
-        detail_metrics=[m.metric_id for m in (overflow + secondary)],
         demoted_count=len(overflow),
     )
 

--- a/src/output/renderers/comparison.py
+++ b/src/output/renderers/comparison.py
@@ -24,7 +24,9 @@ from app.metric_catalog import get_sms_code
 from app.models import Corridor, MetricConfig, UnifiedWeatherDisplayConfig
 from app.profile import ActivityProfile
 from app.user import ComparisonResult, LocationResult
-from output.renderers.channel_layout import CHANNEL_LIMITS, render_for_channel
+from output.renderers.channel_layout import (
+    CHANNEL_LIMITS, render_for_channel, telegram_metric_notice,
+)
 from output.renderers.compare_metric_catalog import COMPARE_METRIC_CATALOG
 from output.renderers.compare_metric_ids import FRONTEND_TO_RENDERER_METRIC_ID
 from output.renderers.email.compare_html import (
@@ -766,7 +768,9 @@ def render_compare_telegram(
         # Groessen). Je eigene Zeile INNERHALB dieses Ortsblocks, weil beide
         # Zahlen ortsabhaengig sind.
         if layout.demoted_count > 0:
-            block.append("   " + _telegram_metric_notice(layout.demoted_count))
+            block.append("   " + telegram_metric_notice(
+                layout.demoted_count, context="vergleich",
+            ))
         if no_data_count > 0:
             block.append("   " + _telegram_no_data_notice(no_data_count))
         # Issue #1332 (PO-Korrektur 2026-07-23): Sicherheits-Filter + geteilte,
@@ -849,24 +853,6 @@ def _telegram_notice(omitted: int) -> str:
     if omitted <= 0:
         return ""
     return f"\n… +{omitted} weitere Orte (Telegram-Limit) — vollständig per E-Mail"
-
-
-def _telegram_metric_notice(demoted_count: int) -> str:
-    """Ehrlicher Kuerzungs-Hinweis fuer Metrik-PLATZMANGEL (#1362, AC-2): eine
-    Groesse HAT einen Wert an diesem Ort, passt aber wegen der 7-Zellen-
-    Grenze nicht mehr (``ChannelLayout.demoted_count`` -- Gegenstueck zum
-    Ohne-Daten-Fall, s. ``_telegram_no_data_notice``). Wird als eigene Zeile
-    INNERHALB des jeweiligen Ortsblocks angehaengt (Adversary-Korrektur:
-    Platzverfuegbarkeit ist ortsabhaengig, s. ``render_compare_telegram``) --
-    deshalb OHNE fuehrenden Zeilenumbruch (anders als ``_telegram_notice``,
-    das direkt an den Gesamttext angehaengt wird). Leer, wenn nichts
-    verdraengt wurde."""
-    if demoted_count <= 0:
-        return ""
-    return (
-        f"… +{demoted_count} weitere Wettergrößen je Ort (Telegram-Limit) "
-        "— vollständig per E-Mail"
-    )
 
 
 def _telegram_no_data_notice(no_data_count: int) -> str:

--- a/src/output/renderers/narrow.py
+++ b/src/output/renderers/narrow.py
@@ -28,7 +28,9 @@ from utils.timezone import local_fmt, local_hour
 
 from output.renderers.alert.render import _esc
 from output.renderers.fallback_notice import build_fallback_lines, select_fallback_meta
-from output.renderers.channel_layout import VISIBILITY_GATE_IDS, render_for_channel
+from output.renderers.channel_layout import (
+    VISIBILITY_GATE_IDS, render_for_channel, telegram_metric_notice,
+)
 from output.renderers.day_window import (
     DAY_WINDOW_END_HOUR, DAY_WINDOW_START_HOUR, collect_hiking_window_points,
     hiking_field_min_max, night_temp_min_c, night_wind_chill_min_c,
@@ -103,36 +105,6 @@ def _wrap(text: str, width: int) -> list[str]:
             lines.append(w[:width])
             w = w[width:]
         cur = w
-    if cur:
-        lines.append(cur)
-    return lines
-
-
-def _detail_lines(
-    metric_ids: list[str], row: dict, friendly_keys: set[str], width: int,
-) -> list[str]:
-    """Baue die ``·``-getrennte Detail-Zeile(n) fuer ``detail_metrics``.
-
-    Wird auf ``width`` umgebrochen, sodass auch Signal jede Zeile <=26 haelt.
-    """
-    parts: list[str] = []
-    for mid in metric_ids:
-        val = _cell(mid, row, friendly_keys)
-        parts.append(f"{_compact_label(mid)} {val}")
-
-    lines: list[str] = []
-    cur = ""
-    for part in parts:
-        candidate = part if not cur else f"{cur} · {part}"
-        if len(candidate) <= width:
-            cur = candidate
-            continue
-        if cur:
-            lines.append(cur)
-        # Ein Einzel-Part koennte breiter als width sein -> hart umbrechen.
-        for sub in _wrap(part, width):
-            lines.append(sub)
-        cur = ""
     if cur:
         lines.append(cur)
     return lines
@@ -842,6 +814,14 @@ def render_telegram_bubbles(
     if vortag_line:
         overview_lines.append("")
         overview_lines.extend(_wrap(_esc(vortag_line), _TG_PROSE_WIDTH))
+    # Issue #1741: Kappungshinweis (>7 primary-Metriken verlieren ihre
+    # stuendliche Aufloesung in der Segment-Tabelle) -- ans Ende der
+    # Kurzuebersicht, EINMAL fuer den ganzen Trip (dieselbe `layout`-
+    # Berechnung wie die Segment-Tabellen oben, nicht je Segment neu).
+    notice = telegram_metric_notice(layout.demoted_count, context="route")
+    if notice:
+        overview_lines.append("")
+        overview_lines.extend(_wrap(_esc(notice), _TG_PROSE_WIDTH))
     bubbles.append(TelegramBubble(text="\n".join(overview_lines)))
 
     # 3./4. Segment-/Ziel-Bubbles: Mini-Header + echte Monospace-Tabelle.

--- a/tests/tdd/test_channel_metric_matrix.py
+++ b/tests/tdd/test_channel_metric_matrix.py
@@ -260,8 +260,17 @@ def test_ac13_email_column_selection_and_order(metric_id):
 
 
 def _telegram_cells(dc: UnifiedWeatherDisplayConfig) -> list[str]:
-    layout = render_for_channel("telegram", dc, "evening")
-    return layout.table_columns + layout.detail_metrics
+    """Prueft die Kaskaden-AUSWAHL fuer Telegram, nicht die Sichtbarkeit in
+    Tabelle/Kurzuebersicht (s. Kommentar bei ``test_ac4_*_telegram_table_
+    budget`` weiter unten) -- deshalb die rohe Kanal-Auswahl
+    (``get_metrics_for_channel``), nicht ``ChannelLayout.table_columns``
+    (das kappt bei 7 Slots). Die reinen Sichtbarkeits-Gates
+    (``VISIBILITY_GATE_IDS``) bleiben ausgenommen -- sie landen strukturell
+    nie in einem Bucket, unabhaengig von der Kaskade (#1741)."""
+    return [
+        m.metric_id for m in dc.get_metrics_for_channel("telegram", "evening")
+        if m.metric_id not in VISIBILITY_GATE_IDS
+    ]
 
 
 @pytest.mark.parametrize("metric_id", _ALL_METRIC_IDS)
@@ -869,8 +878,12 @@ def _kaskade_mail_headers(dc: UnifiedWeatherDisplayConfig, report_type: str = "e
 
 
 def _kaskade_telegram_cells(dc: UnifiedWeatherDisplayConfig, report_type: str = "evening") -> list[str]:
-    layout = render_for_channel("telegram", dc, report_type)
-    return layout.table_columns + layout.detail_metrics
+    """Kaskaden-AUSWAHL fuer Telegram (nicht Sichtbarkeit) -- s. Docstring
+    von ``_telegram_cells`` oben, gleiche Begruendung (#1741)."""
+    return [
+        m.metric_id for m in dc.get_metrics_for_channel("telegram", report_type)
+        if m.metric_id not in VISIBILITY_GATE_IDS
+    ]
 
 
 def _kaskade_sms_text(dc: UnifiedWeatherDisplayConfig, report_type: str = "evening") -> str:

--- a/tests/tdd/test_felt_night_catalog_exclusions.py
+++ b/tests/tdd/test_felt_night_catalog_exclusions.py
@@ -119,11 +119,6 @@ class TestFeltNightIsNeverAnHourlyColumn:
             f"{NIGHT_METRIC!r} erscheint als Tabellenspalte: "
             f"{layout.table_columns!r}"
         )
-        assert NIGHT_METRIC not in layout.detail_metrics, (
-            f"{NIGHT_METRIC!r} erscheint als Detail-Zeile: "
-            f"{layout.detail_metrics!r} -- channel_layout.py:88 filtert "
-            f"bisher nur „temperature_night“ aus der Menge heraus."
-        )
 
     def test_compare_hourly_excludes_felt_night_with_reason(self):
         """Ortsvergleich-Seite: ``HOURLY_EXCLUDED_METRIC_IDS`` +

--- a/tests/tdd/test_issue_360_channel_renderer.py
+++ b/tests/tdd/test_issue_360_channel_renderer.py
@@ -148,7 +148,6 @@ def test_ac1_signal_five_primary_all_in_table():
     assert layout.table_columns == [
         "temperature", "wind", "gust", "rain_probability", "precipitation",
     ]
-    assert layout.detail_metrics == []
     assert layout.demoted_count == 0
 
 
@@ -186,7 +185,6 @@ def test_ac3_email_no_limit_keeps_all_primary():
 
     assert layout.table_columns == [m[0] for m in _NINE_PRIMARY]
     assert len(layout.table_columns) == 9
-    assert layout.detail_metrics == []
     assert layout.demoted_count == 0
 
 
@@ -198,7 +196,8 @@ def test_ac3_email_no_limit_keeps_all_primary():
 def test_ac4_sms_pushes_everything_to_detail():
     """GIVEN derselbe dc mit 9 primary-Metriken
     WHEN render_for_channel("sms", dc, "morning") läuft
-    THEN ist table_columns == [] und alle Werte liegen flach in detail_metrics."""
+    THEN ist table_columns == [] und demoted_count == 9 (alle 9 primary
+    verdraengt, keine Tabellenspalte)."""
     from src.output.renderers.channel_layout import render_for_channel
 
     dc = _build_dc(_NINE_PRIMARY)
@@ -206,8 +205,7 @@ def test_ac4_sms_pushes_everything_to_detail():
     layout = render_for_channel("sms", dc, "morning")
 
     assert layout.table_columns == []
-    assert layout.detail_metrics == [m[0] for m in _NINE_PRIMARY]
-    assert len(layout.detail_metrics) == 9
+    assert layout.demoted_count == 9
 
 
 # ===========================================================================

--- a/tests/tdd/test_issue_429_channel_layouts.py
+++ b/tests/tdd/test_issue_429_channel_layouts.py
@@ -273,11 +273,10 @@ def test_ac5_channel_limits_still_applied_with_per_channel_layouts():
 
     # CHANNEL_LIMITS["telegram"]["max_table_cols"] = 8 → 7 Metrik-Slots (Slot 0 = Zeit).
     assert len(layout.table_columns) == 7
-    # Die 3 überzähligen Metriken wandern in detail_metrics.
+    # Die 3 überzähligen Metriken werden verdrängt (demoted_count).
     assert layout.demoted_count == 3
     # Reihenfolge in table_columns muss der Telegram-Layout-Reihenfolge entsprechen.
     assert layout.table_columns == [f"metric_{i}" for i in range(7)]
-    assert layout.detail_metrics[:3] == [f"metric_{i}" for i in range(7, 10)]
 
 
 # ---------------------------------------------------------------------------
@@ -303,19 +302,17 @@ def test_ac6_legacy_trip_render_bit_identical():
         "temperature", "wind", "gust", "rain_probability", "precipitation",
         "wind_chill", "cloud_total", "thunder", "fresh_snow",
     ]
-    assert layout.detail_metrics == ["visibility"]
     assert layout.demoted_count == 0
 
-    # Telegram: limit 8 → 7 primaries + Rest in detail
+    # Telegram: limit 8 → 7 primaries + Rest verdrängt
     layout_tg = render_for_channel("telegram", dc, "evening")
     assert len(layout_tg.table_columns) == 7
     assert layout_tg.demoted_count == 2
-    assert layout_tg.detail_metrics == ["thunder", "fresh_snow", "visibility"]
 
-    # SMS: 0 Tabellen-Spalten
+    # SMS: 0 Tabellen-Spalten, alle 9 primaries verdrängt
     layout_sms = render_for_channel("sms", dc, "evening")
     assert layout_sms.table_columns == []
-    assert len(layout_sms.detail_metrics) >= 9  # alles in Detail
+    assert layout_sms.demoted_count == 9
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tdd/test_issue_887_report_inkonsistenz.py
+++ b/tests/tdd/test_issue_887_report_inkonsistenz.py
@@ -223,7 +223,7 @@ def test_ac4_telegram_no_crash_when_pop_max_pct_is_none():
 
 
 # ---------------------------------------------------------------------------
-# AC-5: Keine extra Metriken → keine Detail-Zeile in Telegram
+# AC-5 (#1741 AC-2): Keine extra Metriken -> keine Kappungshinweis-Zeile
 # ---------------------------------------------------------------------------
 
 def test_ac5_telegram_no_detail_line_when_only_temp_and_wind():
@@ -231,7 +231,9 @@ def test_ac5_telegram_no_detail_line_when_only_temp_and_wind():
     AC-5: Given display_config nur mit temperature + wind
     When render_telegram_bubbles(...) aufgerufen wird (Issue #1001)
     Then keine col_label-Detail-Zeile (Rain%, Gust, etc. fehlen weiterhin —
-    #1001 verwendet ohnehin nur noch compact_label, nie col_label)
+    #1001 verwendet ohnehin nur noch compact_label, nie col_label) UND
+    (#1741 AC-2, umgebaut) keine Kappungshinweis-Zeile -- 2 aktive
+    primary-Metriken bleiben unter dem 7er-Tabellenlimit, demoted_count==0.
     """
     from src.output.renderers.narrow import render_telegram_bubbles
 
@@ -247,6 +249,9 @@ def test_ac5_telegram_no_detail_line_when_only_temp_and_wind():
     result = "\n".join(b.text for b in bubbles)
     assert "Rain%" not in result, f"Unerwartetes 'Rain%' in Output:\n{result}"
     assert "Gust" not in result, f"Unerwartetes 'Gust' in Output:\n{result}"
+    assert "weitere Wettergrößen nur als Tageswert" not in result, (
+        f"#1741 AC-2: Kappungshinweis erscheint trotz demoted_count==0:\n{result}"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tdd/test_telegram_metric_notice.py
+++ b/tests/tdd/test_telegram_metric_notice.py
@@ -21,7 +21,7 @@ import dataclasses
 
 from app.models import MetricConfig, UnifiedWeatherDisplayConfig
 from output.renderers import narrow
-from output.renderers.channel_layout import ChannelLayout
+from output.renderers.channel_layout import ChannelLayout, telegram_metric_notice
 from output.renderers.trip_report import TripReportFormatter
 
 from tests.tdd import _min_temp_felt_fixtures as F
@@ -141,6 +141,44 @@ def test_notice_appears_exactly_once_across_bubbles_with_multiple_segments():
             assert fragment not in " ".join(b.split()), (
                 f"AC-3: Hinweistext in einer Segment-Tabellen-Bubble gefunden: {b!r}"
             )
+
+
+# --- F001 (Adversary-Fund, Gegenpruefung) -- die beiden Wortlaute sind ---
+# --- BEWUSST verschieden (kein Kanal ersetzt einen anderen) und muessen --
+# --- deshalb je Kontext WOERTLICH gepinnt werden, nicht nur am Fragment --
+# --- "+N weitere Wettergrößen", das in beiden Wortlauten identisch ist. --
+# --- Erwartung ist ein Literal in diesem Test, NICHT aus channel_layout.py
+# --- importiert/abgeleitet -- sonst bewacht der Test die Quelle nicht. ---
+
+
+def test_vergleich_notice_full_wording_is_pinned_and_route_wording_absent():
+    text = telegram_metric_notice(2, context="vergleich")
+    assert text == (
+        "… +2 weitere Wettergrößen je Ort (Telegram-Limit) "
+        "— vollständig per E-Mail"
+    ), f"F001: Vergleichs-Wortlaut weicht ab: {text!r}"
+    assert "nur als Tageswert" not in text, (
+        f"F001: Trip-Wortlaut-Fragment im Vergleichs-Text gefunden: {text!r}"
+    )
+
+
+def test_route_notice_full_wording_is_pinned_and_vergleich_wording_absent():
+    text = telegram_metric_notice(2, context="route")
+    assert text == (
+        "… +2 weitere Wettergrößen nur als Tageswert (Telegram-Limit)"
+    ), f"F001: Trip-Wortlaut weicht ab: {text!r}"
+    assert "je Ort" not in text, (
+        f"F001: Vergleichs-Wortlaut-Fragment 'je Ort' im Trip-Text gefunden: {text!r}"
+    )
+    assert "vollständig per E-Mail" not in text, (
+        f"F001: Vergleichs-Wortlaut-Fragment 'vollständig per E-Mail' im "
+        f"Trip-Text gefunden: {text!r}"
+    )
+
+
+def test_notice_is_empty_string_for_zero_demoted_in_both_contexts():
+    assert telegram_metric_notice(0, context="vergleich") == ""
+    assert telegram_metric_notice(0, context="route") == ""
 
 
 # --- AC-6: toter Pfad entfernt --------------------------------------------

--- a/tests/tdd/test_telegram_metric_notice.py
+++ b/tests/tdd/test_telegram_metric_notice.py
@@ -1,0 +1,156 @@
+"""Telegram-Trip-Nachricht: Kappungshinweis in der Kurzuebersicht (#1741).
+
+SPEC: docs/specs/modules/fix_1741_telegram_kappungshinweis.md — AC-1, AC-2,
+AC-3, AC-6 (AC-4/AC-5 sind Regressionsschutz ueber bestehende Testdateien,
+brauchen keine neue Datei).
+
+Bug: Ueberzaehlige Telegram-Metriken (>7 aktive ``primary``) verlieren ihre
+stuendliche Aufloesung in der Segment-Tabelle, aber die Telegram-Nachricht
+selbst sagt nirgends, dass gekappt wurde. KEIN bestehender Test prueft die
+GERENDERTE Ausgabe darauf -- ``test_channel_metric_matrix.py:800-806`` haelt
+das schriftlich fest und weicht dem Problem bewusst aus (dort wird nur
+``ChannelLayout`` gegengeprueft, nie der Bubble-Text). Diese Datei rendert
+deshalb echte Bubbles ueber den Produktivpfad
+(``TripReportFormatter().format_email()`` -> ``report.telegram_bubbles``),
+Vorbild ``test_channel_metric_matrix.py::_kaskade_report``/
+``_s4_telegram_bubbles`` (Zeilen 851/3251).
+"""
+from __future__ import annotations
+
+import dataclasses
+
+from app.models import MetricConfig, UnifiedWeatherDisplayConfig
+from output.renderers import narrow
+from output.renderers.channel_layout import ChannelLayout
+from output.renderers.trip_report import TripReportFormatter
+
+from tests.tdd import _min_temp_felt_fixtures as F
+
+# Wortlaut-Fragment aus der Spec (Implementation Details §2), OHNE das
+# fuehrende "… +N " -- das wird je Test mit dem erwarteten N zusammengesetzt.
+_NOTICE_FRAGMENT = "weitere Wettergrößen nur als Tageswert (Telegram-Limit)"
+
+# 9 reale, katalogisierte primary-Metriken, winterfrei -- F.segment() liefert
+# fuer alle neun einen echten Wert ohne Zusatz-Aggregation (anders als
+# snow_depth/snowfall_limit/fresh_snow, die eine praeparierte Aggregation
+# brauchen, s. test_channel_metric_matrix.py::_matrix_segment). Reihenfolge
+# nach METRIC_PRIORITY (channel_layout.py), sodass die ersten 7 in die
+# Tabelle rutschen und die letzten 2 ueberzaehlig sind (demoted_count == 2).
+_NINE_PRIMARY_METRIC_IDS = [
+    "temperature", "wind", "gust", "rain_probability", "precipitation",
+    "wind_chill", "cloud_total", "thunder", "visibility",
+]
+assert len(_NINE_PRIMARY_METRIC_IDS) == 9
+
+
+def _dc_with_primary_metrics(metric_ids: list[str]) -> UnifiedWeatherDisplayConfig:
+    """Globale Auswahl, KEINE Kanal-Ebene -- Telegram faellt auf die
+    Grundauswahl zurueck (ADR-0050 Regel 1), alle Metriken im
+    ``primary``-Bucket, Reihenfolge == Eingabe-Reihenfolge."""
+    return UnifiedWeatherDisplayConfig(
+        trip_id="1741-kappungshinweis",
+        metrics=[
+            MetricConfig(metric_id=mid, enabled=True, bucket="primary", order=i)
+            for i, mid in enumerate(metric_ids)
+        ],
+    )
+
+
+def _telegram_bubbles(
+    dc: UnifiedWeatherDisplayConfig, segments: list | None = None,
+) -> list[str]:
+    """Echter Renderpfad (Vorbild ``_kaskade_report``/``_s4_telegram_bubbles``,
+    test_channel_metric_matrix.py:851/3251) -- NICHT ``render_for_channel()``
+    direkt, das den Kollabierungsschritt umgeht und keine Bubble-Texte
+    erzeugt (Konstruktionshinweis der Spec, AC-1)."""
+    segs = segments if segments is not None else [F.segment()]
+    report = TripReportFormatter().format_email(
+        segs, trip_name="Kappungshinweis1741", report_type="evening",
+        night_weather=F.night_weather(), display_config=dc,
+        stage_name=F.STAGE_NAME, tz=F.TZ,
+    )
+    return report.telegram_bubbles
+
+
+def _kurzuebersicht_bubble(bubbles: list[str]) -> str:
+    """Findet die Kurzuebersicht-Bubble am PRAEFIX ihres Textes, nicht per
+    festem Index -- die Bubble-Reihenfolge darf sich aendern, ohne dass der
+    Test aus dem falschen Grund bricht (AC-1-Vorgabe)."""
+    for text in bubbles:
+        if text.startswith("Kurzübersicht"):
+            return text
+    raise AssertionError(f"keine Kurzuebersicht-Bubble gefunden: {bubbles!r}")
+
+
+# --- AC-1: >7 aktive primary-Metriken -> Hinweis mit korrektem N ----------
+
+
+def test_overview_bubble_shows_notice_with_correct_count_when_over_seven_metrics():
+    dc = _dc_with_primary_metrics(_NINE_PRIMARY_METRIC_IDS)
+    bubbles = _telegram_bubbles(dc)
+    kb = _kurzuebersicht_bubble(bubbles)
+    # Zeilenumbruch-tolerant: die Zeile ist 60 Zeichen lang und damit breiter
+    # als _TG_PROSE_WIDTH (56) -- _wrap() darf sie auf zwei Zeilen verteilen.
+    normalized = " ".join(kb.split())
+    assert f"+2 {_NOTICE_FRAGMENT}" in normalized, (
+        f"AC-1: Kappungshinweis mit N=2 fehlt in der Kurzuebersicht "
+        f"(9 primary-Metriken, 7 Tabellen-Slots): {kb!r}"
+    )
+
+
+# --- AC-2: <=7 aktive primary-Metriken -> Hinweiszeile fehlt vollstaendig -
+
+
+def test_overview_bubble_has_no_notice_when_seven_or_fewer_metrics():
+    dc = _dc_with_primary_metrics(_NINE_PRIMARY_METRIC_IDS[:7])
+    bubbles = _telegram_bubbles(dc)
+    kb = _kurzuebersicht_bubble(bubbles)
+    assert _NOTICE_FRAGMENT not in " ".join(kb.split()), (
+        f"AC-2: Kappungshinweis erscheint trotz demoted_count==0: {kb!r}"
+    )
+    assert "+0" not in kb, f"AC-2: '+0' im Bubble-Text: {kb!r}"
+    assert "\n\n\n" not in kb, (
+        f"AC-2: ueberzaehlige Leerzeile im Bubble-Text: {kb!r}"
+    )
+
+
+# --- AC-3: Ueberlauf + >=2 Segmente -> Hinweis GENAU EINMAL, nur in der ---
+# --- Kurzuebersicht, nie in einer Segment-Tabellen-Bubble -----------------
+
+
+def test_notice_appears_exactly_once_across_bubbles_with_multiple_segments():
+    seg1 = F.segment()
+    seg2_raw = F.segment(day=F.DAY + 1)
+    seg2 = dataclasses.replace(
+        seg2_raw, segment=dataclasses.replace(seg2_raw.segment, segment_id=2),
+    )
+    dc = _dc_with_primary_metrics(_NINE_PRIMARY_METRIC_IDS)
+    bubbles = _telegram_bubbles(dc, segments=[seg1, seg2])
+
+    fragment = f"+2 {_NOTICE_FRAGMENT}"
+    hits = [b for b in bubbles if fragment in " ".join(b.split())]
+    assert len(hits) == 1, (
+        f"AC-3: Hinweistext soll GENAU EINMAL ueber alle Bubbles vorkommen, "
+        f"gefunden in {len(hits)} Bubbles: {bubbles!r}"
+    )
+    assert hits[0].startswith("Kurzübersicht"), (
+        f"AC-3: Hinweistext steht nicht in der Kurzuebersicht-Bubble: {hits[0]!r}"
+    )
+    for b in bubbles:
+        if "<pre>" in b:
+            assert fragment not in " ".join(b.split()), (
+                f"AC-3: Hinweistext in einer Segment-Tabellen-Bubble gefunden: {b!r}"
+            )
+
+
+# --- AC-6: toter Pfad entfernt --------------------------------------------
+
+
+def test_channel_layout_and_narrow_have_no_dead_detail_path():
+    field_names = {f.name for f in dataclasses.fields(ChannelLayout)}
+    assert "detail_metrics" not in field_names, (
+        f"AC-6: ChannelLayout traegt noch das tote Feld 'detail_metrics': {field_names}"
+    )
+    assert not hasattr(narrow, "_detail_lines"), (
+        "AC-6: narrow-Modul hat noch das tote Attribut '_detail_lines'"
+    )

--- a/tests/tdd/test_temp_tagesrichtung_aufloesung.py
+++ b/tests/tdd/test_temp_tagesrichtung_aufloesung.py
@@ -393,23 +393,17 @@ class TestDayDirectionsNeverBecomeColumns:
         layout = render_for_channel("email", dc, "evening")
 
         in_spalten = [m for m in NEW_IDS if m in layout.table_columns]
-        in_details = [m for m in NEW_IDS if m in layout.detail_metrics]
         assert not in_spalten, (
             f"Geisterspalte(n) {in_spalten} im E-Mail-Layout: "
             f"{layout.table_columns!r}"
-        )
-        assert not in_details, (
-            f"Geister-Detailzeile(n) {in_details} im E-Mail-Layout: "
-            f"{layout.detail_metrics!r}"
         )
 
     @pytest.mark.parametrize("channel", ["telegram", "sms"])
     def test_other_channels_place_none_of_them_in_a_bucket(self, channel):
         """Dieselbe Zusicherung fuer Telegram und SMS. „Laeuft durch dieselbe
         Funktion" ist eine Annahme, kein Nachweis: beide Kanaele haben eigene
-        Spaltenlimits (``CHANNEL_LIMITS``), und SMS verschiebt seine
-        ``primary``-Menge komplett in ``detail_metrics`` — ein Filter, der nur
-        die Tabellenspalten saeuberte, waere hier sichtbar."""
+        Spaltenlimits (``CHANNEL_LIMITS``) — ein Filter, der nur die
+        Tabellenspalten saeuberte, waere hier sichtbar."""
         from output.renderers.channel_layout import render_for_channel
 
         dc = _dc(("temperature", True), (TEMP_LOW, True), (TEMP_HIGH, True),
@@ -417,12 +411,10 @@ class TestDayDirectionsNeverBecomeColumns:
                  ("precipitation", True))
         layout = render_for_channel(channel, dc, "evening")
 
-        gefunden = [m for m in NEW_IDS
-                    if m in layout.table_columns or m in layout.detail_metrics]
+        gefunden = [m for m in NEW_IDS if m in layout.table_columns]
         assert not gefunden, (
-            f"[{channel}] Sichtbarkeits-Gates {gefunden} landen in einem "
-            f"Bucket. Spalten: {layout.table_columns!r}, "
-            f"Detail: {layout.detail_metrics!r}"
+            f"[{channel}] Sichtbarkeits-Gates {gefunden} landen in einer "
+            f"Tabellenspalte: {layout.table_columns!r}"
         )
 
 


### PR DESCRIPTION
Schliesst #1741.

## Was der Nutzer merkt

Waehlt man fuer Telegram mehr als 7 Wettergroessen, zeigt die Segment-Tabelle nur die ersten 7. Die uebrigen standen bisher zwar als Tageswert in der Kurzuebersicht, aber **die Nachricht sagte nicht, dass gekappt wurde** — wer unterwegs liest, ohne den Editor offen zu haben, konnte das nicht wissen.

Neu am Ende der Kurzuebersicht-Bubble:

> … +2 weitere Wettergroessen nur als Tageswert (Telegram-Limit)

Der Ortsvergleich hatte so einen Hinweis laengst; beide kommen jetzt aus einem geteilten Baustein `telegram_metric_notice(demoted_count, *, context)`.

## Drei Praemissen des Tickets, die die Analyse nicht bestaetigt hat

1. **Keine Regression.** `_detail_lines()` wurde in `6b27798f` (#1001) abgeklemmt — das setzt den **PO-Entscheid vom 2026-06-06** um (`WeatherV2Reihenfolge.svelte:4`, Issue #587: „Kein '→ Detail'-Knopf, keine Detail-Zeile"). Die #1001-Spec hat es nur nicht protokolliert. Deshalb wird die Detailzeile **nicht** wiederbelebt, sondern der tote Pfad entfernt und der Entscheid nachdokumentiert.
2. **Nicht „ohne Hinweis".** Der Editor warnt dreifach (Chip `−N`, Schnittlinie „✂ ab hier Telegram-Limit", warngefaerbter Text). Was fehlte, war der Hinweis in der **Nachricht**.
3. **Kein Totalverlust.** Die Kurzuebersicht zeigt alle aktiven Metriken als Tagesaussage; verloren geht nur die **stuendliche Aufloesung**.

## Warum ein eigener Wortlaut statt des Compare-Texts

Der Ortsvergleich sagt „… je Ort (Telegram-Limit) — vollstaendig per E-Mail". Beim Trip traegt das nicht: die Groessen stehen direkt darueber als Tageswert, und bei abgeschaltetem Mailversand ginge der Verweis ins Leere (kein Kanal ersetzt einen anderen). Der Compare-Wortlaut bleibt **bit-identisch**.

## Adversary: BROKEN → VERIFIED

Die Mutations-Gegenprobe fand **F001 (HIGH)**: Vertauscht man die beiden Kanal-Wortlaute, blieb der gesamte `test_compare_kanal_metriken.py`-Lauf **gruen** — er prueft nur das Fragment `"+N weitere Wettergroessen"`, das in beiden Texten identisch ist. Der als AC-4-Regressionsschutz benannte Test haette eine Vertauschung nie bemerkt.

Geschlossen in `e9a31813` (nur Tests): drei Waechter pinnen beide Wortlaute **woertlich als Literal im Test** — nicht aus `channel_layout.py` importiert, sonst bewacht der Test seine eigene Quelle nicht. Beide Vertauschungsrichtungen machen ihn jetzt rot.

Alle 6 ACs sind **durch Mutation belegt**, nicht durch einen gruenen Lauf:

| AC | Mutation, die faengt |
|---|---|
| AC-1 | Trip-Wortlaut vertauscht |
| AC-2 | `demoted_count <= 0`-Wache entfernt |
| AC-3 | Hinweis pro Segment → zaehlt 3 statt 1 |
| AC-4 | beide Vertauschungsrichtungen (nach F001-Fix) |
| AC-5 | `sms_trip.py` importiert `channel_layout` strukturell nicht |
| AC-6 | `_detail_lines` bzw. `detail_metrics` wieder eingefuehrt — beide Haelften einzeln |

## Tests

- Zielgerichtet: **535 passed, 8 skipped**
- Vollauf mit CI-Flags: **10.296 passed**, 2 Fehlschlaege ohne Bezug zu diesem PR — beides Live-Schicht-Tests, die lokale Staging-Umgebung brauchen (`test_issue_1014_live_optin` schlaegt an einer Schutzwache gegen die Produktiv-`.env` im Worktree an, `test_issue_937_staging_rolling_trip` macht ein echtes `httpx.post`)
- Netto **−44 Zeilen** Produktivcode

## Nebenbefund

F002 (MEDIUM, nicht erreichbar) in #1196 gebucht: Der umgebaute Testhelfer setzt `bucket ∈ {primary, secondary}` voraus, statt es zu erzwingen.

## Bekannte Grenze

Der Hinweis erreicht nur den `rich`-Stil. Der Tour-Trip „KHW 403" faehrt `telegram_style=kurzform` und bekommt den SMS-Text — dort wirkt der Fix nicht. Der PO hat #1741 in Kenntnis dessen im Milestone belassen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DuF4pfYEzKQSKCxS3DHfZ4