### PR TITLE
docs(#1741): #1001-Spec — Wegfall der Detail-Zeile nachtragen

### DIFF
--- a/docs/specs/modules/feat_1001_telegram_redesign.md
+++ b/docs/specs/modules/feat_1001_telegram_redesign.md
@@ -34,6 +34,15 @@ Darstellung zu sprengen.
 - **File:** `src/output/renderers/narrow.py` — neue Funktion `render_telegram_bubbles()`
   ersetzt `render_narrow()` für `channel == "telegram"` vollständig (Breaking Replace).
   Entfernt: `_tg_segment_line()`, `_tg_extra_detail_line()`, `_tg_day_footer()`,
+  **[Nachtrag 2026-08-21, #1741]** außerdem entfiel im selben Commit (`6b27798f`) die
+  Aufrufstelle von `_detail_lines()` — die Detail-Zeile fiel damit für Telegram ganz weg.
+  Das setzt die **PO-Entscheidung vom 2026-06-06** um („Kein ‚→ Detail'-Knopf, keine
+  Detail-Zeile", Issue #587, s. `WeatherV2Reihenfolge.svelte:4`), war hier aber nie
+  protokolliert. Weil `_detail_lines()` und `ChannelLayout.detail_metrics` stehen blieben,
+  sah der Wegfall 7 Wochen später wie eine vergessene Verkabelung aus und wurde als Bug
+  #1741 gemeldet. Beide sind seit #1741 (`cbd1a650`) entfernt; jenseits des
+  Spaltenbudgets liegende Metriken erscheinen in der Kurzübersicht als Tageswert plus
+  Kappungshinweis. Siehe `docs/specs/modules/fix_1741_telegram_kappungshinweis.md`.
   der Text-Befehls-Footer-Block (Zeile 531-536) und die `cmd_hint`-Zeile. Wiederverwendet:
   `_narrow_table()` (Zeile 115-151, bislang nur für den abgeschalteten Signal-Kanal
   aktiv), `_wrap()`, `_compact_label()`, `_tg_vortag_line()`.


### PR DESCRIPTION
Reiner Doku-Nachtrag, kein Code.

Die Spec zu #1001 listete nur `_tg_extra_detail_line()` als entfernt. Dass im selben Commit (`6b27798f`) auch die Aufrufstelle von `_detail_lines()` wegfiel — und dass das die **PO-Entscheidung vom 2026-06-06** umsetzt (#587: „Kein '→ Detail'-Knopf, keine Detail-Zeile") — stand dort nicht.

Genau diese Lücke hat #1741 erzeugt: Weil `_detail_lines()` und `ChannelLayout.detail_metrics` stehen blieben, sah der Wegfall sieben Wochen später wie eine vergessene Verkabelung aus und wurde als Bug gemeldet. Die Analyse zu #1741 musste den Entscheid aus einem Frontend-Kommentar rekonstruieren.

Der Nachtrag verweist auf `docs/specs/modules/fix_1741_telegram_kappungshinweis.md`.

Ergänzt die bereits gelieferte Korrektur in `docs/reference/api_contract.md` (PR #2031), die `bucket=secondary` weiterhin als „Detail-Zeile" beschrieb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DuF4pfYEzKQSKCxS3DHfZ4