### PR TITLE
fix(#1818): Timeline/Glance melden Datenluecke statt fehlender Etappe

### DIFF
--- a/docs/context/fix-1818-timeline-zweitagesanker.md
+++ b/docs/context/fix-1818-timeline-zweitagesanker.md
@@ -1,0 +1,126 @@
+# Context: fix-1818-timeline-zweitagesanker
+
+Issue: [#1818](https://github.com/henemm/gregor_zwanzig/issues/1818) · Label `bug`, `priority:high`,
+`area:output` · Milestone **Tour KHW 2026-08** · Basis `cba7ffa3`
+
+## Request Summary
+
+Die Telegram-Abfragen `timeline_heute` / `timeline_morgen` / `glance` antworten fuer einen der
+beiden Tage **„Keine Etappe geplant"**, obwohl die Etappe existiert. Die Antwort behauptet etwas
+ueber die **Tourplanung**, weiss aber nur etwas ueber den **Datenbestand**: der undatierte
+Wetter-Anker traegt strukturell nur EINEN Tag.
+
+## Wirkkette (belegt)
+
+| Schritt | Datei:Zeile | Was passiert |
+|---|---|---|
+| 1 | `src/services/trip_report_scheduler.py:927-950` (`_get_target_date`) | `"morning"` → Ortstag, `"evening"` → Ortstag+1. **Genau ein** `target_date` je Lauf. |
+| 2 | `src/services/trip_report_scheduler.py:1505-1512` (`_write_briefing_anchor`) | schreibt `save(trip.id, segment_weather, target_date)` → **ueberschreibt** `{trip_id}.json` komplett; zusaetzlich `save_dated(...)` → `{trip_id}_{YYYY-MM-DD}.json`. |
+| 3 | `src/services/weather_snapshot.py:96-107` (`save`) | `target_date` existiert **nur einmal auf oberster Ebene**; kein Datum je Segment. |
+| 4 | `src/services/weather_extractor.py:80-109` (`timeline`) | gibt **alle** Segmente der Datei zurueck, filtert **nicht** nach Tag; `target_date` wird nur durchgereicht. |
+| 5 | `src/services/trip_command_processor.py:837-877` (`_aggregate_day`), `:969-1007` (`_fmt_timeline`) | Tagestrennung passiert **erst hier** (`local_dt(p.arrival_time, tz).date() == target_date`). Kein Treffer → `"{label} ({datum}): Keine Etappe geplant"`. |
+
+**Folge:** Nach dem Morgen-Briefing traegt der Anker heute → `timeline_morgen` faellt aus.
+Nach dem Abend-Briefing traegt er morgen → `timeline_heute` faellt aus. Die betroffene Seite
+wechselt im Tagesrhythmus.
+
+## Zwei Sperren, die einen naiven Fix wirkungslos machen
+
+**Sperre A — der Nachlade-Pfad ist doppelt verriegelt.**
+`_fetch_and_save_snapshot` (`trip_command_processor.py:278-316`) laeuft nur, wenn
+`not timeline.available` (`:541`). Selbst wenn man diese Bedingung auf „kein Punkt fuer den
+angefragten Tag" erweitert, bricht der Helper **intern erneut ab**: sein eigener Cache-Check
+(`:289-296`) kehrt bei `raw["target_date"] == today.isoformat()` sofort zurueck — und genau das
+ist der Normalfall nach einem Morgen-Briefing. Ein Fix nur an `:541` waere strukturell
+wirkungslos.
+
+**Sperre B — Nachladen wuerde die Alarm-Vergleichsbasis zerstoeren.**
+`_fetch_and_save_snapshot` schreibt `briefing_backed=False` (`:312-314`). Heute ist das
+harmlos, weil er nur laeuft, wenn gar kein Anker existiert. Bei einem Fix wuerde er einen
+**vorhandenen briefing-backed Anker ueberschreiben** — und `TripAlertService._get_cached_weather`
+(`src/services/trip_alert.py:738-742`) verwirft eine nicht-briefing-gestuetzte Basis
+(`reason="not_briefing_backed"`, ADR-0009 / #1699). Ein Button-Druck des Wanderers wuerde damit
+den Abweichungs-Alarm blind machen.
+
+## Kostenloser Teil-Rueckfall: die datierten Snapshots
+
+`_write_briefing_anchor` legt **zusaetzlich** `{trip_id}_{YYYY-MM-DD}.json` ab
+(`save_dated`, `weather_snapshot.py:115-141`, Retention 7 Tage via `_prune_dated_snapshots:182`).
+Daraus folgt eine Asymmetrie, die den Loesungszuschnitt bestimmt:
+
+| Zeitpunkt | Undatierter Anker traegt | Fehlender Tag | Liegt er datiert vor? |
+|---|---|---|---|
+| Nach Morgen-Briefing | heute | **morgen** | **Nein** — `{trip}_{morgen}.json` entsteht erst im heutigen Abend-Briefing |
+| Nach Abend-Briefing | morgen | **heute** | **Ja** — `{trip}_{heute}.json` stammt aus dem heutigen Morgen-Briefing |
+
+Die Abend-Haelfte des Bugs ist also **ohne einen einzigen API-Abruf** behebbar; die
+Vormittags-Haelfte nicht.
+
+## Kontingent (Issue #1329) — schliesst einen Weg aus
+
+Open-Meteo Free-Tier: **10.000 Anfragen/Tag**, chronisch ausgeschoepft
+(`docs/specs/modules/fix_1329_forecast_cache_budget.md:19-22`; Prod-Log 2026-07-20: HTTP 429
+durchgehend 00–14 Uhr). `_fetch_weather` (`trip_report_scheduler.py:1935-1977`) kostet
+**1 Call je Segment**. Der Weg „Anker traegt immer beide Tage" wuerde den Verbrauch **je
+Briefing verdoppeln** — bei einem Kontingent, das bereits 429er produziert. Dieser Weg
+scheidet damit aus Betriebsgruenden aus, nicht aus Geschmacksgruenden.
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `src/services/trip_command_processor.py` | Abfrage-Dispatch `:505-560`, Nachlade-Helper `:278-316`, Formatierer `:837-1030` — **Hauptaenderungsort** |
+| `src/services/weather_extractor.py` | `timeline()` `:80-109` — liefert ungefilterte Punkte |
+| `src/services/weather_snapshot.py` | `save` `:77-113`, `save_dated`/`load_dated` `:115-179`, `load_briefing_backed` `:347-370` |
+| `src/services/trip_report_scheduler.py` | `_get_target_date` `:927-950`, `_write_briefing_anchor` `:1505-1512` — nur lesend relevant |
+| `src/services/trip_alert.py` | `_get_cached_weather` `:629-750` — **Kollisionsflaeche**, kein Tagesfilter auf der undatierten Basis |
+
+## Existing Patterns
+
+- **Prioritaetskette statt Einzelquelle:** `trip_alert.py:629-750` (#1916) loest Wetterdaten
+  ueber gestufte Quellen auf (Briefing-Anker → rollierender Alarm-Anker → undatierter Rueckfall)
+  mit benanntem `reason` je Ablehnung. Dasselbe Muster passt auf die Timeline-Aufloesung.
+- **Herkunft mitfuehren statt raten:** `briefing_backed` (#1699) haelt fest, ob Daten als
+  Vergleichsbasis taugen. Neue Schreibpfade muessen die Herkunft bewusst setzen.
+- **Read-Modify-Write statt Replace** (CLAUDE.md, BUG-DATALOSS-GR221): `save()` ist heute ein
+  reiner Replace — jede Erweiterung des Ankers muss das beruecksichtigen.
+- **Ehrliche Fehlanzeige statt Falschaussage:** `_fmt_gewitter` `:938-941` trennt bereits
+  „kein Snapshot verfuegbar" von „keine Etappe geplant" — das Vorbild fehlt nur der Timeline.
+
+## Dependencies
+
+- **Upstream:** `WeatherSnapshotService` (Persistenz), `TripReportSchedulerService._fetch_weather`
+  (Provider-Abruf), `trip_local_now`/`display_tz` (#1795, ADR-0044 Ortszeit-Aufloesung).
+- **Downstream:** Telegram-Inbound-Antworten (`timeline_heute`, `timeline_morgen`, `glance`,
+  `heute_gewitter`); indirekt der Alarm-Pfad ueber den geteilten undatierten Anker.
+
+## Existing Specs & ADRs
+
+- `docs/specs/modules/fix_1699_anker_ohne_briefing.md` — `briefing_backed`, ADR-0009
+- `docs/specs/modules/fix_1329_forecast_cache_budget.md` — Kontingent
+- `docs/context/fix-1795-timeline-ortszeit.md` — Fundstelle dieses Befunds, Abgrenzung
+- ADR-0044 (Ortszeit), ADR-0056 (rollierender Alarm-Anker), ADR-0009 (Vergleichsbasis)
+
+## Risks & Considerations
+
+1. **Alarm-Vergleichsbasis (hoch).** Jede Aenderung am undatierten Anker `{trip_id}.json`
+   trifft `trip_alert.py:711-750` mit. Dort gibt es — anders als in `_aggregate_day` — **keinen
+   Tagesfilter**: ein zweitaegiger Anker wuerde morgige Segmente still in den Δ-Vergleich
+   einspeisen. Nachweis-Pflicht in der Spec.
+2. **Radar-Unterdrueckung (mittel).** `trip_alert.py:680` (`load_dated(trip.id, today)`) und
+   `:1324` lesen die datierten Snapshots. Wuerde ein Abfrage-Pfad dort schreiben, veraenderte er
+   die eingefrorene Briefing-Referenz (#818/#1667, AC-11) — genau das, was `save_alarm_anchor`
+   (`weather_snapshot.py:225-240`) bewusst vermeidet.
+3. **Kontingent (mittel).** Jeder Nachlade-Weg kostet Calls. Bei 429 muss die Antwort ehrlich
+   ausfallen statt in „Keine Etappe geplant" zurueckzufallen — sonst ist der Bug unter Last
+   unveraendert sichtbar.
+4. **Testfixturen verdecken den Bug (hoch, nachweisrelevant).**
+   `tests/tdd/test_issue_651_telegram_query_glance.py:108-119` und
+   `tests/tdd/test_timeline_folgt_der_ortszeit.py:95-101` schreiben ihren Anker **kuenstlich mit
+   beiden Tagen in EINEM `save()`-Aufruf**. Der Produktionspfad — zwei getrennte, einander
+   ueberschreibende Laeufe — kommt in **keinem** Test vor. Ein RED-Test muss den Anker daher
+   ueber **zwei aufeinanderfolgende `_write_briefing_anchor`-artige Schreibvorgaenge** aufbauen,
+   sonst ist er trivial gruen.
+5. **Nur ein `target_date`-Feld.** Die Ankerstruktur kann zwei Tage im `segments`-Array tragen,
+   aber nicht zwei Zieltage benennen. Jeder Leser, der `load_target_date()` als Torwaechter
+   nutzt, bekaeme eine halbe Wahrheit.

--- a/docs/context/fix-1818-timeline-zweitagesanker.md
+++ b/docs/context/fix-1818-timeline-zweitagesanker.md
@@ -24,6 +24,32 @@ Wetter-Anker traegt strukturell nur EINEN Tag.
 Nach dem Abend-Briefing traegt er morgen → `timeline_heute` faellt aus. Die betroffene Seite
 wechselt im Tagesrhythmus.
 
+### Der Fehltext steht an VIER Stellen, nicht an einer
+
+`_aggregate_day` ist die gemeinsame Datenquelle **dreier** Formatierer; jeder hat seine eigene
+Fehlanzeige, jede mit demselben Denkfehler (Challenger-Befund 1):
+
+| Formatierer | Zeile | Text |
+|---|---|---|
+| `_fmt_timeline` | `:1007` | `"{label} ({datum}): Keine Etappe geplant"` |
+| `_fmt_glance` (heute-Zweig) | `:929` | `"heute (…): Keine Etappe geplant"` |
+| `_fmt_glance` (morgen-Zweig) | `:933` | `"morgen (…): Keine Etappe geplant"` |
+| `_fmt_gewitter` | `:944` | `"Heute (…): Keine Etappe geplant — kein Gewitter-Status"` |
+
+`glance` steht **namentlich im Bug-Titel**. Eine Loesung, die nur `_fmt_timeline` anfasst,
+laesst das gemeldete Symptom bestehen und waere trotzdem gruen, wenn die Tests der Wirkkette
+folgen. Alle vier Stellen gehoeren in den Aenderungs-Scope.
+
+### Ein dritter Ankerzustand (selten, aber real)
+
+Neben „traegt heute" und „traegt morgen" gibt es einen dritten: `send_test_report`
+(`trip_report_scheduler.py:1024-1050`, Nutzerkommando `### report: morning|evening`) waehlt
+ueber `select_test_stage` `:981-1023` einen **Fallback-Tag**, der weder heute noch morgen ist;
+`_send_trip_report` `:1245-1248` korrigiert `target_date` darauf, bevor der Anker geschrieben
+wird. Der Anker bleibt in sich konsistent, traegt aber einen beliebigen Zukunftstag. Eine
+Loesung, die **je angefragtem Tag aufloest**, ist dagegen unempfindlich; eine Loesung, die aus
+dem Ankerzustand global auf „heute oder morgen" schliesst, waere es nicht.
+
 ## Zwei Sperren, die einen naiven Fix wirkungslos machen
 
 **Sperre A — der Nachlade-Pfad ist doppelt verriegelt.**
@@ -84,8 +110,11 @@ scheidet damit aus Betriebsgruenden aus, nicht aus Geschmacksgruenden.
   Vergleichsbasis taugen. Neue Schreibpfade muessen die Herkunft bewusst setzen.
 - **Read-Modify-Write statt Replace** (CLAUDE.md, BUG-DATALOSS-GR221): `save()` ist heute ein
   reiner Replace — jede Erweiterung des Ankers muss das beruecksichtigen.
-- **Ehrliche Fehlanzeige statt Falschaussage:** `_fmt_gewitter` `:938-941` trennt bereits
-  „kein Snapshot verfuegbar" von „keine Etappe geplant" — das Vorbild fehlt nur der Timeline.
+- **Ehrliche Fehlanzeige statt Falschaussage:** `_fmt_gewitter` `:937-941` trennt „kein Snapshot
+  verfuegbar" von „keine Etappe geplant" — **aber nur auf oberster Ebene** (`not
+  timeline.available`, also gar kein Anker). Der **tagesgenaue** Fall `:944` faellt in
+  denselben Fehltext zurueck. Das Muster taugt als Vorbild fuer die Form, nicht als Beleg,
+  dass die Stelle schon richtig waere (Challenger-Befund 1).
 
 ## Dependencies
 
@@ -121,6 +150,20 @@ scheidet damit aus Betriebsgruenden aus, nicht aus Geschmacksgruenden.
    ueberschreibende Laeufe — kommt in **keinem** Test vor. Ein RED-Test muss den Anker daher
    ueber **zwei aufeinanderfolgende `_write_briefing_anchor`-artige Schreibvorgaenge** aufbauen,
    sonst ist er trivial gruen.
-5. **Nur ein `target_date`-Feld.** Die Ankerstruktur kann zwei Tage im `segments`-Array tragen,
+5. **Der Verweis auf `morgen` fuellt die Timeline NICHT (hoch, formulierungsrelevant).**
+   Das Kommando `morgen` (`trip_command_processor.py:534` → `_trigger_on_demand` `:588-620` →
+   `send_on_demand_report`) versendet ein volles Briefing, schreibt aber **keinen Anker**:
+   `write_anchor_and_reset_memory` steigt bei `on_demand=True` bewusst aus
+   (`trip_report_scheduler.py:1495-1501`, #1007). Ein Hinweistext der Form „dann fuellt sich
+   die Timeline" waere also falsch und erzeugte eine Frustschleife — der Nutzer drueckte
+   danach denselben Knopf und saehe dieselbe Fehlanzeige. Der Text darf nur zusichern, was
+   eintritt: **das Briefing wird zugestellt**.
+6. **Dritte Kopie derselben Quellenkette (mittel, Architektur).** `trip_alert.py:629-750`
+   (#1916, #1661) implementiert bereits eine gestufte „welcher Snapshot gilt fuer Tag X"-Kette.
+   Eine zweite, unabhaengige Kette im Abfragepfad ist vertretbar — Anzeige und Δ-Vergleich
+   haben unterschiedliche Vertrauensregeln (`briefing_backed` gilt nur fuer den Vergleich) —
+   muss in der Spec aber **begruendet** werden, sonst entsteht beim naechsten Ticket eine
+   dritte (Challenger-Befund 3).
+7. **Nur ein `target_date`-Feld.** Die Ankerstruktur kann zwei Tage im `segments`-Array tragen,
    aber nicht zwei Zieltage benennen. Jeder Leser, der `load_target_date()` als Torwaechter
    nutzt, bekaeme eine halbe Wahrheit.

--- a/docs/specs/modules/fix_1818_timeline_tagesaufloesung.md
+++ b/docs/specs/modules/fix_1818_timeline_tagesaufloesung.md
@@ -1,0 +1,223 @@
+---
+entity_id: fix_1818_timeline_tagesaufloesung
+type: module
+created: 2026-08-21
+updated: 2026-08-21
+status: draft
+version: "1.0"
+tags: [telegram, timeline, snapshot, bug]
+---
+
+# Timeline-Tagesaufloesung: Datenluecke statt Tourplanungs-Aussage
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Die Telegram-Abfragen `timeline_heute`, `timeline_morgen`, `glance` und `heute_gewitter` melden
+heute eine fehlende Wetterlage fuer einen Tag faelschlich als **„Keine Etappe geplant"** — eine
+Aussage ueber die Tourplanung, obwohl das System nur etwas ueber den Datenbestand weiss. Diese
+Spec aendert die vier betroffenen Formatierer so, dass sie (a) einen fehlenden Tag zuerst aus
+bereits vorhandenen datierten Snapshots decken, bevor sie aufgeben, und (b) im verbleibenden
+Fall ehrlich zwischen „keine Daten" und „keine Etappe" unterscheiden.
+
+## Source
+
+- **File:** `src/services/trip_command_processor.py`
+- **Identifier:** `_fmt_timeline` (:1007), `_fmt_glance` (:929, :933), `_fmt_gewitter` (:944),
+  `_aggregate_day` (:837-877), Query-Dispatch (:505-560)
+
+> **Schicht-Hinweis:** Python-Core / Domain-Backend (`src/services/`), FastAPI-Core-seitige
+> Telegram-Inbound-Verarbeitung. Kein Go-API-, kein Frontend-Anteil.
+
+## Estimated Scope
+
+- **LoC:** ~80-120
+- **Files:** 2-3
+- **Effort:** medium
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `src/services/weather_snapshot.py` (`WeatherSnapshotService.load_dated`) | module | Liest den tagesdatierten Snapshot `{trip_id}_{YYYY-MM-DD}.json` als Rueckfallquelle, rein lesend |
+| `src/services/weather_extractor.py` (`timeline`) | module | Liefert die ungefilterten Segmentpunkte aus dem undatierten Anker; bleibt unveraendert, wird nur mit den ggf. um den Rueckfall ergaenzten Rohdaten aufgerufen |
+| `src/services/trip_segments.py` (`convert_trip_to_segments`) | module | Netzfreie Segmentbildung je Tag — beantwortet „existiert an diesem Tag ueberhaupt eine Etappe?" unabhaengig vom Wetter-Anker |
+| `src/services/trip_report_scheduler.py` (`_write_briefing_anchor`) | module | Erzeugt sowohl den undatierten Anker als auch den datierten Snapshot; wird von dieser Spec **nicht** veraendert, nur als Quelle gelesen |
+| `src/services/trip_alert.py` (`_get_cached_weather`) | module | Kollisionsflaeche: liest denselben undatierten Anker fuer den Alarm-Δ-Vergleich; muss durch diese Aenderung unberuehrt bleiben (siehe Known Limitations) |
+
+## Implementation Details
+
+**Gestufte Quellenauflösung je angefragtem Tag.** Fuer jeden angefragten Tag (`heute`/`morgen`)
+prueft der Formatierer zuerst, ob der bereits geladene undatierte Anker (`{trip_id}.json`, via
+`weather_extractor.timeline()`) Segmentpunkte fuer diesen Tag traegt (bestehende
+`_aggregate_day`-Filterung nach `local_dt(p.arrival_time, tz).date() == target_date`). Ist das
+nicht der Fall, wird `WeatherSnapshotService.load_dated(trip_id, target_date)` als Rueckfall
+gelesen — rein lesend, kein neuer Schreibpfad. Liefert auch das nichts, gibt es fuer diesen Tag
+keine Daten.
+
+**Aussage von Datenverfuegbarkeit trennen.** Nur wenn beide Quellen leer sind, entscheidet
+`services.trip_segments.convert_trip_to_segments(trip, target_date)` — eine netzfreie,
+rein tourplan-basierte Segmentbildung ohne Wetterdaten — ob an diesem Tag ueberhaupt eine Etappe
+existiert:
+- Etappe vorhanden, aber keine Wetterdaten → ehrliche Fehlanzeige „noch keine Wetterdaten fuer
+  {label} ({datum})" mit Verweis auf das Kommando, das fuer diesen Tag ein Briefing zustellt.
+- Keine Etappe an diesem Tag → die bestehende Aussage „Keine Etappe geplant" bleibt (sie ist in
+  diesem Fall zutreffend).
+
+Diese Unterscheidung wird in allen vier betroffenen Formatierern (`_fmt_timeline:1007`,
+`_fmt_glance` heute-Zweig `:929`, `_fmt_glance` morgen-Zweig `:933`, `_fmt_gewitter:944`)
+umgesetzt — nicht nur an einer Stelle, da alle vier auf `_aggregate_day` aufsetzen und alle vier
+denselben Denkfehler wiederholen (Challenger-Befund, siehe `docs/context/fix-1818-timeline-zweitagesanker.md`).
+
+**Kein On-Demand-Abruf im Abfragepfad.** Der bestehende Nachlade-Helper
+`_fetch_and_save_snapshot` (`trip_command_processor.py:278-316`) wird von dieser Aenderung
+**nicht** aufgerufen und nicht erweitert. Fehlt ein Tag auch nach dem Rueckfall auf den
+datierten Snapshot, bleibt die Antwort eine ehrliche Fehlanzeige statt eines API-Abrufs.
+
+**Nicht-Ziele (explizit ausgeschlossen):** `_write_briefing_anchor`
+(`trip_report_scheduler.py:1505-1512`), `WeatherSnapshotService.save()`, `save_dated()` sowie
+jeglicher Code in `trip_alert.py` bleiben unveraendert. Diese Spec fuegt **keinen** neuen
+Schreibpfad auf Snapshot-Dateien hinzu.
+
+### Architektur-Begruendung: keine geteilte Funktion mit `trip_alert.py`
+
+`trip_alert.py:629-750` (#1916/#1661) implementiert bereits eine gestufte Quellenkette fuer
+Wetterdaten (Briefing-Anker → rollierender Alarm-Anker → undatierter Rueckfall). Die hier
+gebaute Kette ist bewusst **keine** gemeinsame Funktion mit jener, weil Anzeige und
+Δ-Vergleich unterschiedliche Vertrauensregeln haben: `briefing_backed` (ADR-0009/#1699)
+entscheidet, ob Daten als **Vergleichsbasis** fuer den Abweichungs-Alarm taugen — fuer die
+reine **Anzeige** einer Timeline ist diese Frage bedeutungslos, denn hier wird nichts
+verglichen, sondern nur der zuletzt bekannte Wert gezeigt. Eine geteilte Funktion muesste das
+Kriterium `briefing_backed` parametrisieren und wuerde beide Aufrufer aneinander koppeln —
+eine Aenderung am Alarm-Vertrauensmodell haette dann ungewollt Auswirkungen auf die
+Timeline-Anzeige und umgekehrt.
+
+### Begruendung gegen den Nachlade-Weg
+
+Open-Meteo Free-Tier ist auf 10.000 Anfragen/Tag begrenzt und in Produktion real erschoepft
+(`docs/specs/modules/fix_1329_forecast_cache_budget.md:19-22`, HTTP 429 im Prod-Log). Zusaetzlich
+schreibt `_fetch_and_save_snapshot` (`trip_command_processor.py:278-316`) den Anker mit
+`briefing_backed=False` — ein Abruf ueber den Abfragepfad wuerde damit einen vorhandenen
+briefing-gestuetzten Anker ueberschreiben und die Alarm-Vergleichsbasis zerstoeren
+(`trip_alert.py:738-742` verwirft nicht-briefing-gestuetzte Basen). Der Rueckgriff auf bereits
+vorhandene datierte Snapshots ist dagegen kostenlos und veraendert keinen Schreibzustand.
+
+## Expected Behavior
+
+- **Input:** Telegram-Kommandos `timeline_heute`, `timeline_morgen`, `glance`, `heute_gewitter`
+  fuer einen Trip, dessen undatierter Wetter-Anker nur einen der beiden Tage traegt.
+- **Output:** Fuer den fehlenden Tag entweder (a) Stundenwerte aus dem passenden datierten
+  Snapshot, falls vorhanden, oder (b) eine ehrliche Datenluecken-Meldung mit Verweis auf das
+  briefing-ausloesende Kommando, falls eine Etappe existiert, oder (c) die unveraenderte Aussage
+  „Keine Etappe geplant", falls tatsaechlich keine Etappe an diesem Tag existiert.
+- **Side effects:** Keine. Es wird nichts geschrieben, kein Netzabruf ausgeloest, kein Feld eines
+  bestehenden Ankers veraendert.
+
+## Acceptance Criteria
+
+- **AC-1:** Given ein Trip hat für morgen eine Etappe und der Wetter-Anker trägt nur den
+  heutigen Tag / When der Nutzer `timeline_morgen` abfragt / Then meldet die Antwort, dass für
+  morgen noch keine Wetterdaten vorliegen, und behauptet NICHT „Keine Etappe geplant".
+  - Test: Zwei aufeinanderfolgende, einander ueberschreibende Briefing-Schreibvorgaenge bauen
+    einen Anker auf, der nur „heute" traegt; der Nutzer fragt per Telegram-Kommando
+    `timeline_morgen` ab und liest eine Datenluecken-Meldung statt einer Tourplanungs-Aussage.
+
+- **AC-2:** Given ein Trip hat für morgen KEINE Etappe (Ruhetag oder Tag nach Tourende) / When
+  der Nutzer `timeline_morgen` abfragt / Then bleibt die Antwort „Keine Etappe geplant" — diese
+  Aussage ist dann zutreffend.
+  - Test: Ein Trip, dessen letzte Etappe heute endet, wird per `timeline_morgen` abgefragt; der
+    Nutzer liest weiterhin „Keine Etappe geplant" und keine Datenluecken-Meldung.
+
+- **AC-3:** Given der undatierte Anker trägt morgen (das Abend-Briefing lief zuletzt) und ein
+  datierter Snapshot für heute existiert / When der Nutzer `timeline_heute` abfragt / Then
+  zeigt das System die Stundenwerte des heutigen Tages aus dem datierten Snapshot.
+  - Test: Nach einem simulierten Abend-Briefing (Anker traegt morgen) und einem vorhandenen
+    `{trip_id}_{heute}.json` fragt der Nutzer `timeline_heute` ab und sieht konkrete
+    Stundenwerte statt einer Fehlanzeige.
+
+- **AC-4:** Given der undatierte Anker und ein datierter Snapshot tragen denselben Tag mit
+  unterschiedlichen Werten / When dieser Tag abgefragt wird / Then stammen die angezeigten
+  Werte aus dem undatierten Anker, nicht aus dem datierten Snapshot.
+  - Test: Ein Anker und ein datierter Snapshot fuer denselben Tag mit bewusst unterschiedlichen
+    Temperaturwerten werden angelegt; der Nutzer fragt den Tag ab und liest den Wert aus dem
+    Anker, nicht aus dem Snapshot.
+
+- **AC-5:** Given ein Trip hat an beiden Tagen Etappen, der Anker trägt nur einen davon und
+  für den anderen existiert kein datierter Snapshot / When der Nutzer `glance` abfragt / Then
+  meldet die Zeile des fehlenden Tages fehlende Wetterdaten, während die Zeile des vorhandenen
+  Tages unverändert aggregiert bleibt.
+  - Test: Ein Trip mit Etappen an beiden Tagen, Anker traegt nur heute, kein datierter Snapshot
+    fuer morgen; der Nutzer fragt `glance` ab und sieht in einer Antwort sowohl die aggregierte
+    heutige Zeile als auch die Datenluecken-Zeile fuer morgen.
+
+- **AC-6:** Given ein Trip hat heute eine Etappe, der Anker trägt nur morgen und für heute
+  existiert kein datierter Snapshot / When der Nutzer `heute_gewitter` abfragt / Then meldet
+  die Antwort fehlende Wetterdaten für heute statt „Keine Etappe geplant — kein
+  Gewitter-Status".
+  - Test: Anker traegt nur morgen, kein datierter Snapshot fuer heute, Trip hat heute eine
+    Etappe; der Nutzer fragt `heute_gewitter` ab und liest eine Datenluecken-Meldung statt
+    „Keine Etappe geplant — kein Gewitter-Status".
+
+- **AC-7:** Given eine der Abfragen timeline/glance/gewitter wird bei fehlenden Daten
+  beantwortet / When die Antwort erzeugt wird / Then löst sie keinen Wetter-Abruf aus und
+  verändert keine Snapshot-Datei; insbesondere bleibt das Feld `briefing_backed` eines
+  vorhandenen Ankers unverändert.
+  - Test: Vor und nach der Abfrage wird der Dateiinhalt (Aenderungszeitstempel und
+    `briefing_backed`-Feld) des undatierten Ankers verglichen; ausserdem wird nachgewiesen,
+    dass kein HTTP-Aufruf an den Wetter-Provider stattfand.
+
+- **AC-8:** Given die ehrliche Fehlanzeige erscheint / When der Nutzer sie liest / Then
+  verweist sie auf das Kommando, das für diesen Tag ein Briefing auslöst, und sagt
+  ausschließlich die Zustellung des Briefings zu — sie verspricht nicht, dass sich die
+  Timeline-Ansicht danach füllt.
+  - Test: Der Nutzer liest den Text der Datenluecken-Meldung und findet darin den Verweis auf
+    das briefing-versendende Kommando sowie eine Formulierung, die nur die Zustellung des
+    Briefings zusagt, nicht das nachtraegliche Fuellen der Timeline-Ansicht (das On-Demand-
+    Kommando `morgen` schreibt laut `trip_report_scheduler.py:1495-1501` keinen Anker).
+
+## Known Limitations
+
+- Der dritte, seltene Ankerzustand aus `send_test_report`/`select_test_stage`
+  (`trip_report_scheduler.py:981-1050`), bei dem der Anker weder heute noch morgen traegt,
+  sondern einen beliebigen Fallback-Tag, wird durch die tagesgenaue Aufloesung automatisch mit
+  abgedeckt, ist aber nicht Gegenstand eines eigenen Acceptance-Criterion.
+- Die Ankerstruktur besitzt weiterhin nur ein einziges `target_date`-Feld auf oberster Ebene;
+  diese Spec aendert daran nichts. Jeder kuenftige Code, der `target_date` als Torwaechter fuer
+  „welche Tage traegt der Anker" nutzt, bekommt weiterhin nur eine halbe Wahrheit.
+- `trip_alert.py:629-750` bleibt unveraendert und behaelt seine eigene, unabhaengige
+  Quellenkette fuer den Δ-Vergleich; ein zweitaegiger Anker wuerde dort weiterhin ohne
+  Tagesfilter gelesen — das ist Bestandsverhalten und nicht Teil dieses Fixes, aber jede
+  Implementierung MUSS durch einen Test nachweisen, dass sie an dieser Lesestelle nichts
+  veraendert (siehe AC-7).
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Es handelt sich um eine lokale Korrektur der Lesepfade in vier bestehenden
+  Formatierern, keine neue Persistenz-, Auth- oder Kanalentscheidung. Die betroffenen
+  Vertrauensregeln (`briefing_backed`, ADR-0009) bleiben unveraendert; es wird lediglich eine
+  zusaetzliche, rein lesende Quelle (datierter Snapshot) in eine bestehende Anzeige-Kette
+  eingefuegt.
+
+## Nachweisführung
+
+- **Bestandsfixturen verdecken den Bug.** `tests/tdd/test_issue_651_telegram_query_glance.py:108-119`
+  und `tests/tdd/test_timeline_folgt_der_ortszeit.py:95-101` bauen den Anker **künstlich mit
+  beiden Tagen in EINEM `save()`-Aufruf** auf. Der Produktionspfad — zwei getrennte, einander
+  überschreibende Briefing-Läufe — kommt in keinem bestehenden Test vor. Ein RED-Test MUSS den
+  Anker über **zwei aufeinanderfolgende, einander überschreibende Schreibvorgänge** aufbauen
+  (analog zu zwei `_write_briefing_anchor`-Läufen), sonst ist er trivial grün.
+- **AC-2 ist der Gegenfall zu AC-1** und existiert, um eine Bedingungs-Inversion („Etappe
+  vorhanden?" verdreht) fangbar zu machen. Ohne AC-2 bleibt diese Mutation unsichtbar.
+- **AC-4 existiert**, um eine Vertauschung der Quellen-Reihenfolge (datierter Snapshot vor
+  undatiertem Anker gelesen) fangbar zu machen. Undatierter und datierter Snapshot müssen dafür
+  bewusst **unterschiedliche Werte** tragen — identische Fixturen machen den Test wirkungslos.
+- Tests lösen ihren Prüfling **relativ zur eigenen Testdatei** auf, nie über den festen
+  Hauptrepo-Pfad, damit sie im Worktree korrekt gegen den lokalen Stand laufen.
+
+## Changelog
+
+- 2026-08-21: Initial spec created

--- a/src/services/trip_command_processor.py
+++ b/src/services/trip_command_processor.py
@@ -16,12 +16,16 @@ import re
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from app.loader import get_data_dir, get_snapshots_dir, load_all_trips, save_trip
 from app.trip import Stage, Trip
 from services.trip_day import anchor_tz, display_tz, trip_local_now, trip_local_today
 from utils.timezone import UTC, local_dt, local_fmt, local_hour
+
+if TYPE_CHECKING:  # nur fuer die Typangabe — zur Laufzeit bleibt der
+    # Import von ``weather_extractor`` wie bisher call-time (Issue #1818).
+    from services.weather_extractor import TimelineResult
 
 logger = logging.getLogger(__name__)
 
@@ -140,6 +144,51 @@ _THUNDER_LABEL = {
     "MED": "mäßig",
     "HIGH": "hoch",
 }
+
+# Issue #1818: der Hinweis, der die ehrliche Fehlanzeige begleitet — je Tag
+# das Kommando, das FUER DIESEN TAG ein Briefing ausloest. `/heute`/`/morgen`
+# versenden ein volles Briefing, schreiben aber KEINEN Anker
+# (`trip_report_scheduler.py:1495-1501`, #1007). Der Text sagt deshalb
+# ausschliesslich die ZUSTELLUNG des Briefings zu — ein Versprechen, dass sich
+# die Timeline-Ansicht danach fuelle, waere falsch und erzeugte eine
+# Frustschleife (Kontext-Risiko 5).
+_BRIEFING_HINWEIS = {
+    "today": "mit /heute wird dir das Briefing für heute sofort zugestellt",
+    "tomorrow": "mit /morgen wird dir das Briefing für morgen sofort zugestellt",
+}
+
+# Issue #1818 (Adversary-Finding F005): die Groessen, aus denen die vier
+# Formatierer ihre Tagesaussage bauen -- `_fmt_timeline` zeigt genau
+# temp_min_c/temp_max_c/wind_max_kmh/precip_sum_mm/thunder_level_max,
+# `_aggregate_day` aggregiert dieselben plus pop_max_pct (Buttons/Glance).
+# Ein Wegpunkt, der KEINE davon traegt, kann in keiner Ausgabe etwas anderes
+# als Fragezeichen erzeugen.
+_TAGESWERTE = (
+    "temp_min_c", "temp_max_c", "wind_max_kmh", "precip_sum_mm",
+    "thunder_level_max", "pop_max_pct",
+)
+
+
+def _traegt_tageswerte(point) -> bool:
+    """POSITIV-Kriterium (Issue #1818, F005): traegt dieser Wegpunkt
+    mindestens EINEN auswertbaren Tageswert?
+
+    Bewusst KEINE Negativliste bekannter Fehlerformen: `_fetch_weather`
+    erzeugt bei einem teilweise gescheiterten Abruf ein Segment mit
+    `SegmentWeatherSummary()` (alle Felder None) und `has_error=True`
+    (`trip_report_scheduler.py:2033-2043`) -- aber `has_error` ueberlebt die
+    Umrechnung in `TimelinePoint` gar nicht (dort steht nur `metrics`), und
+    kuenftige Ausfallformen saehen wieder anders aus. Geprueft wird deshalb,
+    was der Punkt LIEFERT, nicht woran er gescheitert ist.
+
+    Nicht gelesen werden die Nicht-Messgroessen der `SegmentWeatherSummary`
+    (`aggregation_config` traegt mit `{}` einen nicht-`None`-Default,
+    `cape_model_id` ist Herkunft, `wind_dir_deg_avg` ein Test-Alias) -- eine
+    generische "irgendein Feld ist gesetzt"-Pruefung wuerde den leeren
+    Platzhalter faelschlich als brauchbar durchwinken.
+    """
+    return any(getattr(point.metrics, feld, None) is not None
+               for feld in _TAGESWERTE)
 
 # Issue #1001: Aktionen-Bubble-Keyboard (Multi-Bubble-Telegram-Redesign).
 # Eigenes Praefix `act_` verhindert Kollision mit den `dd_*`/`tl_*`-Drilldown-
@@ -542,8 +591,17 @@ class TripCommandProcessor:
             _fetch_and_save_snapshot(trip=trip, user_id=user_id, today=today, tomorrow=tomorrow)
             timeline = extractor.timeline(trip.id)
 
+        # Fix #1818: der undatierte Anker traegt strukturell nur EINEN Tag —
+        # der jeweils fehlende wird, falls vorhanden, aus dem datierten
+        # Snapshot rein lesend ergaenzt (kein Abruf, kein Schreibvorgang).
+        timeline = self._mit_datiertem_rueckfall(
+            timeline, trip.id, user_id,
+            ((today, tz_heute), (tomorrow, tz_morgen)),
+        )
+
         if query_key == "glance":
-            body = self._fmt_glance(timeline, today, tomorrow, tz_heute, tz_morgen)
+            body = self._fmt_glance(timeline, today, tomorrow, tz_heute, tz_morgen,
+                                    trip=trip)
             return CommandResult(
                 success=True, command="glance",
                 confirmation_subject=f"[{trip.name}] Glance",
@@ -552,7 +610,7 @@ class TripCommandProcessor:
                 reply_markup=_GLANCE_BUTTONS,
             )
         elif query_key == "heute_gewitter":
-            body = self._fmt_gewitter(timeline, today, tz_heute)
+            body = self._fmt_gewitter(timeline, today, tz_heute, trip=trip)
             return CommandResult(
                 success=True, command="heute_gewitter",
                 confirmation_subject=f"[{trip.name}] Gewitter heute",
@@ -560,7 +618,8 @@ class TripCommandProcessor:
                 trip_name=trip.name,
             )
         elif query_key == "timeline_heute":
-            body = self._fmt_timeline(timeline, today, "Heute", "today", tz_heute)
+            body = self._fmt_timeline(timeline, today, "Heute", "today", tz_heute,
+                                      trip=trip)
             return CommandResult(
                 success=True, command="timeline_heute",
                 confirmation_subject=f"[{trip.name}] Timeline heute",
@@ -569,7 +628,8 @@ class TripCommandProcessor:
                 reply_markup=self._timeline_buttons(timeline, today, "today", tz_heute),
             )
         elif query_key == "timeline_morgen":
-            body = self._fmt_timeline(timeline, tomorrow, "Morgen", "tomorrow", tz_morgen)
+            body = self._fmt_timeline(timeline, tomorrow, "Morgen", "tomorrow", tz_morgen,
+                                      trip=trip)
             return CommandResult(
                 success=True, command="timeline_morgen",
                 confirmation_subject=f"[{trip.name}] Timeline morgen",
@@ -834,6 +894,83 @@ class TripCommandProcessor:
             lines.append(line)
         return "\n".join(lines)
 
+    def _mit_datiertem_rueckfall(self, timeline: "TimelineResult", trip_id: str,
+                                 user_id: str, tage) -> "TimelineResult":
+        """Gestufte Quellenaufloesung JE angefragtem Tag (Issue #1818).
+
+        Der undatierte Anker ``{trip_id}.json`` traegt strukturell nur EINEN
+        Tag: ``_write_briefing_anchor`` (``trip_report_scheduler.py:1505-1512``)
+        ueberschreibt ihn je Briefing-Lauf vollstaendig. Nach dem
+        Morgen-Briefing fehlt darin morgen, nach dem Abend-Briefing heute.
+
+        Reihenfolge (AC-4): der Anker hat Vorrang, sobald er fuer den Tag
+        AUSWERTBARE Werte traegt (`_traegt_tageswerte`, F005) — die blosse
+        Existenz eines Wegpunkts genuegt nicht, sonst gewaenne ein
+        inhaltsleerer Fehler-Platzhalter gegen echte Werte. Nur fuer einen
+        Tag, den er so nicht traegt, wird der bereits vorliegende datierte
+        Snapshot ``{trip_id}_{YYYY-MM-DD}.json`` rein LESEND nachgezogen — kein
+        Netzabruf, kein Schreibvorgang (AC-7). Der Tagesfilter ist derselbe
+        wie in ``_aggregate_day``/``_fmt_timeline`` (Ortstag, #1795), damit
+        ein Rueckfall-Wegpunkt nicht in einen fremden Tag rutscht.
+
+        ``tage`` ist eine Folge von ``(target_date, tz)``-Paaren.
+        """
+        if not timeline.available:
+            return timeline
+        from services.weather_extractor import WeatherExtractor
+        extractor = WeatherExtractor(user_id=user_id)
+        ergaenzt = []
+        verworfen: set[int] = set()
+        for target_date, tz in tage:
+            tages_idx = [i for i, p in enumerate(timeline.points)
+                         if local_dt(p.arrival_time, tz).date() == target_date]
+            if any(_traegt_tageswerte(timeline.points[i]) for i in tages_idx):
+                continue  # der Anker traegt den Tag mit Werten — er gewinnt (AC-4)
+            # Der Anker traegt fuer diesen Tag hoechstens inhaltsleere
+            # Fehler-Platzhalter (F005). Die werden verworfen: bleiben sie
+            # liegen, gewinnt „🌡 ?–? °C" gegen echte Werte aus dem datierten
+            # Snapshot — und wenn auch der nichts hergibt, verdecken sie die
+            # ehrliche Datenluecken-Meldung, weil die Punktliste der
+            # Formatierer dann nicht leer ist.
+            verworfen.update(tages_idx)
+            datiert = extractor.timeline_dated(trip_id, target_date)
+            ergaenzt.extend(
+                p for p in datiert.points
+                if local_dt(p.arrival_time, tz).date() == target_date
+                and _traegt_tageswerte(p)
+            )
+        if not ergaenzt and not verworfen:
+            return timeline
+        return dataclasses.replace(
+            timeline,
+            points=[p for i, p in enumerate(timeline.points)
+                    if i not in verworfen] + ergaenzt,
+        )
+
+    def _tagesaussage_ohne_daten(self, trip: Optional[Trip], target_date: date,
+                                 day_token: str, *, zusatz: str = "") -> str:
+        """Was ueber ``target_date`` zu sagen ist, wenn KEINE Wetterdaten
+        vorliegen (Issue #1818).
+
+        Bisher sagten alle vier Formatierer pauschal „Keine Etappe geplant" —
+        eine Aussage ueber die TOURPLANUNG, obwohl das System nur etwas ueber
+        den DATENBESTAND weiss. ``convert_trip_to_segments`` beantwortet die
+        Planungsfrage netzfrei und rein tourplan-basiert (kein Wetter, kein
+        Schreibvorgang): nichtleere Liste = es gibt an diesem Tag eine Etappe.
+
+        ``trip=None`` (Direktaufruf eines Formatierers ohne Trip-Kontext)
+        behaelt das bisherige Verhalten bei — ohne Tourplan ist die
+        Unterscheidung nicht entscheidbar.
+        """
+        if trip is not None:
+            from services.trip_segments import convert_trip_to_segments
+            if convert_trip_to_segments(trip, target_date):
+                hinweis = _BRIEFING_HINWEIS.get(day_token)
+                if hinweis:
+                    return f"noch keine Wetterdaten — {hinweis}."
+                return "noch keine Wetterdaten."
+        return f"Keine Etappe geplant{zusatz}"
+
     def _aggregate_day(self, timeline, target_date, tz) -> Optional[dict]:
         """Aggregiere Timeline-Punkte für target_date. None wenn keine Punkte.
 
@@ -911,10 +1048,15 @@ class TripCommandProcessor:
             f"🌧 {precip}mm  ⛈ Gewitter: {thunder_label}"
         )
 
-    def _fmt_glance(self, timeline, today, tomorrow, tz_heute, tz_morgen) -> str:
+    def _fmt_glance(self, timeline, today, tomorrow, tz_heute, tz_morgen,
+                    *, trip: Optional[Trip] = None) -> str:
         """Fix #1795 AC-4: je Tag die Zone SEINER EIGENEN Etappe — ``tz_heute``
         für ``today``, ``tz_morgen`` für ``tomorrow`` (nicht eine gemeinsame
-        Zone für beide Tage)."""
+        Zone für beide Tage).
+
+        Fix #1818: ``trip`` trennt „keine Wetterdaten" von „keine Etappe"
+        (s. ``_tagesaussage_ohne_daten``) — je Zeile eigenstaendig, damit der
+        vorhandene Tag unveraendert aggregiert bleibt (AC-5)."""
         if not timeline.available:
             return (
                 "Kein Wetter-Snapshot verfügbar. "
@@ -926,14 +1068,20 @@ class TripCommandProcessor:
         if agg_heute:
             lines.append(self._fmt_day_agg(agg_heute, f"heute ({today:%d.%m})"))
         else:
-            lines.append(f"heute ({today:%d.%m}): Keine Etappe geplant")
+            lines.append(f"heute ({today:%d.%m}): " + self._tagesaussage_ohne_daten(
+                trip, today, "today"))
         if agg_morgen:
             lines.append(self._fmt_day_agg(agg_morgen, f"morgen ({tomorrow:%d.%m})"))
         else:
-            lines.append(f"morgen ({tomorrow:%d.%m}): Keine Etappe geplant")
+            lines.append(f"morgen ({tomorrow:%d.%m}): " + self._tagesaussage_ohne_daten(
+                trip, tomorrow, "tomorrow"))
         return "\n".join(lines)
 
-    def _fmt_gewitter(self, timeline, today, tz) -> str:
+    def _fmt_gewitter(self, timeline, today, tz,
+                      *, trip: Optional[Trip] = None) -> str:
+        """Fix #1818: ``trip`` trennt „keine Wetterdaten" von „keine Etappe"
+        (s. ``_tagesaussage_ohne_daten``); der Zusatz „— kein Gewitter-Status"
+        bleibt dem tatsaechlich etappenlosen Tag vorbehalten (AC-6)."""
         if not timeline.available:
             return (
                 "Kein Wetter-Snapshot verfügbar. "
@@ -941,7 +1089,8 @@ class TripCommandProcessor:
             )
         agg = self._aggregate_day(timeline, today, tz)
         if not agg:
-            return f"Heute ({today:%d.%m}): Keine Etappe geplant — kein Gewitter-Status."
+            return f"Heute ({today:%d.%m}): " + self._tagesaussage_ohne_daten(
+                trip, today, "today", zusatz=" — kein Gewitter-Status.")
         thunder = agg["thunder"]
         label = _THUNDER_LABEL.get(thunder.value if thunder else "NONE", "?")
         # Issue #1475 S5a: derselbe geteilte Textbaustein wie in den Mail-
@@ -966,8 +1115,12 @@ class TripCommandProcessor:
             suffix = f" · {herkunft}{suffix}"
         return f"⛈ Gewitter heute ({today:%d.%m}): {label}{suffix}"
 
-    def _fmt_timeline(self, timeline, target_date, label: str, day_token: str, tz) -> str:
+    def _fmt_timeline(self, timeline, target_date, label: str, day_token: str, tz,
+                      *, trip: Optional[Trip] = None) -> str:
         """Vertikale Timeline: pro Wegpunkt zwei Zeilen (Zeit/Höhe + Metriken).
+
+        Fix #1818: ``trip`` trennt „keine Wetterdaten" von „keine Etappe"
+        (s. ``_tagesaussage_ohne_daten``).
 
         Fix #1795: sowohl der Tagesfilter (``local_dt(...).date()``, AC-3) als
         auch die 🕐-Uhrzeit (``local_fmt``, AC-1/AC-5) laufen über die
@@ -984,7 +1137,8 @@ class TripCommandProcessor:
             key=lambda p: p.arrival_time,
         )
         if not pts:
-            return f"{label} ({target_date:%d.%m}): Keine Etappe geplant"
+            return f"{label} ({target_date:%d.%m}): " + self._tagesaussage_ohne_daten(
+                trip, target_date, day_token)
 
         lines = [f"📋 Timeline · {label} ({target_date:%d.%m})", ""]
         for p in pts:

--- a/src/services/weather_extractor.py
+++ b/src/services/weather_extractor.py
@@ -11,7 +11,7 @@ from datetime import date, datetime, timedelta, timezone
 from typing import List, Optional
 
 from app.day_window import display_end_time
-from app.models import SegmentWeatherSummary
+from app.models import SegmentWeatherData, SegmentWeatherSummary
 from services.weather_snapshot import WeatherSnapshotService
 
 
@@ -91,7 +91,20 @@ class WeatherExtractor:
                 available=False,
                 message=f"Kein Snapshot für Trip '{trip_id}' gefunden.",
             )
-        points = [
+        return TimelineResult(
+            trip_id=trip_id,
+            target_date=target_date,
+            points=self._punkte(segments),
+            available=True,
+        )
+
+    @staticmethod
+    def _punkte(segments: List[SegmentWeatherData]) -> List[TimelinePoint]:
+        """Segmente -> Timeline-Wegpunkte. EINE Umrechnung fuer beide Quellen
+        (undatierter Anker und datierter Snapshot, Issue #1818) — eine zweite
+        Kopie dieser Zuordnung wuerde bei jeder Feldaenderung auseinanderlaufen.
+        """
+        return [
             TimelinePoint(
                 # Issue #1599: Anzeige-Ende statt Alarm-Obergrenze.
                 arrival_time=display_end_time(seg.segment),
@@ -101,10 +114,32 @@ class WeatherExtractor:
             )
             for seg in segments
         ]
+
+    def timeline_dated(self, trip_id: str, target_date: date) -> TimelineResult:
+        """Timeline-Wegpunkte aus dem TAGESDATIERTEN Snapshot
+        ``{trip_id}_{YYYY-MM-DD}.json`` (Issue #1818).
+
+        Rein LESEND: ``load_dated`` legt nichts an und veraendert nichts. Der
+        undatierte Anker ``{trip_id}.json`` traegt strukturell nur EINEN Tag
+        (``_write_briefing_anchor`` ueberschreibt ihn je Briefing-Lauf); diese
+        Quelle deckt einen Tag, den der Anker verloren hat, ohne Netzabruf.
+        """
+        segments = self._snapshots.load_dated(trip_id, target_date)
+        if not segments:
+            return TimelineResult(
+                trip_id=trip_id,
+                target_date=target_date,
+                points=[],
+                available=False,
+                message=(
+                    f"Kein datierter Snapshot für Trip '{trip_id}' "
+                    f"am {target_date.isoformat()}."
+                ),
+            )
         return TimelineResult(
             trip_id=trip_id,
             target_date=target_date,
-            points=points,
+            points=self._punkte(segments),
             available=True,
         )
 

--- a/tests/tdd/test_timeline_tagesgenaue_quellen.py
+++ b/tests/tdd/test_timeline_tagesgenaue_quellen.py
@@ -642,3 +642,184 @@ def test_hinweistext_nennt_das_briefing_kommando_ohne_falsches_versprechen():
             f"fuellt — das tut sie nicht, `morgen`/`heute` schreiben keinen "
             f"Anker (#1007):\n{body}"
         )
+
+
+# ══════════════════════ Adversary-Findings F005 / F001 ══════════════════════
+#
+# Beide Tests decken Zusicherungen ab, die der Adversary-Durchgang als
+# UNGEPRUEFT nachgewiesen hat (docs/artifacts/fix-1818-timeline-
+# zweitagesanker/adversary-dialog.md, F001 CRITICAL und F005 HIGH).
+# ---------------------------------------------------------------------------
+
+def _platzhalter_segmente(tag: date, *, seg_id: int) -> list[SegmentWeatherData]:
+    """Der Wegpunkt eines GESCHEITERTEN Segment-Abrufs (WEATHER-04) — exakt
+    das Objekt, das ``_fetch_weather`` bei aufgebrauchtem Retry-Budget
+    anlegt (``trip_report_scheduler.py:2035-2044``): ``SegmentWeatherSummary()``
+    ohne einen einzigen Messwert, ``has_error=True``, ``provider="unknown"``.
+
+    Auf Touren mit Kontingent-Limits (429) ist das kein Sonderfall, sondern
+    Alltag: der Anker traegt den Tag dann technisch, inhaltlich aber nichts.
+    """
+    ankunft = datetime(tag.year, tag.month, tag.day, 8, 0, tzinfo=timezone.utc)
+    vorlage = _seg(ankunft, seg_id=seg_id, temp_min=0.0, temp_max=0.0)
+    return [SegmentWeatherData(
+        segment=vorlage.segment,
+        timeseries=None,
+        aggregated=SegmentWeatherSummary(),
+        fetched_at=ankunft,
+        provider="unknown",
+        has_error=True,
+        error_message="HTTP 429 (Kontingent)",
+    )]
+
+
+def test_leerer_fehlerplatzhalter_im_anker_verliert_gegen_echte_werte():
+    """Adversary F005.
+
+    GIVEN der Anker traegt fuer HEUTE nur einen inhaltsleeren
+          Fehler-Platzhalter (Teil-Ausfall des Abrufs), waehrend der datierte
+          Snapshot ``{trip}_{heute}.json`` desselben Tages vollstaendige
+          Messwerte (21–29 °C) enthaelt,
+    WHEN  der Nutzer ``timeline_heute`` abfragt,
+    THEN  zeigt die Antwort die ECHTEN Werte aus dem datierten Snapshot — und
+          NICHT die Fragezeichen des Platzhalters.
+
+    Ohne die Nutzbarkeitspruefung genuegt die blosse EXISTENZ eines
+    Wegpunkts, damit der Tag als „vom Anker getragen" gilt: der Rueckfall
+    wird uebersprungen und der Nutzer sieht „🌡 ?–? °C", obwohl die Werte
+    lokal vorliegen.
+    """
+    with freeze_time(EMPFANGEN_UTC):
+        trip = _trip("f005-platzhalter", [HEUTE, MORGEN])
+        # Lauf 1 — Morgen-Briefing mit vollstaendigen Daten: Anker UND
+        # datierter Snapshot fuer HEUTE tragen 21–29 °C.
+        _briefing_lauf(
+            trip.id,
+            _tages_segmente(HEUTE, seg_id=1, temp_min=21.0, temp_max=29.0),
+            HEUTE,
+        )
+        # Lauf 2 — Nachladung aus dem Abfragepfad, deren Abruf scheitert:
+        # ueberschreibt den Anker mit dem leeren Platzhalter, laesst den
+        # datierten Snapshot unberuehrt (``_fetch_and_save_snapshot`` schreibt
+        # keinen datierten).
+        _briefing_lauf_ohne_datierten(
+            trip.id, _platzhalter_segmente(HEUTE, seg_id=1), HEUTE,
+        )
+        assert (get_snapshots_dir("default") / f"{trip.id}_{HEUTE}.json").exists(), (
+            "Testaufbau: der datierte Snapshot fuer heute muss vorliegen."
+        )
+        body = _befehl(trip, "### query: timeline_heute").confirmation_body
+
+    assert "🌡 ?–? °C" not in body, (
+        f"F005: der inhaltsleere Fehler-Platzhalter des Ankers gewinnt gegen "
+        f"die echten Werte des datierten Snapshots:\n{body}"
+    )
+    assert "🌡 21–29 °C" in body, (
+        f"F005: die real vorliegenden Werte '🌡 21–29 °C' aus dem datierten "
+        f"Snapshot fehlen:\n{body}"
+    )
+
+
+def test_ohne_brauchbare_werte_ueberall_erscheint_die_ehrliche_datenluecke():
+    """Adversary F005, Grenzfall — KEINE der beiden Quellen traegt Werte.
+
+    GIVEN ein Briefing-Lauf fuer MORGEN ist im Abruf gescheitert und hat
+          BEIDE Quellen mit inhaltsleeren Fehler-Platzhaltern belegt (Anker
+          UND datierter Snapshot ``{trip}_{morgen}.json``), obwohl der Trip an
+          diesem Tag eine Etappe hat,
+    WHEN  der Nutzer ``timeline_morgen`` abfragt,
+    THEN  erscheint die ehrliche Datenluecken-Meldung — weder „🌡 ?–? °C"
+          noch die Tourplanungs-Aussage „Keine Etappe geplant".
+
+    Prueft beide Haelften der Nutzbarkeitsregel an EINEM Fall: der Platzhalter
+    des Ankers muss verworfen werden UND der Platzhalter des datierten
+    Snapshots darf nicht nachgezogen werden. ``_fmt_timeline`` erreicht
+    ``_tagesaussage_ohne_daten`` nur bei LEERER Punktliste — jeder
+    verbliebene Platzhalter verdeckt die Fehlanzeige.
+    """
+    with freeze_time(EMPFANGEN_UTC):
+        trip = _trip("f005-luecke", [HEUTE, MORGEN])
+        _briefing_lauf(trip.id, _platzhalter_segmente(MORGEN, seg_id=2), MORGEN)
+        assert (get_snapshots_dir("default") / f"{trip.id}_{MORGEN}.json").exists(), (
+            "Testaufbau: der datierte Snapshot fuer morgen muss existieren und "
+            "seinerseits nur Platzhalter tragen — sonst prueft dieser Test nur "
+            "die halbe Regel."
+        )
+        body = _befehl(trip, "### query: timeline_morgen").confirmation_body
+
+    assert "🌡 ?–? °C" not in body, (
+        f"F005: statt einer ehrlichen Fehlanzeige zeigt die Antwort die "
+        f"Fragezeichen des Fehler-Platzhalters:\n{body}"
+    )
+    assert FALSCHAUSSAGE not in body, (
+        f"F005: die Antwort behauptet {FALSCHAUSSAGE!r}, obwohl morgen eine "
+        f"Etappe existiert:\n{body}"
+    )
+    assert LUECKE in body, (
+        f"F005: erwartete ehrliche Fehlanzeige {LUECKE!r} fehlt:\n{body}"
+    )
+
+
+def test_rueckfall_wegpunkt_rutscht_nicht_in_den_nachbartag():
+    """Adversary F001 — der zweite Tagesfilter ueber die Rueckfall-Punkte.
+
+    GIVEN der datierte Snapshot ``{trip}_{heute}.json`` enthaelt ZWEI
+          Wegpunkte: einen spaet am Ortstag heute (22:00 Ortszeit, 10–18 °C)
+          und einen, dessen Ankunft die lokale Mitternacht ueberschreitet und
+          damit auf MORGEN faellt (01:30 Ortszeit, 30–40 °C); der Anker
+          traegt nach dem Abend-Briefing nur MORGEN (12–19 °C),
+    WHEN  der Nutzer heute UND morgen abfragt,
+    THEN  erscheint der Wegpunkt nach lokaler Mitternacht in KEINER der
+          beiden Ansichten — der Rueckfall zieht nur, was ortszeitlich
+          wirklich zum angefragten Tag gehoert.
+
+    Ohne den Tagesfilter in ``_mit_datiertem_rueckfall`` landet dieser
+    Wegpunkt in der gemeinsamen Punktliste und faerbt die MORGEN-Ansicht ein,
+    obwohl er aus der HEUTE-Datei stammt: die Datei ist nach dem NOMINELLEN
+    ``target_date`` benannt, ihre Wegpunkte tragen aber echte Zeitstempel.
+
+    Ortszeit ist die Aufloesungsebene (ADR-0044/#1795): Korsika liegt im
+    August auf UTC+2, 23:30 UTC ist dort bereits 01:30 des Folgetages.
+    """
+    with freeze_time(EMPFANGEN_UTC):
+        trip = _trip("f001-nachbartag", [HEUTE, MORGEN])
+        spaet = _seg(
+            datetime(HEUTE.year, HEUTE.month, HEUTE.day, 20, 0, tzinfo=timezone.utc),
+            seg_id=1, temp_min=10.0, temp_max=18.0,
+        )
+        nach_mitternacht = _seg(
+            datetime(HEUTE.year, HEUTE.month, HEUTE.day, 23, 30, tzinfo=timezone.utc),
+            seg_id=2, temp_min=30.0, temp_max=40.0,
+        )
+        # Lauf 1 — Morgen-Briefing: datierter Snapshot fuer HEUTE mit beiden
+        # Wegpunkten (die Datei traegt das nominelle Datum, nicht die Ortstage
+        # ihrer Wegpunkte).
+        _briefing_lauf(trip.id, [spaet, nach_mitternacht], HEUTE)
+        # Lauf 2 — Abend-Briefing: ueberschreibt den Anker mit MORGEN.
+        _briefing_lauf(
+            trip.id,
+            _tages_segmente(MORGEN, seg_id=3, temp_min=12.0, temp_max=19.0),
+            MORGEN,
+        )
+        heute_body = _befehl(trip, "### query: timeline_heute").confirmation_body
+        morgen_body = _befehl(trip, "### query: timeline_morgen").confirmation_body
+
+    # Vorbedingung: der Rueckfall greift ueberhaupt.
+    assert "🕐 22:00" in heute_body and "🌡 10–18 °C" in heute_body, (
+        f"Testaufbau: der Rueckfall fuer heute greift nicht:\n{heute_body}"
+    )
+    assert "🌡 12–19 °C" in morgen_body, (
+        f"Testaufbau: die morgigen Ankerwerte fehlen:\n{morgen_body}"
+    )
+    assert "🌡 30–40 °C" not in morgen_body, (
+        f"F001: der Wegpunkt aus der HEUTE-Datei, der ortszeitlich auf MORGEN "
+        f"faellt, ist in die morgige Ansicht gerutscht:\n{morgen_body}"
+    )
+    assert "🕐 01:30" not in morgen_body, (
+        f"F001: die 01:30-Zeile stammt aus dem datierten Snapshot fuer HEUTE "
+        f"und gehoert nicht in die morgige Ansicht:\n{morgen_body}"
+    )
+    assert "🌡 30–40 °C" not in heute_body, (
+        f"F001: der Wegpunkt nach lokaler Mitternacht erscheint in der "
+        f"heutigen Ansicht:\n{heute_body}"
+    )

--- a/tests/tdd/test_timeline_tagesgenaue_quellen.py
+++ b/tests/tdd/test_timeline_tagesgenaue_quellen.py
@@ -1,0 +1,644 @@
+"""TDD RED — #1818: Timeline/Glance/Gewitter loesen Wetterdaten TAGESGENAU auf.
+
+SPEC:    docs/specs/modules/fix_1818_timeline_tagesaufloesung.md (AC-1 bis AC-8)
+KONTEXT: docs/context/fix-1818-timeline-zweitagesanker.md
+
+Der undatierte Wetter-Anker ``{trip_id}.json`` traegt strukturell nur EINEN
+Tag: ``_write_briefing_anchor`` (``trip_report_scheduler.py:1505-1512``) ruft
+``WeatherSnapshotService.save()`` je Briefing-Lauf mit genau einem
+``target_date`` auf und ueberschreibt die Datei dabei vollstaendig. Die vier
+Formatierer in ``trip_command_processor.py`` (``_fmt_timeline:1007``,
+``_fmt_glance:929/:933``, ``_fmt_gewitter:944``) melden den dadurch fehlenden
+Tag als **„Keine Etappe geplant"** — eine Aussage ueber die TOURPLANUNG,
+obwohl das System nur etwas ueber den DATENBESTAND weiss.
+
+🔴 Warum diese Datei NEBEN den Bestandstests noetig ist
+--------------------------------------------------------
+``tests/tdd/test_timeline_folgt_der_ortszeit.py:95-101`` und
+``tests/tdd/test_issue_651_telegram_query_glance.py:108-119`` bauen ihren
+Anker **kuenstlich mit beiden Tagen in EINEM ``save()``-Aufruf** auf. Genau
+deshalb hat keiner von ihnen den Bug gesehen. Diese Datei baut den Anker ueber
+``_briefing_lauf()`` — ZWEI aufeinanderfolgende, einander **ueberschreibende**
+``save()``/``save_dated()``-Vorgaenge, also den Produktionspfad. Ein Test, der
+beide Tage in einem Aufruf schreibt, ist trivial gruen und wertlos.
+
+Testpolitik (CLAUDE.md „Test-Politik: Zwei Schichten"): Kern-Schicht, kein
+Netz. Echte ``Trip``/``Stage``/``Waypoint``-Objekte, echte Snapshot-Dateien
+ueber ``WeatherSnapshotService``, echter ``TripCommandProcessor`` ueber den
+produktiven Eintrittspunkt ``process()``. Kein ``Mock()``/``patch()``, keine
+Rueckspiegelung eigener Annahmen. Die Datenwurzel isoliert die projektweite
+autouse-Fixtur ``_isolate_data_root`` (``tests/conftest.py:122``) nach
+``tmp_path`` — der Isolationsnachweis unten belegt das je Test.
+
+Pfadregel #1409: der Pruefling wird relativ zur eigenen Testdatei aufgeloest
+(Wachposten ``_PRUEFLING`` unten), nie ueber den festen Hauptrepo-Pfad — sonst
+kaeme aus dem Worktree falsches Gruen.
+"""
+from __future__ import annotations
+
+import json
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from freezegun import freeze_time
+
+import services.trip_command_processor as _tcp
+from app.loader import get_snapshots_dir, save_trip
+from app.models import (
+    GPXPoint,
+    SegmentWeatherData,
+    SegmentWeatherSummary,
+    ThunderLevel,
+    TripSegment,
+)
+from app.trip import Stage, Trip, Waypoint
+from services.trip_command_processor import (
+    CommandResult,
+    InboundMessage,
+    TripCommandProcessor,
+)
+from services.trip_report_scheduler import TripReportSchedulerService
+from services.weather_snapshot import WeatherSnapshotService
+
+# ---------------------------------------------------------------------------
+# Pfadregel #1409 — der Pruefling MUSS aus demselben Baum stammen wie diese
+# Testdatei. Laeuft die Suite im Worktree, der Import kaeme aber aus dem
+# Hauptrepo, waere jedes Gruen wertlos.
+# ---------------------------------------------------------------------------
+_BAUM = Path(__file__).resolve().parents[2]
+_PRUEFLING = Path(_tcp.__file__).resolve()
+assert _PRUEFLING.is_relative_to(_BAUM), (
+    f"Pfadregel #1409 verletzt: der Pruefling liegt unter {_PRUEFLING}, "
+    f"diese Testdatei aber unter {_BAUM}."
+)
+
+# ---------------------------------------------------------------------------
+# Fixe Tour-Daten. Vizzavona/Korsika (Europe/Paris, im August UTC+2); die
+# Uhrzeiten liegen bewusst AUSSERHALB des Ortstag-Mismatch-Fensters, damit
+# diese Suite ausschliesslich die QUELLENAUFLOESUNG prueft und nicht
+# versehentlich die Ortszeit-Umrechnung aus #1795.
+# ---------------------------------------------------------------------------
+KORSIKA = (42.10, 9.00)
+HEUTE = date(2026, 8, 20)
+MORGEN = date(2026, 8, 21)
+EMPFANGEN_UTC = datetime(2026, 8, 20, 12, 0, tzinfo=timezone.utc)  # 14:00 Ortszeit
+
+# Der Spec-Wortlaut der ehrlichen Fehlanzeige (Implementation Details:
+# „noch keine Wetterdaten fuer {label} ({datum})").
+LUECKE = "noch keine Wetterdaten"
+# Die Falschaussage, die dieser Fix beseitigt.
+FALSCHAUSSAGE = "Keine Etappe geplant"
+
+
+# ---------------------------------------------------------------------------
+# Isolationsnachweis — belegt je Test, dass wirklich in einen temporaeren Baum
+# geschrieben wird und nicht in das echte ``data/`` des Repos.
+# ---------------------------------------------------------------------------
+@pytest.fixture(autouse=True)
+def _isolationsnachweis():
+    verzeichnis = get_snapshots_dir("default").resolve()
+    assert not str(verzeichnis).startswith(str(_BAUM / "data")), (
+        "Testaufbau: die Snapshot-Ablage zeigt auf den echten Datenbaum "
+        f"({verzeichnis}) — die Isolation aus tests/conftest.py greift nicht."
+    )
+    yield
+
+
+# ---------------------------------------------------------------------------
+# Helfer — echte Tourdaten
+# ---------------------------------------------------------------------------
+
+def _stage(stage_id: str, tag: date) -> Stage:
+    """Etappe mit ZWEI Wegpunkten — ``convert_trip_to_segments()`` verwirft
+    Etappen mit weniger (``trip_segments.py``), sie waeren fuer die Frage
+    „existiert an diesem Tag ueberhaupt eine Etappe?" unsichtbar."""
+    lat, lon = KORSIKA
+    return Stage(
+        id=stage_id, name=f"Etappe {tag:%d.%m.}", date=tag,
+        waypoints=[
+            Waypoint(id=f"{stage_id}-A", name="Start", lat=lat, lon=lon,
+                     elevation_m=500),
+            Waypoint(id=f"{stage_id}-B", name="Ziel", lat=lat + 0.05,
+                     lon=lon + 0.05, elevation_m=800),
+        ],
+    )
+
+
+def _trip(trip_id: str, tage: list[date]) -> Trip:
+    trip = Trip(
+        id=trip_id, name=trip_id,
+        stages=[_stage(f"S{i}", tag) for i, tag in enumerate(tage)],
+    )
+    save_trip(trip, "default")
+    return trip
+
+
+def _seg(
+    ankunft_utc: datetime,
+    *,
+    seg_id: int,
+    temp_min: float,
+    temp_max: float,
+    thunder: ThunderLevel = ThunderLevel.NONE,
+) -> SegmentWeatherData:
+    """Ein Wetter-Wegpunkt mit kontrollierter Ankunftszeit und eindeutigem
+    Temperaturpaar — das Paar ist der Fingerabdruck, an dem die Tests die
+    HERKUNFT der angezeigten Werte unterscheiden (AC-4)."""
+    lat, lon = KORSIKA
+    segment = TripSegment(
+        segment_id=seg_id,
+        start_point=GPXPoint(lat=lat, lon=lon, elevation_m=1400.0),
+        end_point=GPXPoint(lat=lat, lon=lon, elevation_m=1500.0),
+        start_time=ankunft_utc - timedelta(hours=2),
+        end_time=ankunft_utc,
+        duration_hours=2.0, distance_km=5.0, ascent_m=100.0, descent_m=0.0,
+    )
+    return SegmentWeatherData(
+        segment=segment,
+        timeseries=None,
+        aggregated=SegmentWeatherSummary(
+            temp_min_c=temp_min, temp_max_c=temp_max, wind_max_kmh=20.0,
+            thunder_level_max=thunder,
+        ),
+        fetched_at=ankunft_utc,
+        provider="test",
+    )
+
+
+def _tages_segmente(tag: date, *, seg_id: int, temp_min: float,
+                    temp_max: float,
+                    thunder: ThunderLevel = ThunderLevel.NONE,
+                    ) -> list[SegmentWeatherData]:
+    """Die Wetterdaten EINES Briefing-Laufs — genau ein Tag, so wie
+    ``_fetch_weather`` sie fuer ``_get_target_date()`` liefert."""
+    return [_seg(
+        datetime(tag.year, tag.month, tag.day, 8, 0, tzinfo=timezone.utc),
+        seg_id=seg_id, temp_min=temp_min, temp_max=temp_max, thunder=thunder,
+    )]
+
+
+def _briefing_lauf(trip_id: str, segmente: list[SegmentWeatherData],
+                   target_date: date, user_id: str = "default") -> None:
+    """EIN Briefing-Lauf — Nachbau von ``_write_briefing_anchor``
+    (``trip_report_scheduler.py:1505-1512``): ``save()`` **ueberschreibt** den
+    undatierten Anker vollstaendig, ``save_dated()`` legt zusaetzlich
+    ``{trip_id}_{YYYY-MM-DD}.json`` ab.
+
+    🔴 Der Aufbau ueber MEHRERE solcher Laeufe ist der Kern dieser Suite: der
+    zweite Lauf loescht die Segmente des ersten aus dem undatierten Anker. Die
+    Bestandsfixturen schreiben stattdessen beide Tage in EINEM ``save()`` und
+    verdecken den Bug damit vollstaendig.
+    """
+    svc = WeatherSnapshotService(user_id)
+    svc.save(trip_id, segmente, target_date)
+    svc.save_dated(trip_id, target_date, segmente)
+
+
+def _briefing_lauf_ohne_datierten(trip_id: str,
+                                  segmente: list[SegmentWeatherData],
+                                  target_date: date,
+                                  user_id: str = "default") -> None:
+    """Ein Schreibvorgang, der NUR den undatierten Anker setzt — wie
+    ``_fetch_and_save_snapshot`` (``trip_command_processor.py:278-316``) es aus
+    dem Abfragepfad tut. Erzeugt die Lage „Anker traegt Tag X, aber es gibt
+    keinen datierten Rueckfall fuer Tag Y"."""
+    WeatherSnapshotService(user_id).save(trip_id, segmente, target_date)
+
+
+def _befehl(trip: Trip, body: str) -> CommandResult:
+    """Befehl ueber den ECHTEN Eintrittspunkt ``process()``."""
+    return TripCommandProcessor().process(InboundMessage(
+        channel="telegram", trip_name=trip.name, body=body, sender="4711",
+        received_at=EMPFANGEN_UTC, user_id="default",
+    ))
+
+
+def _zeile(body: str, praefix: str) -> str:
+    """Die eine Zeile der Antwort, die mit ``praefix`` beginnt."""
+    treffer = [z for z in body.splitlines() if z.startswith(praefix)]
+    assert len(treffer) == 1, (
+        f"Testaufbau: erwartete genau EINE Zeile mit Praefix {praefix!r}, "
+        f"gefunden {len(treffer)}:\n{body}"
+    )
+    return treffer[0]
+
+
+def _schnappschuss_zustand() -> dict[str, tuple[int, bytes]]:
+    """Byte-Inhalt UND Aenderungszeitstempel jeder Snapshot-Datei — die
+    Beobachtung, mit der AC-7 einen Schreibvorgang nachweist (hier ist der
+    Dateizustand SELBST das geprueft Verhalten, kein Inhalts-Surrogat)."""
+    verzeichnis = get_snapshots_dir("default")
+    if not verzeichnis.exists():
+        return {}
+    return {
+        p.name: (p.stat().st_mtime_ns, p.read_bytes())
+        for p in sorted(verzeichnis.iterdir()) if p.is_file()
+    }
+
+
+# ---------------------------------------------------------------------------
+# Aufbauten — je Szenario EIN Anker, gebaut aus mehreren Briefing-Laeufen
+# ---------------------------------------------------------------------------
+
+def _anker_traegt_nur_heute(trip_id: str, tage: list[date]) -> Trip:
+    """Lauf 1 schreibt MORGEN in den Anker, Lauf 2 ueberschreibt ihn mit
+    HEUTE — der morgige Tag ist danach aus dem Anker verschwunden, und einen
+    datierten Rueckfall ``{trip}_{morgen}.json`` gibt es nicht (er entstuende
+    erst im heutigen Abend-Briefing, Kontext-Tabelle „Kostenloser
+    Teil-Rueckfall")."""
+    trip = _trip(trip_id, tage)
+    _briefing_lauf_ohne_datierten(
+        trip.id,
+        _tages_segmente(MORGEN, seg_id=2, temp_min=12.0, temp_max=19.0),
+        MORGEN,
+    )
+    _briefing_lauf(
+        trip.id,
+        _tages_segmente(HEUTE, seg_id=1, temp_min=10.0, temp_max=18.0),
+        HEUTE,
+    )
+    return trip
+
+
+def _anker_traegt_nur_morgen(trip_id: str, tage: list[date]) -> Trip:
+    """Lauf 1 (Morgen-Briefing) schreibt HEUTE ohne datierten Rueckfall,
+    Lauf 2 (Abend-Briefing) ueberschreibt den Anker mit MORGEN — fuer HEUTE
+    existiert danach WEDER im Anker noch datiert etwas."""
+    trip = _trip(trip_id, tage)
+    _briefing_lauf_ohne_datierten(
+        trip.id,
+        _tages_segmente(HEUTE, seg_id=1, temp_min=10.0, temp_max=18.0),
+        HEUTE,
+    )
+    _briefing_lauf(
+        trip.id,
+        _tages_segmente(MORGEN, seg_id=2, temp_min=12.0, temp_max=19.0,
+                        thunder=ThunderLevel.MED),
+        MORGEN,
+    )
+    return trip
+
+
+# ══════════════════════ AC-1 ══════════════════════
+
+def test_fehlender_folgetag_meldet_datenluecke_statt_fehlender_etappe():
+    """AC-1.
+
+    GIVEN der Trip hat morgen eine Etappe, der undatierte Anker traegt nach
+          zwei einander ueberschreibenden Briefing-Laeufen nur HEUTE und ein
+          datierter Snapshot fuer morgen existiert nicht,
+    WHEN  der Nutzer ``timeline_morgen`` abfragt,
+    THEN  meldet die Antwort fehlende Wetterdaten — und behauptet NICHT
+          „Keine Etappe geplant".
+    """
+    with freeze_time(EMPFANGEN_UTC):
+        trip = _anker_traegt_nur_heute("ac1-luecke-morgen", [HEUTE, MORGEN])
+        assert not (get_snapshots_dir("default") / f"{trip.id}_{MORGEN}.json").exists(), (
+            "Testaufbau: es darf KEINEN datierten Snapshot fuer morgen geben, "
+            "sonst prueft AC-1 den Rueckfall statt der Datenluecke."
+        )
+        ergebnis = _befehl(trip, "### query: timeline_morgen")
+
+    body = ergebnis.confirmation_body
+    assert ergebnis.success is True, body
+    assert FALSCHAUSSAGE not in body, (
+        f"AC-1: die Antwort behauptet etwas ueber die TOURPLANUNG "
+        f"({FALSCHAUSSAGE!r}), obwohl fuer morgen eine Etappe existiert und "
+        f"nur die Wetterdaten fehlen:\n{body}"
+    )
+    assert LUECKE in body, (
+        f"AC-1: erwartete ehrliche Fehlanzeige {LUECKE!r} fehlt:\n{body}"
+    )
+
+
+# ══════════════════════ AC-2 (Gegenfall) ══════════════════════
+
+def test_tag_ohne_etappe_bleibt_bei_keine_etappe_geplant():
+    """AC-2 — der Gegenfall zu AC-1.
+
+    GIVEN der Trip endet HEUTE, fuer morgen existiert keine Etappe (und
+          folglich auch kein Wetterdatensatz),
+    WHEN  der Nutzer ``timeline_morgen`` abfragt,
+    THEN  bleibt die Aussage „Keine Etappe geplant" — sie ist hier
+          zutreffend — und es erscheint KEINE Datenluecken-Meldung.
+
+    Existiert, um eine Bedingungs-Inversion („Etappe vorhanden?" verdreht)
+    fangbar zu machen: ohne diesen Test bliebe sie unsichtbar.
+    """
+    with freeze_time(EMPFANGEN_UTC):
+        trip = _trip("ac2-tourende-heute", [HEUTE - timedelta(days=1), HEUTE])
+        _briefing_lauf_ohne_datierten(
+            trip.id,
+            _tages_segmente(HEUTE - timedelta(days=1), seg_id=0,
+                            temp_min=8.0, temp_max=16.0),
+            HEUTE - timedelta(days=1),
+        )
+        _briefing_lauf(
+            trip.id,
+            _tages_segmente(HEUTE, seg_id=1, temp_min=10.0, temp_max=18.0),
+            HEUTE,
+        )
+        ergebnis = _befehl(trip, "### query: timeline_morgen")
+
+    body = ergebnis.confirmation_body
+    assert ergebnis.success is True, body
+    assert FALSCHAUSSAGE in body, (
+        f"AC-2: morgen existiert wirklich keine Etappe — die Antwort muss das "
+        f"weiterhin sagen ({FALSCHAUSSAGE!r}):\n{body}"
+    )
+    assert LUECKE not in body, (
+        f"AC-2: eine Datenluecken-Meldung waere hier falsch, es gibt an diesem "
+        f"Tag keine Etappe:\n{body}"
+    )
+
+
+# ══════════════════════ AC-3 ══════════════════════
+
+def test_datierter_snapshot_deckt_den_tag_den_der_anker_verloren_hat():
+    """AC-3.
+
+    GIVEN das Abend-Briefing lief zuletzt (der Anker traegt MORGEN) und der
+          datierte Snapshot ``{trip}_{heute}.json`` aus dem Morgen-Briefing
+          liegt noch vor,
+    WHEN  der Nutzer ``timeline_heute`` abfragt,
+    THEN  zeigt das System die Stundenwerte des heutigen Tages aus dem
+          datierten Snapshot — konkrete Uhrzeit UND konkrete Messwerte.
+    """
+    with freeze_time(EMPFANGEN_UTC):
+        trip = _trip("ac3-abendbriefing", [HEUTE, MORGEN])
+        # Lauf 1 — Morgen-Briefing: Anker + datierter Snapshot fuer HEUTE.
+        _briefing_lauf(
+            trip.id,
+            _tages_segmente(HEUTE, seg_id=1, temp_min=10.0, temp_max=18.0),
+            HEUTE,
+        )
+        # Lauf 2 — Abend-Briefing: ueberschreibt den Anker mit MORGEN.
+        _briefing_lauf(
+            trip.id,
+            _tages_segmente(MORGEN, seg_id=2, temp_min=12.0, temp_max=19.0),
+            MORGEN,
+        )
+        assert (get_snapshots_dir("default") / f"{trip.id}_{HEUTE}.json").exists(), (
+            "Testaufbau: der datierte Snapshot fuer heute muss vorliegen, "
+            "sonst prueft AC-3 nicht den Rueckfall."
+        )
+        ergebnis = _befehl(trip, "### query: timeline_heute")
+
+    body = ergebnis.confirmation_body
+    assert ergebnis.success is True, body
+    assert FALSCHAUSSAGE not in body, (
+        f"AC-3: der Anker hat heute verloren, der datierte Snapshot traegt ihn "
+        f"aber noch — statt der Werte kommt eine Tourplanungs-Aussage:\n{body}"
+    )
+    assert "🕐 10:00" in body, (
+        "AC-3: erwartete Stundenzeile '🕐 10:00' (Ankunft 08:00 UTC, Korsika "
+        f"UTC+2) fehlt — die heutigen Werte werden nicht gezeigt:\n{body}"
+    )
+    assert "🌡 10–18 °C" in body, (
+        f"AC-3: die heutigen Messwerte '🌡 10–18 °C' aus dem datierten "
+        f"Snapshot fehlen:\n{body}"
+    )
+
+
+# ══════════════════════ AC-4 (Reihenfolge) ══════════════════════
+
+def test_undatierter_anker_schlaegt_den_datierten_snapshot():
+    """AC-4.
+
+    GIVEN fuer HEUTE tragen undatierter Anker (10–18 °C) und datierter
+          Snapshot (25–33 °C) BEWUSST unterschiedliche Werte, und fuer MORGEN
+          existiert nur der datierte Snapshot (15–25 °C),
+    WHEN  beide Tage abgefragt werden,
+    THEN  stammt der heutige Wert aus dem ANKER (nicht aus dem datierten
+          Snapshot) und der morgige aus dem datierten Rueckfall.
+
+    Faengt die Vertauschung der Quellen-Reihenfolge: laese die Implementierung
+    zuerst den datierten Snapshot, zeigte heute 25–33 °C.
+    """
+    with freeze_time(EMPFANGEN_UTC):
+        trip = _trip("ac4-reihenfolge", [HEUTE, MORGEN])
+        # Lauf 1 — Morgen-Briefing mit den urspruenglichen (heissen) Werten.
+        _briefing_lauf(
+            trip.id,
+            _tages_segmente(HEUTE, seg_id=1, temp_min=25.0, temp_max=33.0),
+            HEUTE,
+        )
+        # Lauf 2 — Abend-Briefing: der datierte Snapshot fuer MORGEN entsteht.
+        _briefing_lauf(
+            trip.id,
+            _tages_segmente(MORGEN, seg_id=2, temp_min=15.0, temp_max=25.0),
+            MORGEN,
+        )
+        # Lauf 3 — Abfragepfad-Nachladung: setzt NUR den undatierten Anker
+        # (``_fetch_and_save_snapshot``) und traegt fuer HEUTE frischere,
+        # abweichende Werte. Der datierte Snapshot fuer heute bleibt heiss.
+        _briefing_lauf_ohne_datierten(
+            trip.id,
+            _tages_segmente(HEUTE, seg_id=1, temp_min=10.0, temp_max=18.0),
+            HEUTE,
+        )
+        heute_body = _befehl(trip, "### query: timeline_heute").confirmation_body
+        morgen_body = _befehl(trip, "### query: timeline_morgen").confirmation_body
+
+    assert "🌡 10–18 °C" in heute_body, (
+        f"AC-4: erwartet wird der Wert aus dem UNDATIERTEN Anker "
+        f"('🌡 10–18 °C'):\n{heute_body}"
+    )
+    assert "🌡 25–33 °C" not in heute_body, (
+        f"AC-4: angezeigt wird der Wert aus dem DATIERTEN Snapshot "
+        f"('🌡 25–33 °C') — die Quellen-Reihenfolge ist vertauscht:\n{heute_body}"
+    )
+    assert "🌡 15–25 °C" in morgen_body, (
+        f"AC-4: fuer morgen traegt nur der datierte Snapshot Daten "
+        f"('🌡 15–25 °C') — der Rueckfall greift nicht:\n{morgen_body}"
+    )
+
+
+# ══════════════════════ AC-5 ══════════════════════
+
+def test_glance_meldet_nur_den_fehlenden_tag_als_luecke():
+    """AC-5.
+
+    GIVEN der Trip hat an beiden Tagen Etappen, der Anker traegt nach zwei
+          einander ueberschreibenden Laeufen nur HEUTE, und fuer MORGEN
+          existiert kein datierter Snapshot,
+    WHEN  der Nutzer ``glance`` abfragt,
+    THEN  meldet die MORGEN-Zeile fehlende Wetterdaten, waehrend die
+          HEUTE-Zeile unveraendert aggregiert bleibt.
+
+    Beide Zeilen werden geprueft: ein pauschales „alles ist eine Luecke" faellt
+    hier ebenso durch wie das unveraenderte Bestandsverhalten.
+    """
+    with freeze_time(EMPFANGEN_UTC):
+        trip = _anker_traegt_nur_heute("ac5-glance", [HEUTE, MORGEN])
+        ergebnis = _befehl(trip, "### query: glance")
+
+    body = ergebnis.confirmation_body
+    assert ergebnis.success is True, body
+    zeile_heute = _zeile(body, f"heute ({HEUTE:%d.%m})")
+    zeile_morgen = _zeile(body, f"morgen ({MORGEN:%d.%m})")
+
+    assert "🌡 10–18°C" in zeile_heute, (
+        f"AC-5: die heutige Zeile muss unveraendert aggregiert bleiben "
+        f"('🌡 10–18°C'):\n{zeile_heute}"
+    )
+    assert LUECKE not in zeile_heute, (
+        f"AC-5: fuer heute liegen Daten vor — keine Luecken-Meldung "
+        f"erwartet:\n{zeile_heute}"
+    )
+    assert FALSCHAUSSAGE not in zeile_morgen, (
+        f"AC-5: die morgige Zeile behauptet {FALSCHAUSSAGE!r}, obwohl morgen "
+        f"eine Etappe existiert:\n{zeile_morgen}"
+    )
+    assert LUECKE in zeile_morgen, (
+        f"AC-5: die morgige Zeile muss fehlende Wetterdaten melden:\n{zeile_morgen}"
+    )
+
+
+# ══════════════════════ AC-6 ══════════════════════
+
+def test_gewitterabfrage_meldet_datenluecke_statt_fehlender_etappe():
+    """AC-6.
+
+    GIVEN der Trip hat heute eine Etappe, der Anker traegt nur MORGEN und fuer
+          HEUTE existiert kein datierter Snapshot,
+    WHEN  der Nutzer ``heute_gewitter`` abfragt,
+    THEN  meldet die Antwort fehlende Wetterdaten statt „Keine Etappe geplant
+          — kein Gewitter-Status".
+    """
+    with freeze_time(EMPFANGEN_UTC):
+        trip = _anker_traegt_nur_morgen("ac6-gewitter", [HEUTE, MORGEN])
+        assert not (get_snapshots_dir("default") / f"{trip.id}_{HEUTE}.json").exists(), (
+            "Testaufbau: es darf KEINEN datierten Snapshot fuer heute geben."
+        )
+        ergebnis = _befehl(trip, "### query: heute_gewitter")
+
+    body = ergebnis.confirmation_body
+    assert ergebnis.success is True, body
+    assert FALSCHAUSSAGE not in body, (
+        f"AC-6: die Gewitter-Antwort behauptet {FALSCHAUSSAGE!r}, obwohl heute "
+        f"eine Etappe existiert und nur die Daten fehlen:\n{body}"
+    )
+    assert LUECKE in body, (
+        f"AC-6: erwartete ehrliche Fehlanzeige {LUECKE!r} fehlt:\n{body}"
+    )
+
+
+# ══════════════════════ AC-7 ══════════════════════
+
+def test_datenluecken_antwort_schreibt_nichts_und_ruft_nichts_ab(monkeypatch):
+    """AC-7.
+
+    GIVEN eine Abfrage wird bei fehlenden Daten beantwortet,
+    WHEN  die Antwort erzeugt wird,
+    THEN  loest sie keinen Wetter-Abruf aus und veraendert KEINE
+          Snapshot-Datei — insbesondere bleibt ``briefing_backed`` des
+          vorhandenen Ankers unveraendert.
+
+    Nachweis ohne Mock-Rueckspiegelung: der Netzpfad
+    (``TripReportSchedulerService._fetch_weather``) wird durch eine FALLE
+    ersetzt, die den Aufruf protokolliert und zusaetzlich hart scheitert; der
+    Dateizustand wird ueber Aenderungszeitstempel UND Byte-Inhalt aller
+    Snapshot-Dateien vorher/nachher verglichen. Hier ist der Dateizustand
+    selbst das geprueft Verhalten (Ausnahme zur Dateiinhalt-Regel).
+    """
+    abrufe: list[int] = []
+
+    def _falle(self, segments):  # noqa: ANN001 — Signatur des Prueflings
+        abrufe.append(len(segments))
+        raise AssertionError(
+            "AC-7: der Abfragepfad hat einen Wetter-Abruf ausgeloest."
+        )
+
+    monkeypatch.setattr(TripReportSchedulerService, "_fetch_weather", _falle)
+
+    with freeze_time(EMPFANGEN_UTC):
+        trip = _anker_traegt_nur_heute("ac7-keine-seiteneffekte", [HEUTE, MORGEN])
+        anker = get_snapshots_dir("default") / f"{trip.id}.json"
+        vorher = _schnappschuss_zustand()
+        backed_vorher = json.loads(anker.read_text())["briefing_backed"]
+
+        ergebnis = _befehl(trip, "### query: timeline_morgen")
+
+        nachher = _schnappschuss_zustand()
+        backed_nachher = json.loads(anker.read_text())["briefing_backed"]
+
+    body = ergebnis.confirmation_body
+    assert abrufe == [], (
+        f"AC-7: der Abfragepfad hat {len(abrufe)} Wetter-Abruf(e) ausgeloest."
+    )
+    assert set(nachher) == set(vorher), (
+        "AC-7: der Dateibestand im Snapshot-Verzeichnis hat sich geaendert — "
+        f"neu/entfernt: {set(nachher) ^ set(vorher)}"
+    )
+    for name, (mtime, inhalt) in vorher.items():
+        assert nachher[name][1] == inhalt, (
+            f"AC-7: der Inhalt von {name} wurde durch die Abfrage veraendert."
+        )
+        assert nachher[name][0] == mtime, (
+            f"AC-7: {name} wurde durch die Abfrage neu geschrieben "
+            f"(Aenderungszeitstempel {mtime} -> {nachher[name][0]})."
+        )
+    assert backed_nachher == backed_vorher is True, (
+        f"AC-7: `briefing_backed` des Ankers wurde veraendert "
+        f"({backed_vorher} -> {backed_nachher}) — die Alarm-Vergleichsbasis "
+        f"(ADR-0009) waere zerstoert."
+    )
+    assert LUECKE in body, (
+        f"AC-7: Vorbedingung nicht erfuellt — die Abfrage hat gar keine "
+        f"Datenluecken-Antwort erzeugt:\n{body}"
+    )
+
+
+# ══════════════════════ AC-8 ══════════════════════
+
+def test_hinweistext_nennt_das_briefing_kommando_ohne_falsches_versprechen():
+    """AC-8.
+
+    GIVEN die ehrliche Fehlanzeige erscheint,
+    WHEN  der Nutzer sie liest,
+    THEN  verweist sie auf das Kommando, das FUER DIESEN TAG ein Briefing
+          ausloest (``/m`` fuer morgen, ``/h`` fuer heute), und sagt
+          ausschliesslich die ZUSTELLUNG des Briefings zu — sie verspricht
+          NICHT, dass sich die Timeline-Ansicht danach fuellt.
+
+    Begruendung des Verbots (Kontext, Risiko 5): ``morgen``/``heute``
+    versenden ein volles Briefing, schreiben aber KEINEN Anker
+    (``trip_report_scheduler.py:1495-1501``, #1007). Ein Text der Form „dann
+    fuellt sich die Timeline" erzeugte eine Frustschleife.
+    """
+    zusagen = ("zugestellt", "zustellen", "gesendet", "sendet", "schickt",
+               "verschickt", "verschicken")
+
+    with freeze_time(EMPFANGEN_UTC):
+        trip_morgen = _anker_traegt_nur_heute("ac8-morgen", [HEUTE, MORGEN])
+        body_morgen = _befehl(
+            trip_morgen, "### query: timeline_morgen").confirmation_body
+        trip_heute = _anker_traegt_nur_morgen("ac8-heute", [HEUTE, MORGEN])
+        body_heute = _befehl(
+            trip_heute, "### query: heute_gewitter").confirmation_body
+
+    for kommando, body, tag in (("/m", body_morgen, "morgen"),
+                                ("/h", body_heute, "heute")):
+        assert LUECKE in body, (
+            f"AC-8: Vorbedingung nicht erfuellt — keine Datenluecken-Meldung "
+            f"fuer {tag}:\n{body}"
+        )
+        assert kommando in body, (
+            f"AC-8: der Hinweis fuer {tag} nennt das briefing-ausloesende "
+            f"Kommando {kommando!r} nicht:\n{body}"
+        )
+        assert "Briefing" in body, (
+            f"AC-8: der Hinweis fuer {tag} sagt nicht, dass ein Briefing "
+            f"folgt:\n{body}"
+        )
+        assert any(w in body for w in zusagen), (
+            f"AC-8: der Hinweis fuer {tag} sagt die ZUSTELLUNG des Briefings "
+            f"nicht zu (erwartet eines von {zusagen}):\n{body}"
+        )
+        assert "füll" not in body.lower(), (
+            f"AC-8: der Hinweis fuer {tag} verspricht, dass sich die Timeline "
+            f"fuellt — das tut sie nicht, `morgen`/`heute` schreiben keinen "
+            f"Anker (#1007):\n{body}"
+        )


### PR DESCRIPTION
- **docs(#1818): Kontext -- Wirkkette, zwei Sperren, Kontingent-Ausschluss**
- **docs(#1818): Kontext nach Challenger -- vier Fehltext-Stellen, dritter Ankerzustand, morgen-Verweis**
- **docs(#1818): Spec -- tagesgenaue Quellenaufloesung, Datenluecke statt Tourplanungs-Aussage**
- **test(#1818): RED -- Anker aus zwei einander ueberschreibenden Briefing-Laeufen**
- **fix(#1818): Timeline/Glance melden Datenluecke statt fehlender Etappe**
