### PR TITLE
docs(#2018): Spec auf implemented, Freigabe-Haken nachgezogen

### DIFF
--- a/docs/specs/modules/alert_nachtragsmeldung.md
+++ b/docs/specs/modules/alert_nachtragsmeldung.md
@@ -3,7 +3,7 @@ entity_id: alert_nachtragsmeldung
 type: bugfix
 created: 2026-08-21
 updated: 2026-08-21
-status: draft
+status: implemented
 version: "1.5"
 tags: [alerts, trip, issue-2018, issue-1467, nachtrag, event-identity]
 ---
@@ -12,7 +12,7 @@ tags: [alerts, trip, issue-2018, issue-1467, nachtrag, event-identity]
 
 ## Approval
 
-- [ ] Approved
+- [x] Approved — PO-'go' 2026-08-21; ausgeliefert mit `47c527ee`, Prod-Selftest PASS
 
 ## Purpose
 


### PR DESCRIPTION
Nachtrag zu #2018 (geliefert mit `47c527ee`, Prod-Selftest PASS).

Die Spec stand nach der Auslieferung noch auf `status: draft` mit leerem Approval-Haken, obwohl der PO am 2026-08-21 freigegeben hat und der Stand in Produktion läuft.

Reine Frontmatter-Korrektur, zwei Zeilen, kein Inhalt geändert. Kein Test liest den Spec-Status (nur Kommentar-Referenzen), kein Deploy nötig — reine Doku-Änderung nach der Ausnahmeregel in CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EFcJf9fFxdZcaWa4USsLRy