### PR TITLE
fix(#2012): Gewitter-Wertebereiche rutschen beim Oeffnen eine Stufe nach unten

### DIFF
--- a/docs/context/fix-2012-gewitter-stufen-migration.md
+++ b/docs/context/fix-2012-gewitter-stufen-migration.md
@@ -1,0 +1,88 @@
+# Context: fix-2012-gewitter-stufen-migration
+
+Issue: #2012 — „Bestands-Wertebereiche fuer Gewitter rutschen beim Oeffnen eine Stufe nach unten"
+
+## Request Summary
+
+Die Umrechnung alter Gewitter-Wertebereiche (`percentBoundToOrdinal` in
+`corridorEditorState.ts`) stammt aus der 3-Stufen-Welt und bildet auf 0/1/2 ab. Seit #1474 hat
+die Skala vier Stufen (0=kein · 1=leicht · 2=mittel · 3=hoch). Bestandswerte erscheinen dadurch
+eine Stufe zu niedrig, Stufe 3 ist ueber diesen Pfad unerreichbar.
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `frontend/src/lib/components/shared/corridor-editor/corridorEditorState.ts:119-133` | `percentBoundToOrdinal` — die fehlerhafte Zuordnung |
+| ebd. `:142-155` | `migrateLegacyThunderCorridors` — einziger Aufrufer, schluesselt `thunder_level` → `thunder_level_max` |
+| ebd. `:~200` (`buildRoutePool`) | ruft die Migration vor dem Pool-Aufbau auf |
+| ebd. `:407` | `ORDINAL_ENUM = ['NONE','LOW','MED','HIGH']` — bei #1474 **korrekt** auf vier Stufen gezogen |
+| `frontend/.../corridor-editor/__tests__/routeCorridorPoolCatalogExpansion.test.ts:555-570` | `MIGRATION_CASES` haelt die 3-Stufen-Zuordnung fest (Begruendungstexte nennen 1 = „mittel", 2 = „hoch") |
+| `CorridorEditor.svelte:82-84`, `CorridorEditorMobile.svelte` | `computeInitialRoute()` — laeuft bei **jedem** Oeffnen des Wertebereiche-Tabs |
+
+## Messung am Produktivbestand (2026-08-21, `/var/lib/gregor/users`, 170 JSON-Dateien)
+
+Genau **eine** Zeile traegt den Alt-Schluessel:
+
+```
+henning/briefings/74de939c.json  ("Lottis Abschiedfahrradtour", Datei-Stand 2026-07-16)
+{"metric": "thunder_level", "range": [null, 1], "notify": true, "mark": false}
+```
+
+Die drei uebrigen Gewitter-Zeilen (KHW 403, Le Var ×2) tragen bereits `thunder_level_max` mit
+`[null, 0]`. Positivkontrolle: der Scan findet 6 Objekte mit nicht-leerem `corridors` und 18
+verschiedene Metriken — der Nullbefund fuer Werte > 2 ist nicht trivial wahr.
+
+**Der Datensatz stammt aus der Prozent-Epoche.** Stand `7c42db9f^` (vor 2026-07-30) definierte
+`corridorEditorState.ts:33`:
+
+```ts
+{ metric: 'thunder_level', label: 'Gewitter', unit: '%', scale: [0, 100], step: 5,
+  note: 'Abbruch bei Gewitter', defaultMin: null, defaultMax: 40 }
+```
+
+Die gespeicherte `1` ist also **1 Prozent**, keine Stufe. `percentBoundToOrdinal` reicht 0/1/2
+aber als „ist schon ordinal" unveraendert durch → angezeigt wird **„leicht"** statt **„kein"**.
+
+⇒ Der einzige betroffene Produktivdatensatz wird falsch angezeigt — ueber den
+Durchreich-Zweig, **nicht** ueber den im Issue beschriebenen `> 2`-Zweig. Der Fehler ist damit
+breiter als das Ticket ihn beschreibt: die Funktion kann eine Prozentangabe nicht von einer
+Stufennummer unterscheiden.
+
+## Erzeuger-Lage: kann heute noch ein Prozentwert entstehen?
+
+**Nein.**
+
+- Frontend: der Gewitter-Eintrag ist aus `ROUTE_METRIC_DEFS` **entfernt** (Kommentar
+  `corridorEditorState.ts:44-50`); Gewitter kommt ordinal aus dem Katalog als
+  `thunder_level_max`, `ordinalLabels: ['kein','leicht','mittel','hoch']`
+  (`corridorEditorState.test.ts:52`, `compareMetricCatalogLoader.ts:234`).
+- Go: `thunder_level` existiert nur als `AlertMetric` (`internal/model/trip.go:46`) — das ist die
+  **Alarm**-Seite, kein Korridor-Default. Kein Erzeuger.
+- Python: `loader.py` / `report_config_resolver.py` lesen `corridors` nur, sie erzeugen keine.
+
+⇒ Die Migration ist **kein toter Code** (ein echter Kunde), aber ein **abgeschlossener
+Bestand**: die Menge der zu migrierenden Datensaetze kann nicht mehr wachsen.
+
+## Existing Patterns
+
+- `unknownCorridors`-Pass-Through (`buildRoutePool`, F001 aus #1425 S2): unbekannte Metrik-IDs
+  werden **nie verworfen**, sondern unveraendert wieder mitgespeichert (BUG-DATALOSS-Klasse).
+- Read-Modify-Write mit Merge bei Persistenz (CLAUDE.md § Daten-Schema-Reworks).
+
+## Risks & Considerations
+
+- **Prozent hatte nie eine Wirkung.** Laut Kommentar `corridorEditorState.ts:44-50` war der
+  Stundenwert immer ein Ordinal; ein Prozent-Korridor schloss damit jeden Gewittergrad ein
+  (Umkehrung der Absicht). Eine „richtige" Prozent→Stufe-Uebersetzung existiert nicht — jede
+  Zuordnung ist Konvention, keine Ableitung. Es gibt auch keine kanonische Quelle dafuer:
+  `thunder_ampel_band` (`src/output/metric_format.py:302`) bildet Stufen auf Ampelbaender ab,
+  nicht Prozent auf Stufen.
+- **Reiner Rueckbau kostet Sichtbarkeit.** Ohne Migration faellt die eine Bestandszeile in den
+  `unknownCorridors`-Pass-Through: nicht geloescht, aber im Editor unsichtbar — der Nutzer
+  kann seine Gewitter-Einstellung nicht mehr sehen oder aendern.
+- **Schreib-Zeitpunkt.** Reines Oeffnen zeigt nur falsch an; sobald im Tab irgendetwas
+  geaendert wird, wird der verschobene Wert persistiert.
+- **Der Test muss mitgezogen werden**, sonst blockiert er den Fix — er prueft nur nackte
+  Zahlen, nie das gerenderte Wort, und blieb deshalb seit #1474 gruen.
+- **Keine Tour-Relevanz.** Die KHW-403-Konfiguration steht bereits auf dem neuen Schluessel.

--- a/docs/reference/api_contract.md
+++ b/docs/reference/api_contract.md
@@ -1645,7 +1645,7 @@ Reihenfolge deckungsgleich mit `ALL_METRICS` im Frontend.
       "decimals": 0,
       "higherIsBetter": false,
       "kind": "ordinal",
-      "ordinalLabels": ["kein", "mittel", "hoch"],
+      "ordinalLabels": ["kein", "leicht", "mittel", "hoch"],
       "metric_id": "thunder",
       "aggregation": "max",
       "alertMetric": "thunder_level",
@@ -1673,7 +1673,7 @@ Reihenfolge deckungsgleich mit `ALL_METRICS` im Frontend.
 | Field | Type | Description |
 |-------|------|-------------|
 | metrics[].key | string | Identisch zu `compare_metric_ids.FRONTEND_TO_RENDERER_METRIC_ID`-Keys (keine sechste Kopie der Keyliste) |
-| metrics[].kind | string | `range` (23 Einträge, mit `rangeMin`/`rangeMax`/`step`), `enum` (`precip_type_dominant`, mit `enumValues`) oder `ordinal` (`thunder_level_max`, mit `ordinalLabels` — übernimmt die im Editor tatsächlich sichtbare 3-Stufen-Darstellung statt des rohen Enum, PO-Entscheidung 2026-07-12) |
+| metrics[].kind | string | `range` (23 Einträge, mit `rangeMin`/`rangeMax`/`step`), `enum` (`precip_type_dominant`, mit `enumValues`) oder `ordinal` (`thunder_level_max`, mit `ordinalLabels` — übernimmt die im Editor tatsächlich sichtbare Stufen-Darstellung statt des rohen Enum, PO-Entscheidung 2026-07-12; seit #1474/#1911 vierstufig `["kein","leicht","mittel","hoch"]`, aus der kanonischen Quelle `THUNDER_LABEL_DE` abgeleitet) |
 | metrics[].higherIsBetter | bool | Richtung für die Compare-Winner-Box (`true` = höherer Wert gewinnt) |
 | metrics[].alertMetric | string \| null | **Neu #1435 E1a-1.** Die Alarm-Identität des Paares (Größe, Auswertung), aufgelöst über `metric_catalog.alert_metric_for(metric_id, aggregation)` — `null`, wenn diese Zeile keinen Alarm auslösen kann. Steht an **allen 26** Einträgen, auch den nicht alarmfähigen (dort `null`). Ersetzt die vorherige, unabhängig gepflegte Herkunft von `alarmCapable` |
 | metrics[].alarmCapable | bool | Seit Teil 3 (#1350). Ab #1435 E1a-1 die **Boolean-Sicht auf `alertMetric`** (`alertMetric is not None`), nicht mehr eine zweite, handgepflegte Liste — steuert unverändert die „Warnen"-Button-Sperre im Schwellen-Editor. Die Menge ist verhaltensneutral identisch geblieben: genau dieselben 10 Keys wie zuvor aus `compare_alert.py::_SUMMARY_KEY_TO_CATALOG_ID` (nachgewiesen in `tests/unit/test_alert_metric_identity_delivery.py`); `compare_alert.py` bleibt das tatsächlich alarmauslösende Modul und ist von dieser Etappe unverändert |

--- a/docs/specs/modules/fix_2012_gewitter_stufen_migration.md
+++ b/docs/specs/modules/fix_2012_gewitter_stufen_migration.md
@@ -1,0 +1,298 @@
+---
+entity_id: fix_2012_gewitter_stufen_migration
+type: bugfix
+created: 2026-08-21
+updated: 2026-08-21
+status: draft
+version: "1.1"
+tags: [trip, corridor-editor, thunder, migration, wertebereiche]
+---
+
+# Trip-Wertebereiche: Gewitter-Prozent-Migration auf die 4-Stufen-Skala nachziehen (#2012)
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+`percentBoundToOrdinal()` rechnet gespeicherte Gewitter-Wertebereiche vom
+Alt-Schluessel `thunder_level` (Prozent-Epoche) auf die Ordinalskala des
+neuen Schluessels `thunder_level_max` um. Die Funktion stammt aus der
+3-Stufen-Welt (NONE/MED/HIGH, `percentBoundToOrdinal` bildet auf 0/1/2 ab).
+Seit #1474 hat die Skala vier Stufen (0=kein, 1=leicht, 2=mittel, 3=hoch,
+`_THUNDER_ORDINAL_LABELS`). Die Migration wurde dabei nicht nachgezogen:
+Bestandswerte erscheinen eine Stufe zu niedrig, Stufe 3 ("hoch") ist ueber
+diesen Pfad nicht erreichbar. Zusaetzlich enthaelt die Funktion einen
+konzeptionell falschen Durchreich-Zweig (`v === 0 || v === 1 || v === 2` ->
+"ist schon ordinal") — die Funktion laeuft ausschliesslich auf Zeilen mit
+dem Alt-Schluessel `thunder_level`, und dieser Schluessel trug per
+Definition immer die Prozent-Einheit (Stand `7c42db9f^`, vor der
+Skalen-Umstellung durch #1425). Eine gespeicherte `1` ist 1 Prozent, keine
+Stufe — der Durchreich-Zweig deutet sie faelschlich als Ordinalwert.
+
+Diese Spec korrigiert `percentBoundToOrdinal()` auf eine reine
+Prozent-zu-Stufe-Zuordnung ohne Sonderzweig, koppelt die Zielstufen
+strukturell an die bewachte kanonische Enum-Quelle `ORDINAL_ENUM` statt an
+neue Zahlenliterale, und zieht den bestehenden Migrations-Testfall
+(`MIGRATION_CASES`) auf die korrekte 4-Stufen-Zuordnung.
+
+## Wirkung
+
+Der Fehler ist nicht rein kosmetisch. Der migrierte Ordinalwert wird
+serverseitig als echte Schwelle gegen den gemessenen Gewitterwert
+verglichen: `corridor_inside()` in `src/services/corridor_threshold.py:96-104`
+(Δ-Benachrichtigung, normalisiert per `thunder_ordinal()`) und
+`is_marked()` in `src/output/renderers/email/corridor_mark.py:49-57`
+(Markierung in der Trip-Mail). Reines **Oeffnen** des Wertebereiche-Reiters
+zeigt den Wert nur falsch an — sobald der Nutzer dort etwas aendert und
+speichert, wird die verschobene Schwelle **wirksam**: aus einer Vorgabe
+„melde ab mittel" wird faktisch „melde ab leicht" (eine Stufe empfindlicher
+als eingestellt). Der Fix betrifft also sowohl die Anzeige als auch die
+tatsaechliche Alarm-/Markier-Schwelle, sobald gespeichert wird.
+
+## Source
+
+- **File:** `frontend/src/lib/components/shared/corridor-editor/corridorEditorState.ts`
+- **Identifier:** `percentBoundToOrdinal()` (Zeile 119-133),
+  `migrateLegacyThunderCorridors()` (Zeile 142-155, einziger Aufrufer),
+  `ORDINAL_ENUM` (Zeile 407, kanonische Stufen-Quelle)
+
+> **Schicht-Hinweis:** Reines SvelteKit-Frontend (TypeScript). Kein Go-API-,
+> kein Python-Core-Eingriff — die Migration lebt ausschliesslich im
+> Client-seitigen Lade-Pfad des Trip-Wertebereiche-Editors
+> (`buildRoutePool()`, `context="route"`). Die Wirkung (s. o.) entsteht,
+> weil der bereits migrierte, gespeicherte Wert spaeter unveraendert von
+> Python gelesen wird — dort ist nichts zu aendern.
+
+## Estimated Scope
+
+- **LoC:** ~40-70 (kleiner Funktionskern, ueberwiegend Testfall-Korrektur
+  plus drei Kommentarstellen)
+- **Files:** 4
+- **Effort:** low
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `migrateLegacyThunderCorridors()` (`corridorEditorState.ts:142-155`) | function | Einziger Aufrufer von `percentBoundToOrdinal()` — ruft sie unabhaengig fuer `range[0]` (Untergrenze) und `range[1]` (Obergrenze) auf; bleibt selbst unveraendert |
+| `buildRoutePool()` (`corridorEditorState.ts:187-233`) | function | Ruft `migrateLegacyThunderCorridors()` VOR dem Aufbau der `present`-Map auf (Zeile 199-201) — diese Reihenfolge ist Voraussetzung fuer Nicht-Doppel-Speicherung und bleibt unveraendert |
+| `ORDINAL_ENUM` (`corridorEditorState.ts:407`, `['NONE','LOW','MED','HIGH']`) | data | Einzige Whitelist-Position des lokalen Kopie-Wächters `thunderScaleLocalCopyGuard.test.ts` (`CANONICAL_SYMBOLS`) — `percentBoundToOrdinal()` leitet die Zielstufen ab jetzt ueber `ORDINAL_ENUM.indexOf('MED'\|'HIGH')` statt ueber eigene Zahlenliterale, damit die Funktion strukturell an die kanonische Kette haengt, nicht daneben |
+| `thunderScaleLocalCopyGuard.test.ts` (`frontend/src/lib/components/shared/weather-metrics-tab/__tests__/`) | gate | Waechter gegen lokale Nachbauten der Gewitter-Stufenskala (#1480) — erkennt `percentBoundToOrdinal()` selbst NICHT (Rueckgabewerte sind Zahlen, keine Stufen-Woerter/-Arrays; Funktionsname enthaelt weder "thunder" noch "gewitter"), genau deshalb ist die direkte Kopplung an `ORDINAL_ENUM` in dieser Spec verlangt statt einer Umbenennung |
+| `_THUNDER_ORDINAL_LABELS` (`src/output/renderers/compare_metric_catalog.py:115-122`) | data | Kanonische Quelle der vier Stufennamen (`['kein','leicht','mittel','hoch']`, seit #1474) — Referenzpunkt fuer die korrekte Zuordnung, wird selbst nicht geaendert |
+| `corridor_inside()` / `corridor_threshold.py:96-104` | function | Liest den migrierten Ordinalwert als echte Δ-Alarm-Schwelle — unveraendert, aber die Wirkung dieser Spec entsteht hier (s. „Wirkung") |
+| `is_marked()` / `corridor_mark.py:49-57` | function | Liest den migrierten Ordinalwert als Markier-Schwelle in der Trip-Mail — unveraendert, aber die Wirkung dieser Spec entsteht hier (s. „Wirkung") |
+| `MIGRATION_CASES` (`__tests__/routeCorridorPoolCatalogExpansion.test.ts:555-568`) | test | Haelt die (falsche) 3-Stufen-Zuordnung samt Begruendungstexten fest — muss auf die neue Zuordnung gezogen werden. Von den 12 Faellen aendern sich 9 (alle ausser `[null,0]→[null,0]`, `[null,33]→[null,0]`, `[null,null]→[null,null]`) |
+| Speicher-Test „Speichern nach der Migration schreibt genau EINEN Gewitter-Eintrag" (`__tests__/routeCorridorPoolCatalogExpansion.test.ts:613-637`) | test | Erwartet aktuell `range: [null, 1]` fuer den Eingabewert `[null, 40]` (Zeile 629) — muss auf `[null, 2]` gezogen werden |
+| Idempotenz-Test „ein bereits migrierter Korridor bleibt beim erneuten Laden unveraendert" (`__tests__/routeCorridorPoolCatalogExpansion.test.ts:639-651`) | test | Eingabe traegt bereits den neuen Schluessel `thunder_level_max` mit `range:[null,1]` — durchlaeuft `percentBoundToOrdinal()` gar nicht (der Schluesselvergleich in `migrateLegacyThunderCorridors()` greift nur bei `thunder_level`). Bleibt unveraendert gruen und dient als Negativ-Beleg fuer AC-4; **keine Aenderung noetig** |
+| Einziger Produktiv-Bestandsdatensatz (`henning/briefings/74de939c.json`, Stand 2026-07-16) | data | `{"metric":"thunder_level","range":[null,1],"notify":true,"mark":false}` — 1 Prozent, wird nach dem Fix zu `[null, 0]` ("bis kein") statt bisher `[null, 1]` ("bis leicht") |
+
+## Scope
+
+### Affected Files
+
+| File | Change Type | Description |
+|------|-------------|--------------|
+| `frontend/src/lib/components/shared/corridor-editor/corridorEditorState.ts` | MODIFY | (1) `percentBoundToOrdinal()` (Zeile 119-133): Sonderzweig `if (v === 0 \|\| v === 1 \|\| v === 2) return v;` entfaellt ersatzlos — jede Zahl wird als Prozent gedeutet. Drittelung auf vier Zielstufen: `null -> null`, `0-33 -> ORDINAL_ENUM.indexOf('NONE')` (0, kein), `34-66 -> ORDINAL_ENUM.indexOf('MED')` (2, mittel), `67-100 -> ORDINAL_ENUM.indexOf('HIGH')` (3, hoch) — ueber die kanonische Enum-Quelle abgeleitet, keine neuen Zahlenliterale (s. Implementation Details Punkt 2). (2) Docstring-Kommentar der Funktion (Zeile 119-126) auf die neue Zuordnung korrigiert. (3) Datei-Kopfkommentar Zeile 13 ("kein/mittel/hoch") auf die seit #1474 gueltigen vier Stufen ("kein/leicht/mittel/hoch") korrigiert (reine Doku-Korrektur, keine Verhaltensaenderung). |
+| `frontend/src/lib/components/shared/corridor-editor/__tests__/routeCorridorPoolCatalogExpansion.test.ts` | MODIFY | `MIGRATION_CASES` (Zeile 555-568): 9 von 12 Faellen auf die neue Zuordnung gezogen, Begruendungstexte nennen die heutigen Stufennamen (kein/leicht/mittel/hoch), nicht die alten. Neuer Testfall prueft das **angezeigte Stufenwort** ueber `_THUNDER_ORDINAL_LABELS`-Index, nicht nur die nackte Zahl. Speicher-Test Zeile 613-637: Erwartungswert `range: [null, 1]` -> `[null, 2]`. Idempotenz-Test Zeile 639-651 bleibt **unveraendert** (s. Dependencies). |
+| `tests/tdd/test_alert_metric_mapping_parity.py` | MODIFY | Kommentarstelle Zeile 135-137 ("kein/mittel/hoch", "Ordinal-Stundenwert 0/1/2") auf die seit #1474 gueltige 4-Stufen-Beschreibung ("kein/leicht/mittel/hoch", 0/1/2/3) korrigiert — reine Doku-Korrektur, die dokumentierte Ausnahme selbst (Bedingungen, Wirkung) bleibt inhaltlich unveraendert. |
+
+## Implementation Details
+
+**1. Neue Zuordnung (ersetzt den bisherigen Funktionskoerper vollstaendig):**
+
+```
+null            -> null
+0 - 33 (Prozent) -> ORDINAL_ENUM.indexOf('NONE')  (0, kein)
+34 - 66          -> ORDINAL_ENUM.indexOf('MED')   (2, mittel)
+67 - 100         -> ORDINAL_ENUM.indexOf('HIGH')  (3, hoch)
+```
+
+Beide Grenzen (`range[0]`, `range[1]`) werden weiterhin unabhaengig
+voneinander umgerechnet (unveraendert gegenueber dem Bestand — nur die
+Zuordnungstabelle selbst aendert sich).
+
+**2. Warum ueber `ORDINAL_ENUM.indexOf(...)` statt ueber die Zahlen `2`/`3`:**
+`percentBoundToOrdinal()` ist die Stelle, die #2012 verursacht hat — und sie
+ist dem lokalen Kopie-Waechter `thunderScaleLocalCopyGuard.test.ts` (#1480)
+strukturell unsichtbar: Regel A/C des Waechters erkennen Stufen-**Woerter**
+(Arrays/Objektschluessel bzw. String-Branches in Funktionen mit "thunder"/
+"gewitter" im Namen) — `percentBoundToOrdinal()` arbeitet aber mit rohen
+Zahlen und heisst weder "thunder" noch "gewitter". Eine Umbenennung allein
+wuerde sie nicht in die Scanflaeche des Waechters ziehen (Regel C verlangt
+zusaetzlich Stufen-**Woerter** in den Zweigen, keine Zahlen). Damit die
+Funktion trotzdem an der kanonischen Kette (`ORDINAL_ENUM` -> Katalog ->
+`ordinalLabels` -> `scale`) haengt statt eine vierte, unbewachte Kopie der
+Skala zu fuehren, leitet sie die beiden migrierten Zielstufen ueber
+`ORDINAL_ENUM.indexOf('MED')` bzw. `ORDINAL_ENUM.indexOf('HIGH')` ab.
+`ORDINAL_ENUM` ist der einzige Eintrag in `CANONICAL_SYMBOLS` des
+Waechters — ein kuenftiger Skalenwechsel (Umbenennung/Umsortierung der
+Stufen) verschiebt die Bedeutung dieser Migration dann automatisch mit,
+statt sie ein zweites Mal stillschweigend zurueckzulassen.
+
+**3. Warum der Sonderzweig entfaellt:** `percentBoundToOrdinal()` wird
+ausschliesslich von `migrateLegacyThunderCorridors()` aufgerufen, und die
+laeuft ausschliesslich auf Korridor-Zeilen mit dem Alt-Schluessel
+`thunder_level`. Dieser Schluessel trug in seiner gesamten Lebenszeit
+(bis zur Ablösung durch `thunder_level_max` in #1425) ausschliesslich
+Prozentwerte (`scale: [0, 100]`, Stand `7c42db9f^`). Es gibt keinen
+Erzeuger, der unter diesem Schluessel je eine Ordinalzahl gespeichert hat
+(s. Restrisiko unten). Der bisherige "ist schon ordinal"-Zweig loeste
+dieses nicht existente Problem auf Kosten der tatsaechlichen Faelle: eine
+gespeicherte `1` (1 Prozent) wurde unveraendert als Stufe 1 ("leicht")
+durchgereicht statt als Stufe 0 ("kein") erkannt zu werden.
+
+**4. Warum Stufe 1 ("leicht") ueber die Migration nicht erreichbar ist:**
+Die Stufe "leicht" existierte in der Prozent-Epoche nicht — die 3-Stufen-Welt
+kannte nur kein/mittel/hoch. Kein Bestandswert aus dieser Epoche kann "leicht"
+gemeint haben. Die Drittelung bildet deshalb bewusst auf {0, 2, 3} ab, nicht
+auf die vier gleich breiten Viertel {0, 1, 2, 3} — das wuerde eine Bedeutung
+erfinden, die der Bestandswert nie hatte.
+
+**5. Konkrete Beispiel-Umrechnungen (zur Verifikation der Testfaelle):**
+
+| Prozentwert | Alte Ausgabe (fehlerhaft) | Neue Ausgabe |
+|---|---|---|
+| `null` | `null` | `null` |
+| `[null, 40]` (ausgelieferter Alt-Default) | `[null, 1]` ("bis leicht") | `[null, 2]` ("bis mittel") |
+| `[null, 1]` (einziger Produktiv-Datensatz) | `[null, 1]` ("bis leicht") | `[null, 0]` ("bis kein") |
+| `[null, 100]` | `[null, 2]` ("bis hoch", Stufe 3 unerreichbar) | `[null, 3]` ("bis hoch") |
+
+**6. Was unveraendert bleibt:** `migrateLegacyThunderCorridors()` selbst
+(Schluesselwechsel `thunder_level` -> `thunder_level_max`, Erhalt von
+`notify`/`mark`) und die Aufrufreihenfolge in `buildRoutePool()` (Migration
+laeuft vor der `present`-Map-Bildung — Voraussetzung dafuer, dass der
+Alt-Korridor nicht zusaetzlich als "unbekannt" in `unknownCorridors`
+landet und beim naechsten Speichern doppelt persistiert wird). Zeilen, die
+bereits `thunder_level_max` heissen, durchlaufen `percentBoundToOrdinal()`
+gar nicht (der Schluesselvergleich in `migrateLegacyThunderCorridors()`
+prueft exakt auf `thunder_level`) — Idempotenz ist damit strukturell
+gegeben, nicht ueber diese Funktion. `corridor_threshold.py` und
+`corridor_mark.py` (Python-Core) lesen den bereits migrierten Wert
+unveraendert — kein Python-Eingriff (s. „Wirkung").
+
+## Expected Behavior
+
+- **Input:** Ein gespeicherter Trip-Korridor mit Alt-Schluessel
+  `thunder_level` und einem Prozent-Wertebereich (`range: [min, max]`,
+  `min`/`max` je `null` oder `0-100`).
+- **Output:** Nach dem Laden des Wertebereiche-Editors erscheint die Zeile
+  unter dem Schluessel `thunder_level_max` mit dem gemaess der Tabelle in
+  Implementation Details Punkt 5 umgerechneten Ordinalwert (0/2/3, nie 1).
+  `notify`/`mark` sind unveraendert uebernommen. Sobald der Nutzer speichert,
+  ist dieser Wert die tatsaechliche Δ-Alarm- und Markier-Schwelle (s.
+  „Wirkung").
+- **Side effects:** Bereits migrierte Zeilen (Schluessel `thunder_level_max`)
+  sind unberuehrt. Alle anderen Korridor-Metriken (`wind_gust`,
+  `precipitation_sum`, `temperature_min`, `temperature_max`, `snow_line`)
+  sind unberuehrt. Kein Server-seitiger Migrations-Job — die Umrechnung
+  laeuft ausschliesslich beim Laden im Frontend, wie bisher.
+
+## Acceptance Criteria
+
+- **AC-1:** Given ein gespeicherter Alt-Korridor `{metric:"thunder_level",
+  range:[null,40]}` (der ausgelieferte Default "bis 40 Prozent"), When der
+  Wertebereiche-Editor laedt (`buildRoutePool`), Then erscheint er als
+  `{metric:"thunder_level_max", range:[null,2]}` — angezeigt als "bis
+  mittel", nicht mehr als "bis leicht".
+  - Test: `routeCorridorPoolCatalogExpansion.test.ts`, aktualisierter
+    `MIGRATION_CASES`-Fall; die Assertion prueft zusaetzlich
+    `_THUNDER_ORDINAL_LABELS[row.max] === 'mittel'` (angezeigtes Wort, nicht
+    nur der Index).
+
+- **AC-2:** Given ein gespeicherter Alt-Korridor mit dem einzigen im
+  Produktivbestand vorkommenden Wert `{metric:"thunder_level",
+  range:[null,1]}` (1 Prozent), When der Wertebereiche-Editor laedt, Then
+  erscheint er als `{metric:"thunder_level_max", range:[null,0]}` ("bis
+  kein") — nicht mehr als "bis leicht" wie vor dem Fix.
+  - Test: `routeCorridorPoolCatalogExpansion.test.ts`, neuer
+    `MIGRATION_CASES`-Fall fuer den Produktiv-Wert `[null,1]`, prueft
+    `row.max === 0` und `_THUNDER_ORDINAL_LABELS[0] === 'kein'`.
+
+- **AC-3:** Given ein gespeicherter Alt-Korridor `{metric:"thunder_level",
+  range:[null,100]}` (Prozent-Maximum), When der Wertebereiche-Editor laedt,
+  Then erscheint er als `{metric:"thunder_level_max", range:[null,3]}` — die
+  Stufe "hoch" ist damit ueber die Migration erstmals erreichbar (vor dem
+  Fix strukturell unmoeglich).
+  - Test: `routeCorridorPoolCatalogExpansion.test.ts`, aktualisierter
+    `MIGRATION_CASES`-Fall, prueft `row.max === 3`.
+
+- **AC-4:** Given ein bereits migrierter Korridor
+  `{metric:"thunder_level_max", range:[null,1]}` (Stufe "leicht", echter
+  Ordinalwert unter dem NEUEN Schluessel), When der Wertebereiche-Editor
+  laedt, Then bleibt der Wert unveraendert `[null,1]` — die Korrektur der
+  Prozent-Zuordnung wirkt sich nicht auf bereits migrierte Zeilen aus
+  (Idempotenz ueber den Schluesselwechsel, nicht ueber `percentBoundToOrdinal`).
+  - Test: bestehender Test „ein bereits migrierter Korridor bleibt beim
+    erneuten Laden unveraendert" (`routeCorridorPoolCatalogExpansion.test.ts:639-651`)
+    laeuft unveraendert gruen.
+
+- **AC-5:** Given ein Korridor mit beidseitig gesetztem Wertebereich
+  `{metric:"thunder_level", range:[0,100]}`, When der Wertebereiche-Editor
+  laedt, Then werden Unter- und Obergrenze unabhaengig voneinander
+  umgerechnet zu `range:[0,3]` — nicht zu einem einheitlichen Wert fuer
+  beide Grenzen.
+  - Test: `routeCorridorPoolCatalogExpansion.test.ts`, aktualisierter
+    `MIGRATION_CASES`-Fall "beide Grenzen unabhaengig voneinander".
+
+- **AC-6:** Given `percentBoundToOrdinal()` leitet die beiden migrierten
+  Zielstufen ueber `ORDINAL_ENUM.indexOf('MED')` bzw.
+  `ORDINAL_ENUM.indexOf('HIGH')` ab statt ueber eigene Zahlenliterale `2`/`3`,
+  When der Funktionsquelltext gepruest wird, Then enthaelt er keinen rohen
+  Zahlenliteral-Rueckgabewert `2` oder `3` fuer die beiden Prozent-Zweige —
+  die Migration haengt strukturell an der einzigen von
+  `thunderScaleLocalCopyGuard.test.ts` bewachten kanonischen Quelle, nicht
+  an einer eigenen, unbewachten Zahl.
+  - Test A (Verhalten, traegt die Zusicherung): die Migrations-Tests
+    vergleichen die Zielstufen gegen `ORDINAL_ENUM.indexOf('MED')` bzw.
+    `ORDINAL_ENUM.indexOf('HIGH')` statt gegen die Literale `2`/`3` — eine
+    zusaetzliche Stufe in `ORDINAL_ENUM` verschiebt damit die Bedeutung der
+    migrierten Grenzen nicht, sondern zieht die Erwartung mit.
+  - Test B (Struktur, sekundaer): Struktur-Test in
+    `corridorEditorState.test.ts` (analog `thunderScaleLocalCopyGuard.test.ts`)
+    prueft den Quelltext von `percentBoundToOrdinal` auf Abwesenheit roher
+    Zahlenliterale `2`/`3` als Rueckgabewert. Ergaenzt Test A, ersetzt ihn
+    nicht — ein reiner Quelltext-Scan ist kein Verhaltensnachweis.
+
+## Known Limitations
+
+- **Restrisiko bei einer echten Ordinalzahl unter dem Alt-Schluessel:**
+  Sollte irgendwo doch ein `thunder_level`-Korridor mit einer tatsaechlichen
+  Stufenzahl (statt Prozent) gespeichert sein, wuerde diese jetzt faelschlich
+  als Prozent gedeutet — eine gespeicherte `2` wuerde zu Stufe 0 ("kein")
+  statt zur gemeinten Stufe "mittel". Diese Spec akzeptiert dieses Restrisiko
+  bewusst: Der Alt-Schluessel trug laut Katalog-Definition (Stand
+  `7c42db9f^`) ausschliesslich Prozentwerte, und der gesamte
+  Produktivbestand (170 Dateien, `/var/lib/gregor/users`, Stand 2026-08-21)
+  enthaelt genau eine `thunder_level`-Zeile — mit dem Wert `1`, konsistent
+  mit der Prozent-Deutung. Es gibt keinen Code-Pfad, der seit der
+  Skalen-Umstellung (#1425) noch einen `thunder_level`-Korridor erzeugt
+  (weder Frontend noch Go noch Python) — die Menge der betroffenen
+  Datensaetze kann nicht mehr wachsen.
+- Kein Server-seitiger Migrations-Job — die Umrechnung greift erst, wenn der
+  betroffene Trip ueber den Wertebereiche-Editor geladen wird (unveraendert
+  gegenueber dem Bestand vor dieser Spec).
+- **Nebenbefund, NICHT Teil dieser Spec:** `__tests__/corridorMarkSupport.test.ts:75`
+  fuehrt `'thunder_level'` weiterhin in `TRIP_MARKABLE_METRICS` —
+  `supportsMark()` ist rein namensbasiert und von der Skala unabhaengig,
+  bleibt also von diesem Fix folgenlos unberuehrt. Kein Handlungsbedarf.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Reine Korrektur einer bestehenden Umrechnungstabelle auf
+  eine bereits an anderer Stelle etablierte Skala (`_THUNDER_ORDINAL_LABELS`
+  / `ORDINAL_ENUM`, seit #1474). Kein neuer Provider, kein neuer Kanal, keine
+  neue Auth-/Persistenz-Entscheidung, kein neues Datenformat — der
+  `Corridor`-Datentyp und sein Speicherformat bleiben unveraendert.
+
+## Changelog
+
+- 2026-08-21: Initial spec created
+- 2026-08-21: Ergaenzt um Abschnitt „Wirkung" (Δ-Alarm-/Markier-Wirkung, nicht
+  nur Anzeige), Kopplung an `ORDINAL_ENUM` statt neuer Zahlenliterale (AC-6),
+  zwei zusaetzliche Kommentar-Korrekturstellen (`corridorEditorState.ts:13`,
+  `test_alert_metric_mapping_parity.py:135-137`), Klarstellung zum
+  Idempotenz-Test (Zeile 639-651 bleibt unveraendert), Nebenbefund-Hinweis
+  `corridorMarkSupport.test.ts:75`.

--- a/docs/specs/modules/fix_2012_gewitter_stufen_migration.md
+++ b/docs/specs/modules/fix_2012_gewitter_stufen_migration.md
@@ -249,11 +249,25 @@ unveraendert — kein Python-Eingriff (s. „Wirkung").
     `ORDINAL_ENUM.indexOf('HIGH')` statt gegen die Literale `2`/`3` — eine
     zusaetzliche Stufe in `ORDINAL_ENUM` verschiebt damit die Bedeutung der
     migrierten Grenzen nicht, sondern zieht die Erwartung mit.
-  - Test B (Struktur, sekundaer): Struktur-Test in
-    `corridorEditorState.test.ts` (analog `thunderScaleLocalCopyGuard.test.ts`)
-    prueft den Quelltext von `percentBoundToOrdinal` auf Abwesenheit roher
-    Zahlenliterale `2`/`3` als Rueckgabewert. Ergaenzt Test A, ersetzt ihn
-    nicht — ein reiner Quelltext-Scan ist kein Verhaltensnachweis.
+  - Test A-2 (Verhalten, Kopplungsnachweis) in
+    `routeCorridorPoolCatalogExpansion.test.ts`: importiert eine Kopie von
+    `corridorEditorState.ts` mit einer VERSCHOBENEN `ORDINAL_ENUM` (eine vor
+    `MED` eingeschobene Stufe verschiebt `MED` 2->3 und `HIGH` 3->4) und
+    verlangt, dass die Migration den neuen Indizes folgt — nur eine echte
+    `ORDINAL_ENUM.indexOf(...)`-Kopplung besteht das, ein Zahlenliteral (auch
+    ein zufaellig wertgleiches) faellt durch.
+  - Test B (Struktur, reiner Quelltext-Scan von `percentBoundToOrdinal`) ist
+    mit #2012-Adversary-Runde-2/F002 ersatzlos entfernt: sechs
+    Adversary-Mutationen fanden keinen Fall, den Test B fing und Test A-2
+    nicht auch fing, und Test B blockierte zugleich korrekten, aequivalenten
+    Code (z. B. eine ausgelagerte, korrekt an `ORDINAL_ENUM.indexOf('MED')`
+    gekoppelte Konstante) als Falsch-Positiv, weil er den woertlichen
+    Ausdruck `ORDINAL_ENUM.indexOf('MED')` pro Zweig verlangte. Test A-2
+    traegt die Zusicherung jetzt allein — belegt durch drei einzeln gefahrene
+    Mutationen (Entwickler-Rueckmeldung 2026-08-21): `return
+    ORDINAL_ENUM.indexOf('MED');` -> `return (1 + 1);`, -> `return 2;`, sowie
+    `indexOf('HIGH')` im HIGH-Zweig -> `indexOf('MED')` — alle drei liess
+    Test A-2 rot werden, keine blieb unentdeckt gruen.
 
 ## Known Limitations
 
@@ -296,3 +310,10 @@ unveraendert — kein Python-Eingriff (s. „Wirkung").
   `test_alert_metric_mapping_parity.py:135-137`), Klarstellung zum
   Idempotenz-Test (Zeile 639-651 bleibt unveraendert), Nebenbefund-Hinweis
   `corridorMarkSupport.test.ts:75`.
+- 2026-08-21: Adversary Runde 2, F002/F003 bereinigt. AC-6 Test B (reiner
+  Quelltext-Scan) ersatzlos entfernt — redundant zu Test A-2, blockierte
+  aequivalenten korrekten Code als Falsch-Positiv (F002, 3 Mutationen als
+  Nachweis, s. AC-6). Die temporaere Modulkopie in Test A-2 liegt jetzt im
+  eigenen `__tests__`-Verzeichnis statt in `corridor-editor/` selbst, damit
+  ein liegengebliebener Crash-Rest nicht faelschlich `thunderScaleLocalCopyGuard.test.ts`
+  ausloest (F003).

--- a/frontend/src/lib/components/shared/corridor-editor/__tests__/routeCorridorPoolCatalogExpansion.test.ts
+++ b/frontend/src/lib/components/shared/corridor-editor/__tests__/routeCorridorPoolCatalogExpansion.test.ts
@@ -19,6 +19,7 @@
 import { test, describe } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 
@@ -29,8 +30,15 @@ import {
 	addRow,
 	ROUTE_CTX_DEFAULTS,
 	ROUTE_METRIC_DEFS,
+	ORDINAL_ENUM,
 	type RouteMetricDef,
 } from '../corridorEditorState.ts';
+
+// AC-6 Test A: Zielstufen der Migration werden gegen die kanonische Enum-
+// Quelle abgeleitet, nicht gegen eigene Zahlenliterale — eine zusaetzliche
+// Stufe in ORDINAL_ENUM verschiebt die Bedeutung nicht still.
+const MED_ORDINAL = ORDINAL_ENUM.indexOf('MED');
+const HIGH_ORDINAL = ORDINAL_ENUM.indexOf('HIGH');
 
 const MODULE_SPECIFIER = '../compareMetricCatalogLoader.ts';
 
@@ -550,21 +558,33 @@ describe('Scheibe B / AC-4: Standardwert einer neu hinzugefuegten Gewitter-Zeile
 });
 
 describe('Scheibe B / AC-3: Alt-Korridore werden beim Laden umgeschluesselt und umgerechnet', () => {
-	// Prozent -> Stufe (Spec § Implementation Details Punkt 3):
-	//   null -> null · 0|1|2 unveraendert · 0-33 -> 0 · 34-66 -> 1 · 67-100 -> 2
-	const MIGRATION_CASES: Array<{ from: [number | null, number | null]; to: [number | null, number | null]; why: string }> = [
-		{ from: [null, 40], to: [null, 1], why: 'die alte Vorgabe "bis 40 %" wird "bis mittel"' },
-		{ from: [null, 0], to: [null, 0], why: '0 ist bereits ordinal (kein) und bleibt' },
-		{ from: [null, 1], to: [null, 1], why: '1 ist bereits ordinal (mittel) und bleibt' },
-		{ from: [null, 2], to: [null, 2], why: '2 ist bereits ordinal (hoch) und bleibt' },
+	// Prozent -> Stufe (Spec § Implementation Details Punkt 1, #2012-Korrektur):
+	//   null -> null · JEDE Zahl als Prozent gedeutet (kein "schon ordinal"-
+	//   Sonderzweig mehr) · 0-33 -> 0 (kein) · 34-66 -> 2 (mittel) · 67-100 -> 3 (hoch)
+	//   Stufe 1 ("leicht") ist ueber die Migration nie erreichbar (Spec Punkt 4).
+	const MIGRATION_CASES: Array<{
+		from: [number | null, number | null];
+		to: [number | null, number | null];
+		why: string;
+		word?: string;
+	}> = [
+		{ from: [null, 40], to: [null, MED_ORDINAL], why: 'die alte Vorgabe "bis 40 %" wird "bis mittel" (AC-1)', word: 'mittel' },
+		{ from: [null, 0], to: [null, 0], why: '0 Prozent liegt im ersten Drittel -> kein' },
+		{
+			from: [null, 1],
+			to: [null, 0],
+			why: 'der einzige Produktivwert (1 Prozent) liegt im ersten Drittel -> kein, NICHT mehr "bereits ordinal (mittel)" (AC-2)',
+			word: 'kein',
+		},
+		{ from: [null, 2], to: [null, 0], why: '2 Prozent liegt im ersten Drittel -> kein, NICHT mehr "bereits ordinal (hoch)"' },
 		{ from: [null, 33], to: [null, 0], why: 'oberes Ende des ersten Drittels -> kein' },
-		{ from: [null, 34], to: [null, 1], why: 'unteres Ende des zweiten Drittels -> mittel' },
-		{ from: [null, 66], to: [null, 1], why: 'oberes Ende des zweiten Drittels -> mittel' },
-		{ from: [null, 67], to: [null, 2], why: 'unteres Ende des dritten Drittels -> hoch' },
-		{ from: [null, 100], to: [null, 2], why: 'Prozent-Maximum -> hoch' },
+		{ from: [null, 34], to: [null, MED_ORDINAL], why: 'unteres Ende des zweiten Drittels -> mittel' },
+		{ from: [null, 66], to: [null, MED_ORDINAL], why: 'oberes Ende des zweiten Drittels -> mittel' },
+		{ from: [null, 67], to: [null, HIGH_ORDINAL], why: 'unteres Ende des dritten Drittels -> hoch' },
+		{ from: [null, 100], to: [null, HIGH_ORDINAL], why: 'Prozent-Maximum -> hoch (AC-3, Stufe "hoch" erstmals erreichbar)', word: 'hoch' },
 		{ from: [null, null], to: [null, null], why: 'beidseitig offen bleibt beidseitig offen' },
-		{ from: [50, null], to: [1, null], why: 'auch die Untergrenze wird umgerechnet' },
-		{ from: [0, 100], to: [0, 2], why: 'beide Grenzen unabhaengig voneinander' },
+		{ from: [50, null], to: [MED_ORDINAL, null], why: 'auch die Untergrenze wird umgerechnet' },
+		{ from: [0, 100], to: [0, HIGH_ORDINAL], why: 'beide Grenzen unabhaengig voneinander (AC-5)' },
 	];
 
 	for (const c of MIGRATION_CASES) {
@@ -588,6 +608,15 @@ describe('Scheibe B / AC-3: Alt-Korridore werden beim Laden umgeschluesselt und 
 				false,
 				'AC-3 FAIL: die Zeile traegt noch den alten Prozent-Schluessel'
 			);
+			// AC-1/AC-2: das ANGEZEIGTE Stufenwort pruefen, nicht nur den nackten
+			// Index — der Alt-Test blieb seit #1474 gruen, weil er nur Zahlen verglich.
+			if (c.word != null && c.to[1] != null) {
+				assert.equal(
+					row!.ordinalLabels?.[c.to[1] as number],
+					c.word,
+					`AC-1/AC-2 FAIL: angezeigtes Stufenwort fuer Index ${c.to[1]} ist nicht "${c.word}"`
+				);
+			}
 		});
 	}
 
@@ -626,7 +655,7 @@ describe('Scheibe B / AC-3: Alt-Korridore werden beim Laden umgeschluesselt und 
 		);
 		assert.equal(gewitter.length, 1, `AC-3 FAIL: ${gewitter.length} Gewitter-Eintraege gespeichert statt genau einem`);
 		assert.equal(gewitter[0].metric, 'thunder_level_max');
-		assert.deepEqual(gewitter[0].range, [null, 1]);
+		assert.deepEqual(gewitter[0].range, [null, MED_ORDINAL]);
 		assert.equal(gewitter[0].notify, true, 'notify/mark der Alt-Zeile muessen erhalten bleiben');
 		assert.equal(gewitter[0].mark, true);
 		// Die Nachbar-Zeile bleibt unberuehrt.
@@ -660,5 +689,66 @@ describe('Scheibe B / AC-3: Alt-Korridore werden beim Laden umgeschluesselt und 
 		const row = result.rows.find((r) => r.metric === 'wind_gust');
 		assert.ok(row);
 		assert.equal(row!.max, 40, 'die 40 km/h Boeen-Grenze darf nicht zu einer Stufe verrechnet werden');
+	});
+});
+
+// AC-6 Test B (Struktur, sekundaer zu Test A oben) — #2012, Spec Punkt 2:
+// percentBoundToOrdinal() darf die beiden migrierten Zielstufen NICHT als
+// rohe Zahlenliterale 2/3 zurueckgeben, sondern muss sie ueber die
+// bewachte kanonische Quelle ORDINAL_ENUM.indexOf('MED'|'HIGH') ableiten —
+// sonst bleibt die Funktion dem lokalen Kopie-Waechter
+// thunderScaleLocalCopyGuard.test.ts (#1480) unsichtbar (Zahlen statt
+// Stufen-Woerter, kein "thunder"/"gewitter" im Funktionsnamen).
+// Bauform: reiner Quelltext-Scan wie thunderScaleLocalCopyGuard.test.ts —
+// ergaenzt Test A (Verhalten), ersetzt ihn nicht.
+describe('AC-6 Test B: percentBoundToOrdinal() gibt keine rohen Zahlenliterale 2/3 zurueck', () => {
+	const CORRIDOR_STATE_PATH = resolve(dirname(fileURLToPath(import.meta.url)), '..', 'corridorEditorState.ts');
+
+	function extractFunctionBody(source: string, fnMarker: string): string {
+		const startIdx = source.indexOf(fnMarker);
+		assert.ok(startIdx >= 0, `AC-6 FAIL: "${fnMarker}" nicht in corridorEditorState.ts gefunden`);
+		const braceOpen = source.indexOf('{', startIdx);
+		let depth = 0;
+		let i = braceOpen;
+		for (; i < source.length; i++) {
+			if (source[i] === '{') depth++;
+			else if (source[i] === '}') {
+				depth--;
+				if (depth === 0) break;
+			}
+		}
+		return source.slice(braceOpen, i + 1);
+	}
+
+	test('Quelltext von percentBoundToOrdinal enthaelt keinen "return 2" / "return 3" Literal', () => {
+		const source = readFileSync(CORRIDOR_STATE_PATH, 'utf-8');
+		const body = extractFunctionBody(source, 'function percentBoundToOrdinal(');
+		const rawLiteralReturns = [...body.matchAll(/\breturn\s+(-?\d+(?:\.\d+)?)\b/g)].map((m) => m[1]);
+		assert.equal(
+			rawLiteralReturns.includes('2'),
+			false,
+			'AC-6 FAIL: percentBoundToOrdinal() gibt eine rohe "2" zurueck statt ' +
+				'ORDINAL_ENUM.indexOf(\'MED\') — die Migration haengt an einer unbewachten Zahl, ' +
+				'nicht an der kanonischen Skalen-Quelle'
+		);
+		assert.equal(
+			rawLiteralReturns.includes('3'),
+			false,
+			'AC-6 FAIL: percentBoundToOrdinal() gibt eine rohe "3" zurueck statt ' +
+				'ORDINAL_ENUM.indexOf(\'HIGH\') — die Migration haengt an einer unbewachten Zahl, ' +
+				'nicht an der kanonischen Skalen-Quelle'
+		);
+	});
+
+	test('Quelltext von percentBoundToOrdinal referenziert ORDINAL_ENUM.indexOf', () => {
+		const source = readFileSync(CORRIDOR_STATE_PATH, 'utf-8');
+		const body = extractFunctionBody(source, 'function percentBoundToOrdinal(');
+		assert.match(
+			body,
+			/ORDINAL_ENUM\.indexOf\(/,
+			'AC-6 FAIL: percentBoundToOrdinal() leitet die Zielstufen nicht ueber ' +
+				'ORDINAL_ENUM.indexOf(...) ab — die strukturelle Kopplung an die kanonische ' +
+				'Skalen-Quelle fehlt'
+		);
 	});
 });

--- a/frontend/src/lib/components/shared/corridor-editor/__tests__/routeCorridorPoolCatalogExpansion.test.ts
+++ b/frontend/src/lib/components/shared/corridor-editor/__tests__/routeCorridorPoolCatalogExpansion.test.ts
@@ -708,9 +708,22 @@ describe('AC-6 Test A-2: die Migration folgt einer VERSCHOBENEN ORDINAL_ENUM (Ko
 	const CORRIDOR_STATE_PATH = resolve(dirname(fileURLToPath(import.meta.url)), '..', 'corridorEditorState.ts');
 	const ENUM_LINE = "export const ORDINAL_ENUM = ['NONE', 'LOW', 'MED', 'HIGH'] as const;";
 	const SHIFTED_ENUM_LINE = "export const ORDINAL_ENUM = ['NONE', 'LOW', 'SEVERE', 'MED', 'HIGH'] as const;";
+	// F003 (Adversary Runde 2): die temporaere Modulkopie darf NICHT in
+	// corridor-editor/ selbst liegen -- genau diesen Ordner scannt
+	// thunderScaleLocalCopyGuard.test.ts unter Regel A/P/C als Produktivcode.
+	// Bricht dieser Testprozess vor dem `finally` hart ab (CI-Timeout,
+	// SIGKILL), bleibt die Kopie liegen und der Waechter meldet sie
+	// faelschlich als neuen lokalen ORDINAL_ENUM-Nachbau -- ein fälschlich
+	// blockierendes Gate fuer eine ANDERE Sitzung. Ablage daher im eigenen
+	// __tests__-Verzeichnis: istTestdatei() in thunderScaleLocalCopyGuard
+	// schliesst jeden Pfad mit "__tests__" von der A/P/C-Scanflaeche aus
+	// (nur Regel D laeuft dort, und die verlangt eine Paritaets-BEHAUPTUNG im
+	// Kommentar, die diese Datei nicht traegt). corridorEditorState.ts
+	// importiert ausschliesslich ueber die $lib/*-Aliasse (global per
+	// test-lib-loader.mjs aufgeloest, nicht relativ zum Dateiort) -- die
+	// Ablage im __tests__-Ordner aendert an der Aufloesbarkeit nichts.
 	const TMP_PATH = resolve(
 		dirname(fileURLToPath(import.meta.url)),
-		'..',
 		`corridorEditorState.__tmp_ac6_shifted_${process.pid}.ts`
 	);
 
@@ -757,71 +770,12 @@ describe('AC-6 Test A-2: die Migration folgt einer VERSCHOBENEN ORDINAL_ENUM (Ko
 	});
 });
 
-// AC-6 Test B (Struktur, sekundaer zu Test A/A-2 oben) — #2012, Spec Punkt 2:
-// percentBoundToOrdinal() darf die beiden migrierten Zielstufen NICHT als
-// rohe Zahlenliterale 2/3 zurueckgeben, sondern muss sie ueber die
-// bewachte kanonische Quelle ORDINAL_ENUM.indexOf('MED'|'HIGH') ableiten —
-// sonst bleibt die Funktion dem lokalen Kopie-Waechter
-// thunderScaleLocalCopyGuard.test.ts (#1480) unsichtbar (Zahlen statt
-// Stufen-Woerter, kein "thunder"/"gewitter" im Funktionsnamen).
-// Bauform: reiner Quelltext-Scan wie thunderScaleLocalCopyGuard.test.ts —
-// ergaenzt Test A (Verhalten), ersetzt ihn nicht.
-describe('AC-6 Test B: percentBoundToOrdinal() gibt keine rohen Zahlenliterale 2/3 zurueck', () => {
-	const CORRIDOR_STATE_PATH = resolve(dirname(fileURLToPath(import.meta.url)), '..', 'corridorEditorState.ts');
-
-	function extractFunctionBody(source: string, fnMarker: string): string {
-		const startIdx = source.indexOf(fnMarker);
-		assert.ok(startIdx >= 0, `AC-6 FAIL: "${fnMarker}" nicht in corridorEditorState.ts gefunden`);
-		const braceOpen = source.indexOf('{', startIdx);
-		let depth = 0;
-		let i = braceOpen;
-		for (; i < source.length; i++) {
-			if (source[i] === '{') depth++;
-			else if (source[i] === '}') {
-				depth--;
-				if (depth === 0) break;
-			}
-		}
-		return source.slice(braceOpen, i + 1);
-	}
-
-	// F001-Fix (Adversary): die alte Pruefung war zweigeteilt und GLOBAL ueber
-	// den ganzen Funktionskoerper — "kein nacktes Zahlenliteral irgendwo" UND
-	// "ORDINAL_ENUM.indexOf( kommt irgendwo vor" bestehen beide weiter, wenn
-	// NUR der MED-Zweig auf einen Ausdruck wie `(1 + 1)` verfaelscht wird
-	// (kein nacktes Literal, und der HIGH-Zweig liefert weiterhin ein
-	// "indexOf("-Vorkommen). Diese Fassung zerlegt die Funktion in ihre
-	// einzelnen return-Anweisungen und verlangt PRO ZWEIG exakt
-	// `ORDINAL_ENUM.indexOf('<STUFE>')` — kein Ausdruck, kein Zahlenliteral,
-	// keine andere Stufe.
-	test('jeder return-Zweig ist EXAKT ORDINAL_ENUM.indexOf(<eigene Stufe>) — kein Ausdruck, kein Zahlenliteral', () => {
-		const source = readFileSync(CORRIDOR_STATE_PATH, 'utf-8');
-		const body = extractFunctionBody(source, 'function percentBoundToOrdinal(');
-		const returns = [...body.matchAll(/return\s+([^;]+);/g)].map((m) => m[1].trim());
-		assert.equal(
-			returns.length,
-			4,
-			'Testannahme verletzt: percentBoundToOrdinal() hat nicht mehr genau 4 return-Anweisungen ' +
-				'(null-Guard + 3 Stufen-Zweige) — Test an die neue Struktur anpassen'
-		);
-		const [nullReturn, noneReturn, medReturn, highReturn] = returns;
-		assert.equal(nullReturn, 'null', 'AC-6 FAIL: der null-Guard gibt nicht mehr "null" zurueck');
-		assert.equal(
-			noneReturn,
-			"ORDINAL_ENUM.indexOf('NONE')",
-			'AC-6 FAIL: der NONE-Zweig ist kein reiner ORDINAL_ENUM.indexOf(\'NONE\')-Aufruf'
-		);
-		assert.equal(
-			medReturn,
-			"ORDINAL_ENUM.indexOf('MED')",
-			'AC-6 FAIL: der MED-Zweig ist kein reiner ORDINAL_ENUM.indexOf(\'MED\')-Aufruf — ein ' +
-				'wertgleicher Ausdruck wie "(1 + 1)" faellt hier durch, obwohl er nicht an die ' +
-				'kanonische Skalen-Quelle gekoppelt ist'
-		);
-		assert.equal(
-			highReturn,
-			"ORDINAL_ENUM.indexOf('HIGH')",
-			'AC-6 FAIL: der HIGH-Zweig ist kein reiner ORDINAL_ENUM.indexOf(\'HIGH\')-Aufruf'
-		);
-	});
-});
+// AC-6 Test B (reiner Quelltext-Scan auf percentBoundToOrdinal()) ist mit
+// #2012-Adversary-Runde-2/F002 ersatzlos entfernt: sechs Mutationen fanden
+// keinen Fall, den Test B fing und Test A-2 oben (Verhaltensprüfung gegen
+// eine VERSCHOBENE ORDINAL_ENUM) nicht auch fing — Test B blockierte
+// zugleich korrekten, aequivalenten Code (z. B. eine ausgelagerte Konstante
+// `const MED_STAGE = ORDINAL_ENUM.indexOf('MED'); return MED_STAGE;`) als
+// Falsch-Positiv. Test A-2 traegt die Zusicherung jetzt allein — Nachweis
+// (3 Mutationen, alle von Test A-2 gefangen) in
+// docs/specs/modules/fix_2012_gewitter_stufen_migration.md, AC-6.

--- a/frontend/src/lib/components/shared/corridor-editor/__tests__/routeCorridorPoolCatalogExpansion.test.ts
+++ b/frontend/src/lib/components/shared/corridor-editor/__tests__/routeCorridorPoolCatalogExpansion.test.ts
@@ -19,8 +19,8 @@
 import { test, describe } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
+import { readFileSync, writeFileSync, rmSync } from 'node:fs';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { dirname, resolve } from 'node:path';
 
 import {
@@ -692,7 +692,72 @@ describe('Scheibe B / AC-3: Alt-Korridore werden beim Laden umgeschluesselt und 
 	});
 });
 
-// AC-6 Test B (Struktur, sekundaer zu Test A oben) — #2012, Spec Punkt 2:
+// AC-6 Test A-2 (F001-Fix, Adversary-Mutation): Test A oben vergleicht das
+// Migrationsergebnis gegen MED_ORDINAL/HIGH_ORDINAL — beides Werte, die die
+// Testdatei SELBST per ORDINAL_ENUM.indexOf(...) berechnet und die mit dem
+// heutigen Stand ['NONE','LOW','MED','HIGH'] zufaellig mit den Zahlenliteralen
+// 2/3 uebereinstimmen. Ein Produktivcode, der `return (1 + 1);` /
+// `return (1 + 2);` statt `ORDINAL_ENUM.indexOf('MED'|'HIGH')` zurueckgibt,
+// bleibt fuer Test A unsichtbar, weil BEIDE Seiten denselben Zahlenwert
+// liefern. Dieser Test verschiebt die kanonische Skala selbst (eine
+// eingeschobene Zwischenstufe VOR 'MED' verschiebt MED UND HIGH je um +1
+// Index) und importiert eine Kopie des Moduls mit der verschobenen Skala
+// dynamisch — nur eine echte `ORDINAL_ENUM.indexOf(...)`-Kopplung liefert
+// dann noch die richtigen, neuen Indizes.
+describe('AC-6 Test A-2: die Migration folgt einer VERSCHOBENEN ORDINAL_ENUM (Kopplungsnachweis)', () => {
+	const CORRIDOR_STATE_PATH = resolve(dirname(fileURLToPath(import.meta.url)), '..', 'corridorEditorState.ts');
+	const ENUM_LINE = "export const ORDINAL_ENUM = ['NONE', 'LOW', 'MED', 'HIGH'] as const;";
+	const SHIFTED_ENUM_LINE = "export const ORDINAL_ENUM = ['NONE', 'LOW', 'SEVERE', 'MED', 'HIGH'] as const;";
+	const TMP_PATH = resolve(
+		dirname(fileURLToPath(import.meta.url)),
+		'..',
+		`corridorEditorState.__tmp_ac6_shifted_${process.pid}.ts`
+	);
+
+	test('eine vor "MED" eingeschobene Stufe verschiebt MED (2->3) UND HIGH (3->4) — die Migration muss folgen', async () => {
+		const original = readFileSync(CORRIDOR_STATE_PATH, 'utf-8');
+		assert.ok(
+			original.includes(ENUM_LINE),
+			'Testannahme verletzt: ORDINAL_ENUM-Deklaration in corridorEditorState.ts hat sich veraendert — Test anpassen'
+		);
+		const shiftedSource = original.replace(ENUM_LINE, SHIFTED_ENUM_LINE);
+		writeFileSync(TMP_PATH, shiftedSource, 'utf-8');
+		try {
+			const mod: typeof import('../corridorEditorState.ts') = await import(pathToFileURL(TMP_PATH).href);
+			const shiftedMed = mod.ORDINAL_ENUM.indexOf('MED' as never);
+			const shiftedHigh = mod.ORDINAL_ENUM.indexOf('HIGH' as never);
+			assert.equal(shiftedMed, 3, 'Testannahme verletzt: MED verschiebt sich nicht wie erwartet von 2 auf 3');
+			assert.equal(shiftedHigh, 4, 'Testannahme verletzt: HIGH verschiebt sich nicht wie erwartet von 3 auf 4');
+
+			const extraDefs = await routeExtraDefs();
+			const rowMed = mod
+				.buildRoutePool([{ metric: 'thunder_level', range: [null, 40], notify: true, mark: true }], undefined, extraDefs)
+				.rows.find((r) => r.metric === 'thunder_level_max');
+			assert.ok(rowMed, 'AC-6 FAIL: die migrierte Zeile fehlt in der verschobenen Skala (MED-Fall)');
+			assert.equal(
+				rowMed!.max,
+				shiftedMed,
+				'AC-6 FAIL: "bis 40%" migriert nicht auf den NEUEN Index von MED (3) — die Migration ' +
+					'haengt an einer festen Zahl statt an ORDINAL_ENUM.indexOf(\'MED\')'
+			);
+
+			const rowHigh = mod
+				.buildRoutePool([{ metric: 'thunder_level', range: [null, 100], notify: true, mark: true }], undefined, extraDefs)
+				.rows.find((r) => r.metric === 'thunder_level_max');
+			assert.ok(rowHigh, 'AC-6 FAIL: die migrierte Zeile fehlt in der verschobenen Skala (HIGH-Fall)');
+			assert.equal(
+				rowHigh!.max,
+				shiftedHigh,
+				'AC-6 FAIL: "bis 100%" migriert nicht auf den NEUEN Index von HIGH (4) — die Migration ' +
+					'haengt an einer festen Zahl statt an ORDINAL_ENUM.indexOf(\'HIGH\')'
+			);
+		} finally {
+			rmSync(TMP_PATH, { force: true });
+		}
+	});
+});
+
+// AC-6 Test B (Struktur, sekundaer zu Test A/A-2 oben) — #2012, Spec Punkt 2:
 // percentBoundToOrdinal() darf die beiden migrierten Zielstufen NICHT als
 // rohe Zahlenliterale 2/3 zurueckgeben, sondern muss sie ueber die
 // bewachte kanonische Quelle ORDINAL_ENUM.indexOf('MED'|'HIGH') ableiten —
@@ -720,35 +785,43 @@ describe('AC-6 Test B: percentBoundToOrdinal() gibt keine rohen Zahlenliterale 2
 		return source.slice(braceOpen, i + 1);
 	}
 
-	test('Quelltext von percentBoundToOrdinal enthaelt keinen "return 2" / "return 3" Literal', () => {
+	// F001-Fix (Adversary): die alte Pruefung war zweigeteilt und GLOBAL ueber
+	// den ganzen Funktionskoerper — "kein nacktes Zahlenliteral irgendwo" UND
+	// "ORDINAL_ENUM.indexOf( kommt irgendwo vor" bestehen beide weiter, wenn
+	// NUR der MED-Zweig auf einen Ausdruck wie `(1 + 1)` verfaelscht wird
+	// (kein nacktes Literal, und der HIGH-Zweig liefert weiterhin ein
+	// "indexOf("-Vorkommen). Diese Fassung zerlegt die Funktion in ihre
+	// einzelnen return-Anweisungen und verlangt PRO ZWEIG exakt
+	// `ORDINAL_ENUM.indexOf('<STUFE>')` — kein Ausdruck, kein Zahlenliteral,
+	// keine andere Stufe.
+	test('jeder return-Zweig ist EXAKT ORDINAL_ENUM.indexOf(<eigene Stufe>) — kein Ausdruck, kein Zahlenliteral', () => {
 		const source = readFileSync(CORRIDOR_STATE_PATH, 'utf-8');
 		const body = extractFunctionBody(source, 'function percentBoundToOrdinal(');
-		const rawLiteralReturns = [...body.matchAll(/\breturn\s+(-?\d+(?:\.\d+)?)\b/g)].map((m) => m[1]);
+		const returns = [...body.matchAll(/return\s+([^;]+);/g)].map((m) => m[1].trim());
 		assert.equal(
-			rawLiteralReturns.includes('2'),
-			false,
-			'AC-6 FAIL: percentBoundToOrdinal() gibt eine rohe "2" zurueck statt ' +
-				'ORDINAL_ENUM.indexOf(\'MED\') — die Migration haengt an einer unbewachten Zahl, ' +
-				'nicht an der kanonischen Skalen-Quelle'
+			returns.length,
+			4,
+			'Testannahme verletzt: percentBoundToOrdinal() hat nicht mehr genau 4 return-Anweisungen ' +
+				'(null-Guard + 3 Stufen-Zweige) — Test an die neue Struktur anpassen'
+		);
+		const [nullReturn, noneReturn, medReturn, highReturn] = returns;
+		assert.equal(nullReturn, 'null', 'AC-6 FAIL: der null-Guard gibt nicht mehr "null" zurueck');
+		assert.equal(
+			noneReturn,
+			"ORDINAL_ENUM.indexOf('NONE')",
+			'AC-6 FAIL: der NONE-Zweig ist kein reiner ORDINAL_ENUM.indexOf(\'NONE\')-Aufruf'
 		);
 		assert.equal(
-			rawLiteralReturns.includes('3'),
-			false,
-			'AC-6 FAIL: percentBoundToOrdinal() gibt eine rohe "3" zurueck statt ' +
-				'ORDINAL_ENUM.indexOf(\'HIGH\') — die Migration haengt an einer unbewachten Zahl, ' +
-				'nicht an der kanonischen Skalen-Quelle'
+			medReturn,
+			"ORDINAL_ENUM.indexOf('MED')",
+			'AC-6 FAIL: der MED-Zweig ist kein reiner ORDINAL_ENUM.indexOf(\'MED\')-Aufruf — ein ' +
+				'wertgleicher Ausdruck wie "(1 + 1)" faellt hier durch, obwohl er nicht an die ' +
+				'kanonische Skalen-Quelle gekoppelt ist'
 		);
-	});
-
-	test('Quelltext von percentBoundToOrdinal referenziert ORDINAL_ENUM.indexOf', () => {
-		const source = readFileSync(CORRIDOR_STATE_PATH, 'utf-8');
-		const body = extractFunctionBody(source, 'function percentBoundToOrdinal(');
-		assert.match(
-			body,
-			/ORDINAL_ENUM\.indexOf\(/,
-			'AC-6 FAIL: percentBoundToOrdinal() leitet die Zielstufen nicht ueber ' +
-				'ORDINAL_ENUM.indexOf(...) ab — die strukturelle Kopplung an die kanonische ' +
-				'Skalen-Quelle fehlt'
+		assert.equal(
+			highReturn,
+			"ORDINAL_ENUM.indexOf('HIGH')",
+			'AC-6 FAIL: der HIGH-Zweig ist kein reiner ORDINAL_ENUM.indexOf(\'HIGH\')-Aufruf'
 		);
 	});
 });

--- a/frontend/src/lib/components/shared/corridor-editor/corridorEditorState.ts
+++ b/frontend/src/lib/components/shared/corridor-editor/corridorEditorState.ts
@@ -10,7 +10,7 @@
 //
 // Issue #1425 (S2 Teil 2, Scheibe B): Gewitter ist aus dieser Liste ausgezogen
 // (5 statt 6 fest verdrahtete Groessen) — es kommt jetzt ordinal aus dem
-// zentralen Katalog (`thunder_level_max`, kein/mittel/hoch). Spec:
+// zentralen Katalog (`thunder_level_max`, kein/leicht/mittel/hoch). Spec:
 // docs/specs/modules/fix_1425_s2b_gewitter_skala.md.
 //
 // AC-3: confidence_pct (selectable=false) darf hier nie auftauchen — trivial
@@ -117,19 +117,22 @@ export const ROUTE_CORRIDOR_CATALOG_IDS: Record<string, string[]> = Object.fromE
 );
 
 /**
- * Issue #1425 (S2 Teil 2, Scheibe B): eine Grenze des alten Prozent-Gewitter-
- * Korridors auf die Ordinalskala umrechnen. Beide Grenzen unabhaengig
- * voneinander (Spec § Implementation Details Punkt 3):
- *   null -> null · 0|1|2 -> unveraendert (schon ordinal) ·
- *   >2 als Prozent gedeutet: 0-33 -> 0 (kein), 34-66 -> 1 (mittel),
- *   67-100 -> 2 (hoch).
+ * Issue #1425 (S2 Teil 2, Scheibe B), korrigiert durch #2012: eine Grenze
+ * des alten Prozent-Gewitter-Korridors auf die Ordinalskala umrechnen. Beide
+ * Grenzen unabhaengig voneinander (Spec § Implementation Details Punkt 1).
+ * Jede Zahl wird als Prozent gedeutet — der alte "schon ordinal"-Sonderzweig
+ * (`v === 0 || v === 1 || v === 2`) entfaellt, weil der Alt-Schluessel
+ * `thunder_level` ausschliesslich Prozentwerte trug (Spec Punkt 3):
+ *   null -> null · 0-33 -> ORDINAL_ENUM.indexOf('NONE') (kein) ·
+ *   34-66 -> ORDINAL_ENUM.indexOf('MED') (mittel) ·
+ *   67-100 -> ORDINAL_ENUM.indexOf('HIGH') (hoch).
+ * Stufe "leicht" ist ueber die Migration nie erreichbar (Spec Punkt 4).
  */
 function percentBoundToOrdinal(v: number | null): number | null {
 	if (v == null) return null;
-	if (v === 0 || v === 1 || v === 2) return v;
-	if (v <= 33) return 0;
-	if (v <= 66) return 1;
-	return 2;
+	if (v <= 33) return ORDINAL_ENUM.indexOf('NONE');
+	if (v <= 66) return ORDINAL_ENUM.indexOf('MED');
+	return ORDINAL_ENUM.indexOf('HIGH');
 }
 
 /**

--- a/tests/tdd/test_alert_metric_mapping_parity.py
+++ b/tests/tdd/test_alert_metric_mapping_parity.py
@@ -132,9 +132,9 @@ _FE_BRIDGE_EXCEPTIONS = {"temperature_cold"}
 #
 # Fuer Gewitter laufen die beiden Bruecken ab dieser Scheibe bewusst
 # auseinander. Die Wertebereiche-Zeile zieht auf den ordinalen Katalog-Eintrag
-# `thunder_level_max` (kein/mittel/hoch) um — ein Prozent-Bereich 0-100 gegen
-# einen Ordinal-Stundenwert 0/1/2 markierte vorher gerade DANN, wenn Gewitter
-# herrschte (Umkehrung). Die Alarm-Empfindlichkeit bleibt unveraendert unter
+# `thunder_level_max` (kein/leicht/mittel/hoch) um — ein Prozent-Bereich 0-100
+# gegen einen Ordinal-Stundenwert 0/1/2/3 markierte vorher gerade DANN, wenn
+# Gewitter herrschte (Umkehrung). Die Alarm-Empfindlichkeit bleibt unveraendert unter
 # `thunder_level` in `metric_alert_levels` — einer seit #1371 von
 # `trip.corridors[]` vollstaendig entkoppelten Persistenz.
 #


### PR DESCRIPTION
Behebt #2012.

## Problem

`percentBoundToOrdinal()` rechnet gespeicherte Gewitter-Wertebereiche vom Alt-Schluessel
`thunder_level` (Prozent-Epoche, bis 2026-07-30) auf die Ordinalskala von `thunder_level_max` um.
Die Funktion stammt aus der 3-Stufen-Welt und bildet auf 0/1/2 ab — seit #1474 hat die Skala vier
Stufen (kein/leicht/mittel/hoch). Folge: Bestandswerte erscheinen eine Stufe zu niedrig, Stufe
"hoch" ist ueber diesen Pfad unerreichbar.

Zusaetzlich deutete der Zweig `v === 0 || v === 1 || v === 2` ("schon ordinal") kleine
Prozentwerte faelschlich als Stufennummern — die Funktion laeuft aber ausschliesslich auf
`thunder_level`-Zeilen, und dieser Schluessel trug per Definition immer Prozent
(belegt am Git-Stand `7c42db9f^`).

**Wirkung reicht ueber die Anzeige hinaus:** der migrierte Wert wird serverseitig als
Alarm-/Markier-Schwelle gelesen (`corridor_threshold.py:96-104`, `corridor_mark.py:49-57`).
Reines Oeffnen zeigt falsch an — sobald im Tab etwas geaendert und gespeichert wird, ist die
verschobene Schwelle wirksam.

## Aenderung

| Prozent | bedeutete damals | neue Zielstufe |
|---|---|---|
| `null` | offen | `null` |
| 0-33 | kein | kein |
| 34-66 | mittel | **mittel** (vorher: leicht) |
| 67-100 | hoch | **hoch** (vorher: mittel) |

Die Zielstufen werden ueber `ORDINAL_ENUM.indexOf('NONE'|'MED'|'HIGH')` abgeleitet statt als
Zahlenliterale geschrieben — `percentBoundToOrdinal` war die einzige Stelle im Frontend, die die
Gewitterskala hart mit Zahlen ausdrueckte, ausserhalb jeder Ableitungskette und ausserhalb der
Reichweite von `thunderScaleLocalCopyGuard`. Genau deshalb ist #1474 an ihr vorbeigegangen.

## Datenlage (Produktivbestand, 2026-08-21)

170 JSON-Dateien unter `/var/lib/gregor/users` gescannt: **genau eine** `thunder_level`-Zeile
(`[null, 1]` = 1 Prozent, Trip-Stand 2026-07-16) — wird kuenftig "bis kein" statt "bis leicht".
Alle uebrigen Gewitter-Zeilen tragen bereits `thunder_level_max`. Kein Code-Pfad erzeugt noch
Prozent-Werte (Frontend/Go/Python geprueft), die Menge kann nicht mehr wachsen.

## Nachweis

- Feature-Tests 161 gruen · vollstaendige Frontend-Suite 2752 gruen, 0 rot
- Adversary: 3 Runden, 15 Mutationen. Runde 1 fand F001 (Struktur-Test liess
  `return (1 + 1);` durch) → behoben durch einen Verhaltenstest, der `ORDINAL_ENUM` im Testlauf
  tatsaechlich verschiebt. Runde 2: VERIFIED.
- F002 (Falsch-Positiv des Quelltext-Scans) und F003 (Temp-Datei in der Waechter-Scanflaeche)
  bereinigt; dass der Waechter im simulierten Absturzfall gruen bleibt, ist nachgewiesen.
- svelte-check: 14 Bestandsfehler, Baseline 36 — keine Verschlechterung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DuF4pfYEzKQSKCxS3DHfZ4