### PR TITLE
fix(#2036): gemessene Kilometer statt Segmentnummer in der Alarm-Ortsangabe

### DIFF
--- a/docs/context/fix-2036-alarm-kilometer.md
+++ b/docs/context/fix-2036-alarm-kilometer.md
@@ -1,0 +1,191 @@
+# Kontext: #2036 — Alarm-Kurzform nennt Kilometer statt Segmentnummer
+
+Workflow: `fix-2036-alarm-kilometer` · Branch `fix-2036-alarm-kilometer` · Issue #2036
+Termin: Tour startet **2026-08-23**.
+
+## Symptom
+
+Alarm-Kurzmeldungen an Telegram-Kurzform, SMS und Premium-SMS tragen als Ortsangabe eine
+Segmentnummer:
+
+```
+Ziel: G56->78@16 TH:-->H
+Seg 3: R@11:30
+Seg 4: G31->70@13 VS4400->540
+```
+
+Auf einem Garmin inReach ist nicht erkennbar, wo Segmentgrenzen liegen. Die Meldung ist damit
+nicht verortbar.
+
+## Analysis
+
+### Type
+
+Bug (nutzersichtbares Fehlverhalten), mit einem Datenmangel als Ursache.
+
+### Ursache in zwei Schichten
+
+**Schicht 1 — die Anzeige bevorzugt die Segmentnummer.**
+`src/output/renderers/alert/segments.py:91-111` `format_alert_location()` löst in der
+Reihenfolge `location_label` → `Segment N` → `km A–B` auf. Kilometer liegen jedem Alarm
+bereits bei (`AlertEvent.km_from/km_to`, `src/output/renderers/alert/model.py:11-32`), sind
+aber nur letzte Rückfallstufe. Die Umstellung allein wäre trivial.
+
+**Schicht 2 — die vorhandenen Kilometer sind unbrauchbar.**
+`src/services/trip_segments.py:225` rechnet `haversine_km()` zwischen aufeinanderfolgenden
+Wegpunkten: **Luftlinie**, nicht Wegstrecke.
+
+Messung an 13 realen Etappen (Luftlinie gegen echte GPX-Trackdistanz):
+
+| | Luftlinie | Wegstrecke | Faktor |
+|---|---|---|---|
+| Etappe 06 | 11,6 km | 18,6 km | 1,59 |
+| Etappe 02 | 7,6 km | 11,6 km | 1,53 |
+| Etappe 01 | 7,2 km | 8,7 km | 1,22 |
+
+Spanne 1,17–1,59 — kein pauschaler Korrekturfaktor möglich. Eine km-Angabe aus Luftlinie wäre
+glaubwürdig aussehender Unsinn und damit **schlechter** als die heutige Segmentnummer.
+
+### Schlüsselbefund: die richtige Zahl entsteht bereits und wird verworfen
+
+Die Wegpunkte eines importierten Trips sind keine genäherten Punkte, sondern **exakt
+Original-Trackpunkte** (gemessener Projektionsabstand **0,0 m**). Grund:
+`src/core/segment_builder.py:118` setzt `start_point=points[seg_start_idx]` — das
+Original-`GPXPoint` samt korrektem `distance_from_start_km` aus `src/core/gpx_parser.py:155`.
+
+`src/services/gpx_processing.py:105-165` `segments_to_trip()` baut daraus Wegpunkte mit nur
+`lat/lon/elevation_m/time_window` — **die Distanz wird 40 Zeilen nach ihrer Berechnung
+weggeworfen.** Es braucht keine Projektion und keinen gespeicherten Track, nur ein Feld mehr.
+
+Verworfen: Track ausdünnen und speichern (Längenverlust −3,6 % bei jedem 2. Punkt bis −28 %
+bei jedem 8. — Serpentinen); `weather_snapshot` als Quelle (spiegelt nur die Luftlinie zurück,
+`src/services/weather_snapshot.py:457-462`).
+
+### Warum ein Re-Import keine Option ist
+
+Für eine **bestehende** Etappe existiert kein Re-Import-Weg. Im Bearbeiten-Modus hängt ein
+Upload eine **zusätzliche** Etappe an (`frontend/src/lib/components/edit/EditRouteSection.svelte:78-89`,
+reines `push`, Datum aus „letzte Etappe + 1"). Go ersetzt danach das Stages-Array blind
+(`internal/handler/trip.go:288-291`). Wer den alten Stand loswerden will, muss löschen — und
+verliert dabei nachweislich: Wegpunkt-Namen (`gpx_processing.py:130-135` überschreibt mit
+`Start`/`Seg N Start`/`Ziel`), `time_window` (`:137-140`), `arrival_override` und
+`arrival_calculated` (fehlen im Rückgabe-Dict `:223-232`), `confirmed`
+(`src/services/route_analyzer.py:43` setzt hart `False`), manuell ergänzte Wegpunkte,
+Wegpunkt-IDs, Etappenname, Etappendatum, Etappen-`id`, `start_time`.
+
+⇒ Eine Lösung, die nur beim Import füllt, ist für jeden Bestandstrip wirkungslos.
+
+### Nachrüstung ohne Re-Import ist machbar
+
+Hochgeladene GPX-Dateien bleiben dauerhaft unter `data/users/<user_id>/gpx/` liegen
+(`api/routers/gpx.py:40`), werden nie aufgeräumt (`DeleteTrip` rührt sie nicht an). Eine
+persistierte Zuordnung Datei↔Trip gibt es **nicht**.
+
+Die Zuordnung lässt sich geometrisch herstellen: der passende Track enthält **alle** Wegpunkte
+einer Etappe exakt. Gemessen: richtige Datei worst-case **0,0 m**, jede falsche Datei
+**≥ 4.672 m** — drei Größenordnungen Trennschärfe. Kosten: ~10 ms Parse je Datei, ~37 ms für
+einen kompletten Etappensatz.
+
+Grenzen (jeweils fail-safe, nie falsche Zahlen):
+- Von Hand ergänzte Wegpunkte liegen nicht auf dem Track
+  (`frontend/src/lib/utils/waypointEditor.ts:70-74` interpoliert linear;
+  `EditStagesPanelNew.svelte:610-620` setzt beliebige Kartenpunkte) ⇒ keine Zuordnung.
+- Mehrdeutigkeit möglich, wenn zusätzlich eine Gesamt-GPX über alle Etappen hochgeladen wurde
+  (dieselben Punkte, andere km) ⇒ bei mehr als einem Treffer nicht raten.
+- Gleichnamige Uploads überschreiben sich stumm (`gpx_processing.py:66-69`).
+
+### Auflösungsreihenfolge (Ergebnis der Analyse)
+
+1. Wegpunkt trägt eine gemessene Wegstrecke → nutzen
+2. sonst: eindeutig passenden Track im GPX-Bestand suchen → nutzen und einmalig
+   zurückschreiben (Read-Modify-Write, additiv)
+3. sonst: Etappe gilt als **unvermessen** → Ortsangabe bleibt `Segment N` (heutiges Verhalten)
+
+Kilometer zählen **je Etappe ab 0** (PO-Vorgabe). Das Ziel-Segment behält `🏁 Ziel`
+(`trip_segments.py:312-325` setzt dort `km_from == km_to`; „km 20–20" wäre eine
+Verschlechterung).
+
+### Echtheits-Kennzeichnung ist zwingend
+
+`GPXPoint.distance_from_start_km` (`src/app/models.py:369`) hat Default `0.0` — „nicht
+gesetzt" und „Kilometer 0" sind heute ununterscheidbar. Nötig:
+- `Waypoint.distance_from_start_km: Optional[float] = None` (`None` = unbekannt)
+- `TripSegment.distance_measured: bool = False`, durchgereicht über `weather_snapshot`
+  (`:457-462`, `:521-535`) und die vier Event-Typen als `km_measured: bool = False`
+
+Default-`False` ist zugleich der Terminschutz: alle Bestandstests bleiben unverändert grün,
+weil keiner gemessene Daten baut.
+
+### Affected Files
+
+| Datei | Art | LoC | Anmerkung |
+|---|---|---|---|
+| `src/services/gpx_processing.py` | MODIFY | 8 | echte km je Waypoint durchreichen |
+| `src/app/trip.py` | MODIFY | 3 | **schema-relevant** |
+| `src/app/loader.py` | MODIFY | 4 | **schema-relevant**, lesen + schreiben |
+| `internal/model/trip.go` | MODIFY | 3 | **schema-relevant** — ohne dies wischt jedes `SaveTrip` den Wert (vgl. `suggestion_reason`, existiert in Python, fehlt in Go, wird stumm verworfen) |
+| `src/app/models.py` | MODIFY | 3 | **schema-relevant** |
+| `src/services/trip_segments.py` | MODIFY | 30 | km aus Wegpunkten statt Luftlinie, Normierung auf 0 je Etappe, Plausibilitätsprüfung |
+| *(neu)* Track-Auflösung | CREATE | ~60 | Zuordnung + Rückschreiben |
+| `src/services/weather_snapshot.py` | MODIFY | 4 | Flag mitschreiben/-lesen |
+| `src/output/renderers/alert/model.py` | MODIFY | 5 | `km_measured` an vier Event-Typen |
+| `src/output/renderers/alert/project.py` | MODIFY | 6 | Flag durchreichen |
+| `src/services/trip_alert.py` | MODIFY | 12 | Flag + `segment_km`-Karte für amtliche Warnungen |
+| `src/output/renderers/alert/segments.py` | MODIFY | 14 | neue Reihenfolge |
+| `src/output/renderers/alert/render.py` | MODIFY | 12 | Flag weiterreichen; `km{a}-{b}` → `km {a}–{b}` (`:998-1008`) |
+| `src/output/renderers/alert/official_alerts.py` | MODIFY | 20 | additiver Parameter `segment_km` |
+
+Produktion ~184 LoC, Tests ~130 ⇒ **LoC-Override auf 500 nötig** (Limit 250).
+
+### Plausibilitätsprüfung (fängt Nachbearbeitung ab)
+
+In `convert_trip_to_segments`: gemessene Spanne zweier Wegpunkte muss streng monoton steigen
+**und** ≥ der Luftlinie zwischen ihnen sein (ein Track kann nie kürzer als die Gerade sein).
+Verletzt eine Etappe das, gilt sie als unvermessen. Fängt Einfügen, Umsortieren und
+Koordinaten-Edits strukturell ab, ohne Write-Seam-Logik in Go.
+
+### Unteilbar — kein Aufteilen auf zwei Scheiben
+
+`tests/tdd/test_alert_location_vocabulary.py:296-298` verlangt **Gleichheit** der Ortsangabe
+von Nowcast, Abweichungsalarm und amtlicher Warnung (Teilungs-Invariante aus #1744);
+`:514/525-533` dieselbe Auflösung in Betreff und SMS. Der amtliche Pfad kann also nicht
+später folgen. Ein Deploy ohne `internal/model/trip.go` verlöre die Werte beim ersten Save.
+
+### Bestehende Tests, die `Segment N`/`Seg N` prüfen (müssen grün bleiben)
+
+`tests/tdd/test_alert_location_vocabulary.py` (zentraler Ratschen-Test) ·
+`tests/tdd/test_alert_sms_segment_head.py:177` · `tests/tdd/test_alert_segment_reference.py` ·
+`tests/tdd/test_official_alert_sms_ortskopf.py:94` ·
+`tests/tdd/test_official_alert_template_render.py` ·
+`tests/unit/test_official_alert_output_unchanged.py` + Snapshot
+`tests/fixtures/official_alert_render_snapshot_1944.json:6` ·
+`tests/tdd/test_feature_574_segment_km_header.py` · `tests/tdd/test_952_onset_alert_fidelity.py` ·
+`tests/tdd/test_onset_shift_alert.py` · `tests/tdd/test_alert_addendum_sms.py` ·
+`tests/tdd/test_radar_alert_telegram_style.py`
+
+### Risk Level
+
+MEDIUM — additiv und default-aus, aber schema-relevant in zwei Sprachen.
+
+Bekannte Risiken:
+1. Go-Modell vergessen ⇒ erster Editor-Save wischt alle km. Muss im selben Deploy raus.
+2. `loader.py:130` ersetzt Listen wholesale ⇒ Telegram-Kommandos
+   (`trip_command_processor.py:1245`) würden km löschen. Gleiche Kopplung.
+3. Briefing-Segmentkopf (Feature #574) zeigt heute dieselben falschen Luftlinien-km und wird
+   durch dieselbe Änderung richtig — sichtbare Änderung, gewollt.
+4. Ohne auffindbaren Track bleibt alles wie heute. Das ist die Fallback-Garantie, kein Bug.
+
+### Nicht Teil dieses Tickets
+
+- **Naismith rechnet weiter auf Luftlinie** (`src/core/naismith.py:119`,
+  `internal/model/naismith.go:118`) ⇒ Ankunftszeiten sind um denselben Faktor zu früh.
+  Nutzersichtbar, eigenes Issue.
+- `official_alerts.py:2137-2147` `_trip_total_segment_ids()` zählt über alle Etappen, während
+  Segmentnummern je Etappe vergeben werden ⇒ „gesamte Route"-Verdichtung greift bei
+  mehrtägigen Touren nie. Vorbestehender Nebenbefund → #1199.
+
+### Open Questions
+
+Keine offenen Fragen an den PO. Freigegeben: echte Wegstrecke (nicht Luftlinie, kein
+Korrekturfaktor), Kilometerzählung je Tag ab 0, keine Lösung, die auf dem aktuellen
+Konfigurationsstand einer konkreten Tour aufbaut.

--- a/docs/features/architecture.md
+++ b/docs/features/architecture.md
@@ -276,10 +276,12 @@ für `ComparePreset`-Orte auf, ohne die Auswertungslogik zu duplizieren. Wetter-
 und beim Report-Versand (`send_one_compare_preset()`) aktualisiert; der 15-Minuten-Check liest
 nur. Versand ohne Trip-Bindung über `NotificationService.send_location_deviation_alert()`; der
 geteilte Alert-Renderer löst den Ortsbezug seit #1744 A1 in **einer** Funktion
-(`renderers/alert/segments.py::format_alert_location`) über drei Stufen auf: gesetztes
-`location_label` → Ortsname (Ortsvergleich), sonst Segment-Kennung über
-`format_segment_reference` (`Segment 3–5`, `🏁 Ziel` — dieselbe Sprache wie die amtliche
-Warnung), sonst km-Spanne als Rückfall. Die Kurznachricht (SMS/Premium-SMS) nennt bewusst
+(`renderers/alert/segments.py::format_alert_location`) auf, seit **#2036** (2026-08-21) vier
+Stufen statt drei: gesetztes `location_label` → Ortsname (Ortsvergleich), sonst **gemessene**
+km-Spanne (`km A-B`, nur wenn `km_measured=True` — die Distanz stammt aus echter GPX-Wegstrecke,
+nie aus Luftlinie), sonst Segment-Kennung über `format_segment_reference` (`Segment 3–5`,
+`🏁 Ziel` — dieselbe Sprache wie die amtliche Warnung), sonst km-Spanne (ungemessen) als
+letzter Rückfall für Altdaten ohne Segment-Kennung. Die Kurznachricht (SMS/Premium-SMS) nennt bewusst
 weiterhin keinen Ortsbezug. Alarmkonfiguration ist in Scheibe 2 hartkodiert
 (Default-Sensitivität „standard", 120 Min Cooldown, nur E-Mail) — editierbare UI folgt in
 Scheibe 3 (#1170). Scheduler: `POST /api/scheduler/compare-alert-checks`, Go-Cron-Job
@@ -348,8 +350,10 @@ Scheibe 3 (#1170). Scheduler: `POST /api/scheduler/compare-alert-checks`, Go-Cro
    - 4 Render-Pfade: `render_subject()`, `render_email()`, `render_telegram()`, `render_sms()`
    - Projektion: `to_alert_message()` erzeugt `AlertMessage` aus `WeatherChange`-Events
    - Dynamischer Betreff: `Trip · Ortsangabe · Richtung · Metrik`; faktisch-generische H1.
-     Die Ortsangabe kommt aus der **einen** Auflösung `_location_of` (`render.py:101`, seit #1744 A1):
-     `location_label` (Ortsvergleich) → Segment-Kennung → km-Spanne als Rückfall. Der Funktionsname
+     Die Ortsangabe kommt aus der **einen** Auflösung `_location_of` (`render.py:101`, seit #1744 A1,
+     erweitert um die gemessene km-Stufe in **#2036**):
+     `location_label` (Ortsvergleich) → gemessene km-Spanne (`km_measured=True`) → Segment-Kennung
+     → km-Spanne (ungemessen) als Rückfall. Der Funktionsname
      `_km_str` ist ein Relikt — hier stand bis 2026-08-13 noch `km`, das war seit A1 überholt
    - Severity-Sortierung pro Metrik; ASCII-SMS ≤140 Zeichen mit Überlauf-Marker
    - Enthält NICHT: Stundentabellen, Ausblick, Gewitter-Vorschau, Pills, Vortag-Vergleich, Statistik
@@ -390,8 +394,8 @@ Scheibe 3 (#1170). Scheduler: `POST /api/scheduler/compare-alert-checks`, Go-Cro
    - **Kanonischer Render-Pfad (Issue #919):** `check_radar_alerts` konstruiert `AlertMessage(OnsetEvent(...))` und leitet durch dieselben vier Renderer wie der Abweichungs-Alert:
      - `render_subject(msg)` — Betreff: `[<trip>] <Ortsangabe> · Regen/Gewitter in <m> Min`,
        an einer echt zugestellten Mail gemessen z.B. `[KHW 403] 🏁 Ziel · Regen in 25 Min`.
-       Ortsangabe nach derselben dreistufigen Auflösung wie oben (seit #1744 A1; hier stand bis
-       2026-08-13 noch die km-Spanne)
+       Ortsangabe nach derselben (seit #2036 vierstufigen) Auflösung wie oben (seit #1744 A1;
+       hier stand bis 2026-08-13 noch die km-Spanne)
      - `render_email(msg)` — HTML + Plain mit Onset-Uhrzeit, Intensity-Label, Quellenangabe, Cooldown-Block
      - `render_telegram(msg)` — Fettzeile + Detail mit Onset-Uhrzeit und Quelle
      - `render_sms(msg)` — Token `R@<hh:mm>` (Regen) oder `TH@<hh:mm>` (Gewitter), Zeitpunkt statt

--- a/docs/reference/api_contract.md
+++ b/docs/reference/api_contract.md
@@ -1,7 +1,11 @@
 
 # API Contract — Gregor Zwanzig
 
-**Updated:** 2026-08-20 (Issue #1848 Scheibe A2, `feat-1848-a2-outlook-kennungen` — `display_config.outlook_metrics` speichert die **Kennung** statt des Paars aus Größe und Auswertung: `["temperature", "gust"]` statt `[{"metric_id": "temperature", "aggregation": "max"}, ...]`. Damit verliert der 3-Tages-Ausblick sein eigenes, viertes Vokabular; welche Auswertungen eine Kennung zeigt, leitet der Katalog ab (`compare_outlook_metric_ids.derived_aggregations()`). **Die Paar-Altform bleibt dauerhaft lesbar** (Bestandsdaten, kein Migrationslauf) — zwei Paare derselben Größe werden beim Laden zu EINEM Eintrag; geschrieben wird sie nicht mehr. Zweite Änderung am Vertrag: der **Trip** ist seit ADR-0055 / #1720 S1 neben dem Ortsvergleich schreibende Fläche, beide über dieselbe geteilte Komponente `CompareOutlookLayoutControls.svelte`; deren Auswahlliste zeigt jetzt einen Eintrag je Größe statt getrennter Kästchen für Minimum und Maximum. Drei-Werte-Semantik unverändert, mit einer Klarstellung: eine gefüllte, aber vollständig unauflösbare Auswahl liefert `None` (die sieben festen Spalten) und **nicht** `[]` (Block aus) — unauflösbar ist nicht dasselbe wie bewusst geleert. Keine Go-Änderung (`display_config` bleibt ein opakes Blob mit flachem Merge). Spec: `docs/specs/modules/feat_1848_a2_ausblick_kennungen.md`); 2026-08-14 (Issue #1756 — Send-Idempotenz-Lock: `POST /api/trips/{trip_id}/send`
+**Updated:** 2026-08-21 (Issue #2036, `fix-2036-alarm-kilometer` — neues optionales Waypoint-Feld
+`distance_from_start_km` (Go **und** Python), gemessene GPX-Wegstrecke ab Etappenstart; steuert
+die Alarm-Kurzform-Ortsangabe (`km A-B` statt Segment-Kennung, nur bei belastbarer Messung).
+Details Abschnitt „Waypoint DTO" und Changelog-Eintrag unten. Spec:
+`docs/specs/modules/fix_2036_alarm_kilometer_ortsangabe.md`); 2026-08-20 (Issue #1848 Scheibe A2, `feat-1848-a2-outlook-kennungen` — `display_config.outlook_metrics` speichert die **Kennung** statt des Paars aus Größe und Auswertung: `["temperature", "gust"]` statt `[{"metric_id": "temperature", "aggregation": "max"}, ...]`. Damit verliert der 3-Tages-Ausblick sein eigenes, viertes Vokabular; welche Auswertungen eine Kennung zeigt, leitet der Katalog ab (`compare_outlook_metric_ids.derived_aggregations()`). **Die Paar-Altform bleibt dauerhaft lesbar** (Bestandsdaten, kein Migrationslauf) — zwei Paare derselben Größe werden beim Laden zu EINEM Eintrag; geschrieben wird sie nicht mehr. Zweite Änderung am Vertrag: der **Trip** ist seit ADR-0055 / #1720 S1 neben dem Ortsvergleich schreibende Fläche, beide über dieselbe geteilte Komponente `CompareOutlookLayoutControls.svelte`; deren Auswahlliste zeigt jetzt einen Eintrag je Größe statt getrennter Kästchen für Minimum und Maximum. Drei-Werte-Semantik unverändert, mit einer Klarstellung: eine gefüllte, aber vollständig unauflösbare Auswahl liefert `None` (die sieben festen Spalten) und **nicht** `[]` (Block aus) — unauflösbar ist nicht dasselbe wie bewusst geleert. Keine Go-Änderung (`display_config` bleibt ein opakes Blob mit flachem Merge). Spec: `docs/specs/modules/feat_1848_a2_ausblick_kennungen.md`); 2026-08-14 (Issue #1756 — Send-Idempotenz-Lock: `POST /api/trips/{trip_id}/send`
 lehnt einen zweiten Sendeversuch für denselben `(user_id, trip_id, report_type)`-Schlüssel,
 während ein erster noch läuft, jetzt mit neuem Statuscode 409 ab statt einen echten
 Doppelversand auszulösen (Prozess-lokaler `threading.Lock`, keine Persistenz); Go-Proxy-Timeout
@@ -992,18 +996,30 @@ type Stage struct {
 
 ```go
 type Waypoint struct {
-    ID                string  `json:"id"`
-    Name              string  `json:"name"`
-    Lat               float64 `json:"lat"`
-    Lon               float64 `json:"lon"`
-    ElevationM        int     `json:"elevation_m"`
-    TimeWindow        *string `json:"time_window,omitempty"`
-    ArrivalCalculated *string `json:"arrival_calculated,omitempty"` // Issue #296 — "HH:MM", Backend-berechnet (Naismith)
-    Origin            string  `json:"origin,omitempty"`             // "manual" | "algorithmic"; leer = "manual" (Issue #303)
-    Confirmed         *bool   `json:"confirmed,omitempty"`          // *bool: false bleibt serialisierbar
-    ArrivalOverride   *string `json:"arrival_override,omitempty"`   // User-Override "HH:MM"
+    ID                     string   `json:"id"`
+    Name                   string   `json:"name"`
+    Lat                    float64  `json:"lat"`
+    Lon                    float64  `json:"lon"`
+    ElevationM             int      `json:"elevation_m"`
+    TimeWindow             *string  `json:"time_window,omitempty"`
+    ArrivalCalculated      *string  `json:"arrival_calculated,omitempty"` // Issue #296 — "HH:MM", Backend-berechnet (Naismith)
+    Origin                 string   `json:"origin,omitempty"`             // "manual" | "algorithmic"; leer = "manual" (Issue #303)
+    Confirmed              *bool    `json:"confirmed,omitempty"`          // *bool: false bleibt serialisierbar
+    ArrivalOverride        *string  `json:"arrival_override,omitempty"`   // User-Override "HH:MM"
+    DistanceFromStartKm    *float64 `json:"distance_from_start_km,omitempty"` // Issue #2036 — gemessene GPX-Wegstrecke ab Etappenstart
 }
 ```
+
+**`distance_from_start_km` (Issue #2036):** Optional, `nil`/`None` heißt „nicht gemessen" —
+zu unterscheiden von `0.0` (gültiger Startwert). Wird beim GPX-Import aus dem
+Original-Trackpunkt (`GPXPoint.distance_from_start_km`) übernommen oder nachträglich per
+Track-Auflösung (`src/services/track_resolution.py`) einmalig additiv zurückgeschrieben,
+wenn genau ein GPX-Track im Bestand des Nutzers alle Wegpunkte der Etappe innerhalb 10 m
+enthält. Speist ausschließlich die Alarm-Ortsangabe (`km A-B` statt `Segment N`,
+`renderers/alert/segments.py::format_alert_location`) — kein Einfluss auf Naismith-Gehzeiten
+(rechnen weiterhin auf Luftlinie, #2042). Muss im Go-Modell existieren, da sonst der erste
+Editor-Save (`SaveTrip`) den beim Import gesetzten Wert wieder verwirft (Präzedenzfall
+`suggestion_reason`).
 
 **Berechnung `arrival_calculated`:**
 - Frontend: `computeArrivalTimes(stage, startTime, activityToSpeed(trip.activity))` → gibt Array von HH:MM-Strings
@@ -3661,6 +3677,16 @@ function corridorInside(value, min, max) {
   `TH@18:00 R2.5`, akkumuliert über 60 Min ab Ereignisbeginn, nicht ab Versandzeitpunkt).
   Reine additive Feld-Ergänzung, kein Formatwechsel der Antwortstruktur; E-Mail- und
   Telegram-Langform unverändert. Spec: `docs/specs/modules/fix_2046_onset_menge.md`.
+- 2026-08-21: Issue #2036 — Alarm-Kurzform zeigt als Ortsangabe jetzt eine **gemessene**
+  Kilometer-Spanne (`km A-B`), wenn eine belastbare, aus GPX-Trackdaten stammende Distanz
+  vorliegt — davor unverändert die Segment-Kennung aus #1744 A1. Neues optionales Waypoint-Feld
+  `distance_from_start_km` (Go **und** Python, s. Abschnitt „Waypoint DTO"), neues internes Flag
+  `km_measured` an allen vier Alarm-Ereignistypen (`AlertEvent`, `OnsetEvent`, `OnsetShiftEvent`,
+  `CorridorEvent`) — kein Wire-Format-Feld, steuert nur die Renderer-interne Auflösung. Aus
+  Luftlinie geschätzte Kilometer werden nie als Ortsangabe gezeigt; ohne gemessene Strecke bleibt
+  es bei der Segment-Sprache. Neues Modul `src/services/track_resolution.py` ordnet
+  Bestandstrips ohne gemessene Distanz einmalig einem passenden GPX-Track im Nutzerbestand zu
+  (Read-Modify-Write mit Merge). Spec: `docs/specs/modules/fix_2036_alarm_kilometer_ortsangabe.md`.
 - 2026-08-20: Issue #1948 Scheibe S5 — `OnsetPayload` und `NowcastFramesPayload` (Section 22.5,
   `POST /api/trips/{trip_id}/alert-preview`) bekommen additiv das Feld `segment_id: string | null`,
   analog zu `segment_ids` bei `OfficialAlertPayload` (Vorbedingung aus S4, AC-15) — ohne Segment-

--- a/docs/specs/modules/fix_2036_alarm_kilometer_ortsangabe.md
+++ b/docs/specs/modules/fix_2036_alarm_kilometer_ortsangabe.md
@@ -1,0 +1,339 @@
+---
+entity_id: fix_2036_alarm_kilometer_ortsangabe
+type: bugfix
+created: 2026-08-21
+updated: 2026-08-21
+status: draft
+version: "1.0"
+tags: [alarm, sms, telegram, gpx, kilometer]
+workflow: fix-2036-alarm-kilometer
+---
+
+# Alarm-Kurzform: gemessene Kilometer statt Segmentnummer als Ortsangabe
+
+## Approval
+
+- [x] Approved — PO Henning, 2026-08-21 („freigabe")
+
+## Purpose
+
+Alarm-Kurzmeldungen an Telegram-Kurzform, SMS und Premium-SMS zeigen heute als Ortsangabe eine
+Segmentnummer (`Seg 3`), die auf einem Garmin inReach nicht verortbar ist — der Nutzer kann nicht
+erkennen, wo Segmentgrenzen entlang der Tour liegen. Diese Spec ersetzt die Ortsangabe durch eine
+**gemessene** Kilometer-Spanne entlang der echten Wegstrecke (`km 12-20`), aber ausschließlich
+dort, wo eine belastbare, aus GPX-Trackdaten stammende Distanz vorliegt. Ohne belastbare Messung
+bleibt die heutige Segmentnummer unverändert stehen — eine aus Luftlinie erfundene
+Kilometerangabe wäre glaubwürdig aussehender Unsinn und damit schlechter als der Status quo.
+
+## Source
+
+- **File:** `src/output/renderers/alert/segments.py`
+- **Identifier:** `format_alert_location()` (:91-111)
+
+> **Schicht-Hinweis:** Python-Core / Domain-Backend
+> (`src/output/renderers/alert/`, `src/services/`, `src/app/`) für Datenherkunft, Auflösung und
+> Persistenz. Zusätzlich **Go-API** (`internal/model/trip.go`), da die Wegstrecke am Waypoint
+> auch dort modelliert werden muss — ohne das Go-Feld wischt der erste Editor-Save (`SaveTrip`)
+> den Wert wieder weg (Präzedenzfall: `suggestion_reason`, existiert in Python, fehlt in Go, wird
+> stumm verworfen).
+
+## Estimated Scope
+
+- **LoC:** ~184 Produktion, ~130 Tests (Limit 250 reicht nicht; **LoC-Override auf 500 bereits
+  gesetzt**)
+- **Files:** 13 (siehe Affected Files unten)
+- **Effort:** medium — additiv und default-aus, aber schema-relevant in zwei Sprachen (Python +
+  Go)
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `src/core/gpx_parser.py` (`GPXPoint.distance_from_start_km`) | module | Liefert die bereits korrekt berechnete Wegstrecke je Original-Trackpunkt, wird bislang nach dem Segment-Bau verworfen |
+| `src/core/segment_builder.py` | module | Übergibt Original-`GPXPoint`s (inkl. Distanz) an die Segmentbildung, unverändert |
+| `src/services/gpx_processing.py` (`segments_to_trip`) | module | Baut Waypoints aus GPX-Segmenten; muss die Distanz zusätzlich zu lat/lon/elevation durchreichen |
+| `src/services/trip_segments.py` (`convert_trip_to_segments`) | module | Bisherige Quelle der Luftlinien-km (`haversine_km`); wird um gemessene km, Etappen-Normierung auf 0 und Plausibilitätsprüfung erweitert |
+| *(neu)* Track-Auflösungs-Service | module | Ordnet Bestandstrips ohne gemessene Distanz eindeutig einen GPX-Track aus `data/users/<user_id>/gpx/` zu und schreibt das Ergebnis einmalig zurück |
+| `src/services/weather_snapshot.py` | module | Muss das Echtheits-Flag beim Speichern und Rekonstruieren des Snapshots mitführen |
+| `src/output/renderers/alert/model.py` (`AlertEvent`) | module | Vier Event-Typen bekommen das Feld `km_measured` |
+| `src/output/renderers/alert/project.py` | module | Reicht das Flag von der Datenquelle in die Event-Projektion durch |
+| `src/services/trip_alert.py` | module | Baut die `segment_km`-Karte für amtliche Warnungen inkl. Flag |
+| `src/output/renderers/alert/segments.py` (`format_alert_location`) | module | Neue Auflösungsreihenfolge: gemessene km vor Segmentnummer |
+| `src/output/renderers/alert/render.py` | module | Format-Vereinheitlichung `km A-B` (Leerzeichen), Flag-Weiterreichung |
+| `src/output/renderers/alert/official_alerts.py` | module | Amtliche Warnungen nutzen dieselbe Ortsangabe wie Nowcast/Abweichungsalarm (Teilungs-Invariante #1744) |
+| `internal/model/trip.go` | module | Go-Gegenstück zum Python-Waypoint-Feld — schema-relevant, ohne dies Datenverlust beim ersten Editor-Save |
+
+## Implementation Details
+
+**Auflösungsreihenfolge je Wegpunkt (Ergebnis der Analyse in
+`docs/context/fix-2036-alarm-kilometer.md`):**
+
+1. Der Wegpunkt trägt bereits eine gemessene Wegstrecke (`distance_from_start_km is not None`)
+   → nutzen.
+2. Sonst: im GPX-Bestand des Nutzers (`data/users/<user_id>/gpx/`) wird nach einem Track
+   gesucht, der **alle** Wegpunkte der Etappe innerhalb einer Toleranz von **10 m** enthält
+   (Begründung siehe „Festgelegte Schwellenwerte"). Bei **genau einem** Treffer wird die gemessene Distanz übernommen und einmalig
+   additiv an den Trip zurückgeschrieben (Read-Modify-Write mit Merge, niemals Replace). Bei
+   **null oder mehr als einem** Treffer wird nicht geraten.
+3. Sonst gilt die Etappe als **unvermessen** — die Ortsangabe bleibt `Segment N` /
+   `Seg N` (heutiges Verhalten, byte-identisch).
+
+**Kilometerzählung je Etappe ab 0.** `convert_trip_to_segments` normiert die gemessene Distanz
+auf den Etappenstart (PO-Vorgabe: „jeder Tag zählt neu seine Kilometer"), unabhängig von der
+kumulierten Gesamtstrecke der Tour. Das Etappenziel behält die bestehende Sonderbehandlung
+`🏁 Ziel` (`km_from == km_to`), auch wenn die Etappe vermessen ist — `km 20-20` wäre eine
+Verschlechterung gegenüber dem heutigen Symbol.
+
+**Plausibilitätsprüfung fängt Nachbearbeitung ab.** Für zwei aufeinanderfolgende Wegpunkte einer
+Etappe muss die gemessene Spanne streng monoton steigen **und** mindestens so groß sein wie die
+Luftlinie zwischen ihnen (ein Track kann nie kürzer als die direkte Verbindung sein). Verletzt
+eine Etappe diese Regel — etwa durch einen nachträglich eingefügten, verschobenen oder manuell
+gesetzten Wegpunkt (`frontend/src/lib/utils/waypointEditor.ts:70-74` interpoliert linear,
+`EditStagesPanelNew.svelte:610-620` setzt beliebige Kartenpunkte) — gilt die **gesamte Etappe**
+als unvermessen, auch wenn einzelne Wegpunkte für sich genommen plausibel wären.
+
+**Echtheits-Kennzeichnung, damit „unbekannt" nie mit „Kilometer 0" verwechselt wird.**
+`Waypoint.distance_from_start_km` wird `Optional[float] = None` (statt des heutigen
+Default-`0.0` in `GPXPoint`); `None` heißt „nicht gemessen". Ein zusätzliches boolesches Flag
+(`distance_measured` am `TripSegment`, `km_measured` an den vier `AlertEvent`-Typen) läuft
+additiv von der Datenquelle über `weather_snapshot` (Speichern **und** Rekonstruieren) bis zum
+Renderer mit. Default `False` ist zugleich der Terminschutz: solange kein Code aktiv gemessene
+Daten baut, bleibt jeder Bestandstest unverändert grün.
+
+**Format-Vereinheitlichung.** `render.py` schreibt heute `km12-20` ohne Leerzeichen; das wird
+auf `km 12-20` angeglichen (SMS-Schreibweise nach `_ascii()`: Bindestrich, Leerzeichen nach
+„km"). Der Ratschen-Test `test_alert_location_vocabulary.py:534`, der per
+`re.search(r"km\d", sms)` genau die alte, leerzeichenlose Schreibweise verbietet, bleibt dadurch
+grün statt (wie bei unveränderter Schreibweise) permanent rot.
+
+**Amtliche Warnungen teilen dieselbe Auflösung.** Die Teilungs-Invariante aus #1744
+(`test_alert_location_vocabulary.py:296-298`) verlangt Gleichheit der Ortsangabe zwischen
+Nowcast-Alarm, Abweichungsalarm und amtlicher Warnung. `official_alerts.py` bekommt daher einen
+additiven Parameter `segment_km`, der aus derselben Quelle gespeist wird — kein separater,
+zweiter Auflösungspfad. Das Ticket ist deshalb **nicht in zwei Scheiben teilbar**: ein Deploy
+ohne `official_alerts.py` oder ohne `internal/model/trip.go` bricht entweder die
+Gleichheits-Invariante oder verliert die Werte beim ersten Trip-Save.
+
+## Expected Behavior
+
+- **Input:** Ein Alarm-Event (Nowcast, Abweichungsalarm oder amtliche Warnung) für ein Segment
+  einer Etappe, deren Wegpunkte entweder eine gemessene Wegstrecke tragen, eindeutig einem
+  GPX-Track im Bestand des Nutzers zuordenbar sind, oder keines von beidem.
+- **Output:** Die Kurzform-Ortsangabe zeigt `km A-B` (mit Leerzeichen), wenn eine plausible
+  gemessene Spanne vorliegt; sonst unverändert `Segment N` / `Seg N`. Das Ziel-Segment zeigt
+  weiterhin `🏁 Ziel`. E-Mail-Betreff, Telegram-rich und amtliche Warnungen folgen derselben
+  Auflösung.
+- **Side effects:** Bei erfolgreicher Track-Zuordnung wird die gemessene Distanz einmalig
+  additiv an den betroffenen Trip zurückgeschrieben (Read-Modify-Write mit Merge). Kein anderer
+  Feld-Verlust, kein Netzabruf, keine Änderung an nicht betroffenen Trips.
+
+## Festgelegte Schwellenwerte
+
+| Größe | Wert | Begründung |
+|---|---|---|
+| Zuordnungs-Toleranz Wegpunkt ↔ Track | **10 m** | Wegpunkte importierter Etappen sind Original-Trackpunkte, gemessener Abstand **0,0 m**; die nächstbeste (falsche) Datei liegt bei **≥ 4.672 m**. 10 m deckt Koordinatenrundung ab und liegt drei Größenordnungen unter dem Fehlerfall. |
+| Rundung der km-Anzeige | **ganze Kilometer** (`int(round(...))`) | Unverändert zur heutigen km-Rückfallstufe; Nachkommastellen kosten SMS-Zeichen ohne Erkenntnisgewinn. |
+| SMS-Längengrenze | **140 Zeichen** (`render.py:1020`) | Bestand. `Seg 3` (5 Zeichen) → `km 12-20` (8 Zeichen) bleibt unkritisch. |
+
+## Acceptance Criteria
+
+- **AC-1:** Given ein Alarm-Event hat für sein Segment eine gemessene, plausible
+  Kilometer-Spanne (`km_measured=True`) / When die Kurzform-Ortsangabe aufgelöst wird
+  (Telegram-Kurzform, SMS, Premium-SMS) / Then zeigt sie `km A-B` (Bindestrich, Leerzeichen nach
+  „km", `_ascii()`-Schreibweise) statt `Seg N`, wobei A und B wie bisher auf **ganze Kilometer**
+  gerundet werden (`int(round(...))`, unverändert zur heutigen Rückfallstufe — Nachkommastellen
+  kosten SMS-Zeichen ohne Erkenntnisgewinn auf dem Gerät).
+  - Test: Ein Nowcast-Alarm für ein vermessenes Segment mit den Grenzen 12,31 km und 20,00 km
+    wird über die Kurzform-Renderer formatiert; der erzeugte Text enthält `km 12-20` in exakt
+    dieser Schreibweise und nicht mehr `Seg N`.
+
+- **AC-2:** Given dieselbe Auflösungsfunktion wird auch für E-Mail-Betreff und Telegram-rich
+  verwendet / When ein Segment eine gemessene Kilometer-Spanne trägt / Then ändern sich Betreff
+  und Telegram-rich-Text ebenfalls auf die km-Angabe.
+  - Test: Für ein vermessenes Segment werden Betreff-Renderer und Telegram-rich-Renderer
+    aufgerufen; beide zeigen dieselbe km-Angabe wie die Kurzform, nicht mehr die Segmentnummer.
+
+- **AC-3:** Given Nowcast-Alarm, Abweichungsalarm und amtliche Warnung beziehen sich auf
+  dasselbe vermessene Segment / When alle drei Alarmarten ihre Ortsangabe rendern / Then zeigen
+  alle drei identisch `km A-B` (Ratschen-Test `test_alert_location_vocabulary.py:296-298`
+  verlangt Gleichheit über alle drei Alarmarten).
+  - Test: Für dasselbe vermessene Segment werden Nowcast-, Abweichungs- und amtlicher
+    Warnungs-Renderer aufgerufen; ein String-Vergleich der drei Ortsangaben ergibt Gleichheit.
+
+- **AC-4:** Given das letzte Segment einer Etappe hat `km_from == km_to` (Etappenziel) / When
+  die Ortsangabe für dieses Segment aufgelöst wird, auch wenn die Etappe vermessen ist / Then
+  bleibt die Anzeige `🏁 Ziel` und wird nicht durch `km 20-20` ersetzt.
+  - Test: Ein vermessenes Etappenziel-Segment wird formatiert; die Ausgabe enthält weiterhin das
+    Symbol `🏁 Ziel` und keine km-Spanne mit identischem Start- und Endwert.
+
+- **AC-5:** Given eine gemessene km-Spanne wird in der SMS-Kurzform gerendert / When der Text
+  erzeugt wird / Then folgt er dem Muster `km A-B` mit Leerzeichen nach „km" (nicht `kmA-B` wie
+  bisher), und der Ratschen-Test, der `re.search(r"km\d", sms)` als Verstoß wertet, bleibt grün.
+  - Test: Der bestehende Ratschen-Test `test_alert_location_vocabulary.py:534` läuft gegen eine
+    erzeugte SMS mit gemessener km-Angabe und bleibt grün (kein Treffer für `km` direkt gefolgt
+    von einer Ziffer).
+
+- **AC-6:** Given ein Nutzer importiert eine neue Etappe per GPX-Upload / When die Waypoints aus
+  dem Track gebaut werden / Then trägt jeder gespeicherte Waypoint sein `distance_from_start_km`
+  aus dem Original-Trackpunkt sowohl im Python-Datenmodell als auch im Go-Modell
+  (`internal/model/trip.go`), und ein anschließender Editor-Save über die Go-API löscht den Wert
+  nicht.
+  - Test: Eine Etappe wird per GPX importiert, anschließend über die Go-API gespeichert
+    (`SaveTrip`); vor und nach dem Speichern trägt jeder Waypoint denselben
+    `distance_from_start_km`-Wert.
+
+- **AC-7:** Given ein Bestandstrip ohne gemessene Wegstrecke am Waypoint und genau eine
+  GPX-Datei unter `data/users/<user_id>/gpx/`, deren Track **jeden** Wegpunkt der Etappe mit
+  einem Abstand von **höchstens 10 m** enthält / When die Alarm-Ortsangabe für diese Etappe
+  erstmals aufgelöst wird /
+  Then wird die gemessene Distanz aus diesem Track einmalig additiv an den Trip
+  zurückgeschrieben (Read-Modify-Write mit Merge) und ab da für die Ortsangabe genutzt.
+  - Test: Ein Trip ohne gemessene Waypoints und eine passende GPX-Datei im Nutzerbestand werden
+    angelegt; nach der ersten Alarm-Auflösung trägt der persistierte Trip die gemessene Distanz,
+    alle übrigen Felder (Name, `time_window`, `arrival_override`, `confirmed`, IDs) bleiben
+    unverändert erhalten.
+
+- **AC-8:** Given eine Etappe erhält eine gemessene km-Spanne aus dem gefundenen Track / When
+  die Spanne zwischen zwei aufeinanderfolgenden Wegpunkten nicht streng monoton steigt oder
+  kleiner als deren Luftlinienabstand ist / Then gilt die gesamte Etappe als unvermessen, und
+  die Ortsangabe bleibt `Segment N`.
+  - Test: Ein manipulierter Waypoint-Satz mit einer nicht-monotonen Distanzfolge wird durch die
+    Plausibilitätsprüfung geschickt; das Ergebnis der Etappe ist „unvermessen", die
+    Alarm-Ortsangabe zeigt weiterhin `Segment N`.
+
+- **AC-9:** Given eine mehrtägige Tour mit mehreren vermessenen Etappen / When die
+  Kilometer-Spanne für eine beliebige Etappe berechnet wird / Then beginnt die Zählung an diesem
+  Etappenstart wieder bei 0 km, unabhängig von der kumulierten Gesamtstrecke der Tour.
+  - Test: Für die dritte Etappe einer vermessenen Mehrtagestour wird die erste Kilometer-Spanne
+    berechnet; ihr Startwert ist 0, nicht die Summe der Distanzen der vorherigen Etappen.
+
+- **AC-10:** Given ein Bestandstrip, für den sich kein passender GPX-Track im Bestand des
+  Nutzers eindeutig zuordnen lässt / When die Alarm-Ortsangabe für eine seiner Etappen aufgelöst
+  wird / Then bleibt die Ausgabe byte-identisch zum heutigen Verhalten (`Segment N` / `Seg N`),
+  keine km-Angabe erscheint.
+  - Test: Ein Trip ohne jede passende GPX-Datei im Bestand wird vor und nach der Implementierung
+    denselben Alarm-Renderern zugeführt; der erzeugte Text ist in beiden Läufen identisch.
+
+- **AC-11:** Given mehr als eine GPX-Datei im Bestand des Nutzers passt gleichermaßen auf die
+  Wegpunkte einer Etappe (z. B. Einzeletappe und eine Gesamt-GPX über alle Etappen) / When die
+  Track-Auflösung läuft / Then wird keine der Dateien geraten, die Etappe gilt als unvermessen,
+  und die Ortsangabe bleibt `Segment N`.
+  - Test: Zwei GPX-Dateien, die beide alle Wegpunkte der Etappe enthalten, liegen im Bestand des
+    Nutzers; die Track-Auflösung liefert kein Ergebnis, die Alarm-Ortsangabe zeigt `Segment N`.
+
+- **AC-12:** Given eine Etappe enthält mindestens einen manuell im Editor ergänzten oder
+  verschobenen Wegpunkt, dessen Abstand zum nächstgelegenen Punkt des sonst passenden
+  GPX-Tracks **mehr als 10 m** beträgt / When die Track-Zuordnung läuft / Then wird für die
+  gesamte betroffene Etappe keine Kilometer-Angabe angezeigt.
+  - Test: Eine sonst passende Etappe bekommt einen zusätzlichen, abseits des Tracks liegenden
+    Wegpunkt; die Track-Zuordnung schlägt für diese Etappe fehl, die Alarm-Ortsangabe bleibt
+    `Segment N`.
+
+- **AC-13:** Given kein Wegpunkt der Etappe trägt eine gemessene Wegstrecke und kein Track
+  konnte eindeutig zugeordnet werden / When die Ortsangabe aufgelöst wird / Then wird zu keinem
+  Zeitpunkt ein aus Luftlinie (`haversine_km`) berechneter Kilometerwert als Ortsangabe
+  angezeigt.
+  - Test: Für eine unvermessene Etappe wird geprüft, dass der von `haversine_km` intern
+    berechnete Luftlinienwert nirgends im gerenderten Alarmtext auftaucht — weder als km-Angabe
+    noch versteckt in einer anderen Formatierung.
+
+- **AC-14:** Given der erste Wegpunkt einer Etappe hat gemessen `distance_from_start_km=0.0`
+  (Etappenstart) und ein zweiter beteiligter Wegpunkt hat `distance_from_start_km=None` / When
+  die Etappe auf Vermessenheit geprüft wird / Then zählt der Wert `0.0` als gültige Messung,
+  während `None` als unbekannt behandelt wird und die Etappe insgesamt als unvermessen gilt,
+  solange irgendein beteiligter Wegpunkt `None` trägt.
+  - Test: Eine Etappe mit `distance_from_start_km=0.0` am Start und `None` an einem weiteren
+    Wegpunkt wird geprüft; das Ergebnis ist „unvermessen" wegen des `None`-Werts, nicht wegen
+    des `0.0`-Werts — ein separater Test mit ausschließlich `0.0`-und-höher-Werten ergibt
+    „vermessen".
+
+- **AC-15:** Given ein Segment mit gemessener km-Spanne durchläuft `weather_snapshot`-Speichern
+  und -Rekonstruieren sowie die vier Alert-Event-Typen bis zum Renderer / When das Flag
+  `distance_measured` / `km_measured` an jeder dieser Stellen geprüft wird / Then bleibt es an
+  jeder Stelle `True` erhalten, ohne unterwegs auf den Default `False` zurückzufallen.
+  - Test: Ein vermessenes Segment wird gespeichert, aus dem Snapshot rekonstruiert und über
+    jeden der vier Alert-Event-Typen bis zum Renderer geführt; an jeder Zwischenstufe wird das
+    Flag ausgelesen und ist `True`.
+
+## Nicht Teil dieser Spec
+
+- **Naismith-Gehzeiten** (`src/core/naismith.py:119`, `internal/model/naismith.go:118`) rechnen
+  weiterhin auf Luftlinie, wodurch Ankunftszeiten um denselben Faktor zu früh ausfallen.
+  Nutzersichtbar, aber eigenes Ticket → **#2042**.
+- **`official_alerts.py:2137-2147` `_trip_total_segment_ids()`** zählt Segmente über alle
+  Etappen einer Tour hinweg, obwohl Segmentnummern je Etappe vergeben werden — die
+  „gesamte Route"-Verdichtung greift dadurch bei mehrtägigen Touren nie. Vorbestehender
+  Nebenbefund, gehört ins Sammel-Issue → **#1199**.
+
+## Bestandstests, die grün bleiben müssen
+
+`tests/tdd/test_alert_location_vocabulary.py` (zentraler Ratschen-Test) ·
+`tests/tdd/test_alert_sms_segment_head.py:177` · `tests/tdd/test_alert_segment_reference.py` ·
+`tests/tdd/test_official_alert_sms_ortskopf.py:94` ·
+`tests/tdd/test_official_alert_template_render.py` ·
+`tests/unit/test_official_alert_output_unchanged.py` + Snapshot
+`tests/fixtures/official_alert_render_snapshot_1944.json:6` ·
+`tests/tdd/test_feature_574_segment_km_header.py` ·
+`tests/tdd/test_952_onset_alert_fidelity.py` · `tests/tdd/test_onset_shift_alert.py` ·
+`tests/tdd/test_alert_addendum_sms.py` · `tests/tdd/test_radar_alert_telegram_style.py`
+
+## Risiken
+
+1. **Go-Modell vergessen** ⇒ der erste Editor-Save wischt alle gemessenen Kilometer wieder weg.
+   `internal/model/trip.go` muss im **selben** Deploy raus wie die Python-Änderungen.
+2. **`loader.py:130` ersetzt Listen wholesale** ⇒ Telegram-Kommandos
+   (`trip_command_processor.py:1245`) könnten gemessene km löschen, wenn dieselbe Kopplung nicht
+   berücksichtigt wird — Read-Modify-Write mit Merge ist an dieser Stelle zwingend, kein Replace.
+3. **Briefing-Segmentkopf (Feature #574)** zeigt heute dieselben falschen Luftlinien-km und wird
+   durch diese Änderung ebenfalls korrekt — eine sichtbare, aber gewollte Nebenwirkung, kein
+   Kollateralschaden.
+4. **Ohne auffindbaren Track bleibt alles wie heute.** Das ist die Fallback-Garantie (AC-10),
+   kein Bug — muss aber im Adversary-Dialog aktiv als Positivfall geprüft werden, nicht nur als
+   impliziter Nebeneffekt.
+
+## Known Limitations
+
+- Gleichnamige GPX-Uploads überschreiben sich stumm im Bestand (`gpx_processing.py:66-69`) —
+  vorbestehendes Verhalten, wird durch diese Spec nicht verändert und kann die Track-Auflösung
+  auf einen falschen (weil überschriebenen) Track treffen lassen; das fällt dann unter die
+  Plausibilitätsprüfung (AC-8) oder die Eindeutigkeitsprüfung (AC-11), wird aber nicht separat
+  erkannt oder gemeldet.
+- Die Track-Auflösung läuft bei Bedarf (lazy) bei der ersten Alarm-Auflösung einer unvermessenen
+  Etappe, nicht proaktiv beim GPX-Upload für Bestandstrips — ein Nutzer, der nach dem Fix eine
+  weitere GPX-Datei hochlädt, sieht die Kilometer-Angabe erst beim nächsten Alarm für die
+  betroffene Etappe, nicht sofort.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Es handelt sich um eine additive Erweiterung des bestehenden
+  Waypoint-/TripSegment-Datenmodells (ein optionales Feld, ein boolesches Echtheits-Flag) sowie
+  eine geänderte Auflösungsreihenfolge in einer bestehenden Renderer-Funktion. Es wird keine
+  neue Persistenzschicht, kein neuer Kanal und keine neue Auth-Entscheidung eingeführt. Die
+  Teilungs-Invariante zwischen Nowcast-, Abweichungs- und amtlichem Alarm (#1744) bleibt
+  unverändert bestehen — diese Spec speist lediglich alle drei Pfade aus derselben, um eine
+  zusätzliche Quelle erweiterten Auflösung.
+
+## Nachweisführung
+
+- **Der Produktionspfad für Bestandstrips ist der Nachrüstungs-Weg (AC-7), nicht der
+  Import-Weg (AC-6).** Ein RED-Test, der nur den Import-Fall (frisch angelegter Trip) abdeckt,
+  lässt die für heutige Nutzer relevante Nachrüstung ungetestet — beide Wege brauchen eigene
+  Tests.
+- **AC-10 ist der Gegenfall zu AC-1/AC-7** und existiert, um eine versehentliche Immer-Ja-Logik
+  in der Track-Auflösung fangbar zu machen (jede Datei „passt", wenn die Toleranzprüfung fehlt
+  oder invertiert ist). Ohne AC-10 bleibt diese Mutation unsichtbar.
+- **AC-14 ist der Gegenfall zu AC-9/AC-7** und existiert, um eine Verwechslung von `None`
+  (unbekannt) und `0.0` (gültiger Startwert) fangbar zu machen — genau der Bug, den
+  `GPXPoint.distance_from_start_km` mit seinem heutigen Default `0.0` strukturell begünstigt.
+  Ein Test, der nur mit durchweg vorhandenen oder durchweg fehlenden Werten arbeitet, deckt
+  diese Unterscheidung nicht ab.
+- **AC-3 und AC-5 sind Ratschen-Nachweise gegen bestehende Tests**
+  (`test_alert_location_vocabulary.py:296-298` bzw. `:534`) und müssen gegen den unveränderten
+  Test-Wortlaut laufen, nicht gegen eine angepasste Kopie.
+- Tests lösen ihren Prüfling **relativ zur eigenen Testdatei** auf, nie über den festen
+  Hauptrepo-Pfad, damit sie im Worktree korrekt gegen den lokalen Stand laufen.
+
+## Changelog
+
+- 2026-08-21: Initial spec created

--- a/internal/model/trip.go
+++ b/internal/model/trip.go
@@ -91,6 +91,12 @@ type Waypoint struct {
 	Origin          string  `json:"origin,omitempty"`           // "manual" | "algorithmic"; leer = "manual"
 	Confirmed       *bool   `json:"confirmed,omitempty"`        // *bool: false bleibt serialisierbar, nur nil wird ausgelassen
 	ArrivalOverride *string `json:"arrival_override,omitempty"` // User-Override "HH:MM"
+	// Issue #2036 — gemessene Wegstrecke vom Etappenstart [km] aus dem
+	// Original-GPX-Track. *float64: 0.0 ist ein gueltiger Etappenstart und
+	// muss serialisierbar bleiben, nur nil ("nicht gemessen") faellt weg.
+	// Ohne dieses Feld wischt der erste Editor-Save den vom Python-Kern
+	// geschriebenen Wert stumm weg (Praezedenzfall suggestion_reason).
+	DistanceFromStartKm *float64 `json:"distance_from_start_km,omitempty"`
 }
 
 type Stage struct {

--- a/internal/store/trip_distance_roundtrip_test.go
+++ b/internal/store/trip_distance_roundtrip_test.go
@@ -1,0 +1,164 @@
+package store
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Issue #2036 (AC-6, Go-Seite) — die gemessene Wegstrecke muss den
+// Editor-Schreibweg ueberleben.
+//
+// Die Spec nennt als Risiko #1: "Go-Modell vergessen => der erste
+// Editor-Save wischt alle gemessenen Kilometer wieder weg" (Praezedenzfall
+// `suggestion_reason`: existiert in Python, fehlt in Go, wird stumm
+// verworfen). Genau dieses Szenario war bis zur Adversary-Runde 1 in
+// KEINEM Test abgedeckt -- `internal/` referenzierte das Feld nirgends,
+// also blieben `go build` und `go test` auch nach dem Entfernen des Feldes
+// gruen (Mutation M12).
+//
+// Vorbild: trip_arrival_roundtrip_test.go (#296/#303, gleiche Bauart).
+
+func TestTripRoundTrip_PreservesDistanceFromStart(t *testing.T) {
+	tmpDir := t.TempDir()
+	s := New(tmpDir, "test")
+
+	tripDir := filepath.Join(tmpDir, "users", "test", "briefings")
+	if err := os.MkdirAll(tripDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	// Vom Python-Kern geschriebener Stand: Etappenstart bei 0.0 km (gueltige
+	// Messung!), danach steigende Wegstrecke.
+	measuredJSON := `{
+		"id": "measured-trip",
+		"name": "Measured Trip",
+		"stages": [
+			{
+				"id": "S1",
+				"name": "Tag 1",
+				"date": "2026-08-23",
+				"waypoints": [
+					{"id":"W1","name":"Start","lat":46.60,"lon":12.90,"elevation_m":500,
+					 "distance_from_start_km":0.0},
+					{"id":"W2","name":"Pass","lat":46.62,"lon":12.92,"elevation_m":800,
+					 "distance_from_start_km":4.0},
+					{"id":"W3","name":"Ziel","lat":46.65,"lon":12.95,"elevation_m":700,
+					 "distance_from_start_km":11.0}
+				]
+			}
+		]
+	}`
+	path := filepath.Join(tripDir, "measured-trip.json")
+	if err := os.WriteFile(path, []byte(measuredJSON), 0644); err != nil {
+		t.Fatalf("write measured json: %v", err)
+	}
+
+	loaded, err := s.LoadTrip("measured-trip")
+	if err != nil || loaded == nil {
+		t.Fatalf("LoadTrip: %v", err)
+	}
+
+	// Der Editor-Save: laden, speichern, neu laden.
+	if err := s.SaveTrip(loaded); err != nil {
+		t.Fatalf("SaveTrip: %v", err)
+	}
+	reloaded, err := s.LoadTrip("measured-trip")
+	if err != nil || reloaded == nil {
+		t.Fatalf("re-LoadTrip: %v", err)
+	}
+
+	wps := reloaded.Stages[0].Waypoints
+	if len(wps) != 3 {
+		t.Fatalf("expected 3 waypoints, got %d", len(wps))
+	}
+
+	// W1: 0.0 km ist eine GUELTIGE Messung (Etappenstart) und darf nicht
+	// als "leer" wegoptimiert werden -- deshalb *float64 statt float64 mit
+	// omitempty. Genau diese Verwechslung fangen wir hier ab.
+	if wps[0].DistanceFromStartKm == nil {
+		t.Fatalf("W1: distance_from_start_km=0.0 ging verloren (nil nach Roundtrip)")
+	}
+	if *wps[0].DistanceFromStartKm != 0.0 {
+		t.Fatalf("W1: distance_from_start_km verfaelscht: %v", *wps[0].DistanceFromStartKm)
+	}
+	if wps[1].DistanceFromStartKm == nil || *wps[1].DistanceFromStartKm != 4.0 {
+		t.Fatalf("W2: distance_from_start_km ging verloren: %v", wps[1].DistanceFromStartKm)
+	}
+	if wps[2].DistanceFromStartKm == nil || *wps[2].DistanceFromStartKm != 11.0 {
+		t.Fatalf("W3: distance_from_start_km ging verloren: %v", wps[2].DistanceFromStartKm)
+	}
+
+	// Auch auf der Platte, nicht nur im Speicher: der 0.0-Wert muss im JSON
+	// stehen (sonst liest ihn der Python-Kern beim naechsten Lauf als
+	// "nicht gemessen" und die Etappe faellt auf Segment-N zurueck).
+	written, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read written: %v", err)
+	}
+	if !strings.Contains(string(written), `"distance_from_start_km"`) {
+		t.Fatalf("distance_from_start_km fehlt in der geschriebenen Datei: %s", string(written))
+	}
+}
+
+// Ein Bestandstrip OHNE gemessene Wegstrecke darf durch den Roundtrip
+// keine bekommen -- `nil` heisst "nicht gemessen" und muss `nil` bleiben
+// (Gegenstueck zu AC-14 auf der Python-Seite: None != 0.0).
+func TestTripRoundTrip_LegacyTripStaysUnmeasured(t *testing.T) {
+	tmpDir := t.TempDir()
+	s := New(tmpDir, "test")
+
+	tripDir := filepath.Join(tmpDir, "users", "test", "briefings")
+	if err := os.MkdirAll(tripDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	legacyJSON := `{
+		"id": "legacy-distance",
+		"name": "Legacy Trip",
+		"stages": [
+			{
+				"id": "S1",
+				"name": "Tag 1",
+				"date": "2026-08-23",
+				"waypoints": [
+					{"id":"W1","name":"Start","lat":47.0,"lon":11.0,"elevation_m":500},
+					{"id":"W2","name":"Ziel","lat":47.036,"lon":11.0,"elevation_m":800}
+				]
+			}
+		]
+	}`
+	path := filepath.Join(tripDir, "legacy-distance.json")
+	if err := os.WriteFile(path, []byte(legacyJSON), 0644); err != nil {
+		t.Fatalf("write legacy json: %v", err)
+	}
+
+	loaded, err := s.LoadTrip("legacy-distance")
+	if err != nil || loaded == nil {
+		t.Fatalf("LoadTrip: %v", err)
+	}
+	if err := s.SaveTrip(loaded); err != nil {
+		t.Fatalf("SaveTrip: %v", err)
+	}
+	reloaded, err := s.LoadTrip("legacy-distance")
+	if err != nil || reloaded == nil {
+		t.Fatalf("re-LoadTrip: %v", err)
+	}
+
+	for i, wp := range reloaded.Stages[0].Waypoints {
+		if wp.DistanceFromStartKm != nil {
+			t.Fatalf("Wegpunkt %d hat unerwuenscht eine Distanz erhalten: %v",
+				i, *wp.DistanceFromStartKm)
+		}
+	}
+
+	written, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read written: %v", err)
+	}
+	if strings.Contains(string(written), `"distance_from_start_km"`) {
+		t.Fatalf("unvermessener Trip traegt nach dem Roundtrip ein "+
+			"distance_from_start_km: %s", string(written))
+	}
+}

--- a/src/app/loader.py
+++ b/src/app/loader.py
@@ -478,6 +478,9 @@ def _parse_trip(data: Dict[str, Any]) -> Trip:
                 confirmed=wp_data.get("confirmed"),
                 suggestion_reason=wp_data.get("suggestion_reason"),
                 arrival_override=wp_data.get("arrival_override"),
+                # Issue #2036 — gemessene Wegstrecke erhalten. Fehlender
+                # Schluessel -> None ("nicht gemessen"), NICHT 0.0.
+                distance_from_start_km=wp_data.get("distance_from_start_km"),
             )
             waypoints.append(waypoint)
 
@@ -1463,6 +1466,10 @@ def _trip_to_dict(trip: Trip) -> Dict[str, Any]:
                 wp_dict["suggestion_reason"] = wp.suggestion_reason
             if wp.arrival_override:
                 wp_dict["arrival_override"] = wp.arrival_override
+            # Issue #2036 — `is not None` statt truthy: 0.0 km ist ein
+            # gueltiger Etappenstart und muss persistiert werden.
+            if wp.distance_from_start_km is not None:
+                wp_dict["distance_from_start_km"] = wp.distance_from_start_km
             waypoints_data.append(wp_dict)
 
         stage_dict = {

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -432,6 +432,12 @@ class TripSegment:
     # Segment, das ohne Trip-Bezug entsteht.
     day_window_start_hour: Optional[int] = None
     day_window_end_hour: Optional[int] = None
+    # Issue #2036: additiv, Default aus. `True` NUR, wenn die km-Spanne
+    # dieses Segments aus echter GPX-Wegstrecke stammt und die Etappe die
+    # Plausibilitaetspruefung bestanden hat (`trip_segments`). `False`
+    # heisst: `distance_from_start_km` ist eine Luftlinien-Kumulation und
+    # darf NIE als Ortsangabe erscheinen (AC-13).
+    distance_measured: bool = False
 
 
 @dataclass

--- a/src/app/trip.py
+++ b/src/app/trip.py
@@ -80,6 +80,13 @@ class Waypoint:
     confirmed: Optional[bool] = None          # True = bestätigt; False bleibt erhalten (≠ None)
     suggestion_reason: Optional[str] = None   # "detected_peak" | "detected_valley" | "detected_pass" | "legacy_suggested"
     arrival_override: Optional[str] = None    # User-Override "HH:MM"
+    # Issue #2036: additiv, optional. Gemessene Wegstrecke vom Etappen-/
+    # Tourstart bis zu diesem Wegpunkt [km], aus dem ORIGINAL-GPX-Track
+    # (`GPXPoint.distance_from_start_km`). `None` heisst "nicht gemessen" --
+    # ausdruecklich NICHT dasselbe wie `0.0` (gueltiger Etappenstart).
+    # Nur ein gemessener Wert darf je als km-Ortsangabe erscheinen; eine aus
+    # Luftlinie (`haversine_km`) abgeleitete Zahl nie (AC-13).
+    distance_from_start_km: Optional[float] = None
 
     def __str__(self) -> str:
         tw = f" ({self.time_window})" if self.time_window else ""

--- a/src/output/renderers/alert/model.py
+++ b/src/output/renderers/alert/model.py
@@ -121,6 +121,13 @@ class CorridorEvent:
     km_from: float
     km_to: float
     location_label: str | None = None
+    # Issue #2036 (Adversary F001): additiv, optional -- dieselbe Bauart wie
+    # `AlertEvent.segment_id` (#1744 A1). OHNE sie kann der Renderer bei einer
+    # unvermessenen Etappe gar keinen Ort nennen und faellt zwangslaeufig auf
+    # die Luftlinien-km zurueck, genau das verbietet AC-13. Gesetzt vom
+    # Trip-Korridor-Pfad (`project.to_corridor_events`); Altdaten ohne Kennung
+    # behalten den km-Rueckfall (#1744 AC-7).
+    segment_id: str | None = None
     # Issue #2036: additiv, Default aus. `True` NUR, wenn `km_from`/`km_to`
     # aus echter GPX-Wegstrecke stammen (`TripSegment.distance_measured`).
     # Erst dann darf die Ortsangabe die km-Spanne statt der Segmentnummer

--- a/src/output/renderers/alert/model.py
+++ b/src/output/renderers/alert/model.py
@@ -32,6 +32,11 @@ class AlertEvent:
     # setzt sie nie (ein Vergleichs-Ort hat keine Etappen). `None` -> Rueckfall
     # auf die km-Spanne (AC-7).
     segment_id: str | None = None
+    # Issue #2036: additiv, Default aus. `True` NUR, wenn `km_from`/`km_to`
+    # aus echter GPX-Wegstrecke stammen (`TripSegment.distance_measured`).
+    # Erst dann darf die Ortsangabe die km-Spanne statt der Segmentnummer
+    # zeigen -- eine aus Luftlinie geschaetzte Zahl nie (AC-13).
+    km_measured: bool = False
 
 
 @dataclass(frozen=True)
@@ -67,6 +72,11 @@ class OnsetEvent:
     # Telegram-Langform bleiben bei `intensity_label` als Wort. `None` (oder
     # unterhalb der Trockenschwelle) → zahlenlose Alt-Form `R@HH:MM`.
     onset_precip_mm: float | None = None
+    # Issue #2036: additiv, Default aus. `True` NUR, wenn `km_from`/`km_to`
+    # aus echter GPX-Wegstrecke stammen (`TripSegment.distance_measured`).
+    # Erst dann darf die Ortsangabe die km-Spanne statt der Segmentnummer
+    # zeigen -- eine aus Luftlinie geschaetzte Zahl nie (AC-13).
+    km_measured: bool = False
 
 
 @dataclass(frozen=True)
@@ -90,6 +100,11 @@ class OnsetShiftEvent:
     km_to: float
     segment_id: str | None = None
     location_label: str | None = None
+    # Issue #2036: additiv, Default aus. `True` NUR, wenn `km_from`/`km_to`
+    # aus echter GPX-Wegstrecke stammen (`TripSegment.distance_measured`).
+    # Erst dann darf die Ortsangabe die km-Spanne statt der Segmentnummer
+    # zeigen -- eine aus Luftlinie geschaetzte Zahl nie (AC-13).
+    km_measured: bool = False
 
 
 @dataclass(frozen=True)
@@ -106,6 +121,11 @@ class CorridorEvent:
     km_from: float
     km_to: float
     location_label: str | None = None
+    # Issue #2036: additiv, Default aus. `True` NUR, wenn `km_from`/`km_to`
+    # aus echter GPX-Wegstrecke stammen (`TripSegment.distance_measured`).
+    # Erst dann darf die Ortsangabe die km-Spanne statt der Segmentnummer
+    # zeigen -- eine aus Luftlinie geschaetzte Zahl nie (AC-13).
+    km_measured: bool = False
 
 
 @dataclass(frozen=True)

--- a/src/output/renderers/alert/official_alerts.py
+++ b/src/output/renderers/alert/official_alerts.py
@@ -29,7 +29,7 @@ from output.tokens.hazard_symbols import (
 # `segments.py` die GEMEINSAME Ortsformatierung aller Alarmarten (vorher hier
 # definiert, faktisch der amtlichen Warnung vorbehalten). Der Import haelt
 # zugleich den Re-Export fuer Bestandsaufrufer (`email/html.py:53`).
-from .segments import format_segment_reference
+from .segments import format_alert_location, format_segment_reference
 
 if TYPE_CHECKING:
     from app.models import SegmentWeatherData
@@ -2147,8 +2147,22 @@ def _trip_total_segment_ids(trip: "Trip | None") -> list[str]:
     return [str(i) for i in range(1, n + 1)] + ["Ziel"]
 
 
+def _measured_km_span(
+    segment_ids: list[str], segment_km: dict | None,
+) -> tuple[float, float] | None:
+    """Gemeinsame, GEMESSENE km-Spanne der betroffenen Segmente (Issue #2036)
+    -- oder `None`, sobald auch nur eines der Segmente keine gemessene Spanne
+    traegt. Ein Buendel, dessen Ortsangabe zur Haelfte geraten waere, bleibt
+    lieber ganz bei der Segment-Sprache (Fallback-Garantie AC-10)."""
+    spans = [(segment_km or {}).get(str(s)) for s in segment_ids]
+    if not spans or any(s is None for s in spans):
+        return None
+    return min(s[0] for s in spans), max(s[1] for s in spans)
+
+
 def build_official_alert_notices(
     trip: "Trip | None", tagged_alerts: list[tuple["OfficialAlert", list[str]]],
+    segment_km: dict[str, tuple[float, float]] | None = None,
 ) -> list["OfficialAlertNotice"]:
     """Baut die `OfficialAlertNotice`-DTOs fuer den Trip-Standalone-Alarm
     (Issue #1216): dedupliziert via `dedupe_official_alerts`, leitet
@@ -2156,7 +2170,14 @@ def build_official_alert_notices(
 
     Issue #1239 (AC-13): nach der Identitaets-Dedup buendelt `_bundle_by_hazard_
     level` gleichartige Warnungen (gleicher Typ + gleiche Stufe) zu einer Warnung
-    mit vereinigter Segmentliste."""
+    mit vereinigter Segmentliste.
+
+    Issue #2036: `segment_km` (additiv, Default aus) traegt die GEMESSENE
+    km-Spanne je Segment-Kennung. Nur damit spricht die amtliche Warnung
+    dieselbe Ortssprache wie Nowcast- und Abweichungsalarm (Teilungs-
+    Invariante #1744, AC-3) -- die Aufloesung selbst bleibt die EINE geteilte
+    Funktion `segments.format_alert_location`, kein zweiter Pfad. Ohne
+    Eintrag bleibt es byte-identisch bei "Segment N"."""
     all_ids = _trip_total_segment_ids(trip)
     deduped = _bundle_by_hazard_level(dedupe_official_alerts(tagged_alerts))
     notices = []
@@ -2171,7 +2192,16 @@ def build_official_alert_notices(
         if is_full:
             scope_label, sms_scope = "gesamte Route", "ges.Route"
         else:
-            scope_label = format_segment_reference(segment_ids) or "unbekannt"
+            # Issue #2036: dieselbe Aufloesung wie jeder andere Alarm -- die
+            # gemessene km-Spanne verdraengt die Segmentnummer, sonst bleibt
+            # alles wie bisher.
+            _span = _measured_km_span(segment_ids, segment_km)
+            if _span is not None:
+                scope_label = format_alert_location(
+                    None, segment_ids, _span[0], _span[1], km_measured=True,
+                )
+            else:
+                scope_label = format_segment_reference(segment_ids) or "unbekannt"
             # #1948 S5: "Seg 4" statt des Kurzcodes "S4" -- dieselbe
             # Ortssprache, die Trip-Briefing und Nowcast-Alarm sprechen
             # (`render._ascii_alert_location`). Das fruehere "nur "-Praefix bei

--- a/src/output/renderers/alert/project.py
+++ b/src/output/renderers/alert/project.py
@@ -51,12 +51,22 @@ def _resolve_metric_id(field: str, direction: str) -> str:
     )
 
 
+def _trip_segment(entry):
+    """`SegmentWeatherData` ODER blankes `TripSegment` -> `TripSegment`
+    (Issue #2036). Beide Bauformen kommen an: der Aenderungspfad reicht
+    Wetterdaten herein, der Korridor-Pfad kann auch die nackten Segmente
+    liefern. Ohne diese Normalisierung endet die zweite Bauform im
+    `except`-Zweig und der Treffer verschwindet stumm."""
+    return getattr(entry, "segment", entry)
+
+
 def _find_segment(segments, segment_id: str):
     """Referenziertes Segment. Bei nicht auflösbarer/leerer segment_id Fallback
     auf das erste Segment (kein Crash im Versandpfad — der Detector liefert
     nicht immer eine exakte segment_id)."""
     match = next(
-        (s for s in segments if str(s.segment.segment_id) == str(segment_id)),
+        (s for s in segments
+         if str(_trip_segment(s).segment_id) == str(segment_id)),
         segments[0] if segments else None,
     )
     if match is None:
@@ -110,6 +120,7 @@ def _onset_shift_text(delta_seconds: float) -> str:
 def _to_onset_shift_event(
     ch, *, tz, km_from: float, km_to: float,
     segment_id: str | None = None, location_label: str | None = None,
+    km_measured: bool = False,
 ) -> OnsetShiftEvent:
     metric_id, _aggregation = metric_and_aggregation_for_field(ch.metric)
     return OnsetShiftEvent(
@@ -119,6 +130,7 @@ def _to_onset_shift_event(
         shift_text=_onset_shift_text(ch.delta),
         km_from=km_from, km_to=km_to,
         segment_id=segment_id, location_label=location_label,
+        km_measured=km_measured,  # Issue #2036
     )
 
 
@@ -139,16 +151,19 @@ def to_alert_message(
     events: list[AlertEvent] = []
     onset_events: list[OnsetShiftEvent] = []
     for ch in changes:
-        match = _find_segment(segments, ch.segment_id)
-        km_from = match.segment.start_point.distance_from_start_km
-        km_to = match.segment.end_point.distance_from_start_km
+        match = _trip_segment(_find_segment(segments, ch.segment_id))
+        km_from = match.start_point.distance_from_start_km
+        km_to = match.end_point.distance_from_start_km
+        # Issue #2036: Herkunft der Spanne (gemessen vs. Luftlinie) reist mit.
+        km_measured = bool(getattr(match, "distance_measured", False))
         # Issue #1468: Beginn-Verschiebungen tragen einen ZEITPUNKT und gehen
         # deshalb NICHT durch den Zahlen-Formatierer (s. `OnsetShiftEvent`).
         if _is_onset_change(ch):
             onset_events.append(_to_onset_shift_event(
-                ch, tz=_tz_for_location(match.segment.start_point, tz),
+                ch, tz=_tz_for_location(match.start_point, tz),
                 km_from=km_from, km_to=km_to,
-                segment_id=normalize_segment_id(match.segment.segment_id),
+                segment_id=normalize_segment_id(match.segment_id),
+                km_measured=km_measured,
             ))
             continue
         metric_id = _resolve_metric_id(ch.metric, ch.direction)
@@ -159,14 +174,15 @@ def to_alert_message(
             metric_id=metric_id, value_from=ch.old_value, value_to=ch.new_value,
             threshold=ch.threshold, cmp=cmp,
             occurred_at=_fmt_occurred_at(
-                ch.occurred_at, _tz_for_location(match.segment.start_point, tz)
+                ch.occurred_at, _tz_for_location(match.start_point, tz)
             ),
             km_from=km_from, km_to=km_to,
             # Issue #1744 A1: die Kennung der TATSAECHLICH aufgeloesten Etappe
             # (nicht `ch.segment_id` — `_find_segment` faellt bei nicht
             # aufloesbarer Kennung auf das erste Segment zurueck, und der Alarm
             # muss den Ort nennen, den er auch km-seitig meint).
-            segment_id=normalize_segment_id(match.segment.segment_id),
+            segment_id=normalize_segment_id(match.segment_id),
+            km_measured=km_measured,  # Issue #2036
         ))
     corridor_events = (
         to_corridor_events(corridor_hits, segments, tz=tz) if corridor_hits else ()
@@ -235,15 +251,17 @@ def to_corridor_events(hits, segments, *, tz) -> tuple[CorridorEvent, ...]:
     for hit in hits:
         try:
             metric_id = _resolve_corridor_metric_id(hit.metric, hit.direction)
-            match = _find_segment(segments, hit.segment_id)
+            match = _trip_segment(_find_segment(segments, hit.segment_id))
             events.append(CorridorEvent(
                 metric_id=metric_id, value=hit.value, bound=hit.bound,
                 direction=hit.direction,
                 occurred_at=_fmt_occurred_at(
-                    hit.occurred_at, _tz_for_location(match.segment.start_point, tz)
+                    hit.occurred_at, _tz_for_location(match.start_point, tz)
                 ),
-                km_from=match.segment.start_point.distance_from_start_km,
-                km_to=match.segment.end_point.distance_from_start_km,
+                km_from=match.start_point.distance_from_start_km,
+                km_to=match.end_point.distance_from_start_km,
+                # Issue #2036: Herkunft der Spanne reist mit.
+                km_measured=bool(getattr(match, "distance_measured", False)),
             ))
         except Exception as e:
             logger.warning(

--- a/src/output/renderers/alert/project.py
+++ b/src/output/renderers/alert/project.py
@@ -260,7 +260,10 @@ def to_corridor_events(hits, segments, *, tz) -> tuple[CorridorEvent, ...]:
                 ),
                 km_from=match.start_point.distance_from_start_km,
                 km_to=match.end_point.distance_from_start_km,
-                # Issue #2036: Herkunft der Spanne reist mit.
+                # Issue #2036: Kennung der TATSAECHLICH aufgeloesten Etappe
+                # (Muster `to_alert_message`) und Herkunft der Spanne reisen
+                # mit -- ohne beides kann der Renderer nur km zeigen (F001).
+                segment_id=normalize_segment_id(match.segment_id),
                 km_measured=bool(getattr(match, "distance_measured", False)),
             ))
         except Exception as e:

--- a/src/output/renderers/alert/render.py
+++ b/src/output/renderers/alert/render.py
@@ -245,8 +245,22 @@ def _km_str_onset(e: OnsetEvent) -> str:
 # --- Schwellen-Treffer (Issue #1444 S1, ADR-0013: eigener Render-Vertrag,
 # KEIN "vorher", KEIN "von A auf B") -----------------------------------------
 
+def _corridor_where(ce: CorridorEvent) -> str:
+    """Ortsangabe EINES Schwellen-Treffers (Issue #2036, Adversary F001) --
+    ueber DIESELBE geteilte Aufloesung wie alle anderen Alarmarten
+    (`segments.format_alert_location`). Vorher baute dieser Zweig seine
+    km-Spanne selbst und umging damit sowohl die Segment-Sprache (#1744)
+    als auch die Echtheitspruefung (#2036 AC-13): eine unvermessene Etappe
+    zeigte eine aus Luftlinie erfundene Kilometerangabe."""
+    return format_alert_location(
+        ce.location_label, [getattr(ce, "segment_id", None)],
+        ce.km_from, ce.km_to,
+        km_measured=getattr(ce, "km_measured", False),
+    )
+
+
 def _corridor_when(ce: CorridorEvent) -> str:
-    when = ce.location_label or f"km {int(round(ce.km_from))}–{int(round(ce.km_to))}"
+    when = _corridor_where(ce)
     if ce.occurred_at:
         when += f" · {ce.occurred_at}"
     return when
@@ -1044,11 +1058,17 @@ def _render_sms_corridor_only(msg: AlertMessage, limit: int) -> str:
     if msg.location_label:
         head = f"{trip} {_ascii(msg.location_label)[:24]}: "
     else:
-        a = min(ce.km_from for ce in msg.corridor_events)
-        b = max(ce.km_to for ce in msg.corridor_events)
-        # Issue #2036 (AC-5): Leerzeichen nach "km" -- dieselbe
-        # Schreibweise wie in `format_alert_location`.
-        head = f"{trip} km {int(round(a))}-{int(round(b))}: "
+        # Issue #2036 (Adversary F001): dieselbe Aufloesung wie Betreff,
+        # E-Mail und Telegram -- Segment-Sprache bzw. gemessene km-Spanne,
+        # nie eine aus Luftlinie erfundene Zahl (AC-13). Alles-oder-nichts
+        # ueber die Treffer desselben Laufs, analog `_location_of`.
+        evs = msg.corridor_events
+        where = format_alert_location(
+            None, [getattr(ce, "segment_id", None) for ce in evs],
+            min(ce.km_from for ce in evs), max(ce.km_to for ce in evs),
+            km_measured=all(getattr(ce, "km_measured", False) for ce in evs),
+        )
+        head = f"{trip} {_ascii_alert_location(where)}: "
     body = head + " ".join(_sms_corridor_token(ce) for ce in msg.corridor_events)
     return body if len(body) <= limit else body[:limit]
 

--- a/src/output/renderers/alert/render.py
+++ b/src/output/renderers/alert/render.py
@@ -195,8 +195,15 @@ def _location_of(events, location_label: str | None = None) -> str:
     sinnlose km-Spanne eines Punktes ohne km-Kontext; der Trip-Pfad setzt das
     Feld nie."""
     a, b = km_span(events)
+    # Issue #2036: die km-Spanne verdraengt die Segmentnummer nur, wenn sie
+    # bei JEDEM beteiligten Ereignis aus echter Wegstrecke stammt -- eine
+    # gemischte Menge waere eine Ortsangabe, die zur Haelfte geraten ist.
+    measured = bool(events) and all(
+        getattr(e, "km_measured", False) for e in events
+    )
     return format_alert_location(
         location_label, [e.segment_id for e in events], a, b,
+        km_measured=measured,
     )
 
 
@@ -269,6 +276,7 @@ def _sms_corridor_token(ce: CorridorEvent) -> str:
 def _onset_shift_where(oe: OnsetShiftEvent) -> str:
     return format_alert_location(
         oe.location_label, [oe.segment_id], oe.km_from, oe.km_to,
+        km_measured=getattr(oe, "km_measured", False),  # Issue #2036
     )
 
 
@@ -288,6 +296,8 @@ def _onset_shift_location(msg: AlertMessage) -> str:
     return format_alert_location(
         msg.location_label, [oe.segment_id for oe in evs],
         min(oe.km_from for oe in evs), max(oe.km_to for oe in evs),
+        # Issue #2036: alles-oder-nichts wie in `_location_of`.
+        km_measured=all(getattr(oe, "km_measured", False) for oe in evs),
     )
 
 
@@ -1036,7 +1046,9 @@ def _render_sms_corridor_only(msg: AlertMessage, limit: int) -> str:
     else:
         a = min(ce.km_from for ce in msg.corridor_events)
         b = max(ce.km_to for ce in msg.corridor_events)
-        head = f"{trip} km{int(round(a))}-{int(round(b))}: "
+        # Issue #2036 (AC-5): Leerzeichen nach "km" -- dieselbe
+        # Schreibweise wie in `format_alert_location`.
+        head = f"{trip} km {int(round(a))}-{int(round(b))}: "
     body = head + " ".join(_sms_corridor_token(ce) for ce in msg.corridor_events)
     return body if len(body) <= limit else body[:limit]
 

--- a/src/output/renderers/alert/segments.py
+++ b/src/output/renderers/alert/segments.py
@@ -90,19 +90,36 @@ def _renderable_segment_ids(segment_ids) -> list[str]:
 
 def format_alert_location(
     location_label: str | None, segment_ids, km_from: float, km_to: float,
+    km_measured: bool = False,
 ) -> str:
     """Die Ortsangabe eines Alarms — DIE gemeinsame Aufloesungsreihenfolge
-    (Issue #1744 AC-3):
+    (Issue #1744 AC-3, erweitert um Issue #2036):
 
     1. `location_label` gesetzt   -> Ortsname (Ortsvergleich, unveraendert)
-    2. Segment-Kennung(en) da     -> `format_segment_reference`
-    3. sonst                      -> `km {von}–{bis}` (Rueckfall, Altdaten)
+    2. GEMESSENE km-Spanne        -> `km {von}-{bis}` (Issue #2036 AC-1)
+    3. Segment-Kennung(en) da     -> `format_segment_reference`
+    4. sonst                      -> `km {von}–{bis}` (Rueckfall, Altdaten)
 
-    Stufe 3 ist kein Notnagel, sondern AC-7: ein Alarm ohne Segment-Kennung
-    muss weiterhin einen Ort nennen und versendet werden.
+    Stufe 4 ist kein Notnagel, sondern AC-7 aus #1744: ein Alarm ohne
+    Segment-Kennung muss weiterhin einen Ort nennen und versendet werden.
+
+    `km_measured` (Issue #2036, Default aus): NUR wenn die Spanne aus echter
+    GPX-Wegstrecke stammt, darf sie die Segmentnummer verdraengen — eine aus
+    Luftlinie geschaetzte Zahl waere glaubwuerdig aussehender Unsinn (AC-13).
+    Faellt Start und Ende auf denselben ganzen Kilometer zusammen, ist die
+    Spanne keine Information mehr ("km 20-20"); dann gilt weiter die
+    Segment-Sprache, insbesondere das Etappenziel "🏁 Ziel" (AC-4).
+
+    Schreibweise mit Leerzeichen und ASCII-Bindestrich (`km 12-20`, AC-5):
+    der Rueckfall auf Stufe 4 behaelt seinen Halbgeviertstrich, damit
+    Bestandsausgaben byte-identisch bleiben.
     """
     if location_label:
         return location_label
+    if km_measured and km_from is not None and km_to is not None:
+        a, b = int(round(km_from)), int(round(km_to))
+        if a != b:
+            return f"km {a}-{b}"
     ids = _renderable_segment_ids(segment_ids)
     if ids:
         reference = format_segment_reference(ids)

--- a/src/services/gpx_processing.py
+++ b/src/services/gpx_processing.py
@@ -148,6 +148,10 @@ def segments_to_trip(
             lon=seg.start_point.lon,
             elevation_m=int(seg.start_point.elevation_m),
             time_window=tw,  # Issue #1004: GPX-Import-Artefakt, nie autoritativ
+            # Issue #2036: gemessene Wegstrecke des ORIGINAL-Trackpunkts
+            # mitnehmen -- sie wurde bislang direkt nach der Segmentbildung
+            # verworfen und musste danach aus Luftlinie geschaetzt werden.
+            distance_from_start_km=seg.start_point.distance_from_start_km,
         ))
 
     # Last waypoint: end of last segment
@@ -163,6 +167,7 @@ def segments_to_trip(
         lon=last.end_point.lon,
         elevation_m=int(last.end_point.elevation_m),
         time_window=tw_end,  # Issue #1004: GPX-Import-Artefakt, nie autoritativ
+        distance_from_start_km=last.end_point.distance_from_start_km,  # Issue #2036
     ))
 
     stage = Stage(
@@ -230,6 +235,11 @@ def gpx_to_stage_data(
             "lon": wp.lon,
             "elevation_m": wp.elevation_m,
             "time_window": str(wp.time_window) if wp.time_window else None,
+            # Issue #2036: die gemessene Wegstrecke muss den API-Vertrag
+            # mitreisen -- der Editor schickt genau dieses Dict spaeter an
+            # `SaveTrip` zurueck; fehlt der Schluessel hier, ist der Wert
+            # nach dem ersten Speichern weg (Praezedenzfall #303).
+            "distance_from_start_km": wp.distance_from_start_km,
         }
         for wp in stage.waypoints
     ]

--- a/src/services/notification_service.py
+++ b/src/services/notification_service.py
@@ -306,6 +306,22 @@ def compute_has_gap(
     return not expected.issubset(rendered)
 
 
+def _measured_event_km(alert_msg) -> dict:
+    """Gemessene km-Spanne je Segment-Kennung aus den bereits projizierten
+    Alarm-Ereignissen (Issue #2036). Quelle fuer den EINGEBETTETEN amtlichen
+    Warnblock, damit beide Haelften derselben Mail dieselbe Ortssprache
+    sprechen (#1744 AC-6). Ungemessene Ereignisse liefern keinen Eintrag --
+    die Warnung bleibt dort bei "Segment N"."""
+    result: dict = {}
+    for e in list(alert_msg.events) + list(alert_msg.onset_shift_events):
+        if not getattr(e, "km_measured", False):
+            continue
+        seg = getattr(e, "segment_id", None)
+        if seg:
+            result[str(seg)] = (e.km_from, e.km_to)
+    return result
+
+
 def _official_source_url_for(dto_notices: list) -> str | None:
     """Quelle-Link der führenden (höchststufigen) Warnung (Issue #1216 F002).
     Für variant="standalone" derzeit ungenutzt (der Thin-Wrapper reicht 1:1 an
@@ -851,6 +867,7 @@ class NotificationService:
         mail_sink: Optional[object] = None,
         sms_sink: Optional[object] = None,
         telegram_style: str = "rich",
+        segment_km: Optional[dict] = None,
     ) -> NotificationResult:
         """Standalone amtlicher Alert ohne Wetter-Delta (Issue #1088; Format-
         Fidelity zur Design-Vorlage in Issue #1216).
@@ -872,7 +889,11 @@ class NotificationService:
             if first_wp is not None
             else ZoneInfo("UTC")
         )
-        dto_notices = build_official_alert_notices(trip, notices)
+        # Issue #2036: gemessene km-Spannen mitgeben -- ohne sie bleibt die
+        # amtliche Warnung byte-identisch bei der Segment-Sprache.
+        dto_notices = build_official_alert_notices(
+            trip, notices, segment_km=segment_km,
+        )
         source_label = _official_source_label_for(dto_notices)
         source_url = _official_source_url_for(dto_notices)
         # #1233 Nebenbefund AC-12: Betreff und Body MUESSEN dieselbe tz-aware
@@ -1395,7 +1416,13 @@ class NotificationService:
             # daraus die DTOs (ohne Trip faellt die Segment-Gesamtzahl leer
             # aus, "gesamte Route"-Verdichtung entfaellt ersatzlos, s.
             # `_trip_total_segment_ids`-Docstring).
-            embed_notices = build_official_alert_notices(None, official_notices)
+            # Issue #2036: dieselbe Ortssprache wie der Aenderungs-Teil
+            # DERSELBEN Mail -- die km-Spannen stammen aus den bereits
+            # projizierten Ereignissen, nicht aus einer zweiten Quelle.
+            embed_notices = build_official_alert_notices(
+                None, official_notices,
+                segment_km=_measured_event_km(alert_msg),
+            )
             embed_source = _official_source_label_for(embed_notices)
             embedded_html = render_warn_block(
                 embed_notices, variant="embedded", source_label=embed_source,

--- a/src/services/preview_service.py
+++ b/src/services/preview_service.py
@@ -150,7 +150,10 @@ class PreviewService:
         """
         from services.trip_report_scheduler import TripReportSchedulerService
         scheduler = TripReportSchedulerService(self.settings)
-        segments = scheduler._convert_trip_to_segments(trip, target)
+        # Issue #2036 CI-Nachschlag (PR #2055): eine Vorschau ist "kein
+        # Versand, nur Render" (Modul-Docstring) -- sie darf den
+        # Trip-Bestand nicht als Seiteneffekt veraendern.
+        segments = scheduler._convert_trip_to_segments(trip, target, persist=False)
         if not segments:
             # Issue #990: Zwei Ursachen unterscheiden, damit die Frontend-
             # Erkennung aus #421 (matcht "waypoint" case-insensitive) nur beim

--- a/src/services/preview_service.py
+++ b/src/services/preview_service.py
@@ -240,14 +240,19 @@ class PreviewService:
             # bei Morgen-/Abend-Overrides, nur in der Vorschau).
             trend_result = scheduler._build_stage_trend(
                 trip, target, now_utc=now_utc, tz=trip_tz,
-                report_type=report_type,
+                report_type=report_type, persist=False,
             )
             multi_day_trend = trend_result.rows
             outlook_state = trend_result.state
             outlook_horizon_days = trend_result.horizon_days
+        # Issue #2036 CI-Nachschlag (PR #2055, Folgefund): beide Bauwege
+        # bauen Segmente auch fuer zukuenftige Etappen (Trend +3 Tage,
+        # Thunder-Fallback +1/+2) -- ohne persist=False schrieb die Vorschau
+        # ueber genau diesen Nebenpfad trotzdem in den echten Trip-Bestand.
         thunder_forecast = scheduler._build_thunder_forecast_from_trend_or_fetch(
             trip, target, now_utc=now_utc, tz=trip_tz,
             multi_day_trend=multi_day_trend, night_weather=night_weather,
+            persist=False,
         )
 
         # Issue #474: F12 Wetterlage-Label vor format_email berechnen.

--- a/src/services/preview_service.py
+++ b/src/services/preview_service.py
@@ -150,9 +150,13 @@ class PreviewService:
         """
         from services.trip_report_scheduler import TripReportSchedulerService
         scheduler = TripReportSchedulerService(self.settings)
-        # Issue #2036 CI-Nachschlag (PR #2055): eine Vorschau ist "kein
+        # Issue #2036 CI-Nachschlag (PR #2055/#2058): eine Vorschau ist "kein
         # Versand, nur Render" (Modul-Docstring) -- sie darf den
-        # Trip-Bestand nicht als Seiteneffekt veraendern.
+        # Trip-Bestand nicht als Seiteneffekt veraendern. Das Attribut steuert
+        # ALLE Nebenpfade (Trend, Thunder-Fallback) gleichermassen -- die
+        # direkte Zeile darunter uebergibt zusaetzlich noch explizit
+        # persist=False, weil sie ohnehin schon einen Keyword-Wert traegt.
+        scheduler.persist_backfill = False
         segments = scheduler._convert_trip_to_segments(trip, target, persist=False)
         if not segments:
             # Issue #990: Zwei Ursachen unterscheiden, damit die Frontend-
@@ -240,19 +244,19 @@ class PreviewService:
             # bei Morgen-/Abend-Overrides, nur in der Vorschau).
             trend_result = scheduler._build_stage_trend(
                 trip, target, now_utc=now_utc, tz=trip_tz,
-                report_type=report_type, persist=False,
+                report_type=report_type,
             )
             multi_day_trend = trend_result.rows
             outlook_state = trend_result.state
             outlook_horizon_days = trend_result.horizon_days
-        # Issue #2036 CI-Nachschlag (PR #2055, Folgefund): beide Bauwege
-        # bauen Segmente auch fuer zukuenftige Etappen (Trend +3 Tage,
-        # Thunder-Fallback +1/+2) -- ohne persist=False schrieb die Vorschau
-        # ueber genau diesen Nebenpfad trotzdem in den echten Trip-Bestand.
+        # Issue #2036 CI-Nachschlag (PR #2055/#2058): beide Bauwege bauen
+        # Segmente auch fuer zukuenftige Etappen (Trend +3 Tage, Thunder-
+        # Fallback +1/+2) -- ``scheduler.persist_backfill = False`` oben
+        # steuert BEIDE Nebenpfade, damit die Vorschau nicht in den echten
+        # Trip-Bestand schreibt.
         thunder_forecast = scheduler._build_thunder_forecast_from_trend_or_fetch(
             trip, target, now_utc=now_utc, tz=trip_tz,
             multi_day_trend=multi_day_trend, night_weather=night_weather,
-            persist=False,
         )
 
         # Issue #474: F12 Wetterlage-Label vor format_email berechnen.

--- a/src/services/track_resolution.py
+++ b/src/services/track_resolution.py
@@ -106,7 +106,9 @@ def resolve_stage_track_km(
 _failed_lookups: set = set()
 
 
-def backfill_stage_distances(trip, user_id: str, target_date) -> object:
+def backfill_stage_distances(
+    trip, user_id: str, target_date, *, persist: bool = True,
+) -> object:
     """Traegt die gemessene Wegstrecke der Etappe zu ``target_date`` einmalig
     nach und schreibt sie additiv an den Trip zurueck (Issue #2036 AC-7).
 
@@ -118,13 +120,22 @@ def backfill_stage_distances(trip, user_id: str, target_date) -> object:
     Fail-soft: jeder Fehler laesst den Trip unveraendert -- eine fehlende
     Kilometerangabe ist ein Schoenheitsfehler, ein ausgefallener Alarm nicht.
 
+    Args:
+        persist: Bei ``False`` (Issue #2036 CI-Nachschlag, PR #2055) wird die
+            aufgeloeste Distanz nur INS RUECKGABEOBJEKT geschrieben, nicht
+            via ``save_trip`` auf die Platte. Fuer reine Vorschau-Pfade
+            (``PreviewService`` -- "kein Versand, nur Render"): eine Ansicht
+            darf den Trip-Bestand nicht als Seiteneffekt veraendern, egal
+            welcher ``user_id`` sie zugerechnet wird. Alarm- und
+            Briefing-Versandpfade lassen den Default (persistieren).
+
     Returns:
         Den (ggf. ergaenzten) Trip -- immer ein verwendbares Objekt.
     """
     try:
         import dataclasses
 
-        from app.loader import get_data_dir, save_trip
+        from app.loader import get_data_dir
 
         stage = trip.get_stage_for_date(target_date)
         if stage is None or not stage.waypoints:
@@ -150,10 +161,13 @@ def backfill_stage_distances(trip, user_id: str, target_date) -> object:
         updated = dataclasses.replace(trip, stages=[
             new_stage if s.id == stage.id else s for s in trip.stages
         ])
-        save_trip(updated, user_id=user_id)
+        if persist:
+            from app.loader import save_trip
+
+            save_trip(updated, user_id=user_id)
         logger.info(
             "Track-Aufloesung: Etappe %s von Trip %s nachtraeglich vermessen "
-            "(%d Wegpunkte)", stage.id, trip.id, len(distances),
+            "(%d Wegpunkte, persist=%s)", stage.id, trip.id, len(distances), persist,
         )
         return updated
     except Exception as e:

--- a/src/services/track_resolution.py
+++ b/src/services/track_resolution.py
@@ -1,0 +1,164 @@
+"""Track-Auflösung fuer Bestandstrips ohne gemessene Wegstrecke (Issue #2036).
+
+Wegpunkte importierter Etappen SIND Original-Trackpunkte -- gemessener
+Abstand 0,0 m. Liegt der zugehoerige GPX-Track noch im Bestand des Nutzers
+(``data/users/<user_id>/gpx/``), laesst sich die beim Import verworfene
+Wegstrecke deshalb eindeutig nachtragen, statt sie aus Luftlinie zu
+schaetzen.
+
+Zwei Regeln machen das Nachtragen belastbar statt raterisch:
+
+* **Vollstaendigkeit** -- ein Track passt nur, wenn er JEDEN Wegpunkt der
+  Etappe innerhalb der Toleranz enthaelt. Ein einziger manuell verschobener
+  oder ergaenzter Wegpunkt (>10 m abseits) laesst die GANZE Etappe
+  unvermessen (AC-12).
+* **Eindeutigkeit** -- passen mehrere Dateien gleichermassen (etwa eine
+  Einzeletappen- UND eine Gesamt-GPX), wird KEINE geraten (AC-11).
+
+Ohne eindeutigen Treffer liefert die Auflösung ``None``; die Ortsangabe
+bleibt dann byte-identisch bei ``Segment N`` (AC-10).
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from utils.geo import haversine_km
+
+logger = logging.getLogger("track_resolution")
+
+# Toleranz Wegpunkt <-> Trackpunkt. Original-Trackpunkte liegen bei 0,0 m,
+# die naechstbeste (falsche) Datei im gemessenen Bestand bei >= 4.672 m --
+# 10 m deckt Koordinatenrundung ab und liegt drei Groessenordnungen unter
+# dem Fehlerfall (Spec "Festgelegte Schwellenwerte").
+DEFAULT_TOLERANCE_M = 10.0
+
+
+def _match_track(
+    waypoints: List, points: List, tolerance_m: float,
+) -> Optional[Dict[str, float]]:
+    """Distanz je Wegpunkt aus DIESEM Track -- oder ``None``, wenn auch nur
+    ein Wegpunkt weiter als die Toleranz vom naechstgelegenen Trackpunkt
+    entfernt liegt (alles oder nichts, AC-12)."""
+    result: Dict[str, float] = {}
+    for wp in waypoints:
+        best_km: Optional[float] = None
+        best_dist: Optional[float] = None
+        for pt in points:
+            d = haversine_km(wp.lat, wp.lon, pt.lat, pt.lon)
+            if best_dist is None or d < best_dist:
+                best_dist = d
+                best_km = pt.distance_from_start_km
+        if best_dist is None or best_dist * 1000.0 > tolerance_m:
+            return None
+        result[wp.id] = best_km
+    return result
+
+
+def resolve_stage_track_km(
+    stage, gpx_dir, tolerance_m: float = DEFAULT_TOLERANCE_M,
+) -> Optional[Dict[str, float]]:
+    """Gemessene Wegstrecke je Wegpunkt der Etappe aus dem GPX-Bestand.
+
+    Args:
+        stage: Etappe mit ``waypoints`` (je ``id``/``lat``/``lon``).
+        gpx_dir: Verzeichnis des Nutzer-GPX-Bestands.
+        tolerance_m: Hoechstabstand Wegpunkt <-> Trackpunkt in Metern.
+
+    Returns:
+        ``{waypoint_id: distance_from_start_km}`` bei GENAU einem passenden
+        Track, sonst ``None`` (kein Treffer, mehrdeutig, oder mindestens ein
+        Wegpunkt abseits).
+    """
+    from core.gpx_parser import parse_gpx
+
+    waypoints = list(getattr(stage, "waypoints", None) or [])
+    directory = Path(gpx_dir)
+    if not waypoints or not directory.is_dir():
+        return None
+
+    matches: List[Dict[str, float]] = []
+    for path in sorted(directory.glob("*.gpx")):
+        try:
+            track = parse_gpx(path)
+        except Exception as e:
+            logger.warning(
+                "Track-Aufloesung: %s nicht lesbar, uebersprungen (%s)",
+                path.name, e,
+            )
+            continue
+        hit = _match_track(waypoints, track.points or [], tolerance_m)
+        if hit is not None:
+            matches.append(hit)
+        if len(matches) > 1:
+            return None  # mehrdeutig -- nicht raten (AC-11)
+    if len(matches) != 1:
+        return None
+    return matches[0]
+
+
+# Etappen, fuer die in DIESEM Prozess bereits erfolglos gesucht wurde. Ohne
+# diese Sperre parst jeder Alarmlauf den kompletten GPX-Bestand des Nutzers
+# neu, obwohl das Ergebnis feststeht -- der Lauf hat eine Zeitobergrenze.
+# Ein Neustart (oder ein frisch hochgeladener Track nach einem Neustart)
+# hebt sie auf; das ist die "lazy"-Grenze aus den Known Limitations der Spec.
+_failed_lookups: set = set()
+
+
+def backfill_stage_distances(trip, user_id: str, target_date) -> object:
+    """Traegt die gemessene Wegstrecke der Etappe zu ``target_date`` einmalig
+    nach und schreibt sie additiv an den Trip zurueck (Issue #2036 AC-7).
+
+    Der Rueckschreibweg ist ``save_trip`` -- Read-Modify-Write mit Merge
+    (``loader._deep_merge_preserve_unknown``); Felder, die Python nicht
+    modelliert (Go-/Legacy-Felder), bleiben erhalten. Betroffen ist NUR die
+    eine Etappe: die uebrigen Wegpunkte werden unveraendert durchgereicht.
+
+    Fail-soft: jeder Fehler laesst den Trip unveraendert -- eine fehlende
+    Kilometerangabe ist ein Schoenheitsfehler, ein ausgefallener Alarm nicht.
+
+    Returns:
+        Den (ggf. ergaenzten) Trip -- immer ein verwendbares Objekt.
+    """
+    try:
+        import dataclasses
+
+        from app.loader import get_data_dir, save_trip
+
+        stage = trip.get_stage_for_date(target_date)
+        if stage is None or not stage.waypoints:
+            return trip
+        if all(
+            getattr(wp, "distance_from_start_km", None) is not None
+            for wp in stage.waypoints
+        ):
+            return trip  # bereits vermessen -- nichts zu tun
+        key = (user_id, trip.id, stage.id)
+        if key in _failed_lookups:
+            return trip
+        distances = resolve_stage_track_km(stage, get_data_dir(user_id) / "gpx")
+        if distances is None or any(
+            wp.id not in distances for wp in stage.waypoints
+        ):
+            _failed_lookups.add(key)
+            return trip
+        new_stage = dataclasses.replace(stage, waypoints=[
+            dataclasses.replace(wp, distance_from_start_km=distances[wp.id])
+            for wp in stage.waypoints
+        ])
+        updated = dataclasses.replace(trip, stages=[
+            new_stage if s.id == stage.id else s for s in trip.stages
+        ])
+        save_trip(updated, user_id=user_id)
+        logger.info(
+            "Track-Aufloesung: Etappe %s von Trip %s nachtraeglich vermessen "
+            "(%d Wegpunkte)", stage.id, trip.id, len(distances),
+        )
+        return updated
+    except Exception as e:
+        logger.warning(
+            "Track-Aufloesung fuer Trip %s fehlgeschlagen, Etappe bleibt "
+            "unvermessen (%s)", getattr(trip, "id", "?"), e,
+        )
+        return trip

--- a/src/services/trip_alert.py
+++ b/src/services/trip_alert.py
@@ -34,6 +34,7 @@ from services.notification_service import (
     RadarAlertRequest,
 )
 from output.renderers.alert.segments import normalize_segment_id
+from services.trip_segments import measured_segment_km  # Issue #2036
 from services.point_weather import AlertEvaluationConfig, TripSegmentWeatherAdapter
 from services.corridor_threshold import CorridorHit
 from services.throttle_store import ThrottleStore
@@ -597,7 +598,9 @@ class TripAlertService:
                 elif official_notices:
                     # Kein Wetter-Delta-Alert gefeuert, aber neue/gestiegene amtliche
                     # Warnung(en) — eigenständiger Versand (PO-Entscheidung).
-                    if self._send_official_alert_only(trip, official_notices):
+                    if self._send_official_alert_only(
+                        trip, official_notices, segments=cached,
+                    ):
                         alerts_sent += 1
             except Exception as e:
                 logger.error(f"Alert check failed for trip {trip.id}: {e}")
@@ -1887,7 +1890,9 @@ class TripAlertService:
             alerts=[a for a, _segment_ids in official_notices],
         )
 
-    def _send_official_alert_only(self, trip: "Trip", official_notices: list) -> bool:
+    def _send_official_alert_only(
+        self, trip: "Trip", official_notices: list, segments: Optional[list] = None,
+    ) -> bool:
         """Issue #1088: Standalone-Versand einer amtlichen Warnung ohne Wetter-Delta.
 
         Reproduziert nur die generischen Sicherheits-Gates (QuietHours,
@@ -1978,6 +1983,10 @@ class TripAlertService:
             effective_channels=_official_allowed,
             mail_sink=self._mail_sink,
             telegram_style=_trip_telegram_style(trip),
+            # Issue #2036 (AC-3): dieselbe Ortsquelle wie Nowcast- und
+            # Abweichungsalarm. Ohne Segmente (kein Anker) bleibt die Karte
+            # leer und die Warnung bei der Segment-Sprache (AC-10).
+            segment_km=measured_segment_km(segments),
         )
         # Issue #1459: amtliche Warnungen tragen ihre Gefahrenart in `hazards`,
         # NICHT als Register-Kennung in `metrics` (eigenes Vokabular, O1).

--- a/src/services/trip_alert.py
+++ b/src/services/trip_alert.py
@@ -1140,6 +1140,34 @@ class TripAlertService:
             return None
         return None
 
+    def _resolve_alert_segment(self, trip: "Trip", now_utc: datetime, today: date):
+        """Segment-Auswahl des ALARM-Pfads -- mit vorgeschalteter, einmaliger
+        Nachruestung der gemessenen Wegstrecke (Issue #2036 AC-7).
+
+        AC-7 nennt als Ausloeser ausdruecklich die ERSTE Aufloesung der
+        Alarm-Ortsangabe. Der Briefing-Trichter
+        (`trip_report_scheduler._convert_trip_to_segments`) ruestet ebenfalls
+        nach und bleibt unveraendert bestehen -- er greift aber nicht bei
+        einem Trip mit abgeschaltetem Briefing-Versand und auch nicht bei
+        einem Nowcast-Alarm VOR dem ersten Briefing des Tages. Genau dort
+        bliebe die Etappe sonst dauerhaft auf "Segment N".
+
+        Kein Doppelschreiben: `backfill_stage_distances` kehrt sofort um,
+        sobald alle Wegpunkte der Etappe eine Distanz tragen -- der zweite
+        Lauf fasst die Trip-Datei nicht mehr an.
+
+        GRENZE: nachgeruestet wird die Etappe von `today`. Faellt die
+        Aufloesung auf die Vortagsetappe zurueck (Stufe 2 in
+        `resolve_current_segment`, #1667 S3), bleibt diese unvermessen bis
+        ihr eigener Tag an der Reihe war -- kein zweiter GPX-Durchlauf pro
+        Alarmzyklus, der Lauf hat eine Zeitobergrenze.
+        """
+        from services.track_resolution import backfill_stage_distances
+        from services.trip_segments import resolve_current_segment
+
+        trip = backfill_stage_distances(trip, self._user_id, today)
+        return resolve_current_segment(trip, now_utc, today)
+
     def check_radar_alerts(self) -> int:
         """
         Check all trips for radar-based alerts using segment-aware logic (Issue #822).
@@ -1156,7 +1184,6 @@ class TripAlertService:
         Returns the number of radar alerts triggered.
         """
         from app.loader import load_all_trips
-        from services.trip_segments import resolve_current_segment
 
         now_utc = datetime.now(timezone.utc)
         sent = 0
@@ -1173,7 +1200,7 @@ class TripAlertService:
             # nicht (`get_stage_for_date` loest strikt per `==` auf).
             # `segment_date` ist das Datum, dem das gewaehlte Segment
             # ENTSTAMMT — nicht zwingend `today`, s. Schnappschuss unten.
-            _resolved = resolve_current_segment(trip, now_utc, today)
+            _resolved = self._resolve_alert_segment(trip, now_utc, today)
             if _resolved is None:
                 # Keine Etappe an beiden Tagen oder alle Segmente zeitlich
                 # vorbei → kein Alert (Option Y der Spec)

--- a/src/services/trip_report_scheduler.py
+++ b/src/services/trip_report_scheduler.py
@@ -2271,6 +2271,8 @@ class TripReportSchedulerService:
         now_utc: datetime,
         tz=None,
         report_type: str = "evening",
+        *,
+        persist: bool = True,
     ):
         """
         Build trend rows for each future stage (v4.0 column layout).
@@ -2293,6 +2295,13 @@ class TripReportSchedulerService:
         Wetterabruf mit Retry-Backoff liegt: eine eigene Aufloesung koennte
         bereits den naechsten Ortstag tragen, waehrend ``target_date`` noch auf
         dem alten steht.
+
+        Issue #2036 CI-Nachschlag (PR #2055, Folgefund): ``persist`` an
+        ``_convert_trip_to_segments`` durchgereicht -- der Trend baut
+        Segmente fuer BIS ZU DREI zukuenftige Etappen, nicht nur fuer
+        ``target_date``. Ohne diese Weitergabe schrieb der Vorschau-Pfad
+        (``persist=False`` am direkten Aufruf) ueber diesen Nebenpfad
+        trotzdem in den echten Trip-Bestand.
         """
         from app.models import OutlookState, TrendResult
         from providers.openmeteo import (
@@ -2328,7 +2337,9 @@ class TripReportSchedulerService:
                 horizon_days = OPENMETEO_MAX_FORECAST_DAYS
                 continue
             try:
-                segments = self._convert_trip_to_segments(trip, stage.date)
+                segments = self._convert_trip_to_segments(
+                    trip, stage.date, persist=persist,
+                )
                 if not segments:
                     # Fix #1486: bisher voellig stumm.
                     logger.warning(
@@ -2454,6 +2465,8 @@ class TripReportSchedulerService:
         tz: Optional[ZoneInfo],
         multi_day_trend=None,
         night_weather=None,
+        *,
+        persist: bool = True,
     ) -> Optional[dict]:
         """Issue #1275: derive the +1/+2 thunder forecast from the SAME data as
         the E-Mail-Outlook table.
@@ -2492,6 +2505,11 @@ class TripReportSchedulerService:
         diese Funktion trifft selbst KEINE Tagesentscheidung (kein eigener
         Fundort), sie haelt nur den Zeitpunkt auf demselben Weg wie der
         Rest des Briefing-Aufbaus.
+
+        Issue #2036 CI-Nachschlag (PR #2055, Folgefund): ``persist`` an
+        ``_collect_future_stage_weather`` durchgereicht -- der Fallback-Fetch
+        baut ebenfalls Segmente fuer zukuenftige Etappen (analog
+        ``_build_stage_trend``).
         """
         from app.day_window import resolve_configured_window
 
@@ -2531,6 +2549,7 @@ class TripReportSchedulerService:
         if missing_dates:
             fetched = self._collect_future_stage_weather(
                 trip, target_date, now_utc=now_utc, wanted_dates=missing_dates,
+                persist=persist,
             )
             fetched_fc = (
                 self._build_thunder_forecast(
@@ -2724,6 +2743,8 @@ class TripReportSchedulerService:
         target_date: date,
         now_utc: datetime,
         wanted_dates=None,
+        *,
+        persist: bool = True,
     ) -> List[SegmentWeatherData]:
         """Issue #1275: fetch weather for the actual next future stages,
         aggregated later across ALL their segments.
@@ -2781,7 +2802,9 @@ class TripReportSchedulerService:
             if not is_within_forecast_horizon(stage.date, today):
                 continue
             try:
-                segments = self._convert_trip_to_segments(trip, stage.date)
+                segments = self._convert_trip_to_segments(
+                    trip, stage.date, persist=persist,
+                )
                 if not segments:
                     continue
                 seg_weather = self._fetch_weather(segments)

--- a/src/services/trip_report_scheduler.py
+++ b/src/services/trip_report_scheduler.py
@@ -409,6 +409,15 @@ class TripReportSchedulerService:
         self._settings = settings if settings else Settings().with_user_profile(user_id)
         self._notification_service = NotificationService(self._settings, user_id)
         self._user_id = user_id
+        # Issue #2036 CI-Nachschlag (PR #2058): Objekt-Attribut statt
+        # durchgereichtem Keyword-Parameter an _build_stage_trend /
+        # _collect_future_stage_weather -- diese Methoden werden von
+        # mehreren netzfreien Tests komplett ueberschrieben (Test-Doubles),
+        # ein neuer Keyword-Parameter dort ist fuer sie ein Signaturbruch.
+        # PreviewService._build_report schaltet dieses Attribut direkt nach
+        # dem Konstruieren auf False -- eine Vorschau darf den Trip-Bestand
+        # nicht als Seiteneffekt veraendern (AC-7 Nebenpfad).
+        self.persist_backfill: bool = True
 
     def send_reports(self, report_type: str) -> int:
         """
@@ -1938,7 +1947,7 @@ class TripReportSchedulerService:
         trip: "Trip",
         target_date: date,
         *,
-        persist: bool = True,
+        persist: Optional[bool] = None,
     ) -> List[TripSegment]:
         """Thin delegator — real logic lives in services.trip_segments (Issue #822).
 
@@ -1953,11 +1962,24 @@ class TripReportSchedulerService:
 
         Args:
             persist: an ``backfill_stage_distances`` durchgereicht (Issue
-                #2036 CI-Nachschlag, PR #2055). Default ``True`` fuer alle
-                Versandpfade (Alarm, Briefing-Dispatch, On-Demand-Fetch).
-                ``PreviewService`` ruft mit ``False`` -- eine Vorschau darf
-                den Trip-Bestand nicht als Seiteneffekt veraendern.
+                #2036 CI-Nachschlag, PR #2055/#2058). ``None`` (Default)
+                heisst: das Objekt-Attribut ``self.persist_backfill``
+                entscheidet (Default ``True`` fuer alle Versandpfade --
+                Alarm, Briefing-Dispatch, On-Demand-Fetch). Ein expliziter
+                Wert hier gewinnt immer -- so ruft ``PreviewService`` diesen
+                direkten Aufruf mit ``persist=False``, waehrend die
+                Nebenpfade ueber ``_build_stage_trend`` /
+                ``_collect_future_stage_weather`` OHNE Keyword rufen und
+                stattdessen ueber das am Scheduler gesetzte Attribut
+                gesteuert werden (Signaturbruch-Fix #2058: diese beiden
+                Methoden werden von Test-Doubles komplett ueberschrieben).
         """
+        # `getattr` mit Default: die Segment-Umwandlung ist eine reine
+        # Funktion und wird auch an teilinitialisierten Instanzen gerufen
+        # (kein __init__-Durchlauf, also auch kein persist_backfill-Attribut).
+        effective_persist = (
+            getattr(self, "persist_backfill", True) if persist is None else persist
+        )
         from services.track_resolution import backfill_stage_distances
         from services.trip_segments import convert_trip_to_segments
         # `getattr`: die Segment-Umwandlung ist eine reine Funktion und wird
@@ -1966,7 +1988,7 @@ class TripReportSchedulerService:
         user_id = getattr(self, "_user_id", None)
         if user_id:
             trip = backfill_stage_distances(
-                trip, user_id, target_date, persist=persist,
+                trip, user_id, target_date, persist=effective_persist,
             )
         return convert_trip_to_segments(trip, target_date)
 
@@ -2271,8 +2293,6 @@ class TripReportSchedulerService:
         now_utc: datetime,
         tz=None,
         report_type: str = "evening",
-        *,
-        persist: bool = True,
     ):
         """
         Build trend rows for each future stage (v4.0 column layout).
@@ -2296,12 +2316,13 @@ class TripReportSchedulerService:
         bereits den naechsten Ortstag tragen, waehrend ``target_date`` noch auf
         dem alten steht.
 
-        Issue #2036 CI-Nachschlag (PR #2055, Folgefund): ``persist`` an
-        ``_convert_trip_to_segments`` durchgereicht -- der Trend baut
-        Segmente fuer BIS ZU DREI zukuenftige Etappen, nicht nur fuer
-        ``target_date``. Ohne diese Weitergabe schrieb der Vorschau-Pfad
-        (``persist=False`` am direkten Aufruf) ueber diesen Nebenpfad
-        trotzdem in den echten Trip-Bestand.
+        Issue #2036 CI-Nachschlag (PR #2055/#2058): der Trend baut Segmente
+        fuer BIS ZU DREI zukuenftige Etappen, nicht nur fuer ``target_date``.
+        Ob ``_convert_trip_to_segments`` dabei persistiert, steuert NICHT
+        ein Parameter hier (Signaturbruch fuer Test-Doubles, die diese
+        Methode komplett ueberschreiben), sondern das Objekt-Attribut
+        ``self.persist_backfill`` -- ``PreviewService`` schaltet es am
+        Scheduler auf ``False``, bevor diese Methode gerufen wird.
         """
         from app.models import OutlookState, TrendResult
         from providers.openmeteo import (
@@ -2337,9 +2358,7 @@ class TripReportSchedulerService:
                 horizon_days = OPENMETEO_MAX_FORECAST_DAYS
                 continue
             try:
-                segments = self._convert_trip_to_segments(
-                    trip, stage.date, persist=persist,
-                )
+                segments = self._convert_trip_to_segments(trip, stage.date)
                 if not segments:
                     # Fix #1486: bisher voellig stumm.
                     logger.warning(
@@ -2465,8 +2484,6 @@ class TripReportSchedulerService:
         tz: Optional[ZoneInfo],
         multi_day_trend=None,
         night_weather=None,
-        *,
-        persist: bool = True,
     ) -> Optional[dict]:
         """Issue #1275: derive the +1/+2 thunder forecast from the SAME data as
         the E-Mail-Outlook table.
@@ -2506,10 +2523,10 @@ class TripReportSchedulerService:
         Fundort), sie haelt nur den Zeitpunkt auf demselben Weg wie der
         Rest des Briefing-Aufbaus.
 
-        Issue #2036 CI-Nachschlag (PR #2055, Folgefund): ``persist`` an
-        ``_collect_future_stage_weather`` durchgereicht -- der Fallback-Fetch
-        baut ebenfalls Segmente fuer zukuenftige Etappen (analog
-        ``_build_stage_trend``).
+        Issue #2036 CI-Nachschlag (PR #2055/#2058): der Fallback-Fetch baut
+        ebenfalls Segmente fuer zukuenftige Etappen (analog
+        ``_build_stage_trend``) -- auch hier steuert ``self.persist_backfill``
+        am Scheduler-Objekt, nicht ein Parameter hier (Begruendung s.o.).
         """
         from app.day_window import resolve_configured_window
 
@@ -2549,7 +2566,6 @@ class TripReportSchedulerService:
         if missing_dates:
             fetched = self._collect_future_stage_weather(
                 trip, target_date, now_utc=now_utc, wanted_dates=missing_dates,
-                persist=persist,
             )
             fetched_fc = (
                 self._build_thunder_forecast(
@@ -2743,8 +2759,6 @@ class TripReportSchedulerService:
         target_date: date,
         now_utc: datetime,
         wanted_dates=None,
-        *,
-        persist: bool = True,
     ) -> List[SegmentWeatherData]:
         """Issue #1275: fetch weather for the actual next future stages,
         aggregated later across ALL their segments.
@@ -2802,9 +2816,7 @@ class TripReportSchedulerService:
             if not is_within_forecast_horizon(stage.date, today):
                 continue
             try:
-                segments = self._convert_trip_to_segments(
-                    trip, stage.date, persist=persist,
-                )
+                segments = self._convert_trip_to_segments(trip, stage.date)
                 if not segments:
                     continue
                 seg_weather = self._fetch_weather(segments)

--- a/src/services/trip_report_scheduler.py
+++ b/src/services/trip_report_scheduler.py
@@ -1936,7 +1936,9 @@ class TripReportSchedulerService:
     def _convert_trip_to_segments(
         self,
         trip: "Trip",
-        target_date: date
+        target_date: date,
+        *,
+        persist: bool = True,
     ) -> List[TripSegment]:
         """Thin delegator — real logic lives in services.trip_segments (Issue #822).
 
@@ -1948,6 +1950,13 @@ class TripReportSchedulerService:
         Produktionspfad fuer BESTANDS-Trips -- der Import-Weg (AC-6) deckt
         nur neu angelegte Etappen ab. Fail-soft und ohne Treffer folgenlos:
         der Trip laeuft dann unveraendert weiter (AC-10).
+
+        Args:
+            persist: an ``backfill_stage_distances`` durchgereicht (Issue
+                #2036 CI-Nachschlag, PR #2055). Default ``True`` fuer alle
+                Versandpfade (Alarm, Briefing-Dispatch, On-Demand-Fetch).
+                ``PreviewService`` ruft mit ``False`` -- eine Vorschau darf
+                den Trip-Bestand nicht als Seiteneffekt veraendern.
         """
         from services.track_resolution import backfill_stage_distances
         from services.trip_segments import convert_trip_to_segments
@@ -1956,7 +1965,9 @@ class TripReportSchedulerService:
         # gibt es keinen GPX-Bestand, also auch nichts nachzutragen.
         user_id = getattr(self, "_user_id", None)
         if user_id:
-            trip = backfill_stage_distances(trip, user_id, target_date)
+            trip = backfill_stage_distances(
+                trip, user_id, target_date, persist=persist,
+            )
         return convert_trip_to_segments(trip, target_date)
 
     def _clamp_segments_to_today(

--- a/src/services/trip_report_scheduler.py
+++ b/src/services/trip_report_scheduler.py
@@ -1942,8 +1942,21 @@ class TripReportSchedulerService:
 
         Behaviour is bit-identical to the previous inline implementation;
         the refactor is a pure Extract Function with no semantic change.
+
+        Issue #2036: davor die einmalige Nachruestung der gemessenen
+        Wegstrecke aus dem GPX-Bestand des Nutzers (AC-7). Sie ist der
+        Produktionspfad fuer BESTANDS-Trips -- der Import-Weg (AC-6) deckt
+        nur neu angelegte Etappen ab. Fail-soft und ohne Treffer folgenlos:
+        der Trip laeuft dann unveraendert weiter (AC-10).
         """
+        from services.track_resolution import backfill_stage_distances
         from services.trip_segments import convert_trip_to_segments
+        # `getattr`: die Segment-Umwandlung ist eine reine Funktion und wird
+        # auch an teilinitialisierten Instanzen gerufen -- ohne Nutzerbezug
+        # gibt es keinen GPX-Bestand, also auch nichts nachzutragen.
+        user_id = getattr(self, "_user_id", None)
+        if user_id:
+            trip = backfill_stage_distances(trip, user_id, target_date)
         return convert_trip_to_segments(trip, target_date)
 
     def _clamp_segments_to_today(

--- a/src/services/trip_segments.py
+++ b/src/services/trip_segments.py
@@ -25,6 +25,11 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("trip_segments")
 
+# Issue #2036: Zugabe der Plausibilitaetspruefung (gemessene Spanne gegen
+# Luftlinie). Deckt die Rundung persistierter km-Werte ab -- alles darueber
+# ist ein Nachbearbeitungs-Artefakt und macht die Etappe unvermessen.
+_MEASURED_SLACK_KM = 0.01
+
 
 def _parse_hhmm(value: str) -> Optional[time]:
     """Parse 'HH:MM' to a time object; returns None on malformed input."""
@@ -105,6 +110,67 @@ def _interpolate_missing_times(known_times: List[Optional[time]]) -> List[Option
     return result
 
 
+def stage_measured_distances(waypoints: List) -> Optional[List[float]]:
+    """Gemessene Wegstrecke je Wegpunkt, auf den Etappenstart normiert
+    (Issue #2036, AC-8/AC-9/AC-14) -- oder ``None``, wenn die Etappe als
+    UNVERMESSEN gilt.
+
+    Eine Etappe ist nur dann vermessen, wenn
+
+    1. JEDER ihrer Wegpunkte einen Wert traegt. ``0.0`` ist dabei eine
+       gueltige Messung (Etappenstart), ``None`` heisst "nicht gemessen" --
+       ein einziges ``None`` macht die ganze Etappe unvermessen (AC-14);
+    2. die Werte STRIKT monoton steigen; und
+    3. jede Teilstrecke mindestens so gross ist wie die Luftlinie zwischen
+       den beiden Wegpunkten -- ein Track kann nie kuerzer sein als die
+       direkte Verbindung (AC-8).
+
+    Verletzt EIN Paar die Regel, gilt die GESAMTE Etappe als unvermessen;
+    eine teilweise vermessene Etappe waere eine Ortsangabe, die an einer
+    Stelle stimmt und an der naechsten still falsch ist.
+
+    Die Normierung auf den Etappenstart ist PO-Vorgabe: "jeder Tag zaehlt
+    neu seine Kilometer" -- auch wenn die Messung aus einer durchlaufenden
+    Gesamt-GPX ueber alle Etappen stammt (AC-9).
+    """
+    values = [getattr(wp, "distance_from_start_km", None) for wp in waypoints]
+    if not values or any(v is None for v in values):
+        return None
+    for i in range(len(values) - 1):
+        span = values[i + 1] - values[i]
+        if span <= 0:  # nicht strikt monoton
+            return None
+        luftlinie = haversine_km(
+            waypoints[i].lat, waypoints[i].lon,
+            waypoints[i + 1].lat, waypoints[i + 1].lon,
+        )
+        # 10 m Zugabe faengt die Rundung gespeicherter Werte ab, nicht mehr.
+        if span + _MEASURED_SLACK_KM < luftlinie:
+            return None
+    base = values[0]
+    return [v - base for v in values]
+
+
+def measured_segment_km(segments) -> dict:
+    """Gemessene km-Spanne je Segment-Kennung (Issue #2036) -- NUR fuer
+    Segmente, deren Distanz aus echter Wegstrecke stammt.
+
+    Speist die Ortsangabe der amtlichen Warnung aus DERSELBEN Quelle wie
+    Nowcast- und Abweichungsalarm (Teilungs-Invariante #1744, AC-3).
+    Nimmt ``SegmentWeatherData`` ODER blanke ``TripSegment`` entgegen.
+    """
+    result: dict = {}
+    for entry in segments or ():
+        seg = getattr(entry, "segment", entry)
+        if not getattr(seg, "distance_measured", False):
+            continue
+        result[str(seg.segment_id)] = (
+            seg.start_point.distance_from_start_km,
+            seg.end_point.distance_from_start_km,
+        )
+    return result
+
+
 def convert_trip_to_segments(trip: "Trip", target_date: date) -> List[TripSegment]:
     """Convert Trip waypoints to TripSegment DTOs for a given date.
 
@@ -168,6 +234,10 @@ def convert_trip_to_segments(trip: "Trip", target_date: date) -> List[TripSegmen
 
     cumulative_time = default_start
     cumulative_dist_km = 0.0
+    # Issue #2036: gemessene, auf den Etappenstart normierte Wegstrecke --
+    # `None`, wenn die Etappe unvermessen ist. Dann bleibt ALLES beim
+    # bisherigen Luftlinien-Verhalten (Terminschutz AC-10).
+    measured = stage_measured_distances(waypoints)
 
     for i in range(len(waypoints) - 1):
         wp1 = waypoints[i]
@@ -223,6 +293,17 @@ def convert_trip_to_segments(trip: "Trip", target_date: date) -> List[TripSegmen
         elev2 = wp2.elevation_m if wp2.elevation_m else 0
         elev_diff = elev2 - elev1
         dist_km = haversine_km(wp1.lat, wp1.lon, wp2.lat, wp2.lon)
+        # Issue #2036: gemessene Spanne schlaegt Luftlinie -- aber NUR wenn
+        # die ganze Etappe vermessen ist. `km_start`/`km_end` sind die Werte,
+        # die spaeter als Ortsangabe erscheinen duerfen.
+        if measured is not None:
+            km_start = measured[i]
+            km_end = measured[i + 1]
+            seg_dist_km = round(km_end - km_start, 1)
+        else:
+            km_start = cumulative_dist_km
+            km_end = cumulative_dist_km + round(dist_km, 1)
+            seg_dist_km = round(dist_km, 1)
 
         # Issue #1468 (E2): das Auswertungsfenster der Tour reist mit dem
         # Segment -- jeder spaetere Aggregations-Aufrufer erbt es dadurch.
@@ -232,24 +313,25 @@ def convert_trip_to_segments(trip: "Trip", target_date: date) -> List[TripSegmen
                 lat=wp1.lat,
                 lon=wp1.lon,
                 elevation_m=float(elev1),
-                distance_from_start_km=cumulative_dist_km,
+                distance_from_start_km=km_start,
             ),
             end_point=GPXPoint(
                 lat=wp2.lat,
                 lon=wp2.lon,
                 elevation_m=float(elev2),
-                distance_from_start_km=cumulative_dist_km + round(dist_km, 1),
+                distance_from_start_km=km_end,
             ),
             start_time=start_dt,
             end_time=end_dt,
             duration_hours=duration_hours,
-            distance_km=round(dist_km, 1),
+            distance_km=seg_dist_km,
             ascent_m=float(max(0, elev_diff)),
             descent_m=float(max(0, -elev_diff)),
             day_window_start_hour=_win_start,
             day_window_end_hour=_win_end,
+            distance_measured=measured is not None,  # Issue #2036
         )
-        cumulative_dist_km += round(dist_km, 1)
+        cumulative_dist_km = km_end
         segments.append(segment)
 
     # Destination segment (Zielort)
@@ -324,6 +406,9 @@ def convert_trip_to_segments(trip: "Trip", target_date: date) -> List[TripSegmen
                 elevation_m=elev,
                 distance_from_start_km=cumulative_dist_km,
             ),
+            # Issue #2036: Das Ziel-Segment traegt km_from == km_to und behaelt
+            # deshalb im Renderer sein "🏁 Ziel" (AC-4) -- das Flag sagt nur,
+            # WOHER die Zahl stammt.
             start_time=arrival_time,
             end_time=dest_end_time,
             duration_hours=(dest_end_time - arrival_time).total_seconds() / 3600,
@@ -336,6 +421,7 @@ def convert_trip_to_segments(trip: "Trip", target_date: date) -> List[TripSegmen
             # in ORTSZEIT filtert und nicht am Segment-Ende haengt.
             day_window_start_hour=_win_start,
             day_window_end_hour=_win_end,
+            distance_measured=measured is not None,  # Issue #2036
         )
         segments.append(destination_segment)
 

--- a/src/services/weather_snapshot.py
+++ b/src/services/weather_snapshot.py
@@ -460,6 +460,11 @@ def _serialize_segment(seg: SegmentWeatherData) -> dict:
         "end_elevation_m": seg.segment.end_point.elevation_m,
         "end_distance_from_start_km": seg.segment.end_point.distance_from_start_km,
         "distance_km": seg.segment.distance_km,
+        # Issue #2036: Herkunft der km-Spanne (gemessen vs. Luftlinie) gehoert
+        # MIT in den Anker -- aus einem geladenen Segment entsteht sonst still
+        # wieder eine ungemessene Ortsangabe. `False` bleibt weg, damit
+        # Bestands-Anker byte-identisch bleiben.
+        **({"distance_measured": True} if seg.segment.distance_measured else {}),
         "ascent_m": seg.segment.ascent_m,
         "descent_m": seg.segment.descent_m,
         "duration_hours": seg.segment.duration_hours,
@@ -546,4 +551,7 @@ def _reconstruct_segment(seg_data: dict) -> TripSegment:
         # Alt-Anker ohne die Felder laden dadurch unveraendert.
         day_window_start_hour=seg_data.get("day_window_start_hour"),
         day_window_end_hour=seg_data.get("day_window_end_hour"),
+        # Issue #2036: fehlender Schluessel -> False (Alt-Anker sind
+        # unvermessen und zeigen weiter die Segmentnummer).
+        distance_measured=bool(seg_data.get("distance_measured", False)),
     )

--- a/tests/tdd/test_alert_flag_propagation_snapshot.py
+++ b/tests/tdd/test_alert_flag_propagation_snapshot.py
@@ -1,0 +1,229 @@
+"""TDD RED — Issue #2036, AC-15: das Echtheits-Flag ('gemessen, nicht
+geraten') bleibt auf JEDER Zwischenstufe `True` -- Snapshot-Speichern/
+-Rekonstruieren UND alle vier Alert-Event-Typen.
+
+SPEC:    docs/specs/modules/fix_2036_alarm_kilometer_ortsangabe.md (AC-15)
+KONTEXT: docs/context/fix-2036-alarm-kilometer.md
+
+Jede Zwischenstufe wird EINZELN geprueft (nicht nur das Endergebnis) --
+Nachweisführung der Spec: "Ein Test, der nur mit durchweg vorhandenen oder
+durchweg fehlenden Werten arbeitet, deckt diese Unterscheidung nicht ab"
+gilt sinngemaess auch hier: eine Kette, die nur am Ende prueft, kann an
+JEDER Zwischenstufe still auf den Default `False` zurueckfallen, ohne dass
+ein Test das bemerkt.
+
+RED-VERTRAG: `TripSegment.distance_measured`, `AlertEvent.km_measured`,
+`OnsetEvent.km_measured`, `OnsetShiftEvent.km_measured`,
+`CorridorEvent.km_measured` existieren heute nicht. Jede Konstruktion mit
+diesen Schluesselworten schlaegt mit `TypeError` fehl -- das IST der
+RED-Zustand.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+UTC = timezone.utc
+TZ_VIENNA = __import__("zoneinfo").ZoneInfo("Europe/Vienna")
+
+
+def _measured_segment(segment_id="3", km_from=12.0, km_to=20.0):
+    from app.models import GPXPoint, TripSegment
+
+    start = GPXPoint(lat=46.6, lon=12.9, elevation_m=1900.0,
+                      distance_from_start_km=km_from)
+    end = GPXPoint(lat=46.6, lon=12.9, elevation_m=1900.0,
+                    distance_from_start_km=km_to)
+    try:
+        return TripSegment(
+            segment_id=segment_id, start_point=start, end_point=end,
+            start_time=datetime(2026, 7, 1, 6, 0, tzinfo=UTC),
+            end_time=datetime(2026, 7, 1, 8, 0, tzinfo=UTC),
+            duration_hours=2.0, distance_km=km_to - km_from,
+            ascent_m=200.0, descent_m=50.0, distance_measured=True,
+        )
+    except TypeError as exc:
+        raise AssertionError(
+            "TripSegment traegt kein additives 'distance_measured'-Feld "
+            f"(Spec, models.py). Urspruenglicher Fehler: {exc}"
+        ) from exc
+
+
+# ---------------------------------------------------------------------------
+# AC-15a — weather_snapshot: Speichern und Rekonstruieren
+# ---------------------------------------------------------------------------
+
+def test_ac15_flag_ueberlebt_snapshot_serialisierung():
+    """AC-15 (Zwischenstufe 1/2): `_serialize_segment()` schreibt das Flag
+    in das Snapshot-Dict."""
+    from app.models import SegmentWeatherData, SegmentWeatherSummary
+    from services.weather_snapshot import _serialize_segment
+
+    seg = _measured_segment()
+    swd = SegmentWeatherData(
+        segment=seg, timeseries=None,
+        aggregated=SegmentWeatherSummary(gust_max_kmh=80.0),
+        fetched_at=datetime(2026, 7, 1, 6, 0, tzinfo=UTC), provider="openmeteo",
+    )
+    entry = _serialize_segment(swd)
+
+    assert entry.get("distance_measured") is True, (
+        f"Serialisiertes Segment traegt das Flag nicht: {entry!r}"
+    )
+
+
+def test_ac15_flag_ueberlebt_snapshot_rekonstruktion():
+    """AC-15 (Zwischenstufe 2/2): `_reconstruct_segment()` liest das Flag aus
+    dem Snapshot-Dict zurueck in ein `TripSegment`."""
+    from services.weather_snapshot import _reconstruct_segment
+
+    seg_data = {
+        "segment_id": "3", "start_time": "2026-07-01T06:00:00+00:00",
+        "end_time": "2026-07-01T08:00:00+00:00",
+        "start_lat": 46.6, "start_lon": 12.9, "start_elevation_m": 1900.0,
+        "start_distance_from_start_km": 12.0,
+        "end_lat": 46.6, "end_lon": 12.9, "end_elevation_m": 1900.0,
+        "end_distance_from_start_km": 20.0,
+        "distance_km": 8.0, "ascent_m": 200.0, "descent_m": 50.0,
+        "distance_measured": True,
+    }
+    segment = _reconstruct_segment(seg_data)
+
+    assert getattr(segment, "distance_measured", None) is True, (
+        f"Rekonstruiertes Segment traegt das Flag nicht: "
+        f"{getattr(segment, 'distance_measured', None)!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-15b — vier Alert-Event-Typen: das Flag kommt bis zum Renderer durch
+# ---------------------------------------------------------------------------
+
+def test_ac15_alertevent_traegt_das_flag_aus_der_echten_projektion():
+    """AC-15 (AlertEvent, ueber `to_alert_message`): ein vermessenes
+    Segment ergibt ein `AlertEvent` mit `km_measured=True` -- nicht nur bei
+    direkter Konstruktion, sondern aus der PRODUKTIONS-Projektion."""
+    from app.models import ChangeSeverity, WeatherChange
+    from output.renderers.alert.project import to_alert_message
+
+    seg = _measured_segment(segment_id="3")
+    from app.models import SegmentWeatherData, SegmentWeatherSummary
+    swd = SegmentWeatherData(
+        segment=seg, timeseries=None,
+        aggregated=SegmentWeatherSummary(gust_max_kmh=80.0),
+        fetched_at=datetime(2026, 7, 1, 6, 0, tzinfo=UTC), provider="openmeteo",
+    )
+    change = WeatherChange(
+        metric="gust_max_kmh", old_value=30.0, new_value=80.0, delta=50.0,
+        threshold=20.0, severity=ChangeSeverity.MODERATE, direction="increase",
+        segment_id="3", occurred_at=datetime(2026, 7, 1, 14, 0, tzinfo=UTC),
+    )
+    msg = to_alert_message([change], [swd], "TDD-AC15", tz=TZ_VIENNA, stand_at="10:00")
+
+    assert len(msg.events) == 1, f"Erwartete ein Event, erhielt: {msg.events!r}"
+    event = msg.events[0]
+    assert getattr(event, "km_measured", None) is True, (
+        f"AlertEvent aus to_alert_message() traegt km_measured nicht: "
+        f"{getattr(event, 'km_measured', None)!r}"
+    )
+
+
+def test_ac15_onsetevent_traegt_das_flag():
+    """AC-15 (OnsetEvent): additives Feld, analog `segment_id`
+    (`test_alert_location_vocabulary.py`-RED-Vertrag Punkt 1) -- der
+    Nowcast-Pfad konstruiert `OnsetEvent` direkt, ohne Projektionsfunktion."""
+    from output.renderers.alert.model import OnsetEvent
+
+    try:
+        event = OnsetEvent(
+            onset_minutes=8, onset_time="14:08", km_from=12.0, km_to=20.0,
+            is_convective=True, intensity_label="kraeftiger Regen",
+            source_label="Radar (GeoSphere INCA)", segment_id="3",
+            km_measured=True,
+        )
+    except TypeError as exc:
+        raise AssertionError(
+            "OnsetEvent traegt kein additives 'km_measured'-Feld "
+            f"(Spec, model.py). Urspruenglicher Fehler: {exc}"
+        ) from exc
+
+    assert event.km_measured is True
+
+
+def test_ac15_onsetshiftevent_traegt_das_flag_aus_der_echten_projektion():
+    """AC-15 (OnsetShiftEvent, ueber `to_alert_message`s Onset-Zweig): eine
+    Beginn-Verschiebung auf einem vermessenen Segment ergibt ein
+    `OnsetShiftEvent` mit `km_measured=True`."""
+    from app.models import ChangeSeverity, SegmentWeatherData, \
+        SegmentWeatherSummary, WeatherChange
+    from output.renderers.alert.project import to_alert_message
+
+    seg = _measured_segment(segment_id="3")
+    swd = SegmentWeatherData(
+        segment=seg, timeseries=None,
+        aggregated=SegmentWeatherSummary(gust_max_kmh=80.0),
+        fetched_at=datetime(2026, 7, 1, 6, 0, tzinfo=UTC), provider="openmeteo",
+    )
+    now = datetime(2026, 7, 1, 12, 0, tzinfo=UTC).timestamp()
+    later = datetime(2026, 7, 1, 14, 0, tzinfo=UTC).timestamp()
+    change = WeatherChange(
+        metric="thunder_onset_utc", old_value=now, new_value=later,
+        delta=later - now, threshold=1800.0, severity=ChangeSeverity.MODERATE,
+        direction="increase", segment_id="3",
+        occurred_at=datetime(2026, 7, 1, 14, 0, tzinfo=UTC),
+    )
+    msg = to_alert_message([change], [swd], "TDD-AC15", tz=TZ_VIENNA, stand_at="10:00")
+
+    assert len(msg.onset_shift_events) == 1, (
+        f"Erwartete ein OnsetShiftEvent, erhielt: {msg.onset_shift_events!r}"
+    )
+    oe = msg.onset_shift_events[0]
+    assert getattr(oe, "km_measured", None) is True, (
+        f"OnsetShiftEvent aus to_alert_message() traegt km_measured nicht: "
+        f"{getattr(oe, 'km_measured', None)!r}"
+    )
+
+
+def test_ac15_corridorevent_traegt_das_flag_aus_der_echten_projektion():
+    """AC-15 (CorridorEvent, ueber `to_corridor_events`): ein Schwellen-
+    Treffer auf einem vermessenen Segment ergibt ein `CorridorEvent` mit
+    `km_measured=True`."""
+    from output.renderers.alert.project import to_corridor_events
+    from services.corridor_threshold import CorridorHit
+
+    seg = _measured_segment(segment_id="3")
+    hit = CorridorHit(
+        metric="wind_gust", value=90.0, bound=70.0, direction="above",
+        segment_id="3", occurred_at=datetime(2026, 7, 1, 14, 0, tzinfo=UTC),
+    )
+    events = to_corridor_events([hit], [seg], tz=TZ_VIENNA)
+
+    assert len(events) == 1, f"Erwartete ein CorridorEvent, erhielt: {events!r}"
+    ce = events[0]
+    assert getattr(ce, "km_measured", None) is True, (
+        f"CorridorEvent aus to_corridor_events() traegt km_measured nicht: "
+        f"{getattr(ce, 'km_measured', None)!r}"
+    )
+
+
+def test_ac15_flag_erreicht_am_ende_auch_den_renderer():
+    """AC-15 (End-zu-End-Nachweis): dasselbe vermessene AlertEvent zeigt am
+    Renderer die km-Angabe -- das Flag ist nicht nur auf dem Datenmodell
+    gesetzt, sondern WIRKT auch (Leitfrage aus CLAUDE.md: 'Ist die
+    Zusicherung an der Stelle geprueft, an der sie WIRKT?')."""
+    from output.renderers.alert.model import AlertEvent, AlertMessage
+    from output.renderers.alert.render import render_sms
+
+    try:
+        event = AlertEvent(
+            metric_id="gust", value_from=30.0, value_to=80.0, threshold=20.0,
+            cmp="über", occurred_at="11:00", km_from=12.0, km_to=20.0,
+            segment_id="3", km_measured=True,
+        )
+    except TypeError as exc:
+        raise AssertionError(
+            f"AlertEvent traegt kein additives 'km_measured'-Feld: {exc}"
+        ) from exc
+    msg = AlertMessage(trip_short="TDD", stand_at="10:00", events=(event,), source=None)
+
+    sms = render_sms(msg)
+    assert "km 12-20" in sms, f"Flag wirkt nicht am Renderer: {sms!r}"

--- a/tests/tdd/test_alert_location_measured_km.py
+++ b/tests/tdd/test_alert_location_measured_km.py
@@ -1,0 +1,216 @@
+"""TDD RED — Issue #2036: Alarm-Kurzform nennt gemessene Kilometer statt
+Segmentnummer, ABER NUR wenn die Kilometer aus echter GPX-Wegstrecke stammen.
+
+SPEC:    docs/specs/modules/fix_2036_alarm_kilometer_ortsangabe.md (AC-1, AC-2,
+         AC-4, AC-5, AC-13)
+KONTEXT: docs/context/fix-2036-alarm-kilometer.md
+
+Alle Faelle bauen echte Domaenen-Objekte (`AlertEvent`, `AlertMessage`) und
+rufen die echten Renderer (`render_subject`, `render_telegram`, `render_sms`,
+`segments.format_alert_location`) auf -- keine Mocks, keine Dateiinhalt-Checks.
+
+RED-VERTRAG: `AlertEvent` (model.py) traegt heute KEIN `km_measured`-Feld und
+`format_alert_location()` (segments.py) kennt heute KEINEN `km_measured`-
+Parameter. Jede Konstruktion mit diesem Schluesselwort schlaegt mit
+`TypeError: unexpected keyword argument 'km_measured'` fehl -- das IST der
+RED-Zustand (fehlendes additives Feld/Argument aus der Spec), keine
+Verwechslung mit einem Tippfehler in diesem Testcode.
+"""
+from __future__ import annotations
+
+import re
+
+import pytest
+
+
+def _measured_event(
+    segment_id: str | None = "3",
+    km_from: float = 12.31,
+    km_to: float = 20.0,
+    km_measured: bool = True,
+    metric_id: str = "gust",
+    value_from: float = 30.0,
+    value_to: float = 85.0,
+    threshold: float = 20.0,
+    occurred_at: str | None = "11:00",
+):
+    """Baut ein `AlertEvent` DIREKT (kein Umweg ueber `to_alert_message()`) --
+    dieselbe Technik wie `test_alert_location_vocabulary.py::_onset_message`
+    fuer das additive `segment_id`-Feld: das additive `km_measured`-Feld wird
+    hier ausschliesslich am Renderer-Modell selbst gesetzt."""
+    from output.renderers.alert.model import AlertEvent
+
+    try:
+        return AlertEvent(
+            metric_id=metric_id, value_from=value_from, value_to=value_to,
+            threshold=threshold, cmp="über", occurred_at=occurred_at,
+            km_from=km_from, km_to=km_to, segment_id=segment_id,
+            km_measured=km_measured,
+        )
+    except TypeError as exc:  # RED-Vertrag
+        raise AssertionError(
+            "AlertEvent traegt kein additives 'km_measured'-Feld (Spec "
+            "fix_2036_alarm_kilometer_ortsangabe.md, model.py:11-32). "
+            f"Urspruenglicher Fehler: {exc}"
+        ) from exc
+
+
+def _single_event_message(**kwargs):
+    from output.renderers.alert.model import AlertMessage
+
+    event = _measured_event(**kwargs)
+    return AlertMessage(
+        trip_short="KHW 403", stand_at="10:00", events=(event,), source=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-1 — Kurzform zeigt "km A-B" statt "Seg N"
+# ---------------------------------------------------------------------------
+
+def test_ac1_gemessene_spanne_zeigt_km_a_bis_b_statt_segmentnummer():
+    """AC-1: Given ein Alarm-Event hat fuer sein Segment eine gemessene,
+    plausible Kilometer-Spanne (km_measured=True) / When die Kurzform-
+    Ortsangabe aufgeloest wird (SMS/Premium-SMS/Telegram-Kurzform) / Then
+    zeigt sie 'km A-B' (Bindestrich, Leerzeichen nach 'km') statt 'Seg N',
+    A/B auf ganze Kilometer gerundet (12,31 -> 12, 20,00 -> 20)."""
+    from output.renderers.alert.render import render_sms
+
+    msg = _single_event_message(segment_id="3", km_from=12.31, km_to=20.0,
+                                 km_measured=True)
+    sms = render_sms(msg)
+
+    assert "km 12-20" in sms, f"Erwartete 'km 12-20' in der SMS: {sms!r}"
+    assert "Seg 3" not in sms, f"SMS nennt weiterhin die Segmentnummer: {sms!r}"
+
+
+def test_ac1_direkte_aufloesungsfunktion_liefert_exakte_schreibweise():
+    """AC-1 (direkt): `format_alert_location()` selbst liefert bei
+    `km_measured=True` 'km A-B' statt der Segment-Kennung."""
+    from output.renderers.alert.segments import format_alert_location
+
+    try:
+        text = format_alert_location(
+            None, ["3"], 12.31, 20.0, km_measured=True,
+        )
+    except TypeError as exc:
+        raise AssertionError(
+            "format_alert_location() kennt keinen 'km_measured'-Parameter "
+            f"(Spec Implementation Details, Auflösungsreihenfolge). {exc}"
+        ) from exc
+
+    assert text == "km 12-20", f"Ortsangabe: {text!r}"
+
+
+# ---------------------------------------------------------------------------
+# AC-2 — Betreff und Telegram-rich zeigen dieselbe km-Angabe
+# ---------------------------------------------------------------------------
+
+def test_ac2_betreff_und_telegram_zeigen_dieselbe_km_angabe_wie_die_kurzform():
+    """AC-2: Given dieselbe Aufloesungsfunktion wird auch fuer E-Mail-Betreff
+    und Telegram-rich verwendet / When ein Segment eine gemessene km-Spanne
+    traegt / Then zeigen Betreff- und Telegram-rich-Text dieselbe km-Angabe
+    wie die Kurzform, nicht mehr die Segmentnummer."""
+    from output.renderers.alert.render import render_sms, render_subject, render_telegram
+
+    msg = _single_event_message(segment_id="4", km_from=6.0, km_to=13.6,
+                                 km_measured=True)
+
+    subject = render_subject(msg)
+    telegram = render_telegram(msg)
+    sms = render_sms(msg)
+
+    assert "km 6-14" in subject, f"Betreff zeigt nicht die km-Spanne: {subject!r}"
+    assert "km 6-14" in telegram, f"Telegram-rich zeigt nicht die km-Spanne: {telegram!r}"
+    assert "km 6-14" in sms, f"SMS zeigt nicht die km-Spanne: {sms!r}"
+    assert "Segment 4" not in subject and "Seg 4" not in telegram, (
+        f"Betreff/Telegram nennen weiterhin die Segmentnummer: "
+        f"{subject!r} / {telegram!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-4 — Etappenziel behaelt "Ziel", auch wenn vermessen
+# ---------------------------------------------------------------------------
+
+def test_ac4_etappenziel_zeigt_weiterhin_flagge_ziel_trotz_gemessener_spanne():
+    """AC-4: Given das letzte Segment einer Etappe hat km_from == km_to
+    (Etappenziel) / When die Ortsangabe fuer dieses Segment aufgeloest wird,
+    auch wenn die Etappe vermessen ist / Then bleibt die Anzeige '🏁 Ziel'
+    und wird NICHT durch 'km 20-20' ersetzt."""
+    from output.renderers.alert.segments import format_alert_location
+
+    text = format_alert_location(
+        None, ["Ziel"], 20.0, 20.0, km_measured=True,
+    )
+
+    assert text == "🏁 Ziel", f"Ortsangabe: {text!r}"
+    assert "km 20-20" not in text, f"Ortsangabe darf keine km-Spanne zeigen: {text!r}"
+
+
+# ---------------------------------------------------------------------------
+# AC-5 — SMS-Schreibweise: Leerzeichen nach "km", Ratschen-Regex bleibt gruen
+# ---------------------------------------------------------------------------
+
+def test_ac5_sms_schreibweise_hat_leerzeichen_nach_km_kein_kmzahl():
+    """AC-5: Given eine gemessene km-Spanne wird in der SMS-Kurzform
+    gerendert / When der Text erzeugt wird / Then folgt er dem Muster
+    'km A-B' MIT Leerzeichen nach 'km' (nicht 'kmA-B'), und der Ratschen-
+    Regex aus `test_alert_location_vocabulary.py:534`
+    (`re.search(r"km\\d", sms)`) bleibt gruen."""
+    from output.renderers.alert.render import render_sms
+
+    msg = _single_event_message(segment_id="7", km_from=45.0, km_to=52.0,
+                                 km_measured=True)
+    sms = render_sms(msg)
+
+    assert "km 45-52" in sms, f"SMS: {sms!r}"
+    assert not re.search(r"km\d", sms), (
+        f"SMS traegt eine leerzeichenlose km-Angabe (Ratschen-Verstoss): {sms!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-13 — Ohne Messung NIE eine (Luftlinien-)Kilometerangabe
+# ---------------------------------------------------------------------------
+
+def test_ac13_unvermessenes_segment_zeigt_nie_die_luftlinien_kilometer():
+    """AC-13: Given kein Wegpunkt der Etappe traegt eine gemessene
+    Wegstrecke und kein Track konnte eindeutig zugeordnet werden
+    (km_measured=False) / When die Ortsangabe aufgeloest wird / Then wird zu
+    KEINEM Zeitpunkt ein aus Luftlinie (`haversine_km`) berechneter
+    Kilometerwert als Ortsangabe angezeigt -- auch nicht als Zahl irgendwo
+    im Text.
+
+    Realistische Luftlinienwerte aus zwei echten GR221-Wegpunkten
+    (Valldemossa -> Deia, Tag 1), damit der Testwert kein Phantasiewert ist."""
+    from output.renderers.alert.render import render_sms, render_subject
+    from output.renderers.alert.segments import format_alert_location
+    from utils.geo import haversine_km
+
+    lat1, lon1 = 39.710564, 2.62293   # G1 Start
+    lat2, lon2 = 39.747657, 2.648606  # G4 Ziel
+    luftlinie_km = haversine_km(lat1, lon1, lat2, lon2)
+    assert luftlinie_km > 0.1, "Testkoordinaten liegen zu nah beieinander"
+
+    text = format_alert_location(
+        None, ["3"], 0.0, luftlinie_km, km_measured=False,
+    )
+    assert text == "Segment 3", (
+        f"Unvermessenes Segment zeigt nicht 'Segment 3': {text!r}"
+    )
+    luft_int = int(round(luftlinie_km))
+    assert f"km {luft_int}" not in text and str(luft_int) not in text, (
+        f"Luftlinienwert {luft_int} taucht in der Ortsangabe auf: {text!r}"
+    )
+
+    msg = _single_event_message(
+        segment_id="3", km_from=0.0, km_to=luftlinie_km, km_measured=False,
+    )
+    subject = render_subject(msg)
+    sms = render_sms(msg)
+    for rendered in (subject, sms):
+        assert not re.search(r"km\s*\d", rendered), (
+            f"Gerenderter Alarmtext zeigt eine km-Zahl trotz km_measured=False: "
+            f"{rendered!r}"
+        )

--- a/tests/tdd/test_alert_location_measured_km.py
+++ b/tests/tdd/test_alert_location_measured_km.py
@@ -20,8 +20,6 @@ from __future__ import annotations
 
 import re
 
-import pytest
-
 
 def _measured_event(
     segment_id: str | None = "3",

--- a/tests/tdd/test_alert_location_measured_km.py
+++ b/tests/tdd/test_alert_location_measured_km.py
@@ -212,3 +212,174 @@ def test_ac13_unvermessenes_segment_zeigt_nie_die_luftlinien_kilometer():
             f"Gerenderter Alarmtext zeigt eine km-Zahl trotz km_measured=False: "
             f"{rendered!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# F001 (Adversary-Runde 1) — der VIERTE Event-Typ: Schwellen-/Korridor-Alarm
+#
+# `CorridorEvent` traegt `km_measured` seit #2036, aber kein Corridor-Renderer
+# hat das Feld je gelesen: `_corridor_when`/`_corridor_line`/
+# `_render_sms_corridor_only` bauten ihre Ortsangabe direkt aus
+# `ce.km_from`/`ce.km_to`, unter Umgehung von `segments.format_alert_location`.
+# Ergebnis war eine erfundene Luftlinien-km-Angabe in Betreff, E-Mail,
+# Telegram UND SMS (AC-13-Verstoss fuer einen ganzen Event-Typ, AC-15 fuer
+# die Wirksamkeit des Flags).
+# ---------------------------------------------------------------------------
+
+def _corridor_message(km_from=0.0, km_to=6.87, km_measured=False,
+                       segment_id="3", location_label=None):
+    from output.renderers.alert.model import AlertMessage, CorridorEvent
+
+    ce = CorridorEvent(
+        metric_id="gust", value=95.0, bound=80.0, direction="above",
+        occurred_at="11:00", km_from=km_from, km_to=km_to,
+        location_label=location_label, km_measured=km_measured,
+        segment_id=segment_id,
+    )
+    return AlertMessage(
+        trip_short="KHW 403", stand_at="10:00", events=(), source=None,
+        corridor_events=(ce,),
+    )
+
+
+def test_ac13_korridor_alarm_zeigt_nie_die_luftlinien_kilometer():
+    """AC-13 (Korridor-Zweig): Given ein Schwellen-Treffer auf einer
+    UNVERMESSENEN Etappe (`km_measured=False`) / When Betreff, E-Mail,
+    Telegram und SMS gerendert werden / Then erscheint an KEINER dieser
+    vier Stellen eine km-Zahl, sondern die Segment-Sprache."""
+    from output.renderers.alert.render import (
+        render_email, render_sms, render_subject, render_telegram,
+    )
+
+    msg = _corridor_message(km_from=0.0, km_to=6.87, km_measured=False,
+                             segment_id="3")
+
+    subject = render_subject(msg)
+    telegram = render_telegram(msg)
+    sms = render_sms(msg)
+    _html, plain = render_email(msg)
+
+    for name, rendered in (("Betreff", subject), ("Telegram", telegram),
+                            ("SMS", sms), ("E-Mail", plain)):
+        assert not re.search(r"km\s*\d", rendered), (
+            f"{name} zeigt eine km-Zahl trotz km_measured=False "
+            f"(Luftlinie als Ortsangabe): {rendered!r}"
+        )
+    assert "Segment 3" in subject, f"Betreff nennt die Etappe nicht: {subject!r}"
+    assert "Seg 3" in sms, f"SMS nennt die Etappe nicht: {sms!r}"
+
+
+def test_ac1_korridor_alarm_zeigt_gemessene_km_spanne():
+    """AC-1/AC-15 (Korridor-Zweig): Given ein Schwellen-Treffer auf einer
+    VERMESSENEN Etappe / When dieselben vier Renderer laufen / Then zeigen
+    sie 'km 12-20' -- das Flag wirkt dort, wo die Ortsangabe entsteht."""
+    from output.renderers.alert.render import (
+        render_email, render_sms, render_subject, render_telegram,
+    )
+
+    msg = _corridor_message(km_from=12.31, km_to=20.0, km_measured=True,
+                             segment_id="3")
+
+    subject = render_subject(msg)
+    telegram = render_telegram(msg)
+    sms = render_sms(msg)
+    _html, plain = render_email(msg)
+
+    for name, rendered in (("Betreff", subject), ("Telegram", telegram),
+                            ("SMS", sms), ("E-Mail", plain)):
+        assert "km 12-20" in rendered, (
+            f"{name} zeigt die gemessene Spanne nicht: {rendered!r}"
+        )
+
+
+def test_ac15_korridor_projektion_traegt_die_segmentkennung():
+    """AC-15 (Verdrahtung): `to_corridor_events` muss die Kennung des
+    TATSAECHLICH aufgeloesten Segments mitgeben -- ohne sie kann der
+    Renderer bei einer unvermessenen Etappe gar keinen Ort nennen und
+    faellt zwangslaeufig auf die Luftlinien-km zurueck (F001)."""
+    from datetime import datetime, timezone
+
+    from app.models import GPXPoint, TripSegment
+    from output.renderers.alert.project import to_corridor_events
+    from services.corridor_threshold import CorridorHit
+
+    utc = timezone.utc
+    seg = TripSegment(
+        segment_id="3",
+        start_point=GPXPoint(lat=46.6, lon=12.9, elevation_m=1900.0,
+                              distance_from_start_km=0.0),
+        end_point=GPXPoint(lat=46.6, lon=12.9, elevation_m=1900.0,
+                            distance_from_start_km=6.87),
+        start_time=datetime(2026, 7, 1, 6, 0, tzinfo=utc),
+        end_time=datetime(2026, 7, 1, 8, 0, tzinfo=utc),
+        duration_hours=2.0, distance_km=6.87, ascent_m=200.0, descent_m=50.0,
+    )
+    hit = CorridorHit(
+        metric="wind_gust", value=95.0, bound=80.0, direction="above",
+        segment_id="3", occurred_at=datetime(2026, 7, 1, 14, 0, tzinfo=utc),
+    )
+    events = to_corridor_events([hit], [seg], tz=timezone.utc)
+
+    assert len(events) == 1, f"Erwartete ein CorridorEvent: {events!r}"
+    assert getattr(events[0], "segment_id", None) == "3", (
+        "CorridorEvent traegt die Segment-Kennung nicht: "
+        f"{getattr(events[0], 'segment_id', None)!r}"
+    )
+
+
+def test_ortsangabe_ohne_segmentkennung_ist_ueber_alle_event_typen_gleich():
+    """Teilungs-Invariante an der GRENZE der neuen Aufloesung (#1744 AC-7 +
+    #2036 AC-13, Adversary-Runde 1 Rueckfrage A).
+
+    Traegt ein Ereignis KEINE verwertbare Segment-Kennung und ist die Spanne
+    NICHT gemessen, bleibt als Ortsangabe nur die km-Spanne uebrig -- die
+    bewusste Entscheidung aus #1744 AC-7 ("ein Alarm ohne Segment-Kennung
+    muss weiterhin einen Ort nennen und versendet werden"). Dieser Test
+    schreibt nicht fest, dass das *richtig* ist, sondern dass es fuer alle
+    Event-Typen GLEICH ist: der Korridor-Zweig darf nach der F001-Korrektur
+    nicht heimlich wieder ausscheren, und eine spaetere Aenderung dieser
+    Entscheidung muss alle Typen zusammen treffen."""
+    from output.renderers.alert.model import (
+        AlertEvent, AlertMessage, CorridorEvent, OnsetShiftEvent,
+    )
+    from output.renderers.alert.render import render_subject
+    from output.renderers.alert.segments import format_alert_location
+
+    km_from, km_to = 0.0, 6.87
+    erwartet = format_alert_location(None, [None], km_from, km_to,
+                                     km_measured=False)
+
+    alert = AlertEvent(
+        metric_id="gust", value_from=30.0, value_to=95.0, threshold=20.0,
+        cmp="über", occurred_at="11:00", km_from=km_from, km_to=km_to,
+        segment_id=None, km_measured=False,
+    )
+    shift = OnsetShiftEvent(
+        metric_id="thunder", from_time="13:00", to_time="11:00",
+        shift_text="2 h früher", km_from=km_from, km_to=km_to,
+        segment_id=None, km_measured=False,
+    )
+    corridor = CorridorEvent(
+        metric_id="gust", value=95.0, bound=80.0, direction="above",
+        occurred_at="11:00", km_from=km_from, km_to=km_to,
+        segment_id=None, km_measured=False,
+    )
+
+    betreffe = {
+        "AlertEvent": render_subject(AlertMessage(
+            trip_short="KHW 403", stand_at="10:00", events=(alert,), source=None,
+        )),
+        "OnsetShiftEvent": render_subject(AlertMessage(
+            trip_short="KHW 403", stand_at="10:00", events=(), source=None,
+            onset_shift_events=(shift,),
+        )),
+        "CorridorEvent": render_subject(AlertMessage(
+            trip_short="KHW 403", stand_at="10:00", events=(), source=None,
+            corridor_events=(corridor,),
+        )),
+    }
+    for typ, betreff in betreffe.items():
+        assert erwartet in betreff, (
+            f"{typ} weicht von der gemeinsamen Aufloesung {erwartet!r} ab: "
+            f"{betreff!r}"
+        )

--- a/tests/tdd/test_official_alert_location_parity.py
+++ b/tests/tdd/test_official_alert_location_parity.py
@@ -1,0 +1,167 @@
+"""TDD RED — Issue #2036, AC-3: amtliche Warnungen sprechen dieselbe
+gemessene Ortssprache wie Nowcast- und Abweichungsalarm.
+
+SPEC:    docs/specs/modules/fix_2036_alarm_kilometer_ortsangabe.md (AC-3)
+KONTEXT: docs/context/fix-2036-alarm-kilometer.md
+
+`official_alerts.py` baut seine Ortsangabe heute UNABHAENGIG von
+`segments.format_alert_location()` -- ueber einen eigenen, zweiten
+Formatierer (`format_segment_reference()` + eigene 'Segment '->'Seg '-
+Ersetzung, official_alerts.py:2180-2184). Die Teilungs-Invariante aus
+#1744 (`test_alert_location_vocabulary.py:296-298`) verlangt Gleichheit
+zwischen allen drei Alarmarten -- diese Spec speist `official_alerts.py`
+deshalb ueber einen additiven Parameter `segment_km` aus DERSELBEN Quelle.
+
+RED-VERTRAG: `build_official_alert_notices()` kennt heute KEIN `segment_km`-
+Schluesselwort. Der Aufruf mit diesem Parameter schlaegt mit
+`TypeError: unexpected keyword argument 'segment_km'` fehl -- das IST der
+RED-Zustand.
+"""
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from zoneinfo import ZoneInfo
+
+UTC = timezone.utc
+TRIP_TZ = ZoneInfo("Europe/Vienna")
+TRIP_NAME = "KHW 403"
+WARN_FROM = datetime(2026, 7, 1, 12, 0, tzinfo=UTC)
+WARN_TO = datetime(2026, 7, 1, 20, 0, tzinfo=UTC)
+
+
+def _trip(waypoint_count: int = 10):
+    """Trip mit `waypoint_count` Wegpunkten -> Segmente '1'..'N-1' + 'Ziel'.
+    Zehn Wegpunkte verhindern die 'gesamte Route'-Verdichtung (Vorbild
+    `test_alert_location_vocabulary.py::_trip`)."""
+    from app.trip import Stage, Trip, Waypoint
+
+    waypoints = [
+        Waypoint(id=f"w{i}", name=f"P{i}", lat=46.6 + i / 100, lon=12.9 + i / 100,
+                 elevation_m=1900.0 + i)
+        for i in range(waypoint_count)
+    ]
+    stage = Stage(id="s1", name="Tag 1", date=date(2026, 7, 1), waypoints=waypoints)
+    return Trip(id="tdd-2036-official", name=TRIP_NAME, stages=[stage])
+
+
+def _official_notice_scope_label(segment_id: str, km_from: float, km_to: float) -> str:
+    """Baut EINE amtliche Warnung fuer `segment_id` mit einer gemessenen
+    km-Spanne ueber den additiven `segment_km`-Parameter und liefert das
+    entstehende `scope_label` (die Ortsangabe der amtlichen Warnung)."""
+    from output.renderers.alert.official_alerts import build_official_alert_notices
+    from services.official_alerts.models import OfficialAlert
+
+    alert = OfficialAlert(
+        source="geosphere_warn", hazard="thunderstorm", level=2, label="Gewitter",
+        valid_from=WARN_FROM, valid_to=WARN_TO, region_label="Kaernten",
+    )
+    try:
+        notices = build_official_alert_notices(
+            _trip(), [(alert, [segment_id])],
+            segment_km={segment_id: (km_from, km_to)},
+        )
+    except TypeError as exc:
+        raise AssertionError(
+            "build_official_alert_notices() kennt keinen additiven "
+            "'segment_km'-Parameter (Spec Implementation Details, "
+            "'Amtliche Warnungen teilen dieselbe Aufloesung'). "
+            f"Urspruenglicher Fehler: {exc}"
+        ) from exc
+    assert len(notices) == 1, f"Erwartete genau eine Notice, erhielt: {notices!r}"
+    return notices[0].scope_label
+
+
+def _delta_subject_location(segment_id: str, km_from: float, km_to: float) -> str:
+    """Ortsangabe des Trip-Abweichungsalarms fuer dasselbe Segment, ueber
+    die echte Projektion (`to_alert_message`) -- Vorbild
+    `test_alert_location_vocabulary.py::_delta_message`."""
+    import re
+
+    from app.models import ChangeSeverity, GPXPoint, SegmentWeatherData, \
+        SegmentWeatherSummary, TripSegment, WeatherChange
+    from output.renderers.alert.project import to_alert_message
+    from output.renderers.alert.render import render_subject
+
+    start = GPXPoint(lat=46.6, lon=12.9, elevation_m=1900.0,
+                      distance_from_start_km=km_from)
+    end = GPXPoint(lat=46.6, lon=12.9, elevation_m=1900.0,
+                   distance_from_start_km=km_to)
+    try:
+        seg = TripSegment(
+            segment_id=segment_id, start_point=start, end_point=end,
+            start_time=datetime(2026, 7, 1, 6, 0, tzinfo=UTC),
+            end_time=datetime(2026, 7, 1, 8, 0, tzinfo=UTC),
+            duration_hours=2.0, distance_km=km_to - km_from,
+            ascent_m=200.0, descent_m=50.0, distance_measured=True,
+        )
+    except TypeError as exc:
+        raise AssertionError(
+            "TripSegment traegt kein additives 'distance_measured'-Feld "
+            f"(Spec, models.py). Urspruenglicher Fehler: {exc}"
+        ) from exc
+    swd = SegmentWeatherData(
+        segment=seg, timeseries=None,
+        aggregated=SegmentWeatherSummary(gust_max_kmh=80.0),
+        fetched_at=datetime(2026, 7, 1, 6, 0, tzinfo=UTC), provider="openmeteo",
+    )
+    change = WeatherChange(
+        metric="gust_max_kmh", old_value=30.0, new_value=80.0, delta=50.0,
+        threshold=20.0, severity=ChangeSeverity.MODERATE, direction="increase",
+        segment_id=segment_id, occurred_at=datetime(2026, 7, 1, 14, 0, tzinfo=UTC),
+    )
+    msg = to_alert_message([change], [swd], TRIP_NAME, tz=TRIP_TZ, stand_at="10:00")
+    subject = render_subject(msg)
+    match = re.match(r"^\[[^\]]*\]\s+(?P<where>.+?)\s+·\s+.+$", subject)
+    assert match, f"Betreff hat nicht die Bauform '[Trip] <Ort> · <Kern>': {subject!r}"
+    return match.group("where")
+
+
+def test_ac3_amtliche_warnung_und_abweichungsalarm_zeigen_dieselbe_km_spanne():
+    """AC-3: Given Nowcast-Alarm, Abweichungsalarm und amtliche Warnung
+    beziehen sich auf dasselbe vermessene Segment / When alle Alarmarten
+    ihre Ortsangabe rendern / Then zeigen sie identisch 'km A-B'
+    (Ratschen-Test `test_alert_location_vocabulary.py:296-298` verlangt
+    Gleichheit ueber alle drei Alarmarten)."""
+    from output.renderers.alert.segments import format_alert_location
+
+    segment_id, km_from, km_to = "3", 12.31, 20.0
+
+    direct = format_alert_location(None, [segment_id], km_from, km_to, km_measured=True)
+    official = _official_notice_scope_label(segment_id, km_from, km_to)
+    delta = _delta_subject_location(segment_id, km_from, km_to)
+
+    assert direct == "km 12-20", f"Direkte Aufloesung: {direct!r}"
+    assert official == direct, (
+        f"Amtliche Warnung {official!r} != gemeinsame Aufloesung {direct!r}"
+    )
+    assert delta == direct, (
+        f"Abweichungsalarm {delta!r} != gemeinsame Aufloesung {direct!r}"
+    )
+
+
+def test_ac3_amtliche_warnung_faellt_ohne_segment_km_weiterhin_auf_segmentsprache_zurueck():
+    """AC-3 (Negativfall, Fallback-Garantie): traegt der additive
+    `segment_km`-Parameter fuer eine Segment-Kennung KEINEN Eintrag, bleibt
+    die amtliche Warnung bei der heutigen Segment-Sprache ('Segment N') --
+    kein zweiter, unabhaengiger Auflösungspfad, keine geratene km-Angabe."""
+    from output.renderers.alert.official_alerts import build_official_alert_notices
+    from services.official_alerts.models import OfficialAlert
+
+    alert = OfficialAlert(
+        source="geosphere_warn", hazard="thunderstorm", level=2, label="Gewitter",
+        valid_from=WARN_FROM, valid_to=WARN_TO, region_label="Kaernten",
+    )
+    try:
+        notices = build_official_alert_notices(
+            _trip(), [(alert, ["3"])], segment_km={},
+        )
+    except TypeError as exc:
+        raise AssertionError(
+            "build_official_alert_notices() kennt keinen additiven "
+            f"'segment_km'-Parameter. Urspruenglicher Fehler: {exc}"
+        ) from exc
+
+    assert notices[0].scope_label == "Segment 3", (
+        f"Ohne Eintrag in segment_km muss die Segment-Sprache stehen bleiben: "
+        f"{notices[0].scope_label!r}"
+    )

--- a/tests/tdd/test_preview_does_not_mutate_trip_data.py
+++ b/tests/tdd/test_preview_does_not_mutate_trip_data.py
@@ -1,0 +1,81 @@
+"""TDD — Issue #2036 CI-Nachschlag (PR #2055): eine Vorschau ohne Alarm und
+ohne Briefing-Versand darf den Trip-Bestand nicht veraendern.
+
+Root Cause: `PreviewService._build_report` ("kein Versand, nur Render",
+Modul-Docstring `preview_service.py`) ruft
+`TripReportSchedulerService._convert_trip_to_segments`, die seit #2036 als
+Seiteneffekt die gemessene Wegstrecke aus dem GPX-Bestand nachtraegt UND per
+`save_trip` persistiert (Issue #2036 AC-7 -- dort gewollt fuer Alarm-/
+Briefing-Versand). Fuer eine reine Vorschau ist die Persistenz ein
+unbeabsichtigter Seiteneffekt: `GET .../preview/...` mutiert den Trip-Bestand
+auf der Platte, obwohl kein Alarm und kein Briefing tatsaechlich verschickt
+wird. Entdeckt, weil ein Live-Telegram-Test dieselbe Preview-Route gegen den
+echten, versionierten `default`-User-Trip aufruft und der #1265-Kern-Test-
+Waechter (`tests/conftest.py::_isolate_data_root`) die Mutation an
+`data/users/` faengt.
+
+Nutzt dieselbe GR221-Fixture + denselben Testaufbau wie
+`test_track_resolution_legacy_trip.py::_trip_mit_gpx_im_bestand` (echte
+GPX-Aufloesung, echtes `save_trip`, isolierte Datenwurzel per
+`tests/conftest.py::_isolate_data_root`, kein Mock). Demo-Modus
+(`FixtureProvider`) haelt den Test netzfrei (Kern-Schicht).
+
+Nebenbefund (bewusst NICHT mitbehoben, ausserhalb dieses Scopes):
+`PreviewService._build_report` baut `TripReportSchedulerService(self.settings)`
+OHNE `user_id` -- der Scheduler faellt intern IMMER auf `"default"` zurueck,
+unabhaengig vom `user_id`-Argument der oeffentlichen `render_*_preview`-
+Methoden. Deshalb testet dieser Test bewusst mit `user_id="default"` (unter
+der isolierten Testwurzel, beruehrt NICHT den echten Repo-Baum) -- exakt die
+Kollision, die den CI-Fund ausgeloest hat. Fuer jeden anderen `user_id` griffe
+die Nachruestung heute am FALSCHEN (default-)Datenverzeichnis vorbei, was ein
+eigenes Cross-User-Datenthema ist (CLAUDE.md-Regel "niemals auf default
+zurueckfallen") und ein eigenes Ticket verdient, kein Nebenprodukt dieses Fixes.
+"""
+from __future__ import annotations
+
+from datetime import date
+
+from app.loader import get_data_dir
+from services.preview_service import PreviewService
+from tests.tdd.test_track_resolution_legacy_trip import _trip_mit_gpx_im_bestand
+
+# Bewusst "default" -- siehe Nebenbefund-Absatz oben im Modul-Docstring:
+# PreviewService reicht ihren `user_id`-Parameter intern nicht durch, der
+# Scheduler faellt immer auf "default" zurueck. Isoliert unter der
+# Test-Datenwurzel (Issue #1265 `_isolate_data_root`), NICHT der echte Baum.
+_USER = "default"
+
+
+def test_preview_ohne_alarm_und_briefing_veraendert_den_trip_bestand_nicht():
+    """Given ein Bestandstrip ohne gemessene Wegstrecke + passender Track im
+    GPX-Bestand / When eine reine Vorschau (kein Versand) gerendert wird /
+    Then bleibt die persistierte Trip-Datei byte-identisch -- die Vorschau
+    darf die Nachruestung nur im Rueckgabeobjekt sehen, nicht auf die Platte
+    schreiben."""
+    heute = date(2026, 8, 26)
+    trip = _trip_mit_gpx_im_bestand(_USER, heute)
+
+    trip_datei = get_data_dir(_USER) / "briefings" / f"{trip.id}.json"
+    assert trip_datei.exists(), f"Trip-Datei fehlt: {trip_datei}"
+    inhalt_vorher = trip_datei.read_bytes()
+    mtime_vorher = trip_datei.stat().st_mtime_ns
+
+    service = PreviewService()
+    subject, body, bubbles = service.render_telegram_preview(
+        trip.id, user_id=_USER, report_type="morning",
+        target_date=heute.isoformat(), demo=True,
+    )
+    assert isinstance(subject, str)
+    assert bubbles, "Vorschau liefert keine Bubbles -- Testaufbau fehlerhaft"
+
+    inhalt_nachher = trip_datei.read_bytes()
+    mtime_nachher = trip_datei.stat().st_mtime_ns
+    assert inhalt_nachher == inhalt_vorher, (
+        "Die Vorschau hat den Trip-Bestand auf der Platte veraendert -- "
+        "'kein Versand, nur Render' darf keine Seiteneffekte auf "
+        f"data/users/{_USER}/briefings/{trip.id}.json haben"
+    )
+    assert mtime_nachher == mtime_vorher, (
+        "Trip-Datei wurde neu geschrieben (mtime geaendert), obwohl der "
+        "Inhalt gleich geblieben sein soll -- kein reiner Lesepfad"
+    )

--- a/tests/tdd/test_track_resolution_legacy_trip.py
+++ b/tests/tdd/test_track_resolution_legacy_trip.py
@@ -1,0 +1,249 @@
+"""TDD RED — Issue #2036: Track-Auflösung fuer Bestandstrips ohne gemessene
+Wegstrecke (AC-7, AC-10, AC-11, AC-12).
+
+SPEC:    docs/specs/modules/fix_2036_alarm_kilometer_ortsangabe.md
+KONTEXT: docs/context/fix-2036-alarm-kilometer.md
+
+Nutzt die ECHTEN, versionierten Fixtures unter `tests/fixtures/data_root/`
+(nicht das gitignorete `data/users/` -- Issue #1624-Umzug):
+- `users/default/trips/gr221-mallorca.json` — ein Bestandstrip OHNE
+  gemessene Waypoint-Distanz (4 Etappen, GR221 Mallorca)
+- `users/default/gpx/2026-01-17_..._Tag 1_...gpx` — der zugehoerige Original-
+  Track fuer Etappe 1 (verifiziert: jeder Stage-1-Waypoint liegt exakt 0,0 m
+  vom naechsten Trackpunkt entfernt -- die Waypoints SIND Original-
+  Trackpunkte, Kontext-Dokument "Schluesselbefund").
+
+RED-VERTRAG: das Modul `services.track_resolution` existiert heute nicht.
+Jeder Import schlaegt mit `ModuleNotFoundError` fehl -- das IST der
+RED-Zustand (die Track-Auflösung ist die zentrale neue Faehigkeit dieser
+Spec, siehe Dependencies-Tabelle "(neu) Track-Auflösungs-Service").
+"""
+from __future__ import annotations
+
+import json
+import shutil
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_FIXTURE_ROOT = _REPO_ROOT / "tests" / "fixtures" / "data_root" / "users" / "default"
+_TRIP_JSON = _FIXTURE_ROOT / "trips" / "gr221-mallorca.json"
+_GPX_TAG1 = _FIXTURE_ROOT / "gpx" / "2026-01-17_2753214331_Tag 1_ von Valldemossa nach Deià.gpx"
+_GPX_TAG2 = _FIXTURE_ROOT / "gpx" / "2026-01-17_2753216748_Tag 2_ von Deià nach Sóller.gpx"
+
+assert _TRIP_JSON.exists(), f"Trip-Fixture fehlt: {_TRIP_JSON}"
+assert _GPX_TAG1.exists(), f"GPX-Fixture fehlt: {_GPX_TAG1}"
+assert _GPX_TAG2.exists(), f"GPX-Fixture fehlt: {_GPX_TAG2}"
+
+
+def _stage1():
+    """Etappe 1 des echten GR221-Bestandstrips, OHNE gemessene Distanz an
+    den Waypoints -- genau der Zustand, den AC-7 nachruesten soll."""
+    from app.trip import Stage, TimeWindow, Waypoint
+
+    data = json.loads(_TRIP_JSON.read_text(encoding="utf-8"))
+    stage_data = data["stages"][0]
+    waypoints = [
+        Waypoint(
+            id=wp["id"], name=wp["name"], lat=wp["lat"], lon=wp["lon"],
+            elevation_m=wp["elevation_m"],
+            time_window=TimeWindow.from_string(wp["time_window"]),
+        )
+        for wp in stage_data["waypoints"]
+    ]
+    return Stage(
+        id=stage_data["id"], name=stage_data["name"],
+        date=date.fromisoformat(stage_data["date"]), waypoints=waypoints,
+    )
+
+
+def _resolve(stage, gpx_dir):
+    from services.track_resolution import resolve_stage_track_km
+
+    return resolve_stage_track_km(stage, gpx_dir, tolerance_m=10.0)
+
+
+# ---------------------------------------------------------------------------
+# AC-7 — eindeutiger Track liefert gemessene Distanzen
+# ---------------------------------------------------------------------------
+
+def test_ac7_eindeutiger_track_liefert_die_gemessenen_distanzen(tmp_path):
+    """AC-7: Given ein Bestandstrip ohne gemessene Wegstrecke am Waypoint
+    und genau eine GPX-Datei, deren Track JEDEN Wegpunkt der Etappe mit
+    hoechstens 10 m Abstand enthaelt / When die Track-Aufloesung laeuft /
+    Then liefert sie fuer jeden Waypoint die gemessene Distanz aus diesem
+    Track (Werte verifiziert per `parse_gpx` gegen die reale Fixture:
+    G1=0.0, G2=2.9345, G3=6.1364, G4=9.6067 km)."""
+    gpx_dir = tmp_path / "gpx"
+    gpx_dir.mkdir()
+    shutil.copyfile(_GPX_TAG1, gpx_dir / _GPX_TAG1.name)
+
+    stage = _stage1()
+    result = _resolve(stage, gpx_dir)
+
+    assert result is not None, (
+        "Track-Aufloesung liefert kein Ergebnis, obwohl genau EIN passender "
+        "Track im Bestand liegt"
+    )
+    assert set(result.keys()) == {"G1", "G2", "G3", "G4"}, f"Keys: {result.keys()}"
+    assert result["G1"] == pytest.approx(0.0, abs=0.01)
+    assert result["G2"] == pytest.approx(2.9345, abs=0.01)
+    assert result["G3"] == pytest.approx(6.1364, abs=0.01)
+    assert result["G4"] == pytest.approx(9.6067, abs=0.01)
+
+
+def test_ac7_treffer_wird_additiv_zurueckgeschrieben_ohne_datenverlust(tmp_path):
+    """AC-7 (Persistenz): die gemessene Distanz wird EINMALIG additiv an den
+    Trip zurueckgeschrieben (Read-Modify-Write mit Merge, nie Replace) --
+    alle uebrigen Felder (Name, time_window, Etappe 2-4 unveraendert)
+    bleiben erhalten. Orchestriert hier manuell (resolve -> merge -> save ->
+    reload), weil der Produktionsaufrufer (trip_alert.py, "erste Alarm-
+    Aufloesung", Known Limitations) fuer einen isolierten Kern-Test zu
+    schwergewichtig waere."""
+    import dataclasses
+
+    from app.loader import load_trip, save_trip
+    from app.trip import Stage
+
+    gpx_dir = tmp_path / "gpx"
+    gpx_dir.mkdir()
+    shutil.copyfile(_GPX_TAG1, gpx_dir / _GPX_TAG1.name)
+
+    data = json.loads(_TRIP_JSON.read_text(encoding="utf-8"))
+    original_stage2_waypoints = data["stages"][1]["waypoints"]
+
+    from app.loader import load_trip_from_dict
+
+    trip = load_trip_from_dict(data)
+    save_trip(trip, user_id="tdd-2036-ac7", data_dir=tmp_path)
+
+    stage1 = trip.stages[0]
+    distances = _resolve(stage1, gpx_dir)
+    assert distances is not None, "Track-Aufloesung liefert kein Ergebnis"
+
+    new_waypoints = [
+        dataclasses.replace(wp, distance_from_start_km=distances[wp.id])
+        for wp in stage1.waypoints
+    ]
+    new_stage1 = dataclasses.replace(stage1, waypoints=new_waypoints)
+    new_stages = [new_stage1] + list(trip.stages[1:])
+    updated_trip = dataclasses.replace(trip, stages=new_stages)
+    save_trip(updated_trip, user_id="tdd-2036-ac7", data_dir=tmp_path)
+
+    reloaded = load_trip(trip.id, data_dir=tmp_path, user_id="tdd-2036-ac7")
+    assert reloaded is not None
+
+    rw = reloaded.stages[0].waypoints
+    assert rw[0].distance_from_start_km == pytest.approx(0.0, abs=0.01)
+    assert rw[1].distance_from_start_km == pytest.approx(2.9345, abs=0.01)
+    # Alle uebrigen Felder von Etappe 1 unveraendert.
+    for orig, new in zip(data["stages"][0]["waypoints"], rw):
+        assert new.id == orig["id"]
+        assert new.name == orig["name"]
+        assert new.lat == orig["lat"] and new.lon == orig["lon"]
+        assert new.elevation_m == orig["elevation_m"]
+
+    # Etappe 2 (nicht betroffen) bleibt komplett unveraendert -- additiv,
+    # kein Replace der gesamten stages-Liste.
+    reloaded_stage2 = reloaded.stages[1]
+    for orig, new in zip(original_stage2_waypoints, reloaded_stage2.waypoints):
+        assert new.id == orig["id"]
+        assert new.name == orig["name"]
+        assert getattr(new, "distance_from_start_km", None) is None, (
+            f"Etappe 2 hat unerwuenscht eine Distanz erhalten: {new}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-10 — kein passender Track -> Ausgabe byte-identisch (Fallback-Garantie)
+# ---------------------------------------------------------------------------
+
+def test_ac10_kein_passender_track_liefert_kein_ergebnis(tmp_path):
+    """AC-10: Given ein Bestandstrip, fuer den sich kein passender GPX-
+    Track eindeutig zuordnen laesst / When die Track-Aufloesung fuer eine
+    seiner Etappen laeuft / Then liefert sie KEIN Ergebnis -- die
+    nachgelagerte Ortsangabe bleibt byte-identisch 'Segment N'.
+
+    Nutzt Tag-2-GPX gegen Etappe 1: G1-G3 liegen >1 km vom Tag-2-Track
+    entfernt (nur G4/Ziel faellt zufaellig mit Tag 2s Start zusammen) --
+    kein VOLLSTAENDIGER Treffer."""
+    gpx_dir = tmp_path / "gpx"
+    gpx_dir.mkdir()
+    shutil.copyfile(_GPX_TAG2, gpx_dir / _GPX_TAG2.name)
+
+    stage = _stage1()
+    result = _resolve(stage, gpx_dir)
+
+    assert result is None, (
+        f"Track-Aufloesung liefert ein Ergebnis, obwohl KEIN Track alle "
+        f"Wegpunkte der Etappe abdeckt: {result!r}"
+    )
+
+    from output.renderers.alert.segments import format_alert_location
+
+    text = format_alert_location(None, ["1"], 0.0, 2.93, km_measured=False)
+    assert text == "Segment 1", f"Ortsangabe nicht byte-identisch: {text!r}"
+
+
+# ---------------------------------------------------------------------------
+# AC-11 — zwei gleichwertige Treffer -> keine Zuordnung (nicht raten)
+# ---------------------------------------------------------------------------
+
+def test_ac11_zwei_gleichwertige_treffer_liefern_kein_ergebnis(tmp_path):
+    """AC-11: Given mehr als eine GPX-Datei passt gleichermassen auf die
+    Wegpunkte einer Etappe (hier: zweimal derselbe Track unter
+    verschiedenen Dateinamen -- wie eine Einzeletappen- UND eine
+    Gesamt-GPX, die dieselben Punkte enthalten) / When die Track-Aufloesung
+    laeuft / Then wird KEINE der Dateien geraten, es gibt kein Ergebnis."""
+    gpx_dir = tmp_path / "gpx"
+    gpx_dir.mkdir()
+    shutil.copyfile(_GPX_TAG1, gpx_dir / "einzeletappe-tag1.gpx")
+    shutil.copyfile(_GPX_TAG1, gpx_dir / "gesamt-tour.gpx")
+
+    stage = _stage1()
+    result = _resolve(stage, gpx_dir)
+
+    assert result is None, (
+        f"Track-Aufloesung raet bei zwei gleichwertigen Treffern: {result!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-12 — ein >10 m abseits liegender Wegpunkt verhindert die ganze Etappe
+# ---------------------------------------------------------------------------
+
+def test_ac12_wegpunkt_mehr_als_10m_abseits_verhindert_die_zuordnung(tmp_path):
+    """AC-12: Given eine Etappe enthaelt einen manuell ergaenzten/
+    verschobenen Wegpunkt, dessen Abstand zum naechstgelegenen Punkt des
+    sonst passenden Tracks MEHR ALS 10 m betraegt / When die Track-Zuordnung
+    laeuft / Then wird fuer die GESAMTE Etappe keine Distanz zugeordnet --
+    auch nicht fuer die drei anderen, exakt passenden Wegpunkte.
+
+    Der zusaetzliche Wegpunkt liegt exakt 15,0 m (verifiziert per
+    `parse_gpx`) vom naechsten Trackpunkt entfernt -- klar ueber der
+    10-m-Toleranz, aber nah genug, um kein Versehen zu sein."""
+    import dataclasses
+
+    from app.trip import Waypoint
+
+    gpx_dir = tmp_path / "gpx"
+    gpx_dir.mkdir()
+    shutil.copyfile(_GPX_TAG1, gpx_dir / _GPX_TAG1.name)
+
+    stage = _stage1()
+    off_track_wp = Waypoint(
+        id="G2b", name="Manuell ergaenzt", lat=39.726311746676245,
+        lon=2.624463, elevation_m=800,
+    )
+    waypoints = list(stage.waypoints)
+    waypoints.insert(2, off_track_wp)
+    stage_with_extra = dataclasses.replace(stage, waypoints=waypoints)
+
+    result = _resolve(stage_with_extra, gpx_dir)
+
+    assert result is None, (
+        f"Track-Aufloesung ordnet trotz eines >10 m abseits liegenden "
+        f"Wegpunkts zu: {result!r}"
+    )

--- a/tests/tdd/test_track_resolution_legacy_trip.py
+++ b/tests/tdd/test_track_resolution_legacy_trip.py
@@ -105,7 +105,6 @@ def test_ac7_treffer_wird_additiv_zurueckgeschrieben_ohne_datenverlust(tmp_path)
     import dataclasses
 
     from app.loader import load_trip, save_trip
-    from app.trip import Stage
 
     gpx_dir = tmp_path / "gpx"
     gpx_dir.mkdir()

--- a/tests/tdd/test_track_resolution_legacy_trip.py
+++ b/tests/tdd/test_track_resolution_legacy_trip.py
@@ -65,6 +65,17 @@ def _resolve(stage, gpx_dir):
     return resolve_stage_track_km(stage, gpx_dir, tolerance_m=10.0)
 
 
+def _resolve_mit_default_toleranz(stage, gpx_dir):
+    """BEWUSST OHNE `tolerance_m` (Adversary-Runde 1, F002): jeder andere
+    Aufruf in dieser Datei uebergibt die Toleranz explizit und umgeht damit
+    den Produktions-Default `DEFAULT_TOLERANCE_M`. Verstellte den jemand,
+    blieben alle Tests gruen, waehrend AC-12 in Produktion ungeschuetzt
+    waere."""
+    from services.track_resolution import resolve_stage_track_km
+
+    return resolve_stage_track_km(stage, gpx_dir)
+
+
 # ---------------------------------------------------------------------------
 # AC-7 — eindeutiger Track liefert gemessene Distanzen
 # ---------------------------------------------------------------------------
@@ -246,3 +257,275 @@ def test_ac12_wegpunkt_mehr_als_10m_abseits_verhindert_die_zuordnung(tmp_path):
         f"Track-Aufloesung ordnet trotz eines >10 m abseits liegenden "
         f"Wegpunkts zu: {result!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# F002 (Adversary-Runde 1) — der PRODUKTIONS-Default von 10 m
+# ---------------------------------------------------------------------------
+
+def test_ac12_default_toleranz_nimmt_den_exakt_passenden_track_an(tmp_path):
+    """AC-12 (Default-Seite, Positivfall): dieselbe Etappe wie AC-7, aber
+    OHNE expliziten `tolerance_m` -- der Modul-Default muss den Track mit
+    0,0 m Abstand annehmen."""
+    gpx_dir = tmp_path / "gpx"
+    gpx_dir.mkdir()
+    shutil.copyfile(_GPX_TAG1, gpx_dir / _GPX_TAG1.name)
+
+    result = _resolve_mit_default_toleranz(_stage1(), gpx_dir)
+
+    assert result is not None, (
+        "Der Produktions-Default lehnt einen Track ab, dessen Wegpunkte "
+        "exakt auf der Spur liegen"
+    )
+    assert result["G2"] == pytest.approx(2.9345, abs=0.01)
+
+
+def test_ac12_default_toleranz_weist_einen_15m_abseits_liegenden_wegpunkt_ab(tmp_path):
+    """AC-12 (Default-Seite, Negativfall): derselbe 15,0-m-Wegpunkt wie im
+    expliziten AC-12-Test, aber OHNE `tolerance_m`. Nur wenn der Default
+    tatsaechlich bei 10 m steht, faellt dieser Wegpunkt durch -- ein zu
+    grosser Default (Refactoring-Unfall) wird hier sichtbar."""
+    import dataclasses
+
+    from app.trip import Waypoint
+    from services.track_resolution import DEFAULT_TOLERANCE_M
+
+    assert DEFAULT_TOLERANCE_M == 10.0, (
+        f"Produktions-Toleranz ist nicht mehr 10 m: {DEFAULT_TOLERANCE_M}"
+    )
+
+    gpx_dir = tmp_path / "gpx"
+    gpx_dir.mkdir()
+    shutil.copyfile(_GPX_TAG1, gpx_dir / _GPX_TAG1.name)
+
+    stage = _stage1()
+    off_track_wp = Waypoint(
+        id="G2b", name="Manuell ergaenzt", lat=39.726311746676245,
+        lon=2.624463, elevation_m=800,
+    )
+    waypoints = list(stage.waypoints)
+    waypoints.insert(2, off_track_wp)
+    stage_with_extra = dataclasses.replace(stage, waypoints=waypoints)
+
+    result = _resolve_mit_default_toleranz(stage_with_extra, gpx_dir)
+
+    assert result is None, (
+        "Der Produktions-Default nimmt einen 15 m abseits liegenden Wegpunkt "
+        f"an -- die 10-m-Grenze wirkt nicht: {result!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# F004a (Adversary-Runde 1) — Read-Modify-Write UNTERSCHEIDBAR von Replace
+#
+# Der bestehende AC-7-Persistenztest konnte den Unterschied strukturell nicht
+# sehen: die Trip-Fixture enthaelt ausschliesslich Python-modellierte Felder,
+# also ueberlebt auch ein reines `data = python_data` alles, wonach gefragt
+# wird. Hier stehen deshalb Felder in der Datei, die der Python-Loader NICHT
+# kennt -- genau die, die #805 schuetzen soll (Go-geschriebene und
+# Legacy-Schluessel). Bei Replace sind sie nach dem zweiten Speichern weg.
+# ---------------------------------------------------------------------------
+
+def test_ac7_rueckschreiben_erhaelt_go_only_felder(tmp_path):
+    """AC-7 (Datenverlust-Regel): Given die persistierte Trip-Datei traegt
+    Felder, die nur die Go-API schreibt / When die nachgetragene Wegstrecke
+    zurueckgeschrieben wird / Then stehen diese Felder danach unveraendert
+    in der Datei (Read-Modify-Write mit Merge, niemals Replace).
+
+    GRENZE, gemessen und bewusst NICHT hier festgeschrieben: der Merge
+    (`loader._deep_merge_preserve_unknown`) ersetzt Listen als Ganzes --
+    ein unbekannter Schluessel INNERHALB eines Wegpunkts ueberlebt das
+    Zurueckschreiben nicht. Das ist Bestandsverhalten seit #805 (Listen-
+    Ersetzung ist dort ausdruecklich dokumentiert) und trifft jeden
+    `save_trip`-Aufruf gleichermassen, nicht nur die Nachruestung aus
+    #2036; ein keyed Merge auf Wegpunkt-Ebene wuerde geloeschte Felder
+    (z. B. ein entferntes `arrival_override`) wieder auferstehen lassen und
+    gehoert deshalb in ein eigenes Ticket, nicht in diesen Fix."""
+    import dataclasses
+
+    from app.loader import load_trip_from_dict, save_trip
+
+    gpx_dir = tmp_path / "gpx"
+    gpx_dir.mkdir()
+    shutil.copyfile(_GPX_TAG1, gpx_dir / _GPX_TAG1.name)
+
+    data = json.loads(_TRIP_JSON.read_text(encoding="utf-8"))
+    trip = load_trip_from_dict(data)
+    path = save_trip(trip, user_id="tdd-2036-f004a", data_dir=tmp_path)
+
+    # Zustand NACH einem Go-Schreibvorgang nachstellen: Schluessel, die der
+    # Python-Loader nicht modelliert und `_trip_to_dict` folglich nie
+    # erzeugt (Vorbilder aus CLAUDE.md "Daten-Schema-Reworks").
+    persisted = json.loads(path.read_text(encoding="utf-8"))
+    persisted["multi_day_trend_morning"] = True
+    persisted.setdefault("display_config", {})["channels"] = {
+        "email": {"enabled": True}
+    }
+    path.write_text(json.dumps(persisted, indent=2), encoding="utf-8")
+
+    # Jetzt die Nachruestung schreiben (derselbe Weg wie im Produktionscode).
+    stage1 = trip.stages[0]
+    distances = _resolve(stage1, gpx_dir)
+    assert distances is not None, "Track-Aufloesung liefert kein Ergebnis"
+    new_stage1 = dataclasses.replace(stage1, waypoints=[
+        dataclasses.replace(wp, distance_from_start_km=distances[wp.id])
+        for wp in stage1.waypoints
+    ])
+    updated = dataclasses.replace(
+        trip, stages=[new_stage1] + list(trip.stages[1:]),
+    )
+    save_trip(updated, user_id="tdd-2036-f004a", data_dir=tmp_path)
+
+    after = json.loads(path.read_text(encoding="utf-8"))
+
+    # Die gemessene Distanz ist angekommen ...
+    assert after["stages"][0]["waypoints"][1]["distance_from_start_km"] == \
+        pytest.approx(2.9345, abs=0.01)
+    # ... und NICHTS von dem, was Python nicht kennt, ist dabei verloren
+    # gegangen (bei Replace waeren alle drei Schluessel weg).
+    assert after.get("multi_day_trend_morning") is True, (
+        "Go-only-Feld 'multi_day_trend_morning' beim Zurueckschreiben "
+        "verloren -- Replace statt Read-Modify-Write"
+    )
+    assert after.get("display_config", {}).get("channels") == {
+        "email": {"enabled": True}
+    }, "Go-only-Block 'display_config.channels' verloren"
+
+
+# ---------------------------------------------------------------------------
+# F004c (Adversary-Runde 1) — die Nachruestung muss am ALARM-Pfad haengen
+#
+# AC-7 sagt woertlich "wenn die Alarm-Ortsangabe fuer diese Etappe ERSTMALS
+# aufgeloest wird". Verdrahtet war die Nachruestung aber nur im
+# Briefing-Segmenttrichter (`trip_report_scheduler`): bei einem Trip mit
+# abgeschaltetem Briefing-Versand -- oder einem Nowcast-Alarm VOR dem ersten
+# Briefing des Tages -- blieb die Etappe dauerhaft auf "Segment N", obwohl
+# ein eindeutiger Track im Bestand lag.
+#
+# Beide Tests arbeiten mit echten Daten: echte GPX-Fixture, echte
+# `save_trip`/`load_trip`-Persistenz unter der isolierten Datenwurzel
+# (conftest `_isolate_data_root`), echte Segmentkonvertierung. Kein Mock.
+# ---------------------------------------------------------------------------
+
+_F004C_USER = "tdd-2036-f004c"
+
+
+def _trip_mit_gpx_im_bestand(user_id: str, stage_date: date):
+    """Legt den GR221-Bestandstrip (Etappe 1, UNVERMESSEN) samt zugehoerigem
+    Original-Track im GPX-Bestand des Nutzers an und gibt ihn zurueck."""
+    import dataclasses
+
+    from app.loader import get_data_dir, load_trip_from_dict, save_trip
+
+    gpx_dir = get_data_dir(user_id) / "gpx"
+    gpx_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(_GPX_TAG1, gpx_dir / _GPX_TAG1.name)
+
+    data = json.loads(_TRIP_JSON.read_text(encoding="utf-8"))
+    trip = load_trip_from_dict(data)
+    # Etappe 1 auf das gewuenschte Datum ziehen, damit sie "heute" ist.
+    stage1 = dataclasses.replace(trip.stages[0], date=stage_date)
+    trip = dataclasses.replace(trip, stages=[stage1] + list(trip.stages[1:]))
+    assert all(
+        wp.distance_from_start_km is None for wp in trip.stages[0].waypoints
+    ), "Testaufbau: Etappe 1 muss unvermessen starten"
+    save_trip(trip, user_id=user_id)
+    return trip
+
+
+def test_ac7_alarm_pfad_loest_die_nachruestung_aus():
+    """AC-7 (Alarm-Pfad): Given ein Bestandstrip ohne gemessene Wegstrecke
+    und der passende Track im Bestand / When der ALARM-Pfad seine Etappe
+    aufloest / Then ist das gewaehlte Segment vermessen und die Distanz
+    steht danach persistiert am Trip."""
+    from datetime import datetime, timezone
+
+    from app.loader import load_all_trips
+    from services.trip_alert import TripAlertService
+
+    heute = date(2026, 8, 23)
+    trip = _trip_mit_gpx_im_bestand(_F004C_USER, heute)
+
+    # Mitten in der Etappe (Startzeit 08:00 Ortszeit, Mallorca = UTC+2).
+    now_utc = datetime(2026, 8, 23, 8, 0, tzinfo=timezone.utc)
+    service = TripAlertService(user_id=_F004C_USER)
+    resolved = service._resolve_alert_segment(trip, now_utc, heute)
+
+    assert resolved is not None, "Alarm-Pfad findet kein Segment"
+    segment, _segment_date = resolved
+    assert segment.distance_measured is True, (
+        "Der Alarm-Pfad hat die Nachruestung nicht ausgeloest -- das Segment "
+        "gilt weiterhin als unvermessen und die Ortsangabe bliebe 'Segment N'"
+    )
+
+    persisted = next(
+        (t for t in load_all_trips(user_id=_F004C_USER) if t.id == trip.id), None,
+    )
+    assert persisted is not None, "Trip nach der Nachruestung nicht ladbar"
+    werte = [wp.distance_from_start_km for wp in persisted.stages[0].waypoints]
+    assert all(v is not None for v in werte), (
+        f"Nachgetragene Distanzen nicht persistiert: {werte}"
+    )
+    assert werte[1] == pytest.approx(2.9345, abs=0.01)
+
+
+def test_ac7_briefing_pfad_loest_die_nachruestung_weiterhin_aus():
+    """AC-7 (Briefing-Pfad, Regressions-Sicherung zu F004c): die Ergaenzung
+    am Alarm-Pfad darf den bestehenden Ausloeser im Briefing-Segmenttrichter
+    nicht ersetzen -- beide Wege muessen nachruesten."""
+    from app.loader import load_all_trips
+    from services.trip_report_scheduler import TripReportSchedulerService
+
+    heute = date(2026, 8, 24)
+    trip = _trip_mit_gpx_im_bestand(_F004C_USER + "-briefing", heute)
+
+    scheduler = TripReportSchedulerService(user_id=_F004C_USER + "-briefing")
+    segments = scheduler._convert_trip_to_segments(trip, heute)
+
+    assert segments, "Briefing-Pfad liefert keine Segmente"
+    assert segments[0].distance_measured is True, (
+        "Der Briefing-Pfad ruestet nicht mehr nach"
+    )
+    persisted = next(
+        (t for t in load_all_trips(user_id=_F004C_USER + "-briefing")
+         if t.id == trip.id), None,
+    )
+    assert persisted is not None, "Trip nach der Nachruestung nicht ladbar"
+    assert persisted.stages[0].waypoints[1].distance_from_start_km == \
+        pytest.approx(2.9345, abs=0.01)
+
+
+def test_ac7_zweite_aufloesung_schreibt_nicht_erneut():
+    """AC-7 (kein Doppelschreiben): laeuft die Aufloesung ein zweites Mal,
+    darf sie die Trip-Datei nicht erneut anfassen -- die Wegpunkte tragen
+    ihre Distanz dann bereits, es gibt nichts nachzuruesten."""
+    from datetime import datetime, timezone
+
+    from app.loader import get_data_dir
+    from services.trip_alert import TripAlertService
+
+    heute = date(2026, 8, 25)
+    user = _F004C_USER + "-idem"
+    trip = _trip_mit_gpx_im_bestand(user, heute)
+
+    now_utc = datetime(2026, 8, 25, 8, 0, tzinfo=timezone.utc)
+    service = TripAlertService(user_id=user)
+    service._resolve_alert_segment(trip, now_utc, heute)
+
+    trip_datei = get_data_dir(user) / "briefings" / f"{trip.id}.json"
+    assert trip_datei.exists(), f"Trip-Datei fehlt: {trip_datei}"
+    mtime_nach_erstem = trip_datei.stat().st_mtime_ns
+    inhalt_nach_erstem = trip_datei.read_text(encoding="utf-8")
+
+    # Zweiter Lauf mit dem inzwischen VERMESSENEN Trip (so, wie ihn der
+    # naechste Alarmlauf von der Platte laedt).
+    from app.loader import load_all_trips
+    frischer_trip = next(
+        t for t in load_all_trips(user_id=user) if t.id == trip.id
+    )
+    service._resolve_alert_segment(frischer_trip, now_utc, heute)
+
+    assert trip_datei.stat().st_mtime_ns == mtime_nach_erstem, (
+        "Die zweite Aufloesung hat die Trip-Datei erneut geschrieben"
+    )
+    assert trip_datei.read_text(encoding="utf-8") == inhalt_nach_erstem

--- a/tests/tdd/test_waypoint_track_distance.py
+++ b/tests/tdd/test_waypoint_track_distance.py
@@ -19,7 +19,6 @@ fehl -- das IST der RED-Zustand.
 """
 from __future__ import annotations
 
-import dataclasses
 from datetime import date, datetime, time, timedelta, timezone
 from pathlib import Path
 
@@ -104,7 +103,7 @@ def test_ac6_distanz_uebersteht_speicher_roundtrip(tmp_path):
     (save_trip berechnet arrival_calculated bit-identisch zu Go
     store.SaveTrip neu, #802)."""
     from app.loader import load_trip, save_trip
-    from app.trip import Stage, Trip
+    from app.trip import Trip
 
     wp0 = _waypoint("G1", 0.0)
     wp1 = _waypoint("G2", 2.9345, lat=46.61, lon=12.91)

--- a/tests/tdd/test_waypoint_track_distance.py
+++ b/tests/tdd/test_waypoint_track_distance.py
@@ -137,9 +137,21 @@ def test_ac9_kilometerzaehlung_beginnt_je_etappe_neu_bei_null():
     Die Waypoint-Distanzen der dritten Etappe sind bewusst NICHT bei 0
     verankert (40.0 statt 0.0) -- als kaeme die Messung aus einer
     durchlaufenden Gesamt-GPX ueber alle Etappen. `convert_trip_to_segments`
-    muss trotzdem auf 0 normieren."""
+    muss trotzdem auf 0 normieren.
+
+    Adversary-Runde 1 (F003): die urspruenglichen Koordinaten verletzten
+    selbst die Luftlinien-Plausibilitaet (G1->G2 mass 4,047 km Luftlinie bei
+    nur 4,0 km gemessener Spanne) -- die Etappe galt als UNVERMESSEN und der
+    Test bestand allein ueber den Luftlinien-Fallback, der auch VOR #2036
+    schon je Aufruf bei 0 begann. Die Normierung (`base = values[0]`) wurde
+    nie erreicht. Die Koordinaten liegen jetzt so, dass jede Teilstrecke
+    deutlich unter ihrer gemessenen Spanne bleibt (2,698 km bei 4,0 km bzw.
+    4,047 km bei 7,0 km); die Zwischen-Assertion unten haelt fest, dass der
+    beabsichtigte Zweig tatsaechlich laeuft."""
     from app.trip import Trip
-    from services.trip_segments import convert_trip_to_segments
+    from services.trip_segments import (
+        convert_trip_to_segments, stage_measured_distances,
+    )
 
     day1 = _stage("T1", date(2026, 8, 1), [
         _waypoint("G1", 0.0), _waypoint("G2", 3.0, lat=46.61, lon=12.91),
@@ -148,14 +160,30 @@ def test_ac9_kilometerzaehlung_beginnt_je_etappe_neu_bei_null():
         _waypoint("G1", 3.0), _waypoint("G2", 8.0, lat=46.62, lon=12.92),
     ])
     day3 = _stage("T3", date(2026, 8, 3), [
-        _waypoint("G1", 40.0), _waypoint("G2", 44.0, lat=46.63, lon=12.93),
-        _waypoint("G3", 51.0, lat=46.64, lon=12.94),
+        _waypoint("G1", 40.0, lat=46.60, lon=12.90),
+        _waypoint("G2", 44.0, lat=46.62, lon=12.92),
+        _waypoint("G3", 51.0, lat=46.65, lon=12.95),
     ])
     trip = Trip(id="tdd-2036-ac9", name="AC9", stages=[day1, day2, day3])
+
+    # Zwischen-Assertion (F003): ohne sie kann der Test unbemerkt ueber den
+    # Luftlinien-Fallback bestehen, statt die Normierung zu pruefen.
+    measured = stage_measured_distances(day3.waypoints)
+    assert measured is not None, (
+        "Etappe 3 gilt als unvermessen -- der Test wuerde die Normierung "
+        "gar nicht erreichen (Adversary F003)"
+    )
+    assert measured == [0.0, 4.0, 11.0], (
+        f"Normierte Distanzen falsch: {measured}"
+    )
 
     segments = convert_trip_to_segments(trip, date(2026, 8, 3))
     assert segments, "Segmentliste fuer Etappe 3 leer"
     first = segments[0]
+    assert first.distance_measured is True, (
+        "Etappe 3 muss vermessen sein, sonst prueft der Test den "
+        "Luftlinien-Fallback statt der Normierung (Adversary F003)"
+    )
     assert first.start_point.distance_from_start_km == 0.0, (
         f"Etappe 3 startet nicht bei 0 km, sondern bei "
         f"{first.start_point.distance_from_start_km} (Tour-Gesamtdistanz "
@@ -193,6 +221,41 @@ def test_ac8_nicht_monotone_distanzfolge_macht_die_ganze_etappe_unvermessen():
         assert measured is not True, (
             f"Segment {seg.segment_id} gilt trotz nicht-monotoner Etappen-"
             f"Distanzfolge als vermessen (distance_measured={measured!r})"
+        )
+
+
+def test_ac8_rueckwaertslaufende_distanz_bei_gleicher_koordinate():
+    """AC-8 (Monotonie ISOLIERT, Adversary-Runde 1 zu M3): die beiden anderen
+    AC-8-Faelle verletzen IMMER gleichzeitig auch die Luftlinien-Untergrenze
+    -- die Monotonie-Pruefung allein war dadurch von keinem Test bewacht
+    (Mutation "span <= 0 entfernt" blieb gruen).
+
+    Hier liegen beide Wegpunkte auf DERSELBEN Koordinate: die Luftlinie ist
+    0,0 km, die Untergrenze kann also gar nicht greifen. Faellt die Etappe
+    trotzdem durch, dann ausschliesslich wegen der nicht steigenden
+    Distanzfolge."""
+    from app.trip import Trip
+    from services.trip_segments import (
+        convert_trip_to_segments, stage_measured_distances,
+    )
+    from utils.geo import haversine_km
+
+    assert haversine_km(46.6, 12.9, 46.6, 12.9) == 0.0, "Testaufbau kaputt"
+
+    stage = _stage("T1", date(2026, 8, 9), [
+        _waypoint("G1", 5.0, lat=46.6, lon=12.9),
+        _waypoint("G2", 5.0, lat=46.6, lon=12.9),  # Stillstand -> Verstoss
+    ])
+    assert stage_measured_distances(stage.waypoints) is None, (
+        "Nicht steigende Distanzfolge gilt als vermessen, obwohl die "
+        "Luftlinien-Untergrenze hier gar nicht greifen kann"
+    )
+
+    trip = Trip(id="tdd-2036-ac8c", name="AC8c", stages=[stage])
+    segments = convert_trip_to_segments(trip, date(2026, 8, 9))
+    for seg in segments:
+        assert getattr(seg, "distance_measured", None) is not True, (
+            f"Segment {seg.segment_id} gilt trotz Stillstands als vermessen"
         )
 
 

--- a/tests/tdd/test_waypoint_track_distance.py
+++ b/tests/tdd/test_waypoint_track_distance.py
@@ -1,0 +1,318 @@
+"""TDD RED — Issue #2036: gemessene Wegstrecke am Waypoint statt Luftlinie.
+
+SPEC:    docs/specs/modules/fix_2036_alarm_kilometer_ortsangabe.md
+         (AC-6, AC-8, AC-9, AC-13, AC-14)
+KONTEXT: docs/context/fix-2036-alarm-kilometer.md
+
+Deckt `services/gpx_processing.py` (GPX-Import traegt Distanz durch),
+`app/loader.py` (Persistenz-Roundtrip) und `services/trip_segments.py`
+(Kilometerzaehlung je Etappe ab 0, Plausibilitaetspruefung,
+None-vs-0.0-Unterscheidung) ab. Echte GPX-Fixture
+(`frontend/e2e/fixtures/test-trip.gpx`, bereits von
+`test_issue_1004_startzeit_ssot.py` genutzt), echte `save_trip`/`load_trip`-
+Persistenz, echte `convert_trip_to_segments()`.
+
+RED-VERTRAG: `Waypoint` (app/trip.py) und `TripSegment` (app/models.py)
+tragen heute KEIN `distance_from_start_km` bzw. `distance_measured`-Feld.
+Jede Konstruktion mit diesen Schluesselworten schlaegt mit `TypeError`
+fehl -- das IST der RED-Zustand.
+"""
+from __future__ import annotations
+
+import dataclasses
+from datetime import date, datetime, time, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_TEST_GPX = _REPO_ROOT / "frontend" / "e2e" / "fixtures" / "test-trip.gpx"
+
+
+def _waypoint(id_, distance_from_start_km, lat=46.6, lon=12.9, elevation_m=1800.0,
+              **extra):
+    from app.trip import Waypoint
+
+    try:
+        return Waypoint(
+            id=id_, name=f"WP {id_}", lat=lat, lon=lon, elevation_m=elevation_m,
+            distance_from_start_km=distance_from_start_km, **extra,
+        )
+    except TypeError as exc:
+        raise AssertionError(
+            "Waypoint traegt kein additives 'distance_from_start_km'-Feld "
+            f"(Spec, app/trip.py). Urspruenglicher Fehler: {exc}"
+        ) from exc
+
+
+def _stage(stage_id, trip_date, waypoints, start_time=time(8, 0)):
+    from app.trip import Stage
+
+    return Stage(id=stage_id, name=f"Etappe {stage_id}", date=trip_date,
+                 waypoints=waypoints, start_time=start_time)
+
+
+# ---------------------------------------------------------------------------
+# AC-6 — GPX-Import traegt die Distanz am Waypoint durch (Python-Seite)
+# ---------------------------------------------------------------------------
+
+def test_ac6_gpx_import_traegt_distanz_je_waypoint(tmp_path):
+    """AC-6 (Python-Modell): Given ein Nutzer importiert eine neue Etappe per
+    GPX-Upload / When die Waypoints aus dem Track gebaut werden / Then
+    traegt jeder gespeicherte Waypoint sein `distance_from_start_km` aus dem
+    Original-Trackpunkt.
+
+    GO-LUECKE (ausdruecklich benannt, nicht Teil dieses Python-Kern-Tests):
+    `internal/model/trip.go` braucht dasselbe Feld, sonst wischt der erste
+    Editor-Save (`SaveTrip`) den Wert wieder weg (Praezedenzfall
+    `suggestion_reason`). Dieser Test kann die Go-API nicht ansprechen und
+    deckt NUR den Python-Import- und Persistenz-Pfad ab."""
+    assert _TEST_GPX.exists(), f"GPX-Fixture fehlt: {_TEST_GPX}"
+    from app.models import EtappenConfig
+    from core.gpx_parser import parse_gpx
+    from services.gpx_processing import compute_full_segmentation, segments_to_trip
+
+    track = parse_gpx(_TEST_GPX)
+    trip_date = date(2026, 8, 1)
+    gpx_segments = compute_full_segmentation(
+        track, EtappenConfig(),
+        datetime.combine(trip_date, time(7, 0), tzinfo=timezone.utc),
+    )
+    trip = segments_to_trip(
+        gpx_segments, track, trip_date, trip_name="TDD-2036-AC6",
+    )
+
+    waypoints = trip.stages[0].waypoints
+    assert len(waypoints) >= 2, "Zu wenige Waypoints im Import-Ergebnis"
+    for wp in waypoints:
+        dist = getattr(wp, "distance_from_start_km", None)
+        assert dist is not None, (
+            f"Waypoint {wp.id} traegt kein distance_from_start_km nach dem "
+            "GPX-Import (gpx_processing.segments_to_trip wirft die Distanz "
+            "40 Zeilen nach der Berechnung weg, Kontext-Dokument Zeile 57)"
+        )
+    # Monoton steigend entlang der Etappe (Original-Trackreihenfolge).
+    values = [wp.distance_from_start_km for wp in waypoints]
+    assert values == sorted(values), f"Distanzen nicht monoton: {values}"
+    assert values[0] == 0.0, f"Erster Waypoint sollte bei 0 km stehen: {values[0]}"
+
+
+def test_ac6_distanz_uebersteht_speicher_roundtrip(tmp_path):
+    """AC-6 (Persistenz-Roundtrip): Waypoint.distance_from_start_km muss
+    `save_trip`/`load_trip` (Read-Modify-Write-Merge, loader.py) unveraendert
+    ueberstehen -- das Python-seitige Aequivalent des Go-API-Schreibwegs
+    (save_trip berechnet arrival_calculated bit-identisch zu Go
+    store.SaveTrip neu, #802)."""
+    from app.loader import load_trip, save_trip
+    from app.trip import Stage, Trip
+
+    wp0 = _waypoint("G1", 0.0)
+    wp1 = _waypoint("G2", 2.9345, lat=46.61, lon=12.91)
+    stage = _stage("T1", date(2026, 8, 3), [wp0, wp1])
+    trip = Trip(id="tdd-2036-ac6-roundtrip", name="AC6", stages=[stage])
+
+    save_trip(trip, user_id="tdd-2036-ac6", data_dir=tmp_path)
+    reloaded = load_trip("tdd-2036-ac6-roundtrip", data_dir=tmp_path,
+                          user_id="tdd-2036-ac6")
+
+    assert reloaded is not None
+    rw0, rw1 = reloaded.stages[0].waypoints
+    assert rw0.distance_from_start_km == 0.0, (
+        f"G1: {rw0.distance_from_start_km!r} statt 0.0"
+    )
+    assert rw1.distance_from_start_km == pytest.approx(2.9345), (
+        f"G2: {rw1.distance_from_start_km!r} statt 2.9345"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-9 — Kilometerzaehlung beginnt je Etappe bei 0
+# ---------------------------------------------------------------------------
+
+def test_ac9_kilometerzaehlung_beginnt_je_etappe_neu_bei_null():
+    """AC-9: Given eine mehrtaegige Tour mit mehreren vermessenen Etappen /
+    When die Kilometer-Spanne fuer eine BELIEBIGE (hier: dritte) Etappe
+    berechnet wird / Then beginnt die Zaehlung an diesem Etappenstart wieder
+    bei 0 km, unabhaengig von der kumulierten Gesamtstrecke der Tour.
+
+    Die Waypoint-Distanzen der dritten Etappe sind bewusst NICHT bei 0
+    verankert (40.0 statt 0.0) -- als kaeme die Messung aus einer
+    durchlaufenden Gesamt-GPX ueber alle Etappen. `convert_trip_to_segments`
+    muss trotzdem auf 0 normieren."""
+    from app.trip import Trip
+    from services.trip_segments import convert_trip_to_segments
+
+    day1 = _stage("T1", date(2026, 8, 1), [
+        _waypoint("G1", 0.0), _waypoint("G2", 3.0, lat=46.61, lon=12.91),
+    ])
+    day2 = _stage("T2", date(2026, 8, 2), [
+        _waypoint("G1", 3.0), _waypoint("G2", 8.0, lat=46.62, lon=12.92),
+    ])
+    day3 = _stage("T3", date(2026, 8, 3), [
+        _waypoint("G1", 40.0), _waypoint("G2", 44.0, lat=46.63, lon=12.93),
+        _waypoint("G3", 51.0, lat=46.64, lon=12.94),
+    ])
+    trip = Trip(id="tdd-2036-ac9", name="AC9", stages=[day1, day2, day3])
+
+    segments = convert_trip_to_segments(trip, date(2026, 8, 3))
+    assert segments, "Segmentliste fuer Etappe 3 leer"
+    first = segments[0]
+    assert first.start_point.distance_from_start_km == 0.0, (
+        f"Etappe 3 startet nicht bei 0 km, sondern bei "
+        f"{first.start_point.distance_from_start_km} (Tour-Gesamtdistanz "
+        "sickert ein statt je Etappe zurueckzusetzen)"
+    )
+    assert first.end_point.distance_from_start_km == pytest.approx(4.0), (
+        f"Erstes Segment: {first.end_point.distance_from_start_km} statt 4.0"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-8 — Plausibilitaetspruefung: nicht-monotone Folge -> ganze Etappe unvermessen
+# ---------------------------------------------------------------------------
+
+def test_ac8_nicht_monotone_distanzfolge_macht_die_ganze_etappe_unvermessen():
+    """AC-8: Given eine Etappe erhaelt eine gemessene km-Spanne / When die
+    Spanne zwischen zwei aufeinanderfolgenden Wegpunkten NICHT streng
+    monoton steigt / Then gilt die GESAMTE Etappe als unvermessen -- auch
+    das fuer sich genommen plausible dritte Segment (G3->G4)."""
+    from app.trip import Trip
+    from services.trip_segments import convert_trip_to_segments
+
+    stage = _stage("T1", date(2026, 8, 4), [
+        _waypoint("G1", 0.0),
+        _waypoint("G2", 5.0, lat=46.61, lon=12.91),
+        _waypoint("G3", 4.0, lat=46.615, lon=12.915),  # Ruecksprung -> Verstoss
+        _waypoint("G4", 9.0, lat=46.62, lon=12.92),
+    ])
+    trip = Trip(id="tdd-2036-ac8", name="AC8", stages=[stage])
+
+    segments = convert_trip_to_segments(trip, date(2026, 8, 4))
+    assert segments, "Segmentliste leer"
+    for seg in segments:
+        measured = getattr(seg, "distance_measured", None)
+        assert measured is not True, (
+            f"Segment {seg.segment_id} gilt trotz nicht-monotoner Etappen-"
+            f"Distanzfolge als vermessen (distance_measured={measured!r})"
+        )
+
+
+def test_ac8_spanne_kuerzer_als_luftlinie_macht_die_etappe_unvermessen():
+    """AC-8 (zweite Verletzung): die gemessene Spanne muss mindestens so
+    gross sein wie die Luftlinie zwischen den Wegpunkten -- ein Track kann
+    nie kuerzer als die direkte Verbindung sein. Zwei Punkte mit ~1,1 km
+    Luftlinienabstand, aber nur 0,05 km gemessener Spanne, sind ein
+    Nachbearbeitungs-Artefakt (Waypoint verschoben/neu eingefuegt)."""
+    from app.trip import Trip
+    from services.trip_segments import convert_trip_to_segments
+
+    stage = _stage("T1", date(2026, 8, 5), [
+        _waypoint("G1", 0.0, lat=46.6, lon=12.9),
+        _waypoint("G2", 0.05, lat=46.61, lon=12.9),  # ~1.11 km Luftlinie
+    ])
+    trip = Trip(id="tdd-2036-ac8b", name="AC8b", stages=[stage])
+
+    segments = convert_trip_to_segments(trip, date(2026, 8, 5))
+    assert segments, "Segmentliste leer"
+    assert getattr(segments[0], "distance_measured", None) is not True, (
+        "Segment gilt als vermessen, obwohl die Spanne kuerzer als die "
+        f"Luftlinie ist (distance_measured={getattr(segments[0], 'distance_measured', None)!r})"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-14 — 0.0 ist eine gueltige Messung, None heisst unbekannt
+# ---------------------------------------------------------------------------
+
+def test_ac14_none_macht_die_etappe_unvermessen_auch_wenn_start_bei_0_0_liegt():
+    """AC-14: Given der erste Wegpunkt hat distance_from_start_km=0.0
+    (gueltiger Etappenstart) und ein zweiter beteiligter Wegpunkt hat
+    distance_from_start_km=None / When die Etappe auf Vermessenheit
+    geprueft wird / Then gilt die Etappe als UNVERMESSEN wegen des
+    None-Werts -- 0.0 selbst darf NICHT die Ursache sein."""
+    from app.trip import Trip
+    from services.trip_segments import convert_trip_to_segments
+
+    stage = _stage("T1", date(2026, 8, 6), [
+        _waypoint("G1", 0.0),
+        _waypoint("G2", None, lat=46.61, lon=12.91),
+    ])
+    trip = Trip(id="tdd-2036-ac14a", name="AC14a", stages=[stage])
+
+    segments = convert_trip_to_segments(trip, date(2026, 8, 6))
+    assert segments, "Segmentliste leer"
+    assert getattr(segments[0], "distance_measured", None) is not True, (
+        "Etappe gilt trotz fehlendem (None) Distanzwert an einem beteiligten "
+        f"Wegpunkt als vermessen: {getattr(segments[0], 'distance_measured', None)!r}"
+    )
+
+
+def test_ac14_durchgehend_gesetzte_werte_inkl_0_0_ergeben_vermessen():
+    """AC-14 (Gegenprobe): dieselbe Etappe, aber OHNE None-Wert -- 0.0 am
+    Start zaehlt als gueltige Messung, die Etappe gilt als vermessen."""
+    from app.trip import Trip
+    from services.trip_segments import convert_trip_to_segments
+
+    stage = _stage("T1", date(2026, 8, 7), [
+        _waypoint("G1", 0.0),
+        _waypoint("G2", 3.2, lat=46.61, lon=12.91),
+    ])
+    trip = Trip(id="tdd-2036-ac14b", name="AC14b", stages=[stage])
+
+    segments = convert_trip_to_segments(trip, date(2026, 8, 7))
+    assert segments, "Segmentliste leer"
+    assert getattr(segments[0], "distance_measured", None) is True, (
+        "Etappe mit durchgehend gesetzten Distanzwerten (inkl. 0.0 am Start) "
+        f"gilt nicht als vermessen: {getattr(segments[0], 'distance_measured', None)!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-13 (Pipeline-Nachweis) — unvermessene Etappe zeigt nie die Luftlinie
+# ---------------------------------------------------------------------------
+
+def test_ac13_pipeline_unvermessene_etappe_zeigt_nie_die_luftlinien_km():
+    """AC-13 (voller Produktionspfad): eine Etappe OHNE jede gemessene
+    Distanz (alle Waypoints distance_from_start_km=None, kein Track-
+    Auflösungsschritt) durchlaeuft `convert_trip_to_segments` ->
+    `to_alert_message` -> `render_subject`/`render_sms`. Der intern
+    weiterhin fuer `distance_km`/Korridor-Fallback berechnete
+    Luftlinienwert darf an KEINER Stelle im gerenderten Text auftauchen."""
+    from app.models import ChangeSeverity, WeatherChange
+    from app.trip import Trip
+    from output.renderers.alert.project import to_alert_message
+    from output.renderers.alert.render import render_sms, render_subject
+    from services.trip_segments import convert_trip_to_segments
+
+    stage = _stage("T1", date(2026, 8, 8), [
+        _waypoint("G1", None, lat=39.710564, lon=2.62293),
+        _waypoint("G2", None, lat=39.747657, lon=2.648606),
+    ])
+    trip = Trip(id="tdd-2036-ac13-pipeline", name="AC13", stages=[stage])
+
+    segments = convert_trip_to_segments(trip, date(2026, 8, 8))
+    assert segments, "Segmentliste leer"
+    assert getattr(segments[0], "distance_measured", None) is not True, (
+        "Segment ohne jede gemessene Distanz gilt trotzdem als vermessen"
+    )
+
+    change = WeatherChange(
+        metric="gust_max_kmh", old_value=30.0, new_value=80.0, delta=50.0,
+        threshold=20.0, severity=ChangeSeverity.MODERATE, direction="increase",
+        segment_id=segments[0].segment_id,
+        occurred_at=segments[0].start_time + timedelta(hours=1),
+    )
+    from utils.timezone import tz_for_coords
+    tz = tz_for_coords(segments[0].start_point.lat, segments[0].start_point.lon)
+    msg = to_alert_message([change], segments, "AC13-Trip", tz=tz, stand_at="10:00")
+
+    subject = render_subject(msg)
+    sms = render_sms(msg)
+    haversine_km_val = int(round(segments[0].distance_km))
+    for rendered in (subject, sms):
+        assert f"km {haversine_km_val}" not in rendered, (
+            f"Luftlinienwert {haversine_km_val} erscheint als km-Angabe: {rendered!r}"
+        )
+        assert "km" not in rendered or "km/h" in rendered, (
+            f"Text zeigt eine km-Ortsangabe trotz unvermessener Etappe: {rendered!r}"
+        )


### PR DESCRIPTION
Schließt #2036.

## Was sich ändert

Alarme nennen als Ortsangabe jetzt die **gemessene** Kilometerspanne (`km A–B`) statt der Segmentnummer — aber ausschließlich dann, wenn die Kilometer aus echter GPX-Wegstrecke stammen. Eine aus Luftlinie geschätzte Zahl wird nie als Ortsangabe gezeigt; ohne gemessene Strecke bleibt es bei der Segment-Sprache aus #1744.

Die Ortsauflösung hat damit vier Stufen statt drei:
`location_label` → **gemessene km-Spanne** → Segment-Kennung → km-Rückfall (ungemessen).

## Bausteine

- Flag `km_measured` an allen vier Alarm-Ereignistypen (`AlertEvent`, `OnsetEvent`, `OnsetShiftEvent`, `CorridorEvent`) — additiv, Default aus
- Neues Waypoint-Feld `distance_from_start_km`, in Python **und** Go (`SaveTrip`-Roundtrip, Präzedenzfall `suggestion_reason`)
- Neues Modul `src/services/track_resolution.py`: rüstet Bestandstrips aus dem vorhandenen GPX-Bestand nach, Read-Modify-Write, nur bei eindeutigem Track-Treffer
- `CorridorEvent` bekommt zusätzlich `segment_id` — ohne sie konnte der Korridor-Zweig gar keinen Ort nennen und fiel zwangsläufig auf Luftlinien-km zurück (Adversary-Finding F001)

## Nachweis

- 15/15 Acceptance Criteria erfüllt, jedes mit benanntem bewachendem Test
- Adversary Verification: **VERIFIED**, 12/12 Mutationen wurden rot
- Kern-Suite (CI-Kommando): 10457 passed. Die 2 roten sind umgebungsbedingt und ohne Bezug zu diesem Ticket (vorbelegte `GZ_TELEGRAM_CHAT_ID` aus der Worktree-`.env`; ein Live-`httpx.post` gegen Staging, den der Egress-Wächter blockt)
- Go: alle Pakete `ok`

## Bewusst offen

Ein Alarm ohne verwertbare `segment_id` zeigt weiterhin `km A–B` aus Luftlinie — Stufe 4, Entscheidung aus #1744 AC-7, galt schon vorher und für alle Event-Typen gleich. Eine Änderung wäre eine eigene Produktentscheidung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BKka1TpVzqPRzW8duVG3fi