### PR TITLE
fix(#2046): Onset-Kurznachricht nennt die erwartete Regenmenge

### DIFF
--- a/api/routers/validator.py
+++ b/api/routers/validator.py
@@ -237,6 +237,10 @@ class OnsetPayload(BaseModel):
     source_label: str
     cooldown_display: str | None = None
     segment_id: str | None = None
+    # Issue #2046: Mengenangabe der Onset-Kurznachricht (mm der Stunde ab dem
+    # Beginn), additiv und optional -- Muster `segment_id` o. Ohne sie rendert
+    # der Vorschauweg die zahlenlose Alt-Form.
+    onset_precip_mm: float | None = None
 
 
 class OfficialAlertPayload(BaseModel):

--- a/docs/context/fix-2046-onset-menge.md
+++ b/docs/context/fix-2046-onset-menge.md
@@ -1,0 +1,97 @@
+# Context: fix-2046-onset-menge
+
+Issue #2046 — „Alert ohne echten Inhalt". Branch `fix-2046-onset-menge`, Basis `24e83b14`
+(enthält #2020 und #1818). Standard Track (Intake-Score 3).
+
+## Request Summary
+
+Der Nutzer erhielt per Telegram im Kurzstil den Radar-Onset-Alarm `Ziel: R@18:00`. Die
+Nachricht nennt keinerlei Regenmenge — nur Kürzel und Uhrzeit. Gesucht ist eine Kurzform,
+die sagt, **wie viel** Regen erwartet wird, nicht nur **wann** er beginnt.
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `src/output/renderers/alert/render.py:553-581` | `_render_sms_onset` — erzeugt exakt `Ziel: R@18:00` (`token = f"{kuerzel}@{...}"`, `body = f"{head}: {token}"`), liest von `OnsetEvent` nur `is_convective` und die Ortsfelder |
+| `src/output/renderers/alert/render.py:1042-1080` | `_render_sms_body` — Onset-Weiche `if msg.source is not None` |
+| `src/output/renderers/alert/model.py:38-62` | `OnsetEvent` — trägt `intensity_label` (Text), **kein** numerisches Mengen-/Ratenfeld |
+| `src/output/renderers/alert/project.py:397-405` | Ortsvergleich-Bündelpfad baut `OnsetEvent` direkt aus `NowcastResult` |
+| `src/services/radar_service.py:636-779` | `_derive_result` — berechnet `window_precip_mm` (mm) und `max_rate_mm_h` (mm/h) sowie `intensity_label` |
+| `src/services/radar_service.py:129-169` | `NowcastResult` — führt beide Zahlen bereits, seit #2020 |
+| `src/services/trip_alert.py:1468-1479` | Abbruchstelle Trip-Pfad: `RadarAlertRequest` übernimmt nur `intensity_label` + `is_convective` |
+| `src/services/notification_service.py:165-194,1272-1314,1372-1374` | `RadarAlertRequest`-DTO, `send_radar_alert`, `render_alert_sms(...)`-Aufruf ohne `limit`-Override |
+| `src/services/validator_render_service.py:108-152` | Vorschau-/Testeinspeiseweg baut `OnsetEvent` aus dem API-Payload `body.onset` |
+| `src/output/tokens/metrics.py:14-67` | Briefing-Grammatik: `R` mit einer Nachkommastelle, `TH:` als Stufe (L/M/H) |
+
+## Wirkkette der Zahl — wo sie abbricht
+
+```
+_derive_result  window_precip_mm / max_rate_mm_h   (radar_service.py:745-778)  ✅ vorhanden
+      │
+      ├─ Trip-Pfad:   trip_alert.py:1468-1479  → RadarAlertRequest   ❌ Zahl wird nicht übernommen
+      │                notification_service.py:1290 → OnsetEvent     ❌ Feld existiert nicht
+      ├─ Vergleich:   project.py:397-405       → OnsetEvent          ❌ Zahl wird nicht gelesen
+      └─ Vorschau:    validator_render_service.py:108-121            ❌ Payload kennt kein Mengenfeld
+                                   ↓
+                      _render_sms_onset  →  "Ziel: R@18:00"
+```
+
+Einzige Leser von `window_precip_mm`/`max_rate_mm_h` im gesamten `src/`-Baum sind
+`radar_service.py` selbst und die Überholungsprüfung `trip_alert.py:1382-1383`.
+
+## Existing Patterns
+
+- **Briefing-SMS ist die Referenz-Grammatik** (#1948-Konzept v3, Abschnitt 1): Regen erscheint
+  als `R4.0@14` — Zahl mit einer Nachkommastelle plus Stunde; Gewitter erscheint als `TH:M@14`
+  — **nie** als Zahl, sondern als Stufe. Ein `TH2.5` wäre in dieser Grammatik missverständlich.
+- **Zweig a (Abweichungsalarm) nennt bereits Werte** (`_sms_token`), Zweig c (Radar-Onset) als
+  einziger nicht.
+- **Additiv-optionale Felder mit Default** sind das etablierte Muster für `OnsetEvent`
+  (`location_label` #1041, `segment_id` #1744, `onset_day_offset` #2009) — jeweils
+  bit-identisch im unveränderten Fall.
+
+## Dependencies
+
+- **Upstream:** `RadarNowcastService._derive_result` (Frames aus BrightSky/INCA/ARPAE-2I/
+  AROME-FR/ICON-D2/Open-Meteo `minutely_15`; jeder Frame trägt numerisch `precip_mm_h`).
+- **Downstream:** SMS, **Premium-SMS (Garmin inReach)** und **Telegram im Kurzstil** erhalten
+  denselben gerenderten `sms_body` (`notification_service.py:1461-1476`) — eine Änderung am
+  Token wirkt auf alle drei Kanäle gleichzeitig; E-Mail und Telegram-Langform sind nicht
+  betroffen (eigene Renderer, zeigen `intensity_label` als Wort).
+
+## Existing Specs
+
+- `docs/specs/modules/fix_1948_s4_nowcast_sms_zielbild.md` — hat `_render_sms_onset` gebaut
+  (Zeitpunkt statt Countdown, gemeinsamer Ortskopf). **Enthält keine Aussage zu Menge/
+  Intensität** — das Weglassen war keine dokumentierte Entscheidung, sondern eine Lücke.
+- `docs/specs/modules/fix_2020_alarm_ausloesung.md` — führte `window_precip_mm`/`max_rate_mm_h`
+  ein. Die dortige Aussage „`max_rate_mm_h` bewusst ohne Regel-Leser" betrifft die
+  **Auslösungslogik**, nicht die Anzeige.
+- `docs/specs/modules/fix_2036_alarm_kilometer_ortsangabe.md` — parallele Arbeit am **Kopf**
+  derselben Zeile.
+
+## Risks & Considerations
+
+- 🔴 **Messgrundlage:** `window_precip_mm` ist die Menge der nächsten **60 Minuten ab jetzt**
+  (`radar_service.py:708-754`), der Alarm feuert aber bei Beginn bis **55 Minuten voraus**
+  (`RADAR_ONSET_THRESHOLD_MIN = 55`). Bei spätem Beginn deckt das Fenster fast nur die noch
+  trockene Zeit ab — die Zahl wäre systematisch zu klein und würde den Alarm entwerten.
+  Die anzuzeigende Menge muss am **Beginn** ausgerichtet sein, nicht an „jetzt".
+- **Gewitter-Onset (`TH`)**: Die Briefing-Grammatik reserviert die Position hinter `TH:` für
+  eine Stufe. Eine Mengenangabe braucht dort eine eigene, unmissverständliche Form.
+- **Ausweichform**: Ohne belastbare Zahl (keine Frames nach dem Beginn, Datenausfall) darf
+  keine `0.0` erscheinen — dann bleibt die heutige Form ohne Zahl.
+- **Zeichenlimit** 140 (Default, kein Aufrufer übergibt 160); heutige Zeile 13 Zeichen — keine
+  Platznot, harter Schnitt `body[:limit]` bleibt unangetastet.
+- **Kollision #2036**: ändert `format_alert_location`/den Kopf derselben Zeile, liegt noch
+  nicht auf `origin/main`. Getrennte Teilstrings, Zusammenführung per Rebase.
+- **Kanal-Parität**: Trip-Radar UND Ortsvergleich-Radar nutzen denselben Renderer — beide
+  Projektionspfade müssen die Zahl führen, sonst entsteht eine stille Lücke im Vergleichspfad.
+
+## Tests, die den heutigen Token festnageln
+
+`test_alert_sms_onset_zeitpunkt.py`, `test_alert_onset_day_rollover.py`,
+`test_alert_preview_nowcast_replay.py`, `test_952_onset_alert_fidelity.py`,
+`test_alert_sms_location_positions.py`, `test_alert_addendum_sms.py`,
+`test_issue_919_radar_alert_canonical.py`, `test_multi_location_onset_alert.py`.

--- a/docs/features/architecture.md
+++ b/docs/features/architecture.md
@@ -396,8 +396,15 @@ Scheibe 3 (#1170). Scheduler: `POST /api/scheduler/compare-alert-checks`, Go-Cro
      - `render_telegram(msg)` — Fettzeile + Detail mit Onset-Uhrzeit und Quelle
      - `render_sms(msg)` — Token `R@<hh:mm>` (Regen) oder `TH@<hh:mm>` (Gewitter), Zeitpunkt statt
        Countdown (seit #1948 S4; Kurznachricht kürzt bei der Stunde die führende Null,
-       `TH@9:05` statt `TH@09:05`), ≤140 Zeichen GSM-7
-     - `OnsetEvent`-Datenklasse: `onset_minutes`, `onset_time`, `km_from`/`km_to`, `is_convective`, `intensity_label`, `source_label`
+       `TH@9:05` statt `TH@09:05`), ≤140 Zeichen GSM-7. **Seit #2046** trägt der Token bei
+       belastbarer Menge (≥ 0,1 mm, akkumuliert über 60 Min **ab dem Beginn**, nicht ab
+       Versandzeitpunkt) zusätzlich die erwartete Regenmenge: `R2.5@18:00` (Regen, Zahl
+       direkt hinter dem Kürzel) bzw. `TH@18:00 R2.5` (Gewitter, Zahl als eigenes Token
+       nach der Zeit — hinter `TH` bleibt die Stufen-Position frei). Ohne belastbare Zahl
+       (`None`, unter 0,1 mm, Daten nicht verfügbar) bleibt die zahlenlose Form
+       (`R@18:00`/`TH@18:00`) erhalten; E-Mail- und Telegram-Langform sind unverändert und
+       zeigen weiterhin `intensity_label` als Wort.
+     - `OnsetEvent`-Datenklasse: `onset_minutes`, `onset_time`, `km_from`/`km_to`, `is_convective`, `intensity_label`, `source_label`, `onset_precip_mm` (additiv, #2046 — Menge ab Ereignisbeginn, getrennt von `NowcastResult.window_precip_mm`, das ab „jetzt" misst)
      - `AlertMessage.cooldown_display` trägt den dynamischen Cooldown-Text (z.B. „2 Stunden")
      - `src/outputs/radar_alert.py` ist gelöscht — kein separater Inline-Body-Bau mehr
    - **Throttle-Semantik unverändert** (Issue #773): `radar_alert_throttle.json` + `alert_log` auch bei Best-Effort-Versandfehlern

--- a/docs/reference/api_contract.md
+++ b/docs/reference/api_contract.md
@@ -3370,7 +3370,7 @@ S1-Eingangsprotokoll (`src/services/alert_input_capture.py`, siehe
 |------|-----|------|
 | changes | `ChangePayload[]` | Zweig a (Δ-Alarm): rohe Änderungswerte je Etappe (`metric`, `old_value`, `new_value`, `delta`, `threshold`, `severity`, `direction`, `segment_id`) |
 | segment_times | `SegmentTimePayload[]` | Optional bei `changes` — fehlt es, synthetisiert der Endpoint die Etappen-Zeitfenster aus dem geladenen Trip über dieselbe Produktions-Segmentierung wie der Versandpfad (`convert_trip_to_segments`) |
-| onset | `OnsetPayload` \| null | Radar-Onset (Zweig c, Alt-Form vor S2): `onset_minutes`, `onset_time`, `km_from`, `km_to`, `is_convective`, `intensity_label`, `source_label`, `cooldown_display?`, `segment_id?` (additiv seit #1948 S5, AC-15 — ohne Segment-Kennung fiel der Zweig auf den km-Rückfall zurück) |
+| onset | `OnsetPayload` \| null | Radar-Onset (Zweig c, Alt-Form vor S2): `onset_minutes`, `onset_time`, `km_from`, `km_to`, `is_convective`, `intensity_label`, `source_label`, `cooldown_display?`, `segment_id?` (additiv seit #1948 S5, AC-15 — ohne Segment-Kennung fiel der Zweig auf den km-Rückfall zurück), `onset_precip_mm?` (additiv seit #2046 — Menge in mm, akkumuliert über 60 Min ab Ereignisbeginn; `None`/fehlend ⇒ SMS-Onset-Token ohne Zahl) |
 | official | `OfficialAlertPayload[]` \| null | **NEU (#1948 S2), Zweig b:** amtliche Warnung(en), Feldspiegel von `OfficialAlert` — `source`, `hazard`, `level: int`, `label`, `valid_from?`, `valid_to?`, `url?`, `region_label?`, `dedup_id?`, `segment_ids: string[]` |
 | nowcast_frames | `NowcastFramesPayload` \| null | **NEU (#1948 S2), Zweig c:** Replay eines S1-Nowcast-Mitschnitts — `source`, `frames: [{timestamp, precip_mm_h, is_convective}]`, `km_from`, `km_to`, `segment_id?` (additiv seit #1948 S5, AC-15, analog zu `OnsetPayload`) |
 
@@ -3655,6 +3655,12 @@ function corridorInside(value, min, max) {
 
 ## Changelog
 
+- 2026-08-21: Issue #2046 — `OnsetPayload` (Section 22.5, `POST /api/trips/{trip_id}/
+  alert-preview`) bekommt additiv das Feld `onset_precip_mm: float | null`. Speist die neue
+  Mengenangabe im SMS-/Premium-SMS-/Telegram-Kurzstil-Onset-Token (`R2.5@18:00` bzw.
+  `TH@18:00 R2.5`, akkumuliert über 60 Min ab Ereignisbeginn, nicht ab Versandzeitpunkt).
+  Reine additive Feld-Ergänzung, kein Formatwechsel der Antwortstruktur; E-Mail- und
+  Telegram-Langform unverändert. Spec: `docs/specs/modules/fix_2046_onset_menge.md`.
 - 2026-08-20: Issue #1948 Scheibe S5 — `OnsetPayload` und `NowcastFramesPayload` (Section 22.5,
   `POST /api/trips/{trip_id}/alert-preview`) bekommen additiv das Feld `segment_id: string | null`,
   analog zu `segment_ids` bei `OfficialAlertPayload` (Vorbedingung aus S4, AC-15) — ohne Segment-

--- a/docs/specs/modules/fix_2046_onset_menge.md
+++ b/docs/specs/modules/fix_2046_onset_menge.md
@@ -82,10 +82,24 @@ onset_precip_mm: Optional[float] = None
 `window_precip_mm`-Schleife, Z. 745-754): dieselbe Struktur wie die
 `compare_window`/`compare_window_by_ts`-Berechnung (Z. 719-754), aber mit
 `onset_horizon = onset_time_dt + timedelta(minutes=60)` als Fensterende und
-`onset_time_dt` (aus `onset_minutes`, das bereits oben berechnet wird) als
-Fensterstart statt `now`. Nur wenn `onset_minutes is not None`; sonst bleibt
-`onset_precip_mm = None`. Kein zweiter Frame-Abruf — dieselbe `frames`-Liste, die
-auch `window_precip_mm` speist (AC-12).
+dem Zeitstempel des Beginn-Frames als Fensterstart statt `now`. Nur wenn
+`onset_minutes is not None`; sonst bleibt `onset_precip_mm = None`. Kein
+zweiter Frame-Abruf — dieselbe `frames`-Liste, die auch `window_precip_mm`
+speist (AC-12).
+
+> **Fensterstart ist der EXAKTE Frame-Zeitstempel, nicht `now +
+> onset_minutes`** (PO-bestätigt 2026-08-21, aus der Implementierung
+> nachgetragen). `onset_minutes` ist der GERUNDETE Anzeigewert
+> (`max(0, round(delta))`, `radar_service.py`) — bei einem echten Abstand von
+> 49,6 Minuten steht dort `50`. Ein daraus zurückgerechnetes `now +
+> timedelta(minutes=50)` läge NACH dem Beginn-Frame und schöbe ihn über die
+> `>=`-Fenstergrenze aus seinem eigenen Fenster heraus; die angezeigte Menge
+> fiele um den ersten Frame zu klein aus. Die Implementierung sammelt deshalb
+> `onset_ts` in derselben Schleife ein, die `onset_minutes` bestimmt. Bei
+> regelmäßiger Kadenz (5/15 Min) sind beide Varianten identisch — der
+> Unterschied tritt erst bei unregelmäßigen Produktivrastern auf. **Nicht
+> „an die Spec angleichen": der gerundete Anzeigewert darf die Messgrundlage
+> nicht verschieben.**
 
 **3. Additive Felder auf `OnsetEvent`** (`model.py`, Muster `onset_day_offset`
 #2009, Z. 56-62): `onset_precip_mm: float | None = None`.
@@ -358,3 +372,7 @@ unverändert grün oder werden am Goldstring fortgeschrieben:**
 
 - 2026-08-21: Initial spec created (#2046, Radar-Onset-Kurznachricht mit
   Mengenangabe).
+- 2026-08-21: Fensterstart der Mengenrechnung präzisiert — exakter
+  Beginn-Frame-Zeitstempel statt aus dem gerundeten `onset_minutes`
+  zurückgerechneter Zeitpunkt (PO-bestätigt, aus der Implementierung
+  nachgetragen). Akzeptanzkriterien unverändert.

--- a/docs/specs/modules/fix_2046_onset_menge.md
+++ b/docs/specs/modules/fix_2046_onset_menge.md
@@ -1,0 +1,360 @@
+---
+entity_id: fix_2046_onset_menge
+type: bugfix
+created: 2026-08-21
+updated: 2026-08-21
+status: draft
+version: "1.0"
+tags: [alarm, sms, nowcast, radar, format]
+---
+
+# Radar-Onset-Kurznachricht bekommt eine Mengenangabe — #2046
+
+## Approval
+
+- [x] Approved — PO Henning, 2026-08-21 ('go' auf alle 12 Akzeptanzkriterien)
+
+## Purpose
+
+Der Radar-Onset-Alarm (Zweig c: Gewitter-/Regen-Anmarsch) ist heute der einzige
+Alarmzweig, dessen Kurzform (`Ziel: R@18:00`) keinerlei Wert nennt — nur Kürzel und
+Uhrzeit. Diese Spec ergänzt eine Mengenangabe, gemessen über die 60 Minuten **ab dem
+Beginn** (nicht ab „jetzt"), und reicht sie additiv durch alle Wirkketten (Trip-Pfad,
+Ortsvergleich-Bündel, Vorschau-/Testeinspeiseweg) bis in `_render_sms_onset`.
+
+## Source
+
+- **File:** `src/output/renderers/alert/render.py`
+- **Identifier:** `_render_sms_onset()` (Z. 553-581)
+
+Begleitend: `src/services/radar_service.py` (`_derive_result`, Z. 636-779;
+`NowcastResult`, Z. 129-172), `src/services/trip_alert.py` (`check_radar_alerts`,
+Z. 1330-1479), `src/services/notification_service.py` (`RadarAlertRequest` Z. 165-194,
+`send_radar_alert` Z. 1272-1314), `src/output/renderers/alert/model.py` (`OnsetEvent`
+Z. 38-62), `src/output/renderers/alert/project.py`
+(`to_multi_location_onset_alert_message`, Z. 397-405), `src/services/
+validator_render_service.py` (`render_alert_preview` Z. 108-121, `_render_nowcast_replay`
+Z. 220-261), `api/routers/validator.py` (`OnsetPayload`, Z. 226-239).
+
+> **Schicht-Hinweis:** Alle Änderungen liegen ausschließlich im Python-Core
+> (`src/services/`, `src/output/`, `api/routers/`) — kein Go-API-, kein Frontend-Anteil.
+
+## Estimated Scope
+
+- **LoC:** ~90–130 (additives Feld über sechs Dateien + Rechenlogik in
+  `_derive_result` + Token-Zusammenbau in `_render_sms_onset`, unter dem
+  250-LoC-Workflow-Limit)
+- **Files:** 6 Produktivdateien (`radar_service.py`, `model.py`, `trip_alert.py`,
+  `notification_service.py`, `project.py`, `render.py`, `validator_render_service.py`,
+  `api/routers/validator.py` — de facto 8, aber mehrere nur Ein-Zeiler) + 8
+  Bestandstestdateien fortgeschrieben + mind. 1 neues Testmodul (TDD-RED)
+- **Effort:** medium
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `NowcastResult.window_precip_mm` | field (`radar_service.py:157-160`) | Bestehendes Mengenfeld, misst 60 Min **ab jetzt** — bleibt für die #2020-Auslöseregel unangetastet, ist NICHT die neue Anzeige-Zahl |
+| `_derive_result` | method (`radar_service.py:636-779`) | Ort der neuen Rechnung; besitzt bereits die komplette Akkumulationsmechanik (Frame-Dedup Z. 739-743, Deckelung `_MAX_FRAME_COVERAGE` Z. 752, Fensterende als harte Grenze Z. 752) — wird für das neue Fenster wiederverwendet, nicht neu erfunden |
+| `RADAR_ONSET_THRESHOLD_MIN` | constant (`radar_service.py:113`, Wert 55) | Erklärt die Lücke: Alarm feuert bis 55 Min vor Beginn, `window_precip_mm`-Fenster deckt aber nur die ersten 60 Min ab jetzt — bei spätem Beginn fast nur Trockenzeit |
+| `OnsetEvent` | dataclass (`model.py:38-62`) | Trägt heute `intensity_label` (Text), kein numerisches Feld — bekommt additiv-optionales `onset_precip_mm` |
+| `RadarAlertRequest` | DTO (`notification_service.py:165-194`) | Trip-Pfad-Transport; bekommt additiv-optionales `onset_precip_mm` |
+| `_fmt_num` / `LEVELS` | function/dict (`src/output/tokens/metrics.py:14,17-19`) | Referenz-Zahlformat (`R{value:.1f}`) und Stufen-Grammatik (`TH:` reserviert Position für L/M/H) — Begründung für die getrennte Stellung bei Gewitter |
+| `to_multi_location_onset_alert_message` | function (`project.py:319-410`) | Ortsvergleich-Bündelpfad, baut `OnsetEvent` direkt aus `NowcastResult` — zweiter Leser der neuen Zahl |
+| `render_alert_preview` / `_render_nowcast_replay` | function (`validator_render_service.py:71-159,220-261`) | Vorschau-/Testeinspeiseweg; `_render_nowcast_replay` ruft `_derive_result` direkt und rekursiv `render_alert_preview` — beide Stellen müssen die Zahl durchreichen |
+| `OnsetPayload` | Pydantic-Model (`api/routers/validator.py:226-239`) | API-Payload-Schema für den direkten Vorschauweg (nicht Replay) — bekommt additiv-optionales Feld, Muster `segment_id` |
+
+## Implementation Details
+
+**1. Neues Feld auf `NowcastResult` (`radar_service.py`, nahe `window_precip_mm`,
+Z. 157-160):**
+
+```python
+onset_precip_mm: Optional[float] = None
+# Issue #2046: akkumulierte Menge der 60 Minuten AB `onset_minutes` (nicht ab
+# jetzt wie window_precip_mm) -- Grundlage der SMS-Mengenangabe. None wenn
+# onset_minutes None ist ODER im Fenster ab dem Beginn keine Frames liegen.
+# Eigenes Fenster, dieselbe Akkumulationsmechanik wie window_precip_mm
+# (Frame-Dedup, _MAX_FRAME_COVERAGE-Deckel, Fensterende als harte Grenze).
+```
+
+**2. Rechnung in `_derive_result`** (`radar_service.py`, nach der bestehenden
+`window_precip_mm`-Schleife, Z. 745-754): dieselbe Struktur wie die
+`compare_window`/`compare_window_by_ts`-Berechnung (Z. 719-754), aber mit
+`onset_horizon = onset_time_dt + timedelta(minutes=60)` als Fensterende und
+`onset_time_dt` (aus `onset_minutes`, das bereits oben berechnet wird) als
+Fensterstart statt `now`. Nur wenn `onset_minutes is not None`; sonst bleibt
+`onset_precip_mm = None`. Kein zweiter Frame-Abruf — dieselbe `frames`-Liste, die
+auch `window_precip_mm` speist (AC-12).
+
+**3. Additive Felder auf `OnsetEvent`** (`model.py`, Muster `onset_day_offset`
+#2009, Z. 56-62): `onset_precip_mm: float | None = None`.
+
+**4. Durchreichung entlang der Wirkkette** (alle additiv, Default `None`,
+Muster `segment_id`/`onset_day_offset`):
+
+- `RadarAlertRequest` (`notification_service.py:165-194`) — neues Feld.
+- `trip_alert.py:1330-1479` (`check_radar_alerts`) — `result.onset_precip_mm` aus
+  dem `NowcastResult` in den `RadarAlertRequest`-Konstruktoraufruf übernehmen
+  (analog `is_convective=result.is_convective`).
+- `notification_service.py:1272-1314` (`send_radar_alert`) —
+  `onset_precip_mm=request.onset_precip_mm` in den `OnsetEvent`-Konstruktoraufruf.
+- `project.py:397-405` (`to_multi_location_onset_alert_message`) —
+  `onset_precip_mm=nc.onset_precip_mm` in den `OnsetEvent`-Konstruktoraufruf (`nc`
+  ist das `NowcastResult` je Ort).
+- `validator_render_service.py:108-121` (`render_alert_preview`, has_onset-Zweig) —
+  `onset_precip_mm=getattr(body.onset, "onset_precip_mm", None)`, Muster
+  `segment_id` Z. 118-120.
+- `validator_render_service.py:220-261` (`_render_nowcast_replay`) —
+  `onset_precip_mm=result.onset_precip_mm` in den `onset_ns`-`SimpleNamespace`
+  (Z. 246-256).
+- `api/routers/validator.py:226-239` (`OnsetPayload`) —
+  `onset_precip_mm: float | None = None`.
+
+**5. Token-Zusammenbau in `_render_sms_onset`** (`render.py:553-581`):
+
+```python
+kuerzel = "TH" if e.is_convective else "R"
+menge = _fmt_num("R", e.onset_precip_mm) if e.onset_precip_mm is not None else None
+zeit = f"@{_sms_onset_time(e.onset_time, e.onset_day_offset)}"
+if kuerzel == "TH":
+    token = f"TH{zeit}" + (f" R{menge}" if menge is not None else "")
+else:
+    token = f"{kuerzel}{f'{menge}' if menge is not None else ''}{zeit}"
+```
+
+`_fmt_num` importiert aus `output.tokens.metrics` (bereits Briefing-Referenz für
+die Zahlform, eine Nachkommastelle). Kopf-Fallunterscheidung (`location_label`
+vs. `COMPARE_RADAR_SOURCE` vs. Trip-km-Rückfall) bleibt unverändert — diese Spec
+ändert nur den Token-Teil hinter dem Doppelpunkt.
+
+**Ausweichform (AC-4):** `onset_precip_mm is None` **oder** kleiner als eine
+belastbare Untergrenze in Größenordnung von `_DRY_THRESHOLD_MM_H` (0,1 mm/h über
+60 Min ≈ 0,1 mm) führt zur heutigen Form ohne Zahl — dieselbe Schwelle, die
+bereits `_derive_result` für „trocken" verwendet (Z. 655, `_DRY_THRESHOLD_MM_H`).
+`onset_precip_mm == 0.0` wird dabei wie `None` behandelt: die Anzeige unterscheidet
+nicht zwischen „nicht berechenbar" und „berechnet, aber null" — beides ergibt die
+zahlenlose Form, damit niemals `R0.0@` entsteht.
+
+## Expected Behavior
+
+- **Input:** `NowcastResult` mit gesetztem `onset_minutes` und Frames, die bis
+  mindestens in die erste Minute nach dem Beginn reichen.
+- **Output:** `render_sms()` liefert für den Onset-Zweig `{Kopf}: R{menge}@{HH:MM}`
+  (Regen) bzw. `{Kopf}: TH@{HH:MM} R{menge}` (Gewitter), `menge` mit einer
+  Nachkommastelle; ohne belastbare Zahl unverändert `{Kopf}: R@{HH:MM}` bzw.
+  `{Kopf}: TH@{HH:MM}`.
+- **Side effects:** keine — reine additive Feld-Durchreichung plus
+  Renderer-Formatierung. Kein Datenmodell-Bruch (alle neuen Felder optional mit
+  Default `None`), keine Persistenz betroffen. E-Mail- und Telegram-Langform-
+  Rendering bleiben unverändert (nutzen weiterhin `intensity_label` als Wort,
+  lesen `onset_precip_mm` nicht).
+
+## Acceptance Criteria
+
+- **AC-1:** Given ein Trip-Onset-Alarm mit einem nicht-konvektiven Ereignis
+  (`is_convective=False`, `onset_time="18:00"`, `onset_precip_mm=2.5`) / When
+  `render_sms(msg)` über den Onset-Zweig gerendert wird / Then enthält der Text
+  exakt das Token `R2.5@18:00` — Kürzel, Zahl mit einer Nachkommastelle und
+  Uhrzeit ohne Trennzeichen dazwischen.
+  - Test: Unit-Test gegen `_render_sms_onset` mit konstruiertem `OnsetEvent`,
+    Substring-Vergleich auf `R2.5@18:00`.
+
+- **AC-2:** Given denselben Aufbau wie AC-1, aber konvektiv
+  (`is_convective=True`, `onset_time="18:00"`, `onset_precip_mm=2.5`) / When
+  `render_sms(msg)` über denselben Onset-Zweig gerendert wird / Then enthält der
+  Text exakt `TH@18:00 R2.5` — die Zahl steht als eigenes Token NACH dem
+  Zeit-Token, getrennt durch ein Leerzeichen, und hinter `TH` selbst steht
+  niemals eine Ziffer (Stufen-Position bleibt frei für L/M/H).
+  - Test: Unit-Test, gespiegelt zu AC-1, prüft sowohl das Vorhandensein von
+    `TH@18:00 R2.5` als auch die Abwesenheit von `TH2` bzw. `TH2.5`.
+
+- **AC-3:** Given ein `NowcastResult`, dessen `onset_minutes=50` ist (Beginn in
+  50 Minuten, unter der 55-Minuten-Auslöseschwelle) und dessen Frames VOR dem
+  Beginn durchgängig trocken sind (0 mm/h), AB dem Beginn aber 12 mm/h liefern /
+  When `_derive_result` sowohl `window_precip_mm` (60 Min ab jetzt) als auch
+  `onset_precip_mm` (60 Min ab Beginn) berechnet / Then weist `window_precip_mm`
+  nur rund 2 mm aus (10 trockene Minuten + 50 Minuten bei 12 mm/h, aber vom
+  60-Minuten-Fenster ab jetzt nur die letzten 10 Minuten mit Regen erfasst,
+  exakter Wert von der Frame-Kadenz abhängig, GRÖSSENORDNUNG deutlich unter 12
+  mm), während `onset_precip_mm` rund 12 mm ausweist (volle Stunde ab Beginn bei
+  12 mm/h) — die neue Zahl entwertet den Alarm nicht durch Untertreibung, weil
+  sie am Beginn ausgerichtet ist, nicht an „jetzt".
+  - Test: Unit-Test gegen `_derive_result` mit konstruierten Frames (Kadenz z. B.
+    5-Minuten-Raster, Regen erst ab Minute 50), Vergleich beider Feldwerte
+    gegeneinander — Wächter, der rot schlägt, sollte `onset_precip_mm`
+    versehentlich wieder ab „jetzt" statt ab dem Beginn gerechnet werden.
+
+- **AC-4:** Given ein `OnsetEvent` ohne belastbare Zahl — drei Varianten:
+  (a) `onset_precip_mm=None` (keine Frames im Fenster ab Beginn), (b)
+  `onset_precip_mm=0.0` (Menge unterhalb der Trockenschwelle), (c) ein
+  `NowcastResult` mit `data_unavailable=True` bzw. `throttled=True` / When
+  `render_sms(msg)` in allen drei Fällen gerendert wird / Then bleibt die
+  heutige Form ohne Zahl (`R@18:00` bzw. `TH@18:00`) erhalten — in keinem Fall
+  entsteht `R0.0@18:00`.
+  - Test: Drei Unit-Tests (a/b/c) gegen `_render_sms_onset`, jeweils Abwesenheit
+    jeder Ziffernfolge unmittelbar hinter `R` bzw. `TH` geprüft.
+
+- **AC-5:** Given `onset_precip_mm=2.0` (glatte Zahl ohne Nachkommaanteil) und
+  `onset_precip_mm=12.34` (zwei Nachkommastellen) / When beide über
+  `render_sms(msg)` gerendert werden / Then erscheint die Zahl in beiden Fällen
+  mit genau einer Nachkommastelle und Punkt als Trennzeichen (`R2.0@…`,
+  `R12.3@…`), niemals mit Einheit („mm") im Text — identisch zur
+  Briefing-Zahlform aus `output.tokens.metrics._fmt_num`.
+  - Test: Unit-Test, zwei Eingaben, Regex-Vergleich auf `R\d+\.\d@` und
+    Abwesenheit von `mm` im Token-Teil.
+
+- **AC-6:** Given einen Ortsvergleich-Bündel-Onset-Alarm mit zwei Orten, bei dem
+  das führende Ereignis `onset_precip_mm=1.8` trägt / When
+  `to_multi_location_onset_alert_message` das Ergebnis baut und `render_sms(msg)`
+  darauf gerendert wird / Then enthält der Text `R1.8@…` — dieselbe Zahl und
+  Formatregel wie im Trip-Pfad (AC-1), nicht bloß eine leere Kurzform mit
+  Ortsnamen.
+  - Test: Unit-Test über `to_multi_location_onset_alert_message` mit zwei
+    Orts-`NowcastResult`s (führender Ort mit gesetzter Menge), gerendertes `sms`
+    auf die Zahl geprüft.
+
+- **AC-7:** Given dieselben Onset-Ereignisse für SMS, Premium-SMS und Telegram im
+  Kurzstil / When `send_radar_alert(...)` alle drei konfigurierten Kanäle
+  bedient / Then zeigen alle drei Kanäle denselben Token-Text inklusive Menge,
+  weil sie denselben gerenderten `sms_body` erhalten
+  (`notification_service.py:1461-1476`) — kein Kanal zeigt eine andere Zahl oder
+  lässt sie aus.
+  - Test: Vergleichstest — ein `_dispatch_alert_message`-Aufruf mit allen drei
+    Kanälen aktiv, `sent`-Payloads von SMS/Premium-SMS/Telegram-Kurzstil auf
+    identischen Text geprüft.
+
+- **AC-8:** Given denselben Onset-Alarm, einmal über `render_sms` und einmal über
+  `_render_email_onset` bzw. `_render_telegram_onset` (Langform) gerendert /
+  Then bleiben E-Mail- und Telegram-Langform-Ausgabe bit-identisch zum
+  Vor-#2046-Zustand — sie zeigen weiter `intensity_label` als Wort, `
+  onset_precip_mm` hat dort keinen Leser.
+  - Test: Vergleichstest — bestehende E-Mail-/Telegram-Langform-Regressionstests
+    laufen unverändert grün; ergänzend ein struktureller Test, dass
+    `_render_email_onset`/`_render_telegram_onset` `onset_precip_mm` nicht
+    referenzieren (Grep-Nicht-Berührungs-Nachweis, kein Verhaltensersatz).
+
+- **AC-9:** Given ein Onset-Alarm mit langem Ortsnamen UND `onset_precip_mm=99.9`
+  (Extremfall, maximale Zeichenlänge der Zahl) / When `render_sms(msg, limit=140)`
+  gerendert wird / Then bleibt der resultierende Text unter 140 Zeichen ohne dass
+  der harte Schnitt `body[:limit]` (`render.py:580-581`) im Normalfall greift —
+  die zusätzliche Zahl (max. 5 Zeichen: `99.9` plus Trennzeichen) verbraucht
+  Zeichenbudget, reißt es aber bei realistischen Ortsnamen nicht.
+  - Test: Unit-Test mit einem 30-Zeichen-Ortsnamen und `onset_precip_mm=99.9`,
+    `len(sms) <= 140` geprüft; kein Goldstring-Vergleich, reine Längenprüfung.
+
+- **AC-10:** Given der direkte Vorschau-Payload (`OnsetPayload` mit
+  `onset_precip_mm=3.1`) UND der Replay-Payload (`nowcast_frames`, aus dem
+  `_derive_result` intern `onset_precip_mm` berechnet) / When beide über
+  `POST /api/trips/{trip_id}/alert-preview` gerendert werden / Then trägt das
+  Antwortfeld `sms` in beiden Fällen dieselbe Zahl-Grammatik — der
+  Testeinspeiseweg erzeugt dieselbe Ausgabe wie der Produktivpfad, keine der
+  beiden Payload-Varianten verliert die Zahl auf dem Weg zum Renderer.
+  - Test: Zwei Endpunkt-Tests (direkter `onset`-Payload, `nowcast_frames`-Replay)
+    gegen `POST /api/trips/{trip_id}/alert-preview?user_id=…`, `sms`-Feld auf
+    Vorhandensein der erwarteten Zahl geprüft.
+
+- **AC-11:** Given bestehende Aufrufer von `RadarAlertRequest`, `OnsetEvent` und
+  `OnsetPayload`, die das neue Feld `onset_precip_mm` nicht setzen (Default
+  `None`) / When dieselben Eingaben wie vor #2046 über den kompletten Pfad bis
+  `render_sms` laufen / Then ist die Ausgabe bit-identisch zum Vor-#2046-Zustand
+  — additives Feld mit Default, keine Pflichtangabe, kein Bruch für Alt-Aufrufer.
+  - Test: Regressionslauf der acht in „Test-Plan" gelisteten Bestandstestdateien
+    ohne inhaltliche Anpassung an ihren Fixtures (nur Format-Anpassung, wo der
+    Goldstring selbst betroffen ist, s. Test-Plan) — kein Bestandstest darf
+    wegen des neuen Feldes allein rot werden.
+
+- **AC-12:** Given die Frame-Liste, aus der `_derive_result` sowohl
+  `onset_minutes` als auch `window_precip_mm` ableitet / When `onset_precip_mm`
+  berechnet wird / Then verwendet die Rechnung DIESELBE Frame-Liste (kein
+  zweiter Provider-Abruf, kein zweiter `RadarNowcastService`-Aufruf) und
+  verändert weder `onset_minutes` noch `window_precip_mm` noch `max_rate_mm_h`
+  noch die #2020-Auslöseregel (`radar_alert_due`, `trip_alert.py:1382-1383`
+  bleibt unverändert).
+  - Test: Unit-Test, der `_derive_result` einmal aufruft und alle vier Felder
+    (`onset_minutes`, `window_precip_mm`, `max_rate_mm_h`, `onset_precip_mm`)
+    aus demselben Ergebnisobjekt prüft — kein zweiter Mock-Abruf im Test
+    selbst, der einen zweiten Produktiv-Abruf verschleiern würde.
+
+## Known Limitations
+
+- **Frame-Abdeckung reicht nicht immer bis `onset_time + 60 min`.** Deckt die
+  verfügbare Quelle das volle Stunden-Fenster ab dem Beginn nicht ab (Datenausfall,
+  Provider-Grenze), wird über die tatsächlich vorhandenen Frames gerechnet — die
+  Menge fällt dann eher zu klein als zu groß aus. Das ist bewusst konservativ,
+  dieselbe Richtung wie die bestehende `window_precip_mm`-Deckelung
+  (`radar_service.py:700-707`, `_MAX_FRAME_COVERAGE`).
+- **Kein zweiter Regel-Leser.** `onset_precip_mm` ist wie `max_rate_mm_h`
+  (seit #2020) rein beschreibend/anzeigend — es fließt NICHT in
+  `radar_alert_due()` oder die Überholungsprüfung (`trip_alert.py:1382-1383`)
+  ein. Eine künftige Verknüpfung wäre eine eigene, separat zu spezifizierende
+  Entscheidung.
+- **Extremfall doppelte Zahl bei sehr langem Ortsnamen** bleibt ungelöst
+  (geerbtes Risiko aus #1948 S4, `format_alert_location` Stufe 1 kappt lange
+  Ortsnamen nicht) — durch AC-9 nur für den Normalfall abgesichert, der harte
+  Schnitt `body[:limit]` bleibt die letzte Verteidigungslinie.
+
+## Nicht-Ziele
+
+- **Keine Änderung an der Auslöseschwelle** (`RADAR_ONSET_THRESHOLD_MIN = 55`)
+  oder an der #2020-Überholungsprüfung — diese Spec ändert ausschließlich die
+  Anzeige, nicht die Entscheidung, ob ein Alarm gesendet wird.
+- **Keine Änderung an E-Mail- oder Telegram-Langform** — beide bleiben bei
+  `intensity_label` als Wort.
+- **Keine neue Datenquelle, kein zweiter Provider-Abruf** — die neue Zahl
+  entsteht ausschließlich aus den Frames, die `_derive_result` ohnehin schon
+  erhält.
+- **Kein Umbau des Ortskopfs** derselben Zeile — das ist der Gegenstand des
+  parallelen, noch nicht gemergten #2036 (`fix_2036_alarm_kilometer_
+  ortsangabe.md`). Beide Änderungen betreffen unterschiedliche Teilstrings
+  derselben Zeile (Kopf vor dem Doppelpunkt vs. Token danach) und werden per
+  Rebase zusammengeführt.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Additive Feld-Durchreichung entlang einer bestehenden
+  Wirkkette plus eine reine Renderer-Formaterweiterung. Kein neues
+  Datenmodell-Konzept (das additive-optionale-Feld-Muster ist bereits über
+  `location_label`/`segment_id`/`onset_day_offset` etabliert), keine neue
+  Architekturentscheidungsfläche (kein neuer Kanal, kein neuer Provider,
+  keine Persistenz-Änderung, keine Änderung an der Auslöseregel).
+
+## Test-Plan
+
+**Bestehende Tests, die den heutigen zahlenlosen Token festnageln — laufen
+unverändert grün oder werden am Goldstring fortgeschrieben:**
+
+- `tests/tdd/test_alert_sms_onset_zeitpunkt.py` — Goldstrings ohne Menge bleiben
+  gültig, solange die Fixtures `onset_precip_mm` nicht setzen (AC-11); wo
+  Fixtures künftig eine Menge tragen sollen, Ergänzung um neue Testfälle statt
+  Änderung bestehender.
+- `tests/tdd/test_alert_onset_day_rollover.py` — Tagesüberlauf-Suffix bleibt
+  unberührt vom Mengen-Token, reiner Regressionsnachweis.
+- `tests/tdd/test_alert_preview_nowcast_replay.py` — Replay-Pfad, Kandidat für
+  AC-10 (Endpunkt-Nachweis), muss `onset_precip_mm` aus `_derive_result`
+  durchreichen.
+- `tests/tdd/test_952_onset_alert_fidelity.py` — Datenblock-Zeile (E-Mail),
+  Regressionsnachweis für AC-8.
+- `tests/tdd/test_alert_sms_location_positions.py` — Kopf-Positionen, muss mit
+  dem neuen Token-Teil nach dem Doppelpunkt kompatibel bleiben.
+- `tests/tdd/test_alert_addendum_sms.py` — Nachtrags-Zeile, Regressionsnachweis
+  gegen ungewollte Kollision mit dem Mengen-Token.
+- `tests/tdd/test_issue_919_radar_alert_canonical.py` — kanonischer
+  Radar-Alarm-Pfad, Regressionsnachweis für AC-11.
+- `tests/tdd/test_multi_location_onset_alert.py` — Ortsvergleich-Bündelpfad,
+  Kandidat für AC-6.
+
+**Neue Testdateien, benannt nach Verhalten (nicht nach Issue-Nummer):**
+
+- `tests/tdd/test_onset_kurzform_menge.py` — AC-1/AC-2/AC-4/AC-5 (Regen- und
+  Gewitter-Token mit/ohne Menge, Zahlformat).
+- `tests/tdd/test_onset_menge_ab_beginn_nicht_ab_jetzt.py` — AC-3 (Messgrundlage,
+  durchgerechnetes Gegenbeispiel), AC-12 (ein Aufruf, vier Felder).
+- `tests/tdd/test_onset_menge_kanalparitaet.py` — AC-7 (SMS/Premium-SMS/Telegram
+  identisch), AC-9 (Zeichenlimit mit langem Ortsnamen + Extremwert).
+
+## Changelog
+
+- 2026-08-21: Initial spec created (#2046, Radar-Onset-Kurznachricht mit
+  Mengenangabe).

--- a/src/output/renderers/alert/model.py
+++ b/src/output/renderers/alert/model.py
@@ -60,6 +60,13 @@ class OnsetEvent:
     # unveraenderten Normalfall (0). Beide Onset-Pfade setzen es (Trip UND
     # Ortsvergleich-Buendel, ADR-0021).
     onset_day_offset: int = 0
+    # Issue #2046: additiv, optional (Muster `onset_day_offset` o.). Erwartete
+    # Niederschlagsmenge (mm) der STUNDE AB DEM BEGINN — Quelle
+    # `NowcastResult.onset_precip_mm`. Gelesen AUSSCHLIESSLICH vom
+    # Kurznachrichten-Renderer (`_render_sms_onset`); E-Mail und
+    # Telegram-Langform bleiben bei `intensity_label` als Wort. `None` (oder
+    # unterhalb der Trockenschwelle) → zahlenlose Alt-Form `R@HH:MM`.
+    onset_precip_mm: float | None = None
 
 
 @dataclass(frozen=True)

--- a/src/output/renderers/alert/project.py
+++ b/src/output/renderers/alert/project.py
@@ -400,6 +400,12 @@ def to_multi_location_onset_alert_message(
             intensity_label=nc.intensity_label, source_label=nc.source,
             location_label=location_name if multi else None,
             onset_day_offset=day_offset(now, onset_dt, loc_tz),
+            # Issue #2046: die Mengenangabe der Kurznachricht kommt im
+            # Ortsvergleich-Buendel aus DEMSELBEN NowcastResult wie im
+            # Trip-Pfad -- sonst entstuende hier eine stille Luecke, weil
+            # dieser Pfad sein OnsetEvent selbst baut (ADR-0021: Trip und
+            # Ortsvergleich teilen die Ausgabe).
+            onset_precip_mm=nc.onset_precip_mm,
         ))
     trip_short = (
         ", ".join(name for name, _loc, _nc in valid_groups)

--- a/src/output/renderers/alert/render.py
+++ b/src/output/renderers/alert/render.py
@@ -16,7 +16,7 @@ from output.metric_format import THUNDER_LABEL_DE, _THUNDER_JE_ORDINAL
 from output.renderers.email.design_tokens import (
     FONT_DATA, FONT_UI, G_ACCENT, G_DANGER, G_INK, G_INK_MUTED, G_SUCCESS,
 )
-from output.tokens.metrics import LEVELS
+from output.tokens.metrics import LEVELS, _fmt_num
 from utils.ascii_fold import fold_ascii
 
 from .model import (
@@ -550,6 +550,28 @@ def _sms_onset_time(onset_time: str, day_offset: int = 0) -> str:
     return f"{base}+{day_offset}" if day_offset else base
 
 
+# Issue #2046: Untergrenze, ab der eine Mengenangabe in der Kurznachricht
+# belastbar ist. Groessenordnung von `radar_service._DRY_THRESHOLD_MM_H`
+# (0,1 mm/h ueber eine Stunde ~ 0,1 mm) -- dieselbe Schwelle, die den Beginn
+# ueberhaupt erst als "nass" einstuft. BEWUSST hier als eigene Konstante und
+# nicht aus `services.radar_service` importiert: ein Renderer haengt sich nicht
+# an die Service-Schicht. Alles darunter (inklusive `0.0` und `None`) faellt
+# auf die zahlenlose Alt-Form zurueck -- `R0.0@18:00` darf nie entstehen, die
+# Anzeige unterscheidet nicht zwischen "nicht berechenbar" und "praktisch null".
+_SMS_ONSET_MENGE_MIN_MM = 0.1
+
+
+def _sms_onset_menge(value: float | None) -> str | None:
+    """Zahlanteil der Onset-Mengenangabe (Issue #2046) oder `None`.
+
+    Zahlform kommt aus `output.tokens.metrics._fmt_num` — DERSELBE Formatierer
+    wie im Briefing (`R{value:.1f}`), damit Kurznachricht und Briefing keine
+    zwei Zahlen-Dialekte sprechen. Keine Einheit im Text (Zeichenbudget)."""
+    if value is None or value < _SMS_ONSET_MENGE_MIN_MM:
+        return None
+    return _fmt_num("R", value)
+
+
 def _render_sms_onset(msg: AlertMessage, limit: int = 140) -> str:
     """Issue #1948 S4: die Nowcast-/Onset-Kurznachricht nennt einen ZEITPUNKT
     (`TH@15:40`) statt eines Countdowns (`TH!8`) und spricht im Kopf dieselbe
@@ -570,7 +592,18 @@ def _render_sms_onset(msg: AlertMessage, limit: int = 140) -> str:
     ihn mit (AC-10)."""
     e = msg.events[0]
     kuerzel = "TH" if e.is_convective else "R"
-    token = f"{kuerzel}@{_sms_onset_time(e.onset_time, e.onset_day_offset)}"
+    zeit = _sms_onset_time(e.onset_time, e.onset_day_offset)
+    menge = _sms_onset_menge(getattr(e, "onset_precip_mm", None))
+    if menge is None:
+        token = f"{kuerzel}@{zeit}"
+    elif kuerzel == "TH":
+        # Issue #2046: im Gewitter-Fall steht die Menge als EIGENES Token NACH
+        # der Zeit. Die Position unmittelbar hinter `TH` gehoert in der
+        # Briefing-Grammatik der Stufe (LEVELS: L/M/H) -- ein `TH2.5` dort
+        # waere als Stufe lesbar und damit missverstaendlich.
+        token = f"TH@{zeit} R{menge}"
+    else:
+        token = f"R{menge}@{zeit}"
     if getattr(e, "location_label", None):
         head = _ascii_alert_location(e.location_label)
     elif msg.source == COMPARE_RADAR_SOURCE:

--- a/src/services/notification_service.py
+++ b/src/services/notification_service.py
@@ -195,6 +195,11 @@ class RadarAlertRequest:
     # eingestuft hat. `send_radar_alert()` reicht sie unveraendert auf die
     # `AlertMessage` durch; ohne sie bleibt der Versand byte-identisch.
     addendum_reference: str | None = None
+    # Issue #2046: additiv, optional. Erwartete Niederschlagsmenge (mm) der
+    # Stunde AB DEM BEGINN (`NowcastResult.onset_precip_mm`) -- die Zahl, die
+    # die Onset-Kurznachricht nennt. Ohne sie bleibt der Versand
+    # byte-identisch (zahlenlose Alt-Form).
+    onset_precip_mm: float | None = None
 
 
 def build_service_error_email_html(trip_name: str, report_type: str, error_lines: str) -> str:
@@ -1292,6 +1297,7 @@ class NotificationService:
             briefing_context=request.briefing_context,
             segment_id=request.segment_id,  # Issue #1744 A1
             onset_day_offset=request.onset_day_offset,  # Issue #2009
+            onset_precip_mm=request.onset_precip_mm,  # Issue #2046
         )
         # Issue #1402: kein stiller Rueckfall mehr -- `request.tz` ist seit
         # `RadarAlertRequest` ein Pflichtfeld.

--- a/src/services/radar_service.py
+++ b/src/services/radar_service.py
@@ -94,6 +94,14 @@ _OVERTAKE_COMPARE_WINDOW_MIN = 60
 # Deckung naher Frames nach oben oder unten verfaelschen).
 _MAX_FRAME_COVERAGE = timedelta(minutes=15)
 
+# Issue #2046: Laenge des Mengenfensters AB DEM BEGINN (Anzeige-Zahl der
+# Onset-Kurznachricht). Bewusst ein EIGENER Name neben
+# _OVERTAKE_COMPARE_WINDOW_MIN, obwohl beide heute 60 sind: die beiden Fenster
+# haben verschiedene Bezugspunkte (Beginn vs. jetzt) und verschiedene Zwecke
+# (Anzeige vs. Ueberholungsregel) -- ein geteilter Name wuerde die naechste
+# Aenderung des einen still auf das andere durchschlagen lassen.
+_ONSET_PRECIP_WINDOW_MIN = 60
+
 # Issue #2009: einzige Quelle der Onset-Alarmschwelle, ersetzt die bisher
 # doppelt gepflegten Literale in trip_alert.py und compare_radar_alert.py
 # (ADR-0021 — Trip und Ortsvergleich teilen den Code). Wert 55: am Cron-Takt
@@ -169,6 +177,17 @@ class NowcastResult:
                                      # STUNDE ab jetzt (eigenes Fenster, s.
                                      # _OVERTAKE_COMPARE_WINDOW_MIN) -- vergleichbar
                                      # mit precip_1h_mm im Briefing.
+    onset_precip_mm: Optional[float] = None
+    # Issue #2046: akkumulierte Menge der 60 Minuten AB DEM BEGINN (nicht ab
+    # jetzt wie window_precip_mm) -- Grundlage der SMS-Mengenangabe. `None`,
+    # wenn `onset_minutes` `None` ist ODER im Fenster ab dem Beginn keine
+    # Frames liegen. Eigenes Fenster, aber DIESELBE Akkumulationsmechanik wie
+    # window_precip_mm (gemeinsamer Rechenkern `_accumulate_precip_mm`:
+    # Frame-Dedup, _MAX_FRAME_COVERAGE-Deckel, Fensterende als harte Grenze).
+    # Der Alarm feuert bis RADAR_ONSET_THRESHOLD_MIN (55) Minuten vor dem
+    # Beginn -- das Fenster ab jetzt deckt dann fast nur Trockenzeit ab und
+    # untertriebe die Menge systematisch. BEWUSST beschreibend: kein Leser in
+    # radar_alert_due()/der #2020-Ueberholungsregel.
 
 
 def _offline_fixture_active() -> bool:
@@ -176,6 +195,51 @@ def _offline_fixture_active() -> bool:
     Aktivierungsregel wie providers/base.py:144. EIN Schalter fuer den
     gesamten Radar-Pfad, kein separater Radar-Env-Var (ADR-0033 Punkt 3)."""
     return bool(os.environ.get("GZ_TEST_FIXTURE_DIR", "").strip())
+
+
+def _accumulate_precip_mm(
+    frames: list, all_ts_sorted: list, start: datetime, end: datetime,
+) -> float:
+    """Akkumulierte Niederschlagsmenge (mm) im Zeitfenster [`start`, `end`).
+
+    Issue #2046: der bisher in `_derive_result` inline stehende Rechenkern des
+    #2020-Mengenfensters, unveraendert, nur um Fensterstart/-ende
+    parametrisiert. GEMEINSAM genutzt von `window_precip_mm` (ab jetzt) und
+    `onset_precip_mm` (ab dem Beginn) -- eine zweite Kopie wuerde beide
+    Mechaniken auseinanderlaufen lassen.
+
+    Die Mechanik im Einzelnen (Herleitung s. #2020, Adversary-Runden 2/3):
+      * Dedup auf EINEN Eintrag je Zeitstempel; bei widerspruechlichen Werten
+        gewinnt der HOEHERE (F010 -- sonst zaehlt derselbe Zeitabschnitt aus
+        Providerwiederholung/Sidecar-Merge doppelt).
+      * Dauer JE Frame aus seinem eigenen naechsten Nachbarn in der
+        VOLLSTAENDIGEN Frame-Liste (`all_ts_sorted`), nie aus einer globalen
+        Kadenz-Schaetzung (F006/F007).
+      * Gedeckelt auf `_MAX_FRAME_COVERAGE` UND nie ueber `end` hinaus: ein
+        einzelner Frame nach Datenausfall darf nicht bis zum Fensterende
+        gestreckt werden. Fehlende Frames machen die Menge dadurch eher zu
+        klein als zu gross (bewusst konservativ).
+      * Fenstergrenze ausschliessend (`<`): ein Frame exakt auf `end` bekaeme
+        ueber `frame_end` ohnehin Dauer null.
+    """
+    by_ts: dict[datetime, float] = {}
+    for frame in frames:
+        if not (start <= frame.timestamp < end):
+            continue
+        existing = by_ts.get(frame.timestamp)
+        if existing is None or frame.precip_mm_h > existing:
+            by_ts[frame.timestamp] = frame.precip_mm_h
+
+    total = 0.0
+    for ts, rate in sorted(by_ts.items()):
+        next_idx = bisect.bisect_right(all_ts_sorted, ts)
+        next_ts_full = (
+            all_ts_sorted[next_idx] if next_idx < len(all_ts_sorted) else end
+        )
+        frame_end = min(next_ts_full, ts + _MAX_FRAME_COVERAGE, end)
+        duration_h = max(0.0, (frame_end - ts).total_seconds() / 3600.0)
+        total += rate * duration_h
+    return total
 
 
 class RadarNowcastService:
@@ -651,10 +715,17 @@ class RadarNowcastService:
 
         # onset_minutes: first frame with precip >= threshold
         onset_minutes: Optional[int] = None
+        # Issue #2046: der EXAKTE Zeitstempel desselben Frames -- Fensterstart
+        # der Mengenrechnung ab dem Beginn. Bewusst nicht aus `onset_minutes`
+        # zurueckgerechnet: das ist der GERUNDETE Anzeigewert, und ein Aufrunden
+        # (delta 49.6 -> 50) wuerde den Beginn-Frame aus seinem eigenen Fenster
+        # herausschieben.
+        onset_ts: Optional[datetime] = None
         for frame in sorted(window, key=lambda f: f.timestamp):
             if frame.precip_mm_h >= _DRY_THRESHOLD_MM_H:
                 delta = (frame.timestamp - now).total_seconds() / 60.0
                 onset_minutes = max(0, round(delta))
+                onset_ts = frame.timestamp
                 break
 
         # Max rate im 180-Min-Nowcast-Fenster -- speist NUR intensity_label
@@ -721,37 +792,26 @@ class RadarNowcastService:
             key=lambda f: f.timestamp,
         )
 
-        # Issue #2020 Adversary-Runde 3, F010: eine Providerwiederholung
-        # oder ein Sidecar-Merge (siehe Kommentar zu _MAX_FRAME_COVERAGE
-        # oben -- exakt diese Ursache) kann zwei Frames mit IDENTISCHEM
-        # Zeitstempel liefern. `all_ts_sorted` ist ein Set und dedupliziert
-        # bereits, die Akkumulationsschleife lief bisher aber ueber ALLE
-        # (nicht deduplizierten) Frames: bisect_right liefert fuer beide
-        # Duplikate denselben next_ts_full, also bekaeme JEDER der beiden
-        # unabhaengig die VOLLE Deckung bis dahin -- derselbe Zeitabschnitt
-        # wuerde zweimal gezaehlt. Vor der Summierung deshalb auf einen
-        # Eintrag je Zeitstempel reduziert. Bei widerspruechlichen Werten
-        # zum selben Zeitpunkt gewinnt bewusst der HOEHERE Regenwert: es ist
-        # derselbe Zeitabschnitt, er wird genau einmal gezaehlt, und unter
-        # widerspruechlichen Messwerten ist der hoehere Wert derjenige,
-        # dessen Verlust wehtaete -- dieses Ticket existiert, weil eine
-        # Warnung zu spaet kam.
-        compare_window_by_ts: dict[datetime, float] = {}
-        for frame in compare_window:
-            existing = compare_window_by_ts.get(frame.timestamp)
-            if existing is None or frame.precip_mm_h > existing:
-                compare_window_by_ts[frame.timestamp] = frame.precip_mm_h
+        # Der Rechenkern (Frame-Dedup mit "hoeherer Wert gewinnt", Dauer je
+        # Frame aus dem eigenen Nachbarn, _MAX_FRAME_COVERAGE-Deckel,
+        # Fensterende als harte Grenze) steht seit #2046 in
+        # `_accumulate_precip_mm` -- unveraendert, nur um die Fenstergrenzen
+        # parametrisiert, damit die Mengenzahl AB DEM BEGINN dieselbe Mechanik
+        # benutzt und nicht als zweite Kopie davon abdriften kann.
+        window_precip_mm = _accumulate_precip_mm(
+            frames, all_ts_sorted, now, compare_horizon,
+        )
 
-        window_precip_mm = 0.0
-        for ts, rate in sorted(compare_window_by_ts.items()):
-            next_idx = bisect.bisect_right(all_ts_sorted, ts)
-            next_ts_full = (
-                all_ts_sorted[next_idx] if next_idx < len(all_ts_sorted)
-                else compare_horizon
+        # Issue #2046: Anzeige-Menge der Onset-Kurznachricht -- 60 Minuten AB
+        # DEM BEGINN statt ab jetzt. DIESELBE `frames`-Liste, kein zweiter
+        # Quellen-Abruf (AC-12); veraendert weder onset_minutes noch
+        # window_precip_mm noch max_rate_mm_h.
+        onset_precip_mm: Optional[float] = None
+        if onset_ts is not None:
+            onset_precip_mm = _accumulate_precip_mm(
+                frames, all_ts_sorted, onset_ts,
+                onset_ts + timedelta(minutes=_ONSET_PRECIP_WINDOW_MIN),
             )
-            frame_end = min(next_ts_full, ts + _MAX_FRAME_COVERAGE, compare_horizon)
-            duration_h = max(0.0, (frame_end - ts).total_seconds() / 3600.0)
-            window_precip_mm += rate * duration_h
 
         # Issue #2020 Adversary-Fund F001: max_rate_mm_h fuer die
         # Ueberholungspruefung MUSS aus demselben Fenster stammen wie
@@ -776,6 +836,7 @@ class RadarNowcastService:
             data_unavailable=data_unavailable,
             max_rate_mm_h=compare_window_max_rate_mm_h,
             window_precip_mm=window_precip_mm,
+            onset_precip_mm=onset_precip_mm,  # Issue #2046
         )
 
 

--- a/src/services/trip_alert.py
+++ b/src/services/trip_alert.py
@@ -1479,6 +1479,11 @@ class TripAlertService:
                 intensity_label=_label,
                 source_label=radar_svc.source_label(result.source),
                 briefing_context=_briefing_context,
+                # Issue #2046: die Menge der Stunde AB DEM BEGINN aus DEMSELBEN
+                # NowcastResult, das schon onset_minutes/intensity_label
+                # liefert (analog `is_convective=result.is_convective`) -- rein
+                # beschreibend, ohne Einfluss auf die Ausloeseregel.
+                onset_precip_mm=result.onset_precip_mm,
                 tz=tz,
             )
 

--- a/src/services/validator_render_service.py
+++ b/src/services/validator_render_service.py
@@ -118,6 +118,10 @@ def render_alert_preview(
             # #1948 S5 (AC-15): die Segment-Kennung des Payloads erreicht das
             # Event -- sonst faellt der Ortskopf auf "km N-M" zurueck.
             segment_id=getattr(body.onset, "segment_id", None),
+            # Issue #2046: Mengenangabe der Kurznachricht. `getattr`, weil
+            # dieser Zweig sowohl den API-Payload (`OnsetPayload`) als auch
+            # den Replay-SimpleNamespace bedient -- Muster `segment_id` o.
+            onset_precip_mm=getattr(body.onset, "onset_precip_mm", None),
         )
         msg = AlertMessage(
             trip_short=trip_obj.name,
@@ -255,6 +259,10 @@ def _render_nowcast_replay(trip_obj: Trip, body_nf: Any) -> dict:
         ),
         cooldown_display=None,
         segment_id=getattr(body_nf, "segment_id", None),
+        # Issue #2046: aus DEMSELBEN `_derive_result`-Ergebnis wie
+        # onset_minutes/intensity_label -- der Replay-Weg muss dieselbe Zahl
+        # zeigen wie der Produktivpfad (AC-10).
+        onset_precip_mm=result.onset_precip_mm,
     )
     out = render_alert_preview(
         trip_obj, SimpleNamespace(onset=onset_ns, official=None, nowcast_frames=None),

--- a/tests/tdd/test_alert_preview_nowcast_replay.py
+++ b/tests/tdd/test_alert_preview_nowcast_replay.py
@@ -69,6 +69,36 @@ def _wet_frames(now: datetime) -> list[dict]:
     ]
 
 
+def _spaeter_onset_frames(now: datetime) -> list[dict]:
+    """Issue #2046 / Adversary-Finding F003: SPAETER Beginn (+50 Min), danach
+    durchgehend 3.0 mm/h im 15-Minuten-Raster bis +125 Min.
+
+    `_wet_frames` oben kann die beiden Mengenfelder von `_derive_result` gar
+    nicht unterscheiden — bei einem Beginn nach 20 Minuten liegen alle nassen
+    Frames in BEIDEN Fenstern (`[jetzt, jetzt+60)` und `[Beginn, Beginn+60)`).
+    Hier fallen sie um den Faktor 6 auseinander (Herleitung von Hand,
+    `_MAX_FRAME_COVERAGE` = 15 Min, Fensterende ausschliessend, Dauer je Frame
+    bis zum eigenen naechsten Nachbarn):
+
+      ab jetzt (`window_precip_mm`, `[+0, +60)`):
+        +5 (0.0 mm/h) -> 0.00 mm; +50 (3.0 mm/h) bis Fensterende +60 = 10 Min
+        -> 0.50 mm. Summe 0.5 mm -> Token waere `R0.5@…`.
+      ab dem Beginn (`onset_precip_mm`, `[+50, +110)`):
+        +50/+65/+80/+95 je 15 Min x 3.0 mm/h = je 0.75 mm; +110 und +125
+        liegen ausserhalb. Summe 3.0 mm -> Token `R3.0@…`.
+    """
+    frames = [
+        {"timestamp": (now + timedelta(minutes=5)).isoformat(),
+         "precip_mm_h": 0.0, "is_convective": False},
+    ]
+    frames += [
+        {"timestamp": (now + timedelta(minutes=m)).isoformat(),
+         "precip_mm_h": 3.0, "is_convective": False}
+        for m in (50, 65, 80, 95, 110, 125)
+    ]
+    return frames
+
+
 def _dry_frames(now: datetime) -> list[dict]:
     """Alle Raten unter der Trockenschwelle (0.1 mm/h) -- kein Onset."""
     return [
@@ -106,9 +136,17 @@ class TestAC6_OnsetReplayDetectsOnset:
         # den ZEITPUNKT (`R@HH:MM`) statt des Countdowns (`R!<Minuten>`). Die
         # abgeleiteten Minuten bleiben ueber `email_plain`/`telegram` pruefbar,
         # die dieselbe `_derive_result`-Ableitung wie der Live-Pfad tragen.
-        assert re.search(r"\bR@\d{1,2}:\d{2}\b", data["sms"]), (
-            f"AC-6: SMS muss ein nicht-konvektives 'R@HH:MM'-Zeitpunkt-Token "
-            f"tragen: {data['sms']!r}"
+        # FORTGESCHRIEBEN (Issue #2046, AC-10): der Replay-Weg reicht die aus
+        # DENSELBEN Frames abgeleitete Menge bis in die Kurznachricht durch —
+        # das Token traegt sie jetzt zwischen Kuerzel und Zeit (`R1.4@17:32`).
+        # Der Wert ist deterministisch: Beginn bei +20 Min mit 2.5 mm/h
+        # (Deckung 15 Min bis zum naechsten Frame -> 0.625 mm) plus +40 Min mit
+        # 3.0 mm/h (letzter Frame, auf _MAX_FRAME_COVERAGE gedeckelt ->
+        # 0.75 mm) = 1.375 mm -> "1.4". Bewusst MIT Zahl geprueft statt nur
+        # optional: sonst bliebe die Endpunkt-Durchreichung ungewacht.
+        assert re.search(r"\bR1\.4@\d{1,2}:\d{2}\b", data["sms"]), (
+            f"AC-6/AC-10: SMS muss ein nicht-konvektives Zeitpunkt-Token MIT "
+            f"der abgeleiteten Menge tragen ('R1.4@HH:MM'): {data['sms']!r}"
         )
         assert not re.search(r"\b(TH|R)!\d+", data["sms"]), (
             f"AC-6: das Countdown-Format ist abgeloest: {data['sms']!r}"
@@ -131,6 +169,52 @@ class TestAC6_OnsetReplayDetectsOnset:
             f"AC-6: Intensitaets-Label 'Mäßiger Regen' (2.5 mm/h) muss "
             f"reflektiert werden.\nplain={data['email_plain']!r}\n"
             f"telegram={data['telegram']!r}"
+        )
+
+
+    def test_spaeter_onset_zeigt_die_menge_ab_beginn_nicht_ab_jetzt(
+        self, client, stub_trip,
+    ):
+        """AC-10 GIVEN einen Frame-Mitschnitt mit SPAETEM Beginn (+50 Min) und
+        durchgehendem Regen bis +125 Min
+        WHEN der Replay-Weg (`_render_nowcast_replay`) die Vorschau baut
+        THEN traegt die Kurznachricht `R3.0@HH:MM` — die Menge der Stunde AB
+        DEM BEGINN — und ausdruecklich NICHT `R0.5@HH:MM`, die Menge der
+        Stunde ab jetzt.
+
+        Wirkort-Nachweis (Adversary-Finding F003): der Test darueber kann die
+        beiden Felder nicht unterscheiden (frueher Beginn -> deckungsgleiche
+        Fenster). Wird in `services/validator_render_service.py`
+        `onset_precip_mm=result.onset_precip_mm` gegen
+        `result.window_precip_mm` vertauscht, wird DIESER Test rot.
+
+        Beide Zahlen aus den Frames hergeleitet (Rechenweg im Docstring von
+        `_spaeter_onset_frames`), nicht aus der Implementierung abgeschrieben.
+        """
+        user_id, trip_id = stub_trip
+        request_now = datetime.now(timezone.utc)
+        body = {"nowcast_frames": {
+            "source": "radar", "frames": _spaeter_onset_frames(request_now),
+            "km_from": 2.0, "km_to": 6.0,
+        }}
+        resp = client.post(
+            f"/api/trips/{trip_id}/alert-preview",
+            params={"user_id": user_id}, json=body,
+        )
+        assert resp.status_code == 200, f"Body: {resp.text[:300]}"
+        data = resp.json()
+        assert data.get("onset_detected") is True, (
+            f"Voraussetzung: der Beginn bei +50 Min liegt im Nowcast-Horizont "
+            f"und muss erkannt werden: {data!r}"
+        )
+        sms = data["sms"]
+        assert re.search(r"\bR3\.0@\d{1,2}:\d{2}\b", sms), (
+            "F003: der Replay-Weg muss die Menge AB DEM BEGINN zeigen "
+            f"(R3.0@HH:MM = 4 x 3.0 mm/h x 15 Min): {sms!r}"
+        )
+        assert not re.search(r"\bR0\.5@\d{1,2}:\d{2}\b", sms), (
+            "F003: der Replay-Weg zeigt die Menge AB JETZT (R0.5@HH:MM) statt "
+            f"der Menge ab dem Beginn: {sms!r}"
         )
 
 

--- a/tests/tdd/test_alert_preview_onset_payload.py
+++ b/tests/tdd/test_alert_preview_onset_payload.py
@@ -1,0 +1,124 @@
+"""Der DIREKTE Onset-Payload am Vorschau-Endpunkt traegt die Mengenangabe.
+
+SPEC: docs/specs/modules/fix_2046_onset_menge.md — AC-10, Zweig „direkter
+Vorschau-Payload" (`OnsetPayload` mit `onset_precip_mm`).
+
+Warum eine eigene Datei: `test_alert_preview_nowcast_replay.py` deckt den
+ZWEITEN Zweig desselben ACs ab (`nowcast_frames`-Replay) — und der laeuft
+ueber einen `SimpleNamespace`, beruehrt den Pydantic-Validierungsweg des
+Endpunkts also gar nicht. Der Adversary (Finding F002) konnte deshalb das
+Feld `OnsetPayload.onset_precip_mm` vollstaendig entfernen, ohne dass ein
+Test rot wurde: Pydantic verwirft ein unbekanntes Feld still, und die Zahl
+verschwindet lautlos aus der Vorschau.
+
+Kein Mock — echter FastAPI-TestClient, echter Endpunkt, echte Trip-Fixture
+auf Platte, echter Renderer. Geprueft wird das Antwortfeld, das der Nutzer
+in der Vorschau liest.
+"""
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import uuid
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.real_data_root
+
+
+@pytest.fixture
+def client():
+    from api.routers import validator
+    app = FastAPI()
+    app.include_router(validator.router)
+    return TestClient(app)
+
+
+@pytest.fixture
+def stub_trip():
+    user_id = f"test_2046_onset_{uuid.uuid4().hex[:8]}"
+    trip_id = "trip-2046-onset"
+    trip_dir = Path("data/users") / user_id / "briefings"
+    trip_dir.mkdir(parents=True, exist_ok=True)
+    (trip_dir / f"{trip_id}.json").write_text(json.dumps({
+        "id": trip_id, "name": "Vorschau-Trip", "stages": [],
+    }))
+    yield user_id, trip_id
+    shutil.rmtree(Path("data/users") / user_id, ignore_errors=True)
+
+
+def _onset_body(**overrides) -> dict:
+    onset = {
+        "onset_minutes": 25,
+        "onset_time": "18:00",
+        "km_from": 0.0,
+        "km_to": 6.0,
+        "is_convective": False,
+        "intensity_label": "mäßiger Regen",
+        "source_label": "Radar (DWD)",
+    }
+    onset.update(overrides)
+    return {"onset": onset}
+
+
+class TestAC10DirekterOnsetPayload:
+    def test_onset_payload_mit_menge_erreicht_die_kurznachricht(
+        self, client, stub_trip,
+    ):
+        """AC-10 GIVEN einen direkten Vorschau-Payload
+        (`{"onset": {..., "onset_precip_mm": 3.1}}`, OHNE `nowcast_frames`)
+        WHEN `POST /api/trips/{trip_id}/alert-preview` ihn rendert
+        THEN traegt das Antwortfeld `sms` das Token `R3.1@18:00` — dieselbe
+        Zahl-Grammatik wie der Produktivpfad; der Testeinspeiseweg verliert
+        die Zahl nicht zwischen Pydantic-Modell und Renderer.
+
+        Deckt Adversary-Finding F002: ohne diesen Test liesse sich das Feld
+        `OnsetPayload.onset_precip_mm` ersatzlos streichen, ohne dass etwas
+        rot wird — Pydantic verwirft den unbekannten Schluessel still.
+        """
+        user_id, trip_id = stub_trip
+        resp = client.post(
+            f"/api/trips/{trip_id}/alert-preview",
+            params={"user_id": user_id},
+            json=_onset_body(onset_precip_mm=3.1),
+        )
+
+        assert resp.status_code == 200, f"Body: {resp.text[:300]}"
+        sms = resp.json().get("sms") or ""
+        assert "R3.1@18:00" in sms, (
+            "F002: der direkte Onset-Payload verliert die Mengenangabe auf dem "
+            f"Weg zum Renderer: {sms!r}"
+        )
+        assert "R@18:00" not in sms, (
+            f"Die zahlenlose Alt-Form steht noch in der Kurznachricht: {sms!r}"
+        )
+
+    def test_onset_payload_ohne_menge_bleibt_bei_der_alt_form(
+        self, client, stub_trip,
+    ):
+        """AC-10/AC-11 GIVEN denselben Payload OHNE `onset_precip_mm`
+        WHEN derselbe Endpunkt rendert
+        THEN bleibt die zahlenlose Alt-Form `R@18:00` stehen — Gegenprobe,
+        damit die Zusicherung oben nicht trivial aus einer beliebigen Zahl
+        irgendwo im Text erfuellt wird, und Regressionsschutz fuer
+        Alt-Aufrufer, die das optionale Feld nicht setzen.
+        """
+        user_id, trip_id = stub_trip
+        resp = client.post(
+            f"/api/trips/{trip_id}/alert-preview",
+            params={"user_id": user_id},
+            json=_onset_body(),
+        )
+
+        assert resp.status_code == 200, f"Body: {resp.text[:300]}"
+        sms = resp.json().get("sms") or ""
+        assert "R@18:00" in sms, (
+            f"Ohne Mengenangabe muss die Alt-Form erhalten bleiben: {sms!r}"
+        )
+        assert not re.search(r"\bR\d", sms), (
+            f"Ohne Mengenangabe darf keine Zahl hinter dem Kuerzel stehen: {sms!r}"
+        )

--- a/tests/tdd/test_alert_sms_onset_zeitpunkt.py
+++ b/tests/tdd/test_alert_sms_onset_zeitpunkt.py
@@ -39,6 +39,12 @@ from output.renderers.alert.render import (
 _ZEITPUNKT_TOKEN_RE = re.compile(r"\b(TH|R)@(\d{1,2}):(\d{2})\b")
 # Countdown-Token des Alt-Formats (`TH!8` / `R!25`) — darf nirgends mehr stehen.
 _COUNTDOWN_TOKEN_RE = re.compile(r"\b(TH|R)!\d+")
+# FORTGESCHRIEBEN (Issue #2046, AC-1/AC-5/AC-11): dieselbe Zusicherung, aber
+# mit optionalem Mengen-Zwischenteil. Nur der ECHTE Einspeiseweg unten leitet
+# eine Menge aus den Frames ab und nennt sie im Token (`R0.6@17:32`); alle
+# Goldstring-Faelle dieser Datei setzen `onset_precip_mm` nicht und bleiben
+# unveraendert zahlenlos — genau die Regressions-Invariante aus AC-11.
+_ZEITPUNKT_TOKEN_MIT_MENGE_RE = re.compile(r"\b(TH|R)(?:\d+\.\d)?@(\d{1,2}):(\d{2})\b")
 
 
 def _onset_event(**kw) -> OnsetEvent:
@@ -202,7 +208,7 @@ def test_ac3_endpunkt_replay_liefert_zeitpunkt_token_ueber_den_echten_einspeisew
     finally:
         shutil.rmtree(Path("data/users") / user_id, ignore_errors=True)
 
-    match = _ZEITPUNKT_TOKEN_RE.search(sms)
+    match = _ZEITPUNKT_TOKEN_MIT_MENGE_RE.search(sms)
     assert match, f"Endpunkt-SMS traegt kein '<Kuerzel>@HH:MM'-Token: {sms!r}"
     assert match.group(1) == "R", (
         f"Nicht-konvektiver Frame muss ein 'R@'-Token liefern: {sms!r}"

--- a/tests/tdd/test_onset_kurzform_menge.py
+++ b/tests/tdd/test_onset_kurzform_menge.py
@@ -1,0 +1,283 @@
+"""TDD RED — Issue #2046: die Radar-Onset-Kurznachricht nennt die erwartete
+Regenmenge.
+
+SPEC: docs/specs/modules/fix_2046_onset_menge.md — AC-1, AC-2, AC-4, AC-5.
+
+Fachlicher Kern: der Onset-Zweig (`_render_sms_onset`) ist heute der einzige
+Alarmzweig, dessen Kurzform KEINEN Wert nennt (`Ziel: R@18:00`). Neu nennt sie
+die ueber die Stunde AB DEM BEGINN erwartete Menge:
+
+* Regen:   `Ziel: R2.5@18:00`   — Zahl klebt am Kuerzel, kein Trennzeichen.
+* Gewitter: `Ziel: TH@18:00 R2.5` — die Zahl steht als EIGENES Token hinter
+  der Zeit, weil die Position direkt hinter `TH` in der Briefing-Grammatik
+  der Stufe (L/M/H) gehoert und ein `TH2.5` dort missverstaendlich waere.
+
+RED-Ursache: `OnsetEvent` kennt das additive Feld `onset_precip_mm` noch
+nicht -> `TypeError` beim Konstruktor-Aufruf. Die Regressionswaechter, die
+das Feld NICHT setzen (AC-4a-Vergleichsfassung), bleiben davon unberuehrt.
+
+Mock-frei: echte `OnsetEvent`/`AlertMessage`-Objekte durch die echten
+Renderer. Alle Zeitangaben sind FEST gesetzt (keine Wanduhr) — ausser im
+Ortsvergleich-Buendel (AC-4c), dessen Konstruktor `onset_time` selbst aus
+`datetime.now()` ableitet; dort wird auf Struktur statt Goldstring geprueft.
+"""
+from __future__ import annotations
+
+import inspect
+import re
+from datetime import timezone
+from pathlib import Path
+
+import pytest
+
+from output.renderers.alert.model import AlertMessage, OnsetEvent
+from output.renderers.alert.render import render_sms
+
+# Eine Ziffer UNMITTELBAR hinter dem Kuerzel — die Mengen-Schreibweise des
+# Regen-Falls. Im Gewitter-Fall darf sie NIE auftreten (Stufen-Position).
+_ZIFFER_HINTER_KUERZEL_RE = re.compile(r"\b(TH|R)(\d)")
+# Vollstaendiger Regen-Mengen-Token: `R<zahl mit einer Nachkommastelle>@HH:MM`.
+_MENGEN_TOKEN_RE = re.compile(r"\bR(\d+)\.(\d)@(\d{1,2}):(\d{2})\b")
+
+_UNSET = object()  # Sentinel: `onset_precip_mm` gar nicht erst uebergeben.
+
+
+def _onset_event(*, onset_precip_mm: object = _UNSET, **kw) -> OnsetEvent:
+    """Ein Trip-Radar-Onset-Ereignis mit festen Feldern (keine Wanduhr).
+
+    `onset_precip_mm` wird NUR uebergeben, wenn ein Aufrufer es ausdruecklich
+    setzt (Muster `test_alert_addendum_sms.py`): so bleibt die Vergleichs-
+    fassung ohne Menge unabhaengig vom Modell-Erweiterungsstand gruen,
+    waehrend die Mengen-Faelle heute am `TypeError` scheitern.
+    """
+    fields = dict(
+        onset_minutes=30, onset_time="18:00", km_from=8.0, km_to=8.0,
+        is_convective=False, intensity_label="Mäßiger Regen",
+        source_label="Radar (DWD)", segment_id="Ziel",
+    )
+    fields.update(kw)
+    if onset_precip_mm is not _UNSET:
+        fields["onset_precip_mm"] = onset_precip_mm
+    return OnsetEvent(**fields)
+
+
+def _onset_msg(event: OnsetEvent) -> AlertMessage:
+    """`source is not None` routet `render_sms` in den Onset-Zweig."""
+    return AlertMessage(
+        trip_short="KHW 403", stand_at="17:30", events=(event,),
+        source="Radar (DWD)",
+    )
+
+
+def _sms(*, onset_precip_mm: object = _UNSET, **kw) -> str:
+    return render_sms(_onset_msg(_onset_event(onset_precip_mm=onset_precip_mm, **kw)))
+
+
+def test_prueling_stammt_aus_diesem_arbeitsbaum():
+    """Vorbedingung (kein AC): der gepruefte Renderer wird RELATIV ZU DIESER
+    Testdatei aufgeloest — sonst pruefte ein Worktree-Lauf still die Datei des
+    Hauptrepos und lieferte falsches Gruen."""
+    from output.renderers.alert import render as render_module
+
+    modul_pfad = Path(inspect.getfile(render_module)).resolve()
+    arbeitsbaum = Path(__file__).resolve().parents[2]
+    assert modul_pfad.is_relative_to(arbeitsbaum), (
+        f"Prueling stammt nicht aus diesem Arbeitsbaum: {modul_pfad}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-1 — Regen: Zahl klebt am Kuerzel, davor das Kuerzel, dahinter die Zeit
+# ---------------------------------------------------------------------------
+
+
+def test_ac1_regen_onset_traegt_die_menge_direkt_hinter_dem_kuerzel():
+    """AC-1 GIVEN ein Trip-Onset-Alarm mit nicht-konvektivem Ereignis
+    (`is_convective=False`, `onset_time="18:00"`, `onset_precip_mm=2.5`)
+    WHEN `render_sms(msg)` ueber den Onset-Zweig rendert
+    THEN enthaelt der Text exakt das Token `R2.5@18:00` — Kuerzel, Zahl mit
+    EINER Nachkommastelle und Uhrzeit ohne Trennzeichen dazwischen.
+
+    RED heute: `OnsetEvent` kennt `onset_precip_mm` nicht (`TypeError`)."""
+    sms = _sms(onset_precip_mm=2.5)
+
+    assert "R2.5@18:00" in sms, (
+        f"RED: Mengen-Token 'R2.5@18:00' fehlt in der Kurznachricht: {sms!r}"
+    )
+    assert sms == "Ziel: R2.5@18:00", (
+        f"Erwartet 'Ziel: R2.5@18:00' (Kopf unveraendert, Menge im Token), "
+        f"bekam {sms!r}"
+    )
+    assert " R2.5" not in sms.split(": ", 1)[1], (
+        f"Im Regen-Fall darf die Zahl NICHT als eigenes Token stehen: {sms!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-2 — Gewitter: Zahl als eigenes Token NACH der Zeit, nie hinter `TH`
+# ---------------------------------------------------------------------------
+
+
+def test_ac2_gewitter_onset_traegt_die_menge_als_eigenes_token_nach_der_zeit():
+    """AC-2 GIVEN denselben Aufbau wie AC-1, aber konvektiv
+    (`is_convective=True`, `onset_time="18:00"`, `onset_precip_mm=2.5`)
+    WHEN `render_sms(msg)` ueber denselben Onset-Zweig rendert
+    THEN enthaelt der Text exakt `TH@18:00 R2.5` — die Zahl steht als eigenes
+    Token NACH dem Zeit-Token, durch ein Leerzeichen getrennt — und hinter
+    `TH` selbst steht NIEMALS eine Ziffer (die Position gehoert der Stufe
+    L/M/H der Briefing-Grammatik).
+
+    RED heute: `OnsetEvent` kennt `onset_precip_mm` nicht (`TypeError`)."""
+    sms = _sms(onset_precip_mm=2.5, is_convective=True,
+               intensity_label="Starker Hagel/Gewitter")
+
+    assert "TH@18:00 R2.5" in sms, (
+        f"RED: Gewitter-Mengen-Token 'TH@18:00 R2.5' fehlt: {sms!r}"
+    )
+    assert sms == "Ziel: TH@18:00 R2.5", (
+        f"Erwartet 'Ziel: TH@18:00 R2.5', bekam {sms!r}"
+    )
+    assert "TH2" not in sms and "TH2.5" not in sms, (
+        f"Die Stufen-Position hinter 'TH' ist mit einer Menge belegt: {sms!r}"
+    )
+    treffer = _ZIFFER_HINTER_KUERZEL_RE.search(sms)
+    assert treffer is None, (
+        f"Ziffer unmittelbar hinter dem Kuerzel {treffer.group(1)!r} im "
+        f"Gewitter-Fall: {sms!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-4 — ohne belastbare Zahl bleibt die heutige Form (nie `R0.0@`)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("is_convective, kuerzel", [(False, "R"), (True, "TH")])
+def test_ac4a_ohne_menge_bleibt_die_heutige_zahlenlose_form(is_convective, kuerzel):
+    """AC-4 (a) GIVEN ein `OnsetEvent` mit `onset_precip_mm=None` (keine
+    Frames im Fenster ab dem Beginn)
+    WHEN `render_sms(msg)` rendert
+    THEN bleibt die heutige Form ohne Zahl (`R@18:00` bzw. `TH@18:00`) —
+    byte-identisch zur Fassung, die das Feld gar nicht erst uebergibt.
+
+    RED heute: `OnsetEvent` kennt `onset_precip_mm` nicht (`TypeError`)."""
+    label = "Starker Hagel/Gewitter" if is_convective else "Mäßiger Regen"
+    mit_none = _sms(onset_precip_mm=None, is_convective=is_convective,
+                    intensity_label=label)
+    ohne_feld = _sms(is_convective=is_convective, intensity_label=label)
+
+    assert mit_none == f"Ziel: {kuerzel}@18:00", (
+        f"Ohne Zahl muss die heutige Form stehenbleiben: {mit_none!r}"
+    )
+    assert mit_none == ohne_feld, (
+        "Ein ungesetztes Mengenfeld darf die Kurznachricht nicht anfassen.\n"
+        f"  mit None   = {mit_none!r}\n  ohne Feld  = {ohne_feld!r}"
+    )
+    assert _ZIFFER_HINTER_KUERZEL_RE.search(mit_none) is None, (
+        f"Ziffer unmittelbar hinter dem Kuerzel ohne belastbare Zahl: "
+        f"{mit_none!r}"
+    )
+
+
+@pytest.mark.parametrize("is_convective, kuerzel", [(False, "R"), (True, "TH")])
+def test_ac4b_null_menge_erzeugt_niemals_r0_0(is_convective, kuerzel):
+    """AC-4 (b) GIVEN ein `OnsetEvent` mit `onset_precip_mm=0.0` (Menge
+    unterhalb der Trockenschwelle)
+    WHEN `render_sms(msg)` rendert
+    THEN entsteht NIEMALS `R0.0@18:00` — die Anzeige unterscheidet nicht
+    zwischen "nicht berechenbar" und "berechnet, aber null".
+
+    RED heute: `OnsetEvent` kennt `onset_precip_mm` nicht (`TypeError`)."""
+    label = "Starker Hagel/Gewitter" if is_convective else "Mäßiger Regen"
+    sms = _sms(onset_precip_mm=0.0, is_convective=is_convective,
+               intensity_label=label)
+
+    assert sms == f"Ziel: {kuerzel}@18:00", (
+        f"Eine Null-Menge muss die zahlenlose Form ergeben: {sms!r}"
+    )
+    assert "0.0" not in sms, f"Null-Menge steht als Zahl in der SMS: {sms!r}"
+    assert "R0" not in sms, f"Null-Menge steht als Zahl in der SMS: {sms!r}"
+
+
+@pytest.mark.parametrize("flag", ["data_unavailable", "throttled"])
+def test_ac4c_nowcast_ohne_belastbare_daten_rendert_ohne_zahl(flag):
+    """AC-4 (c) GIVEN ein `NowcastResult`, das als `data_unavailable=True`
+    bzw. `throttled=True` gekennzeichnet ist und deshalb KEINE belastbare
+    Menge traegt (`onset_precip_mm=None`)
+    WHEN daraus ueber den Ortsvergleich-Bündelpfad eine Kurznachricht
+    entsteht
+    THEN steht dort die zahlenlose Form (`R@HH:MM`) — kein `R0.0`, keine
+    erfundene Zahl.
+
+    Wanduhrfest: der Buendel-Konstruktor leitet `onset_time` aus
+    `datetime.now()` ab, deshalb Struktur- statt Goldstring-Pruefung.
+
+    RED heute: `NowcastResult` kennt `onset_precip_mm` nicht (`TypeError`)."""
+    from output.renderers.alert.project import to_multi_location_onset_alert_message
+    from services.radar_service import NowcastResult
+
+    nc = NowcastResult(
+        onset_minutes=30, intensity_label="Mäßiger Regen", source="radar",
+        is_convective=False, onset_precip_mm=None, **{flag: True},
+    )
+    msg = to_multi_location_onset_alert_message(
+        [("Zermatt", nc)], tz=timezone.utc, stand_at="10:00",
+    )
+    sms = render_sms(msg)
+
+    assert re.search(r"\bR@\d{1,2}:\d{2}", sms), (
+        f"Erwartet die zahlenlose Form 'R@HH:MM': {sms!r}"
+    )
+    assert _ZIFFER_HINTER_KUERZEL_RE.search(sms) is None, (
+        f"Ohne belastbare Daten darf keine Zahl am Kuerzel kleben: {sms!r}"
+    )
+    assert "0.0" not in sms, f"Erfundene Null-Menge in der SMS: {sms!r}"
+
+
+# ---------------------------------------------------------------------------
+# AC-5 — Zahlform: genau eine Nachkommastelle, Punkt, keine Einheit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("menge, erwartet", [(2.0, "R2.0@18:00"), (12.34, "R12.3@18:00")])
+def test_ac5_zahlformat_eine_nachkommastelle_punkt_und_keine_einheit(menge, erwartet):
+    """AC-5 GIVEN `onset_precip_mm=2.0` (glatte Zahl) bzw. `12.34` (zwei
+    Nachkommastellen)
+    WHEN beide ueber `render_sms(msg)` gerendert werden
+    THEN erscheint die Zahl in BEIDEN Faellen mit genau EINER Nachkommastelle
+    und Punkt als Trennzeichen (`R2.0@…`, `R12.3@…`) und NIEMALS mit Einheit
+    ("mm") im Text — identisch zur Briefing-Zahlform aus
+    `output.tokens.metrics._fmt_num`.
+
+    RED heute: `OnsetEvent` kennt `onset_precip_mm` nicht (`TypeError`)."""
+    sms = _sms(onset_precip_mm=menge)
+
+    assert erwartet in sms, f"RED: erwartete Zahlform {erwartet!r} fehlt: {sms!r}"
+    treffer = _MENGEN_TOKEN_RE.search(sms)
+    assert treffer is not None, (
+        f"Kein 'R<zahl>.<zahl>@HH:MM'-Token in der Kurznachricht: {sms!r}"
+    )
+    assert len(treffer.group(2)) == 1, (
+        f"Die Zahl muss GENAU eine Nachkommastelle tragen: {sms!r}"
+    )
+    assert "mm" not in sms, f"Einheit 'mm' steht im Kurznachrichten-Text: {sms!r}"
+    assert "," not in sms, f"Dezimal-Komma statt Punkt: {sms!r}"
+
+
+def test_ac5_zahlform_ist_dieselbe_wie_im_briefing():
+    """AC-5 (Kopplung) GIVEN denselben Wert `12.34`
+    WHEN die Kurznachricht ihn rendert
+    THEN traegt sie GENAU die Zeichenfolge, die der Briefing-Zahlformatierer
+    `_fmt_num("R", 12.34)` liefert — die beiden Formate duerfen nicht
+    auseinanderlaufen (eine eigene Rundungsregel im Alarm-Renderer waere ein
+    stiller zweiter Zahlen-Dialekt).
+
+    RED heute: `OnsetEvent` kennt `onset_precip_mm` nicht (`TypeError`)."""
+    from output.tokens.metrics import _fmt_num
+
+    sms = _sms(onset_precip_mm=12.34)
+
+    assert f"R{_fmt_num('R', 12.34)}@" in sms, (
+        f"Die Kurznachricht weicht von der Briefing-Zahlform "
+        f"{_fmt_num('R', 12.34)!r} ab: {sms!r}"
+    )

--- a/tests/tdd/test_onset_kurzform_menge.py
+++ b/tests/tdd/test_onset_kurzform_menge.py
@@ -34,8 +34,19 @@ from output.renderers.alert.model import AlertMessage, OnsetEvent
 from output.renderers.alert.render import render_sms
 
 # Eine Ziffer UNMITTELBAR hinter dem Kuerzel — die Mengen-Schreibweise des
-# Regen-Falls. Im Gewitter-Fall darf sie NIE auftreten (Stufen-Position).
+# Regen-Falls. Wird von den ZAHLENLOSEN Faellen (AC-4a/AC-4c) benutzt: dort
+# darf hinter KEINEM der beiden Kuerzel eine Ziffer stehen.
 _ZIFFER_HINTER_KUERZEL_RE = re.compile(r"\b(TH|R)(\d)")
+# KORRIGIERT (PO-Entscheid 2026-08-21): eigene, auf `TH` verengte Fassung fuer
+# die Stufen-Zusicherung aus AC-2. Die urspruengliche Alternative `(TH|R)` an
+# jener Stelle war in sich unerfuellbar — sie traf das von AC-2 SELBST
+# geforderte Mengen-Token (`\bR2` in `Ziel: TH@18:00 R2.5`) und schloss damit
+# den Goldstring aus, den derselbe Test zwei Zeilen darueber verlangt. Die
+# Zusicherung selbst bleibt unveraendert: hinter `TH` steht NIE eine Ziffer,
+# weil diese Position in der Briefing-Grammatik der Stufe (L/M/H) gehoert.
+# Nur ihr fehlerhafter Ausdruck ist ersetzt; die allgemeine Fassung oben
+# bleibt fuer AC-4a/AC-4c in Kraft und bewacht dort weiterhin BEIDE Kuerzel.
+_ZIFFER_HINTER_TH_RE = re.compile(r"\bTH(\d)")
 # Vollstaendiger Regen-Mengen-Token: `R<zahl mit einer Nachkommastelle>@HH:MM`.
 _MENGEN_TOKEN_RE = re.compile(r"\bR(\d+)\.(\d)@(\d{1,2}):(\d{2})\b")
 
@@ -140,10 +151,10 @@ def test_ac2_gewitter_onset_traegt_die_menge_als_eigenes_token_nach_der_zeit():
     assert "TH2" not in sms and "TH2.5" not in sms, (
         f"Die Stufen-Position hinter 'TH' ist mit einer Menge belegt: {sms!r}"
     )
-    treffer = _ZIFFER_HINTER_KUERZEL_RE.search(sms)
+    treffer = _ZIFFER_HINTER_TH_RE.search(sms)
     assert treffer is None, (
-        f"Ziffer unmittelbar hinter dem Kuerzel {treffer.group(1)!r} im "
-        f"Gewitter-Fall: {sms!r}"
+        f"Ziffer unmittelbar hinter 'TH' im Gewitter-Fall — diese Position "
+        f"gehoert der Stufe (L/M/H), nicht der Menge: {sms!r}"
     )
 
 

--- a/tests/tdd/test_onset_langform_ignoriert_menge.py
+++ b/tests/tdd/test_onset_langform_ignoriert_menge.py
@@ -1,0 +1,82 @@
+"""TDD — Issue #2046 AC-8: E-Mail-/Telegram-Langform ignorieren `onset_precip_mm`.
+
+Die Kurzform (`_render_sms_onset`) bekam mit #2046 eine Mengenangabe
+(`R2.5@18:00`). Die Langform bleibt laut Spec unveraendert: sie zeigt weiter
+`intensity_label` als Wort und liest `onset_precip_mm` NICHT. Zwei Ebenen,
+wie von der Spec verlangt (`docs/specs/modules/fix_2046_onset_menge.md`,
+AC-8):
+
+1. Verhaltenstest (der eigentliche Waechter): dieselbe Eingabe einmal mit
+   `onset_precip_mm=None`, einmal mit einem gesetzten Wert gerendert -- beide
+   Ausgaben muessen zeichengleich sein.
+2. Struktureller Nachweis via `inspect.getsource()`: der Bezeichner
+   `onset_precip_mm` kommt im Quelltext der beiden Funktionen nicht vor.
+
+Mock-frei: echte Dataclass-Konstruktion, echte Renderer-Aufrufe.
+
+SPEC: docs/specs/modules/fix_2046_onset_menge.md, AC-8
+"""
+from __future__ import annotations
+
+import inspect
+
+from output.renderers.alert.model import AlertMessage, OnsetEvent
+from output.renderers.alert.render import _render_email_onset, _render_telegram_onset
+
+
+def _onset_msg(*, onset_precip_mm: float | None) -> AlertMessage:
+    onset = OnsetEvent(
+        onset_minutes=18, onset_time="18:00", km_from=5.0, km_to=9.0,
+        is_convective=False, intensity_label="leichter Regen",
+        source_label="Radar (DWD)", onset_precip_mm=onset_precip_mm,
+    )
+    return AlertMessage(
+        trip_short="GR20", stand_at="17:42", events=(onset,),
+        source="Radar (DWD)", cooldown_display="2 Stunden",
+    )
+
+
+class TestEmailLangformIgnoriertMenge:
+    def test_html_und_plain_zeichengleich_mit_und_ohne_menge(self):
+        html_ohne, plain_ohne = _render_email_onset(_onset_msg(onset_precip_mm=None))
+        html_mit, plain_mit = _render_email_onset(_onset_msg(onset_precip_mm=2.5))
+
+        assert html_ohne == html_mit, (
+            "E-Mail-HTML unterscheidet sich, obwohl nur onset_precip_mm variiert:\n"
+            f"  ohne: {html_ohne!r}\n  mit:  {html_mit!r}"
+        )
+        assert plain_ohne == plain_mit, (
+            "E-Mail-Plain-Text unterscheidet sich, obwohl nur onset_precip_mm "
+            f"variiert:\n  ohne: {plain_ohne!r}\n  mit:  {plain_mit!r}"
+        )
+
+
+class TestTelegramLangformIgnoriertMenge:
+    def test_text_zeichengleich_mit_und_ohne_menge(self):
+        tg_ohne = _render_telegram_onset(_onset_msg(onset_precip_mm=None))
+        tg_mit = _render_telegram_onset(_onset_msg(onset_precip_mm=2.5))
+
+        assert tg_ohne == tg_mit, (
+            "Telegram-Langform unterscheidet sich, obwohl nur onset_precip_mm "
+            f"variiert:\n  ohne: {tg_ohne!r}\n  mit:  {tg_mit!r}"
+        )
+
+
+class TestStrukturellerNichtberuehrungsNachweis:
+    """AC-8 verlangt zusaetzlich einen Grep-Nicht-Beruehrungs-Nachweis ueber
+    `inspect.getsource()` (kein Dateiinhalt-Check per `file.read_text()`,
+    das waere nach der Test-Politik ein verbotener Verhaltensersatz)."""
+
+    def test_render_email_onset_referenziert_onset_precip_mm_nicht(self):
+        source = inspect.getsource(_render_email_onset)  # doc-compliance-test
+        assert "onset_precip_mm" not in source, (
+            "_render_email_onset() referenziert onset_precip_mm -- laut AC-8 "
+            "darf die Langform dieses Feld nicht lesen."
+        )
+
+    def test_render_telegram_onset_referenziert_onset_precip_mm_nicht(self):
+        source = inspect.getsource(_render_telegram_onset)  # doc-compliance-test
+        assert "onset_precip_mm" not in source, (
+            "_render_telegram_onset() referenziert onset_precip_mm -- laut "
+            "AC-8 darf die Langform dieses Feld nicht lesen."
+        )

--- a/tests/tdd/test_onset_menge_ab_beginn_nicht_ab_jetzt.py
+++ b/tests/tdd/test_onset_menge_ab_beginn_nicht_ab_jetzt.py
@@ -1,0 +1,256 @@
+"""TDD RED — Issue #2046: die angezeigte Menge ist am BEGINN ausgerichtet,
+nicht an "jetzt".
+
+SPEC: docs/specs/modules/fix_2046_onset_menge.md — AC-3 (Messgrundlage,
+durchgerechnetes Gegenbeispiel) und AC-12 (ein Aufruf, vier Felder, kein
+zweiter Abruf).
+
+Fachlicher Kern (das Risiko, das dieses Ticket ueberhaupt erst hat): das
+bestehende Feld `window_precip_mm` misst die Menge der 60 Minuten AB JETZT,
+der Onset-Alarm feuert aber bis 55 Minuten vor dem Beginn
+(`RADAR_ONSET_THRESHOLD_MIN`). Bei spaetem Beginn deckt dieses Fenster fast
+nur noch trockene Zeit ab — die Zahl waere systematisch zu klein und wuerde
+den Alarm durch Untertreibung entwerten. Das neue Feld `onset_precip_mm`
+misst deshalb die 60 Minuten AB DEM BEGINN.
+
+Der Wächter unten schlaegt rot, sobald jemand `onset_precip_mm` (wieder) ab
+"jetzt" rechnet, ODER es als blosse Rate mal eine Stunde hochrechnet statt
+ueber die Frames zu akkumulieren.
+
+Mock-frei: echte `RadarFrame`-Objekte mit echten Zeitstempeln, echter
+`RadarNowcastService`, injizierte Zeit (`now=`/`now_fn=`) statt Wanduhr,
+echter zaehlender `frame_source` (DI-Naht des Services) statt `patch`.
+"""
+from __future__ import annotations
+
+import inspect
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from providers.brightsky import RadarFrame
+from services.radar_service import RadarNowcastService
+
+# Fester Bezugszeitpunkt — keine Wanduhr im Test.
+NOW = datetime(2026, 8, 21, 12, 0, tzinfo=timezone.utc)
+# 5-Minuten-Raster (RADOLAN-Kadenz), 180 Minuten weit — deckt sowohl das
+# 60-Min-Fenster ab jetzt als auch das 60-Min-Fenster ab Minute 50 voll ab.
+RASTER_MIN = 5
+DAUER_MIN = 180
+REGEN_RATE = 12.0  # mm/h
+
+
+def _frames(*, regen_ab_min: int, regen_bis_min: int = DAUER_MIN + 1,
+            rate: float = REGEN_RATE) -> list[RadarFrame]:
+    """Frames im 5-Minuten-Raster ab `NOW`: trocken, ausser im Abschnitt
+    [`regen_ab_min`, `regen_bis_min`) — dort `rate` mm/h."""
+    frames = []
+    for offset in range(0, DAUER_MIN + RASTER_MIN, RASTER_MIN):
+        nass = regen_ab_min <= offset < regen_bis_min
+        frames.append(RadarFrame(
+            timestamp=NOW + timedelta(minutes=offset),
+            precip_mm_h=rate if nass else 0.0,
+            is_convective=False,
+        ))
+    return frames
+
+
+def _service() -> RadarNowcastService:
+    """Eigener Service MIT EIGENEM Cache — der geteilte Prozess-Cache wuerde
+    Abruf-Zaehlungen zwischen Tests verfaelschen."""
+    from services.radar_cache import RadarNowcastCacheService
+
+    return RadarNowcastService(cache=RadarNowcastCacheService(), now_fn=lambda: NOW)
+
+
+def test_prueling_stammt_aus_diesem_arbeitsbaum():
+    """Vorbedingung (kein AC): der gepruefte Dienst wird RELATIV ZU DIESER
+    Testdatei aufgeloest — sonst pruefte ein Worktree-Lauf still die Datei des
+    Hauptrepos und lieferte falsches Gruen."""
+    import services.radar_service as radar_module
+
+    modul_pfad = Path(inspect.getfile(radar_module)).resolve()
+    arbeitsbaum = Path(__file__).resolve().parents[2]
+    assert modul_pfad.is_relative_to(arbeitsbaum), (
+        f"Prueling stammt nicht aus diesem Arbeitsbaum: {modul_pfad}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-3 — spaeter Beginn: "ab jetzt" untertreibt, "ab Beginn" trifft
+# ---------------------------------------------------------------------------
+
+
+def test_ac3_spaeter_beginn_menge_ab_beginn_statt_ab_jetzt():
+    """AC-3 GIVEN ein `NowcastResult`, dessen Beginn 50 Minuten voraus liegt
+    (unter der 55-Minuten-Ausloeseschwelle), dessen Frames VOR dem Beginn
+    durchgaengig trocken sind (0 mm/h) und AB dem Beginn 12 mm/h liefern
+    WHEN `_derive_result` sowohl `window_precip_mm` (60 Min ab jetzt) als
+    auch `onset_precip_mm` (60 Min ab Beginn) berechnet
+    THEN weist `window_precip_mm` nur rund 2 mm aus (das Fenster ab jetzt
+    erfasst nur die letzten 10 Minuten vor dem Fensterende), waehrend
+    `onset_precip_mm` rund 12 mm ausweist (volle Stunde bei 12 mm/h) — die
+    neue Zahl entwertet den Alarm nicht durch Untertreibung.
+
+    DURCHGERECHNET (5-Min-Raster, Regen ab Minute 50):
+      * Fenster ab jetzt  [0, 60):   Frames 50 und 55 nass -> 2 x 5 Min x
+        12 mm/h = 2.0 mm
+      * Fenster ab Beginn [50, 110): 12 nasse Frames x 5 Min x 12 mm/h =
+        12.0 mm
+
+    Beide Erwartungen stehen mit ENGER Toleranz da: wer `onset_precip_mm`
+    versehentlich wieder ab "jetzt" rechnet, landet bei 2.0 mm und faellt hier
+    hart durch.
+
+    RED heute: `NowcastResult` kennt `onset_precip_mm` nicht
+    (`AttributeError`)."""
+    result = _service()._derive_result(_frames(regen_ab_min=50), "radar", now=NOW)
+
+    assert result.onset_minutes == 50, (
+        f"Voraussetzung: der Beginn muss bei Minute 50 liegen, "
+        f"war {result.onset_minutes!r}"
+    )
+    assert result.window_precip_mm == pytest.approx(2.0, abs=0.25), (
+        "Voraussetzung: das Fenster AB JETZT muss den Regen fast verpassen "
+        f"(rund 2 mm), war {result.window_precip_mm!r}"
+    )
+
+    onset_menge = result.onset_precip_mm
+    assert onset_menge == pytest.approx(12.0, abs=0.6), (
+        "RED: die angezeigte Menge muss die volle Stunde AB DEM BEGINN "
+        f"messen (rund 12 mm), war {onset_menge!r} — bei rund 2 mm ist sie "
+        "faelschlich ab 'jetzt' gerechnet."
+    )
+    assert onset_menge > 4 * result.window_precip_mm, (
+        "RED: bei spaetem Beginn MUSS die Menge ab Beginn die Menge ab jetzt "
+        f"deutlich uebersteigen: {onset_menge!r} vs "
+        f"{result.window_precip_mm!r}"
+    )
+
+
+def test_ac3_kurzer_schauer_wird_akkumuliert_nicht_hochgerechnet():
+    """AC-3 (Gegenprobe zur Rechenart) GIVEN denselben spaeten Beginn, aber
+    einen Regen, der nach 10 Minuten wieder aufhoert (Minute 50 bis 60)
+    WHEN `onset_precip_mm` berechnet wird
+    THEN weist es rund 2 mm aus (10 Minuten bei 12 mm/h) — NICHT 12 mm.
+
+    Nagelt fest, dass ueber die Frames AKKUMULIERT und nicht die Spitzenrate
+    mit einer Stunde multipliziert wird. Der Hauptfall oben allein koennte
+    beide Rechenarten nicht unterscheiden.
+
+    RED heute: `NowcastResult` kennt `onset_precip_mm` nicht."""
+    result = _service()._derive_result(
+        _frames(regen_ab_min=50, regen_bis_min=60), "radar", now=NOW,
+    )
+
+    assert result.onset_minutes == 50
+    assert result.onset_precip_mm == pytest.approx(2.0, abs=0.25), (
+        "RED: ein 10-Minuten-Schauer bei 12 mm/h ergibt rund 2 mm — "
+        f"bekam {result.onset_precip_mm!r} (12 mm hiesse: Rate mal Stunde "
+        "hochgerechnet statt akkumuliert)."
+    )
+
+
+def test_ac3_sofortiger_beginn_laesst_beide_fenster_zusammenfallen():
+    """AC-3 (zweite Gegenprobe) GIVEN Regen, der SOFORT beginnt (Minute 0)
+    WHEN beide Mengen berechnet werden
+    THEN fallen sie zusammen — die beiden Fenster sind dann deckungsgleich.
+
+    Waechter gegen einen konstanten Versatz: eine Implementierung, die die
+    Menge pauschal streckt oder ein anderes Fenster als 60 Minuten benutzt,
+    faellt hier auf, obwohl der Hauptfall oben gruen bliebe.
+
+    RED heute: `NowcastResult` kennt `onset_precip_mm` nicht."""
+    result = _service()._derive_result(_frames(regen_ab_min=0), "radar", now=NOW)
+
+    assert result.onset_minutes == 0
+    assert result.window_precip_mm == pytest.approx(12.0, abs=0.6), (
+        f"Voraussetzung: Dauerregen ab jetzt ergibt rund 12 mm, "
+        f"war {result.window_precip_mm!r}"
+    )
+    assert result.onset_precip_mm == pytest.approx(result.window_precip_mm, abs=0.1), (
+        "RED: bei sofortigem Beginn muessen beide Fenster dieselbe Menge "
+        f"liefern: {result.onset_precip_mm!r} vs {result.window_precip_mm!r}"
+    )
+
+
+def test_ac3_ohne_beginn_gibt_es_keine_menge():
+    """AC-3 (Rand) GIVEN durchgaengig trockene Frames (kein Beginn)
+    WHEN `_derive_result` laeuft
+    THEN bleibt `onset_precip_mm` `None` — es gibt kein Fenster, auf das es
+    sich beziehen koennte (Grundlage der zahlenlosen Ausweichform, AC-4).
+
+    RED heute: `NowcastResult` kennt `onset_precip_mm` nicht."""
+    result = _service()._derive_result(
+        _frames(regen_ab_min=DAUER_MIN + 99), "radar", now=NOW,
+    )
+
+    assert result.onset_minutes is None, "Voraussetzung: kein Beginn im Fenster"
+    assert result.onset_precip_mm is None, (
+        "RED: ohne Beginn darf keine Menge entstehen (schon gar keine 0.0, die "
+        f"als Zahl in die SMS liefe): {result.onset_precip_mm!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-12 — EIN Abruf, EIN Ergebnisobjekt, vier Felder
+# ---------------------------------------------------------------------------
+
+
+class _ZaehlenderFrameSource:
+    """Echter aufrufbarer `frame_source` (DI-Naht des Services, kein Mock):
+    liefert dieselbe Frame-Liste und zaehlt, wie oft er befragt wurde."""
+
+    def __init__(self, frames: list[RadarFrame]) -> None:
+        self._frames = frames
+        self.calls = 0
+
+    def __call__(self, lat: float, lon: float) -> list[RadarFrame]:
+        self.calls += 1
+        return list(self._frames)
+
+
+def test_ac12_ein_abruf_liefert_alle_vier_felder_aus_derselben_frameliste():
+    """AC-12 GIVEN die Frame-Liste, aus der `_derive_result` `onset_minutes`
+    und `window_precip_mm` ableitet
+    WHEN `onset_precip_mm` berechnet wird
+    THEN verwendet die Rechnung DIESELBE Frame-Liste — genau EIN Abruf der
+    Quelle — und alle vier Felder (`onset_minutes`, `window_precip_mm`,
+    `max_rate_mm_h`, `onset_precip_mm`) stammen aus DEMSELBEN Ergebnisobjekt.
+    Weder `onset_minutes` noch `window_precip_mm` noch `max_rate_mm_h`
+    veraendern sich durch die neue Rechnung.
+
+    Der Abruf-Zaehler ist ein echtes aufrufbares Objekt an der vorhandenen
+    `frame_source`-Naht — kein `patch`, das einen zweiten Produktiv-Abruf
+    verschleiern koennte.
+
+    RED heute: `NowcastResult` kennt `onset_precip_mm` nicht
+    (`AttributeError`)."""
+    from services.radar_cache import RadarNowcastCacheService
+
+    quelle = _ZaehlenderFrameSource(_frames(regen_ab_min=50))
+    service = RadarNowcastService(
+        frame_source=quelle, cache=RadarNowcastCacheService(),
+        now_fn=lambda: NOW,
+    )
+
+    result = service.get_nowcast(51.0, 10.0)
+
+    assert quelle.calls == 1, (
+        f"Die neue Zahl darf keinen zweiten Quellen-Abruf ausloesen — "
+        f"{quelle.calls} Abrufe gezaehlt."
+    )
+    assert result.onset_minutes == 50, (
+        f"onset_minutes hat sich veraendert: {result.onset_minutes!r}"
+    )
+    assert result.window_precip_mm == pytest.approx(2.0, abs=0.25), (
+        f"window_precip_mm hat sich veraendert: {result.window_precip_mm!r}"
+    )
+    assert result.max_rate_mm_h == pytest.approx(12.0, abs=0.01), (
+        f"max_rate_mm_h hat sich veraendert: {result.max_rate_mm_h!r}"
+    )
+    assert result.onset_precip_mm == pytest.approx(12.0, abs=0.6), (
+        f"RED: onset_precip_mm fehlt oder misst das falsche Fenster: "
+        f"{result.onset_precip_mm!r}"
+    )

--- a/tests/tdd/test_onset_menge_kanalparitaet.py
+++ b/tests/tdd/test_onset_menge_kanalparitaet.py
@@ -26,20 +26,25 @@ import re
 import socket
 import threading
 import urllib.parse
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from zoneinfo import ZoneInfo
 
 import pytest
 
 import output.channels.telegram as tg_module
 from app.config import Settings
+from app.models import TripReportConfig
 from output.renderers.alert.model import AlertMessage, OnsetEvent
 from output.renderers.alert.project import to_multi_location_onset_alert_message
 from output.renderers.alert.render import render_sms
 from services.notification_service import NotificationService, RadarAlertRequest
 from services.radar_service import NowcastResult
 
-from tests.helpers.nowcast_gate_fixtures import clean_uid, fresh_uid, make_trip
+from tests.helpers.briefing_zeiten import briefing_zeiten_fuer_trip
+from tests.helpers.nowcast_gate_fixtures import (
+    TRIP_ZONE, clean_uid, fresh_uid, make_trip, quiet_window_elsewhere,
+    radar_service, reset_radar_cache,
+)
 
 SMS_TO = "+49000000000"
 PREMIUM_REPLY_TO = "+4915799912345"
@@ -271,6 +276,278 @@ def test_ac7_sms_premium_sms_und_telegram_kurzstil_zeigen_dieselbe_menge(
         )
     finally:
         clean_uid(uid)
+
+
+# ---------------------------------------------------------------------------
+# AC-1/AC-7 am WIRKORT — der echte Trip-Produktivpfad (Adversary-Finding F001)
+#
+# Dieser Test prueft die Wirkkette an der Stelle, an der sie WIRKT: der
+# einzige Produktivpfad, der im Trip-Betrieb einen `RadarAlertRequest` baut,
+# ist `TripAlertService.check_radar_alerts()` (trip_alert.py). Die Tests
+# oben konstruieren den Request selbst und beweisen daher nur den Baustein,
+# nicht die Verdrahtung — genau diese Luecke fand der Adversary (F001):
+# `onset_precip_mm=result.onset_precip_mm` liess sich auf `None` setzen,
+# ohne dass ein einziger Test rot wurde.
+#
+# Kein Baustein wird uebersprungen: echte Radar-Frames -> echter
+# `RadarNowcastService` -> echtes `NowcastResult` -> echtes
+# `check_radar_alerts()` -> echter `NotificationService` -> echter
+# Telegram-Transport -> Nutzlast am Draht. Der Kurzstil-Telegram-Zweig
+# sendet den bereits gerenderten `sms_body` (notification_service.py),
+# also misst der Draht exakt den Text, den SMS und Premium-SMS ebenfalls
+# bekommen (AC-7) — ohne echten SMS-Versand auszuloesen.
+# ---------------------------------------------------------------------------
+
+
+class _DeterministischeOnsetFrames:
+    """Echter aufrufbarer `frame_source` (kein Mock): ZWEI nasse, nicht
+    konvektive Frames im 15-Minuten-Raster ab `onset_minutes`.
+
+    Die Menge ab dem Beginn ist damit von Hand nachrechenbar und haengt an
+    keiner Wanduhrzeit:
+      * Frame 1 bei +20 Min, 3.0 mm/h, Deckung bis zum Nachbarn (15 Min,
+        = `_MAX_FRAME_COVERAGE`) -> 0.75 mm
+      * Frame 2 bei +35 Min, 3.0 mm/h, letzter Frame, auf
+        `_MAX_FRAME_COVERAGE` gedeckelt -> 0.75 mm
+      * Summe = 1.5 mm -> Token `R1.5@HH:MM`
+    """
+
+    RATE_MM_H = 3.0
+    ERWARTETE_MENGE = "1.5"
+
+    def __init__(self, onset_minutes: int = 20) -> None:
+        self._onset = onset_minutes
+        self.calls: list[tuple[float, float]] = []
+
+    def __call__(self, lat: float, lon: float) -> list:
+        from providers.brightsky import RadarFrame
+
+        self.calls.append((lat, lon))
+        ts = datetime.now(timezone.utc) + timedelta(minutes=self._onset)
+        return [
+            RadarFrame(
+                timestamp=ts, precip_mm_h=self.RATE_MM_H, is_convective=False,
+            ),
+            RadarFrame(
+                timestamp=ts + timedelta(minutes=15),
+                precip_mm_h=self.RATE_MM_H, is_convective=False,
+            ),
+        ]
+
+
+class _SpaeterOnsetFrames:
+    """Echter aufrufbarer `frame_source` (kein Mock) mit SPAETEM Beginn — der
+    fachliche Kernfall des Tickets (Adversary-Finding F003).
+
+    `_DeterministischeOnsetFrames` oben kann die beiden Mengenfelder gar nicht
+    unterscheiden: bei einem Beginn nach 20 Minuten liegen alle nassen Frames
+    in BEIDEN Fenstern (`[jetzt, jetzt+60]` und `[Beginn, Beginn+60]`), beide
+    Felder tragen denselben Wert. Erst ein Beginn kurz vor der Alarmschwelle
+    (`RADAR_ONSET_THRESHOLD_MIN = 55`) trennt sie.
+
+    Raster: ein trockener Frame bei +5, dann durchgehend Regen mit 3.0 mm/h ab
+    +50 im 15-Minuten-Takt bis +125. Beide Zahlen von Hand hergeleitet
+    (`_MAX_FRAME_COVERAGE` = 15 Min, Fensterende ausschliessend, Dauer je
+    Frame bis zum eigenen naechsten Nachbarn):
+
+      Menge AB JETZT (`window_precip_mm`, Fenster `[+0, +60)`) — FALSCH fuer
+      die Anzeige, dient hier als Gegenprobe:
+        * +5  (0.0 mm/h): Deckung bis +20 -> 0.00 mm
+        * +50 (3.0 mm/h): Nachbar +65, aber Fensterende +60 kappt -> 10 Min
+                          -> 3.0 * 10/60 = 0.50 mm
+        * Summe = 0.5 mm  -> Token waere `R0.5@…`
+
+      Menge AB DEM BEGINN (`onset_precip_mm`, Fenster `[+50, +110)`) — die
+      Zahl, die in die Kurznachricht gehoert:
+        * +50 -> Nachbar +65   -> 15 Min -> 0.75 mm
+        * +65 -> Nachbar +80   -> 15 Min -> 0.75 mm
+        * +80 -> Nachbar +95   -> 15 Min -> 0.75 mm
+        * +95 -> Nachbar +110, zugleich Fensterende -> 15 Min -> 0.75 mm
+        * +110/+125 liegen AUSSERHALB (Grenze ausschliessend) -> 0.00 mm
+        * Summe = 3.0 mm  -> Token `R3.0@…`
+
+    Faktor 6 zwischen den beiden Feldern: eine Vertauschung von
+    `onset_precip_mm` gegen `window_precip_mm` am Wirkort faellt damit sofort
+    auf. `onset_minutes = 50` liegt bewusst unter der Alarmschwelle 55, der
+    Alarm loest also ueberhaupt aus; die Spitzenrate 3.0 mm/h ergibt im
+    180-Minuten-Fenster weiterhin "Mäßiger Regen".
+    """
+
+    RATE_MM_H = 3.0
+    ONSET_MIN = 50
+    ERWARTETE_MENGE_AB_BEGINN = "3.0"
+    ERWARTETE_MENGE_AB_JETZT = "0.5"
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[float, float]] = []
+
+    def __call__(self, lat: float, lon: float) -> list:
+        from providers.brightsky import RadarFrame
+
+        self.calls.append((lat, lon))
+        jetzt = datetime.now(timezone.utc)
+        frames = [
+            RadarFrame(
+                timestamp=jetzt + timedelta(minutes=5), precip_mm_h=0.0,
+                is_convective=False,
+            ),
+        ]
+        for minute in (50, 65, 80, 95, 110, 125):
+            frames.append(
+                RadarFrame(
+                    timestamp=jetzt + timedelta(minutes=minute),
+                    precip_mm_h=self.RATE_MM_H, is_convective=False,
+                )
+            )
+        return frames
+
+
+def _telegram_kurzform_settings() -> Settings:
+    """Nur Telegram sendebereit — E-Mail, SMS und Premium-SMS ausdruecklich
+    AUS (jedes weggelassene Feld faellt sonst still auf die Prod-`.env` des
+    Arbeitsverzeichnisses zurueck, #1477). `telegram_test_chat_id` ist
+    Pflicht fuer die Herkunftssperre aus einem Nicht-Prod-Checkout."""
+    return Settings(
+        smtp_host=None, smtp_user=None, smtp_pass=None, mail_to=None,
+        telegram_bot_token="test-token-2046-f001",
+        telegram_chat_id="99999", telegram_test_chat_id="99999",
+        sms_gateway_url="", seven_api_key="", seven_sandbox_key="",
+        sms_to="", sms_from=None,
+        premium_sms_reply_to=None, premium_sms_reply_at=None,
+    )
+
+
+def _kurznachricht_vom_echten_trip_pfad(frames, telegram_stub, monkeypatch, suffix):
+    """Faehrt den ECHTEN Trip-Produktivpfad und gibt den Text zurueck, der am
+    Draht ankam. Kein Baustein wird uebersprungen: echte Radar-Frames ->
+    echter `RadarNowcastService` -> echtes `NowcastResult` -> echtes
+    `check_radar_alerts()` -> echter `NotificationService` -> echter
+    Telegram-Transport."""
+    from app.loader import save_trip
+    from services.trip_alert import TripAlertService
+
+    monkeypatch.setattr(tg_module, "TELEGRAM_API_BASE", telegram_stub.base_url)
+
+    uid, trip_id = fresh_uid(f"2046-{suffix}"), f"trip-2046-{suffix}"
+    clean_uid(uid)
+    reset_radar_cache()
+    try:
+        quiet_from, quiet_to = quiet_window_elsewhere(zone=TRIP_ZONE)
+        trip = make_trip(
+            trip_id, cooldown_minutes=0, quiet_from=quiet_from, quiet_to=quiet_to,
+        )
+        morgen, abend = briefing_zeiten_fuer_trip(trip)
+        trip.report_config = TripReportConfig(
+            trip_id=trip_id, send_email=False, send_sms=False,
+            send_telegram=True, send_premium_sms=False,
+            alert_on_changes=True, telegram_style="kurzform",
+            morning_time=morgen, evening_time=abend,
+        )
+        # Der PRODUKTIVE Speicherer (`app.loader.save_trip`), nicht der
+        # verkuerzte Test-Helfer: nur er schreibt `telegram_style` mit, und
+        # `check_radar_alerts()` liest den Trip von Platte zurueck.
+        save_trip(trip, user_id=uid)
+
+        svc = TripAlertService(
+            settings=_telegram_kurzform_settings(), throttle_hours=0,
+            user_id=uid, radar_service=radar_service(frames),
+        )
+
+        sent = svc.check_radar_alerts()
+
+        assert sent == 1, (
+            f"Voraussetzung: genau EIN Radar-Alarm erwartet, war {sent}. "
+            f"Nowcast-Abrufe: {frames.calls!r}"
+        )
+        assert len(telegram_stub.sent) == 1, (
+            f"Erwartet genau EINE Kurznachricht am Draht: {telegram_stub.sent!r}"
+        )
+        return telegram_stub.sent[0].get("text") or ""
+    finally:
+        clean_uid(uid)
+
+
+def test_ac1_der_echte_trip_pfad_stellt_die_menge_zu(telegram_stub, monkeypatch):
+    """AC-1/AC-7 GIVEN einen Trip mit aktivem Segment, dessen ECHTER
+    Nowcast-Abruf aus echten Radar-Frames ein `NowcastResult` mit
+    `onset_precip_mm == 1.5` ableitet (2 x 3.0 mm/h x 15 Min)
+    WHEN `TripAlertService.check_radar_alerts()` laeuft — der einzige
+    Produktivpfad, der im Trip-Betrieb einen `RadarAlertRequest` baut —
+    THEN traegt die TATSAECHLICH abgesetzte Kurznachricht am Draht das
+    Token `R1.5@HH:MM`, nicht die zahlenlose Alt-Form `R@HH:MM`.
+
+    Wirkort-Nachweis (Adversary-Finding F001): kein direkt konstruierter
+    `RadarAlertRequest`. Wird die Durchreichung in `trip_alert.py`
+    (`onset_precip_mm=result.onset_precip_mm`) entfernt, faellt der Text auf
+    `R@HH:MM` zurueck und dieser Test wird rot.
+
+    Frueher Beginn (+20 Min) — beide Mengenfelder tragen hier denselben Wert.
+    Die UNTERSCHEIDUNG der beiden Felder leistet der Test darunter
+    (`…_bei_spaetem_beginn_…`, Adversary-Finding F003).
+    """
+    frames = _DeterministischeOnsetFrames()
+    text = _kurznachricht_vom_echten_trip_pfad(
+        frames, telegram_stub, monkeypatch, "f001",
+    )
+
+    assert re.search(r"\bR1\.5@\d{1,2}:\d{2}", text), (
+        "F001: der echte Trip-Produktivpfad reicht die Mengenangabe nicht "
+        f"bis zur abgesetzten Kurznachricht durch: {text!r}"
+    )
+    assert not re.search(r"\bR@\d{1,2}:\d{2}", text), (
+        f"Die zahlenlose Alt-Form steht noch im Text: {text!r}"
+    )
+    assert _MENGEN_TOKEN_RE.search(text), (
+        f"Der Mengen-Token ist beschaedigt: {text!r}"
+    )
+
+
+def test_ac1_bei_spaetem_beginn_zeigt_der_trip_pfad_die_menge_ab_beginn(
+    telegram_stub, monkeypatch,
+):
+    """AC-1 GIVEN einen Trip, dessen ECHTER Nowcast-Abruf einen SPAETEN
+    Beginn liefert (+50 Min, knapp unter der Alarmschwelle 55) mit
+    durchgehendem Regen von 3.0 mm/h bis +125 Min
+    WHEN `TripAlertService.check_radar_alerts()` laeuft
+    THEN traegt die abgesetzte Kurznachricht `R3.0@HH:MM` — die Menge der
+    Stunde AB DEM BEGINN — und ausdruecklich NICHT `R0.5@HH:MM`, die Menge
+    der Stunde ab jetzt.
+
+    Das ist der fachliche Kernfall des Tickets: der Alarm feuert bis zu
+    `RADAR_ONSET_THRESHOLD_MIN` (55) Minuten VOR dem Beginn; das Fenster
+    „ab jetzt" deckt dann fast nur Trockenzeit ab und untertreibt die Menge
+    systematisch — hier um den Faktor 6.
+
+    Wirkort-Nachweis (Adversary-Finding F003): der Test oben kann die beiden
+    Felder nicht unterscheiden (frueher Beginn -> beide Fenster deckungs-
+    gleich). Wird in `trip_alert.py` `onset_precip_mm=result.onset_precip_mm`
+    gegen `result.window_precip_mm` vertauscht, wird DIESER Test rot.
+
+    Beide Zahlen sind aus den Frames hergeleitet, nicht aus der
+    Implementierung abgeschrieben — Rechenweg im Docstring von
+    `_SpaeterOnsetFrames`.
+    """
+    frames = _SpaeterOnsetFrames()
+    text = _kurznachricht_vom_echten_trip_pfad(
+        frames, telegram_stub, monkeypatch, "f003",
+    )
+
+    erwartet = frames.ERWARTETE_MENGE_AB_BEGINN   # "3.0" — ab dem Beginn
+    falsch = frames.ERWARTETE_MENGE_AB_JETZT      # "0.5" — ab jetzt
+
+    assert re.search(rf"\bR{re.escape(erwartet)}@\d{{1,2}}:\d{{2}}", text), (
+        f"F003: die Kurznachricht muss die Menge AB DEM BEGINN nennen "
+        f"(R{erwartet}@HH:MM = 4 x 3.0 mm/h x 15 Min im Fenster "
+        f"[Beginn, Beginn+60min)): {text!r}"
+    )
+    assert not re.search(rf"\bR{re.escape(falsch)}@\d{{1,2}}:\d{{2}}", text), (
+        f"F003: die Kurznachricht zeigt die Menge AB JETZT (R{falsch}@HH:MM) "
+        f"statt der Menge ab dem Beginn — bei spaetem Beginn deckt das "
+        f"Fenster ab jetzt fast nur Trockenzeit ab: {text!r}"
+    )
+    assert not re.search(r"\bR@\d{1,2}:\d{2}", text), (
+        f"Die zahlenlose Alt-Form steht noch im Text: {text!r}"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tdd/test_onset_menge_kanalparitaet.py
+++ b/tests/tdd/test_onset_menge_kanalparitaet.py
@@ -1,0 +1,318 @@
+"""TDD RED — Issue #2046: die Mengenangabe erreicht ALLE Kurzkanaele und
+sprengt das Zeichenbudget nicht.
+
+SPEC: docs/specs/modules/fix_2046_onset_menge.md — AC-6 (Ortsvergleich-
+Bündelpfad fuehrt dieselbe Zahl wie der Trip-Pfad), AC-7 (SMS, Premium-SMS
+und Telegram im Kurzstil zeigen denselben Text), AC-9 (Zeichenbudget im
+Extremfall).
+
+Warum das zaehlt: auf der Huette am Karnischen Hoehenweg kommt NUR
+Premium-SMS (Garmin inReach) an — eine Zahl, die diesen Kanal nicht erreicht,
+erreicht dort niemanden. Und der Ortsvergleich-Radarpfad baut sein
+`OnsetEvent` an einer ZWEITEN Stelle (`project.to_multi_location_onset_
+alert_message`); wird die Zahl nur im Trip-Pfad durchgereicht, entsteht dort
+eine stille Luecke.
+
+Mock-frei: echte lokale HTTP-Aufzeichnungs-Server fuer seven.io (SMS UND
+Premium-SMS) und die Telegram-Bot-API, echter `NotificationService`-Lauf ueber
+`send_radar_alert()`, echter Buendel-Konstruktor. Kein `Mock()`/`patch()` von
+Verhalten, kein externes Netz, kein echter Versand.
+"""
+from __future__ import annotations
+
+import http.server
+import json
+import re
+import socket
+import threading
+import urllib.parse
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
+
+import pytest
+
+import output.channels.telegram as tg_module
+from app.config import Settings
+from output.renderers.alert.model import AlertMessage, OnsetEvent
+from output.renderers.alert.project import to_multi_location_onset_alert_message
+from output.renderers.alert.render import render_sms
+from services.notification_service import NotificationService, RadarAlertRequest
+from services.radar_service import NowcastResult
+
+from tests.helpers.nowcast_gate_fixtures import clean_uid, fresh_uid, make_trip
+
+SMS_TO = "+49000000000"
+PREMIUM_REPLY_TO = "+4915799912345"
+# Regen-Mengen-Token: Kuerzel, Zahl mit einer Nachkommastelle, dann die Zeit.
+_MENGEN_TOKEN_RE = re.compile(r"\bR\d+\.\d@\d{1,2}:\d{2}\b")
+
+
+def _free_port() -> int:
+    probe = socket.socket()
+    probe.bind(("", 0))
+    port = probe.getsockname()[1]
+    probe.close()
+    return port
+
+
+class _SevenIoStub:
+    """Lokaler HTTP-Server, der die seven.io-POSTs von SMS UND Premium-SMS
+    entgegennimmt (Vorbild `test_alert_addendum_sms.py`). Kein Mock: der echte
+    Transport laeuft, die Nutzlast wird am Draht gemessen."""
+
+    def __init__(self) -> None:
+        self.received: list[dict] = []
+        received = self.received
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def do_POST(self):  # noqa: N802
+                length = int(self.headers.get("Content-Length", 0))
+                data = urllib.parse.parse_qs(self.rfile.read(length).decode())
+                received.append({k: v[0] for k, v in data.items()})
+                self.send_response(200)
+                self.end_headers()
+                self.wfile.write(b"100")
+
+            def log_message(self, *args):  # noqa: D401
+                pass
+
+        self.port = _free_port()
+        self._server = http.server.HTTPServer(("127.0.0.1", self.port), Handler)
+        threading.Thread(target=self._server.serve_forever, daemon=True).start()
+
+    def stop(self) -> None:
+        self._server.shutdown()
+
+
+class _TelegramStub:
+    """Lokaler HTTP-Stub der Telegram-Bot-API (Vorbild
+    `test_radar_alert_telegram_style.py`) — zeichnet jede `sendMessage`-
+    Nutzlast auf."""
+
+    def __init__(self) -> None:
+        self.sent: list[dict] = []
+        sent = self.sent
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def do_POST(self):  # noqa: N802
+                length = int(self.headers.get("Content-Length", 0))
+                try:
+                    payload = json.loads(self.rfile.read(length).decode())
+                except ValueError:
+                    payload = {}
+                sent.append(payload)
+                body = json.dumps(
+                    {"ok": True, "result": {"message_id": 4711}}
+                ).encode()
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, *args):  # noqa: D401
+                pass
+
+        self.port = _free_port()
+        self._server = http.server.HTTPServer(("127.0.0.1", self.port), Handler)
+        threading.Thread(target=self._server.serve_forever, daemon=True).start()
+
+    @property
+    def base_url(self) -> str:
+        return f"http://127.0.0.1:{self.port}"
+
+    def stop(self) -> None:
+        self._server.shutdown()
+
+
+@pytest.fixture()
+def seven_io_stub():
+    stub = _SevenIoStub()
+    yield stub
+    stub.stop()
+
+
+@pytest.fixture()
+def telegram_stub():
+    stub = _TelegramStub()
+    yield stub
+    stub.stop()
+
+
+def _drei_kanal_settings(seven_port: int) -> Settings:
+    """SMS, Premium-SMS und Telegram sendebereit, E-Mail bewusst aus.
+
+    `seven_api_key == seven_sandbox_key` haelt beide Sicherheitssperren des
+    seven.io-Transports zufrieden; `telegram_test_chat_id` ist Pflicht fuer die
+    Herkunftssperre des Telegram-Kanals aus einem Nicht-Prod-Checkout.
+    """
+    return Settings(
+        sms_gateway_url=f"http://127.0.0.1:{seven_port}/api/sms",
+        seven_api_key="sandbox-key-2046",
+        seven_sandbox_key="sandbox-key-2046",
+        sms_to=SMS_TO, sms_from=None,
+        premium_sms_reply_to=PREMIUM_REPLY_TO,
+        premium_sms_reply_at=datetime.now(timezone.utc),
+        telegram_bot_token="test-token-2046",
+        telegram_chat_id="99999", telegram_test_chat_id="99999",
+        smtp_host=None, smtp_user=None, smtp_pass=None, mail_to=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-6 — der Ortsvergleich-Bündelpfad fuehrt dieselbe Zahl
+# ---------------------------------------------------------------------------
+
+
+def test_ac6_ortsvergleich_buendel_traegt_dieselbe_menge_wie_der_trip_pfad():
+    """AC-6 GIVEN einen Ortsvergleich-Bündel-Onset-Alarm mit ZWEI Orten,
+    dessen fuehrendes Ereignis `onset_precip_mm=1.8` traegt
+    WHEN `to_multi_location_onset_alert_message` die Nachricht baut und
+    `render_sms(msg)` sie rendert
+    THEN enthaelt der Text `R1.8@…` — dieselbe Zahl und dieselbe Formatregel
+    wie im Trip-Pfad (AC-1), nicht bloss eine leere Kurzform mit Ortsnamen.
+
+    Wanduhrfest: der Buendel-Konstruktor leitet `onset_time` aus
+    `datetime.now()` ab, deshalb Strukturpruefung der Uhrzeit und exakte
+    Pruefung nur an Kopf und Zahl.
+
+    RED heute: `NowcastResult` kennt `onset_precip_mm` nicht (`TypeError`)."""
+    fuehrend = NowcastResult(
+        onset_minutes=20, intensity_label="Mäßiger Regen", source="radar",
+        is_convective=False, onset_precip_mm=1.8,
+    )
+    zweiter = NowcastResult(
+        onset_minutes=35, intensity_label="Leichter Regen", source="AROME-FR",
+        is_convective=False, onset_precip_mm=0.4,
+    )
+
+    msg = to_multi_location_onset_alert_message(
+        [("Zermatt", fuehrend), ("Chamonix", zweiter)],
+        tz=timezone.utc, stand_at="10:00",
+    )
+    sms = render_sms(msg)
+
+    assert sms.startswith("Zermatt: "), (
+        f"Voraussetzung: der Kopf ist der Ortsname des fuehrenden Events: "
+        f"{sms!r}"
+    )
+    assert re.search(r"\bR1\.8@\d{1,2}:\d{2}", sms), (
+        f"RED: die Menge des fuehrenden Ortes fehlt in der Buendel-Kurzform: "
+        f"{sms!r}"
+    )
+    assert "R@" not in sms, (
+        f"Der Vergleichspfad zeigt noch die zahlenlose Alt-Form: {sms!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-7 — SMS, Premium-SMS und Telegram-Kurzstil zeigen denselben Text
+# ---------------------------------------------------------------------------
+
+
+def test_ac7_sms_premium_sms_und_telegram_kurzstil_zeigen_dieselbe_menge(
+    seven_io_stub, telegram_stub, monkeypatch,
+):
+    """AC-7 GIVEN dieselben Onset-Ereignisse fuer SMS, Premium-SMS und
+    Telegram im Kurzstil (`onset_precip_mm=2.5`, `onset_time="16:45"`)
+    WHEN `send_radar_alert(...)` alle drei konfigurierten Kanaele bedient
+    THEN zeigen ALLE DREI denselben Token-Text INKLUSIVE Menge — kein Kanal
+    zeigt eine andere Zahl, keiner laesst sie aus.
+
+    Die Zusicherung ist der VERGLEICH der drei tatsaechlich abgesetzten
+    Nutzlasten, gemessen am Draht der lokalen Aufzeichnungs-Server.
+
+    RED heute: `RadarAlertRequest` kennt `onset_precip_mm` nicht
+    (`TypeError`)."""
+    monkeypatch.setattr(tg_module, "TELEGRAM_API_BASE", telegram_stub.base_url)
+
+    uid = fresh_uid("2046-ac7")
+    clean_uid(uid)
+    try:
+        settings = _drei_kanal_settings(seven_io_stub.port)
+        svc = NotificationService(settings, uid)
+
+        svc.send_radar_alert(
+            trip=make_trip("trip-2046-ac7"),
+            request=RadarAlertRequest(
+                onset_minutes=25, onset_time="16:45", km_from=0.0, km_to=6.0,
+                is_convective=False, intensity_label="Mäßiger Regen",
+                source_label="Radar (DWD)", tz=ZoneInfo("Europe/Vienna"),
+                segment_id="Ziel", onset_precip_mm=2.5,
+            ),
+            source="Radar (DWD)",
+            cooldown_display="2 Stunden",
+            effective_channels={"sms", "premium_sms", "telegram"},
+            telegram_style="kurzform",
+        )
+
+        nach_ziel = {p.get("to"): p.get("text") for p in seven_io_stub.received}
+        assert set(nach_ziel) == {SMS_TO, PREMIUM_REPLY_TO}, (
+            "Erwartet je EINEN seven.io-POST fuer SMS und Premium-SMS, "
+            f"empfangen: {seven_io_stub.received!r}"
+        )
+        assert len(telegram_stub.sent) == 1, (
+            f"Erwartet genau EINE Telegram-Nachricht: {telegram_stub.sent!r}"
+        )
+
+        sms_text = nach_ziel[SMS_TO]
+        premium_text = nach_ziel[PREMIUM_REPLY_TO]
+        telegram_text = telegram_stub.sent[0].get("text") or ""
+
+        assert "R2.5@16:45" in sms_text, (
+            f"RED: die SMS nennt die Menge nicht: {sms_text!r}"
+        )
+        assert premium_text == sms_text, (
+            "RED: Premium-SMS und SMS muessen denselben Renderer-Ausgang "
+            f"tragen.\n  premium = {premium_text!r}\n  sms     = {sms_text!r}"
+        )
+        assert telegram_text == sms_text, (
+            "RED: der Telegram-Kurzstil muss denselben Text tragen wie die "
+            f"SMS.\n  telegram = {telegram_text!r}\n  sms      = {sms_text!r}"
+        )
+    finally:
+        clean_uid(uid)
+
+
+# ---------------------------------------------------------------------------
+# AC-9 — Zeichenbudget im Extremfall
+# ---------------------------------------------------------------------------
+
+
+def test_ac9_langer_ortsname_mit_extremwert_bleibt_im_zeichenbudget():
+    """AC-9 GIVEN einen Onset-Alarm mit einem 30 Zeichen langen Ortsnamen UND
+    `onset_precip_mm=99.9` (Extremfall, maximale Zeichenlaenge der Zahl)
+    WHEN `render_sms(msg, limit=140)` rendert
+    THEN bleibt der Text unter 140 Zeichen, OHNE dass der harte Schnitt
+    `body[:limit]` greift — die zusaetzliche Zahl verbraucht Zeichenbudget,
+    reisst es bei realistischen Ortsnamen aber nicht.
+
+    Reine Laengenpruefung plus Nachweis, dass die Zahl VOLLSTAENDIG dasteht
+    (ein abgeschnittener Text bestuende die Laengenpruefung sonst trivial).
+
+    RED heute: `OnsetEvent` kennt `onset_precip_mm` nicht (`TypeError`)."""
+    ortsname = "Obertilliacher Bergwiesenalm"  # 28 Zeichen + Puffer unten
+    ortsname = ortsname.ljust(30, "x")
+    assert len(ortsname) == 30, "Voraussetzung: 30-Zeichen-Ortsname"
+
+    event = OnsetEvent(
+        onset_minutes=40, onset_time="18:00", km_from=0.0, km_to=0.0,
+        is_convective=False, intensity_label="Starker Regen",
+        source_label="Radar (DWD)", location_label=ortsname,
+        onset_precip_mm=99.9,
+    )
+    msg = AlertMessage(
+        trip_short="Alpen", stand_at="17:20", events=(event,),
+        source="Radar (DWD)",
+    )
+    sms = render_sms(msg, limit=140)
+
+    assert len(sms) <= 140, (
+        f"RED: {len(sms)} Zeichen ueberschreiten das Render-Limit: {sms!r}"
+    )
+    assert "R99.9@18:00" in sms, (
+        f"RED: der Extremwert steht nicht vollstaendig in der SMS: {sms!r}"
+    )
+    assert _MENGEN_TOKEN_RE.search(sms), (
+        f"Der Mengen-Token ist beschaedigt oder abgeschnitten: {sms!r}"
+    )
+    assert sms.isascii(), f"Kurznachricht ist nicht ASCII-rein: {sms!r}"


### PR DESCRIPTION
Schließt #2046.

## Was sich ändert

Die Onset-Kurznachricht (SMS, Premium-SMS, Telegram-Kurzstil) nennt jetzt die erwartete Regenmenge:

| Zweig | vorher | nachher |
|---|---|---|
| Regen | `R@18:00` | `R2.5@18:00` |
| Gewitter | `TH@18:00` | `TH@18:00 R2.5` |

Im Gewitter-Zweig steht die Zahl bewusst als **eigenes Token nach der Zeit** — hinter `TH` bleibt die Stufen-Position für `L`/`M`/`H` frei.

## Die wesentliche Entscheidung: ab wann wird gemessen?

Die Menge wird über 60 Minuten **ab Beginn des Ereignisses** akkumuliert, nicht ab dem Versandzeitpunkt. Der Unterschied ist nicht kosmetisch: Beginnt der Regen in 50 Minuten und fällt dann mit 12 mm/h, weist ein Fenster „ab jetzt" nur rund 2 mm aus — die Zahl würde den Alarm, an dem sie hängt, selbst entwerten. Ab Beginn gerechnet sind es rund 12 mm.

AC-3 nagelt genau das mit einem durchgerechneten Gegenbeispiel fest; der Test schlägt rot, sollte die Rechnung je wieder auf „ab jetzt" rutschen.

## Ausweichform

Ohne belastbare Zahl (`None`, unter 0,1 mm, Daten nicht verfügbar, gedrosselt) bleibt die bisherige zahlenlose Form. `R0.0@18:00` entsteht nie — die Anzeige unterscheidet nicht zwischen „nicht berechenbar" und „praktisch null", also zeigt sie in beiden Fällen keine Zahl.

## Unberührt

- E-Mail- und Telegram-**Langform** — zeichengleich zum Vorzustand
- Die #2020-Auslöseregel (`radar_alert_due`)
- `onset_minutes`, `window_precip_mm`, `max_rate_mm_h`
- Alle neuen Felder sind additiv mit Default `None`, Alt-Aufrufer brechen nicht

## Nachweise

- **Adversary VERIFIED**, 15/15 Checkpunkte, 2 Runden. Mutations-Gegenprobe: 10 gezielte Verfälschungen, 9 von Tests gefangen.
- Die eine, die durchrutschte, ist behoben: AC-8 verlangt eine Absicherung, dass die Langform die neue Zahl nicht liest — die fehlte. Die E-Mail-Langform ließ sich die Zahl mitlesen, ohne dass einer von 101 Tests rot wurde. Nachgezogen in `tests/tdd/test_onset_langform_ignoriert_menge.py`, diesmal mit belegter Gegenprobe (beide Wächter werden rot).
- Feature-Suite: 119 grün.
- CI-äquivalenter Gesamtlauf: 10.443 grün. Zwei Fehlschläge (`test_issue_1014_live_optin`, `test_issue_937_staging_rolling_trip`) sind isoliert nachgefahren grün — Umgebungsrauschen aus der Testreihenfolge, keine Berührung mit den geänderten Dateien.

## Umfang

+161 LoC Produktivcode (Limit 250). Acht Produktivdateien — über der Richtgröße 4–5, davon aber vier reine Einzeiler-Durchreichungen des neuen Feldes durch die Wirkkette (Service → Renderer → Kanal → Vorschau-Endpunkt). So in der freigegebenen Spec benannt.

## Abgrenzung zu #2020

Beide Tickets fassen die Alarm-Kurzform an. Geprüft und ausgeschlossen, dass sich die Zeichenbudgets addieren: `_render_sms_body` (`render.py:1107-1108`) verzweigt über `msg.source` mit einem frühen Return — Onset und Abweichung werden nie in denselben Text gerendert, jeder Zweig hat sein eigenes Limit.

Folgeticket aus dieser Arbeit: #2054 (Wochentagskürzel statt `+1` bei Mitternachts-Überlauf).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EFcJf9fFxdZcaWa4USsLRy
