### PR TITLE
test(#2050 S1): Alarm-Prüfstrecke — Zeitreihe gegen die echte Auslöseentscheidung

### DIFF
--- a/docs/context/feat-2050-s1-pruefstrecke.md
+++ b/docs/context/feat-2050-s1-pruefstrecke.md
@@ -1,0 +1,228 @@
+# Context: feat-2050-s1-pruefstrecke
+
+Issue #2050, Scheibe 1 — Prüfstrecke: Einspeisung in die Auslöseentscheidung + vorbelegbarer Zustand.
+Erhoben 2026-08-21 auf `b423c913` über drei parallele Explore-Läufe, alle Kernaussagen am Code nachgeprüft.
+
+## Request Summary
+
+Alarm-Szenarien sollen als **Zeitreihe mit Gedächtnis** gegen die *echte* Auslöseentscheidung
+gefahren werden können — mehrere Prüfläufe hintereinander, mit stellbarer Uhr, vorbelegtem
+Zustand und Abgriff aller vier Kanäle ohne echten Versand.
+
+## Zentrale Korrektur am Issue-Bild
+
+Das Issue nennt zwei fehlende Bausteine: „Einspeisung in die Auslöseentscheidung" und
+„vorbelegbarer Zustand". **Beide existieren bereits** — nur unverbunden und ungesichert.
+Der Aufwand liegt woanders.
+
+| Issue sagt | Tatsächlich |
+|---|---|
+| Einspeisung fehlt | `check_and_send_alerts(trip, cached_weather, fresh_weather, official_notices)` nimmt die Daten als Parameter (`trip_alert.py:216`). Radar-Pfad über `_get_radar_service()` (`trip_alert.py:1100`) per Unterklasse ersetzbar. |
+| Vorbelegbarer Zustand fehlt | Alle sechs Zustandsspeicher haben öffentliche Schreibwege (Tabelle unten); `tests/tdd/test_issue_1070_daily_alert_limit.py:643` fährt damit bereits eine echte Mehrlauf-Zeitreihe. |
+| Stellbare Uhr „teils vorhanden" | `freezegun` ist etabliert (~30 Testdateien). Was fehlt, ist die Absicherung für *mehrere* Läufe im selben Prozess. |
+| Alle vier Kanäle abgreifbar | Nur E-Mail in-process. Telegram/SMS/Premium-SMS brauchen einen lokalen HTTP-Stub, weil `TripAlertService` `sms_sink`/`telegram_sink` nicht durchreicht. |
+
+**Der `alert-preview`-Endpoint aus #1948 S2 ist nicht defekt.** Er ist laut eigener Spec
+(`docs/specs/modules/alarm_testeinspeisung.md:20`) und Docstrings bewusst zustandslos und
+für den *Textbau* gebaut. S1 repariert ihn nicht, sondern baut daneben.
+
+## Die drei Auslösepfade
+
+Kein gemeinsamer Trichter. `check_all_trips()` (`trip_alert.py:475`) bündelt zwei der drei
+Arten in einer Trip-Schleife; Radar läuft als eigener Cron mit eigener Schleife.
+
+| Zweig | Entscheidungspunkt | Naht zum Textbau |
+|---|---|---|
+| Vorhersage-Abweichung | `check_and_send_alerts()` `trip_alert.py:216-456`, 9 Gate-Stufen | `NotificationService.send_deviation_alert` (`:1727`) |
+| Amtliche Warnung | `_send_official_alert_only()` `trip_alert.py:1885-2022` | `send_official_alert` (`:1970`) |
+| Radar/Nowcast | inline in `check_radar_alerts()` `trip_alert.py:1140-1623`, 9 Stufen | `send_radar_alert` (`:1546`) |
+
+Geteilte Gate-Bausteine für Trip **und** Ortsvergleich: `src/services/alert_gate.py` —
+`check_nowcast_gate:140`, `check_official_alert_gate:187`, `check_briefing_imminent:282`,
+`check_event_identity_gate:617`, `record_event_identity:695`.
+
+**Gemeinsames Muster aller drei Pfade:** Zustand wird erst *nach* bestätigter Zustellung
+fortgeschrieben (`:430-454`, `:1998-2021`, `:1589-1620`). Ein Szenario muss also zwischen
+„entschieden" und „gebucht" unterscheiden können.
+
+## Zustandsspeicher (alle unter `get_data_dir(user_id)`)
+
+| Zustand | Datei | Schreibweg |
+|---|---|---|
+| Melde-Gedächtnis + amtliches Gedächtnis + Event-Identität | `alert_state/<entity_id>.json` | `AlertStateService.save` (`alert_state.py:73`) |
+| Sperrzeit/Cooldown, alle Scopes | `throttle_state.json` | `ThrottleStore.record` (`throttle_store.py:36-90`) |
+| Tageszähler | `alert_daily_count.json` | `alert_daily_limit.increment` (`:110`) |
+| Briefing-Anker | `briefing_anchor.json` | `record_briefing_sent` (`alert_briefing_anchor.py:192`) |
+| Rollierender Δ-Vergleichspunkt | `weather_snapshots/<trip_id>_alarm_anchor_<channel>.json` | `WeatherSnapshotService.save_alarm_anchor` (`:225`) |
+| Alarm-Protokoll | `alert_log.json` | `alert_log.append_entry` / `append_suppressed_entry` |
+
+Drei Präfixe teilen sich `alert_state`: blank (Metrik/Segment), `official_alert:`,
+`event_identity:`. `reset()` behält **nur** `official_alert:` — jeder andere Präfix fällt
+beim Briefing-Reset weg (`alert_state.py:38-45`).
+
+## Zeitsteuerung — der eigentliche Knackpunkt
+
+Kein Entscheidungs-Eintrittspunkt nimmt einen Zeitpunkt entgegen:
+
+- `check_and_send_alerts()` liest „jetzt" in **einem** Lauf mindestens viermal aus drei
+  Funktionen (`trip_alert.py:279`, `:999`, `deviation_alert_engine.py:284`, Buchung `:430`/`:440`).
+- `check_radar_alerts()` — kein Parameter, fest bei `:1158`.
+- `check_official_alert_triggers(trip, now_utc=None)` nimmt einen Zeitpunkt, reicht ihn an
+  `_get_cached_weather` (`:1789`) — und **überschreibt ihn dann bedingungslos** bei `:1811`.
+  Am Code nachgeprüft. Heute folgenlos (beide Werte liegen Millisekunden auseinander), aber
+  eine gestellte Uhr wird hier still verworfen.
+
+Rohe `datetime.now(`-Fundstellen im Alarm-Pfad: `trip_alert.py:279,430,440,500,695,767,823,999,
+1027,1158,1415,1604,1619,1646,1811,1900,2000,2020` · `deviation_alert_engine.py:284` ·
+`alert_briefing_anchor.py:91,135,207,343` · `alert_log.py:364,462` · `alert_input_capture.py:66,104`.
+
+Sauber injizierbar sind dagegen **alle** `alert_gate.py`-Funktionen (Pflicht-`now`, kein Fallback)
+und `radar_service.py:193` (echter `now_fn`-Hook).
+
+**Folgerung:** Ein `now=`-Parameter durchzureichen wäre ein eigener, breiter Umbau mit genau der
+Falle, die `:1811` schon zeigt. Für S1 ist `freezegun` pro Lauf der tragfähige Weg.
+
+## Mehrlauf-Risiken (der neue Teil)
+
+1. **Singleton-Caches** überleben den einzelnen Lauf. `tests/conftest.py` setzt sie heute
+   *pro Test* zurück: Radar (`:279`), Wetter (`:308`), Thunder-Window (`:294`),
+   Telegram-Rate-Limit (`:323`). Innerhalb einer Zeitreihe im selben Test greift das nicht —
+   Lauf 2 sähe den Cache von Lauf 1. Vgl. die schon bekannte Lehre aus #2018.
+2. **`freeze_time` mehrfach im selben Prozess** ist laut `tests/helpers/wanduhr_matrix.py:12-25`
+   riskant, sobald pydantic-v1-Importpfade berührt werden — dort wurde deshalb auf
+   Subprozess-Isolation ausgewichen. Für S1 zu klären, ob der Alarmpfad das trifft.
+3. **Fixture-Zeitanker folgt der gestellten Uhr.** `FixtureProvider` verankert seine Punkte über
+   `datetime.now()` (`src/providers/fixture.py:110`) — unter `freeze_time` also am gestellten Tag.
+   Das ist günstig, aber es bindet Szenariodaten an das Zeitfenster.
+
+## Kanal-Abgriff ohne Versand
+
+| Kanal | Weg | Beleg |
+|---|---|---|
+| E-Mail | `mail_sink`-Callback, in-process | `trip_alert.py:185`, `notification_service.py:906` |
+| Telegram | lokaler HTTP-Stub (`TELEGRAM_API_BASE` umgebogen) | `tests/tdd/test_radar_alert_telegram_style.py:65-157` |
+| SMS | lokaler HTTP-Stub (`sms_gateway_url`) | `tests/tdd/test_issue_936_sms_stub.py:27,83` |
+| Premium-SMS | derselbe Stub, geteilte Basis `seven_io_base.py` | `tests/unit/test_premium_sms_versand.py:71-173` |
+
+`NotificationService` kennt `sms_sink`/`telegram_sink`, `TripAlertService` reicht sie nicht
+durch (`PremiumSmsOutput(...)` direkt bei `trip_alert.py:956,1264`). Trifft Anforderung D-1.
+
+## Vorbild-Harness
+
+`tests/tdd/test_952_onset_alert_fidelity.py` (818 Zeilen), von zwei weiteren Testdateien
+importiert: `_GuaranteedWetRadar(RadarNowcastService)` als echte Unterklasse statt Mock (`:101`),
+`_trip_with_active_segment` (`:150`), `_clean_user` (`:180`), `_SevenStub` (`:187`).
+Keine Zeitreihe — das wäre das Neue.
+
+Isolationsfundament: `tests/conftest.py:121` `_isolate_data_root` leitet den Datenbaum pro Test
+auf ein temporäres Verzeichnis um und failt, wenn doch in den echten Baum geschrieben wird.
+
+## Provider-Fixtures
+
+`fixtures/openmeteo/{stubai,zillertal,innsbruck}.json` — Auswahl geografisch über `_nearest()`
+(`src/providers/fixture.py:98`), umschaltbar über `GZ_TEST_FIXTURE_DIR` (`tests/conftest.py:20`).
+Radar: `fixtures/radar/minutely_15.json`. Amtlich: `tests/fixtures/meteoalarm{,_feed}/`.
+Szenarioeigene Daten sind also über ein eigenes Fixture-Verzeichnis einspeisbar.
+
+## Risiken
+
+- **Gestubbte Naht verdeckt alles darunter.** Fährt die Prüfstrecke an den Gates vorbei, sind
+  ihre grünen Szenarien wertlos — das ist genau der Defekt, den #2050 abstellen will. Muss
+  Negativ-AC werden: eine Mutation an einer Gate-Stufe MUSS ein Szenario rot färben.
+- **Zustand nur schreiben, nicht lesen.** Ein Szenario, das Zustand vorbelegt, aber nicht
+  nachweist, dass die Entscheidung ihn gelesen hat, prüft nichts.
+- **Cache-Durchschlag zwischen den Läufen einer Zeitreihe** (s.o.) — würde falsches Grün liefern.
+- **`alert_state`-Reset-Asymmetrie**: `reset()` verwirft `event_identity:`-Schlüssel still.
+  Ein Szenario über Briefing-Grenzen hinweg muss das berücksichtigen.
+
+## Nicht Teil von S1
+
+Die zwölf Szenarien selbst (S2–S5), die Protokollergänzung (S6), Ortsvergleich-Pendants,
+und ein durchgängiger `now=`-Umbau des Alarmpfads.
+
+---
+
+## Analysis (Phase 2, 2026-08-21)
+
+### Type
+Feature — neue Test-Infrastruktur, kein Produktivcode-Defekt.
+
+### Entschiedener Ansatz
+
+**Helper-Klasse, keine Fixture-Familie.** Fixtures sind pro Test gebunden; gebraucht wird ein
+Objekt, das *innerhalb* eines Tests mehrfach „Lauf" macht und Historie hält.
+
+`TripAlertService` wird **pro Lauf neu gebaut** — genau wie in Produktion, wo jeder Cron-Tick
+eine frische Instanz erzeugt. Die Kontinuität kommt vom Datenträger unter `get_data_dir(user_id)`,
+nicht vom Python-Objekt. Das macht die Strecke treuer zur echten Auslösung, nicht nur bequemer.
+
+| Datei | Aktion | LoC |
+|---|---|---|
+| `tests/helpers/alarm_pruefstrecke.py` | CREATE | ~190 |
+| `tests/tdd/test_2050_s1_alarm_pruefstrecke_selbstschutz.py` | CREATE | ~110 |
+
+Kern: `AlarmPruefstrecke.lauf(at=..., zweig="deviation"|"official"|"radar", ...)` →
+Cache-Reset → `freeze_time(at)` → frische `TripAlertService` → passender Einstiegspunkt →
+`AlarmPruefstreckeLauf(triggered_count, mail, telegram, sms, premium_sms)`.
+
+### Empirisch geklärt (nicht vermutet)
+
+- **Mehrfaches `freeze_time` im selben Prozess trägt.** Gemessen 2026-08-21 auf `b423c913`:
+  drei aufeinanderfolgende Fenster (14:00 / 14:30 / 23:50 UTC) nach Import von `trip_alert`
+  und `DeviationAlertEngine`, alle drei liefern die gestellte Zeit. Der in
+  `wanduhr_matrix.py:11-21` beschriebene Risikofall betrifft *sitzungsweites* Einfrieren **vor**
+  den Pydantic-v1-Importen — nicht kurze Einzelläufe nach der Testsammlung.
+  **Folge: keine Subprozess-Isolation nötig.**
+  Abgrenzung: gemessen ist die Prozess-Verträglichkeit, nicht ein vollständiger
+  `check_and_send_alerts`-Lauf unter Freeze. Den deckt Schritt 1 der Reihenfolge ab.
+- **Die vier Cache-Resets sind aufrufbare Funktionen**, nicht nur Fixtures — am Quellcode
+  bestätigt: `radar_cache.py:136`, `weather_cache.py:319`, `thunder_window_cache.py:166`,
+  `telegram.py:650`. Die autouse-Fixtures greifen nur einmal pro Test; der Harness ruft sie
+  zu Beginn **jedes Laufs** selbst. Kein neuer Reset-Code nötig.
+
+### Kanal-Abgriff: HTTP-Stub für alle drei Nicht-Mail-Kanäle
+
+Trade-off: Sinks durchreichen wäre leichtgewichtiger pro Lauf, verlangt aber eine neue
+Produktivcode-Naht allein für den Test — Premium-SMS hat **gar keinen** Sink-Parameter
+(`PremiumSmsOutput(...)` steht unbedingt bei `notification_service.py:956,1264`).
+**Entscheidung: lokaler HTTP-Stub**, E-Mail bleibt `mail_sink` in-process. Bei einer Strecke,
+die die echte Entscheidung ungeschminkt zeigen soll, wiegt „null Produktivcode-Änderung"
+schwerer als der Server-Start pro Lauf.
+
+### Selbstschutz — Kern der Scheibe, nicht Beiwerk
+
+Ein Meta-Test sperrt je Zweig einen echten Gate-Baustein per `monkeypatch.setattr` auf dem
+Modul (etabliertes Muster, kein Mock) und verlangt danach `triggered_count == 0` und leere
+Kanal-Listen. Läuft die Strecke trotz erzwungener Sperre durch, ist sie an der Entscheidung
+vorbeigefahren — **das muss rot werden**. Ohne diesen Nachweis produziert die Prüfstrecke
+genau das wertlose Grün, das #2050 abstellen will.
+
+### Reihenfolge
+
+1. Cache-Reset + Mehrlauf-Smoke (blockiert alles andere, wenn falsch)
+2. Harness nur Deviation-Zweig, nur `mail_sink`, gegen ein bekanntes Szenario aus `test_952`
+3. Selbstschutz-Meta-Test für Deviation — grün/rot verifiziert, **bevor** mehr draufkommt
+4. Radar- und Amtlich-Zweig samt Gegenproben
+5. Telegram/SMS/Premium-SMS-Stubs
+
+### Scope
+
+~300 LoC, über dem 250-Limit. **Keine künstliche Teilung**: eine Prüfstrecke ohne ihren eigenen
+Bypass-Nachweis ist der Defekt, den die Scheibe abstellen soll. `loc_limit_override 500` zu
+Beginn setzen.
+
+Risk Level: **LOW** für Produktion (kein Produktivcode geändert), **MEDIUM** für die Scheibe
+selbst (falsches Grün wäre schlimmer als kein Test).
+
+### Harness-Grenzen (dokumentieren, nicht lösen)
+
+- `alert_state.reset()` verwirft `event_identity:`-Schlüssel still (`alert_state.py:38-45`) —
+  Szenarien über eine Briefing-Grenze verlieren Vorbelegung unbemerkt. Sache von S2+.
+- Premium-SMS teilt die Stub-Basis mit SMS (`seven_io_base.py`) → zwei Ports nötig, sonst
+  überschreiben sich die Empfangslisten.
+- `check_official_alert_triggers(now_utc=...)` verwirft den Parameter (`trip_alert.py:1811`).
+  Der Harness bietet `now_utc=` deshalb **gar nicht** als Steuerweg an — sonst suggeriert er
+  eine Wirkung, die es nicht gibt. Steuerung ausschließlich über die gestellte Uhr.
+
+### Open Questions
+Keine offenen technischen Fragen. Die Spec kann geschrieben werden.

--- a/docs/specs/modules/alarm_pruefstrecke.md
+++ b/docs/specs/modules/alarm_pruefstrecke.md
@@ -174,14 +174,14 @@ Eingangsdaten dafür sprächen).
   `monkeypatch.setattr` auf dem Modul erzwungen gesperrt, When ein Prüflauf mit einer amtlichen
   Warnung gefahren wird, die ohne die Sperre einen Versand auslösen würde, Then liefert der Lauf
   `triggered_count == 0` und leere Kanal-Listen für alle vier Kanäle.
-  - Test: amtliche Testmeldung als Eingangsdaten, `check_official_alert_gate` sperren,
+  - Test: amtliche Testmeldung als Eingangsdaten, `check_official_alert_gate` **auf `trip_alert`** sperren,
     Nullbefund über alle vier Kanäle nachweisen.
 
 - **AC-6:** Given der Radar-Zweig-Gate-Baustein (`check_nowcast_gate`) wird per
   `monkeypatch.setattr` auf dem Modul erzwungen gesperrt, When ein Prüflauf mit
   Nowcast-Frames gefahren wird, die ohne die Sperre einen Onset-Alarm auslösen würden, Then
   liefert der Lauf `triggered_count == 0` und leere Kanal-Listen für alle vier Kanäle.
-  - Test: Frames-Fixture mit garantiertem Onset (`_GuaranteedWetRadar`-Muster), Gate sperren,
+  - Test: Frames-Fixture mit garantiertem Onset (`_GuaranteedWetRadar`-Muster), `check_nowcast_gate` **auf `trip_alert`** sperren,
     Nullbefund über alle vier Kanäle nachweisen.
 
 - **AC-7:** Given ein Prüflauf wird mit vorbelegtem Zustand gestartet, der die Auslöseentscheidung
@@ -240,3 +240,24 @@ Eingangsdaten dafür sprächen).
 - 2026-08-21: Testdateiname korrigiert (`test_alarm_pruefstrecke_selbstschutz.py` statt
   Issue-Nummer im Namen, CLAUDE.md-Regel „Testdateien nach Verhalten benennen"), Pfadauflösung
   relativ zur Testdatei ergänzt, AC-4 auf reines Beobachtungsergebnis umformuliert.
+
+## Nachtrag 2026-08-21: Wo die Gate-Sperre ansetzen muss
+
+Beim Schreiben der RED-Tests am Code festgestellt und verifiziert — die Sperre aus AC-4 bis AC-6
+muss je Baustein an einem **anderen Modul** ansetzen, sonst wirkt sie nicht:
+
+| AC | Baustein | Patch-Ziel | Warum |
+|---|---|---|---|
+| AC-4 | `check_briefing_imminent` | `alert_gate` | `trip_alert.py:967` importiert ihn **lokal pro Aufruf** — der Patch auf `alert_gate` wird bei jedem Aufruf frisch gezogen und wirkt. |
+| AC-5 | `check_official_alert_gate` | `trip_alert` | Auf **Modulebene** importiert (`trip_alert.py:22-27`), damit fest an `trip_alert` gebunden. |
+| AC-6 | `check_nowcast_gate` | `trip_alert` | dito. |
+
+Ein Patch auf `alert_gate` würde bei AC-5/AC-6 ins Leere laufen: die realen Aufrufe bei
+`trip_alert.py:1239` und `:1901` blieben unverändert, der Lauf löste trotz „Sperre" aus, und der
+Test wäre rot **aus dem falschen Grund** — nicht weil die Prüfstrecke etwas gefangen hat, sondern
+weil die Sperre nie scharf war. Das etablierte Muster dafür steht in
+`tests/tdd/test_issue_1088_official_alert_triggers.py:800,848`, das dieselben zwei Bausteine
+ebenfalls auf `trip_alert` patcht.
+
+Die Acceptance Criteria selbst sind davon unberührt — geprüft wird unverändert die Wirkung
+(`triggered_count == 0`, leere Kanal-Listen), präzisiert wurde nur der technische Angriffspunkt.

--- a/docs/specs/modules/alarm_pruefstrecke.md
+++ b/docs/specs/modules/alarm_pruefstrecke.md
@@ -1,0 +1,242 @@
+---
+entity_id: alarm_pruefstrecke
+type: feature
+created: 2026-08-21
+updated: 2026-08-21
+status: approved
+workflow: feat-2050-s1-pruefstrecke
+version: "1.0"
+tags: [alarm, testing, harness]
+---
+
+# Alarm-Prüfstrecke (Scheibe S1, Issue #2050)
+
+## Approval
+
+- [x] Approved — PO ("go"), 2026-08-21
+
+## Purpose
+
+Alarm-Szenarien lassen sich heute nicht als **Zeitreihe mit Gedächtnis** gegen die *echte*
+Auslöseentscheidung fahren — es gibt keinen wiederverwendbaren Harness, der mehrere Prüfläufe
+hintereinander mit stellbarer Uhr, vorbelegtem Zustand und Abgriff aller vier Kanäle ohne echten
+Versand durchführt. Diese Scheibe baut genau diese Strecke (`AlarmPruefstrecke`) samt ihrem
+eigenen Selbstschutz-Nachweis. Sie ersetzt NICHT den zustandslosen `alert-preview`-Endpoint aus
+#1948 S2 (`docs/specs/modules/alarm_testeinspeisung.md`) — der bleibt für den Textbau zuständig,
+diese Scheibe für die Auslöseentscheidung selbst. Die zwölf Alarm-Szenarien, die auf dieser
+Strecke laufen sollen, sind spätere Scheiben (S2–S5) und nicht Teil dieser Spec.
+
+## Source
+
+- **File:** `tests/helpers/alarm_pruefstrecke.py` (neu), `tests/tdd/test_alarm_pruefstrecke_selbstschutz.py` (neu)
+- **Identifier:** `AlarmPruefstrecke`, `AlarmPruefstreckeLauf`
+
+> Schicht: Python-Core-Testinfrastruktur (`tests/helpers/`, `tests/tdd/`) — kein Produktivcode
+> in `src/`/`api/` wird geändert, kein Go-/Frontend-Anteil.
+
+## Estimated Scope
+
+- **LoC:** ~300 (Helper ~190, Selbstschutz-Test ~110) — über dem 250-LoC-Standardlimit,
+  `loc_limit_override 500` ist bereits gesetzt (Begründung: eine Prüfstrecke ohne ihren eigenen
+  Bypass-Nachweis ist der Defekt, den #2050 abstellen soll — künstliche Teilung würde genau den
+  Nachweis von der Strecke trennen, die er absichert).
+- **Files:** 2 neue Testdateien
+- **Effort:** medium
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `src/services/trip_alert.py::TripAlertService.check_and_send_alerts` (`:216-456`) | method | Deviation-Zweig-Entscheidungspunkt, nimmt `trip, cached_weather, fresh_weather, official_notices` als Parameter |
+| `src/services/trip_alert.py::TripAlertService._send_official_alert_only` (`:1885-2022`) | method | Amtlicher Zweig-Entscheidungspunkt |
+| `src/services/trip_alert.py::TripAlertService.check_radar_alerts` (`:1140-1623`) | method | Radar/Nowcast-Zweig, Ersetzung des Radar-Providers über `_get_radar_service()` (`:1100`) per echter Unterklasse |
+| `src/services/alert_gate.py` | module | Geteilte Gate-Bausteine (`check_nowcast_gate:140`, `check_official_alert_gate:187`, `check_briefing_imminent:282`, `check_event_identity_gate:617`, `record_event_identity:695`) — Ziel der Selbstschutz-Sperren |
+| Vier Cache-Reset-Funktionen: `services/radar_cache.py:136`, `services/weather_cache.py:319`, `services/thunder_window_cache.py:166`, `output/channels/telegram.py:650` | function | Zu Beginn jedes Laufs aufgerufen, um Mehrlauf-Cache-Durchschlag auszuschließen |
+| `tests/tdd/test_952_onset_alert_fidelity.py::_GuaranteedWetRadar` (`:101`) | class | Vorbild-Muster: echte `RadarNowcastService`-Unterklasse als DI-Seam statt Mock |
+| `tests/tdd/test_issue_1070_daily_alert_limit.py:643` | test | Bestehender Beleg, dass Mehrlauf-Zeitreihen über die vorhandenen Zustandsspeicher bereits funktionieren |
+| `freezegun` | library | Zeitsteuerung pro Lauf; etabliert in ~30 Testdateien des Projekts |
+| `app.loader::get_data_dir` | function | Ort aller sechs Zustandsspeicher, pro Test durch `tests/conftest.py:121` (`_isolate_data_root`) isoliert |
+
+## Implementation Details
+
+### `AlarmPruefstrecke.lauf(...)` — ein Prüflauf
+
+```
+AlarmPruefstrecke.lauf(
+    at: datetime,                       # gestellte Uhrzeit, per freeze_time
+    zweig: Literal["deviation", "official", "radar"],
+    trip: Trip,
+    ...zweigspezifische Eingabedaten (cached_weather/fresh_weather/official_notices
+        für "deviation", official_notices für "official", Frames/Provider für "radar"),
+) -> AlarmPruefstreckeLauf
+```
+
+**Pfadauflösung:** `test_alarm_pruefstrecke_selbstschutz.py` importiert `AlarmPruefstrecke` und
+alle Produktivmodule (`src/services/...`) relativ zur eigenen Testdatei bzw. über den regulären
+`sys.path`/`conftest.py`-Mechanismus der Testsuite — nie über einen fest eingetragenen
+Hauptrepo-Pfad. Sonst prüft ein Lauf aus diesem Worktree den Code eines anderen Checkouts und
+liefert falsches Grün.
+
+Ablauf je Lauf:
+
+1. Vier Cache-Resets aufrufen (Radar, Wetter, Thunder-Window, Telegram-Rate-Limit) — jeder Lauf
+   startet mit leeren Singleton-Caches, unabhängig davon, was ein vorheriger Lauf im selben Test
+   gefüllt hat.
+2. `freeze_time(at)` setzen.
+3. Frische `TripAlertService`-Instanz bauen (kein Wiederverwenden über Läufe hinweg — Kontinuität
+   kommt ausschließlich vom Datenträger unter `get_data_dir(user_id)`, genau wie in Produktion,
+   wo jeder Cron-Tick eine neue Instanz erzeugt).
+4. Den zum `zweig` passenden Entscheidungs-Einstiegspunkt real aufrufen.
+5. Ergebnis in `AlarmPruefstreckeLauf(triggered_count, mail, telegram, sms, premium_sms)`
+   einsammeln.
+
+`now_utc=` wird **bewusst nicht** als Steuerparameter angeboten: `check_official_alert_triggers`
+nimmt zwar `now_utc` entgegen, verwirft ihn aber bedingungslos bei `trip_alert.py:1811` und liest
+stattdessen selbst `datetime.now()`. Einen Parameter anzubieten, den der Produktivcode ignoriert,
+würde eine Wirkung suggerieren, die es nicht gibt. Einzige Zeitsteuerung ist die gestellte Uhr
+(`freeze_time`).
+
+### Kanal-Abgriff ohne echten Versand
+
+- **E-Mail:** `mail_sink`-Callback, in-process (`trip_alert.py:185`, `notification_service.py:906`).
+- **Telegram, SMS, Premium-SMS:** lokale HTTP-Stub-Server, analog
+  `tests/tdd/test_radar_alert_telegram_style.py:65-157` (Telegram) und
+  `tests/tdd/test_issue_936_sms_stub.py:27,83` (SMS). Premium-SMS teilt die Stub-Basis mit SMS
+  (`services/seven_io_base.py`) — die Strecke muss dafür **zwei getrennte Ports** verwenden, sonst
+  überschreiben sich die beiden Empfangslisten.
+
+Kein Produktivcode wird geändert: `TripAlertService` reicht `sms_sink`/`telegram_sink` nicht
+durch (`PremiumSmsOutput(...)` steht unbedingt bei `trip_alert.py:956,1264`), daher HTTP-Stub statt
+Sink-Parameter für alle drei Nicht-Mail-Kanäle.
+
+### Zustand vorbelegen und lesen
+
+Alle sechs Zustandsspeicher (Melde-/amtliches Gedächtnis + Event-Identität in
+`alert_state/<entity_id>.json`, Cooldown in `throttle_state.json`, Tageszähler in
+`alert_daily_count.json`, Briefing-Anker in `briefing_anchor.json`, Δ-Vergleichspunkt in
+`weather_snapshots/...`, Alarm-Protokoll in `alert_log.json`) haben bereits öffentliche
+Schreibwege (`AlertStateService.save`, `ThrottleStore.record`, `alert_daily_limit.increment`,
+`record_briefing_sent`, `WeatherSnapshotService.save_alarm_anchor`, `alert_log.append_entry`).
+Die Prüfstrecke ruft diese Schreibwege vor einem Lauf auf, um Zustand vorzubelegen, und weist
+danach über eine beobachtbare Wirkung nach, dass die Entscheidung den vorbelegten Zustand
+tatsächlich gelesen hat (z. B. Cooldown-Vorbelegung ⇒ Lauf löst NICHT aus, obwohl die
+Eingangsdaten dafür sprächen).
+
+## Expected Behavior
+
+- **Input:** ein `Trip`-Fixture, ein `zweig`, eine gestellte Uhrzeit, zweigspezifische
+  Eingangsdaten (Wetteränderungen/amtliche Meldungen/Radar-Frames), optional vorbelegter Zustand.
+- **Output:** `AlarmPruefstreckeLauf` mit Auslösezähler und den vier Kanal-Ausgaben (leer, wenn
+  nichts ausgelöst wurde).
+- **Side effects:** reale Schreibvorgänge in die sechs Zustandsspeicher unter dem pro-Test
+  isolierten `get_data_dir(user_id)` (durch `_isolate_data_root` isoliert) — kein echter
+  Mail-/SMS-/Telegram-Versand, keine Persistenz außerhalb des Test-Datenbaums.
+
+## Acceptance Criteria
+
+- **AC-1:** Given zwei aufeinanderfolgende Läufe derselben Prüfstrecke für denselben Trip und
+  Zweig, wobei der erste Lauf eine Auslösung bucht, When der zweite Lauf mit frisch gebauter
+  `TripAlertService`-Instanz gestartet wird, Then liest der zweite Lauf nachweislich den vom
+  ersten Lauf geschriebenen Zustand (z. B. greift ein Cooldown, der erst durch den ersten Lauf
+  entstanden ist).
+  - Test: Lauf 1 löst aus und bucht Cooldown/Alert-State; Lauf 2 mit identischen
+    Eingangsdaten prüfen — `triggered_count == 0` wegen des gebuchten Zustands, nicht wegen
+    unveränderter Eingangsdaten.
+
+- **AC-2:** Given derselbe Prüflauf (identische Eingangsdaten, identischer Zweig) wird einmal mit
+  gestellter Uhr zu einem Zeitpunkt innerhalb und einmal zu einem Zeitpunkt außerhalb eines
+  zeitabhängigen Gates (z. B. Nachtruhe/Briefing-Fenster) ausgeführt, When beide Läufe verglichen
+  werden, Then treffen sie nachweislich unterschiedliche Auslöseentscheidungen (`triggered_count`
+  unterscheidet sich zwischen den beiden gestellten Zeitpunkten).
+  - Test: zwei Läufe mit `freeze_time` auf zwei verschiedene, gate-relevante Uhrzeiten,
+    `triggered_count` beider Läufe vergleichen und Ungleichheit nachweisen.
+
+- **AC-3:** Given Lauf 1 füllt einen der vier Singleton-Caches (Radar, Wetter, Thunder-Window,
+  Telegram-Rate-Limit) mit Daten, die eine Auslösung in Lauf 2 verfälschen würden, When Lauf 2
+  über dieselbe Prüfstrecke im selben Testprozess gestartet wird, Then sieht Lauf 2 nachweislich
+  nicht die Cache-Daten von Lauf 1 (Entscheidung von Lauf 2 hängt ausschließlich von seinen
+  eigenen Eingangsdaten ab, nicht von denen aus Lauf 1).
+  - Test: Lauf 1 mit Eingangsdaten füttern, die (ohne Reset) den Cache so besetzen würden, dass
+    Lauf 2 fälschlich auslöst oder fälschlich nicht auslöst; Lauf 2 mit neutralen Eingangsdaten
+    fahren und das cache-unabhängige Ergebnis nachweisen.
+
+- **AC-4:** Given der Briefing-Nähe-Gate-Baustein des Deviation-Zweigs
+  (`alert_gate.check_briefing_imminent`) wird per `monkeypatch.setattr` auf dem Modul erzwungen
+  gesperrt (liefert immer "nicht senden"), When ein Prüflauf mit Eingangsdaten gefahren wird, die
+  ohne die Sperre eine Auslösung erzeugen würden, Then liefert der Lauf `triggered_count == 0`
+  und leere Kanal-Listen für alle vier Kanäle.
+  - Test: bekanntes Auslöse-Szenario aus `test_952_onset_alert_fidelity.py` als Eingangsdaten
+    verwenden, `check_briefing_imminent` sperren (NICHT `check_nowcast_gate` — das ist der
+    Radar-Baustein aus AC-6), `triggered_count == 0` und leere
+    `mail`/`telegram`/`sms`/`premium_sms` nachweisen.
+
+- **AC-5:** Given der amtliche Zweig-Gate-Baustein (`check_official_alert_gate`) wird per
+  `monkeypatch.setattr` auf dem Modul erzwungen gesperrt, When ein Prüflauf mit einer amtlichen
+  Warnung gefahren wird, die ohne die Sperre einen Versand auslösen würde, Then liefert der Lauf
+  `triggered_count == 0` und leere Kanal-Listen für alle vier Kanäle.
+  - Test: amtliche Testmeldung als Eingangsdaten, `check_official_alert_gate` sperren,
+    Nullbefund über alle vier Kanäle nachweisen.
+
+- **AC-6:** Given der Radar-Zweig-Gate-Baustein (`check_nowcast_gate`) wird per
+  `monkeypatch.setattr` auf dem Modul erzwungen gesperrt, When ein Prüflauf mit
+  Nowcast-Frames gefahren wird, die ohne die Sperre einen Onset-Alarm auslösen würden, Then
+  liefert der Lauf `triggered_count == 0` und leere Kanal-Listen für alle vier Kanäle.
+  - Test: Frames-Fixture mit garantiertem Onset (`_GuaranteedWetRadar`-Muster), Gate sperren,
+    Nullbefund über alle vier Kanäle nachweisen.
+
+- **AC-7:** Given ein Prüflauf wird mit vorbelegtem Zustand gestartet, der die Auslöseentscheidung
+  in eine bestimmte Richtung zwingen sollte (z. B. vorbelegter Cooldown, der eine sonst fällige
+  Auslösung unterdrückt), When der Lauf mit Eingangsdaten gefahren wird, die ohne die Vorbelegung
+  auslösen würden, Then zeigt das Ergebnis nachweislich die Wirkung der Vorbelegung
+  (`triggered_count == 0` trotz auslösungsfähiger Eingangsdaten) statt lediglich, dass der
+  Zustand geschrieben wurde.
+  - Test: Cooldown/Alert-State vor dem Lauf direkt über die öffentlichen Schreibwege
+    (`ThrottleStore.record`/`AlertStateService.save`) setzen, denselben Lauf ohne Vorbelegung
+    zum Vergleich fahren, Ergebnisunterschied nachweisen.
+
+- **AC-8:** Given ein Prüflauf löst über einen der drei Zweige einen Versand über alle vier
+  Kanäle aus (E-Mail, Telegram, SMS, Premium-SMS), When der Lauf beendet ist, Then liefert
+  `AlarmPruefstreckeLauf` für jeden der vier Kanäle den tatsächlich gerenderten Inhalt, ohne dass
+  ein echter externer Versand stattgefunden hat (kein Netzwerkzugriff auf Resend/Telegram-API/
+  seven.io außerhalb der lokalen Stubs).
+  - Test: Szenario fahren, das alle vier Kanäle bedient; für jeden Kanal Inhalt auf dem
+    jeweiligen Abgriffsweg (`mail_sink`, lokale HTTP-Stubs) nachweisen; keine Anfrage an eine
+    echte externe URL nachweisen (Stub-Server als einzige Gegenstelle).
+
+## Known Limitations
+
+- `alert_state.reset()` verwirft `event_identity:`-Schlüssel still (`alert_state.py:38-45`) —
+  Szenarien, die über eine Briefing-Grenze hinweg vorbelegten Zustand voraussetzen, verlieren
+  diese Vorbelegung unbemerkt. Betrifft S2+, nicht diese Scheibe.
+- Premium-SMS teilt die Stub-Basis mit SMS (`services/seven_io_base.py`) → die Strecke braucht
+  zwei getrennte Ports, sonst überschreiben sich die beiden Empfangslisten.
+- `check_official_alert_triggers(now_utc=...)` verwirft den übergebenen Parameter
+  (`trip_alert.py:1811`). Die Prüfstrecke bietet `now_utc=` deshalb **gar nicht** als Steuerweg
+  an — sonst würde sie eine Wirkung suggerieren, die es nicht gibt. Zeitsteuerung ausschließlich
+  über die gestellte Uhr (`freeze_time`).
+
+## Nicht Ziel
+
+- Die zwölf Alarm-Szenarien selbst (Scheiben S2–S5 aus #2050).
+- Die Protokollergänzung (Scheibe S6 aus #2050).
+- Ortsvergleich-Pendants der Prüfstrecke.
+- Ein durchgängiger `now=`-Umbau des Alarmpfads (alle rohen `datetime.now(`-Fundstellen in
+  `trip_alert.py`, `deviation_alert_engine.py`, `alert_briefing_anchor.py`, `alert_log.py`,
+  `alert_input_capture.py` bleiben unangetastet).
+- Jede Änderung am `alert-preview`-Endpoint aus #1948 S2
+  (`docs/specs/modules/alarm_testeinspeisung.md`) — der bleibt zustandslos für den Textbau.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Reine Test-Infrastruktur ohne Produktivcode-Änderung, keine neue Route, kein
+  neues Datenmodell, keine Rücknahme einer bestehenden Architekturentscheidung. Kein
+  ADR-würdiger Grundsatzentscheid.
+
+## Changelog
+
+- 2026-08-21: Initial spec created (Scheibe S1 aus #2050, verdichtet aus
+  `docs/context/feat-2050-s1-pruefstrecke.md`).
+- 2026-08-21: Testdateiname korrigiert (`test_alarm_pruefstrecke_selbstschutz.py` statt
+  Issue-Nummer im Namen, CLAUDE.md-Regel „Testdateien nach Verhalten benennen"), Pfadauflösung
+  relativ zur Testdatei ergänzt, AC-4 auf reines Beobachtungsergebnis umformuliert.

--- a/tests/helpers/alarm_pruefstrecke.py
+++ b/tests/helpers/alarm_pruefstrecke.py
@@ -21,9 +21,12 @@ import urllib.parse
 from dataclasses import dataclass, field
 from datetime import datetime
 from http.server import BaseHTTPRequestHandler, HTTPServer
-from typing import Literal, Optional
+from typing import TYPE_CHECKING, Literal, Optional
 
 from freezegun import freeze_time
+
+if TYPE_CHECKING:
+    from app.trip import Trip
 
 from app.config import Settings
 from output.channels import telegram as telegram_mod

--- a/tests/helpers/alarm_pruefstrecke.py
+++ b/tests/helpers/alarm_pruefstrecke.py
@@ -1,0 +1,186 @@
+"""Alarm-Prüfstrecke (Scheibe S1, Issue #2050).
+
+Mehrere Prüfläufe gegen die ECHTE Auslöseentscheidung, mit stellbarer Uhr,
+vorbelegbarem Zustand und Abgriff aller vier Kanäle ohne echten Versand.
+`TripAlertService` wird PRO LAUF neu gebaut — Kontinuität kommt ausschließlich
+vom Datenträger unter `get_data_dir(user_id)`, wie in Produktion, wo jeder
+Cron-Tick eine frische Instanz erzeugt.
+
+`now_utc=` wird bewusst NICHT als Steuerparameter angeboten:
+`check_official_alert_triggers` verwirft ihn bedingungslos (`trip_alert.py:
+1811`) — Zeitsteuerung läuft ausschließlich über die gestellte Uhr
+(`freeze_time`).
+
+SPEC: docs/specs/modules/alarm_pruefstrecke.md
+"""
+from __future__ import annotations
+
+import json
+import threading
+import urllib.parse
+from dataclasses import dataclass, field
+from datetime import datetime
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Literal, Optional
+
+from freezegun import freeze_time
+
+from app.config import Settings
+from output.channels import telegram as telegram_mod
+from output.channels.telegram import reset_telegram_rate_limit_for_tests
+from output.channels.premium_sms import PREMIUM_SMS_SENDER
+from providers.thunder_window_cache import reset_thunder_window_cache_for_tests
+from services.radar_cache import reset_shared_radar_cache_for_tests
+from services.trip_alert import TripAlertService
+from services.weather_cache import reset_shared_weather_cache_for_tests
+
+Zweig = Literal["deviation", "official", "radar"]
+
+
+@dataclass
+class AlarmPruefstreckeLauf:
+    """Ergebnis eines einzelnen Prüflaufs — Auslösezähler + gerenderter
+    Inhalt der vier Kanäle (leer, wenn nichts ausgelöst wurde)."""
+
+    triggered_count: int
+    mail: list = field(default_factory=list)
+    telegram: list = field(default_factory=list)
+    sms: list = field(default_factory=list)
+    premium_sms: list = field(default_factory=list)
+
+
+def _start_json_stub(received: list) -> tuple[HTTPServer, int]:
+    """Lokaler HTTP-Stub für die Telegram-Bot-API (JSON-Body, Vorbild
+    `test_952_onset_alert_fidelity.py::_make_fake_bot_handler`)."""
+
+    class _Handler(BaseHTTPRequestHandler):
+        def log_message(self, *_args):
+            pass
+
+        def do_POST(self):  # noqa: N802
+            length = int(self.headers.get("Content-Length", 0))
+            raw = self.rfile.read(length) if length else b"{}"
+            received.append(json.loads(raw or b"{}"))
+            body = json.dumps({"ok": True, "result": {"message_id": len(received)}}).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+    server = HTTPServer(("127.0.0.1", 0), _Handler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    return server, server.server_address[1]
+
+
+def _start_seven_io_stub(received: list) -> tuple[HTTPServer, int]:
+    """Lokaler HTTP-Stub für das seven.io-Gateway (form-urlencoded,
+    Vorbild `test_issue_936_sms_stub.py::_SMSStub`). SMS UND Premium-SMS
+    teilen `settings.sms_gateway_url` (`seven_io_base.py`) — EIN Stub genügt,
+    die Trennung passiert über das Absenderfeld (`from`), das Premium-SMS
+    fest auf `PREMIUM_SMS_SENDER` setzt und normale SMS nicht."""
+
+    class _Handler(BaseHTTPRequestHandler):
+        def log_message(self, *_args):
+            pass
+
+        def do_POST(self):  # noqa: N802
+            length = int(self.headers.get("Content-Length", 0))
+            raw = self.rfile.read(length) if length else b""
+            data = urllib.parse.parse_qs(raw.decode())
+            received.append({k: v[0] for k, v in data.items()})
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            self.end_headers()
+            self.wfile.write(b"100")
+
+    server = HTTPServer(("127.0.0.1", 0), _Handler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    return server, server.server_address[1]
+
+
+class AlarmPruefstrecke:
+    """Baut für einen `user_id` mehrere Prüfläufe gegen die echte
+    Auslöseentscheidung — der Datenträger unter `get_data_dir(user_id)` trägt
+    die Kontinuität zwischen den Läufen, nicht diese Instanz."""
+
+    def __init__(
+        self, *, user_id: str, settings: Optional[Settings] = None,
+        throttle_hours: int = 2,
+    ) -> None:
+        self._user_id = user_id
+        self._throttle_hours = throttle_hours
+        self._telegram_received: list[dict] = []
+        self._seven_received: list[dict] = []
+        _, telegram_port = _start_json_stub(self._telegram_received)
+        _, seven_port = _start_seven_io_stub(self._seven_received)
+        self._telegram_url = f"http://127.0.0.1:{telegram_port}"
+        base = settings if settings is not None else Settings()
+        # Wie in Produktion (`TripAlertService(settings=None, ...)` baut sich
+        # intern `Settings().with_user_profile(user_id)`, Vorbild
+        # `trip_alert.py:198`): `premium_sms_reply_to`/`_at` sind KEIN
+        # direkter `user.json`-Lookup im Kanal (`premium_sms.py:71-72`),
+        # sondern Felder auf `Settings`, die NUR `with_user_profile()`
+        # befuellt (`app/config.py:355-401`). Ohne diesen Schritt wuerde die
+        # Pruefstrecke Premium-SMS strukturell NIE erreichen, unabhaengig
+        # davon, was vorbelegt wurde -- bitte NICHT als ueberfluessig
+        # entfernen.
+        profiled = base.with_user_profile(user_id)
+        self._settings = profiled.model_copy(update={
+            "sms_gateway_url": f"http://127.0.0.1:{seven_port}/api/sms",
+        })
+
+    def lauf(
+        self, *, at: datetime, zweig: Zweig, trip: "Trip",
+        cached_weather: Optional[list] = None, fresh_weather: Optional[list] = None,
+        official_notices: Optional[list] = None, radar_service: Optional[object] = None,
+    ) -> AlarmPruefstreckeLauf:
+        """Ein Prüflauf: vier Cache-Resets -> gestellte Uhr -> frische
+        `TripAlertService`-Instanz -> passender Entscheidungs-Einstiegspunkt.
+
+        `now_utc=` wird bewusst nirgends durchgereicht (s. Moduldoku).
+        """
+        # Schritt 1: Cache-Reset -- jeder Lauf beginnt mit leeren
+        # Singleton-Caches, unabhängig davon, was ein vorheriger Lauf im
+        # selben Testprozess gefüllt hat (AC-3).
+        reset_shared_radar_cache_for_tests()
+        reset_shared_weather_cache_for_tests()
+        reset_thunder_window_cache_for_tests()
+        reset_telegram_rate_limit_for_tests()
+        self._telegram_received.clear()
+        self._seven_received.clear()
+
+        # `TELEGRAM_API_BASE` ist eine Modulkonstante -- nur für die Dauer
+        # DIESES Laufs umgebogen, damit kein Zustand über die Instanz hinaus
+        # in andere Tests durchschlägt.
+        original_base = telegram_mod.TELEGRAM_API_BASE
+        telegram_mod.TELEGRAM_API_BASE = self._telegram_url
+        try:
+            with freeze_time(at):
+                mail_calls: list[tuple[str, str]] = []
+                svc = TripAlertService(
+                    settings=self._settings, throttle_hours=self._throttle_hours,
+                    user_id=self._user_id, radar_service=radar_service,
+                    mail_sink=lambda subject, body: mail_calls.append((subject, body)),
+                )
+                if zweig == "deviation":
+                    raw = svc.check_and_send_alerts(
+                        trip, cached_weather or [], fresh_weather=fresh_weather,
+                        official_notices=official_notices,
+                    )
+                elif zweig == "official":
+                    raw = svc._send_official_alert_only(trip, official_notices or [])
+                elif zweig == "radar":
+                    raw = svc.check_radar_alerts()
+                else:
+                    raise ValueError(f"Unbekannter Zweig: {zweig!r}")
+        finally:
+            telegram_mod.TELEGRAM_API_BASE = original_base
+
+        telegram_msgs = [p.get("text", "") for p in self._telegram_received]
+        sms_msgs = [e.get("text", "") for e in self._seven_received if e.get("from") != PREMIUM_SMS_SENDER]
+        premium_msgs = [e.get("text", "") for e in self._seven_received if e.get("from") == PREMIUM_SMS_SENDER]
+        return AlarmPruefstreckeLauf(
+            triggered_count=int(raw), mail=list(mail_calls),
+            telegram=telegram_msgs, sms=sms_msgs, premium_sms=premium_msgs,
+        )

--- a/tests/helpers/nowcast_gate_fixtures.py
+++ b/tests/helpers/nowcast_gate_fixtures.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import json
 import shutil
 import uuid
+from contextlib import contextmanager
 from datetime import date as date_type
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -432,6 +433,44 @@ def make_trip(
     trip.alert_quiet_from = quiet_from
     trip.alert_quiet_to = quiet_to
     return trip
+
+
+@contextmanager
+def frozen_active_window(hour_utc: int = 12):
+    """Gestellte Uhr, nicht Wanduhr (#2050, Vorbild #2017 Scheibe B in
+    ``test_issue_822_radar_nowcast_segment.py``): fuer Aufrufer, die einen
+    ``make_trip()``-Trip ueber das PRODUKTIVE ``app.loader.save_trip()``
+    speichern — nicht den verkuerzten ``save_trip()`` dieser Datei.
+
+    ``app.loader.save_trip()`` fuehrt Compute-on-Save aus (Issue #802):
+    ``arrival_start``/``arrival_end`` aus ``make_trip()`` werden dabei
+    VERWORFEN und ``compute_stage_arrivals()`` rechnet WP0/WP1 stattdessen ab
+    einem Default-Start 08:00 Ortszeit per Naismith neu. Bei den
+    Default-Koordinaten dieser Datei (``TRIP_LAT``/``TRIP_LON``, Reykjavik,
+    ganzjaehrig UTC+0) ergibt das 08:00-11:22. Das anschliessende
+    Ziel-Segment (``src/services/trip_segments.py``) verlaengert die
+    Abdeckung bis zum Ende des Default-Tagesfensters (Stunde 19 inklusive ->
+    20:00 Ortszeit exklusiv), eine Vorschau deckt alles VOR 08:00 ab —
+    luecklos aktiv ist damit NUR ``[08:00, 20:00)`` Ortszeit. Ausserhalb
+    davon (20:00-24:00) liefert ``resolve_current_segment()`` ``None`` und
+    ``check_radar_alerts()`` bricht vor dem Nowcast-Abruf ab — abhaengig
+    davon, wann die Testsuite laeuft (gemessen 2026-08-21, #2050: CI-Lauf um
+    19:38 UTC gruen, derselbe Testfall um 20:40 UTC rot).
+
+    Dieser Helfer stellt die Uhr auf ``hour_utc:00`` UTC HEUTE — der Default
+    (12 Uhr) liegt mittig im garantiert aktiven Fenster, unabhaengig von der
+    tatsaechlichen Wanduhr beim Testlauf. Wie in der Vorbild-Datei wird NICHT
+    aus der Wanduhr gerechnet (das waere genau das Anti-Muster, das
+    ``test_fixture_wallclock_ratchet.py`` bewacht) — der Ankerpunkt ist ein
+    fester, weit von beiden Fensterkanten entfernter Wert.
+    """
+    from freezegun import freeze_time
+
+    anker = datetime.combine(
+        date_type.today(), datetime.min.time(), tzinfo=TRIP_ZONE,
+    ) + timedelta(hours=hour_utc)
+    with freeze_time(anker):
+        yield anker
 
 
 def save_trip(trip: Trip, user_id: str) -> None:

--- a/tests/tdd/test_alarm_pruefstrecke_selbstschutz.py
+++ b/tests/tdd/test_alarm_pruefstrecke_selbstschutz.py
@@ -121,6 +121,36 @@ def test_ac1_zweiter_lauf_liest_den_von_lauf_eins_gebuchten_cooldown():
         _clean_user(uid); _clean_user(ctrl)
 
 
+def test_ac1b_jeder_lauf_bekommt_eine_eigene_service_instanz():
+    """Jeder `.lauf()` baut eine EIGENE `TripAlertService` — `mail_sink` wird
+    nur im Konstruktor gesetzt (`trip_alert.py:209`) und ist eine Closure
+    über die `mail_calls`-Liste GENAU DIESES Aufrufs. Bei einer über Läufe
+    wiederverwendeten Instanz schriebe der Service weiterhin in Lauf 1s
+    (bereits verlassene) Liste — Lauf 2s `.mail` bliebe strukturell leer,
+    obwohl er auslöst."""
+    uid = _uid("ac1b")
+    _clean_user(uid)
+    try:
+        _write_tier(uid, "standard")  # #1555: sonst blockt das Tageslimit den 2. Alarm
+        trip1, trip2 = _deviation_trip("trip-ac1b-a"), _deviation_trip("trip-ac1b-b")
+        trip1.report_config.send_email = trip2.report_config.send_email = True
+        cached, fresh = _cached_fresh()
+        strecke = AlarmPruefstrecke(user_id=uid, settings=_settings_all_channels())
+        lauf1 = strecke.lauf(at=_AT, zweig="deviation", trip=trip1, cached_weather=cached, fresh_weather=fresh)
+        assert lauf1.triggered_count == 1 and lauf1.mail, "Voraussetzung: Lauf 1 muss auslösen und Mail liefern"
+
+        lauf2 = strecke.lauf(
+            at=_AT + timedelta(minutes=1), zweig="deviation", trip=trip2,
+            cached_weather=cached, fresh_weather=fresh,
+        )
+        assert lauf2.triggered_count == 1 and lauf2.mail, (
+            "Lauf 2 muss SEINE EIGENE Mail-Sink-Liste befüllt sehen — bei einer "
+            "über Läufe wiederverwendeten Service-Instanz bliebe lauf2.mail leer"
+        )
+    finally:
+        _clean_user(uid)
+
+
 def test_ac2_gleicher_lauf_innerhalb_und_ausserhalb_der_ruhezeit_entscheidet_unterschiedlich():
     """Identische Eingangsdaten, nur die gestellte Uhr wechselt zwischen
     Ruhezeit (22-06 Uhr lokal) und Normalzeit."""

--- a/tests/tdd/test_alarm_pruefstrecke_selbstschutz.py
+++ b/tests/tdd/test_alarm_pruefstrecke_selbstschutz.py
@@ -48,12 +48,21 @@ def _uid(tag: str) -> str:
 
 
 def _settings_all_channels() -> Settings:
+    # Die drei Wächter-Sperren (Issue #1476/#1288/#1336) lesen NICHT die
+    # Prod-Felder, sondern eigene Test-Gegenstücke (`telegram_test_chat_id`,
+    # `telegram_test_bot_token`, `seven_sandbox_key`). Lokal befüllt `.env`
+    # (GZ_TELEGRAM_TEST_CHAT_ID/GZ_SEVEN_SANDBOX_KEY) diese beim `Settings()`-
+    # Konstruktor — in CI fehlen sie, die Sperren blocken. Deshalb hier
+    # EXPLIZIT gesetzt, deckungsgleich mit den Prod-Feldern, damit die
+    # Prüfstrecke aus eigener Kraft läuft, unabhängig von der Umgebung.
     return Settings().model_copy(update={
         "smtp_host": "smtp.test.invalid", "smtp_user": "alert@test.invalid",
         "smtp_pass": "secret", "mail_to": "gregor-test@henemm.com",
         "smtp_port": 587, "is_test_mode": False,
         "telegram_bot_token": "test-token-2050", "telegram_chat_id": "99999",
+        "telegram_test_bot_token": "test-token-2050", "telegram_test_chat_id": "99999",
         "sms_to": "+41791234567", "seven_api_key": "test-stub-key",
+        "seven_sandbox_key": "test-stub-key",
     })
 
 
@@ -97,7 +106,8 @@ def test_ac1_zweiter_lauf_liest_den_von_lauf_eins_gebuchten_cooldown():
     """Lauf 2 schweigt wegen des von Lauf 1 gebuchten Cooldowns — eine
     Kontrolle ohne Lauf 1 löst bei identischen Eingangsdaten trotzdem aus."""
     uid, ctrl = _uid("ac1"), _uid("ac1-ctrl")
-    _clean_user(uid); _clean_user(ctrl)
+    _clean_user(uid)
+    _clean_user(ctrl)
     try:
         trip = _deviation_trip("trip-ac1")
         trip.alert_cooldown_minutes = 120
@@ -118,7 +128,8 @@ def test_ac1_zweiter_lauf_liest_den_von_lauf_eins_gebuchten_cooldown():
             "Zustand, nicht von unveränderten Eingangsdaten"
         )
     finally:
-        _clean_user(uid); _clean_user(ctrl)
+        _clean_user(uid)
+        _clean_user(ctrl)
 
 
 def test_ac1b_jeder_lauf_bekommt_eine_eigene_service_instanz():
@@ -182,12 +193,14 @@ def test_ac3_telegram_ratenbegrenzung_aus_lauf_eins_ueberlebt_nicht_bis_lauf_zwe
     unabhängig auslösefähiger Eingangsdaten stumm — die Gegenprobe am Ende
     unterdrückt den Reset gezielt und zeigt genau das."""
     uid, ctrl = _uid("ac3"), _uid("ac3-ctrl")
-    _clean_user(uid); _clean_user(ctrl)
+    _clean_user(uid)
+    _clean_user(ctrl)
     try:
         # Free-Tier-Reserve (#1555) ließe den zweiten Deviation-Alarm schon
         # am Tageslimit scheitern, bevor die Ratenbegrenzung geprüft wird —
         # `standard` hat genug Budget, um NUR die Ratenbegrenzung zu messen.
-        _write_tier(uid, "standard"); _write_tier(ctrl, "standard")
+        _write_tier(uid, "standard")
+        _write_tier(ctrl, "standard")
         settings = _settings_all_channels().model_copy(
             update={"telegram_rate_limit_max_per_window": 1},
         )
@@ -241,7 +254,8 @@ def test_ac3_telegram_ratenbegrenzung_aus_lauf_eins_ueberlebt_nicht_bis_lauf_zwe
             "Haupttest nichts über den Reset selbst"
         )
     finally:
-        _clean_user(uid); _clean_user(ctrl)
+        _clean_user(uid)
+    _clean_user(ctrl)
 
 
 def test_ac4_briefing_naehe_sperre_unterdrueckt_deviation_alarm_auf_allen_kanaelen(monkeypatch):
@@ -310,7 +324,8 @@ def test_ac7_vorbelegter_cooldown_unterdrueckt_einen_sonst_faelligen_alarm():
     """Cooldown wird VOR dem Lauf über `ThrottleStore.record` gesetzt — der
     Lauf zeigt die Wirkung, eine Kontrolle ohne Vorbelegung löst aus."""
     uid, ctrl = _uid("ac7"), _uid("ac7-ctrl")
-    _clean_user(uid); _clean_user(ctrl)
+    _clean_user(uid)
+    _clean_user(ctrl)
     try:
         trip = _deviation_trip("trip-ac7")
         trip.alert_cooldown_minutes = 120
@@ -325,7 +340,8 @@ def test_ac7_vorbelegter_cooldown_unterdrueckt_einen_sonst_faelligen_alarm():
         lauf_k = kontrolle.lauf(at=_AT, zweig="deviation", trip=trip, cached_weather=cached, fresh_weather=fresh)
         assert lauf_k.triggered_count == 1, "Gegenprobe: ohne Vorbelegung muss derselbe Lauf auslösen"
     finally:
-        _clean_user(uid); _clean_user(ctrl)
+        _clean_user(uid)
+    _clean_user(ctrl)
 
 
 def test_ac8_ausloesender_lauf_liefert_gerenderten_inhalt_auf_allen_vier_kanaelen():

--- a/tests/tdd/test_alarm_pruefstrecke_selbstschutz.py
+++ b/tests/tdd/test_alarm_pruefstrecke_selbstschutz.py
@@ -1,0 +1,320 @@
+"""Issue #2050 Scheibe S1: Alarm-Prüfstrecke Selbstschutz.
+
+Jeder Test deckt einen AC aus `docs/specs/modules/alarm_pruefstrecke.md` ab
+und nutzt `AlarmPruefstrecke` aus `tests.helpers.alarm_pruefstrecke` (Phase 6
+GREEN) gegen die echte Auslöseentscheidung.
+
+Kein Mock()/patch()/MagicMock: echte `RadarNowcastService`-Unterklasse
+(`_GuaranteedWetRadar`, Vorbild #952) als DI-Seam, `monkeypatch.setattr` auf
+echten Modulfunktionen für die Gate-Sperren (AC-4/5/6). Patch-Ziel für
+AC-5/AC-6 ist bewusst `services.trip_alert`, NICHT `services.alert_gate`:
+`trip_alert.py` importiert `check_nowcast_gate`/`check_official_alert_gate`
+per `from ... import` auf Modulebene (Zeile 22-27) — ein Patch auf
+`alert_gate` selbst griffe dort nicht (Vorbild dafür bereits etabliert in
+`test_issue_1088_official_alert_triggers.py:800,848`, das genau dieselben
+zwei Bausteine auf `trip_alert_mod` patcht). `check_briefing_imminent`
+(AC-4) importiert `trip_alert.py` dagegen LOKAL PRO AUFRUF (Zeile 967) —
+dort wirkt ein Patch auf `alert_gate` sehr wohl.
+
+SPEC: docs/specs/modules/alarm_pruefstrecke.md
+"""
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from freezegun import freeze_time
+
+from app.config import Settings
+from app.loader import get_data_dir, save_trip
+from app.models import TripReportConfig
+from services.alert_gate import GateResult
+from services.official_alerts.models import OfficialAlert
+from services.throttle_store import ThrottleStore
+
+from tests.tdd.test_952_onset_alert_fidelity import (
+    _clean_user, _GuaranteedWetRadar, _trip_with_active_segment,
+)
+from tests.tdd.test_issue_1070_daily_alert_limit import _deviation_trip, _weather_data
+
+from tests.helpers.alarm_pruefstrecke import AlarmPruefstrecke
+
+_AT = datetime(2026, 4, 5, 10, 0, tzinfo=timezone.utc)
+
+
+def _uid(tag: str) -> str:
+    return f"tdd-2050-s1-{tag}-{uuid.uuid4().hex[:6]}"
+
+
+def _settings_all_channels() -> Settings:
+    return Settings().model_copy(update={
+        "smtp_host": "smtp.test.invalid", "smtp_user": "alert@test.invalid",
+        "smtp_pass": "secret", "mail_to": "gregor-test@henemm.com",
+        "smtp_port": 587, "is_test_mode": False,
+        "telegram_bot_token": "test-token-2050", "telegram_chat_id": "99999",
+        "sms_to": "+41791234567", "seven_api_key": "test-stub-key",
+    })
+
+
+def _write_premium_profile(uid: str, at: datetime) -> None:
+    """Lernt eine frische Garmin-Rückadresse (Pflicht für Premium-SMS,
+    `output/channels/premium_sms.py`) und setzt den Tier auf `premium`
+    (kein Tageslimit, s. #1070 AC-3)."""
+    d = get_data_dir(uid)
+    d.mkdir(parents=True, exist_ok=True)
+    profile = {
+        "id": uid, "tier": "premium",
+        "premium_sms_reply_to": "+41791234567",
+        "premium_sms_reply_at": (at - timedelta(minutes=5)).isoformat().replace("+00:00", "Z"),
+    }
+    (d / "user.json").write_text(json.dumps(profile), encoding="utf-8")
+
+
+def _write_tier(uid: str, tier: str) -> None:
+    d = get_data_dir(uid)
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "user.json").write_text(json.dumps({"id": uid, "tier": tier}), encoding="utf-8")
+
+
+def _radar_trip(uid: str, trip_id: str, **flags) -> object:
+    """Baut das Trip-Fixture INNERHALB von `freeze_time(_AT)`, weil
+    `_trip_with_active_segment` sein Ankunftsfenster über `datetime.now()`
+    verankert — ohne Freeze wäre das Segment zur gestellten Laufzeit `_AT`
+    nicht mehr aktiv."""
+    config = TripReportConfig(trip_id=trip_id, alert_on_changes=True, **flags)
+    with freeze_time(_AT):
+        trip = _trip_with_active_segment(trip_id, config)
+    save_trip(trip, user_id=uid)
+    return trip
+
+
+def _cached_fresh():
+    return [_weather_data(precip_sum_mm=2.0)], [_weather_data(precip_sum_mm=18.0)]
+
+
+def test_ac1_zweiter_lauf_liest_den_von_lauf_eins_gebuchten_cooldown():
+    """Lauf 2 schweigt wegen des von Lauf 1 gebuchten Cooldowns — eine
+    Kontrolle ohne Lauf 1 löst bei identischen Eingangsdaten trotzdem aus."""
+    uid, ctrl = _uid("ac1"), _uid("ac1-ctrl")
+    _clean_user(uid); _clean_user(ctrl)
+    try:
+        trip = _deviation_trip("trip-ac1")
+        trip.alert_cooldown_minutes = 120
+        cached, fresh = _cached_fresh()
+        strecke = AlarmPruefstrecke(user_id=uid, settings=_settings_all_channels())
+        lauf1 = strecke.lauf(at=_AT, zweig="deviation", trip=trip, cached_weather=cached, fresh_weather=fresh)
+        assert lauf1.triggered_count == 1, "Voraussetzung: Lauf 1 muss auslösen"
+
+        at2 = _AT + timedelta(minutes=30)
+        lauf2 = strecke.lauf(at=at2, zweig="deviation", trip=trip, cached_weather=cached, fresh_weather=fresh)
+        assert lauf2.triggered_count == 0, "Lauf 2 muss durch den Cooldown aus Lauf 1 unterdrückt sein"
+
+        kontrolle = AlarmPruefstrecke(user_id=ctrl, settings=_settings_all_channels())
+        lauf_k = kontrolle.lauf(at=at2, zweig="deviation", trip=trip, cached_weather=cached, fresh_weather=fresh)
+        assert lauf_k.triggered_count == 1, (
+            "Gegenprobe: dieselben Eingangsdaten zum selben Zeitpunkt OHNE "
+            "Lauf 1 müssen auslösen — Lauf 2s Stille kommt vom gebuchten "
+            "Zustand, nicht von unveränderten Eingangsdaten"
+        )
+    finally:
+        _clean_user(uid); _clean_user(ctrl)
+
+
+def test_ac2_gleicher_lauf_innerhalb_und_ausserhalb_der_ruhezeit_entscheidet_unterschiedlich():
+    """Identische Eingangsdaten, nur die gestellte Uhr wechselt zwischen
+    Ruhezeit (22-06 Uhr lokal) und Normalzeit."""
+    uid = _uid("ac2")
+    _clean_user(uid)
+    try:
+        trip = _deviation_trip("trip-ac2")
+        trip.alert_cooldown_minutes = 0
+        trip.alert_quiet_from, trip.alert_quiet_to = "22:00", "06:00"
+        cached, fresh = _cached_fresh()
+        strecke = AlarmPruefstrecke(user_id=uid, settings=_settings_all_channels())
+        innerhalb = strecke.lauf(
+            at=datetime(2026, 4, 5, 23, 0, tzinfo=timezone.utc), zweig="deviation",
+            trip=trip, cached_weather=cached, fresh_weather=fresh,
+        )
+        ausserhalb = strecke.lauf(
+            at=datetime(2026, 4, 6, 10, 0, tzinfo=timezone.utc), zweig="deviation",
+            trip=trip, cached_weather=cached, fresh_weather=fresh,
+        )
+        assert innerhalb.triggered_count == 0, "23:00 UTC liegt in der lokalen Ruhezeit"
+        assert ausserhalb.triggered_count == 1, "10:00 UTC liegt außerhalb der Ruhezeit"
+    finally:
+        _clean_user(uid)
+
+
+def test_ac3_telegram_ratenbegrenzung_aus_lauf_eins_ueberlebt_nicht_bis_lauf_zwei(monkeypatch):
+    """Lauf 1 erschöpft die prozessweite Telegram-Ratenbegrenzung
+    (`max_per_window=1`). Ohne Cache-Reset bliebe Lauf 2 trotz eigener,
+    unabhängig auslösefähiger Eingangsdaten stumm — die Gegenprobe am Ende
+    unterdrückt den Reset gezielt und zeigt genau das."""
+    uid, ctrl = _uid("ac3"), _uid("ac3-ctrl")
+    _clean_user(uid); _clean_user(ctrl)
+    try:
+        # Free-Tier-Reserve (#1555) ließe den zweiten Deviation-Alarm schon
+        # am Tageslimit scheitern, bevor die Ratenbegrenzung geprüft wird —
+        # `standard` hat genug Budget, um NUR die Ratenbegrenzung zu messen.
+        _write_tier(uid, "standard"); _write_tier(ctrl, "standard")
+        settings = _settings_all_channels().model_copy(
+            update={"telegram_rate_limit_max_per_window": 1},
+        )
+        cached, fresh = _cached_fresh()
+        trip1, trip2 = _deviation_trip("trip-ac3-a"), _deviation_trip("trip-ac3-b")
+        trip1.alert_cooldown_minutes = trip2.alert_cooldown_minutes = 0
+        strecke = AlarmPruefstrecke(user_id=uid, settings=settings)
+        lauf1 = strecke.lauf(at=_AT, zweig="deviation", trip=trip1, cached_weather=cached, fresh_weather=fresh)
+        assert lauf1.telegram, "Voraussetzung: Lauf 1 muss den einzigen Ratenlimit-Slot verbrauchen"
+
+        # 1s Abstand, nicht mehr: `freeze_time` verschiebt auch
+        # `time.monotonic()` (Basis der Ratenbegrenzung) — nahe der
+        # Fensterlänge (60s) verfiele der Slot aus Lauf 1 ohnehin natürlich,
+        # unabhängig vom Reset.
+        lauf2 = strecke.lauf(
+            at=_AT + timedelta(seconds=1), zweig="deviation",
+            trip=trip2, cached_weather=cached, fresh_weather=fresh,
+        )
+        assert lauf2.triggered_count == 1 and lauf2.telegram, (
+            "Lauf 2 muss trotz Lauf 1s Ratenlimit-Verbrauch senden — der "
+            "Cache-Reset der Prüfstrecke darf Lauf 1s Zustand nicht durchschlagen lassen"
+        )
+
+        # Gegenprobe: derselbe Ablauf, aber der Reset wird gezielt
+        # unterdrückt -- ohne ihn MUSS Lauf 2 scheitern, sonst bewiese der
+        # Haupttest oben nichts über den Reset selbst. `SEND_SLOT_MAX_WAIT_
+        # SECONDS=0` lässt die Drossel SOFORT abbrechen statt real zu warten
+        # -- unter `freeze_time` steht `time.monotonic()` still, ein
+        # positiver Wert liefe in eine Endlosschleife (real erlebt: Timeout).
+        import output.channels.telegram as telegram_mod
+        import tests.helpers.alarm_pruefstrecke as harness_mod
+        monkeypatch.setattr(telegram_mod, "SEND_SLOT_MAX_WAIT_SECONDS", 0)
+
+        trip3, trip4 = _deviation_trip("trip-ac3-c"), _deviation_trip("trip-ac3-d")
+        trip3.alert_cooldown_minutes = trip4.alert_cooldown_minutes = 0
+        kontrolle = AlarmPruefstrecke(user_id=ctrl, settings=settings)
+        lauf3 = kontrolle.lauf(at=_AT, zweig="deviation", trip=trip3, cached_weather=cached, fresh_weather=fresh)
+        assert lauf3.telegram, "Voraussetzung Gegenprobe: erster Lauf muss senden"
+
+        monkeypatch.setattr(harness_mod, "reset_telegram_rate_limit_for_tests", lambda: None)
+        lauf4 = kontrolle.lauf(
+            at=_AT + timedelta(seconds=1), zweig="deviation",
+            trip=trip4, cached_weather=cached, fresh_weather=fresh,
+        )
+        # `triggered_count` bleibt UNGEPRÜFT: er zählt bereits den Versuch
+        # (Anti-Pattern #656, `notification_service.py:104-110/1059`), nicht
+        # die Zustellung. `telegram` (Stub-Abgriff) ist der einzige Nachweis.
+        assert not lauf4.telegram, (
+            "Gegenprobe: OHNE Cache-Reset muss Lauf 2 am durchgeschlagenen "
+            "Telegram-Ratenlimit aus Lauf 1 scheitern — sonst beweist der "
+            "Haupttest nichts über den Reset selbst"
+        )
+    finally:
+        _clean_user(uid); _clean_user(ctrl)
+
+
+def test_ac4_briefing_naehe_sperre_unterdrueckt_deviation_alarm_auf_allen_kanaelen(monkeypatch):
+    """`check_briefing_imminent` erzwungen gesperrt — ein bekannt
+    auslösendes Deviation-Szenario darf über KEINEN Kanal etwas liefern."""
+    import services.alert_gate as alert_gate_mod
+    monkeypatch.setattr(alert_gate_mod, "check_briefing_imminent", lambda **kw: True)
+
+    uid = _uid("ac4")
+    _clean_user(uid)
+    try:
+        trip = _deviation_trip("trip-ac4")
+        trip.alert_cooldown_minutes = 0
+        cached, fresh = _cached_fresh()
+        strecke = AlarmPruefstrecke(user_id=uid, settings=_settings_all_channels())
+        lauf = strecke.lauf(at=_AT, zweig="deviation", trip=trip, cached_weather=cached, fresh_weather=fresh)
+        assert lauf.triggered_count == 0
+        assert not (lauf.mail or lauf.telegram or lauf.sms or lauf.premium_sms)
+    finally:
+        _clean_user(uid)
+
+
+def test_ac5_amtliches_gate_gesperrt_unterdrueckt_offiziellen_alarm_auf_allen_kanaelen(monkeypatch):
+    """`check_official_alert_gate` erzwungen gesperrt — eine amtliche
+    Warnung, die sonst versendet würde, darf über KEINEN Kanal raus."""
+    import services.trip_alert as trip_alert_mod
+    monkeypatch.setattr(
+        trip_alert_mod, "check_official_alert_gate",
+        lambda **kw: GateResult(False, "test-sperre"),
+    )
+    uid = _uid("ac5")
+    _clean_user(uid)
+    try:
+        trip = _deviation_trip("trip-ac5")
+        trip.alert_cooldown_minutes = 0
+        alert = OfficialAlert(source="tdd-2050-ac5", hazard="thunderstorm", level=3, label="Gewitterwarnung")
+        strecke = AlarmPruefstrecke(user_id=uid, settings=_settings_all_channels())
+        lauf = strecke.lauf(at=_AT, zweig="official", trip=trip, official_notices=[(alert, ["1"])])
+        assert lauf.triggered_count == 0
+        assert not (lauf.mail or lauf.telegram or lauf.sms or lauf.premium_sms)
+    finally:
+        _clean_user(uid)
+
+
+def test_ac6_nowcast_gate_gesperrt_unterdrueckt_radar_onset_auf_allen_kanaelen(monkeypatch):
+    """`check_nowcast_gate` erzwungen gesperrt — ein garantierter Radar-Onset
+    (Vorbild `_GuaranteedWetRadar`) darf über KEINEN Kanal raus."""
+    import services.trip_alert as trip_alert_mod
+    monkeypatch.setattr(
+        trip_alert_mod, "check_nowcast_gate",
+        lambda **kw: GateResult(False, "test-sperre"),
+    )
+    uid = _uid("ac6")
+    _clean_user(uid)
+    try:
+        trip = _radar_trip(uid, "trip-ac6", send_email=True)
+        strecke = AlarmPruefstrecke(user_id=uid, settings=_settings_all_channels())
+        lauf = strecke.lauf(at=_AT, zweig="radar", trip=trip, radar_service=_GuaranteedWetRadar(onset_minutes=12))
+        assert lauf.triggered_count == 0
+        assert not (lauf.mail or lauf.telegram or lauf.sms or lauf.premium_sms)
+    finally:
+        _clean_user(uid)
+
+
+def test_ac7_vorbelegter_cooldown_unterdrueckt_einen_sonst_faelligen_alarm():
+    """Cooldown wird VOR dem Lauf über `ThrottleStore.record` gesetzt — der
+    Lauf zeigt die Wirkung, eine Kontrolle ohne Vorbelegung löst aus."""
+    uid, ctrl = _uid("ac7"), _uid("ac7-ctrl")
+    _clean_user(uid); _clean_user(ctrl)
+    try:
+        trip = _deviation_trip("trip-ac7")
+        trip.alert_cooldown_minutes = 120
+        cached, fresh = _cached_fresh()
+        ThrottleStore(uid).record("trip", trip.id, _AT - timedelta(minutes=10))
+
+        strecke = AlarmPruefstrecke(user_id=uid, settings=_settings_all_channels())
+        lauf = strecke.lauf(at=_AT, zweig="deviation", trip=trip, cached_weather=cached, fresh_weather=fresh)
+        assert lauf.triggered_count == 0, "Vorbelegter Cooldown muss den sonst fälligen Alarm unterdrücken"
+
+        kontrolle = AlarmPruefstrecke(user_id=ctrl, settings=_settings_all_channels())
+        lauf_k = kontrolle.lauf(at=_AT, zweig="deviation", trip=trip, cached_weather=cached, fresh_weather=fresh)
+        assert lauf_k.triggered_count == 1, "Gegenprobe: ohne Vorbelegung muss derselbe Lauf auslösen"
+    finally:
+        _clean_user(uid); _clean_user(ctrl)
+
+
+def test_ac8_ausloesender_lauf_liefert_gerenderten_inhalt_auf_allen_vier_kanaelen():
+    """Radar-Onset über alle vier Kanäle — Inhalt kommt ausschließlich über
+    `mail_sink` bzw. die lokalen Stubs, kein echter externer Versand."""
+    uid = _uid("ac8")
+    _clean_user(uid)
+    try:
+        _write_premium_profile(uid, _AT)
+        trip = _radar_trip(
+            uid, "trip-ac8", send_email=True, send_telegram=True,
+            send_sms=True, send_premium_sms=True,
+        )
+        strecke = AlarmPruefstrecke(user_id=uid, settings=_settings_all_channels())
+        lauf = strecke.lauf(at=_AT, zweig="radar", trip=trip, radar_service=_GuaranteedWetRadar(onset_minutes=12))
+        assert lauf.triggered_count == 1
+        assert lauf.mail and lauf.telegram and lauf.sms and lauf.premium_sms, (
+            f"Alle vier Kanäle müssen Inhalt liefern: mail={lauf.mail!r} "
+            f"telegram={lauf.telegram!r} sms={lauf.sms!r} premium_sms={lauf.premium_sms!r}"
+        )
+    finally:
+        _clean_user(uid)

--- a/tests/tdd/test_onset_menge_kanalparitaet.py
+++ b/tests/tdd/test_onset_menge_kanalparitaet.py
@@ -42,8 +42,8 @@ from services.radar_service import NowcastResult
 
 from tests.helpers.briefing_zeiten import briefing_zeiten_fuer_trip
 from tests.helpers.nowcast_gate_fixtures import (
-    TRIP_ZONE, clean_uid, fresh_uid, make_trip, quiet_window_elsewhere,
-    radar_service, reset_radar_cache,
+    TRIP_ZONE, clean_uid, fresh_uid, frozen_active_window, make_trip,
+    quiet_window_elsewhere, radar_service, reset_radar_cache,
 )
 
 SMS_TO = "+49000000000"
@@ -422,7 +422,16 @@ def _kurznachricht_vom_echten_trip_pfad(frames, telegram_stub, monkeypatch, suff
     Draht ankam. Kein Baustein wird uebersprungen: echte Radar-Frames ->
     echter `RadarNowcastService` -> echtes `NowcastResult` -> echtes
     `check_radar_alerts()` -> echter `NotificationService` -> echter
-    Telegram-Transport."""
+    Telegram-Transport.
+
+    Gestellte Uhr, nicht Wanduhr (#2050): `app.loader.save_trip()` (Compute-
+    on-Save, #802) verwirft die `arrival_start`/`arrival_end`-Vorgabe von
+    `make_trip()` und rechnet die Etappe neu — bei den Default-Koordinaten
+    ist danach nur `[08:00, 20:00)` Ortszeit luecklos aktiv (Beleg und
+    Begruendung: `frozen_active_window()` in
+    `tests/helpers/nowcast_gate_fixtures.py`). Ohne die gestellte Uhr war
+    dieser Helfer ausserhalb dieses Fensters strukturell rot (gemessen
+    2026-08-21: CI-Lauf 19:38 UTC gruen, derselbe Testfall 20:40 UTC rot)."""
     from app.loader import save_trip
     from services.trip_alert import TripAlertService
 
@@ -432,37 +441,38 @@ def _kurznachricht_vom_echten_trip_pfad(frames, telegram_stub, monkeypatch, suff
     clean_uid(uid)
     reset_radar_cache()
     try:
-        quiet_from, quiet_to = quiet_window_elsewhere(zone=TRIP_ZONE)
-        trip = make_trip(
-            trip_id, cooldown_minutes=0, quiet_from=quiet_from, quiet_to=quiet_to,
-        )
-        morgen, abend = briefing_zeiten_fuer_trip(trip)
-        trip.report_config = TripReportConfig(
-            trip_id=trip_id, send_email=False, send_sms=False,
-            send_telegram=True, send_premium_sms=False,
-            alert_on_changes=True, telegram_style="kurzform",
-            morning_time=morgen, evening_time=abend,
-        )
-        # Der PRODUKTIVE Speicherer (`app.loader.save_trip`), nicht der
-        # verkuerzte Test-Helfer: nur er schreibt `telegram_style` mit, und
-        # `check_radar_alerts()` liest den Trip von Platte zurueck.
-        save_trip(trip, user_id=uid)
+        with frozen_active_window():
+            quiet_from, quiet_to = quiet_window_elsewhere(zone=TRIP_ZONE)
+            trip = make_trip(
+                trip_id, cooldown_minutes=0, quiet_from=quiet_from, quiet_to=quiet_to,
+            )
+            morgen, abend = briefing_zeiten_fuer_trip(trip)
+            trip.report_config = TripReportConfig(
+                trip_id=trip_id, send_email=False, send_sms=False,
+                send_telegram=True, send_premium_sms=False,
+                alert_on_changes=True, telegram_style="kurzform",
+                morning_time=morgen, evening_time=abend,
+            )
+            # Der PRODUKTIVE Speicherer (`app.loader.save_trip`), nicht der
+            # verkuerzte Test-Helfer: nur er schreibt `telegram_style` mit, und
+            # `check_radar_alerts()` liest den Trip von Platte zurueck.
+            save_trip(trip, user_id=uid)
 
-        svc = TripAlertService(
-            settings=_telegram_kurzform_settings(), throttle_hours=0,
-            user_id=uid, radar_service=radar_service(frames),
-        )
+            svc = TripAlertService(
+                settings=_telegram_kurzform_settings(), throttle_hours=0,
+                user_id=uid, radar_service=radar_service(frames),
+            )
 
-        sent = svc.check_radar_alerts()
+            sent = svc.check_radar_alerts()
 
-        assert sent == 1, (
-            f"Voraussetzung: genau EIN Radar-Alarm erwartet, war {sent}. "
-            f"Nowcast-Abrufe: {frames.calls!r}"
-        )
-        assert len(telegram_stub.sent) == 1, (
-            f"Erwartet genau EINE Kurznachricht am Draht: {telegram_stub.sent!r}"
-        )
-        return telegram_stub.sent[0].get("text") or ""
+            assert sent == 1, (
+                f"Voraussetzung: genau EIN Radar-Alarm erwartet, war {sent}. "
+                f"Nowcast-Abrufe: {frames.calls!r}"
+            )
+            assert len(telegram_stub.sent) == 1, (
+                f"Erwartet genau EINE Kurznachricht am Draht: {telegram_stub.sent!r}"
+            )
+            return telegram_stub.sent[0].get("text") or ""
     finally:
         clean_uid(uid)
 


### PR DESCRIPTION
Issue #2050, Scheibe S1. Spec: `docs/specs/modules/alarm_pruefstrecke.md` (`status: approved`, PO-Freigabe belegt in [#2050](https://github.com/henemm/gregor_zwanzig/issues/2050#issuecomment-5374102413)).

## Was das ist

Eine Prüfstrecke, mit der Alarm-Szenarien als **Zeitreihe mit Gedächtnis** gegen die *echte* Auslöseentscheidung gefahren werden — mehrere Prüfläufe hintereinander, gestellte Uhr je Lauf, vorbelegbarer Zustand, Abgriff aller vier Kanäle ohne Außenversand.

`TripAlertService` wird **pro Lauf neu gebaut**, genau wie jeder Cron-Tick in Produktion; die Kontinuität kommt vom Datenträger, nicht vom Python-Objekt.

**Kein Produktivcode berührt.** Der Diff besteht aus zwei neuen Testdateien und der Spec.

## Korrektur am Ticket-Bild

Das Issue führt „Einspeisung in die Auslöseentscheidung" und „vorbelegbarer Zustand" als fehlend. Die Kartierung (`docs/context/feat-2050-s1-pruefstrecke.md`, drei parallele Explore-Läufe, am Code nachgeprüft) zeigt: **beide existieren bereits**, nur unverbunden. Was fehlte, war die Absicherung mehrerer Läufe im selben Prozess.

Der `alert-preview`-Endpoint aus #1948 S2 ist **nicht defekt** — er bekennt sich in seiner eigenen Spec zur Zustandslosigkeit und ist für den Textbau gebaut. Diese Scheibe repariert ihn nicht, sondern baut daneben.

## Die drei Selbstschutz-Kriterien

AC-4 bis AC-6 richten die Strecke gegen sich selbst: Wird je Zweig ein echter Gate-Baustein erzwungen gesperrt, MUSS der Lauf null liefern. Ohne diesen Nachweis produziert eine Prüfstrecke wertloses Grün — genau der Defekt, den #2050 abstellen will.

Die Sperre muss je Baustein an einem **anderen Modul** ansetzen:

| AC | Baustein | Patch-Ziel | Warum |
|---|---|---|---|
| AC-4 | `check_briefing_imminent` | `alert_gate` | `trip_alert.py:967` importiert lokal pro Aufruf |
| AC-5 | `check_official_alert_gate` | `trip_alert` | Modulebene-Import (`trip_alert.py:22-27`) |
| AC-6 | `check_nowcast_gate` | `trip_alert` | dito |

Ein Patch auf `alert_gate` liefe bei AC-5/AC-6 ins Leere — der Test wäre rot **aus dem falschen Grund**.

## Drei Fallen, die beim Bau aufgedeckt wurden

1. **Premium-SMS hätte die Strecke strukturell nie erreicht.** `Settings` ohne `with_user_profile()` kennt die gelernte Rückadresse nicht — der Kanal hätte immer geschwiegen, und ein stiller Kanal sieht aus wie ein bestandener Test. Behoben, mit Begründung im Code, damit ihn niemand als überflüssig entfernt.
2. **AC-3 wäre grün geworden, ohne etwas zu prüfen.** `freeze_time` friert auch `time.monotonic()` ein, gegen das die Telegram-Drossel misst. Ein Abstand von exakt einer Fensterlänge ließ den Slot ohnehin verfallen — der Test hätte bestanden, egal ob der Cache-Reset wirkt. Abstand korrigiert, Gegenprobe ergänzt.
3. **AC-3 nutzte einen Free-Tier-Nutzer**, für den wegen der #1555-Nowcast-Reserve effektiv nur *ein* Vorhersage-Alarm pro Tag zulässig ist. Der zweite Lauf scheiterte am Tageslimit statt an der geprüften Frage. Korrektes Produktivverhalten, falsche Testannahme.

## Adversary

Verdict AMBIGUOUS, ein Finding (F001, HIGH) — **geschlossen, nicht vertagt** (`ab2da2fe`).

Der Adversary mutierte den Harness zur Instanz-Wiederverwendung: **alle 8 Tests blieben grün.** Die Zusicherung „pro Lauf neu gebaut" stand nur im Docstring und in AC-1, bewacht war sie nicht. `_mail_sink` schließt über die Mail-Liste genau des Aufrufs, in dem der Service gebaut wurde (`trip_alert.py:209`, nur im Konstruktor gesetzt) — bei Wiederverwendung wäre `AlarmPruefstreckeLauf.mail` im zweiten Lauf strukturell immer leer.

Neuer Wächter `test_ac1b_jeder_lauf_bekommt_eine_eigene_service_instanz`. Gegenprobe belegt: Unter der Mutation wird **nur** der neue Test rot, die 8 Bestandstests bleiben grün — der Beweis, dass die Zusicherung vorher unbewacht war.

Mutationsprotokoll gesamt: **6 von 6 Pflicht-Mutationen werden jetzt gefangen** (5 vorher, die sechste durch F001).

## Testnachweis

```
tests/tdd/test_alarm_pruefstrecke_selbstschutz.py .........  9 passed in 1.50s
```

Regressionsprüfung über die Nachbarschaft, aus der Bausteine importiert werden
(`test_952_onset_alert_fidelity`, `test_issue_1070_daily_alert_limit`,
`test_premium_sms_versand`, `test_radar_alert_telegram_style`): **60 passed**, keine Regression.

Testkommando braucht drei Socket-Flags, weil der Harness echte lokale TCP-Stubs bindet:
`--disable-socket --allow-unix-socket --allow-hosts=127.0.0.1,::1,localhost`

## Nicht Ziel

Die zwölf Szenarien (S2–S5), die Protokollergänzung (S6), Ortsvergleich-Pendants, ein durchgängiger `now=`-Umbau des Alarmpfads, jede Änderung am `alert-preview`-Endpoint.

## Bekannte Grenze, dokumentiert

`check_official_alert_triggers(now_utc=...)` verwirft den übergebenen Zeitpunkt bedingungslos (`trip_alert.py:1811`). Heute folgenlos, aber eine gestellte Uhr würde still verworfen — die Prüfstrecke bietet `now_utc=` deshalb gar nicht erst als Steuerweg an.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HrHWXifzUMB3So33R8pJZC
