### PR TITLE
fix(#2047): WIP-Sicherung vor dem harten Reset im Haupt-Checkout (Scheibe 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -463,6 +463,18 @@ jobs:
           scp -i /tmp/deploy_key -o StrictHostKeyChecking=no \
             /tmp/ci_e2e_findings.json \
             ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}:/tmp/ci_e2e_findings.json
+          # Sicherheitsnetz (#2047): der Verdict-Schritt resettet den Haupt-Checkout
+          # hart auf origin/main — dieser Ordner ist zugleich Arbeitsverzeichnis
+          # interaktiver Sessions. Uncommittete getrackte Arbeit wird deshalb vorher
+          # als Stash-Objekt + Tag gesichert. Das Skript wird aus origin/main bezogen
+          # (nicht aus dem Arbeitsbaum): beim ersten Rollout liegt es dort noch nicht
+          # auf Stand. Schlägt die Sicherung fehl, bricht der Schritt ab (bash -e),
+          # bevor der Reset unten läuft. Ablage per `mktemp` statt festem /tmp-Pfad:
+          # auf dem Server existieren weitere lokale Accounts, ein vorab gelegter
+          # Symlink würde die `>`-Umleitung sonst umbiegen.
+          ssh -i /tmp/deploy_key -o StrictHostKeyChecking=no -o ConnectTimeout=30 \
+            ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} \
+            "cd /home/hem/gregor_zwanzig && t=\$(mktemp /tmp/ci_wip_safety.XXXXXX) && git fetch origin 2>/dev/null && git show origin/main:scripts/wip_safety.sh > \"\$t\" && bash \"\$t\" /home/hem/gregor_zwanzig; rc=\$?; rm -f \"\$t\"; exit \$rc"
           # Issue #1031 Root Cause: staging_gate verlangt bei Telegram-berührenden
           # Changes einen Live-Test (#686 AC-5) — dafür müssen die Staging-Bot-Creds
           # (GZ_TELEGRAM_TEST_CHAT_ID etc.) aus der Server-seitigen Staging-.env

--- a/docs/context/fix-2047-s1-wip-sicherung.md
+++ b/docs/context/fix-2047-s1-wip-sicherung.md
@@ -1,0 +1,67 @@
+# Context: fix-2047-s1-wip-sicherung
+
+## Request Summary
+
+Der CI-Schritt „Staging-Verdict schreiben (CI smoke)" fährt bei **jedem** Merge nach `main`
+ein `git reset --hard origin/main` im Haupt-Checkout `/home/hem/gregor_zwanzig` — **ohne**
+WIP-Sicherung. Uncommittete getrackte Arbeit dort wird zerstört. Scheibe 1 von #2047 setzt
+die Sicherung davor, nach dem bereits bewährten Vorbild aus `deploy-gregor-prod.sh`.
+
+**Abgrenzung:** Die Wirkungslosigkeit des Prod-Gates selbst (Kern von #2047, PO-Entscheid
+„Weg A mit Automatisierung") ist **Scheibe 2** und wird hier nicht angefasst.
+
+## Related Files
+
+| File | Relevance |
+|------|-----------|
+| `.github/workflows/ci.yml:473` | Die fragliche Zeile — SSH-Einzeiler mit ungesichertem `git reset --hard` |
+| `/home/hem/henemm-infra/scripts/deploy-gregor-prod.sh:149-161` | **Vorbild**: `git stash create` + Tag `deploy-safety/<ts>` + Echo mit Wiederherstellungs-Befehl |
+| `.claude/hooks/staging_gate.py:97-110` | `_verified_repo_dir()`/`_head_sha()` — cwd-basiert, deshalb ist der Reset funktional nötig |
+| `.claude/hooks/_e2e_paths.py:283-308` | Attestations-Ablage im geteilten Hauptrepo; Design setzt den Reset voraus |
+
+## Existing Patterns
+
+**WIP-Sicherung (`deploy-gregor-prod.sh:149-161`)** — das zu kopierende Muster:
+
+```
+if ! git diff --quiet || ! git diff --cached --quiet; then
+    SAFETY=$(git stash create "pre-deploy-safety $(date -u +%FT%TZ)" || true)
+    if [ -n "$SAFETY" ]; then
+        TAG="deploy-safety/$(date -u +%Y%m%d-%H%M%S)"
+        git tag "$TAG" "$SAFETY" 2>/dev/null || true
+        echo "... gesichert: $SAFETY (Tag $TAG)"
+```
+
+Kernmechanik: `git stash create` (**nicht** `stash push`) erzeugt ein Stash-Commit-Objekt,
+ohne den Arbeitsbaum anzufassen. Das ist wichtig, weil der Haupt-Checkout mit anderen
+Sessions geteilt wird — `stash push` würde deren Arbeitsbaum unter den Füßen wegziehen.
+Der Tag verankert das Objekt, damit die GC es nicht einsammelt.
+
+## Dependencies
+
+- **Upstream:** Der Schritt braucht `origin/main` als HEAD, weil `staging_gate.py --write-verdict`
+  den SHA aus dem cwd zieht (`_head_sha()`). Ein Wegfall des Resets ist deshalb **kein**
+  Scheibe-1-Fix.
+- **Downstream:** `deploy-gregor-prod.sh` läuft Sekunden später und macht seinerseits einen
+  Reset — diesmal mit Sicherung. Die zwei Resets dürfen sich nicht ins Gehege kommen.
+
+## Risks & Considerations
+
+1. **`git stash create` sichert keine untracked Dateien.** Das ist hier unschädlich, weil
+   `git reset --hard` untracked Dateien ebenfalls nicht anfasst — die Abdeckung ist also
+   deckungsgleich mit dem Schaden.
+2. **Der Haupt-Checkout ist zugleich das Produktions-Arbeitsverzeichnis** aller drei
+   systemd-Dienste (`gregor-python.service`, `gregor-api.service` → `WorkingDirectory=/home/hem/gregor_zwanzig`).
+   → **Nebenbefund für Scheibe 2:** `deploy-gregor-prod.sh` stoppt `gregor-python` *vor* seinem
+   Reset (`:274` vor `:285`); der CI-Verdict-Schritt tut das **nicht**. Der Code-Stand wechselt
+   also unter laufenden Prod-Diensten. Nicht Teil dieser Scheibe.
+3. **Kein Aufräumen der Sicherungs-Tags** ist im Vorbild belegt. Bei jedem Merge ein Tag
+   entsteht nur, wenn tatsächlich uncommittete Arbeit vorlag — das ist selten genug, dass
+   Wildwuchs unwahrscheinlich ist. Wird beobachtet, nicht vorab gelöst.
+4. **Testbarkeit:** `ci.yml` selbst ist nicht ausführbar testbar. Deshalb wandert die
+   Sicherungslogik in ein eigenes Shell-Skript, das gegen ein echtes Wegwerf-Git-Repo
+   geprüft wird (kein Mock). Die Verdrahtung in `ci.yml` wird separat als
+   `# doc-compliance-test` abgesichert.
+5. **Henne-Ei beim ersten Lauf:** Ein neues Skript im Repo liegt beim allerersten CI-Lauf
+   noch nicht im Arbeitsbaum des Servers (HEAD ist dort der alte Stand). Der Aufruf muss
+   das Skript deshalb aus `origin/main` beziehen, nicht aus dem Arbeitsbaum.

--- a/docs/specs/modules/ci_wip_sicherung.md
+++ b/docs/specs/modules/ci_wip_sicherung.md
@@ -19,13 +19,13 @@ tags: [ci, deploy, wip-safety]
 Der CI-Schritt „Staging-Verdict schreiben (CI smoke)" führt bei jedem Merge nach `main` ein
 `git reset --hard origin/main` im Haupt-Checkout `/home/hem/gregor_zwanzig` aus — ohne
 WIP-Sicherung. Dieser Checkout ist zugleich das Arbeitsverzeichnis interaktiver Sessions und
-der Produktions-Serving-Ordner. Ein neues Skript `.claude/hooks/wip_safety.sh` sichert
+der Produktions-Serving-Ordner. Ein neues Skript `scripts/wip_safety.sh` sichert
 uncommittete getrackte Änderungen als Stash-Objekt + Tag, bevor der Reset sie verwirft, nach
 dem bewährten Vorbild aus `deploy-gregor-prod.sh`.
 
 ## Source
 
-- **File:** `.claude/hooks/wip_safety.sh` (neu)
+- **File:** `scripts/wip_safety.sh` (neu)
 - **Identifier:** Shell-Skript, aufgerufen mit einem Repo-Pfad als Argument
 
 ## Estimated Scope
@@ -68,7 +68,7 @@ dem bewährten Vorbild aus `deploy-gregor-prod.sh`.
 `.github/workflows/ci.yml` — Schritt „Staging-Verdict schreiben (CI smoke)": vor der
 bestehenden `ssh ... "cd /home/hem/gregor_zwanzig && git fetch origin && git reset --hard
 origin/main && ..."`-Zeile wird ein Aufruf von `wip_safety.sh` eingefügt. Das Skript wird dabei
-aus `origin/main` bezogen (z. B. `git show origin/main:.claude/hooks/wip_safety.sh | bash -s --
+aus `origin/main` bezogen (z. B. `git show origin/main:scripts/wip_safety.sh | bash -s --
 /home/hem/gregor_zwanzig` oder ein `git fetch` + `git show`-Äquivalent per SSH), nicht aus dem
 Arbeitsbaum des Servers — beim allererstmaligen Rollout liegt das Skript dort noch nicht auf
 dem aktuellen Stand (Henne-Ei, siehe Context-Doc Punkt 5). Schlägt die Sicherung fehl (Exit

--- a/docs/specs/modules/ci_wip_sicherung.md
+++ b/docs/specs/modules/ci_wip_sicherung.md
@@ -57,8 +57,12 @@ dem bewährten Vorbild aus `deploy-gregor-prod.sh`.
    Fehlermeldung auf stderr, die explizit benennt, dass ungesicherte Arbeit vorliegt, Exit
    ungleich 0. Das Skript darf in diesem Fall keinen Erfolg vortäuschen — der Aufrufer (CI)
    muss den nachfolgenden `git reset --hard` unterlassen.
-5. Ist `$SAFETY` gesetzt: Tag `deploy-safety/ci-$(date -u +%Y%m%d-%H%M%S)` auf das Stash-Objekt
-   setzen (`git -C <repo_dir> tag <TAG> <SAFETY>`), dann eine Meldung mit dem vollständigen
+5. Ist `$SAFETY` gesetzt: Tag `deploy-safety/ci-$(date -u +%Y%m%d-%H%M%S)-${SAFETY:0:12}` auf das
+   Stash-Objekt setzen — die Objekt-Kurzform im Namen hält zwei Läufe derselben UTC-Sekunde
+   auseinander (AC-10). Schlägt das Setzen fehl, weil derselbe Tag bereits auf **genau dieses**
+   Stash-Objekt zeigt, ist die Arbeit bereits gesichert: Erfolgsmeldung inklusive
+   Wiederherstellungs-Befehl, Exit 0 (AC-11). Schlägt es aus einem anderen Grund fehl, bricht
+   das Skript ab (AC-9) (`git -C <repo_dir> tag <TAG> <SAFETY>`), dann eine Meldung mit dem vollständigen
    Wiederherstellungs-Befehl ausgeben, analog zur Zeile in `deploy-gregor-prod.sh:159`
    (`git -C <repo_dir> stash apply <SAFETY>` bzw. über den Tag-Namen).
 6. Untrackte Dateien werden nicht angefasst — `git stash create` erfasst sie standardmäßig
@@ -140,6 +144,36 @@ ungleich 0), bricht der CI-Schritt ab, bevor der Reset läuft.
     `git reset --hard origin/main`, und die Aufrufzeile referenziert `origin/main` als Quelle
     des Skripts.
 
+- **AC-9:** Given das Stash-Objekt wurde erzeugt, aber der Tag lässt sich nicht setzen — und
+  zwar aus einem anderen Grund als einem bereits vorhandenen Tag auf **genau diesem** Objekt
+  (Namensraum blockiert, oder der vorhandene Tag zeigt auf einen **abweichenden** Stand) /
+  When `wip_safety.sh` läuft / Then ist der Exit-Code ungleich 0 und die Meldung benennt, dass
+  die Arbeit NICHT dauerhaft gesichert ist — ohne Tag sammelt die GC das Stash-Objekt ein, der
+  Aufrufer darf deshalb NICHT hart resetten.
+  - Test: Echtes Wegwerf-Repo, in dem ein Tag `deploy-safety` (ohne Suffix) den Namensraum als
+    Datei-Ref belegt; Git kann darunter keine Unter-Refs mehr anlegen (D/F-Konflikt). Geprüft
+    werden Exit-Code, Meldungstext und dass kein `deploy-safety/ci-*`-Tag zurückbleibt.
+
+- **AC-10:** Given zwei Sicherungsläufe folgen unmittelbar aufeinander (zwei schnelle Merges —
+  der `deploy`-Job hat kein `concurrency:`-Gate) / When `wip_safety.sh` zweimal läuft / Then
+  gelingen beide Läufe, es entstehen zwei unterscheidbare Tags, und jede Sicherung ist einzeln
+  wiederherstellbar.
+  - Test: Zwei Läufe mit unterschiedlichem WIP-Inhalt gegen dasselbe Wegwerf-Repo; geprüft
+    werden zwei Tags, dass jeder Tag-Name auf die ersten 12 Zeichen der SHA seines
+    Ziel-Objekts endet (Kollisionsfreiheit auch innerhalb derselben UTC-Sekunde), und dass
+    `stash apply` je Tag den zugehörigen Inhalt zurückholt.
+
+- **AC-11:** Given die uncommittete Arbeit ist bereits gesichert und hat sich seither nicht
+  geändert (alltäglich: mehrere Merges am selben Tag) / When `wip_safety.sh` innerhalb
+  derselben UTC-Sekunde erneut läuft und deshalb denselben Tag-Namen erzeugt / Then gelingen
+  beide Läufe mit Exit 0, es bleibt bei genau einem Tag, und die Arbeit ist darüber
+  wiederherstellbar — ein Abbruch wäre eine Lieferblockade, obwohl die Arbeit gesichert IST.
+  - Test: Zwei Läufe gegen dasselbe Wegwerf-Repo bei **unverändertem** Arbeitsbaum, auf den
+    Sekundenbeginn synchronisiert (keine gefälschte Uhr); geprüft werden beide Exit-Codes,
+    genau ein Tag, derselbe Tag-Name in beiden Ausgaben, und dass der aus der zweiten Ausgabe
+    geparste Wiederherstellungs-Befehl nach `git reset --hard origin/main` real ausgeführt den
+    Dateiinhalt zurückholt.
+
 ## Known Limitations
 
 - Untrackte Dateien sind nicht durch die Sicherung abgedeckt — das ist beabsichtigt, weil der
@@ -163,3 +197,6 @@ ungleich 0), bricht der CI-Schritt ab, bevor der Reset läuft.
 ## Changelog
 
 - 2026-08-21: Initial spec created
+- 2026-08-21: AC-11 (Idempotenz bei unverändertem Arbeitsbaum) ergänzt, AC-9 auf den Fall
+  „abweichendes Objekt bzw. echter Tag-Fehler" präzisiert — Adversary-Befund: zwei Läufe in
+  derselben Sekunde bei gleichem Inhalt brachen die CI-Kette ab, obwohl die Arbeit gesichert war.

--- a/docs/specs/modules/ci_wip_sicherung.md
+++ b/docs/specs/modules/ci_wip_sicherung.md
@@ -1,0 +1,165 @@
+---
+entity_id: ci_wip_sicherung
+type: bugfix
+created: 2026-08-21
+updated: 2026-08-21
+status: draft
+version: "1.0"
+tags: [ci, deploy, wip-safety]
+---
+
+# CI-WIP-Sicherung vor `git reset --hard` im Haupt-Checkout
+
+## Approval
+
+- [x] Approved — PO-Freigabe 2026-08-21 („freigabe"), alle 8 ACs
+
+## Purpose
+
+Der CI-Schritt „Staging-Verdict schreiben (CI smoke)" führt bei jedem Merge nach `main` ein
+`git reset --hard origin/main` im Haupt-Checkout `/home/hem/gregor_zwanzig` aus — ohne
+WIP-Sicherung. Dieser Checkout ist zugleich das Arbeitsverzeichnis interaktiver Sessions und
+der Produktions-Serving-Ordner. Ein neues Skript `.claude/hooks/wip_safety.sh` sichert
+uncommittete getrackte Änderungen als Stash-Objekt + Tag, bevor der Reset sie verwirft, nach
+dem bewährten Vorbild aus `deploy-gregor-prod.sh`.
+
+## Source
+
+- **File:** `.claude/hooks/wip_safety.sh` (neu)
+- **Identifier:** Shell-Skript, aufgerufen mit einem Repo-Pfad als Argument
+
+## Estimated Scope
+
+- **LoC:** ~60
+- **Files:** 2
+- **Effort:** low
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `deploy-gregor-prod.sh:149-161` | Referenz-Skript (henemm-infra) | Liefert das zu kopierende Sicherungsmuster (`git stash create` + Tag + Wiederherstellungs-Hinweis) |
+| `.claude/hooks/staging_gate.py:97-110` | Konsument (indirekt) | `_head_sha()`/`_verified_repo_dir()` sind cwd-basiert — deshalb bleibt der Reset selbst funktional nötig |
+| `.github/workflows/ci.yml:456-474` | Aufrufer | Ruft `wip_safety.sh` künftig vor dem `git reset --hard` auf |
+
+## Implementation Details
+
+`wip_safety.sh <repo_dir>`:
+
+1. Wechselt nicht in `<repo_dir>` per `cd`, sondern arbeitet mit `git -C <repo_dir>`, damit das
+   Skript aus einem beliebigen Ort aufgerufen werden kann.
+2. Prüft, ob der Arbeitsbaum schmutzig ist (`git -C <repo_dir> diff --quiet` und
+   `git -C <repo_dir> diff --cached --quiet`). Ist er sauber: keine Aktion, Exit 0.
+3. Ist er schmutzig: `SAFETY=$(git -C <repo_dir> stash create "ci-wip-safety $(date -u +%FT%TZ)")`.
+   Bewusst `stash create`, nicht `stash push` — der Arbeitsbaum bleibt unverändert, weil er mit
+   anderen Sessions geteilt wird.
+4. Ist `$SAFETY` leer (Stash-Objekt konnte nicht erzeugt werden, obwohl der Baum schmutzig ist):
+   Fehlermeldung auf stderr, die explizit benennt, dass ungesicherte Arbeit vorliegt, Exit
+   ungleich 0. Das Skript darf in diesem Fall keinen Erfolg vortäuschen — der Aufrufer (CI)
+   muss den nachfolgenden `git reset --hard` unterlassen.
+5. Ist `$SAFETY` gesetzt: Tag `deploy-safety/ci-$(date -u +%Y%m%d-%H%M%S)` auf das Stash-Objekt
+   setzen (`git -C <repo_dir> tag <TAG> <SAFETY>`), dann eine Meldung mit dem vollständigen
+   Wiederherstellungs-Befehl ausgeben, analog zur Zeile in `deploy-gregor-prod.sh:159`
+   (`git -C <repo_dir> stash apply <SAFETY>` bzw. über den Tag-Namen).
+6. Untrackte Dateien werden nicht angefasst — `git stash create` erfasst sie standardmäßig
+   nicht, und `git reset --hard` lässt sie ebenfalls unberührt. Die Abdeckung ist damit
+   deckungsgleich mit dem tatsächlichen Schaden des nachfolgenden Resets.
+
+`.github/workflows/ci.yml` — Schritt „Staging-Verdict schreiben (CI smoke)": vor der
+bestehenden `ssh ... "cd /home/hem/gregor_zwanzig && git fetch origin && git reset --hard
+origin/main && ..."`-Zeile wird ein Aufruf von `wip_safety.sh` eingefügt. Das Skript wird dabei
+aus `origin/main` bezogen (z. B. `git show origin/main:.claude/hooks/wip_safety.sh | bash -s --
+/home/hem/gregor_zwanzig` oder ein `git fetch` + `git show`-Äquivalent per SSH), nicht aus dem
+Arbeitsbaum des Servers — beim allererstmaligen Rollout liegt das Skript dort noch nicht auf
+dem aktuellen Stand (Henne-Ei, siehe Context-Doc Punkt 5). Schlägt die Sicherung fehl (Exit
+ungleich 0), bricht der CI-Schritt ab, bevor der Reset läuft.
+
+## Expected Behavior
+
+- **Input:** Pfad zu einem Git-Repo-Verzeichnis als einziges Argument.
+- **Output:** Bei schmutzigem Baum ein Tag `deploy-safety/ci-<UTC-Zeitstempel>` plus eine
+  stdout-Meldung mit dem vollständigen Wiederherstellungs-Befehl; bei sauberem Baum keine
+  Ausgabe und Exit 0.
+- **Side effects:** Legt im Erfolgsfall genau ein Git-Tag an, der auf ein Stash-Commit-Objekt
+  zeigt. Verändert weder den Arbeitsbaum noch die Staging-Area noch untrackte Dateien.
+
+## Acceptance Criteria
+
+- **AC-1:** Given im Ziel-Repo liegt eine uncommittete Änderung an einer getrackten Datei /
+  When `wip_safety.sh <repo>` läuft und danach `git reset --hard origin/main` ausgeführt wird /
+  Then existiert ein Tag `deploy-safety/ci-<Zeitstempel>`, und `git stash apply <Tag>` stellt
+  die Änderung inhaltlich wieder her.
+  - Test: Echtes Wegwerf-Git-Repo in Temp-Verzeichnis, echter Commit + echte uncommittete
+    Änderung, Skript-Aufruf, dann Reset, dann `stash apply` gegen den erzeugten Tag — der
+    Dateiinhalt danach entspricht dem vor dem Reset.
+
+- **AC-2:** Given der Arbeitsbaum enthält uncommittete Änderungen / When `wip_safety.sh` läuft /
+  Then ist der Arbeitsbaum danach unverändert (dieselben Dateien weiterhin modifiziert) — die
+  Sicherung darf nichts wegnehmen, weil der Checkout mit anderen Sessions geteilt wird.
+  - Test: `git diff` vor und nach dem Skript-Aufruf auf Gleichheit vergleichen (kein
+    Dateiinhalt-Check auf Textform, sondern realer Diff-Vergleich).
+
+- **AC-3:** Given eine Änderung ist gestaget (`git add`), aber nicht committet / When
+  `wip_safety.sh` läuft und danach hart resettet wird / Then ist auch diese Änderung über den
+  Tag wiederherstellbar.
+  - Test: Wie AC-1, aber die Änderung wird vor dem Skript-Aufruf per `git add` gestaget statt
+    ungestaget zu bleiben; `stash apply` liefert den gestageten Inhalt zurück.
+
+- **AC-4:** Given der Arbeitsbaum ist sauber / When `wip_safety.sh` läuft / Then wird kein Tag
+  angelegt, keine Fehlermeldung ausgegeben, und der Exit-Code ist 0.
+  - Test: Frisches Repo ohne uncommittete Änderungen, Skript-Aufruf, Prüfung dass
+    `git tag --list 'deploy-safety/ci-*'` leer bleibt und `$?` gleich 0 ist.
+
+- **AC-5:** Given der Arbeitsbaum ist schmutzig, aber `git stash create` liefert kein
+  Stash-Objekt / When `wip_safety.sh` läuft / Then ist der Exit-Code ungleich 0 und die
+  Meldung nennt, dass ungesicherte Arbeit vorliegt — die Kette darf in diesem Fall NICHT mit
+  einem harten Reset weiterlaufen.
+  - Test: Repo-Zustand konstruieren, in dem `stash create` real leer zurückgibt (z. B. Repo
+    ohne initialen Commit, sodass kein HEAD zum Vergleich existiert), Skript-Aufruf, Prüfung
+    von Exit-Code und stderr-Text — kein Reset wird im Test danach ausgeführt.
+
+- **AC-6:** Given eine Sicherung wurde angelegt / When die Ausgabe gelesen wird / Then enthält
+  sie den vollständigen Wiederherstellungs-Befehl inklusive Tag-Namen, sodass die Arbeit ohne
+  Zusatzwissen zurückgeholt werden kann.
+  - Test: Ausgabe des Skript-Laufs aus AC-1 parsen und prüfen, dass der ausgegebene Befehl den
+    exakten Tag-Namen enthält und beim tatsächlichen Ausführen die Datei wiederherstellt (nicht
+    nur String-Presence, sondern realer Ausführungsnachweis).
+
+- **AC-7:** Given untrackte Dateien liegen im Arbeitsbaum / When `wip_safety.sh` läuft und
+  danach hart resettet wird / Then sind sie unverändert vorhanden — sie werden vom Reset
+  ohnehin nicht angefasst und dürfen von der Sicherung nicht angerührt werden.
+  - Test: Neue Datei ohne `git add` anlegen, Skript-Aufruf, dann `git reset --hard`, dann
+    prüfen dass die Datei mit identischem Inhalt weiterhin existiert.
+
+- **AC-8:** Given der CI-Schritt „Staging-Verdict schreiben (CI smoke)" in
+  `.github/workflows/ci.yml` / When der Schritt gelesen wird / Then steht der Aufruf der
+  Sicherung VOR dem `git reset --hard`, und das Skript wird aus `origin/main` bezogen, nicht
+  aus dem Arbeitsbaum.
+  - Test: `# doc-compliance-test` — Dateiinhalt-Prüfung auf `.github/workflows/ci.yml`:
+    Position des `wip_safety.sh`-Aufrufs liegt textuell vor der Position von
+    `git reset --hard origin/main`, und die Aufrufzeile referenziert `origin/main` als Quelle
+    des Skripts.
+
+## Known Limitations
+
+- Untrackte Dateien sind nicht durch die Sicherung abgedeckt — das ist beabsichtigt, weil der
+  nachfolgende `git reset --hard` sie ohnehin nicht anfasst (siehe AC-7).
+- Es gibt keine Retention/Aufräumung der `deploy-safety/ci-*`-Tags. Wildwuchs wird beobachtet,
+  nicht in dieser Scheibe gelöst.
+- Der CI-Verdict-Schritt stoppt `gregor-python.service` weiterhin nicht vor dem Reset (anders
+  als `deploy-gregor-prod.sh`) — notierter Nebenbefund für Scheibe 2 von #2047, hier nicht
+  behoben.
+- Die Wirkungslosigkeit des Prod-Gates selbst (Kern von #2047) ist nicht Gegenstand dieser
+  Spec.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Es handelt sich um eine punktuelle Härtung eines bestehenden CI-Schritts
+  (WIP-Verlust verhindern), nicht um eine neue Grundsatzentscheidung zu Test- oder
+  Deploy-Strategie — der Reset selbst bleibt unverändert bestehen, es wird nur ein
+  Sicherheitsnetz nach bereits etabliertem Muster (`deploy-gregor-prod.sh`) ergänzt.
+
+## Changelog
+
+- 2026-08-21: Initial spec created

--- a/scripts/wip_safety.sh
+++ b/scripts/wip_safety.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# WIP-Sicherung vor einem harten Reset (gregor_zwanzig#2047, Scheibe 1).
+#
+# Sichert uncommittete getrackte Arbeit in <repo_dir> als Stash-Objekt + Tag,
+# BEVOR der Aufrufer `git reset --hard origin/main` ausfuehrt. Vorbild:
+# henemm-infra/scripts/deploy-gregor-prod.sh (Sicherheitsnetz vor dem Reset).
+#
+# Bewusst `git stash create` statt `git stash push`: der Arbeitsbaum bleibt
+# unveraendert, weil der Checkout mit anderen Sessions geteilt wird. Untrackte
+# Dateien werden nicht erfasst — der nachfolgende Reset fasst sie ebenfalls nicht an.
+#
+# Usage: bash scripts/wip_safety.sh <repo_dir>
+# Exit 0: nichts zu sichern ODER erfolgreich gesichert.
+# Exit != 0: Sicherung fehlgeschlagen — der Aufrufer darf NICHT hart resetten.
+set -u
+
+REPO_DIR="${1:-}"
+if [ -z "$REPO_DIR" ]; then
+    echo "FEHLER: Repo-Verzeichnis fehlt. Usage: wip_safety.sh <repo_dir>" >&2
+    exit 2
+fi
+if ! git -C "$REPO_DIR" rev-parse --git-dir >/dev/null 2>&1; then
+    echo "FEHLER: '$REPO_DIR' ist kein Git-Repository — Abbruch vor dem harten Reset" >&2
+    exit 2
+fi
+
+# Sauberer Arbeitsbaum: keine Aktion, keine Ausgabe.
+if git -C "$REPO_DIR" diff --quiet 2>/dev/null && git -C "$REPO_DIR" diff --cached --quiet 2>/dev/null; then
+    exit 0
+fi
+
+SAFETY=$(git -C "$REPO_DIR" stash create "ci-wip-safety $(date -u +%FT%TZ)" 2>/dev/null || true)
+SAFETY=$(echo "$SAFETY" | tr -d '[:space:]')
+
+if [ -z "$SAFETY" ]; then
+    echo "FEHLER: Uncommittete Arbeit in '$REPO_DIR' konnte NICHT gesichert werden" >&2
+    echo "       (git stash create lieferte kein Stash-Objekt) — Abbruch, damit kein" >&2
+    echo "       harter Reset die ungesicherte Aenderung verwirft." >&2
+    exit 1
+fi
+
+# Tag-Name traegt zusaetzlich zur UTC-Sekunde die Kurzform des Stash-Objekts: zwei
+# Merges in derselben Sekunde (kein `concurrency:`-Gate im deploy-Job) wuerden sonst
+# im Namen kollidieren und den Lauf abbrechen, obwohl die Sicherung gelungen ist.
+TAG="deploy-safety/ci-$(date -u +%Y%m%d-%H%M%S)-${SAFETY:0:12}"
+if ! git -C "$REPO_DIR" tag "$TAG" "$SAFETY" 2>/dev/null; then
+    # Unveraenderte WIP-Arbeit ergibt in derselben UTC-Sekunde dasselbe Stash-Objekt und
+    # damit denselben Tag-Namen. Zeigt der vorhandene Tag auf genau dieses Objekt, ist die
+    # Arbeit bereits gesichert — Erfolg, kein Fehler (sonst blockiert jeder zweite Merge).
+    EXISTING=$(git -C "$REPO_DIR" rev-parse --verify --quiet "refs/tags/$TAG^{}" 2>/dev/null || true)
+    if [ -n "$EXISTING" ] && [ "$EXISTING" = "$SAFETY" ]; then
+        echo "Uncommittete Aenderungen sind bereits gesichert: $SAFETY (Tag $TAG)"
+        echo "  Der vorhandene Tag zeigt auf genau diesen Stand — die Arbeit ist sicher."
+        echo "  Wiederherstellen mit: git -C $REPO_DIR stash apply $TAG"
+        exit 0
+    fi
+    echo "FEHLER: Uncommittete Arbeit in '$REPO_DIR' ist NICHT gesichert." >&2
+    echo "       Das Stash-Objekt $SAFETY wurde zwar erzeugt, aber der Tag '$TAG' liess" >&2
+    echo "       sich nicht setzen (Namensraum belegt oder Tag zeigt auf einen anderen" >&2
+    echo "       Stand) — ohne Tag sammelt die GC das Objekt ein und die Aenderung ist" >&2
+    echo "       verloren. Abbruch vor dem harten Reset." >&2
+    exit 1
+fi
+
+echo "Uncommittete Aenderungen gesichert: $SAFETY (Tag $TAG)"
+echo "  Wiederherstellen mit: git -C $REPO_DIR stash apply $TAG"
+exit 0

--- a/tests/test_wip_safety.py
+++ b/tests/test_wip_safety.py
@@ -1,0 +1,333 @@
+"""TDD RED fuer #2047 Scheibe 1 — WIP-Sicherung vor ``git reset --hard`` in CI.
+
+Prueflinge:
+
+* ``.claude/hooks/wip_safety.sh`` (Shell-Skript, Aufruf ``bash wip_safety.sh <repo>``)
+* ``.github/workflows/ci.yml`` — Verdrahtung im Schritt "Staging-Verdict schreiben (CI smoke)"
+
+Alle Verhaltenstests laufen gegen ein ECHTES Wegwerf-Git-Repo (``tempfile.mkdtemp``,
+echtes ``git init``/``clone``, echte Commits, echtes ``git reset --hard``, echter
+``subprocess``-Aufruf des Skripts). Keine Mocks — Spec ``docs/specs/modules/ci_wip_sicherung.md``.
+"""
+
+import re
+import shlex
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / ".claude" / "hooks" / "wip_safety.sh"
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+COMMITTED_TEXT = "stand aus origin/main\n"
+WIP_TEXT = "uncommittete WIP-Arbeit einer parallelen Session\n"
+TRACKED = "notiz.txt"
+
+
+def _git(repo: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess:
+    """Echter Git-Aufruf gegen ``repo`` (nie gegen das Projekt-Repo)."""
+    proc = subprocess.run(
+        ["git", "-C", str(repo), *args], capture_output=True, text=True
+    )
+    if check and proc.returncode != 0:
+        raise AssertionError(
+            f"git {' '.join(args)} in {repo} scheiterte (rc={proc.returncode}): "
+            f"{proc.stderr.strip() or proc.stdout.strip()}"
+        )
+    return proc
+
+
+def _run_wip_safety(repo: Path) -> subprocess.CompletedProcess:
+    """Ruft den Pruefling auf — mit sprechender Meldung, falls er fehlt."""
+    assert SCRIPT.exists(), (
+        f"Pruefling fehlt: {SCRIPT} — das Skript muss in Phase 6 angelegt werden "
+        "(Spec docs/specs/modules/ci_wip_sicherung.md)."
+    )
+    return subprocess.run(
+        ["bash", str(SCRIPT), str(repo)], capture_output=True, text=True
+    )
+
+
+def _safety_tags(repo: Path) -> list[str]:
+    out = _git(repo, "tag", "--list", "deploy-safety/ci-*").stdout
+    return [line.strip() for line in out.splitlines() if line.strip()]
+
+
+@pytest.fixture()
+def workdir():
+    """Wegwerf-Verzeichnis, wird nach dem Test restlos abgeraeumt."""
+    path = Path(tempfile.mkdtemp(prefix="wip-safety-"))
+    try:
+        yield path
+    finally:
+        shutil.rmtree(path, ignore_errors=True)
+
+
+@pytest.fixture()
+def repo(workdir: Path) -> Path:
+    """Echtes Repo mit echtem ``origin/main`` (bare Remote + Klon).
+
+    ``git reset --hard origin/main`` — der Befehl, gegen den die Sicherung
+    schuetzen muss — ist damit real ausfuehrbar.
+    """
+    origin = workdir / "origin.git"
+    clone = workdir / "checkout"
+    subprocess.run(
+        ["git", "init", "--bare", "-b", "main", str(origin)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "clone", str(origin), str(clone)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    _git(clone, "config", "user.email", "wip-safety@test.invalid")
+    _git(clone, "config", "user.name", "WIP Safety Test")
+    (clone / TRACKED).write_text(COMMITTED_TEXT, encoding="utf-8")
+    _git(clone, "add", TRACKED)
+    _git(clone, "commit", "-m", "initial")
+    _git(clone, "push", "-u", "origin", "main")
+    return clone
+
+
+def test_uncommittete_aenderung_ueberlebt_harten_reset(repo: Path):
+    """AC-1.
+
+    GIVEN eine uncommittete Aenderung an einer getrackten Datei
+    WHEN wip_safety.sh laeuft und danach ``git reset --hard origin/main``
+    THEN existiert ein Tag ``deploy-safety/ci-<Zeitstempel>`` und
+         ``git stash apply <Tag>`` stellt die Aenderung inhaltlich wieder her.
+    """
+    (repo / TRACKED).write_text(WIP_TEXT, encoding="utf-8")
+
+    proc = _run_wip_safety(repo)
+    assert proc.returncode == 0, f"stderr={proc.stderr}"
+
+    tags = _safety_tags(repo)
+    assert len(tags) == 1, f"genau ein Sicherungs-Tag erwartet, gefunden: {tags}"
+
+    _git(repo, "reset", "--hard", "origin/main")
+    assert (repo / TRACKED).read_text(encoding="utf-8") == COMMITTED_TEXT
+
+    _git(repo, "stash", "apply", tags[0])
+    assert (repo / TRACKED).read_text(encoding="utf-8") == WIP_TEXT
+
+
+def test_arbeitsbaum_bleibt_nach_der_sicherung_unveraendert(repo: Path):
+    """AC-2.
+
+    GIVEN der Arbeitsbaum enthaelt uncommittete Aenderungen
+    WHEN wip_safety.sh laeuft
+    THEN ist der reale Diff davor und danach identisch — die Sicherung darf
+         nichts wegnehmen, weil der Checkout mit anderen Sessions geteilt wird.
+    """
+    (repo / TRACKED).write_text(WIP_TEXT, encoding="utf-8")
+    diff_before = _git(repo, "diff").stdout
+    cached_before = _git(repo, "diff", "--cached").stdout
+    assert diff_before.strip(), "Vorbedingung: der Arbeitsbaum muss schmutzig sein"
+
+    proc = _run_wip_safety(repo)
+    assert proc.returncode == 0, f"stderr={proc.stderr}"
+
+    assert _git(repo, "diff").stdout == diff_before
+    assert _git(repo, "diff", "--cached").stdout == cached_before
+
+
+def test_gestagete_aenderung_ist_ueber_den_tag_wiederherstellbar(repo: Path):
+    """AC-3.
+
+    GIVEN eine Aenderung ist gestaget (``git add``), aber nicht committet
+    WHEN wip_safety.sh laeuft und danach hart resettet wird
+    THEN liefert ``git stash apply <Tag>`` den gestageten Inhalt zurueck.
+    """
+    (repo / TRACKED).write_text(WIP_TEXT, encoding="utf-8")
+    _git(repo, "add", TRACKED)
+    assert _git(repo, "diff", "--cached").stdout.strip(), (
+        "Vorbedingung: die Aenderung muss gestaget sein"
+    )
+
+    proc = _run_wip_safety(repo)
+    assert proc.returncode == 0, f"stderr={proc.stderr}"
+
+    tags = _safety_tags(repo)
+    assert len(tags) == 1, f"genau ein Sicherungs-Tag erwartet, gefunden: {tags}"
+
+    _git(repo, "reset", "--hard", "origin/main")
+    assert (repo / TRACKED).read_text(encoding="utf-8") == COMMITTED_TEXT
+
+    _git(repo, "stash", "apply", tags[0])
+    assert (repo / TRACKED).read_text(encoding="utf-8") == WIP_TEXT
+
+
+def test_sauberer_arbeitsbaum_legt_keinen_tag_an(repo: Path):
+    """AC-4.
+
+    GIVEN der Arbeitsbaum ist sauber
+    WHEN wip_safety.sh laeuft
+    THEN wird kein Tag angelegt, keine Fehlermeldung ausgegeben, Exit-Code 0.
+    """
+    assert not _git(repo, "status", "--porcelain").stdout.strip(), (
+        "Vorbedingung: der Arbeitsbaum muss sauber sein"
+    )
+
+    proc = _run_wip_safety(repo)
+
+    assert proc.returncode == 0, f"stderr={proc.stderr}"
+    assert proc.stderr.strip() == "", f"unerwartete Fehlermeldung: {proc.stderr!r}"
+    assert _safety_tags(repo) == []
+
+
+def test_fehlgeschlagene_sicherung_bricht_mit_fehler_ab(workdir: Path):
+    """AC-5.
+
+    GIVEN der Arbeitsbaum ist schmutzig, aber ``git stash create`` liefert kein
+          Stash-Objekt
+    WHEN wip_safety.sh laeuft
+    THEN ist der Exit-Code ungleich 0 und die Meldung benennt ungesicherte Arbeit —
+         die Kette darf NICHT mit einem harten Reset weiterlaufen.
+
+    Gewaehlter Weg: Repo OHNE initialen Commit mit gestageter Datei. ``git diff
+    --cached --quiet`` meldet dort schmutzig (rc=1), ``git stash create`` bricht
+    mangels HEAD ab und gibt nichts auf stdout aus. Genau diese Vorbedingung wird
+    unten mit einem echten ``git stash create``-Aufruf nachgewiesen.
+    """
+    broken = workdir / "ohne-initial-commit"
+    broken.mkdir()
+    subprocess.run(
+        ["git", "init", "-b", "main", str(broken)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    _git(broken, "config", "user.email", "wip-safety@test.invalid")
+    _git(broken, "config", "user.name", "WIP Safety Test")
+    (broken / TRACKED).write_text(WIP_TEXT, encoding="utf-8")
+    _git(broken, "add", TRACKED)
+
+    assert _git(broken, "diff", "--cached", "--quiet", check=False).returncode != 0, (
+        "Vorbedingung: der Baum muss als schmutzig gelten"
+    )
+    probe = _git(broken, "stash", "create", "probe", check=False)
+    assert probe.stdout.strip() == "", (
+        f"Vorbedingung verfehlt: stash create lieferte doch ein Objekt ({probe.stdout!r}) "
+        "— der Testzustand muss anders konstruiert werden"
+    )
+
+    proc = _run_wip_safety(broken)
+
+    assert proc.returncode != 0, (
+        "die Kette darf nach fehlgeschlagener Sicherung nicht weiterlaufen "
+        f"(stdout={proc.stdout!r})"
+    )
+    message = (proc.stderr + proc.stdout).lower()
+    assert "gesichert" in message, (
+        f"Meldung muss ungesicherte Arbeit benennen, war: {message!r}"
+    )
+    assert any(word in message for word in ("arbeit", "wip", "nderung")), (
+        f"Meldung muss benennen, WAS ungesichert ist, war: {message!r}"
+    )
+
+
+def test_ausgegebener_wiederherstellungs_befehl_holt_die_arbeit_zurueck(repo: Path):
+    """AC-6.
+
+    GIVEN eine Sicherung wurde angelegt
+    WHEN der in der Ausgabe genannte Wiederherstellungs-Befehl tatsaechlich
+         ausgefuehrt wird
+    THEN ist die Datei inhaltlich zurueck — Ausfuehrungsnachweis, nicht nur
+         String-Presence; der Befehl muss den exakten Tag-Namen enthalten.
+    """
+    (repo / TRACKED).write_text(WIP_TEXT, encoding="utf-8")
+
+    proc = _run_wip_safety(repo)
+    assert proc.returncode == 0, f"stderr={proc.stderr}"
+
+    tags = _safety_tags(repo)
+    assert len(tags) == 1, f"genau ein Sicherungs-Tag erwartet, gefunden: {tags}"
+    tag = tags[0]
+
+    match = re.search(r"git\b[^\n]*?stash\s+apply\s+\S+", proc.stdout)
+    assert match, (
+        "Ausgabe enthaelt keinen vollstaendigen Wiederherstellungs-Befehl, "
+        f"stdout war: {proc.stdout!r}"
+    )
+    command = match.group(0).strip("`'\"(),. ")
+    assert tag in command, (
+        f"Wiederherstellungs-Befehl nennt den Tag {tag} nicht: {command!r}"
+    )
+
+    _git(repo, "reset", "--hard", "origin/main")
+    assert (repo / TRACKED).read_text(encoding="utf-8") == COMMITTED_TEXT
+
+    restore = subprocess.run(
+        shlex.split(command), cwd=str(repo), capture_output=True, text=True
+    )
+    assert restore.returncode == 0, (
+        f"ausgegebener Befehl {command!r} scheiterte: {restore.stderr.strip()}"
+    )
+    assert (repo / TRACKED).read_text(encoding="utf-8") == WIP_TEXT
+
+
+def test_untrackte_dateien_bleiben_unangetastet(repo: Path):
+    """AC-7.
+
+    GIVEN untrackte Dateien liegen im Arbeitsbaum
+    WHEN wip_safety.sh laeuft und danach hart resettet wird
+    THEN sind sie mit identischem Inhalt weiterhin vorhanden und weiterhin untrackt.
+    """
+    untracked = repo / "unversioniert.txt"
+    untracked_text = "nur lokal, nie committet\n"
+    untracked.write_text(untracked_text, encoding="utf-8")
+    (repo / TRACKED).write_text(WIP_TEXT, encoding="utf-8")
+
+    proc = _run_wip_safety(repo)
+    assert proc.returncode == 0, f"stderr={proc.stderr}"
+    assert untracked.read_text(encoding="utf-8") == untracked_text
+
+    _git(repo, "reset", "--hard", "origin/main")
+    assert untracked.exists(), "der Reset darf die untrackte Datei nicht entfernen"
+    assert untracked.read_text(encoding="utf-8") == untracked_text
+    assert "?? unversioniert.txt" in _git(repo, "status", "--porcelain").stdout
+
+
+def test_ci_ruft_die_sicherung_vor_dem_harten_reset_aus_origin_main_auf():
+    """AC-8 — # doc-compliance-test
+
+    GIVEN der CI-Schritt "Staging-Verdict schreiben (CI smoke)" in ci.yml
+    WHEN der Schritt gelesen wird
+    THEN steht der Aufruf der Sicherung VOR dem ``git reset --hard origin/main``,
+         und das Skript wird aus ``origin/main`` bezogen, nicht aus dem Arbeitsbaum.
+
+    ``ci.yml`` ist nicht ausfuehrbar testbar (Context-Doc Punkt 4) — deshalb hier
+    ausnahmsweise eine Dateiinhalt-Pruefung.
+    """
+    text = CI_WORKFLOW.read_text(encoding="utf-8")
+    step_marker = "Staging-Verdict schreiben (CI smoke)"
+    assert step_marker in text, f"Schritt {step_marker!r} fehlt in {CI_WORKFLOW}"
+
+    rest = text[text.index(step_marker) :]
+    next_step = re.search(r"\n\s+- name: ", rest)
+    block = rest[: next_step.start()] if next_step else rest
+
+    assert "wip_safety.sh" in block, (
+        f"Schritt {step_marker!r} ruft wip_safety.sh nicht auf — Block:\n{block}"
+    )
+    assert "git reset --hard origin/main" in block, (
+        "der abzusichernde harte Reset steht nicht mehr in diesem Schritt"
+    )
+    assert block.index("wip_safety.sh") < block.index("git reset --hard origin/main"), (
+        "die Sicherung muss VOR dem harten Reset laufen"
+    )
+
+    call_lines = [line for line in block.splitlines() if "wip_safety.sh" in line]
+    assert all("origin/main" in line for line in call_lines), (
+        "das Skript muss aus origin/main bezogen werden, nicht aus dem Arbeitsbaum "
+        f"(Henne-Ei beim ersten Rollout) — Zeilen: {call_lines}"
+    )

--- a/tests/test_wip_safety.py
+++ b/tests/test_wip_safety.py
@@ -2,7 +2,7 @@
 
 Prueflinge:
 
-* ``.claude/hooks/wip_safety.sh`` (Shell-Skript, Aufruf ``bash wip_safety.sh <repo>``)
+* ``scripts/wip_safety.sh`` (Shell-Skript, Aufruf ``bash wip_safety.sh <repo>``)
 * ``.github/workflows/ci.yml`` — Verdrahtung im Schritt "Staging-Verdict schreiben (CI smoke)"
 
 Alle Verhaltenstests laufen gegen ein ECHTES Wegwerf-Git-Repo (``tempfile.mkdtemp``,
@@ -20,7 +20,7 @@ from pathlib import Path
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-SCRIPT = REPO_ROOT / ".claude" / "hooks" / "wip_safety.sh"
+SCRIPT = REPO_ROOT / "scripts" / "wip_safety.sh"
 CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
 
 COMMITTED_TEXT = "stand aus origin/main\n"

--- a/tests/test_wip_safety.py
+++ b/tests/test_wip_safety.py
@@ -15,6 +15,7 @@ import shlex
 import shutil
 import subprocess
 import tempfile
+import time
 from pathlib import Path
 
 import pytest
@@ -295,6 +296,162 @@ def test_untrackte_dateien_bleiben_unangetastet(repo: Path):
     assert untracked.exists(), "der Reset darf die untrackte Datei nicht entfernen"
     assert untracked.read_text(encoding="utf-8") == untracked_text
     assert "?? unversioniert.txt" in _git(repo, "status", "--porcelain").stdout
+
+
+def test_nicht_setzbarer_tag_bricht_mit_fehler_ab(repo: Path):
+    """AC-9.
+
+    GIVEN die Sicherung gelingt, aber der Tag laesst sich nicht setzen
+    WHEN wip_safety.sh laeuft
+    THEN ist der Exit-Code ungleich 0 und die Meldung benennt, dass die Arbeit zwar
+         gesichert, aber nicht verankert ist — ohne Tag sammelt die GC das
+         Stash-Objekt ein, der Aufrufer darf NICHT hart resetten.
+
+    Gewaehlter Weg: ein Tag ``deploy-safety`` (ohne Suffix) belegt den Namensraum als
+    Datei-Ref. Git kann darunter keine Unter-Refs mehr anlegen (D/F-Konflikt:
+    "'refs/tags/deploy-safety' exists; cannot create ..."). Das ist unabhaengig vom
+    konkreten Tag-Namen und damit deterministisch, ohne den Zeitstempel zu kennen.
+    """
+    _git(repo, "tag", "deploy-safety", "HEAD")
+    (repo / TRACKED).write_text(WIP_TEXT, encoding="utf-8")
+
+    probe = _git(repo, "stash", "create", "probe", check=False)
+    assert probe.stdout.strip(), (
+        "Vorbedingung: stash create muss hier ein Objekt liefern — geprueft wird der "
+        "Tag-Zweig, nicht der Stash-Zweig"
+    )
+    blocked = _git(repo, "tag", "deploy-safety/ci-probe", probe.stdout.strip(), check=False)
+    assert blocked.returncode != 0, (
+        "Vorbedingung verfehlt: der Tag liess sich doch setzen — der Testzustand muss "
+        "anders konstruiert werden"
+    )
+
+    proc = _run_wip_safety(repo)
+
+    assert proc.returncode != 0, (
+        "ohne Tag ist die Sicherung fluechtig (GC) — die Kette darf nicht mit einem "
+        f"harten Reset weiterlaufen (stdout={proc.stdout!r})"
+    )
+    message = (proc.stderr + proc.stdout).lower()
+    assert "gesichert" in message, (
+        f"Meldung muss den Zustand der Arbeit benennen, war: {message!r}"
+    )
+    assert "tag" in message, (
+        f"Meldung muss benennen, dass der Tag fehlt, war: {message!r}"
+    )
+    assert _safety_tags(repo) == [], "es darf kein Sicherungs-Tag zurueckbleiben"
+
+
+def test_zwei_laeufe_hintereinander_erzeugen_zwei_wiederherstellbare_sicherungen(
+    repo: Path,
+):
+    """AC-10.
+
+    GIVEN zwei Sicherungslaeufe unmittelbar hintereinander (zwei schnelle Merges —
+          der deploy-Job hat kein concurrency-Gate)
+    WHEN wip_safety.sh zweimal laeuft
+    THEN gelingen beide, es entstehen zwei unterscheidbare Tags, und jede Sicherung
+         ist einzeln wiederherstellbar.
+
+    Der Tag-Name traegt die Kurzform des gesicherten Objekts — deshalb kollidieren
+    auch zwei Laeufe innerhalb derselben UTC-Sekunde nicht. Genau das wird geprueft:
+    jeder Tag endet auf die ersten 12 Zeichen der SHA seines Ziel-Objekts.
+    """
+    first_text = "erster Lauf: WIP-Arbeit A\n"
+    second_text = "zweiter Lauf: WIP-Arbeit B\n"
+
+    (repo / TRACKED).write_text(first_text, encoding="utf-8")
+    first = _run_wip_safety(repo)
+    assert first.returncode == 0, f"stderr={first.stderr}"
+
+    (repo / TRACKED).write_text(second_text, encoding="utf-8")
+    second = _run_wip_safety(repo)
+    assert second.returncode == 0, f"stderr={second.stderr}"
+
+    tags = _safety_tags(repo)
+    assert len(tags) == 2, f"zwei unterscheidbare Sicherungs-Tags erwartet: {tags}"
+
+    for tag in tags:
+        target = _git(repo, "rev-parse", tag).stdout.strip()
+        assert tag.endswith(target[:12]), (
+            f"Tag {tag!r} traegt die Objekt-Kurzform nicht — zwei Laeufe in derselben "
+            "UTC-Sekunde wuerden im Namen kollidieren"
+        )
+
+    _git(repo, "reset", "--hard", "origin/main")
+    restored = {}
+    for tag in tags:
+        _git(repo, "stash", "apply", tag)
+        restored[tag] = (repo / TRACKED).read_text(encoding="utf-8")
+        _git(repo, "checkout", "--", TRACKED)
+
+    assert sorted(restored.values()) == sorted([first_text, second_text]), (
+        f"beide Sicherungen muessen einzeln wiederherstellbar sein: {restored}"
+    )
+
+
+def test_zweiter_lauf_bei_unveraendertem_arbeitsbaum_gilt_als_gesichert(repo: Path):
+    """AC-11.
+
+    GIVEN uncommittete Arbeit liegt im Repo und wurde bereits gesichert, ohne dass sich
+          seither etwas geaendert hat (alltaeglich: mehrere Merges am selben Tag)
+    WHEN wip_safety.sh ein zweites Mal in derselben UTC-Sekunde laeuft — gleicher Inhalt
+         ergibt dasselbe Stash-Objekt und damit denselben Tag-Namen
+    THEN gelingen beide Laeufe (Exit 0), es bleibt bei genau einem Tag, und die Arbeit ist
+         darueber wiederherstellbar. Ein Abbruch waere eine Lieferblockade: ab dem zweiten
+         Merge kaeme kein Deploy mehr durch, obwohl die Arbeit laengst gesichert IST.
+
+    Die Kollision braucht beide Laeufe innerhalb derselben UTC-Sekunde. Statt die Uhr zu
+    faelschen wird auf den Sekundenbeginn synchronisiert und real zweimal gestartet;
+    landen die Laeufe doch auf zwei Sekunden (zwei Tags), wird der Versuch wiederholt.
+    """
+    (repo / TRACKED).write_text(WIP_TEXT, encoding="utf-8")
+
+    first = second = None
+    for _ in range(5):
+        for stale in _safety_tags(repo):
+            _git(repo, "tag", "-d", stale)
+        time.sleep(1.0 - (time.time() % 1.0) + 0.02)  # kurz nach dem Sekundenwechsel starten
+        first = _run_wip_safety(repo)
+        second = _run_wip_safety(repo)
+        if len(_safety_tags(repo)) == 1:
+            break
+    else:
+        raise AssertionError(
+            "die beiden Laeufe fielen fuenfmal in verschiedene UTC-Sekunden — die "
+            "Namenskollision liess sich nicht herstellen"
+        )
+
+    assert first.returncode == 0, f"erster Lauf scheiterte: {first.stderr}"
+    assert second.returncode == 0, (
+        "der zweite Lauf bei unveraendertem Arbeitsbaum muss gelingen — die Arbeit ist "
+        f"bereits gesichert (rc={second.returncode}, stderr={second.stderr!r})"
+    )
+
+    tags = _safety_tags(repo)
+    assert len(tags) == 1, f"genau ein Sicherungs-Tag erwartet, gefunden: {tags}"
+    tag = tags[0]
+    assert tag in first.stdout and tag in second.stdout, (
+        f"beide Laeufe muessen denselben Tag {tag} nennen: {first.stdout!r} / {second.stdout!r}"
+    )
+
+    match = re.search(r"git\b[^\n]*?stash\s+apply\s+\S+", second.stdout)
+    assert match, (
+        "auch der zweite Lauf muss den Wiederherstellungs-Befehl nennen, stdout war: "
+        f"{second.stdout!r}"
+    )
+    command = match.group(0).strip("`'\"(),. ")
+
+    _git(repo, "reset", "--hard", "origin/main")
+    assert (repo / TRACKED).read_text(encoding="utf-8") == COMMITTED_TEXT
+
+    restore = subprocess.run(
+        shlex.split(command), cwd=str(repo), capture_output=True, text=True
+    )
+    assert restore.returncode == 0, (
+        f"ausgegebener Befehl {command!r} scheiterte: {restore.stderr.strip()}"
+    )
+    assert (repo / TRACKED).read_text(encoding="utf-8") == WIP_TEXT
 
 
 def test_ci_ruft_die_sicherung_vor_dem_harten_reset_aus_origin_main_auf():


### PR DESCRIPTION
Scheibe 1 von #2047. **Behebt den Datenverlust, nicht das Gate selbst** — die Wirkungslosigkeit des Prod-Gates (PO-Entscheid „Weg A mit Automatisierung") ist Scheibe 2.

## Problem

Der CI-Schritt „Staging-Verdict schreiben (CI smoke)" fuhr bei **jedem** Merge nach `main` ein `git reset --hard origin/main` im Haupt-Checkout `/home/hem/gregor_zwanzig` — ohne WIP-Sicherung. Uncommittete getrackte Arbeit wurde dort zerstört. `deploy-gregor-prod.sh` sichert ausdrücklich ab (`:149-161`), dieser Aufruf nicht.

Verschärfend: Der Ordner ist nicht nur Arbeitsverzeichnis interaktiver Sessions, sondern zugleich **Produktions-Arbeitsverzeichnis** aller drei systemd-Dienste (`WorkingDirectory=/home/hem/gregor_zwanzig`).

## Lösung

`scripts/wip_safety.sh` sichert vor dem Reset:

- `git stash create` — bewusst **nicht** `stash push`: der Arbeitsbaum wird mit anderen Sessions geteilt und darf sich nicht bewegen
- Verankerung als Tag `deploy-safety/ci-<UTC-Zeitstempel>-<stash-sha>`, sonst sammelt die GC das Objekt ein
- Meldung mit vollständigem Wiederherstellungs-Befehl
- **Idempotent:** zeigt ein gleichnamiger Tag auf dasselbe Objekt, gilt die Arbeit als gesichert (Exit 0). Ohne das hätte bei unverändert liegengebliebener Arbeit der zweite Merge des Tages jede Auslieferung blockiert.
- Nur bei abweichendem Objekt oder echtem Tag-Fehler: Exit ≠ 0 — dann bricht die CI-Kette ab, **bevor** der Reset läuft.

`ci.yml` ruft es vor dem Reset auf, bezogen aus `origin/main` (beim ersten Rollout liegt es im Arbeitsbaum des Servers noch nicht auf Stand) und über `mktemp` abgelegt statt unter festem `/tmp`-Pfad.

**Der Reset selbst bleibt:** `staging_gate.py` zieht den SHA aus dem cwd (`_verified_repo_dir()`, `:97-110`) — ohne den Reset attestierte es den falschen Commit. Seine Ablösung gehört in Scheibe 2.

## Tests

11 Tests gegen **echte** Wegwerf-Git-Repos (bare-Repo + clone + push, echter `git reset --hard`, echter `subprocess`-Aufruf). Keine Mocks. AC-8 ist der einzige Dateiinhalt-Check und trägt den `# doc-compliance-test`-Marker.

## Adversary — drei Runden

| Runde | Verdict | Ergebnis |
|---|---|---|
| 1 | **BROKEN** | F001: Der Tag-Fehlerzweig war ungetestet — Mutation `exit 1` → `exit 0` blieb bei allen 8 Tests grün. Kollision real reproduziert (kein `concurrency:`-Gate im `deploy`-Job). Dazu F004: fester `/tmp`-Pfad. |
| 2 | VERIFIED | Nach Fix: Mutation wird gefangen, `mktemp`-Härtung wirksam, Kettenabbruch mit der echten Runner-Shell belegt. |
| 3 | VERIFIED | Idempotenz-Ergänzung: Erfolgszweig greift nur bei vollem SHA-Match, Netz aus Runde 1 unbeschädigt. |

Protokoll: `docs/artifacts/fix-2047-s1-wip-sicherung/adversary-dialog.md` (11 Punkte belegt).

## Nebenbefunde für Scheibe 2

- Der CI-Reset läuft im Produktions-Arbeitsverzeichnis, **ohne** vorher `gregor-python` zu stoppen — `deploy-gregor-prod.sh` tut das (`:274` vor `:285`), der Verdict-Schritt nicht.
- Zwei kosmetische Fundstellen ohne Sicherheitswirkung → #1199.

Closes #2047 nicht — Scheibe 2 steht aus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EFcJf9fFxdZcaWa4USsLRy
