### PR TITLE
fix(#2052): /jetzt misst am Aufenthaltsort statt am Etappenstart

### DIFF
--- a/docs/context/fix-2052-now-aufenthaltsort.md
+++ b/docs/context/fix-2052-now-aufenthaltsort.md
@@ -1,0 +1,95 @@
+# Context: fix-2052-now-aufenthaltsort
+
+Issue: [#2052](https://github.com/henemm/gregor_zwanzig/issues/2052) · Milestone „Tour KHW 2026-08" · `priority:high`, `type:bug`, `area:alerts`
+Track: Standard (Intake-Summe 3) · Workflow `fix-2052-now-aufenthaltsort`
+
+## Request Summary
+
+Der Telegram-/Mail-Befehl `/now` (Alias `/jetzt`) holt den Radar-Nowcast am **ersten Wegpunkt der heutigen Etappe** statt am **Aufenthaltsort des Nutzers zum Abfragezeitpunkt**. Fragt der Wanderer um 16:00 mitten auf der Etappe „regnet es gleich?", antwortet der Bot für den Ausgangspunkt vom Morgen. Fachlich dieselbe Ursache wie #2017 (dort für den Alarm-Pfad behoben), anderer Codepfad.
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `src/services/trip_command_processor.py:1499-1543` | `_show_now` — der Prüfling. `wp = stage.waypoints[0]` (:1525), `svc.get_nowcast(wp.lat, wp.lon, elevation_m=wp.elevation_m, priority="user_briefing")` (:1529-1531), `tz_for_coords(wp.lat, wp.lon)` (:1536). Importiert `position_at_time` an keiner Stelle. |
+| `src/services/trip_segments.py:469` | `position_at_time(trip, active: TripSegment, segment_date: date, at: datetime) -> GPXPoint` — der zu nutzende geteilte Baustein (#2017). Fail-soft: liefert **immer** einen `GPXPoint`. Höhe wird **roh** interpoliert. |
+| `src/services/trip_segments.py:363-413` | `resolve_current_segment(trip, now_utc, today) -> Optional[Tuple[TripSegment, date]]` — die fehlende Brücke von Etappe zu Segment. Signatur passt **exakt** auf das, was `_show_now` bereits hat. |
+| `src/services/trip_segments.py:108-342` | `convert_trip_to_segments(trip, target_date)` — zerlegt die Wegpunkte einer Stage in Segmente + ein ortsfestes „Ziel"-Segment, das am Tagesfenster-Ende schließt (#1584/#1599). |
+| `src/services/trip_alert.py:1173, 1291-1333` | Referenz-Aufrufstelle A (Alarm). Muster: `resolve_current_segment(...)` → `_at = now_utc + RADAR_ONSET_THRESHOLD_MIN // 2` → `position_at_time(...)` in eigenem `try` → `int(round(_pos.elevation_m))` → `tz_for_coords(lat, lon)` am **neuen** Punkt. |
+| `src/services/trip_report_scheduler.py:1750-1859` | Referenz-Aufrufstelle B (Starkregen-Hinweis im Briefing). Segmentwahl **lokal** statt über `resolve_current_segment()`, bewusst ohne Vortags-Rückgriff. `_at = now_utc + NOWCAST_HORIZON_MIN // 2`. |
+| `tests/test_success_status_guard.py:1855` | 🔴 Struktureller AST-Wächter (#1405) mit **fester Zahl**: `"src/services/trip_command_processor.py::_show_now": 1`. Ein zusätzlicher Aufruf mit unzugewiesenem Rückgabewert in `_show_now` macht ihn rot. Muss bei der Implementierung mitlaufen. |
+| `tests/helpers/nowcast_gate_fixtures.py:89-437` | `make_trip()`/`trip_stage()` — der zentrale Helfer für Zwei-Wegpunkt-Etappen mit steuerbaren Ankunftszeiten. Basis für den neuen Test. |
+| `tests/tdd/test_issue_822_radar_nowcast_segment.py:213-265, 1111-1233` | 🟢 **Die Testvorlage.** `_erwartete_messposition()` rechnet den Sollpunkt unabhängig vom Prüfling nach, `_Aufzeichnend(RadarNowcastService)` fängt die Parameter ab, `test_2017_ac8_...` prüft zusätzlich **Nicht-Trivialität** (Abstand zum Startpunkt > 0.01°). |
+| `tests/tdd/test_radar_alert_follows_ortstag.py:174-258` | Zweistufiger Koordinatennachweis: (1) Punkt liegt auf der Strecke der erwarteten Etappe, (2) an der zum Zeitanteil erwarteten Stelle. |
+| `docs/specs/modules/fix_2017_nowcast_messpunkt.md:343-345` | Nennt `/jetzt` **wörtlich** als bewusst ausgeklammerten Nebenbefund: „Andere Fehlerklasse (kein Onset-Zirkel, sondern falscher Bezugspunkt für eine Sofortabfrage) — eigener Befund". Genau dieses Ticket. |
+| `docs/specs/modules/radar_nowcast.md:106-113` | Known Limitations mit der Verfeinerungskette `waypoints[0]` (#656) → `active.start_point` (#822) → interpolierte Position (#2017). Muss um `/now` fortgeschrieben werden. |
+
+## Existing Patterns
+
+- **Positionsbestimmung ist geteilt, nicht kopiert.** `position_at_time()` ist seit #2017 der einzige Ort, an dem interpoliert wird. Die Aufrufstellen liefern nur `(active, segment_date, at)` und normalisieren danach.
+- **Höhen-Normalisierung wohnt an der Aufrufstelle**, nicht im Baustein: `int(round(_pos.elevation_m)) if ... is not None else None`. Grund (#1991): `get_nowcast` führt `elevation_m` **roh** im Cache-Schlüssel — `1000` und `1000.0` erzeugten zwei Einträge für denselben Punkt.
+- **Zeitzone folgt dem Messpunkt**, nicht dem Etappenstart: `tz_for_coords(lat, lon)` auf die interpolierten Koordinaten (A macht es so).
+- **Fehler an der Positionsbestimmung bekommen einen eigenen `try`**, nicht den des Abrufs — damit die Meldung unterscheidbar bleibt (Adversary-Finding F-ADV1 in #2017).
+- **Testmuster:** echte `RadarNowcastService`-Subklasse als Aufzeichner statt `Mock()`; Sollwert unabhängig vom Prüfling nachgerechnet; explizite Nicht-Trivialitäts-Assertion.
+
+## Dependencies
+
+- **Upstream** (was `_show_now` nutzen wird): `trip_local_today()`, `resolve_current_segment()`, `position_at_time()`, `tz_for_coords()`, `RadarNowcastService.get_nowcast/format_now_text`.
+- **Downstream** (was `_show_now` nutzt): der Telegram-Befehlspfad inkl. Callback `🔄 Aktualisieren` (`callback_data: "now"`), der Mail-Inbound-Pfad (`### now`), `_CALLBACK_QUERY_MAP`, `BOT_COMMANDS`.
+
+## Befunde aus der Recherche
+
+### 1. 🔴 Der Messpunkt von `/now` ist heute durch **keinen einzigen** Test geschützt
+
+Das Ticket listet vier Testdateien, die „mitziehen müssen". Die Prüfung aller 15 einschlägigen Testfunktionen ergibt: **keine davon bricht**, weil überall entweder nur ein Wegpunkt pro Etappe existiert, gar keine Koordinaten geprüft werden, oder nur Routing/Text zugesichert wird.
+
+| Datei | Einschlägige Tests | Bricht bei Umstellung? |
+|---|---|---|
+| `tests/tdd/test_befehlspfade_folgen_ortszone.py` | `test_ac3_jetzt_nimmt_den_wegpunkt_der_ortstag_etappe:188`, `..._nicht_der_systemuhr[jetzt]:602` | Nein — je Etappe genau **ein** Wegpunkt, Interpolation liefert denselben Punkt |
+| `tests/tdd/test_issue_731_unified_commands.py` | `:268`, `:274`, `:368` | Nein — reines Routing/Parser-Mapping |
+| `tests/tdd/test_issue_704_telegram_interactive_navigation.py` | `:161`, `:177`, `:194`, `:223` | Nein — keine Koordinaten-Assertion (obwohl `:194` als einziger ein Zwei-Wegpunkt-Szenario durchläuft) |
+| `tests/unit/test_radar_budget_and_priority.py` | `test_jetzt_command_uses_user_briefing_priority_explicitly:243` | Nein — zeichnet nur `priority` und `tz` auf, nicht `lat/lon` |
+
+Das ist der eigentliche Befund: nicht „Tests müssen angepasst werden", sondern **es gibt nichts, was den Messpunkt bewacht**. Der neue Test schließt eine offene Flanke, er ersetzt keine bestehende Zusicherung. Zwei Mitläufer sind zu beachten: `tests/tdd/test_feature_656_radar_nowcast.py` (fünfte `/now`-Testdatei, im Ticket nicht genannt, ebenfalls koordinaten-unabhängig) und der Struktur-Wächter `tests/test_success_status_guard.py:1855`.
+
+### 2. 🟢 Die Brücke Etappe → Segment existiert und passt ohne Umbau
+
+`_show_now` hat bereits `trip` und `now_utc` und berechnet `today = trip_local_today(trip, now_utc)` (:1512). `resolve_current_segment(trip, now_utc, today)` verlangt exakt diese drei Werte. Es entsteht **keine** neue Auswahllogik — die Intake-Sorge, hier müsse eine Auflösungsschicht gebaut werden, ist damit ausgeräumt.
+
+### 3. 🔴 Offene Designentscheidung: welcher Zeitpunkt wird gemessen?
+
+Die beiden bestehenden Aufrufstellen messen **nicht** zum Abfragezeitpunkt, sondern zur Mitte des Vorhersagefensters (A: `now + 55//2` Min, B: `now + 180//2` Min). Grund in #2017: der Alarm ist eine **Vorwarnung** — relevant ist, wo der Wanderer sein wird, wenn das Ereignis eintritt.
+
+Für `/jetzt` ist das nicht übertragbar. Der Nutzer steht an einem Ort und fragt nach genau diesem Ort. Eine Fenstermitte-Messung könnte „hier ist es trocken" antworten, während er im Regen steht — eine offensichtlich falsche Antwort auf eine Frage nach dem Jetzt. **Empfehlung: `at = now_utc`.** Das ist kein Sonderweg, sondern die wörtliche Anwendung derselben Regel: gemessen wird dort, wo der Nutzer zum relevanten Zeitpunkt ist — und bei `/jetzt` ist der relevante Zeitpunkt jetzt.
+
+Der Zirkelschluss-Vorbehalt aus #2017 („onset-frei") greift hier nicht: `now_utc` ist ein fester, aus dem Nowcast-Ergebnis nicht ableitbarer Wert. Die Anforderung bleibt also gewahrt.
+
+### 4. 🟡 Randfall spät abends: `resolve_current_segment()` liefert `None`
+
+Die Vorrangkette deckt ab: aktives Segment heute → aktives Segment gestern → Vorschau vor dem Start. Das Ziel-Segment schließt am Tagesfenster-Ende (typisch 22:00 Ortszeit inklusiv, also 23:00). Fragt der Nutzer danach `/jetzt`, kommt `None` zurück.
+
+- Heutiges Verhalten in diesem Fall: `waypoints[0]` — der Etappenstart, also die **volle Etappenlänge** daneben.
+- Frühmorgens vor dem Start greift Stufe 3 (Vorschau) → `position_at_time` gibt `start_point` zurück → **bitgleich** zu heute. Kein Randfall.
+
+Zu entscheiden ist, ob der `None`-Fall auf dem heutigen Verhalten bleibt (minimalinvasiv, aber die Nacht-Antwort bleibt falsch) oder auf den letzten Wegpunkt geht (inhaltlich richtig, aber eine Auswahlentscheidung über das Ticket hinaus). Kommt als AC in die Spec.
+
+### 5. 🟢 Bestätigt: kein Verstoß gegen bestehende Entscheidungen
+
+`docs/specs/modules/fix_2017_nowcast_messpunkt.md:414-420` hält fest, dass dieser Bereich keine ADR-Grundsatzentscheidung berührt. `/jetzt` ist dort ausdrücklich als Folge-Issue vorgesehen. `docs/adr/ADR-0044` (Ortstag) bleibt unberührt: der Etappen**tag** bestimmt weiterhin, **welche** Etappe gilt — geändert wird nur, **wo auf ihr** gemessen wird.
+
+## Risks & Considerations
+
+| Risiko | Umgang |
+|---|---|
+| **Struktur-Wächter `success_status_guard` wird rot** — ein zusätzlicher `try/except` mit `logger.error` in `_show_now` verändert die B18-Zählung (Restlisten-Wert `1` bei `:1855`) | Bei der Implementierung mitlaufen lassen; `logger.error` gehört in den **except**-Zweig, nie in den Normalpfad |
+| **Cache-Schlüssel-Vervielfachung (#1991)** — die interpolierte Höhe ist ein `float` und wandert bei jedem Abruf | `int(round(...))` an der Aufrufstelle, wie A und B es tun. Zusätzlich: jede `/jetzt`-Abfrage erzeugt jetzt einen neuen Cache-Schlüssel, weil die Position wandert — bei `priority="user_briefing"` (nie gedrosselt) unkritisch, aber im Budget-Verhalten zu prüfen |
+| **Zeitzone wandert mit** — `tz_for_coords()` auf den interpolierten Punkt statt auf `waypoints[0]` | Beabsichtigt (Muster A). Der bestehende Ortszonen-Test (`test_ac3_jetzt_...`) bleibt grün, weil dort je Etappe nur ein Wegpunkt existiert |
+| **`priority="user_briefing"` muss erhalten bleiben** (#1329 C2) — eine Nutzeraktion wird nie gedrosselt | Als Negativ-AC festnageln; `test_radar_budget_and_priority.py:243` bewacht es bereits |
+| **Falscher Fallback bei `None`** | Siehe Befund 4 — explizite AC statt stiller Annahme |
+| **Kein Live-Netz im Test** | Aufzeichnende `RadarNowcastService`-Subklasse per `monkeypatch.setattr` (`_show_now` hat keinen Konstruktor-DI-Seam) — Muster aus `test_radar_budget_and_priority.py:243-248` |
+
+## Bewusst nicht Teil dieses Tickets
+
+- `src/services/trip_day.py:41,51` — nutzt ebenfalls `stage.waypoints[0]`, dort aber zur Zeitzonen-Bestimmung des Etappentags. Eigene Frage (Etappe über Zeitzonengrenze), im Ticket ausdrücklich ausgeklammert.
+- Die Trip-Konfiguration des PO wird nicht angefasst.
+- Die Tages-/Ortszonen-Logik von `_show_now` (#1402, #1727 S5a, ADR-0044) bleibt unverändert.

--- a/docs/specs/modules/fix_2052_now_aufenthaltsort.md
+++ b/docs/specs/modules/fix_2052_now_aufenthaltsort.md
@@ -1,0 +1,298 @@
+---
+entity_id: fix_2052_now_aufenthaltsort
+type: bugfix
+created: 2026-08-21
+updated: 2026-08-21
+status: approved
+workflow: fix-2052-now-aufenthaltsort
+version: "1.0"
+tags: [alerts, radar, nowcast, trip, now, telegram]
+---
+
+# `/jetzt` misst am Aufenthaltsort statt am Etappenstart (Issue #2052)
+
+## Approval
+
+- [x] Approved — PO-Freigabe 2026-08-21 (AC-2 Messzeitpunkt und AC-9 Tagesende bestätigt)
+
+## Purpose
+
+Der Telegram-/Mail-Befehl `/now` (Alias `/jetzt`, `TripCommandProcessor._show_now`) fragt den
+Radar-Nowcast heute am **ersten Wegpunkt der Etappe** ab (`stage.waypoints[0]`), unabhängig
+davon, wo auf der Etappe der Wanderer zum Abfragezeitpunkt tatsächlich steht. Fragt er um 16:00
+mitten auf der Etappe „regnet es gleich?", antwortet der Bot für den Ausgangspunkt vom Morgen —
+bei einer Tagesetappe von mehreren Kilometern eine irreführende Antwort.
+
+Dieselbe Fehlerklasse wurde für den Alarm- und den Briefing-Pfad bereits in #2017 behoben: dort
+liefert der geteilte Baustein `position_at_time()` die zur Fenstermitte interpolierte Position.
+Diese Spec verdrahtet **denselben Baustein** an der dritten, bisher unbewachten Fundstelle — mit
+einem bewusst **anderen** Zielzeitpunkt: `/jetzt` ist keine Vorwarnung, sondern eine
+Sofortabfrage nach dem Ort, an dem der Nutzer *jetzt* steht. Gemessen wird deshalb `now_utc`
+selbst, nicht die Fenstermitte eines Vorwarnfensters, das es bei einer Sofortabfrage gar nicht
+gibt.
+
+## Source
+
+- **File:** `src/services/trip_command_processor.py`
+- **Identifier:** `class TripCommandProcessor` / `def _show_now`
+- **Schicht:** Python-Core (`src/services/`) — kein Go, kein Frontend.
+
+## Estimated Scope
+
+- **LoC:** ~180–220 (Änderung in `_show_now` ~25–35 LoC, neuer Testfall ~150–180 LoC für 11 ACs
+  inkl. Helfer/Fixtures, ggf. kleine Kommentar-Anpassung am Struktur-Wächter). Unter dem
+  Workflow-Limit von 250, kein `loc_limit_override` nötig.
+- **Files:** 3–4 (1 modifiziert: `trip_command_processor.py`; 1 neu:
+  `tests/tdd/test_jetzt_misst_am_aufenthaltsort.py`; 1 Doku modifiziert:
+  `docs/specs/modules/radar_nowcast.md`; ggf. 1 Kommentar-Anpassung:
+  `tests/test_success_status_guard.py`, nur falls der Struktur-Wächter rot wird).
+- **Effort:** low–medium.
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `services.trip_segments.resolve_current_segment` | function | Liefert `(active, segment_date)` bzw. `None` — Segmentwahl bleibt bei `_show_now`, keine neue Auswahllogik |
+| `services.trip_segments.position_at_time` | function | Interpolierte Position (lat/lon/Höhe) zu einem Zielzeitpunkt — hier `now_utc` statt Fenstermitte |
+| `services.radar_service.RadarNowcastService.get_nowcast` | function | Erhält die interpolierten Koordinaten + normalisierte Höhe statt `waypoints[0]`, `priority="user_briefing"` bleibt unverändert |
+| `services.radar_service.RadarNowcastService.format_now_text` | function | Erhält weiterhin `tz`, jetzt aus den interpolierten Koordinaten |
+| `utils.timezone.tz_for_coords` | function | Angewandt auf die interpolierten Koordinaten statt auf `waypoints[0]` |
+| `app.trip.Trip.get_stage_for_date` | function | Unverändert — liefert `stage`, weiterhin nötig für den Fehlerfall (AC-11) und als Fallback-Quelle für den letzten Wegpunkt (AC-9) |
+
+## Implementation Details
+
+`_show_now` (`trip_command_processor.py:1499-1544`) hat bereits `trip` und `now_utc` und
+berechnet `today = trip_local_today(trip, now_utc)`. Das ist exakt, was
+`resolve_current_segment(trip, now_utc, today)` verlangt — es entsteht keine neue
+Auswahlschicht. Der bestehende `if not stage or not stage.waypoints:`-Fehlerpfad (AC-11) bleibt
+komplett unangetastet, `stage` wird zusätzlich als Fallback-Quelle für AC-9 gebraucht.
+
+Ablauf nach der bestehenden Fehlerprüfung, ersetzt `wp = stage.waypoints[0]`:
+
+```python
+from services.trip_segments import resolve_current_segment, position_at_time
+
+resolved = resolve_current_segment(trip, now_utc, today)
+if resolved is not None:
+    active, segment_date = resolved
+    try:
+        _pos = position_at_time(trip, active, segment_date, now_utc)
+    except Exception as e:
+        logger.error(
+            "Jetzt-Befehl: Positionsbestimmung fuer Trip %s fehlgeschlagen "
+            "(%s) -- falle zurueck auf den ersten Wegpunkt der Etappe.",
+            trip.id, e,
+        )
+        _pos = stage.waypoints[0]
+else:
+    # Vorrangkette liefert None: Etappentag ist abgelaufen (typ. nach 23:00
+    # Ortszeit). Der Wanderer ist am Tagesziel, nicht am Etappenstart.
+    _pos = stage.waypoints[-1]
+
+wp_elevation_m = (
+    int(round(_pos.elevation_m)) if _pos.elevation_m is not None else None
+)
+```
+
+Die vier bisherigen Verwendungen von `wp.lat`/`wp.lon`/`wp.elevation_m` (`get_nowcast`-Aufruf,
+`tz_for_coords`-Aufruf) werden auf `_pos.lat`/`_pos.lon`/`wp_elevation_m` umgestellt.
+`priority="user_briefing"` und der Kommentarblock zu #1329 C2 bleiben unverändert stehen (AC-6).
+
+**Zielzeitpunkt bewusst `now_utc`, nicht `now_utc + Offset//2` wie in #2017:** Der Alarm- und
+Briefing-Pfad messen zur Mitte des Vorwarnfensters, weil sie eine **Vorwarnung** sind — relevant
+ist, wo der Wanderer sein wird, wenn das Ereignis eintritt. `/jetzt` ist keine Vorwarnung; der
+Nutzer steht an einem Ort und fragt nach genau diesem Ort. Eine Fenstermitte-Messung könnte
+„hier ist es trocken" antworten, während er im Regen steht. Der Zirkelschluss-Vorbehalt aus
+#2017 (Onset entsteht erst aus dem Nowcast-Ergebnis, ein fester Zeitpunkt vermeidet den Zirkel)
+bleibt gewahrt: `now_utc` ist ein fester, aus dem Ergebnis nicht ableitbarer Wert — er ist so
+onset-frei wie die Fenstermitte, nur dichter am tatsächlichen Abfragezeitpunkt.
+
+**Fehlerpfad-Trennung (AC-10):** Der `try` umschließt ausschließlich
+`position_at_time(...)`, nicht den nachfolgenden `get_nowcast`-Aufruf — dasselbe Muster wie
+`trip_alert.py:1309-1318` (Adversary-Finding F-ADV1 aus #2017): eine fehlschlagende
+Positionsbestimmung bekommt eine unterscheidbare Meldung und einen definierten Fallback
+(`waypoints[0]`, das bisherige Verhalten), statt unter „Radar nowcast failed" zu verschwinden
+oder den Befehl ganz scheitern zu lassen.
+
+**Doku-Nachzug:** `docs/specs/modules/radar_nowcast.md:110-117` beschreibt die
+Verfeinerungskette der Alarm-/Briefing-Pfade (`waypoints[0]` → `active.start_point` →
+interpolierte Position). Der Abschnitt wird um einen Satz ergänzt, der `/jetzt` als eigenen,
+zeitgleich behobenen Pfad nennt — mit dem abweichenden Zielzeitpunkt `now_utc` statt
+Fenstermitte, damit die Known Limitation nicht den falschen Eindruck erweckt, alle drei Pfade
+maßen inzwischen gleich.
+
+## Expected Behavior
+
+- **Input:** `trip`, `now_utc` (Zeitpunkt der Abfrage) — unverändert die bestehende Signatur von
+  `_show_now`.
+- **Output:** `CommandResult` mit Nowcast-Text für die interpolierte Position statt für
+  `waypoints[0]`; bei fehlender heutiger Etappe unverändert die bestehende Fehlerantwort; bei
+  fehlgeschlagener Positionsbestimmung Fallback auf das bisherige Verhalten (`waypoints[0]`).
+- **Side effects:** Keine zusätzlichen `get_nowcast()`-Aufrufe — weiterhin genau ein Abruf je
+  `/jetzt`-Aufruf. Kein neues Persistenzfeld, keine Migration.
+
+## Test Plan
+
+Neuer Test folgt dem Muster aus `tests/tdd/test_issue_822_radar_nowcast_segment.py`: eine
+Zwei-Wegpunkt-Etappe über `tests/helpers/nowcast_gate_fixtures.py::make_trip()`, eine
+aufzeichnende `RadarNowcastService`-Subklasse per
+`monkeypatch.setattr("services.radar_service.RadarNowcastService", ...)` — `_show_now` importiert
+`RadarNowcastService` lokal innerhalb der Methode (`trip_command_processor.py:1511`) und hat
+keinen Konstruktor-DI-Seam, siehe `tests/unit/test_radar_budget_and_priority.py:243-248`. Der
+Sollwert (erwarteter interpolierter Punkt) wird unabhängig vom Prüfling nachgerechnet, nicht aus
+dessen eigener Logik abgeleitet. Kein Netz, kein `Mock()`.
+
+Testdatei (nach Verhalten benannt, nicht nach Issue-Nummer):
+`tests/tdd/test_jetzt_misst_am_aufenthaltsort.py`.
+
+**Mitlaufende Wächter:**
+
+- `tests/test_success_status_guard.py:1855` führt für `_show_now` die feste B18-Zahl `1`. Kommt
+  durch die neue `try`/`except`-Struktur ein weiterer unzugewiesener Aufruf hinzu, muss die
+  Restliste angepasst und die Anpassung im Commit begründet werden — `logger.error(...)` gehört
+  in den `except`-Zweig, nie in den Normalpfad.
+- `tests/tdd/test_befehlspfade_folgen_ortszone.py` (`test_ac3_jetzt_nimmt_den_wegpunkt_der_ortstag_etappe`,
+  `..._nicht_der_systemuhr[jetzt]`) — Etappen dort haben je einen Wegpunkt, Interpolation liefert
+  denselben Punkt, muss unverändert grün bleiben.
+- `tests/tdd/test_issue_731_unified_commands.py`, `tests/tdd/test_issue_704_telegram_interactive_navigation.py`,
+  `tests/unit/test_radar_budget_and_priority.py::test_jetzt_command_uses_user_briefing_priority_explicitly`,
+  `tests/tdd/test_feature_656_radar_nowcast.py` — prüfen Routing, Priority oder Text, keine
+  Koordinaten; müssen unverändert grün bleiben, dienen als Regressionsschutz.
+
+## Acceptance Criteria
+
+- **AC-1 (Kern):** Given ein Trip mit einer heutigen Etappe, deren aktuelles Segment zum
+  Abfragezeitpunkt läuft / When `/jetzt` aufgerufen wird / Then wird der Nowcast an der über
+  `resolve_current_segment(trip, now_utc, today)` und `position_at_time()` interpolierten
+  Position abgefragt, nicht an `stage.waypoints[0]`.
+  - Test: echter `_show_now`-Aufruf mit Zwei-Wegpunkt-Etappe, Assert auf die tatsächlich an
+    `get_nowcast()` übergebenen Koordinaten (Aufzeichnungs-Subklasse, kein Mock).
+
+- **AC-2 (Zeitpunkt):** Given eine laufende Etappe / When `/jetzt` aufgerufen wird / Then ist der
+  an `position_at_time()` übergebene Zielzeitpunkt `now_utc` selbst — nicht die Fenstermitte
+  (`now_utc + RADAR_ONSET_THRESHOLD_MIN // 2` bzw. `+ NOWCAST_HORIZON_MIN // 2`), die Alarm- und
+  Briefing-Pfad verwenden. `/jetzt` ist eine Sofortabfrage nach dem Ort, an dem der Nutzer
+  **steht**; eine Vorausmessung könnte „trocken" melden, während er im Regen steht. Der
+  Zirkelschluss-Vorbehalt aus #2017 bleibt gewahrt, weil `now_utc` nicht aus dem Nowcast-Ergebnis
+  ableitbar ist.
+  - Test: Zwei-Wegpunkt-Etappe mit unterschiedlichen erwarteten Positionen bei `now_utc` vs.
+    `now_utc + Offset//2`; Assert, dass die tatsächlich abgefragten Koordinaten dem `now_utc`-Punkt
+    entsprechen, nicht dem Fenstermitte-Punkt.
+
+- **AC-3 (Nicht-Trivialität / Gegenprobe):** Given eine Etappe, deren Zielwegpunkt verschoben
+  wird / When `/jetzt` erneut aufgerufen wird / Then verschiebt sich der abgefragte Messpunkt
+  mit — UND interpolierter Punkt und `waypoints[0]` unterscheiden sich messbar (Schwelle wie in
+  `test_issue_822_radar_nowcast_segment.py:1176-1233`), sonst wäre AC-1 trivial erfüllbar.
+  - Test: zwei Läufe mit verschobenem Zielwegpunkt, Assert auf unterschiedliche abgefragte
+    Koordinaten; zusätzlicher Assert, dass der interpolierte Punkt > 0.01° vom Startpunkt entfernt
+    liegt.
+
+- **AC-4 (Höhe):** Given ein Segment mit unterschiedlicher Höhe an Start- und Endpunkt / When
+  `/jetzt` aufgerufen wird / Then wird die Höhe des interpolierten Punktes mitgeführt und **an
+  der Aufrufstelle** in `_show_now` auf ganze Meter normalisiert (`int(round(...))`, `None`
+  bleibt `None`) — `get_nowcast` führt `elevation_m` roh im Cache-Schlüssel, `1000` vs. `1000.0`
+  erzeugte in #1991 zwei Einträge für denselben Punkt.
+  - Test: Assert auf den an `get_nowcast(elevation_m=...)` übergebenen Wert — ganzzahlig, gleich
+    dem gerundeten interpolierten Höhenwert.
+
+- **AC-5 (Zeitzone):** Given eine laufende Etappe / When `/jetzt` aufgerufen wird / Then wird
+  `tz_for_coords()` auf die interpolierten Koordinaten angewandt, nicht mehr auf
+  `waypoints[0]` — die Onset-Uhrzeit im Antworttext gilt für den Messpunkt.
+  - Test: die an `tz_for_coords()` übergebenen Koordinaten aufzeichnen und gegen den
+    interpolierten Punkt prüfen — nicht gegen `waypoints[0]`. (Eine Etappe über eine echte
+    Zeitzonengrenze ist als Nachweis NICHT nötig und wäre ein eigener Randfall, siehe
+    Known Limitations.)
+
+- **AC-6 (Negativ):** Given ein `/jetzt`-Aufruf / When `get_nowcast()` aufgerufen wird / Then
+  bleibt `priority="user_briefing"` unverändert (#1329 C2) — eine Nutzeraktion wird nie
+  gedrosselt.
+  - Test: `tests/unit/test_radar_budget_and_priority.py::test_jetzt_command_uses_user_briefing_priority_explicitly`
+    bleibt unverändert grün (Regressionsschutz, kein neuer Test nötig).
+
+- **AC-7 (Negativ):** Given ein `/jetzt`-Aufruf / When die Etappe für heute aufgelöst wird / Then
+  bleibt die Ortstag-Auswahl unverändert (#1402, #1727 S5a, ADR-0044) — der Etappentag bestimmt
+  weiterhin, **welche** Etappe gilt; geändert wird nur, **wo auf ihr** gemessen wird. Der
+  bestehende Zwei-Zonen-Test muss unverändert grün bleiben.
+  - Test: `tests/tdd/test_befehlspfade_folgen_ortszone.py::test_ac3_jetzt_nimmt_den_wegpunkt_der_ortstag_etappe`
+    und `..._nicht_der_systemuhr[jetzt]` bleiben unverändert grün (Regressionsschutz).
+
+- **AC-8 (Vorschau, Bitgleichheit):** Given der Nutzer fragt `/jetzt` **vor** dem Start der
+  heutigen Etappe / When `resolve_current_segment()` Stufe 3 (Vorschau) greift / Then liefert
+  `position_at_time()` den `start_point` — das Ergebnis ist **bitgleich** zum Verhalten vor
+  dieser Änderung.
+  - Test: `now_utc` vor dem ersten Segment des Tages, Assert auf Koordinaten-Identität mit
+    `waypoints[0]` (nicht nur numerische Nähe).
+
+- **AC-9 (Randfall nach Tagesende):** Given `resolve_current_segment()` liefert `None` (der
+  Nutzer fragt nach dem Ende des Tagesfensters, typisch nach 23:00 Ortszeit) / When `/jetzt`
+  aufgerufen wird / Then wird am **letzten** Wegpunkt der heutigen Etappe gemessen
+  (`stage.waypoints[-1]`), nicht am ersten. Begründung: `None` bedeutet in dieser Vorrangkette
+  eindeutig „der Etappentag ist abgelaufen" — der Wanderer ist dann am Tagesziel, und
+  `waypoints[0]` wäre die volle Etappenlänge daneben.
+  - Test: `now_utc` nach Ende des letzten Tagessegments (und nach dem Vortag), Assert auf
+    Koordinaten-Identität mit `stage.waypoints[-1]`, nicht `waypoints[0]`.
+
+- **AC-10 (Fehlerpfad):** Given `position_at_time()` wirft wider Erwarten eine Exception / When
+  `/jetzt` aufgerufen wird / Then bekommt der Nutzer trotzdem eine Antwort (Rückfall auf
+  `waypoints[0]`, das bisherige Verhalten), und der Fehler wird geloggt. Der `try` umschließt
+  ausschließlich die Positionsbestimmung, nicht den Nowcast-Abruf — damit die Meldung
+  unterscheidbar bleibt (Adversary-Finding F-ADV1 aus #2017). Der `logger`-Aufruf steht im
+  `except`-Zweig, nie im Normalpfad.
+  - Test: `position_at_time` per `monkeypatch` so präpariert, dass sie wirft; Assert, dass
+    `_show_now` trotzdem `success=True` mit Nowcast-Text liefert, mit den Koordinaten von
+    `waypoints[0]`; separater Assert, dass ein `logger.error`-Aufruf erfolgte (Caplog), nicht der
+    Text-Inhalt allein.
+
+- **AC-11 (Bestandsschutz):** Given ein Trip ohne heutige Etappe / When `/jetzt` aufgerufen
+  wird / Then bleibt die bestehende Fehlerantwort („Keine heutige Etappe gefunden…",
+  `success=False`) wortgleich erhalten. Im Erfolgsfall bleibt der `🔄 Aktualisieren`-Button mit
+  `callback_data: "now"` unverändert erhalten — er hängt am Erfolgspfad, der Fehlerpfad trägt
+  heute wie künftig kein `reply_markup`.
+  - Test: Trip ohne heutige Stage → Assert auf `success=False` und exakten Fehlertext; zweiter
+    Assert im Erfolgsfall auf `reply_markup` mit `callback_data == "now"` (Regressionsschutz,
+    bestehender Test `test_issue_704_telegram_interactive_navigation.py` deckt beides bereits).
+
+## Known Limitations
+
+1. **Wandernder Cache-Schlüssel bei `/jetzt`.** Jede `/jetzt`-Abfrage erzeugt jetzt einen
+   potenziell neuen Cache-Schlüssel, weil sich die abgefragte Position mit der Zeit ändert (der
+   Nutzer bewegt sich auf der geplanten Route). Bei `priority="user_briefing"` unkritisch (nie
+   gedrosselt, kein Budget-Wächter betroffen), aber der Effekt ist zu benennen: zwei `/jetzt`-
+   Aufrufe kurz hintereinander an verschiedenen Etappenpunkten teilen sich keinen Cache-Treffer
+   mehr, selbst wenn sie innerhalb der Cache-TTL liegen.
+
+2. **Vortags-Rückgriff kann spät nachts ein gestriges Ziel-Segment liefern.** Die Vorrangkette
+   aus `resolve_current_segment()` (Stufe 2) greift auf das aktive Segment von gestern zurück,
+   bevor sie auf `None` fällt. In seltenen Randfällen (aktives Ziel-Segment von gestern reicht
+   bis kurz vor Mitternacht) kann `/jetzt` kurz nach Mitternacht noch den gestrigen Zielpunkt
+   liefern, statt auf AC-9 (letzter Wegpunkt der heutigen Etappe) zu greifen. Dieses Verhalten
+   ist identisch zum Alarm-/Briefing-Pfad aus #2017 und wird hier nicht gesondert behandelt.
+
+3. **`src/services/trip_day.py:41,51` nutzt weiterhin `waypoints[0]`.** Dort zur
+   Zeitzonen-Bestimmung des Etappentags, nicht zur Positionsbestimmung für den Nowcast —
+   ausdrücklich nicht Teil dieses Tickets (siehe „Bewusst nicht Teil dieses Tickets").
+
+## Bewusst nicht Teil dieses Tickets
+
+- `src/services/trip_day.py:41,51` — nutzt ebenfalls `stage.waypoints[0]`, dort aber zur
+  Zeitzonen-Bestimmung des Etappentags. Eigene Frage (Etappe über Zeitzonengrenze), im Ticket
+  ausdrücklich ausgeklammert.
+- Die Trip-Konfiguration des PO wird nicht angefasst.
+- Die Tages-/Ortszonen-Logik von `_show_now` (#1402, #1727 S5a, ADR-0044) bleibt unverändert —
+  geändert wird nur der Messpunkt innerhalb der bereits gewählten Etappe, nicht die Auswahl der
+  Etappe selbst.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Keine Entscheidungsfläche im Sinne von `docs/adr/README.md` (Kanäle, Provider,
+  Datenmodell/Persistenz, Auth, Editor-Paradigma, Test-/Deploy-Strategie) ist berührt — dieselbe
+  Begründung wie in `docs/specs/modules/fix_2017_nowcast_messpunkt.md:414-420`. Die Änderung
+  verdrahtet einen bereits bestehenden, geteilten Baustein (`position_at_time()`) an einer
+  dritten Fundstelle. Die dazugehörige Known Limitation in
+  `docs/specs/modules/radar_nowcast.md:106-113` wird um `/jetzt` fortgeschrieben (Scope-Eintrag
+  oben), keine neue Grundsatzentscheidung.
+
+## Changelog
+
+- 2026-08-21: Initial spec created (Issue #2052)

--- a/docs/specs/modules/radar_nowcast.md
+++ b/docs/specs/modules/radar_nowcast.md
@@ -119,6 +119,11 @@ Testdatei: `tests/tdd/test_feature_656_radar_nowcast.py` (mock-frei).
   (Naismith), nicht dem tatsächlichen Fortschritt. Sie beseitigt den *systematischen*
   Bias (der Startpunkt liegt immer zurück, nie voraus), nicht die *stochastische*
   Abweichung vom Plan. Details und Messung: `fix_2017_nowcast_messpunkt.md`.
+  Der Befehl `/jetzt` (`TripCommandProcessor._show_now`) ist ein eigener, mit **#2052**
+  zeitgleich nachgezogener Pfad: er nutzt denselben Baustein, misst aber bewusst zu
+  `now_utc` selbst statt zur Fenstermitte — eine Sofortabfrage fragt nach dem Ort, an dem
+  der Nutzer *steht*, nicht nach dem, an dem er bei Ereigniseintritt stehen wird.
+  Details: `fix_2052_now_aufenthaltsort.md`.
 - "Kollisionskurs" im MVP = Onset-/Annäherungs-Trend im Punkt-Nowcast, kein voll-physikalisches Zell-Tracking mit Bewegungsvektor.
 - RADOLAN deckt nur DE + Grenzregionen, INCA nur AT. Für Italien (inkl. Korsika, PO-Entscheidung 2026-07-09) liefert seit Issue #1648 **ausschließlich** ARPAE ICON-2I (2 km, via Open-Meteo) den Nowcast — der frühere Radar-DPC (Protezione Civile, #1162) ist ersatzlos entfernt, weil er strukturell nur eine einzelne Vergangenheits-Momentaufnahme lieferte und das Nowcast-Fenster (`timestamp >= now`) damit nie erreichen konnte. Reicht ARPAE nicht, fällt die Kette weiter auf AROME-FR/ICON-D2 (siehe `radar_nowcast_france.md`/`radar_nowcast_icon_d2.md`) bzw. zuletzt `minutely_15`. Konvektions-Indikator (WMO-weather_code) ist in Open-Meteo verfügbar; BrightSky/GeoSphere-Pfade haben kein natives Konvektions-Feld und nutzen einen Open-Meteo-Sidecar (ADR-0018) — ARPAE führt weather_code bereits mit, kein Sidecar nötig. Damit gibt es für Italien kein natives Radar-Konvektionssignal mehr (vormals Zielbild #1174).
 - Latenz-AC (< 10 s) abhängig von Fremd-API-Verfügbarkeit; Fallback-Kette bei Timeout/Leerantwort.

--- a/src/services/trip_command_processor.py
+++ b/src/services/trip_command_processor.py
@@ -1522,19 +1522,49 @@ class TripCommandProcessor:
                 ),
                 trip_name=trip.name,
             )
-        wp = stage.waypoints[0]
+        # Issue #2052: gemessen wird am AUFENTHALTSORT, nicht am Etappenstart.
+        # Zielzeitpunkt ist bewusst `now_utc` selbst -- anders als Alarm-/
+        # Briefing-Pfad (#2017), die zur Fenstermitte einer VORWARNUNG messen.
+        # /jetzt ist eine Sofortabfrage nach dem Ort, an dem der Nutzer STEHT.
+        from services.trip_segments import position_at_time, resolve_current_segment
+
+        resolved = resolve_current_segment(trip, now_utc, today)
+        if resolved is not None:
+            active, segment_date = resolved
+            try:
+                pos = position_at_time(trip, active, segment_date, now_utc)
+            except Exception as e:
+                logger.error(
+                    "Jetzt-Befehl: Positionsbestimmung fuer Trip %s "
+                    "fehlgeschlagen (%s) -- falle zurueck auf den ersten "
+                    "Wegpunkt der Etappe.",
+                    trip.id, e,
+                )
+                pos = stage.waypoints[0]
+        else:
+            # Vorrangkette liefert None: der Etappentag ist abgelaufen (typ.
+            # nach 23:00 Ortszeit). Der Wanderer ist dann am Tagesziel, nicht
+            # am Etappenstart -- letzterer waere die volle Etappenlaenge daneben.
+            pos = stage.waypoints[-1]
+
+        # #1991: `elevation_m` geht roh in den Cache-Schluessel -- 1000 vs.
+        # 1000.0 sind sonst zwei Eintraege fuer denselben Punkt. Die
+        # Normalisierung wohnt deshalb hier an der Aufrufstelle.
+        elevation_m = (
+            int(round(pos.elevation_m)) if pos.elevation_m is not None else None
+        )
         svc = RadarNowcastService()
         # Issue #1329 C2: /jetzt ist eine Nutzeraktion -- explizit
         # user_briefing (Default, nie gedrosselt), zur Dokumentation der Absicht.
         result = svc.get_nowcast(
-            wp.lat, wp.lon, elevation_m=wp.elevation_m, priority="user_briefing"
+            pos.lat, pos.lon, elevation_m=elevation_m, priority="user_briefing"
         )
         # Issue #1402: ohne tz faellt format_now_text() auf das argumentlose
         # .astimezone() zurueck -- deutet die Onset-Zeit in der PROZESS-
         # Zeitzone des Servers statt der Ortszeit des Wegpunkts.
         from utils.timezone import tz_for_coords
 
-        body = svc.format_now_text(result, tz=tz_for_coords(wp.lat, wp.lon))
+        body = svc.format_now_text(result, tz=tz_for_coords(pos.lat, pos.lon))
         return CommandResult(
             success=True, command="now",
             confirmation_subject=f"[{trip.name}] Nowcast",

--- a/tests/tdd/test_jetzt_misst_am_aufenthaltsort.py
+++ b/tests/tdd/test_jetzt_misst_am_aufenthaltsort.py
@@ -1,0 +1,566 @@
+"""``/jetzt`` misst am Aufenthaltsort, nicht am Etappenstart (Issue #2052).
+
+SPEC: docs/specs/modules/fix_2052_now_aufenthaltsort.md
+
+RED-Zustand: ``TripCommandProcessor._show_now`` liest heute unveraendert
+``stage.waypoints[0]`` und fragt den Nowcast dort ab — egal, wie weit der
+Wanderer zum Abfragezeitpunkt auf der Etappe schon gekommen ist. Kuenftig
+wird ueber ``resolve_current_segment()`` + ``position_at_time()`` an der zu
+``now_utc`` interpolierten Position gemessen.
+
+Mock-frei nach Hausnorm: der Radar-Dienst ist eine echte
+``RadarNowcastService``-UNTERKLASSE, die die Aufrufargumente mitschreibt und
+danach ``super()`` mit dem vorhandenen ``frame_source``-DI-Seam laufen laesst
+— die gesamte Ableitungslogik (Cache, Region, ``_derive_result``,
+``format_now_text``) bleibt die echte, es geht kein Byte ins Netz. Kein
+``Mock()``/``patch()``.
+
+``_show_now`` importiert ``RadarNowcastService`` LOKAL in der Methode
+(``trip_command_processor.py:1511``) und hat keinen Konstruktor-DI-Seam —
+deshalb wird die Klasse an ihrem Wohnort ersetzt
+(``services.radar_service.RadarNowcastService``), s.
+``tests/unit/test_radar_budget_and_priority.py:243-248``.
+
+Die Sollwerte werden ANALYTISCH aus Wegpunkt-Geometrie und Zeitanteil
+gerechnet (:func:`_erwarteter_punkt`) — bewusst OHNE ``position_at_time()``
+bzw. ``_interpolate_point()``. Ein aus dem Pruefling abgeleiteter
+Erwartungswert machte jede Verfaelschung des Prueflings unsichtbar, weil der
+Test sie mitmachte.
+
+Zeitachse: die Etappe liegt in Atlantic/Reykjavik (ganzjaehrig UTC+0, s.
+``nowcast_gate_fixtures.TRIP_LAT``) — die HH:MM-Angaben der Wegpunkte sind
+damit direkt als UTC lesbar. :func:`_erwarteter_punkt` prueft diese Annahme,
+statt sie zu setzen.
+"""
+from __future__ import annotations
+
+import dataclasses
+import logging
+from datetime import date, datetime, time, timedelta, timezone
+from pathlib import Path
+
+from freezegun import freeze_time
+
+from services.trip_command_processor import TripCommandProcessor
+from tests.helpers.nowcast_gate_fixtures import CountingFrameSource, make_trip
+
+# Pfadregel #1409: der Arbeitsbaum wird relativ zu DIESER Datei bestimmt, nie
+# ueber einen festen Hauptrepo-Pfad — sonst prueft ein Worktree-Lauf still den
+# Code des Hauptrepos und ist gruen aus dem falschen Grund.
+_ARBEITSBAUM = Path(__file__).resolve().parents[2]
+
+_TAG = date(2026, 8, 11)
+# Geh-Segment 11:00-13:00 Ortszeit (= UTC), Abfrage um 11:30 -> Zeitanteil 0,25.
+# Bewusst zwei Stunden statt eines ganzen Tages: damit unterscheiden sich die
+# Positionen zu `now_utc` und zu den beiden Fenstermitte-Offsets (s. AC-2)
+# deutlich messbar statt nur in der vierten Nachkommastelle.
+_START, _ENDE = "11:00", "13:00"
+_JETZT = datetime(2026, 8, 11, 11, 30, tzinfo=timezone.utc)
+# Vor dem ersten Segment des Tages (AC-8).
+_VORHER = datetime(2026, 8, 11, 9, 0, tzinfo=timezone.utc)
+# Nach dem Ende des Ziel-Segments (Tagesfenster-Ende 20:00 Ortszeit) — und
+# damit hinter der gesamten Vorrangkette von `resolve_current_segment()`
+# (AC-9). Der Test verifiziert das ausdruecklich, statt es anzunehmen.
+_NACH_TAGESENDE = datetime(2026, 8, 11, 21, 30, tzinfo=timezone.utc)
+
+
+# ─────────────────────────────── Bausteine ──────────────────────────────────
+
+
+def _trip(trip_id: str):
+    """Zwei-Wegpunkt-Etappe aus dem geteilten Helfer (Start 500 m, Ende 600 m,
+    Endpunkt +0.1°/+0.1°) — kein Nachbau aus ``Stage``/``Waypoint``."""
+    return make_trip(
+        trip_id, stage_date=_TAG, arrival_start=_START, arrival_end=_ENDE,
+    )
+
+
+def _wegpunkte(trip):
+    stage = trip.get_stage_for_date(_TAG)
+    return stage.waypoints[0], stage.waypoints[-1]
+
+
+def _setze_wegpunkt(trip, idx: int, **felder):
+    """``Waypoint``/``Stage`` sind ``frozen`` — der Austausch laeuft ueber
+    ``dataclasses.replace`` in der (mutablen) Wegpunktliste der Etappe."""
+    stage = trip.get_stage_for_date(_TAG)
+    stage.waypoints[idx] = dataclasses.replace(stage.waypoints[idx], **felder)
+
+
+def _erwarteter_punkt(trip, at: datetime):
+    """``(lat, lon, hoehe, p)`` zum Zeitpunkt ``at`` — ANALYTISCH gerechnet.
+
+    Nur Wegpunkt-Geometrie, Wegpunkt-Zeiten und die lineare Formel; kein
+    Aufruf von ``position_at_time()``/``_interpolate_point()``.
+    """
+    from utils.timezone import tz_for_coords
+
+    a, b = _wegpunkte(trip)
+    zone = tz_for_coords(a.lat, a.lon)
+    versatz = datetime.combine(_TAG, time(12, 0), tzinfo=zone).utcoffset()
+    assert versatz == timedelta(0), (
+        f"Testvoraussetzung: die Etappe muss in einer UTC+0-Zone liegen, damit "
+        f"die HH:MM-Wegpunktzeiten direkt als UTC gelten — gemessen {versatz}"
+    )
+    start = datetime.combine(
+        _TAG, time.fromisoformat(a.arrival_calculated), tzinfo=timezone.utc,
+    )
+    ende = datetime.combine(
+        _TAG, time.fromisoformat(b.arrival_calculated), tzinfo=timezone.utc,
+    )
+    spanne = (ende - start).total_seconds()
+    assert spanne > 0, "Testvoraussetzung: das Segment braucht eine echte Dauer"
+    p = max(0.0, min(1.0, (at - start).total_seconds() / spanne))
+    hoehe = None
+    if a.elevation_m is not None and b.elevation_m is not None:
+        hoehe = a.elevation_m + p * (b.elevation_m - a.elevation_m)
+    return (
+        a.lat + p * (b.lat - a.lat),
+        a.lon + p * (b.lon - a.lon),
+        hoehe,
+        p,
+    )
+
+
+def _aufzeichnender_typ(calls: list, *, onset_minutes: int = 8):
+    """Echte ``RadarNowcastService``-Unterklasse, die die Aufrufargumente
+    mitschreibt und danach die ECHTE Ableitung laufen laesst.
+
+    Eigener ``RadarNowcastCacheService`` je Instanz: der geteilte Prozess-Cache
+    ist ein Singleton mit 300 s TTL — zwei Laeufe im selben Test wuerden sich
+    sonst Zustand teilen und der zweite maesse einen Cache-Treffer statt des
+    Verhaltens.
+    """
+    from services.radar_cache import RadarNowcastCacheService
+    from services.radar_service import RadarNowcastService
+
+    class _Aufzeichnend(RadarNowcastService):
+        def __init__(self, *_a, **_kw) -> None:
+            super().__init__(
+                frame_source=CountingFrameSource(onset_minutes),
+                cache=RadarNowcastCacheService(),
+            )
+
+        def get_nowcast(self, lat, lon, elevation_m=None, priority="user_briefing"):
+            calls.append({
+                "lat": lat, "lon": lon,
+                "elevation_m": elevation_m, "priority": priority,
+            })
+            return super().get_nowcast(
+                lat, lon, elevation_m=elevation_m, priority=priority,
+            )
+
+    return _Aufzeichnend
+
+
+def _jetzt(monkeypatch, trip, now_utc: datetime):
+    """Ein echter ``_show_now``-Lauf; liefert ``(CommandResult, ruf)``."""
+    import services.trip_command_processor as tcp
+
+    assert Path(tcp.__file__).resolve().is_relative_to(_ARBEITSBAUM), (
+        f"Pfadregel #1409: der Pruefling wurde aus {tcp.__file__} geladen, "
+        f"nicht aus dem Arbeitsbaum {_ARBEITSBAUM} dieser Testdatei"
+    )
+    calls: list = []
+    monkeypatch.setattr(
+        "services.radar_service.RadarNowcastService", _aufzeichnender_typ(calls),
+    )
+    with freeze_time(now_utc):
+        ergebnis = TripCommandProcessor()._show_now(trip, now_utc)
+    assert len(calls) == 1, (
+        f"Testvoraussetzung: genau EIN get_nowcast()-Abruf je /jetzt erwartet, "
+        f"gesehen {len(calls)} — Antwort: {ergebnis.confirmation_body!r}"
+    )
+    return ergebnis, calls[0]
+
+
+def _fenstermitte_offsets() -> list[int]:
+    """Die Zieloffsets, die Alarm- bzw. Briefing-Pfad benutzen (#2017).
+
+    Ueber die MODUL-Referenz gelesen, nie beim Import gebunden: der
+    Laufzeit-Drift-Waechter aus #2009 setzt ``RADAR_ONSET_THRESHOLD_MIN`` zur
+    Laufzeit um; eine gebundene Kopie liefe still daran vorbei.
+    """
+    from services import radar_service as rs
+
+    return [rs.RADAR_ONSET_THRESHOLD_MIN // 2, rs.NOWCAST_HORIZON_MIN // 2]
+
+
+# ──────────────────────────────── AC-1 ──────────────────────────────────────
+
+
+def test_ac1_jetzt_misst_an_der_interpolierten_position(monkeypatch):
+    """AC-1.
+
+    GIVEN eine heutige Etappe 11:00-13:00, deren Segment um 11:30 laeuft,
+    WHEN  ``/jetzt`` aufgerufen wird,
+    THEN  traegt der ``get_nowcast()``-Aufruf die zu ``now_utc`` interpolierte
+          Position — nicht ``stage.waypoints[0]``, den Ort vom Morgen.
+    """
+    trip = _trip("jetzt-2052-ac1")
+    start_wp, _ziel_wp = _wegpunkte(trip)
+    soll_lat, soll_lon, _h, p = _erwarteter_punkt(trip, _JETZT)
+
+    _ergebnis, ruf = _jetzt(monkeypatch, trip, _JETZT)
+
+    assert (abs(ruf["lat"] - soll_lat) < 1e-9
+            and abs(ruf["lon"] - soll_lon) < 1e-9), (
+        f"AC-1: /jetzt fragte den Nowcast an ({ruf['lat']:.5f}, "
+        f"{ruf['lon']:.5f}) ab; erwartet der um {_JETZT:%H:%M} UTC "
+        f"interpolierte Aufenthaltsort ({soll_lat:.5f}, {soll_lon:.5f}), "
+        f"Zeitanteil p={p:.4f}. ({start_wp.lat:.5f}, {start_wp.lon:.5f}) ist "
+        f"der Etappenstart — der Ort, den der Wanderer am Morgen verlassen hat."
+    )
+
+
+# ──────────────────────────────── AC-2 ──────────────────────────────────────
+
+
+def test_ac2_zielzeitpunkt_ist_now_utc_und_nicht_die_fenstermitte(monkeypatch):
+    """AC-2.
+
+    GIVEN dieselbe laufende Etappe,
+    WHEN  ``/jetzt`` um 11:30 aufgerufen wird,
+    THEN  ist der Messzeitpunkt ``now_utc`` SELBST — nicht die Fenstermitte
+          (``RADAR_ONSET_THRESHOLD_MIN // 2`` bzw. ``NOWCAST_HORIZON_MIN // 2``),
+          mit der Alarm- und Briefing-Pfad vorauswaehlen. ``/jetzt`` ist keine
+          Vorwarnung: der Nutzer fragt nach dem Ort, an dem er STEHT.
+
+    Der Fall ist bewusst so gebaut, dass sich die Positionen zu ``now_utc`` und
+    zu beiden Fenstermitten messbar unterscheiden — ein Aufbau, bei dem beide
+    Zeitpunkte denselben Punkt lieferten, bewiese nichts.
+    """
+    trip = _trip("jetzt-2052-ac2")
+    soll_lat, soll_lon, _h, _p = _erwarteter_punkt(trip, _JETZT)
+
+    mitten = {}
+    for offset in _fenstermitte_offsets():
+        m_lat, m_lon, _mh, _mp = _erwarteter_punkt(
+            trip, _JETZT + timedelta(minutes=offset),
+        )
+        assert abs(m_lat - soll_lat) > 0.005 and abs(m_lon - soll_lon) > 0.005, (
+            f"Testvoraussetzung: der Punkt zur Fenstermitte (+{offset} min, "
+            f"{m_lat:.5f}/{m_lon:.5f}) muss sich vom Punkt zu now_utc "
+            f"({soll_lat:.5f}/{soll_lon:.5f}) messbar unterscheiden — sonst "
+            f"kann der Test die beiden Zeitpunkte gar nicht trennen"
+        )
+        mitten[offset] = (round(m_lat, 5), round(m_lon, 5))
+
+    _ergebnis, ruf = _jetzt(monkeypatch, trip, _JETZT)
+
+    assert (abs(ruf["lat"] - soll_lat) < 1e-9
+            and abs(ruf["lon"] - soll_lon) < 1e-9), (
+        f"AC-2: gemessen wurde an ({ruf['lat']:.5f}, {ruf['lon']:.5f}); "
+        f"erwartet der Ort zum Abfragezeitpunkt now_utc "
+        f"({soll_lat:.5f}, {soll_lon:.5f}). Die Fenstermitte-Punkte des "
+        f"Alarm-/Briefing-Pfads waeren {mitten} — eine Vorausmessung koennte "
+        f"'trocken' melden, waehrend der Nutzer im Regen steht."
+    )
+
+
+# ──────────────────────────────── AC-3 ──────────────────────────────────────
+
+
+def test_ac3_messpunkt_wandert_mit_dem_zielwegpunkt(monkeypatch):
+    """AC-3 (Nicht-Trivialitaet / Gegenprobe).
+
+    GIVEN zwei sonst gleiche Touren, deren ZIELwegpunkt verschoben ist,
+    WHEN  ``/jetzt`` jeweils zum selben Zeitpunkt laeuft,
+    THEN  verschiebt sich der abgefragte Messpunkt mit — und er liegt in beiden
+          Laeufen > 0.01° vom Etappenstart entfernt.
+
+    Ohne diese Gegenprobe waere AC-1 trivial erfuellbar (ein Messpunkt, der
+    zufaellig am Start klebt, bestuende sie ebenfalls).
+    """
+    trip_a = _trip("jetzt-2052-ac3a")
+    trip_b = _trip("jetzt-2052-ac3b")
+    start_wp, ziel_wp = _wegpunkte(trip_b)
+    _setze_wegpunkt(trip_b, -1, lat=start_wp.lat + 0.3, lon=start_wp.lon - 0.2)
+    assert _wegpunkte(trip_b)[1] != ziel_wp, "Testaufbau: Ziel nicht verschoben"
+
+    soll_a = _erwarteter_punkt(trip_a, _JETZT)
+    soll_b = _erwarteter_punkt(trip_b, _JETZT)
+
+    _erg_a, ruf_a = _jetzt(monkeypatch, trip_a, _JETZT)
+    _erg_b, ruf_b = _jetzt(monkeypatch, trip_b, _JETZT)
+
+    for name, ruf, soll, trip in (
+        ("A", ruf_a, soll_a, trip_a), ("B", ruf_b, soll_b, trip_b),
+    ):
+        s_wp = _wegpunkte(trip)[0]
+        assert (abs(soll[0] - s_wp.lat) > 0.01
+                and abs(soll[1] - s_wp.lon) > 0.01), (
+            f"Testvoraussetzung Lauf {name}: interpolierter Punkt "
+            f"({soll[0]:.5f}, {soll[1]:.5f}) und Etappenstart "
+            f"({s_wp.lat:.5f}, {s_wp.lon:.5f}) muessen sich um > 0.01° "
+            f"unterscheiden, p={soll[3]:.4f}"
+        )
+        assert (abs(ruf["lat"] - soll[0]) < 1e-9
+                and abs(ruf["lon"] - soll[1]) < 1e-9), (
+            f"AC-3 Lauf {name}: gemessen an ({ruf['lat']:.5f}, "
+            f"{ruf['lon']:.5f}), erwartet ({soll[0]:.5f}, {soll[1]:.5f}) — "
+            f"Etappenstart waere ({s_wp.lat:.5f}, {s_wp.lon:.5f})"
+        )
+
+    assert (ruf_a["lat"], ruf_a["lon"]) != (ruf_b["lat"], ruf_b["lon"]), (
+        f"AC-3: beide Laeufe fragten dieselbe Koordinate ab "
+        f"({ruf_a['lat']:.5f}, {ruf_a['lon']:.5f}), obwohl der Zielwegpunkt "
+        f"verschoben wurde — der Messpunkt folgt der Geometrie also gar nicht"
+    )
+
+
+# ──────────────────────────────── AC-4 ──────────────────────────────────────
+
+
+def test_ac4_hoehe_wandert_mit_und_ist_ganzzahlig(monkeypatch):
+    """AC-4.
+
+    GIVEN ein Segment mit 500 m am Start und 600 m am Ziel,
+    WHEN  ``/jetzt`` bei Zeitanteil 0,25 laeuft,
+    THEN  traegt ``get_nowcast(elevation_m=...)`` die MITGEWANDERTE Hoehe,
+          an der Aufrufstelle auf ganze Meter normalisiert (``int``).
+
+    Der Typ wird mitgeprueft, nicht nur der Wert: ``get_nowcast`` fuehrt
+    ``elevation_m`` roh im Cache-Schluessel — ``1000`` vs. ``1000.0`` erzeugte
+    in #1991 zwei Eintraege fuer denselben Punkt.
+    """
+    trip = _trip("jetzt-2052-ac4")
+    start_wp, ziel_wp = _wegpunkte(trip)
+    _lat, _lon, soll_hoehe, p = _erwarteter_punkt(trip, _JETZT)
+    assert soll_hoehe is not None and abs(soll_hoehe - start_wp.elevation_m) > 5.0, (
+        f"Testvoraussetzung: interpolierte Hoehe {soll_hoehe} und Start-Hoehe "
+        f"{start_wp.elevation_m} muessen sich unterscheiden (p={p:.4f})"
+    )
+
+    _ergebnis, ruf = _jetzt(monkeypatch, trip, _JETZT)
+
+    assert ruf["elevation_m"] == int(round(soll_hoehe)), (
+        f"AC-4: get_nowcast mit elevation_m={ruf['elevation_m']}; erwartet die "
+        f"interpolierte Hoehe {int(round(soll_hoehe))} m (zwischen "
+        f"{start_wp.elevation_m} m und {ziel_wp.elevation_m} m). "
+        f"{start_wp.elevation_m} m waere die Hoehe des verlassenen "
+        f"Startpunkts — neuer Ort, alte Hoehe."
+    )
+    assert isinstance(ruf["elevation_m"], int), (
+        f"AC-4: elevation_m ist {type(ruf['elevation_m']).__name__} "
+        f"({ruf['elevation_m']!r}), erwartet int — die Normalisierung auf ganze "
+        f"Meter wohnt an der Aufrufstelle (#1991: 1000 vs. 1000.0 sind zwei "
+        f"Cache-Eintraege fuer denselben Punkt)"
+    )
+
+
+def test_ac4_hoehe_bleibt_none_wenn_die_wegpunkte_keine_tragen(monkeypatch):
+    """AC-4 (zweite Haelfte: ``None`` bleibt ``None``).
+
+    GIVEN eine Etappe, deren Wegpunkte keine Hoehe tragen, und eine Abfrage
+          nach Tagesende (Rueckfall auf ``stage.waypoints[-1]``, AC-9),
+    WHEN  ``/jetzt`` laeuft,
+    THEN  wird ``elevation_m=None`` uebergeben statt einer erfundenen Zahl.
+
+    Bewusst ueber den Rueckfall-Zweig und nicht ueber die Interpolation:
+    ``convert_trip_to_segments()`` ersetzt eine fehlende Wegpunkt-Hoehe beim
+    Segmentbau durch ``0.0`` (``trip_segments.py:222``) — ueber den
+    Segment-Pfad ist ``None`` strukturell unerreichbar, ueber den
+    Wegpunkt-Rueckfall nicht.
+    """
+    trip = _trip("jetzt-2052-ac4-none")
+    for idx in (0, -1):
+        _setze_wegpunkt(trip, idx, elevation_m=None)
+    _start_wp, ziel_wp = _wegpunkte(trip)
+
+    _ergebnis, ruf = _jetzt(monkeypatch, trip, _NACH_TAGESENDE)
+
+    assert ruf["elevation_m"] is None, (
+        f"AC-4: elevation_m={ruf['elevation_m']!r}; ohne Wegpunkt-Hoehe muss "
+        f"None durchgereicht werden, nicht 0 oder ein gerundeter Ersatzwert"
+    )
+    assert (ruf["lat"], ruf["lon"]) == (ziel_wp.lat, ziel_wp.lon), (
+        f"AC-4/AC-9: gemessen an ({ruf['lat']}, {ruf['lon']}), erwartet der "
+        f"letzte Wegpunkt ({ziel_wp.lat}, {ziel_wp.lon})"
+    )
+
+
+# ──────────────────────────────── AC-5 ──────────────────────────────────────
+
+
+def test_ac5_zeitzone_wird_am_messpunkt_bestimmt(monkeypatch):
+    """AC-5.
+
+    GIVEN eine laufende Etappe,
+    WHEN  ``/jetzt`` laeuft,
+    THEN  wird ``tz_for_coords()`` auf die INTERPOLIERTEN Koordinaten
+          angewandt, nicht mehr auf ``stage.waypoints[0]`` — die Onset-Uhrzeit
+          im Antworttext gilt fuer den Messpunkt.
+
+    Aufgezeichnet wird ueber einen durchreichenden Wrapper auf
+    ``utils.timezone.tz_for_coords``; die echte Aufloesung laeuft weiter. Eine
+    Etappe ueber eine echte Zeitzonengrenze ist als Nachweis nicht noetig
+    (eigener Randfall, s. Known Limitations der Spec).
+    """
+    import utils.timezone as tzmod
+
+    echt = tzmod.tz_for_coords
+    tz_aufrufe: list[tuple[float, float]] = []
+
+    def _aufzeichnend(lat, lon):
+        tz_aufrufe.append((lat, lon))
+        return echt(lat, lon)
+
+    trip = _trip("jetzt-2052-ac5")
+    start_wp, _ziel_wp = _wegpunkte(trip)
+    soll_lat, soll_lon, _h, _p = _erwarteter_punkt(trip, _JETZT)
+
+    monkeypatch.setattr(tzmod, "tz_for_coords", _aufzeichnend)
+    _ergebnis, _ruf = _jetzt(monkeypatch, trip, _JETZT)
+
+    treffer = [
+        (la, lo) for la, lo in tz_aufrufe
+        if abs(la - soll_lat) < 1e-9 and abs(lo - soll_lon) < 1e-9
+    ]
+    assert treffer, (
+        f"AC-5: tz_for_coords() wurde mit {tz_aufrufe} gerufen — der "
+        f"interpolierte Messpunkt ({soll_lat:.5f}, {soll_lon:.5f}) ist nicht "
+        f"darunter. ({start_wp.lat:.5f}, {start_wp.lon:.5f}) ist der "
+        f"Etappenstart; die Onset-Uhrzeit gaelte dann fuer den falschen Ort."
+    )
+
+
+# ──────────────────────────────── AC-8 ──────────────────────────────────────
+
+
+def test_ac8_vor_dem_ersten_segment_bitgleich_zum_startpunkt(monkeypatch):
+    """AC-8 (Vorschau, Bitgleichheit).
+
+    GIVEN eine Abfrage um 09:00, also VOR dem ersten Segment des Tages,
+    WHEN  ``/jetzt`` laeuft und die Vorschau-Stufe von
+          ``resolve_current_segment()`` greift,
+    THEN  sind die abgefragten Koordinaten IDENTISCH (``==``, nicht bloss nah)
+          mit ``stage.waypoints[0]`` — bitgleich zum Verhalten vor dieser
+          Aenderung.
+    """
+    from services.trip_day import trip_local_today
+    from services.trip_segments import resolve_current_segment
+
+    trip = _trip("jetzt-2052-ac8")
+    start_wp, _ziel_wp = _wegpunkte(trip)
+
+    aufgeloest = resolve_current_segment(
+        trip, _VORHER, trip_local_today(trip, _VORHER),
+    )
+    assert aufgeloest is not None, (
+        "Testvoraussetzung: um 09:00 muss die Vorschau-Stufe greifen — sonst "
+        "prueft der Fall den Rueckfall-Zweig statt der Vorschau"
+    )
+
+    _ergebnis, ruf = _jetzt(monkeypatch, trip, _VORHER)
+
+    assert (ruf["lat"], ruf["lon"]) == (start_wp.lat, start_wp.lon), (
+        f"AC-8: vor dem Etappenstart gemessen an ({ruf['lat']!r}, "
+        f"{ruf['lon']!r}); erwartet bitgleich der erste Wegpunkt "
+        f"({start_wp.lat!r}, {start_wp.lon!r}) — der Wanderer ist noch nicht "
+        f"losgelaufen"
+    )
+
+
+# ──────────────────────────────── AC-9 ──────────────────────────────────────
+
+
+def test_ac9_nach_tagesende_wird_am_letzten_wegpunkt_gemessen(monkeypatch):
+    """AC-9 (Randfall nach Tagesende).
+
+    GIVEN eine Abfrage nach dem Ende des Tagesfensters — so gelegt, dass auch
+          der Vortags-Rueckgriff (Stufe 2) nicht greift,
+    WHEN  ``resolve_current_segment()`` damit ``None`` liefert,
+    THEN  wird am LETZTEN Wegpunkt der heutigen Etappe gemessen, nicht am
+          ersten: ``None`` heisst hier eindeutig "der Etappentag ist
+          abgelaufen", der Wanderer ist am Tagesziel.
+
+    Dass wirklich ``None`` herauskommt, wird im Aufbau verifiziert — sonst
+    pruefte der Fall einen anderen Zweig als gemeint.
+    """
+    from services.trip_day import trip_local_today
+    from services.trip_segments import resolve_current_segment
+
+    trip = _trip("jetzt-2052-ac9")
+    start_wp, ziel_wp = _wegpunkte(trip)
+
+    aufgeloest = resolve_current_segment(
+        trip, _NACH_TAGESENDE, trip_local_today(trip, _NACH_TAGESENDE),
+    )
+    assert aufgeloest is None, (
+        f"Testvoraussetzung: um {_NACH_TAGESENDE:%H:%M} UTC muss die "
+        f"Vorrangkette None liefern, tatsaechlich {aufgeloest!r} — sonst "
+        f"prueft der Fall die Interpolation statt des Tagesende-Rueckfalls"
+    )
+
+    _ergebnis, ruf = _jetzt(monkeypatch, trip, _NACH_TAGESENDE)
+
+    assert (ruf["lat"], ruf["lon"]) == (ziel_wp.lat, ziel_wp.lon), (
+        f"AC-9: nach Tagesende gemessen an ({ruf['lat']!r}, {ruf['lon']!r}); "
+        f"erwartet das Tagesziel ({ziel_wp.lat!r}, {ziel_wp.lon!r}). "
+        f"({start_wp.lat!r}, {start_wp.lon!r}) ist der Etappenstart — die "
+        f"volle Etappenlaenge daneben."
+    )
+
+
+# ─────────────────────────────── AC-10 ──────────────────────────────────────
+
+
+def test_ac10_fehlgeschlagene_positionsbestimmung_faellt_zurueck_und_loggt(
+    monkeypatch, caplog,
+):
+    """AC-10 (Fehlerpfad).
+
+    GIVEN ``position_at_time()`` wirft wider Erwarten,
+    WHEN  ``/jetzt`` laeuft,
+    THEN  bekommt der Nutzer TROTZDEM eine Nowcast-Antwort (``success=True``),
+          gemessen am bisherigen Ort ``stage.waypoints[0]``, und der Fehler
+          steht als ``logger.error`` im Protokoll.
+
+    Der Fall bewacht zusaetzlich die Fehlerpfad-TRENNUNG (F-ADV1 aus #2017):
+    das ``try`` darf ausschliesslich die Positionsbestimmung umschliessen.
+    Wuerde jemand spaeter den ganzen Block inklusive ``get_nowcast()``
+    einpacken, bliebe der Abruf aus und der Antworttext leer — genau das
+    faengt die Kombination aus "genau ein Abruf" und "Antwort vorhanden".
+    """
+    import services.trip_segments as segmente
+
+    aufrufe: list = []
+
+    def _wirft(trip, active, segment_date, at):
+        aufrufe.append(at)
+        raise RuntimeError("Positionsbestimmung kaputt (Testfall AC-10)")
+
+    monkeypatch.setattr(segmente, "position_at_time", _wirft)
+
+    trip = _trip("jetzt-2052-ac10")
+    start_wp, _ziel_wp = _wegpunkte(trip)
+
+    with caplog.at_level(logging.ERROR):
+        ergebnis, ruf = _jetzt(monkeypatch, trip, _JETZT)
+
+    assert aufrufe, (
+        "AC-10: position_at_time() wurde ueberhaupt nicht gerufen — /jetzt "
+        "bestimmt die Position also gar nicht ueber den geteilten Baustein "
+        "(heutiger Zustand: es liest stage.waypoints[0] direkt)"
+    )
+    assert ergebnis.success is True and ergebnis.confirmation_body.strip(), (
+        f"AC-10: der Nutzer muss trotz Fehler eine Antwort bekommen — "
+        f"success={ergebnis.success}, body={ergebnis.confirmation_body!r}"
+    )
+    assert (ruf["lat"], ruf["lon"]) == (start_wp.lat, start_wp.lon), (
+        f"AC-10: Rueckfall muss am bisherigen Ort messen "
+        f"({start_wp.lat!r}, {start_wp.lon!r}), gemessen wurde "
+        f"({ruf['lat']!r}, {ruf['lon']!r})"
+    )
+    fehler = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    assert fehler, (
+        "AC-10: kein logger.error-Aufruf — eine fehlgeschlagene "
+        "Positionsbestimmung darf nicht stumm auf den Etappenstart "
+        "zurueckfallen"
+    )
+    assert any("osition" in r.getMessage() for r in fehler), (
+        f"AC-10: die Fehlermeldung muss die POSITIONSbestimmung benennen "
+        f"(unterscheidbar von 'Radar nowcast failed'), gesehen: "
+        f"{[r.getMessage() for r in fehler]}"
+    )


### PR DESCRIPTION
Behebt #2052.

## Problem

`TripCommandProcessor._show_now` fragte den Radar-Nowcast an `stage.waypoints[0]` ab — am Ausgangspunkt vom Morgen, unabhängig davon, wo auf der Etappe der Wanderer zum Abfragezeitpunkt steht. Fragt er um 16:00 mitten auf der Etappe „regnet es gleich?", antwortete der Bot für einen Ort, den er längst hinter sich gelassen hat.

Dieselbe Fehlerklasse wurde für Alarm- und Briefing-Pfad bereits in #2017 behoben. Dieser PR verdrahtet **denselben geteilten Baustein** `position_at_time()` an der dritten, bisher unbewachten Fundstelle.

## Bewusster Unterschied zu #2017

Zielzeitpunkt ist `now_utc` **selbst**, nicht die Fenstermitte. Alarm und Briefing sind Vorwarnungen — relevant ist, wo der Wanderer bei Ereigniseintritt sein wird. `/jetzt` ist eine Sofortabfrage nach dem Ort, an dem er **steht**; eine Vorausmessung könnte „trocken" melden, während er im Regen steht. Der Zirkelschluss-Vorbehalt aus #2017 bleibt gewahrt: `now_utc` ist aus dem Nowcast-Ergebnis nicht ableitbar.

## Randfälle

| Fall | Verhalten |
|---|---|
| Abfrage **vor** Etappenstart | bitgleich zum bisherigen Ergebnis (Startpunkt) — AC-8 |
| Vorrangkette liefert `None` (Etappentag abgelaufen) | Messung am **letzten** Wegpunkt — AC-9; `waypoints[0]` wäre die volle Etappenlänge daneben |
| `position_at_time()` wirft | Rückfall auf `waypoints[0]` + `logger.error`; der `try` umschließt **ausschließlich** die Positionsbestimmung, nicht den Nowcast-Abruf (F-ADV1-Muster aus #2017) — AC-10 |
| Höhe | an der Aufrufstelle auf ganze Meter normalisiert; `elevation_m` geht roh in den Cache-Schlüssel, `1000` vs. `1000.0` ergäben zwei Einträge für denselben Punkt (#1991) — AC-4 |

## Unverändert

Ortstag-Auswahl der Etappe (#1402, #1727 S5a, ADR-0044) · `priority="user_briefing"` (#1329 C2) · Fehlertext ohne heutige Etappe · Aktualisieren-Button. Der B18-Strukturwächter blieb ohne Anpassung grün. `src/services/trip_day.py` ist laut Spec ausdrücklich ausgeklammert und unangetastet.

## Nachweise

- **Zielsuite:** 9/9 grün (vorher 8/9 rot)
- **Regressionswächter** (6 Dateien): 76 grün
- **Erweiterte Regression** auf allen Testdateien, die `_show_now`/`position_at_time`/`resolve_current_segment` berühren (9 weitere Dateien): 122 grün
- **Adversary VERIFIED:** 14/14 Punkte belegt, **Mutations-Gegenprobe 9/9 gefangen** — darunter der Reach-Test am echten Aufrufpfad (`resolve_current_segment` wirkungslos gemacht → 7 Tests rot) und die F-ADV1-Regression (`try` auf `get_nowcast` ausgeweitet → `UnboundLocalError`, exakt das im Testdocstring vorhergesagte Szenario)

Spec: `docs/specs/modules/fix_2052_now_aufenthaltsort.md` (11 ACs, PO-freigegeben)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AB3yZsLveqR733QPhshZVT