### PR TITLE
test(#2050 S2a): Waechter fuer Alarm-Szenarien 2 und 3 auf der Pruefstrecke

### DIFF
--- a/docs/context/feat-2050-s2a-waechter-szenarien-2-3.md
+++ b/docs/context/feat-2050-s2a-waechter-szenarien-2-3.md
@@ -1,0 +1,171 @@
+# Context: #2050 Scheibe S2a — Wächter für Szenarien 2 und 3
+
+> Erhoben 2026-08-22 auf `main` @ `41abfbac` (Worktree `ws-2050-s2`), zwei Explore-Läufe,
+> alle Aussagen am Code belegt. Vorgänger: `docs/context/feat-2050-s1-pruefstrecke.md`.
+
+## Request Summary
+
+Issue #2050 gibt dem Alarmsystem ein Sollverhalten und eine Prüfstrecke dafür. Scheibe S1 hat
+den Harness geliefert (`tests/helpers/alarm_pruefstrecke.py`). **S2a stellt zwei der zwölf
+Szenarien als dauerhafte Wächter auf diese Strecke — ohne Produktivcode zu ändern:**
+
+- **Szenario 2** (Anforderungen C-1, A-3): Briefing kündigte 1 mm an, Radar zeigt 11 mm → Alarm.
+  Gegenprobe: kurze Spitze bei gleicher Menge löst **nicht** aus.
+- **Szenario 3** (Anforderungen C-1, B-2): Gewitterbeginn rückt von 17 auf 15 Uhr vor → Alarm
+  über die **Verschiebung**, beide Zeiten genannt.
+
+Szenario 1 (B-1, „Regen läuft schon") ist **nicht** Teil dieser Scheibe — es braucht Produktivcode
+und kollidiert mit #2020 Scheibe 2. Es wird als **S2b** nachgezogen. Begründung im
+Issue-Kommentar vom 2026-08-22.
+
+## Der Kern: was die bestehenden Tests NICHT prüfen
+
+Beide Szenarien haben bereits Testabdeckung — aber auf einer Ebene, die die eigentliche
+Zusicherung nicht erreicht. Genau das ist das Muster, das Issue #2050 abstellen will.
+
+### Szenario 2 — 17 Tests, kein einziger mit Gedächtnis
+
+`tests/tdd/test_nowcast_briefing_overtake.py` (1405 Zeilen, 17 Tests) fährt die
+Mengen-Überholung über den echten Einstieg `TripAlertService.check_radar_alerts()` — inklusive
+der geforderten Gegenprobe (`test_ac2_high_peak_rate_without_enough_amount_keeps_suppression`,
+`test_ac4_high_peak_rate_alone_never_triggers_the_overtake`).
+
+**Jeder dieser 17 Tests ist ein Einzelaufruf mit leerem Datenträger.** Jeder Testkörper legt eine
+frische `uid` an (`_clean_user`/`_ensure_real_user_dir`); selbst
+`test_ac3_stronger_or_equal_nowcast_never_alarms_less_than_a_weaker_one` (Zeilen 594–670) baut
+zwei **unabhängige** Nutzer `uid1`/`uid2` statt einer Folge. Nirgends wird `check_radar_alerts()`
+zweimal auf demselben Trip gerufen.
+
+**Folge:** Der Sperrzeit-/Cooldown-Mechanismus (`ThrottleStore`) kommt in dieser Datei **nie zum
+Tragen**, weil jeder Lauf ohne Vorgeschichte startet. Die Anforderung A-3 („eine Verschärfung
+überholt jede Sperre") ist damit an der Stelle, an der sie wirkt, unbewacht — geprüft wird nur,
+ob die Überholung *erkannt* wird, nicht ob sie eine *bestehende Sperre bricht*.
+
+### Szenario 3 — 10 Tests, alle unterhalb der Auslöseentscheidung
+
+`tests/tdd/test_onset_shift_alert.py` (767 Zeilen, 10 Tests) prüft `OnsetShiftEvent` (#1468)
+gründlich: beide Uhrzeiten im Text, Richtungswort, Mitternachtsübergang, Erstauftauchen,
+Protokoll, alle vier Kanäle.
+
+**Alle zehn setzen an `WeatherChangeDetectionService.detect_changes()` an** (über den lokalen
+Helfer `_aenderungen()`, Zeile 161), nicht an `TripAlertService.check_and_send_alerts()`.
+
+**Belegte Lücke:** Ein Grep über alle 41 Testdateien, die `check_and_send_alerts` aufrufen,
+gefiltert auf `thunder_onset`, liefert **null Treffer**. Es gibt im gesamten Repo keinen Test, der
+eine Gewitter-Vorverlegung durch die echte Auslöseentscheidung fährt.
+
+**Warum das eine echte Fehlerklasse ist:** `DeviationAlertEngine._select_detector`
+(`src/services/deviation_alert_engine.py:175-204`) wertet `thunder_onset` nur aus, wenn
+`trip.display_config.metric_alert_levels["thunder_onset"]` einen Level ≠ „off" trägt. Ein Trip
+kann den Alarmtyp also **konfigurativ gar nicht erreichen**, ohne dass ein einziger bestehender
+Test das bemerkt — die zehn Tests umgehen diese Auswahl, indem sie die Regeln direkt übergeben.
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `tests/helpers/alarm_pruefstrecke.py` (189 Z.) | Der Harness. Wird **benutzt**, nicht geändert |
+| `tests/tdd/test_nowcast_briefing_overtake.py` (1405 Z.) | Bestehende Abdeckung Szenario 2 — wird **nicht** angefasst |
+| `tests/tdd/test_onset_shift_alert.py` (767 Z.) | Bestehende Abdeckung Szenario 3 — wird **nicht** angefasst |
+| `tests/helpers/nowcast_gate_fixtures.py` (529 Z.) | `make_trip()` (:385), `frozen_active_window()` (:438) — **belegt durch Session #2036** |
+| `src/services/trip_alert.py` | Überholungsprüfung :1370-1378, `_briefing_precip_for_onset` :1111, Cooldown-Adapter :978 |
+| `src/services/deviation_alert_engine.py` | `_select_detector` :175-204 — die Konfigurations-Weiche |
+| `src/services/weather_snapshot.py` | `save_alarm_anchor(trip_id, target_date, segments, channel)` :225 |
+| `src/services/throttle_store.py` | `record(scope, key, now)` :84, `is_throttled` :71 |
+| `src/services/alert_daily_limit.py` | `increment(user_id, now, zone)` :110 |
+| `src/services/alert_state.py` | `AlertStateService.save(entity_id, state)` :73 — Änderungs-Gedächtnis |
+| `src/services/alert_briefing_anchor.py` | `record_briefing_sent(...)` :192, `write_anchor_and_reset_memory(...)` :259 |
+
+## Die Prüfstrecke — API und Eigenheiten
+
+```python
+AlarmPruefstrecke(*, user_id: str, settings: Settings | None = None, throttle_hours: int = 2)
+
+.lauf(*, at: datetime, zweig: Literal["deviation","official","radar"], trip: Trip,
+      cached_weather: list | None = None, fresh_weather: list | None = None,
+      official_notices: list | None = None, radar_service: object | None = None,
+     ) -> AlarmPruefstreckeLauf(triggered_count, mail, telegram, sms, premium_sms)
+```
+
+| Eigenschaft | Bedeutung für S2a |
+|---|---|
+| Zweig → Einstieg | `deviation` → `check_and_send_alerts(...)` · `radar` → `check_radar_alerts()` · `official` → `_send_official_alert_only(...)` |
+| Uhr | Der Harness friert selbst ein (`with freeze_time(at)`), Aufrufer übergibt nur `at=`. Kein `now_utc=` — `check_official_alert_triggers` verwirft es (`trip_alert.py:1811`) |
+| Zwischen zwei Läufen | Vier Cache-Resets (Radar, Weather, Thunder-Window, Telegram-Rate-Limit) + **frische** `TripAlertService`-Instanz. Kontinuität kommt vom Datenträger unter `get_data_dir(user_id)` — genau wie bei jedem Cron-Tick |
+| Vier Kanäle | Kein Setup nötig: zwei lokale HTTP-Stubs (Telegram, seven.io) plus `mail_sink`. SMS vs. Premium-SMS werden am `from`-Feld getrennt (`PREMIUM_SMS_SENDER`) |
+| **Kein Parameter für den Briefing-Anker** | Der Aufrufer muss ihn **vor** dem Lauf über den produktiven Schreibweg setzen — das ist die Naht, an der S2a arbeitet |
+
+## Existing Specs
+
+- `docs/specs/modules/alarm_pruefstrecke.md` — S1, `status: approved`. Sagt ausdrücklich, dass
+  die zwölf Szenarien spätere Scheiben sind und der Zustand über die produktiven Schreibwege
+  vorbelegt wird
+- `docs/specs/modules/alarm_testeinspeisung.md` — der zustandslose `alert-preview`-Endpoint aus
+  #1948 S2. **Nicht** betroffen, bekennt sich in seiner eigenen Spec zur Zustandslosigkeit
+
+## Risks & Considerations
+
+1. **Doppelung statt Zugewinn.** Ein Wächter, der nur nachbaut, was die 17 bzw. 10 bestehenden
+   Tests schon prüfen, ist Ballast. Jeder neue Test muss die oben belegte Lücke treffen:
+   *Zeitreihe mit Gedächtnis* (Szenario 2) bzw. *echte Auslöseentscheidung inklusive
+   Konfigurations-Weiche* (Szenario 3).
+2. **Kein Produktivcode.** Sollte sich zeigen, dass ein Wächter ohne Produktivänderung nicht
+   grün zu bekommen ist, ist das ein **Befund**, kein Anlass zum Nachbessern am Produktivcode —
+   er gehört dann als eigene Scheibe gemeldet.
+3. **Wortlaut-Sperre gegenüber #2020 S2.** Keine textprüfenden Zusicherungen auf Formulierungen,
+   die dort gerade entstehen (Langform `Bis jetzt:` / `Ab jetzt:`, Kurzform-Token
+   `Rest{mm}@{HH}`, Bedeutungswörter bei Zeitangaben). Szenario 3 darf auf `→` und Richtungswort
+   prüfen — das ist #1468-Bestand und dort ausdrücklich Nicht-Ziel.
+4. **Dateibelegung.** `tests/helpers/nowcast_gate_fixtures.py` wird von Session #2036 bearbeitet
+   (Fixture-Falle #1196). S2a darf die Datei **lesen und importieren**, aber nicht ändern.
+5. **Uhrzeit-Abhängigkeit.** `check_radar_alerts()` braucht ein aktives Segment.
+   `save_trip()` rechnet Segmentzeiten per Naismith neu (Compute-on-Save) — Fixture-Zeiten
+   überleben das nicht. Das `at=` der Läufe muss im garantiert aktiven Fenster liegen
+   (Vorbild: `frozen_active_window()`, Default 12:00 UTC).
+6. **Geteilter Prozess-Cache.** Der Harness setzt vier Caches zurück; ein Wächter, der einen
+   eigenen `RadarNowcastCacheService` mitbringt, muss ihn je Lauf frisch bauen, sonst wird die
+   Zeitreihe wirkungslos.
+7. **Mandantentrennung.** Jeder Wächter arbeitet auf einer eigenen `user_id` unter
+   `data/users/<user_id>/`; Parallelläufe anderer Sitzungen dürfen nicht hineinspielen.
+
+## Technischer Ansatz (Analyse)
+
+**Zwei neue Testdateien, kein Produktivcode, keine bestehende Testdatei geändert.**
+
+### Wächter 1 — Szenario 2 als Dreilauf-Zeitreihe (`zweig="radar"`)
+
+Eine `AlarmPruefstrecke` auf **einer** `user_id`, drei aufeinanderfolgende `lauf()`-Aufrufe zu
+gestellten Zeiten innerhalb der Sperrzeit:
+
+| Lauf | Lage | Erwartung | Anforderung |
+|---|---|---|---|
+| 1 | Briefing 1 mm, Radar 11 mm | Alarm, Kanäle tragen Inhalt | C-1 |
+| 2 | unverändert, kurz danach | **schweigt** — und zwar wegen der von Lauf 1 gebuchten Sperre, nicht wegen unveränderter Daten | C-1 |
+| 3 | deutlich verschärft | **kommt durch**, obwohl die Sperre noch läuft | A-3 |
+
+Dazu die Gegenprobe als vierter Lauf auf **eigener** `user_id`: kurze Spitze bei gleicher
+Spitzenrate, aber zu geringer Menge → `triggered_count == 0`.
+
+Der Unterschied „schweigt wegen Sperre" vs. „schweigt wegen gleicher Daten" muss am Ergebnis
+unterscheidbar sein — sonst wäre Lauf 2 trivial grün. Wie das nachgewiesen wird (Alarmprotokoll
+mit benanntem Unterdrückungsgrund, D-2), ist in der Spec festzulegen.
+
+### Wächter 2 — Szenario 3 durch die echte Auslöseentscheidung (`zweig="deviation"`)
+
+Ein Trip mit `display_config.metric_alert_levels["thunder_onset"]` aktiv, `cached_weather` mit
+`thunder_onset_utc` = 17:00, `fresh_weather` = 15:00. Ein `lauf()` über
+`check_and_send_alerts(...)`:
+
+- genau ein Alarm
+- der ausgelieferte Text nennt **beide** Uhrzeiten und das Richtungswort
+- Negativprobe: derselbe Lauf mit `metric_alert_levels["thunder_onset"]` abgeschaltet löst
+  **nicht** aus — das nagelt die Konfigurations-Weiche fest, die heute unbewacht ist
+
+### Bewusst nicht enthalten
+
+- Szenario 1 (B-1) → S2b
+- Änderungen an Produktivcode
+- Änderungen an `test_nowcast_briefing_overtake.py`, `test_onset_shift_alert.py`,
+  `nowcast_gate_fixtures.py`
+- Ein Szenario für Etappen < 1 h (Nebenbefund aus #2020 S2, `trip_segments.py:294-311` vs.
+  `:220-243`, Bug #856) — vermerkt für eine spätere Scheibe

--- a/docs/specs/modules/alarm_szenarien_waechter_2_3.md
+++ b/docs/specs/modules/alarm_szenarien_waechter_2_3.md
@@ -26,12 +26,20 @@ in S1 gebaute `AlarmPruefstrecke` — ohne Produktivcode zu ändern und ohne die
 
 ## Source
 
-- **File (neu):** `tests/tdd/test_alarm_pruefstrecke_radar_serie_mit_sperre.py` (Wächter 1,
-  Szenario 2), `tests/tdd/test_alarm_pruefstrecke_gewitter_vorverlegung.py` (Wächter 2,
+- **File (neu):** `tests/tdd/test_alarm_szenario_briefing_ueberholung_zeitreihe.py` (Wächter 1,
+  Szenario 2), `tests/tdd/test_alarm_szenario_gewitter_vorverlegung.py` (Wächter 2,
   Szenario 3)
 - **Identifier:** keine neuen Produktiv-Symbole — beide Dateien nutzen ausschließlich
   `AlarmPruefstrecke`/`AlarmPruefstreckeLauf` (`tests/helpers/alarm_pruefstrecke.py`) und
-  bestehende produktive Schreibwege (`WeatherSnapshotService.save_alarm_anchor`, `alert_log`).
+  bestehende produktive Schreibwege (`WeatherSnapshotService.save_dated`, `alert_log`).
+
+> **Korrektur beim Bau (2026-08-22):** Der Briefing-Anker wird über `save_dated()` gesetzt, nicht
+> über `save_alarm_anchor()`. Der Radar-Zweig liest den Briefing-Wert über
+> `WeatherSnapshotService(...).load_dated(trip.id, segment_date)` (`trip_alert.py:1362`);
+> `save_alarm_anchor()` schreibt eine andere Datei (`{trip_id}_alarm_anchor_{channel}.json`), die
+> nur `load_alarm_anchor` liest. Über den falschen Weg wäre AC-1 **still grün** geworden — ohne
+> Briefing greift `_briefing_announced` nicht, der Alarm feuert dann ohne jede Überholung und der
+> Wächter hätte nichts bewacht.
 
 > Schicht: Python-Core-Testinfrastruktur (`tests/tdd/`) — kein Produktivcode in `src/`/`api/`
 > wird geändert, kein Go-/Frontend-Anteil.
@@ -115,6 +123,14 @@ Default 12:00 UTC) — kein Test hängt von der Wanduhr ab.
   löst der Lauf genau einen Alarm aus und alle vier Kanäle tragen den gerenderten Inhalt.
   - Test: `AlarmPruefstrecke.lauf(zweig="radar", ...)` mit Briefing-Snapshot 1 mm und
     Radar-Frames für 11 mm; `triggered_count == 1`, alle vier Kanal-Listen nicht leer.
+  - Vorgeschalteter Sonden-Lauf (Fix-Loop 2026-08-22, Adversary-Finding F002): ein Lauf mit
+    ~0,5 mm überholt die Ankündigung NICHT, muss schweigen und protokolliert dabei den vom
+    Prüfling GELESENEN Briefing-Wert (`gate_reason` `briefing_announced:1.0mm`,
+    `trip_alert.py:1393`, gelesen über `alert_log.read_undelivered()`). Damit ist die
+    Ankündigung positiv nachgewiesen statt vorausgesetzt: bricht der Lesepfad
+    (`load_dated`, `trip_alert.py:1363`), greift die Unterdrückung nicht mehr, der Sonden-Lauf
+    löst aus und AC-1 wird rot — vorher blieb er in genau diesem Fall grün, weil ein Alarm
+    ohne jede Überholung von einem Alarm wegen Überholung nicht unterscheidbar war.
 
 - **AC-2:** Given der erste Prüflauf hat ausgelöst und dabei eine Sperrzeit gebucht, When ein
   zweiter Prüflauf mit unveränderter Lage (gleiches Briefing, gleicher Radar-Wert) kurz danach
@@ -127,7 +143,11 @@ Default 12:00 UTC) — kein Test hängt von der Wanduhr ab.
     `gate_reason == alert_log.REASON_COOLDOWN` ("cooldown") nachweisen — NICHT mit einem
     `"briefing_announced:"`-Präfix, der die andere Unterdrückungsursache anzeigen würde.
 
-- **AC-3:** Given die Sperrzeit aus dem ersten Prüflauf ist zum Zeitpunkt des dritten Prüflaufs
+- **AC-3:** ⚠️ **Gemessen rot am 2026-08-22 — ausgelagert nach Issue #2065, nicht Teil dieser
+  Lieferung.** Der Wächter wurde gebaut, ausgeführt und schlägt fehl; die Zusicherung ist heute
+  im Produktivcode nicht erfüllt (Details unter „Known Limitations"). Wortlaut zur
+  Nachvollziehbarkeit:
+  Given die Sperrzeit aus dem ersten Prüflauf ist zum Zeitpunkt des dritten Prüflaufs
   noch aktiv, When der dritte Prüflauf mit deutlich verschärfter Lage (höhere Regenmenge als in
   Lauf 1 und 2) fährt, Then löst dieser Lauf trotz der noch laufenden Sperre einen Alarm aus.
   - Test: dritter Lauf innerhalb desselben Sperrfensters mit verschärften Eingangsdaten fahren,
@@ -167,13 +187,38 @@ Default 12:00 UTC) — kein Test hängt von der Wanduhr ab.
   - Test: identischer Lauf zu AC-5 mit deaktiviertem `thunder_onset`-Level;
     `triggered_count == 0`.
 
+- **AC-8:** Given ein Trip, dessen Briefing nur 0,5 mm ankündigte, und eine Radarlage von
+  ~1,5 mm im Vergleichsfenster — die den Überholungs-FAKTOR damit deutlich überschreitet
+  (2 × 0,5 mm = 1,0 mm), aber unter der absoluten Relevanz-Untergrenze von 2,0 mm bleibt, When
+  ein einzelner Prüflauf über den Radar-Zweig fährt, Then bleibt der Lauf ohne Alarm, und das
+  Alarmprotokoll weist die Briefing-Ankündigung als Grund aus.
+  - Test: eigene `user_id`, Briefing-Snapshot 0,5 mm, Radar-Frames 9 mm/h über 10 Minuten;
+    `triggered_count == 0`, kein Kanalinhalt, `briefing_announced:0.5mm` im
+    Unterdrückungs-Protokoll. Die Faktor-Bedingung wird vor dem Lauf am echten
+    `get_nowcast()`-Ergebnis gegen `trip_alert._BRIEFING_OVERTAKE_FACTOR` (Modul-Referenz)
+    als ERFÜLLT nachgewiesen — sonst prüfte der Fall wieder nur den Faktor.
+  - Warum zusätzlich zu AC-4 (Fix-Loop 2026-08-22, Adversary-Finding F001): die
+    Überholungsprüfung ist eine UND-Verknüpfung aus Faktor-Schwelle und absoluter Untergrenze
+    (`trip_alert.py:1381-1385`). AC-4s ~1,83 mm scheitern bereits am Faktor (2 × 1,0 mm), die
+    absolute Untergrenze wird dort nie zur wirksamen Bedingung — ihr Wegfall
+    (`_OVERTAKE_MIN_ABSOLUTE_MM = 0.0`) blieb von allen sechs Wächtern unbemerkt.
+
 ## Known Limitations
 
-- AC-3 kann nach heutigem Code-Stand strukturell nicht grün sein (`check_nowcast_gate` prüft die
-  Sperrzeit unbedingt VOR jeder Eskalations-/Überholungsbewertung, `trip_alert.py:1239-1273`,
-  ohne Ausnahme für verschärfte Lagen). Zeigt sich das beim Schreiben des Tests, wird das als
-  Befund gemeldet (eigene Scheibe) statt hier Produktivcode zu ändern — passend zur harten
-  Randbedingung dieser Scheibe.
+- **AC-3 ist gemessen rot und nach Issue #2065 ausgelagert (2026-08-22).** Der Wächter wurde
+  gebaut und ausgeführt; er scheitert mit dem protokollierten Unterdrückungsgrund `cooldown`
+  (`alert_log.REASON_COOLDOWN`), nicht mit `briefing_announced:`. Damit ist am Wirkort belegt,
+  was die Analyse vermutet hatte: `check_nowcast_gate` prüft die Sperrzeit unbedingt VOR jeder
+  Eskalations-/Überholungsbewertung (`trip_alert.py:1239-1273` vs. `:1381`) und nimmt keinen
+  Parameter entgegen, über den es von einer Verschärfung erfahren könnte
+  (`alert_gate.py:140-184`). **Anforderung A-3 aus #2050 ist damit verletzt** — ein
+  Produktivfehler, kein Testproblem. Der Testcode liegt unverändert in #2065; diese Scheibe
+  liefert ihn nicht mit, weil sie keinen Produktivcode ändert und ein roter Kerntest nicht
+  mergefähig ist. Die Nummerierung der übrigen ACs bleibt unverändert, damit die Lücke sichtbar
+  bleibt statt zu verschwinden.
+- Abgrenzung dazu: #2020 Scheibe 1 hat die **Briefing-Ankündigungs-Sperre** bei
+  Mengen-Überholung gebrochen, **nicht** den Cooldown nach einem eigenen Alarm. Wer #2020 S1 als
+  „A-3 ist erledigt" liest, liegt falsch.
 - `alert_state.reset()` verwirft `event_identity:`-Schlüssel still (`alert_state.py:38-45`,
   bereits in der S1-Spec vermerkt) — betrifft diese Scheibe nicht direkt, da keiner der beiden
   Wächter über eine Briefing-Grenze hinweg vorbelegten Zustand voraussetzt.
@@ -203,3 +248,13 @@ Default 12:00 UTC) — kein Test hängt von der Wanduhr ab.
 
 - 2026-08-22: Initial spec created (Scheibe S2a aus #2050, verdichtet aus
   `docs/context/feat-2050-s2a-waechter-szenarien-2-3.md`).
+- 2026-08-22: Nach dem Bau — AC-3 gemessen rot, nach #2065 ausgelagert (Anforderung A-3 im
+  Produktivcode verletzt). Dateinamen an die Umsetzung angeglichen. Briefing-Anker über
+  `save_dated()` statt `save_alarm_anchor()` korrigiert; der ursprüngliche Weg hätte AC-1 still
+  grün werden lassen. Lieferumfang damit 6 Wächter.
+- 2026-08-22 (Fix-Loop nach Adversary-Verdict BROKEN): AC-8 ergänzt (absolute Untergrenze der
+  Überholung unabhängig vom Faktor bewacht, F001) und AC-1 um den Sonden-Lauf erweitert
+  (Briefing-Ankündigung positiv nachgewiesen statt vorausgesetzt, F002). Beide Mutationen sind
+  jetzt gemessen rot — Nachweis in
+  `docs/artifacts/feat-2050-s2a-waechter-szenarien-2-3/mutations-nachweis-fixloop.txt`.
+  Lieferumfang damit 7 Wächter, weiterhin ohne jede Produktivcode-Änderung.

--- a/docs/specs/modules/alarm_szenarien_waechter_2_3.md
+++ b/docs/specs/modules/alarm_szenarien_waechter_2_3.md
@@ -1,0 +1,205 @@
+---
+entity_id: alarm_szenarien_waechter_2_3
+type: feature
+created: 2026-08-22
+updated: 2026-08-22
+status: approved
+workflow: feat-2050-s2a-waechter-szenarien-2-3
+version: "1.0"
+tags: [alarm, testing, harness]
+---
+
+# Alarm-Szenarien 2 und 3 als Wächter auf der Prüfstrecke (Scheibe S2a, Issue #2050)
+
+## Approval
+
+- [x] Approved — PO ("Approved"), 2026-08-22
+
+## Purpose
+
+Zwei der zwölf Alarm-Szenarien aus Issue #2050 haben heute Testabdeckung, aber auf einer Ebene,
+die die eigentliche Zusicherung nicht erreicht (Szenario 2: keiner der 17 Tests fährt eine
+Zeitreihe mit Gedächtnis; Szenario 3: keiner der 10 Tests läuft über die echte
+Auslöseentscheidung). Diese Scheibe stellt genau diese Lücke als zwei dauerhafte Wächter auf die
+in S1 gebaute `AlarmPruefstrecke` — ohne Produktivcode zu ändern und ohne die bestehenden
+17+10 Tests anzufassen.
+
+## Source
+
+- **File (neu):** `tests/tdd/test_alarm_pruefstrecke_radar_serie_mit_sperre.py` (Wächter 1,
+  Szenario 2), `tests/tdd/test_alarm_pruefstrecke_gewitter_vorverlegung.py` (Wächter 2,
+  Szenario 3)
+- **Identifier:** keine neuen Produktiv-Symbole — beide Dateien nutzen ausschließlich
+  `AlarmPruefstrecke`/`AlarmPruefstreckeLauf` (`tests/helpers/alarm_pruefstrecke.py`) und
+  bestehende produktive Schreibwege (`WeatherSnapshotService.save_alarm_anchor`, `alert_log`).
+
+> Schicht: Python-Core-Testinfrastruktur (`tests/tdd/`) — kein Produktivcode in `src/`/`api/`
+> wird geändert, kein Go-/Frontend-Anteil.
+
+## Estimated Scope
+
+- **LoC:** ~250-320 (zwei Testdateien, je ~110-180 Zeilen: Wächter 1 braucht Trip- und
+  Snapshot-Aufbau plus vier `lauf()`-Aufrufe mit Log-Auswertung, Wächter 2 braucht
+  Wetter-Fixtures mit `thunder_onset_utc` plus zwei `lauf()`-Aufrufe). Kann das
+  250-LoC-Standardlimit reißen — ggf. `loc_limit_override` wie in S1 (dort 500) nötig.
+- **Files:** 2 neue Testdateien
+- **Effort:** medium
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `tests/helpers/alarm_pruefstrecke.py::AlarmPruefstrecke.lauf` | function | Der Harness selbst — beide Wächter rufen ausschließlich `.lauf(...)`, kein eigener Aufbau der Auslöseentscheidung |
+| `tests/helpers/alarm_pruefstrecke.py::AlarmPruefstreckeLauf` | dataclass | Ergebnisobjekt (`triggered_count`, `mail`, `telegram`, `sms`, `premium_sms`) |
+| `src/services/trip_alert.py::TripAlertService.check_radar_alerts` (`:1140-1623`) | method | Einstiegspunkt für Wächter 1 (`zweig="radar"`) — Überholungsprüfung `:1370-1402`, Cooldown-Gate `:1239-1273`, Buchung nach Zustellung `:1607-1612` |
+| `src/services/trip_alert.py::TripAlertService.check_and_send_alerts` (`:216-456`) | method | Einstiegspunkt für Wächter 2 (`zweig="deviation"`) |
+| `src/services/deviation_alert_engine.py::DeviationAlertEngine._select_detector` (`:175-204`) | method | Die Konfigurations-Weiche, die Wächter 2 gezielt prüft — wertet `thunder_onset` nur bei aktivem `metric_alert_levels`-Eintrag aus |
+| `src/services/alert_gate.py::check_nowcast_gate` (`:140-184`) | function | Liefert bei aktiver Sperrzeit `GateResult(False, REASON_COOLDOWN)` — die Sperre, die Lauf 2 in Wächter 1 zum Schweigen bringt |
+| `src/services/alert_log.py::append_suppressed_entry`/`read_undelivered` | function | Schreib-/Leseweg des Unterdrückungsprotokolls, über das Lauf 2 seinen Unterdrückungsgrund nachweist |
+| `tests/helpers/nowcast_gate_fixtures.py::make_trip`/`frozen_active_window` | function | **Nur lesen/importieren**, nicht ändern (belegt durch Session #2036). Liefert Trip-Fixture und gestellte Uhr im garantiert aktiven Fenster |
+| `tests/tdd/test_nowcast_briefing_overtake.py` (nicht geändert) | reference | Fixture-Muster für Snapshot-Aufbau (`_write_snapshot`) und Frame-Quellen für Radar-Überholung — als Vorbild lesen, nicht importieren (eigener `uid` je Wächter) |
+| `tests/tdd/test_onset_shift_alert.py` (nicht geändert) | reference | Fixture-Muster für `thunder_onset_utc`-Wetterdaten und Textprüfung (Richtungswort, beide Uhrzeiten) — als Vorbild lesen, nicht importieren |
+
+## Implementation Details
+
+**Wächter 1 (`zweig="radar"`), eine `AlarmPruefstrecke` auf einer `user_id`, vier Läufe:**
+
+1. Lauf 1: Briefing-Snapshot kündigt 1 mm an, Radar-Frames liefern 11 mm (Überholungsfaktor
+   erfüllt, `trip_alert.py:1380-1384`) → Alarm.
+2. Lauf 2: kurz danach, unveränderte Eingangsdaten (gleicher Snapshot, gleiche 11 mm) → schweigt.
+   Da die Überholungsbedingung selbst unverändert erfüllt wäre, kann die Stille nur von der durch
+   Lauf 1 gebuchten Sperre kommen (`record_nowcast_sent` → `ThrottleStore`, `trip_alert.py:1607`).
+   Nachgewiesen über `alert_log.read_undelivered()`: der Eintrag trägt
+   `reason == alert_log.REASON_NOWCAST` und `gate_reason == alert_log.REASON_COOLDOWN`
+   ("cooldown") — unterscheidbar vom Unterdrückungsgrund einer unveränderten Lage, der als
+   `"briefing_announced:<mm>mm"` protokolliert würde (`trip_alert.py:1390-1395`, Vorbild
+   `test_ac6_remaining_suppression_creates_alert_log_entry`,
+   `test_nowcast_briefing_overtake.py:799`).
+3. Lauf 3: deutlich verschärfte Lage (höherer Regenwert), Uhr liegt weiterhin innerhalb des
+   Sperrfensters aus Lauf 1 → kommt durch (Anforderung A-3).
+4. Gegenprobe (vierter Lauf, **eigene** `user_id`, kein Bezug zu 1-3): kurze Spitze mit gleicher
+   Spitzenrate wie eine auslösende Lage, aber zu geringer Gesamtmenge → `triggered_count == 0`.
+
+Uhrzeiten aller Läufe liegen im garantiert aktiven Fenster (Vorbild `frozen_active_window()`,
+Default 12:00 UTC) — kein Test hängt von der Wanduhr ab.
+
+**Wächter 2 (`zweig="deviation"`), eine `AlarmPruefstrecke` auf eigener `user_id`, zwei Läufe:**
+
+1. Trip mit `trip.display_config.metric_alert_levels["thunder_onset"]` auf einen Level ≠ "off"
+   gesetzt. `cached_weather` trägt `thunder_onset_utc` = 17:00, `fresh_weather` = 15:00. Ein Lauf
+   über `check_and_send_alerts(...)` → genau ein Alarm; der gerenderte Text (mind. ein Kanal)
+   nennt beide Uhrzeiten (17 und 15 Uhr) und ein Richtungswort für die Vorverlegung (#1468-Bestand,
+   geprüft am `→`-Symbol bzw. dem etablierten Richtungswort — **keine** Prüfung auf Formulierungen
+   aus #2020 S2, s. Nicht-Ziele).
+2. Negativprobe: derselbe Aufbau, aber `metric_alert_levels["thunder_onset"]` auf "off" (oder
+   entfernt) → `triggered_count == 0`. Das nagelt `DeviationAlertEngine._select_detector`
+   (`deviation_alert_engine.py:175-204`) fest, die heute kein Test erreicht (belegter Null-Treffer
+   beim Grep über alle 41 Aufrufer von `check_and_send_alerts`, gefiltert auf `thunder_onset`).
+
+## Expected Behavior
+
+- **Input:** je Wächter ein `Trip`-Fixture (Vorbild `make_trip()`), zweigspezifische
+  Eingangsdaten (Radar-Frames bzw. `cached_weather`/`fresh_weather`), gestellte Uhrzeiten im
+  aktiven Fenster.
+- **Output:** `AlarmPruefstreckeLauf` je Lauf (`triggered_count`, vier Kanal-Inhalte); bei
+  Wächter 1 zusätzlich ein über `alert_log.read_undelivered()` gelesener Protokolleintrag mit
+  benanntem Unterdrückungsgrund für Lauf 2.
+- **Side effects:** reale Schreibvorgänge in die Zustandsspeicher unter dem pro-Test isolierten
+  `get_data_dir(user_id)` (Cooldown, Alarm-Protokoll, Wetter-Snapshot) — kein echter
+  Mail-/SMS-/Telegram-Versand.
+
+## Acceptance Criteria
+
+- **AC-1:** Given ein Trip, dessen Briefing 1 mm Regen ankündigte, während der Radar-Nowcast
+  11 mm für dasselbe Fenster zeigt, When der erste Prüflauf über den Radar-Zweig fährt, Then
+  löst der Lauf genau einen Alarm aus und alle vier Kanäle tragen den gerenderten Inhalt.
+  - Test: `AlarmPruefstrecke.lauf(zweig="radar", ...)` mit Briefing-Snapshot 1 mm und
+    Radar-Frames für 11 mm; `triggered_count == 1`, alle vier Kanal-Listen nicht leer.
+
+- **AC-2:** Given der erste Prüflauf hat ausgelöst und dabei eine Sperrzeit gebucht, When ein
+  zweiter Prüflauf mit unveränderter Lage (gleiches Briefing, gleicher Radar-Wert) kurz danach
+  auf demselben Trip fährt, Then schweigt der zweite Lauf nachweislich WEGEN der gebuchten Sperre
+  — nicht weil sich an der Wetterlage nichts geändert hätte: das Alarmprotokoll trägt für diesen
+  Lauf einen Unterdrückungs-Eintrag mit dem Sperrzeit-Grund, unterscheidbar von dem Grund, den
+  eine echte "Lage unverändert"-Unterdrückung protokollieren würde.
+  - Test: Lauf 2 identisch zu Lauf 1 fahren, `triggered_count == 0`; über
+    `alert_log.read_undelivered()` einen `REASON_NOWCAST`-Eintrag mit
+    `gate_reason == alert_log.REASON_COOLDOWN` ("cooldown") nachweisen — NICHT mit einem
+    `"briefing_announced:"`-Präfix, der die andere Unterdrückungsursache anzeigen würde.
+
+- **AC-3:** Given die Sperrzeit aus dem ersten Prüflauf ist zum Zeitpunkt des dritten Prüflaufs
+  noch aktiv, When der dritte Prüflauf mit deutlich verschärfter Lage (höhere Regenmenge als in
+  Lauf 1 und 2) fährt, Then löst dieser Lauf trotz der noch laufenden Sperre einen Alarm aus.
+  - Test: dritter Lauf innerhalb desselben Sperrfensters mit verschärften Eingangsdaten fahren,
+    `triggered_count >= 1` nachweisen. Bricht dieser Test strukturell (Sperrzeit-Gate liegt in
+    `check_radar_alerts()` VOR der Überholungsprüfung und kennt keine Eskalations-Ausnahme,
+    `trip_alert.py:1239-1273` vs. `:1380-1384`), ist das ein Befund für eine eigene Scheibe, nicht
+    Anlass für Produktivcode in dieser Scheibe (s. Nicht-Ziele).
+
+- **AC-4:** Given eine kurze Regenspitze mit derselben Spitzenrate wie eine auslösende Lage, aber
+  einer Gesamtmenge unterhalb der Überholungs-Untergrenze, auf einem eigenen, von den ersten drei
+  Läufen unabhängigen Trip, When ein einzelner Prüflauf über den Radar-Zweig fährt, Then bleibt
+  der Lauf ohne Alarm.
+  - Test: eigene `user_id`, ein `AlarmPruefstrecke.lauf(zweig="radar", ...)` mit Spitzenrate
+    gleich einem Auslöse-Fall, aber zu geringer Gesamtmenge; `triggered_count == 0`.
+
+- **AC-5:** Given ein Trip, bei dem der Alarmtyp "Gewitterbeginn" aktiv geschaltet ist und dessen
+  zwischengespeicherte Wetterlage einen Gewitterbeginn um 17 Uhr zeigte, während die aktuelle
+  Wetterlage denselben Gewitterbeginn auf 15 Uhr vorverlegt, When ein Prüflauf über den
+  Änderungs-Zweig (die echte Auslöseentscheidung, nicht die Erkennungslogik allein) fährt, Then
+  löst der Lauf genau einen Alarm aus.
+  - Test: `AlarmPruefstrecke.lauf(zweig="deviation", cached_weather=..., fresh_weather=...)` mit
+    `thunder_onset_utc` 17:00 → 15:00 und aktivem `metric_alert_levels["thunder_onset"]`;
+    `triggered_count == 1`.
+
+- **AC-6:** Given derselbe Vorverlegungs-Alarm aus AC-5, When der ausgelieferte Alarmtext gelesen
+  wird, Then nennt der Text beide Uhrzeiten (17 Uhr und 15 Uhr) und macht durch ein Richtungswort
+  bzw. das etablierte Pfeil-Symbol erkennbar, dass sich der Beginn nach VORNE verschoben hat.
+  - Test: Text mindestens eines Kanals (z. B. `mail` oder `telegram`) aus AC-5s Lauf auf beide
+    Uhrzeiten und Richtungsangabe prüfen — keine Prüfung auf Formulierungen, die #2020 Scheibe 2
+    gerade ändert (s. Nicht-Ziele).
+
+- **AC-7:** Given derselbe Trip und dieselbe Wetteränderung wie in AC-5, aber mit
+  `metric_alert_levels["thunder_onset"]` abgeschaltet (Level "off" bzw. Eintrag entfernt), When
+  derselbe Prüflauf über den Änderungs-Zweig fährt, Then löst der Lauf KEINEN Alarm aus — die
+  Konfigurations-Weiche verhindert die Auswertung des Alarmtyps, obwohl die Wetterdaten
+  unverändert einen Gewitterbeginn-Sprung zeigen.
+  - Test: identischer Lauf zu AC-5 mit deaktiviertem `thunder_onset`-Level;
+    `triggered_count == 0`.
+
+## Known Limitations
+
+- AC-3 kann nach heutigem Code-Stand strukturell nicht grün sein (`check_nowcast_gate` prüft die
+  Sperrzeit unbedingt VOR jeder Eskalations-/Überholungsbewertung, `trip_alert.py:1239-1273`,
+  ohne Ausnahme für verschärfte Lagen). Zeigt sich das beim Schreiben des Tests, wird das als
+  Befund gemeldet (eigene Scheibe) statt hier Produktivcode zu ändern — passend zur harten
+  Randbedingung dieser Scheibe.
+- `alert_state.reset()` verwirft `event_identity:`-Schlüssel still (`alert_state.py:38-45`,
+  bereits in der S1-Spec vermerkt) — betrifft diese Scheibe nicht direkt, da keiner der beiden
+  Wächter über eine Briefing-Grenze hinweg vorbelegten Zustand voraussetzt.
+
+## Nicht Ziel
+
+- Szenario 1 (B-1, "Regen läuft schon") — braucht Produktivcode und kollidiert mit #2020
+  Scheibe 2, wird als eigene Scheibe **S2b** nachgezogen.
+- Jede Änderung an Produktivcode (`src/`, `api/`).
+- Änderungen an `tests/tdd/test_nowcast_briefing_overtake.py`,
+  `tests/tdd/test_onset_shift_alert.py`, `tests/helpers/nowcast_gate_fixtures.py` (letztere durch
+  Session #2036 belegt — lesen/importieren erlaubt, ändern nicht).
+- Textprüfende Zusicherungen auf Formulierungen, die #2020 Scheibe 2 gerade ändert: Langform
+  `Bis jetzt:`/`Ab jetzt:`, Kurzform-Token `Rest{mm}@{HH}`, Bedeutungswörter bei Zeitangaben.
+- Ein Szenario für Etappen < 1 h (Nebenbefund aus #2020 S2, `trip_segments.py:294-311` vs.
+  `:220-243`, Bug #856) — für eine spätere Scheibe vermerkt, nicht hier behandelt.
+- Die verbleibenden zehn der zwölf Alarm-Szenarien aus #2050 (spätere Scheiben).
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Reine Test-Infrastruktur ohne Produktivcode-Änderung, keine neue Route, kein
+  neues Datenmodell, keine Rücknahme einer bestehenden Architekturentscheidung. Kein
+  ADR-würdiger Grundsatzentscheid.
+
+## Changelog
+
+- 2026-08-22: Initial spec created (Scheibe S2a aus #2050, verdichtet aus
+  `docs/context/feat-2050-s2a-waechter-szenarien-2-3.md`).

--- a/tests/tdd/test_alarm_szenario_briefing_ueberholung_zeitreihe.py
+++ b/tests/tdd/test_alarm_szenario_briefing_ueberholung_zeitreihe.py
@@ -1,0 +1,392 @@
+"""Issue #2050 Scheibe S2a — Waechter 1: Szenario 2 als Zeitreihe MIT Gedaechtnis.
+
+SPEC: docs/specs/modules/alarm_szenarien_waechter_2_3.md (AC-1, AC-2, AC-4 —
+AC-3 ist nach Issue #2065 ausgelagert, s. Kommentarblock in der Dateimitte)
+
+Was die 17 bestehenden Tests in `test_nowcast_briefing_overtake.py` NICHT
+pruefen: jeder von ihnen ist ein EINZELAUFRUF auf einem leeren Datentraeger,
+der Sperrzeit-Mechanismus (`ThrottleStore`) kommt dort strukturell nie zum
+Tragen. Diese Datei faehrt dieselbe Ueberholungs-Lage als FOLGE mehrerer
+Prueflaeufe auf EINER `user_id` ueber die `AlarmPruefstrecke` — die
+Kontinuitaet kommt vom Datentraeger unter `get_data_dir(user_id)`, genau wie
+bei jedem Cron-Tick in Produktion.
+
+Kein Mock()/patch()/MagicMock: echter `RadarNowcastService` an seiner DI-Naht
+`frame_source=`, Briefing-Anker ueber den produktiven Schreibweg
+`WeatherSnapshotService.save_dated()` (genau die Datei, die
+`check_radar_alerts()` per `load_dated()` liest), Unterdrueckungsgrund ueber
+`alert_log.read_undelivered()` — kein Dateiinhalt-Check.
+
+Keine Wanduhr: alle Zeitpunkte haengen an `_AT` (gestellte Uhr).
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from freezegun import freeze_time
+
+from app.models import (
+    ForecastDataPoint, ForecastMeta, NormalizedTimeseries, Provider,
+    SegmentWeatherData, SegmentWeatherSummary,
+)
+from services import alert_log
+from services.radar_cache import reset_shared_radar_cache_for_tests
+from services.radar_service import RadarNowcastService
+from services.weather_snapshot import WeatherSnapshotService
+
+from tests.helpers.alarm_pruefstrecke import AlarmPruefstrecke
+from tests.tdd.test_952_onset_alert_fidelity import _clean_user
+from tests.tdd.test_alarm_pruefstrecke_selbstschutz import (
+    _AT, _radar_trip, _settings_all_channels, _write_premium_profile,
+)
+
+# Ankuendigung des Briefings fuer JEDE Stunde des Snapshot-Tages: der Onset
+# faellt aus dem Radar-Ergebnis, nicht aus dem Test — ein stundenweise
+# gesetzter Wert waere ein zweiter, stiller Freiheitsgrad.
+BRIEFING_MM = 1.0
+
+# Kleinste Menge, die noch als Ankuendigung zaehlt (`_briefing_announced`
+# verlangt >= 0.5 mm, `trip_alert.py:1365`). Damit liegt die FAKTOR-Schwelle
+# bei nur 1,0 mm — die absolute Untergrenze wird zur allein wirksamen
+# Bedingung (AC-8).
+BRIEFING_KLEIN_MM = 0.5
+
+
+def _uid(tag: str) -> str:
+    return f"tdd-2050-s2a-w1-{tag}-{uuid.uuid4().hex[:6]}"
+
+
+def _gelesene_briefing_werte(uid: str, trip, seit: datetime) -> list:
+    """Die Briefing-Mengen, die der PRUEFLING selbst gelesen hat — aus seinem
+    Unterdrueckungs-Protokoll zurueckgelesen (`gate_reason`
+    `briefing_announced:<mm>mm`, `trip_alert.py:1393`).
+
+    Bewusst NICHT ueber einen eigenen `load_dated()`-Aufruf im Testcode: der
+    liefe an dem Lesepfad vorbei, den `check_radar_alerts()` benutzt, und
+    bliebe gruen, wenn genau dieser Pfad bricht. Der Protokoll-Eintrag traegt
+    den Wert, den die Ueberholungspruefung TATSAECHLICH in der Hand hatte —
+    an dem Ort gemessen, an dem die Zusicherung wirkt."""
+    vorfaelle = alert_log.read_undelivered(
+        uid, entity_id=trip.id, entity_type="trip", since=seit,
+    )
+    werte = []
+    for vorfall in vorfaelle:
+        for grund in vorfall.reasons:
+            text = str(grund)
+            if text.startswith("briefing_announced:") and text.endswith("mm"):
+                werte.append(float(text[len("briefing_announced:"):-2]))
+    return werte
+
+
+def _dauerregen(rate_mm_h: float):
+    """Vier Frames im 15-Min-Raster: jeder steht fuer hoechstens 15 Min
+    (`_MAX_FRAME_COVERAGE`), der letzte wird am Fensterende (60 Min) gekappt
+    -> akkumuliert `rate * 55/60` mm im 60-Min-Vergleichsfenster."""
+    def _quelle(lat: float, lon: float) -> list:
+        from providers.brightsky import RadarFrame
+        jetzt = datetime.now(timezone.utc)
+        return [
+            RadarFrame(timestamp=jetzt + timedelta(minutes=m), precip_mm_h=rate_mm_h)
+            for m in (5, 20, 35, 50)
+        ]
+    return _quelle
+
+
+def _kurze_spitze(rate_mm_h: float):
+    """Nur 10 Minuten Regen, danach trocken -> `rate * 10/60` mm im
+    60-Min-Vergleichsfenster. 11 mm/h ~ 1,83 mm (AC-4, unter BEIDEN
+    Ueberholungs-Bedingungen), 9 mm/h ~ 1,5 mm (AC-8, ueber der Faktor-,
+    unter der absoluten Bedingung), 3 mm/h ~ 0,5 mm (AC-1-Sonde)."""
+    def _quelle(lat: float, lon: float) -> list:
+        from providers.brightsky import RadarFrame
+        jetzt = datetime.now(timezone.utc)
+        return [
+            RadarFrame(timestamp=jetzt + timedelta(minutes=5), precip_mm_h=rate_mm_h),
+            RadarFrame(timestamp=jetzt + timedelta(minutes=15), precip_mm_h=0.0),
+        ]
+    return _quelle
+
+
+def _radar(rate_quelle) -> RadarNowcastService:
+    """Frische Instanz je Lauf — den geteilten Frame-Cache setzt die
+    Pruefstrecke selbst zurueck (`reset_shared_radar_cache_for_tests`)."""
+    return RadarNowcastService(frame_source=rate_quelle)
+
+
+def _briefing_anker(uid: str, trip, mm: float) -> None:
+    """Datierter Briefing-Schnappschuss ueber `save_dated()` — genau die
+    Datei, die `check_radar_alerts()` per `load_dated(trip.id, segment_date)`
+    liest. Segment und Segment-Datum kommen aus DEMSELBEN produktiven
+    Aufloeser (`resolve_current_segment`) wie beim Pruefling; ein von Hand
+    getippter `segment_id` waere nur zufaellig richtig."""
+    from services.trip_day import trip_local_today
+    from services.trip_segments import resolve_current_segment
+
+    with freeze_time(_AT):
+        jetzt = datetime.now(timezone.utc)
+        aufgeloest = resolve_current_segment(trip, jetzt, trip_local_today(trip, jetzt))
+        assert aufgeloest is not None, (
+            "Vorbedingung: der Trip muss zur gestellten Uhr ein aktives Segment "
+            "haben — sonst bricht check_radar_alerts() vor dem Nowcast-Abruf ab."
+        )
+        segment, segment_datum = aufgeloest
+        tagesbeginn = jetzt.replace(hour=0, minute=0, second=0, microsecond=0)
+        reihe = NormalizedTimeseries(
+            meta=ForecastMeta(provider=Provider.OPENMETEO, model="test",
+                              grid_res_km=1.0),
+            data=[ForecastDataPoint(ts=tagesbeginn + timedelta(hours=h),
+                                    precip_1h_mm=mm) for h in range(48)],
+        )
+        WeatherSnapshotService(uid).save_dated(trip.id, segment_datum, [
+            SegmentWeatherData(
+                segment=segment, timeseries=reihe,
+                aggregated=SegmentWeatherSummary(),
+                fetched_at=jetzt, provider="openmeteo",
+            )])
+
+
+def _aufbau(uid: str, tag: str, briefing_mm: float = BRIEFING_MM):
+    """Nutzer (Premium-Profil fuer den vierten Kanal), Trip mit allen vier
+    Kanaelen, Briefing-Anker mit `briefing_mm`."""
+    _clean_user(uid)
+    _write_premium_profile(uid, _AT)
+    # Auch das SPEICHERN laeuft unter der gestellten Uhr: `app.loader.save_trip()`
+    # rechnet Ankunftszeiten beim Schreiben neu (Compute-on-Save, #802). Ohne
+    # den Rahmen haenge der gespeicherte Stand an der Wanduhr des Testlaufs.
+    with freeze_time(_AT):
+        trip = _radar_trip(
+            uid, f"trip-2050-s2a-{tag}", send_email=True, send_telegram=True,
+            send_sms=True, send_premium_sms=True,
+        )
+        _briefing_anker(uid, trip, briefing_mm)
+    return trip
+
+
+def test_ac1_briefing_kuendigte_1mm_an_radar_zeigt_11mm_loest_aus():
+    """AC-1: Briefing 1 mm, Radar ~10 mm im 60-Min-Vergleichsfenster
+    (11 mm/h ueber 55 Min) -> genau ein Alarm, alle vier Kanaele tragen den
+    gerenderten Inhalt.
+
+    Vorgeschaltet ein SONDEN-Lauf, der die Ankuendigung positiv nachweist:
+    ohne ihn kann der Waechter "Alarm, weil die Ueberholung griff" nicht von
+    "Alarm, weil gar kein Briefing gefunden wurde" unterscheiden — bricht der
+    Lesepfad (`load_dated`, `trip_alert.py:1363`), greift die Unterdrueckung
+    nie und der Alarm faellt trivial an."""
+    uid = _uid("ac1")
+    try:
+        trip = _aufbau(uid, "ac1")
+        strecke = AlarmPruefstrecke(user_id=uid, settings=_settings_all_channels())
+
+        # Sonde: ~0,5 mm (3 mm/h ueber 10 Min) ueberholt die Ankuendigung
+        # NICHT -> der Prueflauf muss schweigen UND protokollieren, welchen
+        # Briefing-Wert er dabei gelesen hat. Bucht keine Sperrzeit (die
+        # entsteht erst nach Zustellung, `trip_alert.py:1607`), der
+        # Ausloese-Lauf darunter bleibt also unbeeinflusst.
+        sonde = strecke.lauf(
+            at=_AT, zweig="radar", trip=trip, radar_service=_radar(_kurze_spitze(3.0)),
+        )
+        assert sonde.triggered_count == 0, (
+            f"AC-1 Sonde: ~0,5 mm gegen eine Ankuendigung von {BRIEFING_MM} mm "
+            f"duerfen NICHT ausloesen. Loest es doch aus, wurde die Ankuendigung "
+            f"nicht gelesen — dann bewacht der Ausloese-Lauf unten nichts "
+            f"(triggered_count={sonde.triggered_count})."
+        )
+        assert _gelesene_briefing_werte(uid, trip, _AT) == [BRIEFING_MM], (
+            f"AC-1 Sonde: der Prueflauf muss GENAU die angekuendigten "
+            f"{BRIEFING_MM} mm gelesen haben. Protokolliert wurde "
+            f"{_gelesene_briefing_werte(uid, trip, _AT)!r}."
+        )
+
+        lauf = strecke.lauf(
+            at=_AT, zweig="radar", trip=trip, radar_service=_radar(_dauerregen(11.0)),
+        )
+        assert lauf.triggered_count == 1, (
+            f"AC-1: Briefing kuendigte {BRIEFING_MM} mm an, der Radar zeigt ~10 mm "
+            f"fuer dasselbe Fenster — die Ueberholung MUSS ausloesen. "
+            f"War triggered_count={lauf.triggered_count}."
+        )
+        assert lauf.mail and lauf.telegram and lauf.sms and lauf.premium_sms, (
+            f"AC-1: alle vier Kanaele muessen Inhalt tragen: mail={lauf.mail!r} "
+            f"telegram={lauf.telegram!r} sms={lauf.sms!r} "
+            f"premium_sms={lauf.premium_sms!r}"
+        )
+    finally:
+        _clean_user(uid)
+
+
+def test_ac2_zweiter_lauf_schweigt_nachweislich_wegen_der_gebuchten_sperrzeit():
+    """AC-2: Lauf 2 faehrt dieselbe (unveraenderte) Ueberholungs-Lage 30 Min
+    spaeter, schweigt — und das Alarmprotokoll benennt die SPERRZEIT als
+    Grund, nicht die Briefing-Ankuendigung. Ohne diesen Nachweis waere der
+    Test trivial gruen: "schweigt wegen Sperre" und "schweigt, weil die Lage
+    die Ankuendigung nicht ueberholt" sehen am `triggered_count == 0`
+    identisch aus."""
+    uid = _uid("ac2")
+    try:
+        trip = _aufbau(uid, "ac2")
+        strecke = AlarmPruefstrecke(user_id=uid, settings=_settings_all_channels())
+        lauf1 = strecke.lauf(
+            at=_AT, zweig="radar", trip=trip, radar_service=_radar(_dauerregen(11.0)),
+        )
+        assert lauf1.triggered_count == 1, (
+            "AC-2 Vorbedingung: Lauf 1 muss ausloesen und dabei die Sperrzeit "
+            f"buchen (war {lauf1.triggered_count})."
+        )
+
+        at2 = _AT + timedelta(minutes=30)
+        lauf2 = strecke.lauf(
+            at=at2, zweig="radar", trip=trip, radar_service=_radar(_dauerregen(11.0)),
+        )
+        assert lauf2.triggered_count == 0, (
+            f"AC-2: Lauf 2 muss durch die von Lauf 1 gebuchte Sperrzeit "
+            f"unterdrueckt sein (war {lauf2.triggered_count})."
+        )
+
+        vorfaelle = alert_log.read_undelivered(
+            uid, entity_id=trip.id, entity_type="trip", since=at2,
+        )
+        nowcast = [v for v in vorfaelle if v.trigger == alert_log.REASON_NOWCAST]
+        assert nowcast, (
+            f"AC-2: erwarte einen Unterdrueckungs-Eintrag mit "
+            f"reason={alert_log.REASON_NOWCAST!r} fuer Lauf 2. "
+            f"Gefunden: {vorfaelle!r}"
+        )
+        gruende = {g for v in nowcast for g in v.reasons}
+        assert alert_log.REASON_COOLDOWN in gruende, (
+            f"AC-2: der Unterdrueckungsgrund muss die SPERRZEIT "
+            f"({alert_log.REASON_COOLDOWN!r}) sein. Gefunden: {gruende!r}"
+        )
+        assert not any(str(g).startswith("briefing_announced:") for g in gruende), (
+            f"AC-2: Lauf 2 darf NICHT an der Briefing-Ankuendigung scheitern — "
+            f"dann waere die Zusicherung 'schweigt wegen der Sperre' nicht "
+            f"belegt. Gefunden: {gruende!r}"
+        )
+    finally:
+        _clean_user(uid)
+
+
+# ---------------------------------------------------------------------------
+# LUECKE — hier fehlt AC-3 (Anforderung A-3), und zwar mit Absicht.
+#
+# Szenario 2 aus Issue #2050 verlangt nicht nur "die Ueberholung loest aus"
+# (AC-1) und "die gebuchte Sperre schweigt korrekt" (AC-2), sondern AUCH:
+# eine deutliche VERSCHAERFUNG der Lage muss eine noch laufende Sperrzeit
+# ueberholen. Dieser Teil ist auf genau dieser Strecke am 2026-08-22
+# GEMESSEN ROT: ein dritter Lauf 90 Min nach Lauf 1 (30 mm/h statt 11 mm/h,
+# ~27,5 mm statt ~10 mm) liefert `triggered_count=0`, und das Alarmprotokoll
+# nennt als Grund `cooldown` — nicht `briefing_announced:`. Ursache:
+# `check_nowcast_gate` prueft die Sperrzeit unbedingt VOR jeder
+# Eskalations-/Ueberholungsbewertung (`trip_alert.py:1239-1273` gegen
+# `:1380-1384`) und kennt keine Ausnahme fuer verschaerfte Lagen.
+#
+# Der Waechter dafuer braucht Produktivcode und lebt deshalb in Issue #2065
+# weiter (Testkoerper, pytest-Ausgabe und Code-Ursache sind dort abgelegt).
+# Die Nummerierung der uebrigen Tests bleibt bewusst deckungsgleich mit der
+# Spec (AC-1, AC-2, AC-4) — die Luecke ist ausgelagert, nicht vergessen.
+# ---------------------------------------------------------------------------
+
+
+def test_ac4_kurze_spitze_mit_gleicher_spitzenrate_loest_nicht_aus():
+    """AC-4: EIGENE `user_id` (kein geerbter Zustand aus AC-1/AC-2).
+    Spitzenrate wie im ausloesenden Fall (11 mm/h), Gesamtmenge mit ~1,83 mm
+    unter der Ueberholungs-Untergrenze -> kein Alarm. Die Gleichheit der
+    Spitzenrate wird am ECHTEN Nowcast-Ergebnis gemessen, nicht behauptet:
+    ohne sie waere das nur ein zweiter "kein Alarm"-Test ohne Aussage
+    darueber, WORAN es lag."""
+    uid = _uid("ac4")
+    try:
+        trip = _aufbau(uid, "ac4")
+        lat, lon = trip.stages[0].waypoints[0].lat, trip.stages[0].waypoints[0].lon
+        with freeze_time(_AT):
+            # Der Frame-Cache ist ein PROZESS-Singleton mit Koordinaten-
+            # Schluessel (TTL 300 s): ohne Reset dazwischen liefert der zweite
+            # Abruf die Frames des ersten zurueck — beide Messungen waeren dann
+            # zufaellig gleich und die Gegenprobe wertlos (gemessen).
+            reset_shared_radar_cache_for_tests()
+            spitze = _radar(_kurze_spitze(11.0)).get_nowcast(lat, lon)
+            reset_shared_radar_cache_for_tests()
+            dauer = _radar(_dauerregen(11.0)).get_nowcast(lat, lon)
+            reset_shared_radar_cache_for_tests()
+        assert spitze.max_rate_mm_h == dauer.max_rate_mm_h, (
+            f"AC-4 Testkonstruktion: die Spitzenrate muss der des ausloesenden "
+            f"Falls GLEICHEN ({spitze.max_rate_mm_h} vs. {dauer.max_rate_mm_h})."
+        )
+        assert spitze.window_precip_mm < dauer.window_precip_mm, (
+            f"AC-4 Testkonstruktion: die Gesamtmenge muss deutlich kleiner sein "
+            f"({spitze.window_precip_mm} vs. {dauer.window_precip_mm})."
+        )
+
+        strecke = AlarmPruefstrecke(user_id=uid, settings=_settings_all_channels())
+        lauf = strecke.lauf(
+            at=_AT, zweig="radar", trip=trip, radar_service=_radar(_kurze_spitze(11.0)),
+        )
+        assert lauf.triggered_count == 0, (
+            f"AC-4: gleiche Spitzenrate, aber nur ~{spitze.window_precip_mm:.2f} mm "
+            f"gegen eine Ankuendigung von {BRIEFING_MM} mm — die Sperre muss "
+            f"bestehen bleiben. War triggered_count={lauf.triggered_count}."
+        )
+        assert not (lauf.mail or lauf.telegram or lauf.sms or lauf.premium_sms), (
+            f"AC-4: kein Kanal darf etwas ausliefern: mail={lauf.mail!r} "
+            f"telegram={lauf.telegram!r} sms={lauf.sms!r} "
+            f"premium_sms={lauf.premium_sms!r}"
+        )
+    finally:
+        _clean_user(uid)
+
+
+def test_ac8_absolute_untergrenze_sperrt_obwohl_der_faktor_ueberholt_ist():
+    """AC-8: die Ueberholung ist eine UND-Verknuepfung aus Faktor-Schwelle UND
+    absoluter Untergrenze (`trip_alert.py:1381-1385`). AC-4 haelt nur die
+    Faktor-Haelfte fest — seine ~1,83 mm scheitern schon an der Faktorschwelle
+    (2x1,0 mm), die absolute Untergrenze wird dort nie zur wirksamen Bedingung
+    und ihr Wegfall bliebe unbemerkt.
+
+    Hier liegt die Ankuendigung bei 0,5 mm: die Faktor-Schwelle liegt damit bei
+    1,0 mm und ist von den gemessenen ~1,5 mm LOCKER ueberholt. Verhindert wird
+    der Alarm allein von der absoluten Untergrenze (2,0 mm)."""
+    uid = _uid("ac8")
+    try:
+        trip = _aufbau(uid, "ac8", briefing_mm=BRIEFING_KLEIN_MM)
+        lat, lon = trip.stages[0].waypoints[0].lat, trip.stages[0].waypoints[0].lon
+        with freeze_time(_AT):
+            reset_shared_radar_cache_for_tests()
+            lage = _radar(_kurze_spitze(9.0)).get_nowcast(lat, lon)
+            reset_shared_radar_cache_for_tests()
+
+        # Modul-Referenz statt gebundener Kopie: eine Aenderung des Faktors
+        # soll hier auffallen, nicht stillschweigend mitwandern.
+        from services import trip_alert as trip_alert_mod
+        faktor_schwelle = BRIEFING_KLEIN_MM * trip_alert_mod._BRIEFING_OVERTAKE_FACTOR
+        assert lage.window_precip_mm >= faktor_schwelle, (
+            f"AC-8 Testkonstruktion: die Faktor-Bedingung MUSS erfuellt sein, "
+            f"sonst prueft der Fall wieder nur den Faktor "
+            f"({lage.window_precip_mm} < {faktor_schwelle})."
+        )
+        assert 1.4 <= lage.window_precip_mm <= 1.6, (
+            f"AC-8 Testkonstruktion: erwartet ~1,5 mm (9 mm/h ueber 10 Min), "
+            f"gemessen {lage.window_precip_mm} — liegt die Menge ueber der "
+            f"absoluten Untergrenze, bewacht der Fall nichts mehr."
+        )
+
+        strecke = AlarmPruefstrecke(user_id=uid, settings=_settings_all_channels())
+        lauf = strecke.lauf(
+            at=_AT, zweig="radar", trip=trip, radar_service=_radar(_kurze_spitze(9.0)),
+        )
+        assert lauf.triggered_count == 0, (
+            f"AC-8: ~{lage.window_precip_mm:.2f} mm ueberholen zwar den Faktor "
+            f"({faktor_schwelle} mm), bleiben aber unter der absoluten "
+            f"Relevanz-Untergrenze — kein Alarm erlaubt. War "
+            f"triggered_count={lauf.triggered_count}."
+        )
+        assert _gelesene_briefing_werte(uid, trip, _AT) == [BRIEFING_KLEIN_MM], (
+            f"AC-8: die Stille muss von der Ueberholungspruefung kommen (der "
+            f"Protokolleintrag traegt die gelesenen {BRIEFING_KLEIN_MM} mm), "
+            f"nicht von Sperrzeit oder fehlendem Briefing."
+        )
+        assert not (lauf.mail or lauf.telegram or lauf.sms or lauf.premium_sms), (
+            f"AC-8: kein Kanal darf etwas ausliefern: mail={lauf.mail!r} "
+            f"telegram={lauf.telegram!r} sms={lauf.sms!r}"
+        )
+    finally:
+        _clean_user(uid)

--- a/tests/tdd/test_alarm_szenario_gewitter_vorverlegung.py
+++ b/tests/tdd/test_alarm_szenario_gewitter_vorverlegung.py
@@ -1,0 +1,205 @@
+"""Issue #2050 Scheibe S2a — Waechter 2: Szenario 3 durch die ECHTE Ausloeseentscheidung.
+
+SPEC: docs/specs/modules/alarm_szenarien_waechter_2_3.md (AC-5..AC-7)
+
+Was die 10 bestehenden Tests in `test_onset_shift_alert.py` NICHT pruefen:
+alle zehn setzen an `WeatherChangeDetectionService.detect_changes()` an. Ein
+Grep ueber alle 41 Testdateien, die `check_and_send_alerts` aufrufen,
+gefiltert auf `thunder_onset`, liefert NULL Treffer. Damit ist insbesondere
+die Konfigurations-Weiche `DeviationAlertEngine._select_detector()`
+unbewacht: ein Trip kann den Alarmtyp konfigurativ gar nicht erreichen, ohne
+dass ein Test das bemerkt. Diese Datei faehrt beides ueber die
+`AlarmPruefstrecke` (`zweig="deviation"` -> `check_and_send_alerts()`).
+
+Kein Mock()/patch()/MagicMock: die Kanaltexte kommen ueber den echten
+Telegram-Transport (lokaler HTTP-Stub der Pruefstrecke) bzw. `mail_sink`.
+
+ZEITZONE: die Etappe liegt in Island (UTC+0 ganzjaehrig) — die Erwartungen
+"17:00"/"15:00" stehen als LITERAL im Test und werden nicht aus derselben
+Zonen-Aufloesung gezogen, die der Pruefling benutzt.
+
+WORTLAUT: geprueft wird ausschliesslich #1468-Bestand (beide Uhrzeiten,
+Pfeil, Richtungswort) — KEINE Formulierung, die #2020 Scheibe 2 aendert.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime, timedelta, timezone
+
+from app.models import (
+    ForecastMeta, GPXPoint, MetricConfig, NormalizedTimeseries, Provider,
+    SegmentWeatherData, SegmentWeatherSummary, TripReportConfig, TripSegment,
+    UnifiedWeatherDisplayConfig,
+)
+from app.trip import Stage, Trip, Waypoint
+
+from tests.helpers.alarm_pruefstrecke import AlarmPruefstrecke
+from tests.tdd.test_952_onset_alert_fidelity import _clean_user
+from tests.tdd.test_alarm_pruefstrecke_selbstschutz import (
+    _settings_all_channels, _write_tier,
+)
+
+# Island: UTC+0 ganzjaehrig, keine Sommerzeit.
+ISLAND_LAT, ISLAND_LON = 64.13, -21.90
+TAG = date(2026, 8, 20)
+_AT = datetime(2026, 8, 20, 10, 0, tzinfo=timezone.utc)
+
+# Die beiden Uhrzeiten des Szenarios (Anker 17 Uhr, frischer Stand 15 Uhr).
+ANKER_STUNDE, FRISCH_STUNDE = 17, 15
+
+
+def _uid(tag: str) -> str:
+    return f"tdd-2050-s2a-w2-{tag}-{uuid.uuid4().hex[:6]}"
+
+
+def _utc(stunde: int) -> datetime:
+    """Naiver UTC-Zeitstempel (Hausnorm src/utils/timezone.py)."""
+    return datetime(TAG.year, TAG.month, TAG.day, stunde, 0)
+
+
+def _gewitter_trip(trip_id: str, *, onset_level: str) -> Trip:
+    """Trip, dessen Weather-Tab Gewitter beobachtet und dessen
+    `metric_alert_levels["thunder_onset"]` auf `onset_level` steht.
+
+    `metrics=[thunder]` ist Pflicht (#961 "Deaktivieren-Luecke":
+    `expand_per_metric_levels()` ueberspringt einen Level-Eintrag, dessen
+    Katalog-Metrik auf dem Weather-Tab nicht aktiv ist) — und genau EINE
+    aktive Metrik, damit der Backfill keine zweite Alarmquelle einschaltet.
+    """
+    wp = Waypoint(id="G1", name="Start", lat=ISLAND_LAT, lon=ISLAND_LON,
+                  elevation_m=1000.0)
+    stage = Stage(id="T1", name="Tag 1", date=TAG, waypoints=[wp])
+    trip = Trip(
+        id=trip_id, name="2050 S2a Gewitter-Trip", stages=[stage],
+        display_config=UnifiedWeatherDisplayConfig(
+            trip_id=trip_id,
+            metrics=[MetricConfig(metric_id="thunder", enabled=True)],
+            metric_alert_levels={"thunder_onset": onset_level},
+        ),
+    )
+    trip.report_config = TripReportConfig(
+        trip_id=trip_id, send_email=True, send_telegram=True, alert_on_changes=True,
+    )
+    trip.alert_cooldown_minutes = 0
+    return trip
+
+
+def _stand(onset_stunde: int) -> list:
+    """Ein Etappen-Datenstand mit `thunder_onset_utc` zur genannten Stunde."""
+    segment = TripSegment(
+        segment_id=1,
+        start_point=GPXPoint(lat=ISLAND_LAT, lon=ISLAND_LON, elevation_m=1000.0,
+                             distance_from_start_km=0.0),
+        end_point=GPXPoint(lat=ISLAND_LAT + 0.1, lon=ISLAND_LON + 0.1,
+                           elevation_m=1200.0, distance_from_start_km=8.0),
+        start_time=_utc(6).replace(tzinfo=timezone.utc),
+        end_time=_utc(18).replace(tzinfo=timezone.utc),
+        duration_hours=12.0, distance_km=8.0, ascent_m=500.0, descent_m=200.0,
+    )
+    return [SegmentWeatherData(
+        segment=segment,
+        timeseries=NormalizedTimeseries(
+            meta=ForecastMeta(provider=Provider.OPENMETEO, model="test", grid_res_km=1.0),
+            data=[],
+        ),
+        aggregated=SegmentWeatherSummary(thunder_onset_utc=_utc(onset_stunde)),
+        fetched_at=_AT - timedelta(hours=1), provider="openmeteo",
+    )]
+
+
+def _lauf(uid: str, trip: Trip):
+    _write_tier(uid, "premium")
+    strecke = AlarmPruefstrecke(user_id=uid, settings=_settings_all_channels())
+    return strecke.lauf(
+        at=_AT, zweig="deviation", trip=trip,
+        cached_weather=_stand(ANKER_STUNDE), fresh_weather=_stand(FRISCH_STUNDE),
+    )
+
+
+def test_ac5_gewitterbeginn_von_17_auf_15_uhr_loest_genau_einen_alarm_aus():
+    """AC-5: Anker 17:00, frischer Stand 15:00, `thunder_onset` aktiv ->
+    GENAU EIN Alarm ueber `check_and_send_alerts()`. Unterschied zu den zehn
+    bestehenden Tests: hier laufen Konfigurations-Weiche
+    (`_select_detector`), Freigabe-Kette und echter Versand mit."""
+    uid = _uid("ac5")
+    try:
+        _clean_user(uid)
+        lauf = _lauf(uid, _gewitter_trip("trip-2050-s2a-ac5", onset_level="standard"))
+        assert lauf.triggered_count == 1, (
+            f"AC-5: die Vorverlegung {ANKER_STUNDE}:00 -> {FRISCH_STUNDE}:00 muss "
+            f"ueber die echte Ausloeseentscheidung GENAU EINEN Alarm ergeben. "
+            f"War triggered_count={lauf.triggered_count}."
+        )
+        assert lauf.telegram or lauf.mail, (
+            "AC-5: mindestens ein Kanal muss den Alarm ausliefern "
+            f"(telegram={lauf.telegram!r} mail={lauf.mail!r})."
+        )
+    finally:
+        _clean_user(uid)
+
+
+def test_ac6_alarmtext_nennt_beide_uhrzeiten_und_die_richtung_nach_vorne():
+    """AC-6: derselbe Lauf wie AC-5; der ausgelieferte Telegram-Text nennt
+    17:00 UND 15:00 und macht durch Pfeil + Richtungswort erkennbar, dass
+    sich der Beginn nach VORNE verschoben hat (#1468-Bestand)."""
+    uid = _uid("ac6")
+    try:
+        _clean_user(uid)
+        lauf = _lauf(uid, _gewitter_trip("trip-2050-s2a-ac6", onset_level="standard"))
+        assert lauf.telegram, (
+            f"AC-6 Vorbedingung: der Lauf muss ueber Telegram ausliefern "
+            f"(triggered_count={lauf.triggered_count})."
+        )
+        text = "\n".join(lauf.telegram)
+        for uhrzeit in (f"{ANKER_STUNDE}:00", f"{FRISCH_STUNDE}:00"):
+            assert uhrzeit in text, (
+                f"AC-6: der Alarmtext nennt {uhrzeit} nicht.\n{text}"
+            )
+        assert "→" in text, (
+            f"AC-6: der Alarmtext zeigt die Verschiebung nicht als "
+            f"'alt → neu' (#1468-Bestand).\n{text}"
+        )
+        assert "früher" in text, (
+            f"AC-6: der Alarmtext benennt die Richtung nicht — ein um zwei "
+            f"Stunden VORVERLEGTER Beginn muss als 'früher' erscheinen.\n{text}"
+        )
+        assert "später" not in text, (
+            f"AC-6: der Alarmtext dreht die Richtung um.\n{text}"
+        )
+    finally:
+        _clean_user(uid)
+
+
+def test_ac7_abgeschalteter_alarmtyp_verhindert_den_alarm_bei_gleicher_wetterlage():
+    """AC-7: identischer Lauf zu AC-5, nur `metric_alert_levels`-Level "off"
+    -> KEIN Alarm, obwohl die Wetterdaten unveraendert denselben
+    Gewitterbeginn-Sprung zeigen. Die Positivkontrolle (aktiver Level, eigene
+    `user_id`) laeuft im selben Test: ohne sie waere die Gegenprobe auch dann
+    gruen, wenn ueberhaupt nichts ausloest."""
+    uid, kontrolle = _uid("ac7"), _uid("ac7-ctrl")
+    try:
+        _clean_user(uid)
+        _clean_user(kontrolle)
+        lauf_kontrolle = _lauf(
+            kontrolle, _gewitter_trip("trip-2050-s2a-ac7", onset_level="standard"),
+        )
+        assert lauf_kontrolle.triggered_count == 1, (
+            "AC-7 Positivkontrolle: derselbe Aufbau MIT aktivem Level muss "
+            f"ausloesen (war {lauf_kontrolle.triggered_count}) — sonst prueft "
+            "die Gegenprobe unten nichts."
+        )
+
+        lauf = _lauf(uid, _gewitter_trip("trip-2050-s2a-ac7", onset_level="off"))
+        assert lauf.triggered_count == 0, (
+            f"AC-7: bei abgeschaltetem `thunder_onset`-Level darf die "
+            f"Konfigurations-Weiche (_select_detector) den Alarmtyp gar nicht "
+            f"erst auswerten. War triggered_count={lauf.triggered_count}."
+        )
+        assert not (lauf.mail or lauf.telegram or lauf.sms or lauf.premium_sms), (
+            f"AC-7: kein Kanal darf etwas ausliefern: mail={lauf.mail!r} "
+            f"telegram={lauf.telegram!r} sms={lauf.sms!r} "
+            f"premium_sms={lauf.premium_sms!r}"
+        )
+    finally:
+        _clean_user(uid)
+        _clean_user(kontrolle)


### PR DESCRIPTION
Scheibe **S2a** von #2050: zwei der zwölf Alarm-Szenarien werden zu dauerhaften Wächtern auf der Prüfstrecke aus S1. **Kein Produktivcode geändert**, keine bestehende Testdatei angefasst.

## Warum das keine Doppelung bestehender Tests ist

| Szenario | Bestand | Belegte Lücke |
|---|---|---|
| **2** — Briefing-Überholung | 17 Tests in `test_nowcast_briefing_overtake.py` | **Jeder ist ein Einzelaufruf mit leerem Datenträger.** Der Cooldown kommt dort nie zum Tragen — auch der scheinbare Zweilauf-Test fährt zwei unabhängige Nutzer |
| **3** — Gewitter-Vorverlegung | 10 Tests in `test_onset_shift_alert.py` | **Alle setzen unterhalb der Auslöseentscheidung an.** Grep über alle 41 Aufrufer von `check_and_send_alerts`, gefiltert auf `thunder_onset`: null Treffer |

## Die sieben Wächter

**Szenario 2** — echte Zeitreihe auf **einem** Datenträger, wie der Cron sie fährt:
- **AC-1** Briefing 1 mm, Radar 11 mm löst aus. Ein vorgeschalteter Sonden-Lauf weist nach, dass der Prüfling die Ankündigung wirklich gelesen hat
- **AC-2** Lauf 2 schweigt nachweislich **wegen der gebuchten Sperre** — `gate_reason == "cooldown"`, nicht `briefing_announced:`. Von außen sehen beide Fälle identisch aus
- **AC-4** kurze Spitze bei gleicher Rate löst nicht aus (Faktor-Schwelle)
- **AC-8** absolute Untergrenze sperrt, obwohl der Faktor überholt ist

**Szenario 3** — erstmals durch die echte Auslöseentscheidung:
- **AC-5** Vorverlegung 17 → 15 Uhr löst genau einen Alarm aus
- **AC-6** der Text nennt beide Uhrzeiten und die Richtung
- **AC-7** bei abgeschaltetem `metric_alert_levels["thunder_onset"]` löst derselbe Lauf **nicht** aus — nagelt die Konfigurations-Weiche fest, über die ein Trip den Alarmtyp konfigurativ gar nicht erreichen kann

## Ein Produktfehler gefunden → #2065

**AC-3 ist gemessen rot und ausgelagert.** Anforderung A-3 aus #2050 („eine Verschärfung überholt jede Sperre") ist verletzt: `check_nowcast_gate` bricht mit `continue` ab, **bevor** die Überholungsprüfung erreicht wird (`trip_alert.py:1239-1273` vs. `:1381`), und nimmt keinen Parameter entgegen, über den es von einer Verschärfung erfahren könnte.

Gemessen: Lage von ~10 mm auf ~27,5 mm verschärft, Sperrzeit läuft noch → `triggered_count=0`, Protokollgrund `cooldown`.

Nicht zu verwechseln mit #2020 S1 — das hat die **Briefing-Ankündigungs-Sperre** gebrochen, nicht den Cooldown.

## Adversary: VERIFIED nach einer BROKEN-Runde

Neun Mutationen am Produktivcode. Runde 1 fand zwei Wächter, die grün waren **ohne zu bewachen**:
- **F001** (CRITICAL) — `_OVERTAKE_MIN_ABSOLUTE_MM` auf 0 gesetzt: alle sechs blieben grün. AC-4s Testdaten scheiterten schon am Faktor, die absolute Untergrenze wurde nie zur wirksamen Bedingung → behoben durch AC-8
- **F002** — bei gebrochenem Briefing-Lesepfad blieb AC-1 grün, weil ohne Ankündigung gar keine Überholung nötig ist → behoben durch den Sonden-Lauf

Runde 2 bestätigt beide Fixes durch Wiederholung der Mutationen und prüft zusätzlich, dass AC-8 auf den **Faktor** *nicht* reagiert — sonst hinge er wieder an der falschen Bedingung.

## Tests

44 grün in einem Prozess (7 neue + 37 Nachbarschaft), nach Rebase auf `origin/main` erneut geprüft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CVF3we28houZPpW8fGBo2f
