### PR TITLE
fix(#2020 Scheibe 2): Abweichungsalarm schaut nach vorn statt zurueck

### DIFF
--- a/docs/context/fix-2020-alarm-zeitangaben.md
+++ b/docs/context/fix-2020-alarm-zeitangaben.md
@@ -447,3 +447,23 @@ statt `+1` bei Mitternachts-Überlauf" — `_sms_onset_time` (`render.py:537`, A
 Setzt die mit dieser Spec freigegebene Vereinheitlichung um; **nicht** Teil dieser Scheibe.
 GSM-7-Frage ist dort bereits beantwortbar: Die amtliche Warn-SMS versendet die Kürzel
 (`Do12-22`) seit #1948 S5 im selben Kanal — reine ASCII-Buchstaben, GSM-7-fähig.
+
+### 🔴 Vor dem ersten Schreiben rebasen — #2036 (PR #2055) landet unmittelbar
+
+Zugesagte Vorwarnung der #2036-Session. Alles **additiv**, nichts entfernt, aber in genau
+den Dateien dieser Scheibe:
+
+- `alert/model.py`: `km_measured: bool = False` an **allen vier** Event-Dataclasses
+  (`AlertEvent`, `OnsetEvent`, `OnsetShiftEvent`, `CorridorEvent`); zusätzlich
+  `segment_id: str | None = None` an `CorridorEvent`.
+- `alert/render.py`: `_location_of`, `_onset_shift_where`, `_onset_shift_location` reichen
+  `km_measured` an `format_alert_location` durch; **neu** `_corridor_where`; `_corridor_when`
+  und `_render_sms_corridor_only` bauen ihre km-Spanne nicht mehr selbst, sondern gehen über
+  `format_alert_location`.
+- `alert/project.py`: reicht das Flag in der Projektion weiter.
+- Die Ortsauflösung hat danach **vier** Stufen: `location_label` → gemessene km-Spanne →
+  Segment-Kennung → km-Rückfall.
+
+Berührt diese Scheibe direkt: `_onset_shift_line`/`_onset_shift_where` und `_corridor_when`
+sind Textstellen, in denen auch die Zeitangaben sitzen. **Nach dem Merge rebasen und die
+neue Fassung lesen**, nicht auf der alten weiterbauen.

--- a/docs/context/fix-2020-alarm-zeitangaben.md
+++ b/docs/context/fix-2020-alarm-zeitangaben.md
@@ -420,3 +420,24 @@ ein Folgeticket der #2046-Session, nicht Teil dieser Scheibe.
   rein über die Klammerstellung (`R@14(R@17)`, `output/tokens/metrics.py:65-67`) — eine
   Positions-Konvention ohne Wort. AC-3 muss also ein Wort **neu** einführen; dafür gibt es
   keine Vorlage, wohl aber die Nachbarwörter, an denen es sich ausrichten muss.
+
+### Zeichenbudget der Kurznachricht: Δ- und Onset-Zweig sind getrennt (belegt 2026-08-21)
+
+Von der #2046-Session am Code geprüft, nicht referiert:
+
+- `_render_sms_body` (`render.py:1107-1108`) hat einen **frühen Return**:
+  `if msg.source is not None: return _render_sms_onset(msg, limit)`. Eine `AlertMessage` ist
+  damit **entweder** Onset (`source != None`, `model.py:118`) **oder** Δ — nie beides in einem
+  gerenderten Text.
+- Jeder Zweig hat seinen **eigenen** Hardcut: Onset `render.py:614`, Δ `render.py:1155`. Das
+  `limit` wird pro `render_sms()`-Aufruf gemessen, nicht über beide Befunde hinweg.
+- Die Addendum-Mechanik (`"Erg "`-Präfix, `render.py:1067-1071`) bündelt nur **innerhalb
+  eines** `render_sms()`-Aufrufs, also mehrere Befunde derselben Alarmart.
+
+**Folge für diese Scheibe:** Das Restmengen-Token (`Rest{mm}@{HH}`, ~8–9 Zeichen) zehrt
+allein am Δ-Budget. Die 160-Zeichen-Prüfung (AC-7) ist **unabhängig** von #2046 aufzustellen;
+kein gemeinsamer Messpunkt, kein Merge-Halt.
+
+🔴 **Grenze der Auskunft, ausdrücklich benannt:** Belegt ist die **Renderer-Weiche**, nicht
+der Versandweg. Würden zwei Alarmarten **vor** `render_sms` zu einer Sendung zusammengefasst,
+wäre das eine andere Frage. Im Renderer passiert es nachweislich nicht.

--- a/docs/context/fix-2020-alarm-zeitangaben.md
+++ b/docs/context/fix-2020-alarm-zeitangaben.md
@@ -441,3 +441,9 @@ kein gemeinsamer Messpunkt, kein Merge-Halt.
 🔴 **Grenze der Auskunft, ausdrücklich benannt:** Belegt ist die **Renderer-Weiche**, nicht
 der Versandweg. Würden zwei Alarmarten **vor** `render_sms` zu einer Sendung zusammengefasst,
 wäre das eine andere Frage. Im Renderer passiert es nachweislich nicht.
+
+**Folgeticket #2054** (von der #2046-Session angelegt): „Onset-Kurznachricht: Wochentagskürzel
+statt `+1` bei Mitternachts-Überlauf" — `_sms_onset_time` (`render.py:537`, Aufruf `:595`).
+Setzt die mit dieser Spec freigegebene Vereinheitlichung um; **nicht** Teil dieser Scheibe.
+GSM-7-Frage ist dort bereits beantwortbar: Die amtliche Warn-SMS versendet die Kürzel
+(`Do12-22`) seit #1948 S5 im selben Kanal — reine ASCII-Buchstaben, GSM-7-fähig.

--- a/docs/context/fix-2020-alarm-zeitangaben.md
+++ b/docs/context/fix-2020-alarm-zeitangaben.md
@@ -311,3 +311,63 @@ und die RED-Tests setzen sie explizit.
       **29,4 mm** — „redundant" trifft es nicht. Empfehlung in der Spec vorlegen,
       Entscheidung beim PO.
 
+
+## Nachtrag 2026-08-21 (Scheibe 2, Session `intake-2020-scheibe2`)
+
+Nach Auslieferung von Scheibe 1 (Auslösung, Prod `b423c913`) neu bzw. korrigiert:
+
+- **AC-7 der Spec ist erledigt.** Die Briefing-Unterdrückung schreibt seit Scheibe 1
+  `alert_log.append_suppressed_entry(reason=REASON_NOWCAST, gate_reason="briefing_announced:<mm>mm")`
+  (`src/services/trip_alert.py:1390`). Der Punkt entfällt aus dem Zuschnitt.
+- **Das Nicht-Ziel „Auslöseregel des Nowcasts ändern" ist überholt.** Scheibe 1 hat genau
+  das getan (Mengen-Überholung bricht die Sperre). Der Absatz muss umgeschrieben werden.
+- 🔴 **Für den Tagesbezug in der Kurznachricht existiert bereits eine Notation:**
+  `_sms_onset_time()` (`render.py:537-550`) hängt bei Versatz `+1` an — GSM-7-verträglich,
+  zeichensparend, eingeführt mit #2009. Der Abweichungsalarm-Zweig
+  (`_sms_onset_shift_token`, `render.py:300-307`) hat keine. **Keine zweite Notation
+  einführen** — der geteilte Tageswort-Baustein muss diese Schreibweise für den
+  Kurzkanal übernehmen. (Hinweis der #2046-Session, dort `_sms_onset_time` unberührt.)
+- **SMS-Weiche:** `render_sms` → `_render_sms_body` (`render.py:1042-1080`),
+  `if msg.source is not None` → Onset-Zweig (#2046), sonst Δ-/Korridor-/Onset-Shift-Zweig
+  (diese Scheibe).
+- **Datei-Nachbarschaft:** #2036 (`fix-2036-alarm-kilometer`) ergänzt `km_measured: bool = False`
+  additiv am Ende aller vier Event-Dataclasses und ändert die Ortsangabe-Zeile in `render.py`
+  (`km{A}-{B}` → `km {A}-{B}`, Ratsche `test_alert_location_vocabulary.py:534` verbietet
+  `km` direkt vor einer Ziffer). Merge steht bevor — vor dem Schreiben rebasen.
+
+### 🔴 Nachtrag: `-1` als Zahlensuffix ist im Kurzkanal NICHT eindeutig (selbst geprüft)
+
+Anlass war der Hinweis der #2046-Session, die Fensterform der amtlichen Warn-SMS (`13-22`)
+lasse sich vom Tagesversatz unterscheiden, weil das Fenster keine Minuten trage. **Das
+trägt nicht.** `_tag_hour()` (`official_alerts.py:1896-1902`) schreibt Minuten sehr wohl,
+sobald sie nicht auf `:00` liegen — ein Fenster lautet dann `15:20-17`. Damit sind
+
+- Gültigkeitsfenster `15:20-17` und
+- Tagesversatz `17:00-1`
+
+beide „Uhrzeit mit Minuten, Bindestrich, Zahl" und nicht mehr per Form trennbar.
+
+Dazu kommt: Im Kurzkanal existieren bereits **zwei** Tagesbezug-Schreibweisen —
+`17:00+1` (Zahlensuffix, Onset-Zweig, #2009) und das **Wochentagskürzel** `Sa03` bzw.
+`Do12-22` (amtliche Warnung, #1948 S5, `official_alerts.py:1934-1943`). Für den
+Vergangenheitsfall des Abweichungsalarms (Normalfall `-1`) ist das Wochentagskürzel die
+eindeutigere Fortsetzung: Buchstaben kollidieren mit keiner Stundenzahl.
+
+**Zu entscheiden in der Spec (AC-Freigabe durch den PO), nicht implizit:** Welche der
+beiden bestehenden Notationen trägt den Tagesbezug des Abweichungsalarms im Kurzkanal?
+Eine dritte kommt nicht in Frage.
+
+Nebenbefund für die Umsetzung: `_sms_onset_time` hängt das Vorzeichen fest an
+(`f"{base}+{day_offset}"`, `render.py:550`) — mit `day_offset = -1` entstünde `17:00+-1`.
+Wer die Zahlensuffix-Variante wählt, muss dort auf `f"{day_offset:+d}"` (byte-identisch
+für `0`/`+1`, also regressionsfrei).
+
+Beispiel für die dichteste Stelle der Kurzform, falls die Spec eines zeigt (mit #2036
+und #2046 zusammen): `Ziel: R2.5@18:00…`.
+
+**Zuschnitt des AC (Bitte der #2046-Session, übernommen):** Fällt die Wahl auf das
+Wochentagskürzel, wird `+1` aus #2009 (Onset-Kurzform) zur dann einzigen abweichenden
+Notation im selben Kanal. Das AC muss diese Frage ausdrücklich mitbeantworten — entweder
+„gilt auch für den Onset-Suffix, Umstellung in eigenem Ticket" oder „Onset bleibt bewusst
+bei `+1`, Begründung X". Sonst entsteht die dritte Notation als Altbestand statt als
+Neubau. Die #2046-Session legt das Folgeticket an, sobald die Spec freigegeben ist.

--- a/docs/context/fix-2020-alarm-zeitangaben.md
+++ b/docs/context/fix-2020-alarm-zeitangaben.md
@@ -371,3 +371,10 @@ Notation im selben Kanal. Das AC muss diese Frage ausdrücklich mitbeantworten �
 „gilt auch für den Onset-Suffix, Umstellung in eigenem Ticket" oder „Onset bleibt bewusst
 bei `+1`, Begründung X". Sonst entsteht die dritte Notation als Altbestand statt als
 Neubau. Die #2046-Session legt das Folgeticket an, sobald die Spec freigegeben ist.
+
+**Prüfpunkt aus dem Alarm-Versand-Audit (nur lesende Session, kein Ticket):**
+`docs/context/fix-2009-nowcast-vorlauf.md:162` hält fest, dass kein Test prüft, ob
+`onset_minutes` überhaupt variieren kann — der Default 8 maskiert das suiteweit. Betrifft
+den Nowcast-Vorlauf, nicht den Abweichungsalarm; **kein Ziel dieser Scheibe**. Wenn die
+Zeitangaben-Tests ohnehin eine Referenzzeit durchreichen, ist ein variierender Wert dort
+billig mitzunehmen — sonst liegen lassen und in #1196 buchen.

--- a/docs/context/fix-2020-alarm-zeitangaben.md
+++ b/docs/context/fix-2020-alarm-zeitangaben.md
@@ -414,12 +414,26 @@ ein Folgeticket der #2046-Session, nicht Teil dieser Scheibe.
 - **Kein Leser von `onset_day_offset` außer** `_onset_time_label` und `_sms_onset_time`.
 - Die Kurzform des Δ-Zweigs wirft Minuten **weg**: `@{occurred_at[:2]}` (`render.py:990`),
   ebenso der Korridor (`render.py:263`). Der Tagesbezug muss dort vor die **Stunde**.
-- **Für „das ist die stärkste Stunde" gibt es im Bestand kein Wort.** Etablierte
-  Bedeutungs-Marker sind nur `ab` (Beginn), `-Beginn`, `jetzt`, `Stand:`,
-  `verglichen mit`, `Gültig:`. Der Trip-Report unterscheidet Erstüberschreitung und Spitze
-  rein über die Klammerstellung (`R@14(R@17)`, `output/tokens/metrics.py:65-67`) — eine
-  Positions-Konvention ohne Wort. AC-3 muss also ein Wort **neu** einführen; dafür gibt es
-  keine Vorlage, wohl aber die Nachbarwörter, an denen es sich ausrichten muss.
+- **🔴 KORREKTUR 2026-08-21 (PO-Rückfrage „ist das ein Begriff, den wir sonst verwenden?"):
+  Das Wort „stärkste" gibt es im Bestand sehr wohl** — `output/renderers/email/helpers.py:1786`
+  schreibt seit #795/#1493 `Gewitter {Stufe} ab {HH}:00 · stärkste {HH}:00` in die
+  Briefing-Mail. Die ursprüngliche Behauptung dieses Dokuments („dafür gibt es kein Wort")
+  war falsch; sie kam von einer Suche, die nur die Alarm-Renderer abgedeckt hat und die
+  Briefing-Fläche ausgelassen hat. **Lehre: Vokabular-Fragen über ALLE Ausgabeflächen
+  greppen, nicht nur über die gerade bearbeitete.**
+- Damit ist „stärkste Stunde" keine Neueinführung, sondern die Fortsetzung eines
+  bestehenden Sprachgebrauchs — mit Substantiv, weil „stärkste" allein grammatisch
+  unvollständig ist. Die verbleibende Uneinheitlichkeit (Briefing „stärkste 15:00" vs.
+  Alarm „stärkste Stunde 17:00") ist bewusst NICHT in dieser Scheibe angeglichen: die
+  Briefing-Zeile ist eine andere Fläche, und das Alarm-Vokabular wird in **#2050 B-2**
+  normiert („Beginn / stärkste Stunde / Ende"). Befund dort gebucht.
+- **`max.` ist im Bestand die Form für den WERT, nicht für den Zeitpunkt** (`Temp max`,
+  `Wind max X km/h (HH:00)`, `_AGGREGATION_LABELS_DE` in `metric_catalog.py:894-895`).
+  Deshalb scheidet `max. 17:00` aus: es setzt eine Zahl-Erwartung, liefert aber eine Uhrzeit.
+- Etablierte Bedeutungs-Marker der Alarm-Fläche bleiben `ab` (Beginn), `-Beginn`, `jetzt`,
+  `Stand:`, `verglichen mit`, `Gültig:`. Der Trip-Report unterscheidet Erstüberschreitung
+  und Spitze rein über die Klammerstellung (`R@14(R@17)`, `output/tokens/metrics.py:65-67`)
+  — eine Positions-Konvention ohne Wort.
 
 ### Zeichenbudget der Kurznachricht: Δ- und Onset-Zweig sind getrennt (belegt 2026-08-21)
 

--- a/docs/context/fix-2020-alarm-zeitangaben.md
+++ b/docs/context/fix-2020-alarm-zeitangaben.md
@@ -378,3 +378,45 @@ Neubau. Die #2046-Session legt das Folgeticket an, sobald die Spec freigegeben i
 den Nowcast-Vorlauf, nicht den Abweichungsalarm; **kein Ziel dieser Scheibe**. Wenn die
 Zeitangaben-Tests ohnehin eine Referenzzeit durchreichen, ist ein variierender Wert dort
 billig mitzunehmen — sonst liegen lassen und in #1196 buchen.
+
+### Bestandsaufnahme der Zeit-Notationen (2026-08-21, Explore-Durchgang)
+
+**Die Frage nach der Tagesbezug-Schreibweise ist durch den Bestand entschieden — beide
+zuvor erwogenen Varianten waren Neuerfindungen.**
+
+| Kanal | Bestehende Notation für „Uhrzeit an einem anderen Tag" | Fundort |
+|---|---|---|
+| E-Mail + Telegram, **im Abweichungsalarm selbst** | `gestern 18:03 Uhr` / `vor 2 Tagen 18:03 Uhr` | `format_reference_at`, `src/utils/timezone.py:154-169`, gerendert in `render.py:784-786/845-847/949-951` als „Stand: heute … · verglichen mit gestern …" |
+| E-Mail + Telegram, Radar-Onset | `morgen 00:23` (nur „morgen", kein Wochentag) | `_onset_time_label`, `render.py:367-374` |
+| SMS/Premium-SMS, amtliche Warnung | Wochentagskürzel **klebt** an der Stunde, `:00` entfällt: `Do12-22`, `Fr22-Sa03`; am heutigen Tag entfällt das Kürzel ersatzlos (#1948 S5) | `_tag_time`/`_tag_hour`, `official_alerts.py:1896-1943` |
+| SMS/Premium-SMS, Radar-Onset | Zahlensuffix `9:05+1` | `_sms_onset_time`, `render.py:537-550` |
+
+**Beschluss für diese Scheibe:** Langform übernimmt `gestern HH:MM` (Hausnotation
+desselben Alarms), Kurzform übernimmt das klebende Wochentagskürzel (`R7@Do15`).
+Keine dritte Schreibweise.
+
+**Gegen das Zahlensuffix in der Kurzform sprechen drei belegte Gründe:**
+1. `-` ist in der Kurzform bereits dreifach belegt — Wert gefallen (`-R7`, `render.py:987`),
+   Bereichstrenner (`12-22`), km-Spanne (`km8-8`, `render.py:1006`).
+2. Die Fensterform der amtlichen Warnung ist formgleich: `_tag_hour` setzt Minuten, sobald
+   sie nicht auf `:00` liegen ⇒ `15:20-17` neben `17:00-1`.
+3. `+1` deckt strukturell nur die Zukunft ab (`f"{base}+{day_offset}"`, `render.py:550`
+   ⇒ aus `-1` würde `17:00+-1`).
+
+**Restfrage für die AC-Freigabe:** Zieht `_sms_onset_time` (`+1`, Radar-Onset) auf das
+Wochentagskürzel nach? Sonst bleiben zwei Schreibweisen im selben Kanal. Umsetzung wäre
+ein Folgeticket der #2046-Session, nicht Teil dieser Scheibe.
+
+**Weitere Funde, die den Zuschnitt betreffen:**
+- `OnsetShiftEvent` (`model.py:66-85`) hat **kein** Tagesbezug-Feld; `from_time`/`to_time`
+  sind rohe `HH:MM`-Strings. `AlertEvent.occurred_at` (`model.py:98`) ebenso. Beide
+  brauchen das additive Feld.
+- **Kein Leser von `onset_day_offset` außer** `_onset_time_label` und `_sms_onset_time`.
+- Die Kurzform des Δ-Zweigs wirft Minuten **weg**: `@{occurred_at[:2]}` (`render.py:990`),
+  ebenso der Korridor (`render.py:263`). Der Tagesbezug muss dort vor die **Stunde**.
+- **Für „das ist die stärkste Stunde" gibt es im Bestand kein Wort.** Etablierte
+  Bedeutungs-Marker sind nur `ab` (Beginn), `-Beginn`, `jetzt`, `Stand:`,
+  `verglichen mit`, `Gültig:`. Der Trip-Report unterscheidet Erstüberschreitung und Spitze
+  rein über die Klammerstellung (`R@14(R@17)`, `output/tokens/metrics.py:65-67`) — eine
+  Positions-Konvention ohne Wort. AC-3 muss also ein Wort **neu** einführen; dafür gibt es
+  keine Vorlage, wohl aber die Nachbarwörter, an denen es sich ausrichten muss.

--- a/docs/context/fix-2020-alarm-zeitangaben.md
+++ b/docs/context/fix-2020-alarm-zeitangaben.md
@@ -467,3 +467,9 @@ den Dateien dieser Scheibe:
 Berührt diese Scheibe direkt: `_onset_shift_line`/`_onset_shift_where` und `_corridor_when`
 sind Textstellen, in denen auch die Zeitangaben sitzen. **Nach dem Merge rebasen und die
 neue Fassung lesen**, nicht auf der alten weiterbauen.
+
+**Nachtrag #2036:** `_corridor_when` ist nach dem Merge **zweigeteilt** — die Ortsangabe zieht
+das neue `_corridor_where` (über `format_alert_location`), `_corridor_when` hängt nur noch
+`· {ce.occurred_at}` an. Der Zeitanteil sitzt dort also **isoliert**; die Ortslogik ist für
+diese Scheibe nicht mehr anzufassen. `_onset_shift_where` behält seine Bauart, bekommt nur
+`km_measured=` als zusätzliches Argument. `weather_change_detection.py` fasst #2036 nicht an.

--- a/docs/specs/modules/fix_2020_alarm_blickrichtung.md
+++ b/docs/specs/modules/fix_2020_alarm_blickrichtung.md
@@ -460,6 +460,19 @@ Kurzkanal zwei Schreibweisen für „Uhrzeit an einem anderen Tag" nebeneinander
 - **Kein Vier-Kanäle-Wächter für Zeit-/Restmengen-Label allgemein.** Es gibt keinen
   automatischen Test, der bei künftigen Textänderungen alle vier Kanäle einfordert. AC-7
   deckt den hier geänderten Fall ab, nicht die Gattung. → Eintrag für #1196.
+- **🔴 Der Ortsvergleich bekommt das WORT, aber nicht die Mechanik** (Adversary-Befund
+  F004, 2026-08-21). `to_multi_point_alert_message()`/`to_point_alert_message()`
+  (`project.py:336-387`/`:500-513`) nehmen **kein** `now_utc` entgegen — Tagesbezug,
+  Vergangenheits-Ausweis und Restmenge erreichen den Ortsvergleich also nie. Was dort
+  ankommt, ist allein die geteilte Wortkonstante „stärkste Stunde" aus dem gemeinsamen
+  Renderer (belegt durch die nachgezogene Zusicherung in
+  `test_alert_location_vocabulary.py:367-372`). Das ist ein **Zwischenzustand**: Der
+  Ortsvergleich sagt jetzt „stärkste Stunde 16:00", ohne Vergangenes als vergangen
+  auszuweisen. Bewusst so belassen, weil Ortsvergleich-Themen PO-seitig zurückgestellt
+  sind; die Source-Liste dieser Spec nennt ausschließlich den Trip-Pfad. AC-8/AC-9/AC-10
+  sind generisch formuliert („ein Abweichungsalarm"), gelten aber nur für den Trip-Pfad —
+  diese Einschränkung war in der Spec vor der Umsetzung **nicht** benannt und wird hier
+  nachgetragen. Nachziehen des Ortsvergleichs = eigenes Ticket.
 - **`CorridorEvent` bleibt unangetastet.** Der Schwellen-Alarm-Zweig (`render.py:263`,
   `_sms_corridor_token`) wirft ebenfalls Minuten weg, ist aber keine der beiden
   Ereignisarten aus dem gemeldeten Vorfall. Außerhalb des Zuschnitts dieser Scheibe.

--- a/docs/specs/modules/fix_2020_alarm_blickrichtung.md
+++ b/docs/specs/modules/fix_2020_alarm_blickrichtung.md
@@ -1,0 +1,549 @@
+---
+entity_id: fix_2020_alarm_blickrichtung
+type: module
+created: 2026-08-21
+updated: 2026-08-21
+status: draft
+version: "1.0"
+tags: [alert, deviation-alert, blickrichtung, restmenge, zeitangaben, issue-2020, scheibe-2]
+---
+
+# Abweichungsalarm: Die Meldung schaut nach vorn, nicht zurück (Scheibe 2, Umschnitt)
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Der Abweichungsalarm vom 2026-08-20, 18:15 Ortszeit, meldete „Niederschlag 7,4 → 29,4 mm,
+Beginn 19:00 → 15:00" — zu diesem Zeitpunkt war der überwiegende Teil der Menge bereits
+gefallen. Die Meldung bestand ausschließlich aus Vergangenheit. Der PO hat die dafür
+vorbereitete Wortlaut-Spec (`fix_2020_alarm_zeitangaben.md`, 7 ACs) zurückgewiesen: „ich
+verstehe immer noch nicht, was mir das sagen soll — und was hilft es mir, wenn ich um
+18:15 diese Information bekomme?" **Diese Spec löst jene Spec ab.**
+
+**Widerrufen:** Die dortige Festlegung „der Fehler ist die Formulierung, nicht die
+Zustellung" (Nicht-Ziel „Vergangenheitsfilter") gilt **nicht mehr in dieser Form**. Ein
+Vergangenheitsfilter bleibt zwar weiterhin ausgeschlossen — aber nicht mehr, weil die
+Formulierung angeblich der einzige Fehler wäre, sondern weil der PO ausdrücklich
+entschieden hat, dass eine deutlich höhere Regenmenge als angekündigt die Lage **auch
+rückblickend** ändert (nasse Ausrüstung, Wegzustand, Bäche) und deshalb **immer**
+zugestellt werden soll (siehe „Nicht-Ziele").
+
+Diese Spec macht den Abweichungsalarm **vorwärtsgewandt**: seine Hauptaussage ist die
+Regenmenge, die ab dem Versandzeitpunkt noch kommt, und bis wann sie fällt. Das bereits
+Gefallene bleibt als Einordnung erhalten, ist aber nicht mehr die Botschaft. Zusätzlich
+(unverändert aus Scheibe 2 alt übernommen, sonst stünde wieder eine nackte Uhrzeit da):
+jede Zeitangabe benennt ihre Größe, trägt einen Tagesbezug, wenn der Tag vom Versandtag
+abweicht, und wird als vergangen ausgewiesen, wenn sie vergangen ist. **Scheibe 1**
+(Auslösung/Mengen-Überholung) ist bereits in Produktion (`b423c913`). Diese Scheibe ändert
+**keine** Auslösung, nur Inhalt und Blickrichtung der bereits ausgelösten Meldung.
+
+**🔴 Korrektur 2026-08-21 (nach erster Fassung dieser Spec):** Restmenge und Ende beziehen
+sich zwingend auf das **Tagesfenster des Trips** (konfigurierbar, Default 4–19 Uhr,
+`day_window.py`), nicht auf den Kalendertag — aus demselben Grund, aus dem das Briefing es
+schon so macht (siehe „Implementation Details"). Ein realer Regenfall außerhalb dieses
+Fensters bleibt für den Alarm unsichtbar, damit Alarm und Briefing niemals mit
+verschiedenen Fenstern rechnen. Die ursprüngliche erste Fassung dieser Spec hatte fälschlich
+mit einer Kalendertag-Reihe gerechnet (inkl. einer 22-Uhr-Regenstunde, die je nach
+Trip-Konfiguration außerhalb des Fensters liegen kann) — die Acceptance Criteria unten sind
+entsprechend korrigiert und verwenden ausschließlich konstruierte Beispielreihen mit
+ausdrücklich genanntem Tagesfenster, nicht die tatsächliche, unbekannte Konfiguration des
+PO-Trips.
+
+## Source
+
+- **File:** `src/output/renderers/alert/project.py`, `src/output/renderers/alert/render.py`,
+  `src/output/renderers/alert/model.py`, `src/services/weather_change_detection.py`,
+  `src/app/models.py`
+- **Identifier:** `to_alert_message()`, `_datablock_single()`, `_onset_shift_line()`,
+  `_onset_time_label()`, `_sms_token()`, `_sms_onset_shift_token()`,
+  `WeatherChangeDetectionService.detect_changes()`, `_peak_occurred_at()`, `AlertEvent`,
+  `OnsetShiftEvent`, `WeatherChange`
+
+## Estimated Scope
+
+- **LoC:** ~160 Produktivcode (+180/-30), ~250 Test (das Doppelte der abgelösten Spec —
+  zusätzlich zum Tagesbezug-Zuschnitt kommt die Restmengen-/Ende-Berechnung samt
+  Vier-Kanal-Formatierung und die Fenstergrenzen-Absicherung)
+- **Files:** 7 MODIFY, 1-2 CREATE
+- **Effort:** high
+
+### Affected Files
+
+| Datei | Change Type | Description |
+|---|---|---|
+| `src/app/models.py` | MODIFY | additive Felder `remaining_mm: float \| None`, `precip_ends_at: datetime \| None` an `WeatherChange` (Muster `occurred_at`, Issue #1386) |
+| `src/services/weather_change_detection.py` | MODIFY | neue Hilfsfunktion `_precip_remaining(new_data, now_utc)` (Vorbild `_peak_occurred_at()`, `:301-373`, **dasselbe** Segmentfenster wie dort — `seg_start`/`seg_end`), Aufruf am bestehenden Konstruktionsort von `WeatherChange` für `metric == "precip_sum_mm"` (`:783`) |
+| `src/output/renderers/alert/model.py` | MODIFY | additive Felder an `AlertEvent` (`occurred_day_offset`, `occurred_is_past`, `remaining_mm`, `remaining_until_time`, `remaining_until_day_offset`) und `OnsetShiftEvent` (`to_day_offset`, `to_is_past`), alle mit Default, am Ende des Feldblocks |
+| `src/output/renderers/alert/project.py` | MODIFY | Projektion rechnet Tagesversatz/Vergangenheit je Zeitangabe (`day_offset(now_utc, ...)`) und formatiert Restmenge + Ende aus den neuen `WeatherChange`-Feldern; `_fmt_occurred_at`/`_fmt_onset_at` bleiben in ihrer Form |
+| `src/output/renderers/alert/render.py` | MODIFY | Langform (E-Mail/Telegram): Kopf „mehr Regen als angekündigt" + Restmengen-/Ende-Zeilen für Niederschlags-Summen-Ereignisse, `gestern HH:MM`/`vor N Tagen HH:MM`/`morgen HH:MM`/`seit HH:MM` für alle anderen Zeitangaben; Kurzform (SMS/Premium-SMS): Restmengen-Token `Rest{mm}@{HH}`, Wochentagskürzel für Tagesbezug (`R7@Do15`); Bedeutungswort „stärkste Stunde" für Nicht-Niederschlags-Δ-Ereignisse; `_onset_time_label` auf exakten Versatz gehärtet. **NICHT** anfassen: `_render_sms_onset`, `to_multi_location_onset_alert_message`, `_sms_onset_time` (Fläche der #2046-Session, siehe „Zur Entscheidung mit der Freigabe") |
+| `src/services/notification_service.py` | MODIFY | reicht die bereits vorhandene `now_utc` (`:662`) durch |
+| `src/services/validator_render_service.py` | MODIFY | zweiter Aufrufer, reicht dieselbe Referenzzeit durch |
+| `tests/tdd/test_alert_restmenge_und_ende.py` (oder analog benannt) | CREATE | RED-Nachweis: Restmenge/Ende innerhalb des Tagesfensters, Fenstergrenzen-Absicherung, Gegenfall früh am Tag, ehrliches „nichts mehr", Tagesbezug, alle vier Kanäle |
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `src/services/segment_weather.py` → `_aggregate_for_segment()` (`:237-320`) | Invariante-Beleg | Beleg dafür, dass Alarm-Pfad und Briefing-Pfad **dasselbe** Segmentfenster verwenden (Kommentar `:292-308`: „sonst nennt der Alarm eine andere Stunde als das Briefing") — Restmenge/Ende dürfen dieses Fenster nicht umgehen |
+| `src/app/day_window.py` → `resolve_configured_window()` (`:24-54`) | reuse | EINE Quelle für die effektiven Fenster-Grenzen (Default 4–19, `start > end` gültig über Mitternacht, ADR-0035) |
+| `src/app/day_window.py` → `window_end_utc_exclusive()` (`:57-84`) | Muster (kein Code-Reuse, andere Aufrufsituation) | Beleg für die INKLUSIVE Bedeutung von `end_hour`: die Endstunde zählt VOLL mit, das Fenster endet damit technisch erst um `(end_hour+1):00` Ortszeit — bindend für die Berechnung des „Ende"-Zeitpunkts dieser Scheibe |
+| `src/services/radar_service.py` → `window_precip_mm`-Berechnung (`:745-754`) | Muster (kein Code-Reuse) | Vorwärtsfenster-Summe Rate×Dauer über Frame-Paare — dieselbe Idee, andere Datenform (`RadarFrame` vs. `ForecastDataPoint` mit fertigem `precip_1h_mm`-Stundenwert, daher keine Interpolation über Frame-Nachbarn nötig) |
+| `src/services/weather_metrics.py` → `WeatherMetricsService._onset_of()` (`:629-658`) | Muster (kein Code-Reuse, andere Klasse/anderer Datenfluss) | `min(treffer)` für den Beginn, gefiltert auf das Tagesfenster (`hour_in_window`) — das Ende dieser Scheibe ist das symmetrische `max(treffer)`, ebenfalls fenstergebunden |
+| `src/utils/timezone.py` → `day_offset()` | reuse | Kalendertage zwischen jetzt und Zielzeitpunkt in Ortszeit (aus #2009) |
+| `src/utils/timezone.py` → `format_reference_at()` | reuse | liefert bereits die Hausnotation `gestern HH:MM Uhr`/`vor N Tagen HH:MM Uhr` für die Fußzeile — dieselbe Wortwahl gilt jetzt auch für die Ereignis-Zeitangaben selbst |
+| `src/utils/timezone.py` → `local_fmt()` | reuse | `HH:MM` in Ortszeit — unverändert |
+| `src/output/renderers/alert/official_alerts.py` → `_de_weekday_short()` (`:802`) | reuse | liefert das Wochentagskürzel für die Kurzform — **nicht** nachbauen |
+| `src/services/notification_service.py:662` | caller | berechnet `datetime.now(timezone.utc)` bereits, reicht es künftig durch |
+| `src/services/validator_render_service.py:144` | caller | zweiter Aufrufer der Projektion, reicht dieselbe Referenzzeit durch |
+
+## Implementation Details
+
+**Arbeitsteilung wie in #2009: Der Erkennungsdienst rechnet aus der Rohreihe, die
+Projektion formatiert in Ortszeit, der Renderer setzt die Worte.**
+
+```
+weather_change_detection.py:783   WeatherChange(..., occurred_at=_peak_occurred_at(...),
+                                                  remaining_mm=_precip_remaining(new_data, now_utc)[0],
+                                                  precip_ends_at=_precip_remaining(new_data, now_utc)[1])
+        │   NUR wenn metric == "precip_sum_mm" (Katalog-Summary-Field, dp_field
+        │   "precip_1h_mm", Issue-Beleg: metric_catalog.py:378-385) — andere
+        │   Metriken lassen beide Felder auf None (Δ-Pfad bleibt unveraendert).
+        ▼
+to_alert_message(..., now_utc=now_utc)          project.py
+        │   je Zeitangabe: day_offset()/is_past wie in Scheibe 2 alt
+        │   zusaetzlich: remaining_mm, remaining_until (HH:MM Ortszeit oder
+        │   None = "kein weiterer Regen"), bereits_gefallen = new_value - remaining_mm
+        ▼
+AlertEvent.remaining_mm, .remaining_until_time, .remaining_until_day_offset  (NEU)
+AlertEvent.occurred_day_offset, .occurred_is_past                            (NEU)
+OnsetShiftEvent.to_day_offset, .to_is_past                                   (NEU)
+        │
+        ▼
+render.py    setzt die Worte — E-Mail (HTML + Klartext), Telegram, SMS, Premium-SMS
+```
+
+### 🔴 Bindende Invariante: Restmenge und Ende rechnen im TAGESFENSTER des Trips, nicht über den Kalendertag
+
+`_aggregate_for_segment()` (`segment_weather.py:237-320`) schneidet die Stundenreihe für
+JEDEN Alarm- und Briefing-Aufruf auf dasselbe Segmentfenster (`segment.start_time`/
+`.end_time`), dessen Grenzen aus `resolve_configured_window()` (`day_window.py:24-54`,
+ADR-0035, Default **4–19 Uhr**, konfigurierbar, `start > end` gültig über Mitternacht)
+stammen. Der Code-Kommentar dort begründet es ausdrücklich (`:292-308`): sonst nennt der
+Alarm eine andere Stunde als das Briefing, und beide Vergleichsseiten könnten mit
+verschiedenen Fenstern rechnen. `_peak_occurred_at()` (die bestehende „stärkste
+Stunde"-Berechnung, `weather_change_detection.py:301-373`) folgt genau diesem Fenster
+(`seg_start <= _as_utc(p.ts) <= seg_end`, `:336-343`) — **`_precip_remaining()` verwendet
+dasselbe Fenster**, nicht ein zweites, separat aufgelöstes.
+
+Wichtig für die Grenze selbst: `end_hour` zählt gemäß `window_end_utc_exclusive()`
+(`day_window.py:57-84`, PO-Entscheidung 2026-08-17, ADR-0035) **vollständig mit** — das
+Fenster endet technisch erst um `(end_hour+1):00` Ortszeit. Bei einem Tagesfenster 4–19
+Uhr endet das Fenster also effektiv um **20:00 Ortszeit**, nicht um 19:00. Diese Scheibe
+rechnet grundsätzlich relativ zum konfigurierten Fenster; feste Uhrzeiten in den ACs unten
+sind Beispielwerte zu einem jeweils **ausdrücklich genannten** Fenster, keine Annahme über
+die tatsächliche Konfiguration eines bestimmten Trips (die ist nicht gesichert und kann
+sich jederzeit ändern).
+
+**`_precip_remaining(new_data, now_utc) -> tuple[float, datetime | None]`**
+(neu, `weather_change_detection.py`, Geschwisterfunktion von `_peak_occurred_at`, gleicher
+Zugriff auf `new_data.timeseries.data` und dasselbe `seg_start`/`seg_end`-Fenster):
+
+1. **Restmenge** = Summe aller `precip_1h_mm`-Stundenwerte **innerhalb des Segmentfensters**,
+   deren Stunde nicht bereits vollständig vergangen ist. Regel für die angebrochene Stunde:
+   *die Stunde, in der `now_utc` liegt, zählt VOLL zur Restmenge* (nicht anteilig).
+   Begründung: `precip_1h_mm` ist ein Stundenwert ohne untertägige Rate — eine anteilige
+   Aufteilung würde eine Genauigkeit vortäuschen, die das Modell nicht hergibt. Die volle
+   Zählung ist die **konservative** Richtung (nicht zu wenig warnen).
+2. **Ende** = letzte Stunde **im gesamten Segmentfenster** (nicht nur der laufenden
+   Regenphase) mit `precip_1h_mm >= 0,1 mm` (Mess-Schwelle, keine Alarm-Schwelle — es geht
+   um „hat es noch geregnet", nicht „war es Alarm-relevant"). Begründung für „gesamtes
+   Fenster" statt „laufende Phase": zwei getrennte Regenphasen im selben Fenster (Pause
+   dazwischen) sind ein realer Fall (siehe AC-5). Eine Meldung, die beim ersten Regenende
+   „nichts mehr" sagt, wäre falsch, sobald die zweite Phase im Fenster liegt.
+3. Regen **außerhalb** des Segmentfensters (vor Fensterbeginn oder nach dem effektiven
+   Fensterende) fließt **nicht** in Restmenge oder Ende ein (AC-6) — exakt das, was das
+   Briefing für denselben Zeitraum ebenfalls nicht sieht.
+4. Kein Treffer im restlichen Fenster → `remaining_mm == 0.0` und `precip_ends_at is None`
+   → „kein weiterer Regen [bis Tagesende]" (AC-3).
+
+**Projektion (`project.py`):** `bereits_gefallen = ch.new_value - remaining_mm` — bewusst
+**keine** zweite unabhängige Summierung der bereits vergangenen Stunden, um ein
+Auseinanderdriften zweier separat berechneter Teilsummen auszuschließen (`new_value` ist
+bereits die Fenster-Gesamtsumme aus dem frischen Forecast, da `SegmentWeatherSummary`
+ebenfalls aus der fenstergefilterten Reihe aggregiert wird, `_aggregate_for_segment()`).
+
+**Wortlaut Langform (E-Mail + Telegram), Beispiel mit ausdrücklich genanntem Tagesfenster
+4–19 Uhr (effektives Fensterende 20:00 Ortszeit), konstruierte Stundenreihe angelehnt an
+den realen Fall (13:00=8 · 15:00=10 · 16:00=3 · 17:00=1 mm, angekündigt waren 5 mm),
+Referenzzeit 14:30 Ortszeit — siehe AC-1 für die vollständige Herleitung:**
+
+```
+🏁 Ziel · mehr Regen als angekündigt
+Bis jetzt: ~8 mm gefallen (angekündigt waren 5)
+Ab jetzt: noch ~14 mm, letzter Regen gegen 17:00
+```
+
+Bei `remaining_mm == 0.0` (dieselbe Reihe, Referenzzeit NACH der letzten Regenstunde, aber
+VOR dem effektiven Fensterende — der beanstandete Originalfall, siehe AC-3):
+
+```
+🏁 Ziel · mehr Regen als angekündigt
+Bis jetzt: ~22 mm gefallen (angekündigt waren 5)
+Ab jetzt: kein weiterer Regen bis Tagesende (Fensterende 20:00 Ortszeit)
+```
+
+**Diese Restmengen-/Ende-Zeilen ersetzen den bisherigen Kopf „stärkste Stunde HH:MM" NUR
+für Niederschlags-Summen-Ereignisse** (`e.remaining_mm is not None`). Für alle anderen
+Δ-Metriken (Wind, Temperatur, …) bleibt der Kopf aus Teil 3 („stärkste Stunde") die
+richtige Formulierung — eine „Restmenge" ergibt für Wind/Temperatur keinen Sinn.
+
+**Wortlaut Kurzform (SMS + Premium-SMS):** neuer Kompakt-Token neben dem bestehenden
+Δ-Token aus `_sms_token()` (`render.py:957-995`, unverändert `{code}{von}->{bis}@{HH}`):
+`Rest{round(remaining_mm)}@{Tagesbezug}{HH}` — Tagesbezug nach derselben
+Wochentagskürzel-Regel wie Teil 3 (leer am Versandtag). Beispiel (dieselbe Reihe wie oben,
+Referenzzeit 14:30): `Ziel: R5->22@15 Rest14@17`. Bei „kein weiterer Regen": `Rest0` ohne
+Zeit-Suffix.
+
+### Teil 3 — Zeitangaben benennen ihre Größe und ihren Tagesbezug (aus Scheibe 2 alt übernommen)
+
+**Wortlaut — Langform, Bestandsnotation aus `format_reference_at`:**
+
+| Lage | Zeile „Wo & wann" (Nicht-Niederschlags-Metrik) |
+|---|---|
+| Zeitpunkt liegt heute noch bevor | `🏁 Ziel · stärkste Stunde 17:00` |
+| Zeitpunkt ist heute schon vorbei | `🏁 Ziel · stärkste Stunde war 17:00` |
+| Zeitpunkt liegt einen Tag zurück | `🏁 Ziel · stärkste Stunde war gestern 17:00` |
+| Zeitpunkt liegt ≥2 Tage zurück | `🏁 Ziel · stärkste Stunde war vor 2 Tagen 17:00` |
+| Zeitpunkt liegt einen Tag voraus | `🏁 Ziel · stärkste Stunde morgen 17:00` |
+
+Das ist **keine Neuerfindung**: `format_reference_at` (`src/utils/timezone.py:154-169`)
+erzeugt `gestern HH:MM Uhr`/`vor N Tagen HH:MM Uhr` bereits heute für die Fußzeile
+(„Stand: heute 18:15 · verglichen mit gestern 18:03 Uhr", `render.py:948-951`). Diese
+Scheibe wendet dieselbe Hausnotation auf die Ereignis-Zeitangaben selbst an.
+
+**Wortlaut Kurzform Tagesbezug (SMS + Premium-SMS), Bestandsnotation der amtlichen
+Warnung:** Das Wochentagskürzel klebt vor die Stunde, `_de_weekday_short()`
+(`official_alerts.py:802`, Muster `Do12-22`/`Fr22-Sa03`). Aus dem Δ-Token `R7@15`
+(vereinfachtes Beispiel) wird bei Versatz `-1` an einem Donnerstag `R7@Do15`. Am
+**heutigen** Tag entfällt das Kürzel ersatzlos (dieselbe Regel wie #1948 S5,
+`official_alerts.py:1929-1943`).
+
+**Verworfen: ein Zahlensuffix (`17:00-1`).** Drei belegte Gründe:
+1. `-` ist in der Kurzform bereits dreifach belegt — Wert gefallen (`-R7`), Bereichstrenner
+   (`12-22`), km-Spanne (`km8-8`, `render.py:1006`).
+2. Die Fensterform der amtlichen Warnung ist formgleich: `_tag_hour()`
+   (`official_alerts.py:1896-1902`) setzt Minuten, sobald sie nicht auf `:00` liegen — ein
+   Gültigkeitsfenster lautet dann `15:20-17`, neben `17:00-1` nicht mehr per Form
+   unterscheidbar.
+3. `_sms_onset_time()` hängt das Vorzeichen fest an (`f"{base}+{day_offset}"`,
+   `render.py:550`) — mit `day_offset = -1` entstünde `17:00+-1`. Diese Funktion bleibt in
+   dieser Scheibe unangetastet.
+
+**Ein gemeinsamer Baustein für das Tageswort der Langform — nicht zwei.** Heute löst
+`_onset_time_label()` (`render.py:367-374`) den Tagesversatz nur über **Wahrheitswert**
+auf: `f"morgen {e.onset_time}" if e.onset_day_offset else e.onset_time` — jeder Versatz
+ungleich null wird zu „morgen", auch `-1`. Im Nowcast-Pfad unerreichbar (Vorwärtsfenster),
+im Abweichungsalarm der Normalfall. Deshalb: eine typunabhängige Hilfsfunktion
+`(hhmm: str, day_offset: int, is_past: bool) -> str` löst den **exakten** Versatz auf
+(`-1 → gestern`, `-N → vor N Tagen`, `0 & vergangen → seit … (kein Tageswort)`,
+`0 & bevorstehend → kein Wort`, `1 → morgen`). `_onset_time_label()` wird auf sie
+umgestellt.
+
+**Nachbarschaft in Bewegung:** `render.py` wird parallel von **#2036**
+(`fix-2036-alarm-kilometer`, additives `km_measured: bool = False`, `km{A}-{B}` →
+`km {A}-{B}`) angefasst. Vor dem Schreiben rebasen.
+
+## Expected Behavior
+
+- **Input:** `changes` (WeatherChange-Liste, jetzt additiv mit `remaining_mm`/
+  `precip_ends_at` bei Niederschlags-Summen-Metriken, beide ausschließlich aus der
+  Stundenreihe **innerhalb des Segment-Tagesfensters** berechnet), `tz` (Ortszeit des
+  Segment-Startpunkts), `now_utc` (Referenzzeit des Versands)
+- **Output:** Alarm-Nachricht in vier Kanälen. Niederschlags-Summen-Ereignisse nennen
+  primär die Restmenge ab Versand und deren Ende — beide fenstertreu, nie über das
+  konfigurierte Tagesfenster hinaus; alle Ereignisse benennen ihre Größe, tragen ihren
+  Tagesbezug und weisen ihre Vergangenheit aus.
+- **Side effects:** Keine.
+
+## Acceptance Criteria
+
+- **AC-1:** Given ein Tagesfenster 4–19 Uhr (effektives Fensterende 20:00 Ortszeit, `end_hour`
+  zählt gemäß `window_end_utc_exclusive()` voll mit) und eine Stundenreihe innerhalb dieses
+  Fensters (13:00=8 mm · 15:00=10 mm · 16:00=3 mm · 17:00=1 mm, angekündigt waren 5 mm) /
+  When die Nachricht bei Referenzzeit 14:30 Ortszeit gerendert wird (nach der 13:00-Stunde,
+  vor der 15:00-Stunde) / Then lautet die Hauptaussage vorwärtsgewandt: Kopf
+  `🏁 Ziel · mehr Regen als angekündigt`, `Bis jetzt: ~8 mm gefallen (angekündigt waren 5)`,
+  `Ab jetzt: noch ~14 mm, letzter Regen gegen 17:00`.
+  - Test: Rendering mit dieser konstruierten Stundenreihe und Referenzzeit 14:30 prüft
+    exakt diese drei Zeilen im Klartext (E-Mail/Telegram). Die Reihe bewusst OHNE eine
+    Stunde außerhalb des Fensters (keine Kalendertag-Annahme).
+
+- **AC-2:** Given dieselbe Stundenreihe und dasselbe Tagesfenster wie AC-1 / When die
+  Nachricht mit einer frühen Referenzzeit 10:00 Ortszeit gerendert wird, bevor irgendeine
+  Stunde der Reihe begonnen hat / Then ist die Restmenge nahe der Fenster-Gesamtmenge
+  (`Ab jetzt: noch ~22 mm, letzter Regen gegen 17:00`) und
+  das bereits Gefallene nahe null (`Bis jetzt: ~0 mm gefallen (angekündigt waren 5)`) — die
+  Endzeit (17:00) bleibt gegenüber AC-1 unverändert, weil sie eine Eigenschaft der Reihe
+  ist, nicht der Referenzzeit.
+  - Test: Dieselbe Stundenreihe, Referenzzeit 10:00 statt 14:30; Restmenge und
+    Bereits-Gefallen-Wert verhalten sich gegenläufig zu AC-1 (Restmenge deutlich höher,
+    Bereits-Gefallen deutlich niedriger), keine Formel darf einen negativen oder über der
+    Fenster-Gesamtmenge liegenden Wert liefern.
+
+- **AC-3:** Given dieselbe Stundenreihe und dasselbe Tagesfenster wie AC-1 (letzte
+  Regenstunde 17:00) / When die Nachricht mit Referenzzeit 18:15 Ortszeit gerendert wird —
+  NACH der letzten Regenstunde, aber VOR dem effektiven Fensterende 20:00 (der beanstandete
+  Originalfall, ehemals „Beginn 19:00 → 15:00") / Then meldet sie ehrlich
+  `Ab jetzt: kein weiterer Regen bis Tagesende (Fensterende 20:00 Ortszeit)` statt eine
+  Restmenge zu erfinden oder eine bereits verstrichene Uhrzeit als bevorstehend zu
+  formulieren — UND wird trotzdem zugestellt (PO-Entscheid, keine Unterdrückung), weil
+  bereits mehr gefallen ist als angekündigt.
+  - Test: Rendering mit Referenzzeit 18:15 gegen dieselbe Reihe liefert eine nicht-leere
+    Nachricht mit dem exakten Satz (kein `None`/leerer String) UND `Bis jetzt: ~22 mm
+    gefallen (angekündigt waren 5)`.
+
+- **AC-4:** Given eine Referenzzeit, die mitten in einer angebrochenen Regenstunde
+  innerhalb des Tagesfensters liegt (z. B. 14:20 Ortszeit bei einem Stundenwert von 2,0 mm
+  um 14:00) / When die Restmenge berechnet wird / Then zählt diese angebrochene Stunde
+  VOLL zur Restmenge (nicht anteilig nach verstrichenen Minuten) — dieselbe Stundenreihe
+  ergibt bei Referenzzeit 14:00 exakt denselben Restmengen-Wert wie bei 14:20.
+  - Test: Restmengen-Berechnung mit Referenzzeit 14:00 und 14:20 gegen dieselbe
+    Stundenreihe vergleichen — beide Werte müssen identisch sein (Grenzstabilität der
+    Regel); eine Implementierung, die anteilig kürzt, muss diesen Test brechen.
+
+- **AC-5:** Given ein Tagesfenster 4–19 Uhr und eine Stundenreihe mit zwei getrennten
+  Regenphasen, die BEIDE innerhalb dieses Fensters liegen (6:00=1 mm · 7:00=1 mm, Pause,
+  dann 16:00=1 mm · 17:00=1 mm) / When das Ereignis-Ende bei Referenzzeit 10:00 Ortszeit
+  (zwischen den beiden Phasen) berechnet wird / Then ist das Ende die letzte Regenstunde
+  des GESAMTEN Fensters (17:00), NICHT das Ende der ersten Phase (7:00).
+  - Test: Rendering bei Referenzzeit 10:00 prüft, dass `letzter Regen gegen 17:00` steht —
+    eine Implementierung, die nur die laufende bzw. bereits abgeschlossene erste Phase
+    betrachtet, würde `7:00` oder gar keine Endzeit liefern und muss diesen Test brechen.
+    Der reale Fall vom 2026-08-20 (zwei Phasen mit Pause) bleibt als Beleg im Fließtext,
+    ist aber NICHT der Testfall — seine tatsächliche Fensterkonfiguration ist nicht
+    gesichert.
+
+- **AC-6:** Given dieselbe Stundenreihe wie AC-1, ergänzt um eine zusätzliche Regenstunde
+  AUSSERHALB des Tagesfensters 4–19 (z. B. 21:00=5 mm, außerhalb des effektiven
+  Fensterendes 20:00) / When Restmenge und Ende bei Referenzzeit 10:00 berechnet werden /
+  Then bleiben beide Werte GENAU wie in AC-2 (Restmenge ~22 mm, Ende 17:00) — die
+  21:00-Stunde fließt nicht ein. Wird dieselbe erweiterte Reihe stattdessen mit einem
+  WEITEREN Tagesfenster (z. B. 4–22, effektives Ende 23:00) gerendert, ändern sich beide
+  Werte fenstertreu (Restmenge ~27 mm, Ende 21:00).
+  - Test: Zwei Renderings derselben um 21:00=5 mm erweiterten Reihe — einmal mit Fenster
+    4–19 (muss mit AC-2 identisch bleiben), einmal mit Fenster 4–22 (muss die 21:00-Stunde
+    einschließen). Eine Implementierung, die das Fenster ignoriert oder global über die
+    Reihe summiert, muss mindestens einen der beiden Fälle brechen.
+
+- **AC-7:** Given denselben Abweichungsalarm mit Restmenge und Ende (Reihe/Fenster/
+  Referenzzeit wie AC-1) / When er in alle vier Kanäle gerendert wird (E-Mail HTML,
+  E-Mail Klartext, Telegram, SMS, Premium-SMS) / Then tragen E-Mail und Telegram die
+  vollständigen Sätze aus AC-1, SMS und Premium-SMS tragen denselben Sachverhalt als
+  Kompakt-Token (`Ziel: R5->22@15 Rest14@17`), und die 160-Zeichen-Grenze der
+  Kurznachricht bleibt eingehalten.
+  - Test: Rendering je Kanal prüfen (SMS und Premium-SMS über denselben
+    `_render_sms_body`-Pfad, der laut Bestand denselben Text an beide liefert); für die
+    Kurznachricht zusätzlich Zeichenlängenprüfung ≤160.
+
+- **AC-8:** Given ein Abweichungsalarm, dessen Niederschlagsbeginn zum Versandzeitpunkt
+  bereits verstrichen ist, aber am selben Kalendertag liegt (Beginn 15:00 Ortszeit,
+  Versand 15:30 Ortszeit) / When die Alarm-Nachricht gerendert wird / Then weist die
+  Beginn-Zeile den Zeitpunkt als vergangen aus (`19:00 → seit 15:00 (4 h früher)`) und
+  formuliert ihn nicht als bevorstehend.
+  - Test: Nachricht mit vergangener Onset-Zeit rendern und prüfen, dass der Klartext die
+    Vergangenheitsform trägt; Gegenprobe mit künftiger Onset-Zeit, die sie nicht trägt.
+
+- **AC-9:** Given ein Abweichungsalarm, dessen Zeitpunkt auf einem anderen Kalendertag
+  als dem Versandtag liegt / When die Nachricht in E-Mail oder Telegram gerendert wird /
+  Then nennt die Zeitangabe den Tag beim Namen, in der Hausnotation aus
+  `format_reference_at` — `-1` ergibt `gestern 15:00`, `-2` ergibt `vor 2 Tagen 15:00`,
+  `+1` ergibt `morgen 15:00`.
+  - Test: Je ein Rendering mit Versatz `-1`, `-2` und `+1` gegen dieselbe Uhrzeit; der
+    `-1`- und `-2`-Fall dürfen unter keinen Umständen „morgen" ergeben (Regression zur
+    Wahrheitswert-Prüfung in `render.py:374`). Dieselbe Gegenprobe gilt für den
+    Nowcast-Pfad, der auf denselben Baustein umgestellt wird.
+
+- **AC-10:** Given denselben Fall wie AC-9, aber gerendert in SMS oder Premium-SMS /
+  When die Kurznachricht gebaut wird / Then klebt das Wochentagskürzel vor die Stunde des
+  Kurzform-Tokens — aus `R7@15` wird bei einem Donnerstag und Versatz `-1` `R7@Do15`;
+  kein Kanal fällt auf ein Zahlensuffix zurück.
+  - Test: Rendering mit Versatz `-1` an einem festgelegten Wochentag prüft exakt
+    `R7@Do15` (bzw. das analoge Token für den tatsächlichen Renderer-Aufbau) im
+    SMS-Text, nicht `R7@15-1` oder `R7@15+-1`.
+
+- **AC-11:** Given ein Abweichungsalarm mit einer Wertänderung EINER Nicht-Niederschlags-
+  Metrik (z. B. Windböe), deren Spitzenwert zu einer bestimmten Stunde auftritt / When die
+  Nachricht gerendert wird / Then benennt die Zeile „Wo & wann" die Uhrzeit ausdrücklich
+  als Zeitpunkt des stärksten Werts (`🏁 Ziel · stärkste Stunde 17:00`, bzw.
+  `stärkste Stunde war 17:00` bei einem vergangenen Zeitpunkt) — für diese Metrikart bleibt
+  die alte Kopfform bestehen, weil eine „Restmenge" für Wind/Temperatur keine sinnvolle
+  Größe ist.
+  - Test: Gerenderte Zeile einer Windböen-Änderung enthält die Kennzeichnung der Größe
+    zusätzlich zum Ort und zur Uhrzeit; Gegenprobe, dass eine reine Beginn-Zeile
+    (`-Beginn`) weiterhin ohne dieses Wort auskommt.
+
+- **AC-12:** Given ein Abweichungsalarm, der gleichzeitig eine Wertänderung UND eine
+  Beginn-Verschiebung trägt (der Fall aus #2020, bisher von keinem Test abgedeckt) / When
+  die Nachricht gerendert wird / Then stehen beide Zeitangaben mit unterscheidbarer
+  Bedeutung in derselben Nachricht, sodass eine Restmengen-/Spitzen-Aussage neben einem
+  Beginn um 15:00 nicht als Widerspruch lesbar ist.
+  - Test: Eine `AlertMessage` mit befülltem `events` UND `onset_shift_events` rendern und
+    prüfen, dass beide Zeilen ihre Größe benennen.
+
+- **AC-13:** Given ein Testlauf zu einem beliebigen Systemdatum / When die Nachricht mit
+  einer explizit übergebenen Referenzzeit gerendert wird / Then hängt das Ergebnis
+  ausschließlich von dieser Referenzzeit ab und nicht von der Systemuhr.
+  - Test: Dasselbe Rendering zweimal mit unterschiedlicher Referenzzeit und identischen
+    Wetterdaten ergibt unterschiedliche Tagesbezüge UND unterschiedliche Restmengen; kein
+    Aufruf von `datetime.now()` im Renderpfad der Zeit-/Restmengen-Darstellung.
+    Zusätzlich: `test_onset_shift_alert.py` und `test_alert_event_time_uses_local_timezone.py`
+    (beide ohne `freeze_time`, feste Kalenderdaten) bleiben grün, weil sie die Referenzzeit
+    künftig explizit setzen.
+
+- **AC-14:** Given zwei Kurzform-Ausschnitte, die im selben Kanal nebeneinander
+  vorkommen können — die Tagesbezug-Form dieses Alarms (`R7@Do15`) und die Fensterform
+  der amtlichen Warnung (`Do12-22` bzw. `15:20-17` bei `_tag_hour`) / When ein
+  Wächter-Test beide aus dem echten Renderer-Code zieht und in einer Zeile
+  gegenüberstellt / Then macht eine spätere Änderung der Fensterform (z. B. Umstellung
+  auf `HH:MM-HH:MM`) diesen Test sofort rot, bevor die Verwechselbarkeit in Produktion
+  erneut auftritt.
+  - Test: Testfall ruft `_tag_hour`/`_de_weekday_short` und den neuen Tagesbezug-Baustein
+    mit denselben Beispielwerten auf und prüft strukturelle Unterscheidbarkeit (keine
+    Form, bei der beide Ausgaben identisch aussehen könnten); der Test bricht, wenn
+    jemand die Fensterform ohne Rücksicht auf diese Kollision ändert.
+
+## Zur Entscheidung mit der Freigabe
+
+Ein Punkt gehört zur Freigabe, ist aber kein Akzeptanzkriterium, weil diese Scheibe ihn
+nicht umsetzt:
+
+**Zieht der Radar-Onset-Kurzform-Zweig nach?** Er schreibt denselben Sachverhalt heute als
+Zahlensuffix (`17:00+1`, `_sms_onset_time`, `render.py:550`). Bleibt er so, trägt der
+Kurzkanal zwei Schreibweisen für „Uhrzeit an einem anderen Tag" nebeneinander.
+
+- **Empfehlung:** Wochentagskürzel für beide Zweige — dann gibt es genau eine Schreibweise.
+  Die Umstellung ist **nicht** Teil dieser Scheibe; sie wird ein Folgeticket der
+  #2046-Session, die diesen Zweig ohnehin gerade bearbeitet und die Anlage zugesagt hat.
+- **Alternative:** Onset bleibt bei `+1`. Dann gehört die Begründung in den
+  Freigabe-Kommentar, damit die Abweichung dokumentiert ist und nicht als Versehen
+  wiederkehrt.
+
+`_sms_onset_time` bleibt in dieser Scheibe in jedem Fall unangetastet.
+
+## Known Limitations
+
+- **Restmenge/Ende gelten nur für die Niederschlags-Summen-Metrik (`precip_sum_mm`).**
+  Andere Δ-Metriken (Wind, Temperatur, Gewitter) behalten den „stärkste Stunde"-Kopf aus
+  Teil 3 — eine Restmengen-Aussage ergibt für sie keinen Sinn. Eine künftige Metrik mit
+  ähnlicher Vorwärts-Semantik (z. B. Schneefall-Summe) bräuchte ein eigenes Ticket.
+- **Die angebrochene Stunde zählt komplett zur Restmenge** — eine bewusst vereinfachende,
+  konservative Annahme (kein untertägiger Rate-Wert im Bestand). Bei einer Metrik mit
+  tatsächlich stark ungleichmäßiger Verteilung innerhalb der Stunde kann die Restmenge
+  geringfügig überschätzt werden.
+- **🔴 Regen nach Fensterende (Nachtregen) erscheint weder in der Restmenge noch in der
+  Endzeit.** Restmenge und Ende sind strikt auf das konfigurierte Tagesfenster begrenzt
+  (Default effektiv 4–20 Uhr) — für jemanden, der abends im Zelt liegt, kann ein
+  Regenfall nach Fensterende trotzdem relevant sein, und diese Scheibe macht ihn nicht
+  sichtbar. Die Alternative — der Alarm rechnet über das Tagesfenster hinaus — würde Alarm
+  und Briefing auseinanderlaufen lassen (dieselbe Stunde hieße dann in beiden Meldungen
+  etwas anderes) und ist deshalb hier bewusst NICHT gewählt. Das bleibt ein offener Punkt
+  für den PO, ohne Ziel dieser Scheibe zu sein — bei Bedarf ein eigenes Ticket.
+- **„Stärkste Stunde" ist für maximum- und summenbasierte Nicht-Niederschlags-Größen
+  treffend** (Windböe, Gewitter). Für eine künftige Größe, deren Alarm auf einem Minimum
+  beruht, kann die Formulierung schief wirken — bewusst nicht Teil dieses Zuschnitts.
+- **Der Tagesbezug erscheint nicht am Versandtag.** Wer die Fußzeile „Stand: heute 18:15"
+  überliest, hat für Zeiten desselben Tages weiterhin keinen expliziten Tag. Bewusste
+  Abwägung gegen Textlärm; per PO-Entscheid umkehrbar.
+- **Kein Vier-Kanäle-Wächter für Zeit-/Restmengen-Label allgemein.** Es gibt keinen
+  automatischen Test, der bei künftigen Textänderungen alle vier Kanäle einfordert. AC-7
+  deckt den hier geänderten Fall ab, nicht die Gattung. → Eintrag für #1196.
+- **`CorridorEvent` bleibt unangetastet.** Der Schwellen-Alarm-Zweig (`render.py:263`,
+  `_sms_corridor_token`) wirft ebenfalls Minuten weg, ist aber keine der beiden
+  Ereignisarten aus dem gemeldeten Vorfall. Außerhalb des Zuschnitts dieser Scheibe.
+- **`_sms_onset_time` (Radar-Onset-Zahlensuffix) bleibt unangetastet** — Gegenstand des
+  Freigabe-Punkts oben, Umsetzung ggf. per Folgeticket der #2046-Session.
+
+## Nicht-Ziele (ausdrücklich ausgeschlossen)
+
+- **Wiederholung desselben Alarms und die stehende Vergleichsbasis.** Der Alarm ging am
+  2026-08-20 um 15:30 und um 18:15 mit bitgleichem Inhalt raus, weil die Vergleichsbasis
+  bewusst den ganzen Tag stehen bleibt (`trip_alert.py:412-413`, #1916). Das gehört zu
+  **#2018** und **#1987** — die #2018-Session hat die Belege.
+- **Früher warnen.** Untersucht und ausgeschlossen: Die Prüfung läuft alle 15 Minuten ohne
+  Ergebnis-Cache; Open-Meteo hat den Beginn nachträglich auf einen bereits verstrichenen
+  Zeitpunkt vorverlegt. Ein schnellerer Takt ändert daran nichts.
+- **Ein Filter, der vergangene Ereignisse unterdrückt — bleibt Nicht-Ziel, aber mit neuer
+  Begründung.** Die alte Begründung („der Fehler ist die Formulierung, nicht die
+  Zustellung") ist **widerrufen**. Die neue, PO-bestätigte Begründung: Eine Meldung, bei
+  der deutlich mehr Regen gefallen ist als angekündigt, bleibt relevant, auch wenn nichts
+  mehr kommt — nasse Ausrüstung, Wegzustand, Bäche ändern sich rückblickend. Ein Filter
+  würde genau diese Meldungen verschlucken. Deshalb: die Meldung wird IMMER zugestellt
+  (auch bei `remaining_mm == 0.0`), aber sie sagt jetzt ausdrücklich, dass nichts mehr
+  kommt, statt es zu verschweigen oder als bevorstehend zu formulieren.
+- **Über das Tagesfenster hinaus rechnen (Nachtregen sichtbar machen).** Bewusst
+  ausgeschlossen, weil es Alarm und Briefing mit unterschiedlichen Fenstern rechnen ließe
+  (siehe Known Limitations). Ein eigenes Ticket, falls der PO das will.
+- **Die Auslöseregel des Nowcasts ändern — bereits erledigt, gehört nicht zu dieser
+  Scheibe.** Scheibe 1 (#2020, Prod `b423c913`) hat die Briefing-Sperre bereits gehärtet:
+  sie bricht jetzt bei mengenmäßiger Überholung (`window_precip_mm >= 2 × _briefing_precip`
+  UND `>= 2,0 mm`). Diese Scheibe ändert **keine** Auslösung mehr — sie ändert
+  ausschließlich, **wie** die bereits ausgelöste Nachricht ihren Inhalt und ihre
+  Blickrichtung formuliert.
+- **`_sms_onset_time`, `_render_sms_onset`, `to_multi_location_onset_alert_message` bleiben
+  unangetastet** — Fläche der #2046-Session.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Die Spec führt keine neue Entscheidungsfläche ein. Sie zieht die in #2009
+  getroffene Entscheidung (Tagesbezug als additives Modellfeld, Rechnen in der Projektion
+  bzw. im Erkennungsdienst, Formulieren im Renderer) auf den zweiten Alarmpfad nach, und
+  überträgt für die Restmengen-/Ende-Berechnung ein bereits im Bestand etabliertes Muster
+  (Vorwärtsfenster-Summe, `radar_service.window_precip_mm`) auf eine andere Datenquelle
+  (Forecast-Stundenreihe statt Radar-Frames). Die Fensterbindung selbst ist keine neue
+  Entscheidung, sondern die bereits in ADR-0035/#1372 S1b getroffene Konvention
+  (Tagesfenster als gemeinsame Rechengrundlage von Alarm und Briefing), hier nur konsequent
+  auf die neue Berechnung angewandt.
+
+## Changelog
+
+- 2026-08-21: Initial spec created (Issue #2020, Scheibe 2 alt: `fix_2020_alarm_zeitangaben.md`)
+- 2026-08-21: **Umschnitt nach PO-Rückweisung der Wortlaut-Spec.** Neue Spec
+  `fix_2020_alarm_blickrichtung.md` löst `fix_2020_alarm_zeitangaben.md` ab. Kern der
+  Änderung: Die Meldung wird vorwärtsgewandt — Restmenge ab Versandzeitpunkt und deren
+  Ende (letzte Regenstunde des Tagesfensters) werden die Hauptaussage für
+  Niederschlags-Summen-Ereignisse; das bereits Gefallene bleibt als Einordnung erhalten.
+  Der Fall „kein weiterer Regen" wird ausdrücklich gemeldet, NICHT unterdrückt (PO-Entscheid:
+  eine deutlich höhere Regenmenge als angekündigt ändert die Lage auch rückblickend). Die
+  alte Begründung des Nicht-Ziels „Vergangenheitsfilter" („der Fehler ist die Formulierung,
+  nicht die Zustellung") wird widerrufen und durch die neue PO-Begründung ersetzt. Die
+  Zeitangaben-Kriterien aus Scheibe 2 alt (Tagesbezug, Vergangenheits-Ausweis, „stärkste
+  Stunde"-Marker, Wächter-Test gegen Formkollision) wandern unverändert in diese Spec.
+- 2026-08-21: **Sachfehler-Korrektur (Fenster statt Kalendertag).** Restmenge und Ende
+  rechnen zwingend im Tagesfenster des Trips (`segment_weather.py:285-320`,
+  `resolve_configured_window()`, ADR-0035), nicht über den Kalendertag — Beleg: die
+  Ziel-Segmentgrenzen entstehen aus demselben Fenster, das auch das Briefing verwendet,
+  ausdrücklich damit Alarm und Briefing nie mit verschiedenen Fenstern rechnen. Als
+  Invariante in „Implementation Details" ergänzt (inkl. `window_end_utc_exclusive()`-
+  Beleg: `end_hour` zählt voll, effektives Fensterende ist `(end_hour+1):00`). **AC-1**
+  komplett umgebaut: nutzt jetzt Referenzzeit 14:30 statt 18:15, damit tatsächlich eine
+  Restmenge entsteht (der ursprüngliche 18:15-Fall läge bei Standardfenster bereits am
+  Fensterende und ergäbe „nichts mehr"). Der 18:15-Fall (beanstandeter Originalfall)
+  bekommt dafür ein **eigenes, neues AC-3**: zeigt, dass die Meldung dort ehrlich
+  „kein weiterer Regen bis Tagesende" sagt statt eine Restmenge zu erfinden, und trotzdem
+  zugestellt wird. **AC-2** (frühe Referenzzeit) von der 22-Uhr-Endzeit befreit, nennt
+  jetzt die letzte Regenstunde innerhalb des Fensters. **AC-5** (zwei Regenphasen) neu
+  konstruiert mit beiden Phasen **innerhalb** desselben Fensters (6/7 Uhr und 16/17 Uhr,
+  Fenster 4–19) — der reale Fall vom 20.08. bleibt als Beleg im Fließtext, ist aber nicht
+  mehr der Testfall, weil seine tatsächliche Fensterkonfiguration nicht gesichert ist.
+  **Neues AC-6** (Fenstergrenzen-Absicherung): Regen nach Fensterende darf Restmenge/Ende
+  nicht beeinflussen, Gegenprobe mit einem weiteren Fenster liefert fenstertreu andere
+  Werte. Alle nachfolgenden ACs entsprechend verschoben (vier Kanäle jetzt AC-7,
+  Zeitangaben-Kriterien jetzt AC-8 bis AC-14). Neue Known Limitation zu Nachtregen
+  außerhalb des Fensters (offener PO-Punkt, kein Ziel dieser Scheibe) sowie ein
+  korrespondierendes Nicht-Ziel ergänzt. Insgesamt jetzt **14 ACs** (zuvor 13). Keine
+  konkrete Trip-Konfiguration mehr als Testgrundlage — alle Beispiele nennen ihr Fenster
+  ausdrücklich.

--- a/docs/specs/modules/fix_2020_alarm_blickrichtung.md
+++ b/docs/specs/modules/fix_2020_alarm_blickrichtung.md
@@ -3,7 +3,7 @@ entity_id: fix_2020_alarm_blickrichtung
 type: module
 created: 2026-08-21
 updated: 2026-08-21
-status: draft
+status: approved
 version: "1.0"
 tags: [alert, deviation-alert, blickrichtung, restmenge, zeitangaben, issue-2020, scheibe-2]
 ---
@@ -12,7 +12,7 @@ tags: [alert, deviation-alert, blickrichtung, restmenge, zeitangaben, issue-2020
 
 ## Approval
 
-- [ ] Approved
+- [x] Approved — PO-Freigabe 2026-08-21 („go")
 
 ## Purpose
 

--- a/docs/specs/modules/fix_2020_alarm_zeitangaben.md
+++ b/docs/specs/modules/fix_2020_alarm_zeitangaben.md
@@ -3,10 +3,16 @@ entity_id: fix_2020_alarm_zeitangaben
 type: module
 created: 2026-08-21
 updated: 2026-08-21
-status: draft
+status: superseded
 version: "1.0"
 tags: [alert, deviation-alert, zeitangaben, issue-2020, scheibe-2]
 ---
+
+> ⚠️ **ABGELÖST am 2026-08-21 durch `fix_2020_alarm_blickrichtung.md`.**
+> Diese Spec war nie freigegeben. Der PO hat den reinen Wortlaut-Zuschnitt zurückgewiesen:
+> eine verständlich formulierte Meldung, die ausschließlich Vergangenes erzählt, hilft
+> nicht. Die Nachfolge-Spec dreht die Blickrichtung (Restmenge ab jetzt + Ende) und
+> übernimmt die Zeitangaben-Kriterien dieser Spec als Teilaspekt.
 
 # Abweichungsalarm: Zeitangaben sagen, was sie meinen und wann sie liegen (Scheibe 2)
 

--- a/docs/specs/modules/fix_2020_alarm_zeitangaben.md
+++ b/docs/specs/modules/fix_2020_alarm_zeitangaben.md
@@ -5,10 +5,10 @@ created: 2026-08-21
 updated: 2026-08-21
 status: draft
 version: "1.0"
-tags: [alert, deviation-alert, zeitangaben, issue-2020]
+tags: [alert, deviation-alert, zeitangaben, issue-2020, scheibe-2]
 ---
 
-# Abweichungsalarm: Zeitangaben sagen, was sie meinen und wann sie liegen
+# Abweichungsalarm: Zeitangaben sagen, was sie meinen und wann sie liegen (Scheibe 2)
 
 ## Approval
 
@@ -21,6 +21,8 @@ jede meint und auf welchen Tag sie sich bezieht — und formuliert sie durchgän
 läge das Ereignis noch bevor. Diese Spec macht jede Zeitangabe im Abweichungsalarm
 selbsterklärend: sie benennt ihre Größe, trägt einen Tagesbezug, wenn der Tag vom
 Versandtag abweicht, und wird als vergangen ausgewiesen, wenn sie vergangen ist.
+**Scheibe 2** von #2020 — Scheibe 1 (Auslösung/Mengen-Überholung) ist bereits in
+Produktion (`b423c913`). Diese Scheibe ändert **keine** Auslösung, nur den Wortlaut.
 
 ## Source
 
@@ -33,17 +35,28 @@ Versandtag abweicht, und wird als vergangen ausgewiesen, wenn sie vergangen ist.
 
 - **LoC:** ~80 Produktivcode (+80/-25), ~150 Test
 - **Files:** 5 MODIFY, 1 CREATE
-- **Effort:** medium
+
+### Affected Files
+
+| Datei | Change Type | Description |
+|---|---|---|
+| `src/output/renderers/alert/model.py` | MODIFY | additive Felder (Tagesversatz, Vergangenheits-Merker) an `AlertEvent` und `OnsetShiftEvent`, mit Default, am Ende des Feldblocks |
+| `src/output/renderers/alert/project.py` | MODIFY | Projektion rechnet den Versatz (`day_offset(now_utc, ziel_utc, tz)`) und den Vergangenheits-Merker je Zeitangabe; `_fmt_occurred_at`/`_fmt_onset_at` bleiben in ihrer Form |
+| `src/output/renderers/alert/render.py` | MODIFY | Langform (E-Mail/Telegram) formuliert `gestern HH:MM`/`vor N Tagen HH:MM`/`morgen HH:MM`/`seit HH:MM`; Kurzform (SMS/Premium-SMS) klebt das Wochentagskürzel vor die Stunde (`R7@Do15`); Bedeutungswort für die Spitzenstunde in der „Wo & wann"-Zeile; `_onset_time_label` wird auf den exakten Versatz gehärtet. **NICHT** anfassen: `_render_sms_onset`, `to_multi_location_onset_alert_message`, `_sms_onset_time` (Fläche der #2046-Session, siehe Abschnitt „Zur Entscheidung mit der Freigabe") |
+| `src/services/notification_service.py` | MODIFY | reicht die bereits vorhandene `now_utc` (`:662`) durch |
+| `src/services/validator_render_service.py` | MODIFY | zweiter Aufrufer, reicht dieselbe Referenzzeit durch |
+| `tests/tdd/…` | CREATE | neue Testdatei, nach Verhalten benannt (nicht nach Issue-Nummer) |
 
 ## Dependencies
 
 | Entity | Type | Purpose |
 |--------|------|---------|
 | `src/utils/timezone.py` → `day_offset()` | reuse | Kalendertage zwischen jetzt und Zielzeitpunkt in Ortszeit (aus #2009) |
+| `src/utils/timezone.py` → `format_reference_at()` | reuse | liefert bereits die Hausnotation `gestern HH:MM Uhr`/`vor N Tagen HH:MM Uhr` für die Fußzeile — dieselbe Wortwahl gilt jetzt auch für die Ereignis-Zeitangaben selbst |
 | `src/utils/timezone.py` → `local_fmt()` | reuse | `HH:MM` in Ortszeit — unverändert |
+| `src/output/renderers/alert/official_alerts.py` → `_de_weekday_short()` (`:802`) | reuse | liefert das Wochentagskürzel für die Kurzform — **nicht** nachbauen |
 | `src/services/notification_service.py:662` | caller | berechnet `datetime.now(timezone.utc)` bereits, reicht es künftig durch |
 | `src/services/validator_render_service.py:144` | caller | zweiter Aufrufer der Projektion, reicht dieselbe Referenzzeit durch |
-| `src/services/trip_alert.py:1330` | observability | Briefing-Unterdrückung des Nowcasts protokollieren |
 
 ## Implementation Details
 
@@ -68,37 +81,64 @@ OnsetShiftEvent.to_is_past        bool      (NEU, additiv)
 render.py    setzt die Worte — E-Mail (HTML + Klartext), Telegram, SMS, Premium-SMS
 ```
 
-**Wortlaut (Vorschlag zur Freigabe — hier entscheidet der PO):**
+**Wortlaut — Langform (E-Mail + Telegram), Bestandsnotation aus `format_reference_at`:**
 
 | Lage | Zeile „Wo & wann" | Zeile „Niedersch-Beginn" |
 |---|---|---|
 | Zeitpunkt liegt heute noch bevor | `🏁 Ziel · stärkste Stunde 17:00` | `19:00 → 15:00 (4 h früher)` |
 | Zeitpunkt ist heute schon vorbei | `🏁 Ziel · stärkste Stunde war 17:00` | `19:00 → seit 15:00 (4 h früher)` |
-| Zeitpunkt liegt an einem anderen Tag | `🏁 Ziel · stärkste Stunde morgen 17:00` | `19:00 → morgen 15:00 (4 h früher)` |
+| Zeitpunkt liegt einen Tag zurück | `🏁 Ziel · stärkste Stunde war gestern 17:00` | `19:00 → gestern 15:00 (4 h früher)` |
+| Zeitpunkt liegt ≥2 Tage zurück | `🏁 Ziel · stärkste Stunde war vor 2 Tagen 17:00` | `19:00 → vor 2 Tagen 15:00 (4 h früher)` |
+| Zeitpunkt liegt einen Tag voraus | `🏁 Ziel · stärkste Stunde morgen 17:00` | `19:00 → morgen 15:00 (4 h früher)` |
 
-Der Tagesbezug erscheint **nur**, wenn der Tag vom Versandtag abweicht. Für den
-Versandtag selbst trägt die Fußzeile („Stand: heute 18:15") den Tag bereits; ein
-zusätzliches „heute" in jeder Zeile wäre Lärm.
-*Alternative, falls der PO es ausdrücklich will: „heute" immer ausschreiben. Das ist
-eine reine Wortentscheidung und ändert an der Mechanik nichts.*
+Das ist **keine Neuerfindung**: `format_reference_at` (`src/utils/timezone.py:154-169`)
+erzeugt `gestern HH:MM Uhr`/`vor N Tagen HH:MM Uhr` bereits heute für die Fußzeile
+(„Stand: heute 18:15 · verglichen mit gestern 18:03 Uhr", `render.py:784-786/845-847/949-951`).
+Diese Scheibe wendet dieselbe Hausnotation auf die Ereignis-Zeitangaben selbst an, statt
+eine zweite Schreibweise zu erfinden. Für die Zukunft existiert bereits `morgen HH:MM`
+(`_onset_time_label`, `render.py:367-374`); der Tagesbezug erscheint **nur**, wenn der
+Tag vom Versandtag abweicht — für den Versandtag selbst trägt die Fußzeile den Tag
+bereits, ein zusätzliches „heute" in jeder Zeile wäre Lärm.
 
-**Ein gemeinsamer Baustein für das Tageswort — nicht zwei.**
-Heute löst `_onset_time_label()` (`render.py:303-310`) den Tagesversatz auf, arbeitet
+**Wortlaut — Kurzform (SMS + Premium-SMS), Bestandsnotation der amtlichen Warnung:**
+Das Wochentagskürzel klebt vor die Stunde, `_de_weekday_short()` (`official_alerts.py:802`,
+Muster `Do12-22`/`Fr22-Sa03`). Aus dem Δ-Token `R7@15` (`render.py:990-993`) wird bei
+Versatz `-1` an einem Donnerstag `R7@Do15`. Am **heutigen** Tag entfällt das Kürzel
+ersatzlos (dieselbe Regel wie #1948 S5, `official_alerts.py:1929-1943`).
+
+**Verworfen: ein Zahlensuffix (`17:00-1`).** Drei belegte Gründe:
+1. `-` ist in der Kurzform bereits dreifach belegt — Wert gefallen (`-R7`, `render.py:987`),
+   Bereichstrenner (`12-22`), km-Spanne (`km8-8`, `render.py:1006`).
+2. Die Fensterform der amtlichen Warnung ist formgleich: `_tag_hour()`
+   (`official_alerts.py:1896-1902`) setzt Minuten, sobald sie nicht auf `:00` liegen —
+   ein Gültigkeitsfenster lautet dann `15:20-17`, neben einem Tagesversatz `17:00-1` nicht
+   mehr per Form unterscheidbar.
+3. `_sms_onset_time()` hängt das Vorzeichen fest an (`f"{base}+{day_offset}"`,
+   `render.py:550`) — mit `day_offset = -1` entstünde `17:00+-1`. Diese Funktion bleibt
+   in dieser Scheibe unangetastet (siehe Abschnitt „Zur Entscheidung mit der Freigabe").
+
+**Ein gemeinsamer Baustein für das Tageswort der Langform — nicht zwei.**
+Heute löst `_onset_time_label()` (`render.py:367-374`) den Tagesversatz auf, arbeitet
 aber auf `OnsetEvent` (Nowcast) und prüft nur auf **Wahrheitswert**:
 
 ```
-render.py:310:  return f"morgen {e.onset_time}" if e.onset_day_offset else e.onset_time
+render.py:374:  return f"morgen {e.onset_time}" if e.onset_day_offset else e.onset_time
 ```
 
 Damit wird aus **jedem** Versatz ungleich null ein „morgen" — auch aus `-1`. Im
 Nowcast-Pfad ist das unerreichbar (Vorwärtsfenster, `radar_service.py:599-602`), im
 Abweichungsalarm wäre es der Normalfall.
 
-Deshalb: eine **typunabhängige Hilfsfunktion** `(hhmm: str, day_offset: int) -> str`
-löst den **exakten** Versatz in das Wort auf (`-1 → gestern`, `0 → kein Wort`,
-`1 → morgen`, sonst Wochentag). `_onset_time_label()` wird auf sie umgestellt, der
-Abweichungsalarm benutzt dieselbe. Eine zweite Auflösungstabelle daneben wäre genau die
-Doppelpflege, die das Projekt an anderer Stelle (#1435) abgeschafft hat.
+Deshalb: eine **typunabhängige Hilfsfunktion** `(hhmm: str, day_offset: int, is_past: bool) -> str`
+löst den **exakten** Versatz in das Wort auf (`-1 → gestern`, `-N → vor N Tagen`,
+`0 & vergangen → seit … (kein Tageswort)`, `0 & bevorstehend → kein Wort`,
+`1 → morgen`). `_onset_time_label()` wird auf sie umgestellt, der Abweichungsalarm
+benutzt dieselbe. Eine zweite Auflösungstabelle daneben wäre genau die Doppelpflege, die
+das Projekt an anderer Stelle (#1435) abgeschafft hat.
+
+**Nachbarschaft in Bewegung:** `render.py` wird parallel von **#2036**
+(`fix-2036-alarm-kilometer`, additives `km_measured: bool = False` an allen vier
+Event-Dataclasses, `km{A}-{B}` → `km {A}-{B}`) angefasst. Vor dem Schreiben rebasen.
 
 ## Expected Behavior
 
@@ -106,34 +146,39 @@ Doppelpflege, die das Projekt an anderer Stelle (#1435) abgeschafft hat.
   `tz` (Ortszeit des Segment-Startpunkts), **neu** `now_utc` (Referenzzeit des Versands)
 - **Output:** Alarm-Nachricht in vier Kanälen, in der jede Uhrzeit ihre Größe benennt,
   ihren Tagesbezug trägt und ihre Vergangenheit ausweist
-- **Side effects:** Keine. Zusätzlich wird die bereits bestehende Unterdrückung eines
-  Nowcasts durch das Briefing im Alarm-Protokoll vermerkt (bisher nur `logger.debug`).
+- **Side effects:** Keine.
 
 ## Acceptance Criteria
 
 - **AC-1:** Given ein Abweichungsalarm, dessen Niederschlagsbeginn zum Versandzeitpunkt
-  bereits verstrichen ist (Beginn 15:00 Ortszeit, Versand 15:30 Ortszeit) / When die
-  Alarm-Nachricht gerendert wird / Then weist die Beginn-Zeile den Zeitpunkt als
-  vergangen aus (`19:00 → seit 15:00 (4 h früher)`) und formuliert ihn nicht als
-  bevorstehend.
+  bereits verstrichen ist, aber am selben Kalendertag liegt (Beginn 15:00 Ortszeit,
+  Versand 15:30 Ortszeit) / When die Alarm-Nachricht gerendert wird / Then weist die
+  Beginn-Zeile den Zeitpunkt als vergangen aus (`19:00 → seit 15:00 (4 h früher)`) und
+  formuliert ihn nicht als bevorstehend.
   - Test: Nachricht mit vergangener Onset-Zeit rendern und prüfen, dass der Klartext
     die Vergangenheitsform trägt; Gegenprobe mit künftiger Onset-Zeit, die sie nicht trägt.
 
 - **AC-2:** Given ein Abweichungsalarm, dessen Zeitpunkt auf einem anderen Kalendertag
-  als dem Versandtag liegt / When die Nachricht gerendert wird / Then nennt die
-  Zeitangabe den Tag beim Namen, und zwar passend zum tatsächlichen Versatz — `-1`
-  ergibt „gestern", `+1` ergibt „morgen".
-  - Test: Je ein Rendering mit Versatz `-1` und `+1` gegen dieselbe Uhrzeit; der
-    `-1`-Fall darf unter keinen Umständen „morgen" ergeben (Regression zur
-    Wahrheitswert-Prüfung in `render.py:310`). Dieselbe Gegenprobe gilt für den
+  als dem Versandtag liegt / When die Nachricht in E-Mail oder Telegram gerendert wird
+  / Then nennt die Zeitangabe den Tag beim Namen, in der Hausnotation aus
+  `format_reference_at` — `-1` ergibt `gestern 15:00`, `-2` ergibt `vor 2 Tagen 15:00`,
+  `+1` ergibt `morgen 15:00`.
+  - Test: Je ein Rendering mit Versatz `-1`, `-2` und `+1` gegen dieselbe Uhrzeit; der
+    `-1`- und `-2`-Fall dürfen unter keinen Umständen „morgen" ergeben (Regression zur
+    Wahrheitswert-Prüfung in `render.py:374`). Dieselbe Gegenprobe gilt für den
     Nowcast-Pfad, der auf denselben Baustein umgestellt wird.
 
 - **AC-3:** Given ein Abweichungsalarm mit einer Wertänderung, deren Spitzenwert zu
   einer bestimmten Stunde auftritt / When die Nachricht gerendert wird / Then benennt
-  die Zeile „Wo & wann" die Uhrzeit als Zeitpunkt des stärksten Werts und lässt sie
-  nicht unkommentiert neben einer Beginn-Zeit stehen.
+  die Zeile „Wo & wann" die Uhrzeit ausdrücklich als Zeitpunkt des stärksten Werts
+  (`🏁 Ziel · stärkste Stunde 17:00`, bzw. `stärkste Stunde war 17:00` bei einem
+  vergangenen Zeitpunkt) und lässt sie nicht unkommentiert neben einer Beginn-Zeit
+  stehen. Das Wort „stärkste Stunde" ist neu im Bestand — es reiht sich neben die
+  etablierten Bedeutungs-Marker `ab` (Beginn), `-Beginn`, `jetzt`, `Stand:`,
+  `verglichen mit`, `Gültig:` ein, ohne mit einem davon zu kollidieren.
   - Test: Gerenderte Zeile enthält die Kennzeichnung der Größe zusätzlich zum Ort und
-    zur Uhrzeit.
+    zur Uhrzeit; Gegenprobe, dass eine reine Beginn-Zeile (`-Beginn`) weiterhin ohne
+    dieses Wort auskommt.
 
 - **AC-4:** Given ein Abweichungsalarm, der gleichzeitig eine Wertänderung UND eine
   Beginn-Verschiebung trägt (der Fall aus #2020, bisher von keinem Test abgedeckt) /
@@ -143,10 +188,13 @@ Doppelpflege, die das Projekt an anderer Stelle (#1435) abgeschafft hat.
   - Test: Eine `AlertMessage` mit befülltem `events` UND `onset_shift_events` rendern
     und prüfen, dass beide Zeilen ihre Größe benennen.
 
-- **AC-5:** Given dieselbe Alarm-Nachricht mit vergangenem Zeitpunkt / When sie in alle
-  vier Kanäle gerendert wird (E-Mail HTML, E-Mail Klartext, Telegram, SMS,
-  Premium-SMS) / Then trägt jeder Kanal die Vergangenheits- bzw. Tagesbezug-Information;
-  kein Kanal fällt auf die alte, mehrdeutige Form zurück.
+- **AC-5:** Given dieselbe Alarm-Nachricht mit einem Zeitpunkt an einem anderen
+  Kalendertag als dem Versandtag / When sie in alle vier Kanäle gerendert wird (E-Mail
+  HTML, E-Mail Klartext, Telegram, SMS, Premium-SMS) / Then tragen E-Mail und Telegram
+  die Langform (`gestern 15:00`), SMS und Premium-SMS tragen das Wochentagskürzel
+  geklebt vor die Stunde des Kurzform-Tokens — aus `R7@15` wird bei einem Donnerstag
+  `R7@Do15`; kein Kanal fällt auf die alte, mehrdeutige Form zurück; die
+  160-Zeichen-Grenze der Kurznachricht bleibt eingehalten.
   - Test: Rendering je Kanal prüfen; für die Kurznachricht zusätzlich, dass die
     160-Zeichen-Grenze eingehalten bleibt.
 
@@ -155,14 +203,39 @@ Doppelpflege, die das Projekt an anderer Stelle (#1435) abgeschafft hat.
   ausschließlich von dieser Referenzzeit ab und nicht von der Systemuhr.
   - Test: Dasselbe Rendering zweimal mit unterschiedlicher Referenzzeit und identischen
     Wetterdaten ergibt unterschiedliche Tagesbezüge; kein Aufruf von `datetime.now()`
-    im Renderpfad der Zeitdarstellung.
+    im Renderpfad der Zeitdarstellung. Zusätzlich: `test_onset_shift_alert.py` und
+    `test_alert_event_time_uses_local_timezone.py` (beide ohne `freeze_time`, feste
+    Kalenderdaten) bleiben grün, weil sie die Referenzzeit künftig explizit setzen.
 
-- **AC-7:** Given ein Nowcast, der unterdrückt wird, weil das Briefing den Niederschlag
-  bereits angekündigt hatte / When der Alarm-Tick durchläuft / Then hinterlässt die
-  Unterdrückung einen nachvollziehbaren Eintrag im Alarm-Protokoll mit dem Grund,
-  statt nur eine Debug-Zeile im Anwendungs-Log.
-  - Test: Tick mit angekündigtem, nicht-konvektivem Niederschlag auslösen und prüfen,
-    dass ein Unterdrückungs-Eintrag mit dem Grund im Protokoll landet.
+- **AC-7:** Given zwei Kurzform-Ausschnitte, die im selben Kanal nebeneinander
+  vorkommen können — die Tagesbezug-Form dieses Alarms (`R7@Do15`) und die Fensterform
+  der amtlichen Warnung (`Do12-22` bzw. `15:20-17` bei `_tag_hour`) / When ein
+  Wächter-Test beide aus dem echten Renderer-Code zieht und in einer Zeile
+  gegenüberstellt / Then macht eine spätere Änderung der Fensterform (z.B. Umstellung
+  auf `HH:MM-HH:MM`) diesen Test sofort rot, bevor die Verwechselbarkeit in Produktion
+  erneut auftritt.
+  - Test: Testfall ruft `_tag_hour`/`_de_weekday_short` und den neuen Tagesbezug-Baustein
+    mit denselben Beispielwerten auf und prüft strukturelle Unterscheidbarkeit (keine
+    Form, bei der beide Ausgaben identisch aussehen könnten); der Test bricht, wenn
+    jemand die Fensterform ohne Rücksicht auf diese Kollision ändert.
+
+## Zur Entscheidung mit der Freigabe
+
+Ein Punkt gehört zur Freigabe, ist aber kein Akzeptanzkriterium, weil diese Scheibe ihn
+nicht umsetzt:
+
+**Zieht der Radar-Onset-Kurzform-Zweig nach?** Er schreibt denselben Sachverhalt heute als
+Zahlensuffix (`17:00+1`, `_sms_onset_time`, `render.py:550`). Bleibt er so, trägt der
+Kurzkanal zwei Schreibweisen für „Uhrzeit an einem anderen Tag" nebeneinander.
+
+- **Empfehlung:** Wochentagskürzel für beide Zweige — dann gibt es genau eine Schreibweise.
+  Die Umstellung ist **nicht** Teil dieser Scheibe; sie wird ein Folgeticket der
+  #2046-Session, die diesen Zweig ohnehin gerade bearbeitet und die Anlage zugesagt hat.
+- **Alternative:** Onset bleibt bei `+1`. Dann gehört die Begründung in den
+  Freigabe-Kommentar, damit die Abweichung dokumentiert ist und nicht als Versehen
+  wiederkehrt.
+
+`_sms_onset_time` bleibt in dieser Scheibe in jedem Fall unangetastet.
 
 ## Known Limitations
 
@@ -174,9 +247,15 @@ Doppelpflege, die das Projekt an anderer Stelle (#1435) abgeschafft hat.
 - **Der Tagesbezug erscheint nicht am Versandtag.** Wer die Fußzeile „Stand: heute
   18:15" überliest, hat für Zeiten desselben Tages weiterhin keinen expliziten Tag.
   Bewusste Abwägung gegen Textlärm; per PO-Entscheid umkehrbar.
-- **Kein Vier-Kanäle-Wächter.** Es gibt keinen automatischen Test, der bei künftigen
-  Textänderungen alle vier Kanäle einfordert. AC-5 deckt den hier geänderten Fall ab,
-  nicht die Gattung. → Eintrag für #1196.
+- **Kein Vier-Kanäle-Wächter für Zeit-Label allgemein.** Es gibt keinen automatischen
+  Test, der bei künftigen Textänderungen alle vier Kanäle einfordert. AC-5 deckt den
+  hier geänderten Fall ab, nicht die Gattung. → Eintrag für #1196.
+- **`CorridorEvent` bleibt unangetastet.** Der Schwellen-Alarm-Zweig (`render.py:263`,
+  `_sms_corridor_token`) wirft ebenfalls Minuten weg, ist aber keine der beiden
+  Ereignisarten aus dem gemeldeten Vorfall (B3/B4). Außerhalb des Zuschnitts dieser
+  Scheibe; ein analoger Tagesbezug wäre ein eigenes Ticket.
+- **`_sms_onset_time` (Radar-Onset-Zahlensuffix) bleibt unangetastet** — Gegenstand von
+  AC-7, Umsetzung ggf. per Folgeticket der #2046-Session.
 
 ## Nicht-Ziele (ausdrücklich ausgeschlossen)
 
@@ -191,18 +270,35 @@ Doppelpflege, die das Projekt an anderer Stelle (#1435) abgeschafft hat.
   nicht verhindert (der Regen lief um 18:15 noch, das Etappenfenster reichte bis 20:00)
   und würde künftig wertvolle Meldungen verschlucken. Der Fehler ist die Formulierung,
   nicht die Zustellung.
-- **Die Auslöseregel des Nowcasts ändern.** Dass ein mit 7,4 mm angekündigter Regen die
-  Unterdrückung eines Nowcasts über 29,4 mm rechtfertigt, ist fachlich fragwürdig — aber
-  eine eigene Produktentscheidung mit Flut-Risiko. AC-7 macht die Unterdrückung
-  zunächst nur **sichtbar**; die Regeländerung bekommt ein eigenes Issue.
+- **Die Auslöseregel des Nowcasts ändern — bereits erledigt, gehört nicht zu dieser
+  Scheibe.** Scheibe 1 (#2020, Prod `b423c913`) hat die Briefing-Sperre bereits
+  gehärtet: sie bricht jetzt bei mengenmäßiger Überholung
+  (`window_precip_mm >= 2 × _briefing_precip` UND `>= 2,0 mm`). Diese Scheibe ändert
+  **keine** Auslösung mehr — sie ändert ausschließlich, **wie** die bereits ausgelöste
+  Nachricht ihre Zeitangaben formuliert.
 
 ## Architektur-Entscheidung (ADR)
 
 - **ADR-Nr.:** keine
 - **Rationale:** Die Spec führt keine neue Entscheidungsfläche ein, sondern zieht eine
   bereits in #2009 getroffene Entscheidung (Tagesbezug als additives Modellfeld,
-  Rechnen in der Projektion, Formulieren im Renderer) auf den zweiten Alarmpfad nach.
+  Rechnen in der Projektion, Formulieren im Renderer) auf den zweiten Alarmpfad nach,
+  und übernimmt für die Wortwahl ausschließlich bereits im Bestand etablierte
+  Notationen (`format_reference_at`, Wochentagskürzel der amtlichen Warnung) statt neue
+  zu erfinden.
 
 ## Changelog
 
 - 2026-08-21: Initial spec created (Issue #2020)
+- 2026-08-21: Scheibe-2-Zuschnitt nach Auslieferung von Scheibe 1 (Prod `b423c913`)
+  aktualisiert: AC-7 (Nowcast-Protokoll-Sichtbarkeit) entfernt — von Scheibe 1 bereits
+  geliefert (`trip_alert.py:1390`, `alert_log.append_suppressed_entry`). Nicht-Ziel
+  „Auslöseregel des Nowcasts ändern" umgeschrieben — Scheibe 1 hat die Auslösung
+  bereits geändert (Mengen-Überholung), diese Scheibe rührt daran nicht mehr.
+  Tagesbezug-Wortlaut auf die bestehenden Bestandsnotationen festgelegt: Langform
+  (E-Mail/Telegram) übernimmt `gestern HH:MM`/`vor N Tagen HH:MM` aus
+  `format_reference_at`, Kurzform (SMS/Premium-SMS) übernimmt das klebende
+  Wochentagskürzel der amtlichen Warnung (`R7@Do15`); das erwogene Zahlensuffix
+  `17:00-1` verworfen (drei belegte Kollisionsgründe). Zwei neue ACs ergänzt: AC-7
+  (offene PO-Entscheidung zur Vereinheitlichung mit `_sms_onset_time`) und AC-8
+  (Wächter-Test gegen Formkollision mit der amtlichen Warnung).

--- a/src/app/day_window.py
+++ b/src/app/day_window.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 from datetime import date, datetime, time, timedelta, timezone, tzinfo
 from typing import TYPE_CHECKING, Optional
 
+from utils.timezone import to_utc
+
 if TYPE_CHECKING:  # pragma: no cover - nur fuer Typpruefer
     from app.models import TripSegment
 
@@ -82,6 +84,65 @@ def window_end_utc_exclusive(
         .astimezone(timezone.utc)
         + timedelta(hours=1)
     )
+
+
+def segment_window_points(
+    start_time: datetime, end_time: datetime, points,
+) -> list:
+    """Die Stundenpunkte, die zu GENAU diesem Segmentfenster gehoeren.
+
+    🔴 EINE Quelle fuer zwei Rechnungen (Issue #2020 Scheibe 2, Befunde
+    F001/F005). Aus dieser Punktmenge entsteht ueber
+    ``segment_weather._aggregate_for_segment()`` die Fenster-Gesamtmenge
+    ``SegmentWeatherSummary.precip_sum_mm`` -- und genau dieselbe Menge ist
+    ``WeatherChange.new_value``, von der der Abweichungsalarm seine Restmenge
+    ABZIEHT (``bereits_gefallen = new_value - remaining``). Laufen beide
+    Seiten ueber verschiedene Punktmengen, driftet die Differenz: sie wird
+    negativ oder die Restmenge uebersteigt die Gesamtmenge. Beide Kanten sind
+    in #2020 tatsaechlich aufgetreten, jede einzeln entdeckt -- deshalb steht
+    die Regel jetzt an EINER Stelle statt zweimal nebeneinander.
+
+    Regeln, unveraendert uebernommen aus dem bisherigen Inline-Filter in
+    ``_aggregate_for_segment()``:
+
+    * Grenzen und Punkte werden auf die volle Stunde gefloort (Issue #1334:
+      Vergleich ueber volle Zeitstempel statt nur die Stundenzahl -- ein
+      reiner Stundenvergleich zog sonst dieselbe Uhrzeit von JEDEM Tag der
+      Reihe).
+    * Die Endstunde ist EXKLUSIV (Bug #806): jede Stunde gehoert genau EINEM
+      Segment, sonst zaehlt die Randstunde in zwei Segmenten mit.
+    * Faellt ein Segment vollstaendig in eine Stunde (``start_floor ==
+      end_floor``, z. B. 14:10-14:40), waere das Fenster mit der
+      Exklusiv-Regel LEER. Dann gilt der Punkt AUF dieser Stunde (Bug #856).
+      Ohne diesen Zweig behauptete der Alarm bei kurzen Zwischensegmenten,
+      es sei alles gefallen und es komme nichts mehr -- beides falsch
+      (Befund F005). Kurze Segmente sind real: ``trip_segments`` kennt fuer
+      Zwischensegmente keine Mindestdauer, nur das Ziel-Segment hat eine.
+
+    ``to_utc()`` auf beiden Seiten: Hausnorm ist naive UTC
+    (``ForecastDataPoint.__post_init__``, #1345), Segmentgrenzen sind je nach
+    Aufrufer naiv ODER aware -- und ein aware Zeitstempel mit tzinfo != UTC
+    muss ERST umgerechnet werden, bevor er gestrippt wird (#1345, Adversary
+    F001 dort), sonst gilt die Ortszeit als Weltzeit.
+    """
+    start_floor = to_utc(start_time).replace(
+        minute=0, second=0, microsecond=0, tzinfo=None,
+    )
+    end_floor = to_utc(end_time).replace(
+        minute=0, second=0, microsecond=0, tzinfo=None,
+    )
+    treffer = []
+    for dp in points or ():
+        ts = getattr(dp, "ts", None)
+        if ts is None:
+            continue
+        ts = to_utc(ts).replace(tzinfo=None)
+        if (
+            (ts == start_floor) if start_floor == end_floor
+            else (start_floor <= ts < end_floor)
+        ):
+            treffer.append(dp)
+    return treffer
 
 
 def display_end_time(segment: "TripSegment") -> datetime:

--- a/src/output/renderers/alert/model.py
+++ b/src/output/renderers/alert/model.py
@@ -37,6 +37,36 @@ class AlertEvent:
     # Erst dann darf die Ortsangabe die km-Spanne statt der Segmentnummer
     # zeigen -- eine aus Luftlinie geschaetzte Zahl nie (AC-13).
     km_measured: bool = False
+    # --- Issue #2020 Scheibe 2: Zeitangaben tragen ihren Tag ---------------
+    # Alle additiv und defaultet -> im unveraenderten Normalfall (Versandtag,
+    # bevorstehender Zeitpunkt, Nicht-Niederschlags-Metrik) byte-identisch.
+    # GERECHNET wird in der Projektion aus der Referenzzeit `now_utc`
+    # (`day_offset()`), der Renderer setzt nur die Worte -- Muster #2009.
+    # Kalendertage zwischen Versandtag und `occurred_at` (0 = selber Tag,
+    # -1 = gestern, +1 = morgen).
+    occurred_day_offset: int = 0
+    # Liegt `occurred_at` zum Versandzeitpunkt bereits hinter uns?
+    occurred_is_past: bool = False
+    # DE-Wochentagskuerzel von `occurred_at` fuer die Kurzform ("Do15" statt
+    # des verworfenen Zahlensuffix "15-1"); nur bei Versatz != 0 gelesen.
+    occurred_weekday: str | None = None
+    # --- Niederschlags-Summen-Ereignisse: die Blickrichtung nach vorn -------
+    # Menge (mm), die ab dem Versandzeitpunkt im Tagesfenster noch faellt.
+    # `None` = diese Metrik kennt keine Restmenge (Wind, Temperatur, ...) ->
+    # der Renderer bleibt beim "staerkste Stunde"-Kopf.
+    remaining_mm: float | None = None
+    # "HH:MM" Ortszeit der letzten noch bevorstehenden Regenstunde des
+    # Fensters; `None` = es kommt nichts mehr (ausdrueckliche Meldung, KEINE
+    # Unterdrueckung -- PO-Entscheid).
+    remaining_until_time: str | None = None
+    remaining_until_day_offset: int = 0
+    remaining_until_weekday: str | None = None
+    # "HH:MM" Ortszeit des effektiven Tagesfenster-Endes (`end_hour` zaehlt
+    # voll mit, ADR-0035) -- die Grenze, bis zu der die Restmenge ueberhaupt
+    # blickt. Steht im "kein weiterer Regen"-Satz, damit die Aussage ihre
+    # Reichweite nennt statt sie zu verschweigen.
+    window_end_time: str | None = None
+    window_end_day_offset: int = 0
 
 
 @dataclass(frozen=True)
@@ -105,6 +135,12 @@ class OnsetShiftEvent:
     # Erst dann darf die Ortsangabe die km-Spanne statt der Segmentnummer
     # zeigen -- eine aus Luftlinie geschaetzte Zahl nie (AC-13).
     km_measured: bool = False
+    # Issue #2020 Scheibe 2: additiv, defaultet (Muster `AlertEvent` oben).
+    # Tagesversatz und Vergangenheit des NEUEN Beginns (`to_time`) -- eine
+    # nackte Uhrzeit sagt nicht, ob der Beginn noch bevorsteht oder laengst
+    # verstrichen ist, und genau das war der Vorwurf aus #2020.
+    to_day_offset: int = 0
+    to_is_past: bool = False
 
 
 @dataclass(frozen=True)

--- a/src/output/renderers/alert/project.py
+++ b/src/output/renderers/alert/project.py
@@ -12,10 +12,15 @@ from datetime import datetime, timedelta, timezone
 from app.metric_catalog import (
     _METRICS, ONSET_AGGREGATION, get_cmp, metric_and_aggregation_for_field,
 )
-from utils.timezone import day_offset, local_fmt, resolve_location_tz
+from utils.timezone import (
+    _as_utc, day_offset, local_dt, local_fmt, resolve_location_tz,
+)
 from .model import (
     AlertEvent, AlertMessage, CorridorEvent, OnsetEvent, OnsetShiftEvent,
 )
+# Issue #2020 Scheibe 2: EIN Wochentagskuerzel-Erzeuger fuer die Kurzform --
+# derselbe, den die amtliche Warnung schon benutzt (kein Nachbau).
+from .official_alerts import _de_weekday_short
 from .segments import normalize_segment_id
 
 logger = logging.getLogger("alert_project")
@@ -120,8 +125,11 @@ def _onset_shift_text(delta_seconds: float) -> str:
 def _to_onset_shift_event(
     ch, *, tz, km_from: float, km_to: float,
     segment_id: str | None = None, location_label: str | None = None,
-    km_measured: bool = False,
+    km_measured: bool = False,   # Issue #2036
+    now_utc=None,                # Issue #2020 Scheibe 2
 ) -> OnsetShiftEvent:
+    to_utc = datetime.fromtimestamp(ch.new_value, timezone.utc)
+    to_offset, to_past, _weekday = _when_fields(to_utc, now_utc, tz)
     metric_id, _aggregation = metric_and_aggregation_for_field(ch.metric)
     return OnsetShiftEvent(
         metric_id=metric_id,
@@ -131,12 +139,78 @@ def _to_onset_shift_event(
         km_from=km_from, km_to=km_to,
         segment_id=segment_id, location_label=location_label,
         km_measured=km_measured,  # Issue #2036
+        to_day_offset=to_offset, to_is_past=to_past,
     )
+
+
+# --- Issue #2020 Scheibe 2: Tagesbezug + Blickrichtung ----------------------
+
+def _when_fields(target_utc, now_utc, tz) -> tuple[int, bool, str | None]:
+    """(Tagesversatz, vergangen?, DE-Wochentagskuerzel) einer Zeitangabe.
+
+    EINE Stelle fuer alle drei Groessen, damit Kalendertag und
+    Vergangenheits-Kennzeichen nie aus verschiedenen Zonen stammen. Ohne
+    Referenzzeit (Aufrufer ohne `now_utc`) bleibt alles auf dem neutralen
+    Bestandswert -- der Renderer schreibt dann wie bisher die nackte Uhrzeit.
+    """
+    if target_utc is None or now_utc is None:
+        return 0, False, None
+    target_utc = _as_utc(target_utc)
+    now_utc = _as_utc(now_utc)
+    offset = day_offset(now_utc, target_utc, tz)
+    weekday = _de_weekday_short(local_dt(target_utc, tz)) if offset else None
+    return offset, target_utc < now_utc, weekday
+
+
+def _remaining_fields(eintrag, ch, now_utc, tz) -> dict:
+    """Restmenge/Ende/Fensterende EINES Niederschlags-Summen-Ereignisses.
+
+    `eintrag` ist der ROHE Eintrag aus `_find_segment()` -- also die
+    `SegmentWeatherData` mit ihrer Stundenreihe, NICHT das ueber
+    `_trip_segment()` normalisierte `TripSegment` (Issue #2036). Ein blanker
+    Segment-Eintrag (Korridor-Pfad) traegt keine Reihe und faellt unten
+    still auf "nicht bestimmbar" zurueck -- richtig, weil dort nichts zu
+    rechnen ist.
+
+    Gerechnet wird in `weather_change_detection._precip_remaining()` -- also
+    an derselben Stelle und mit demselben Segmentfenster wie die "staerkste
+    Stunde" (`_peak_occurred_at()`), bindende Invariante der Spec. HIER
+    passiert nur die Umrechnung in Ortszeit und der Tagesbezug.
+
+    Leeres dict = das Ereignis behaelt seinen "staerkste Stunde"-Kopf und
+    sagt ueber die Restmenge nichts. Das gilt fuer alle drei Faelle, in denen
+    es nichts zu sagen GIBT: andere Metrik, keine Referenzzeit -- und
+    `remaining_mm is None`, also "nicht bestimmbar" (keine Stundenreihe,
+    Provider-Fehler; z. B. der Vorschau-Stub des Validators). Der Mangelfall
+    wird bewusst NUR in `_precip_remaining()` entschieden, nicht hier noch
+    einmal parallel: zwei Stellen wuerden auseinanderlaufen, und ein
+    unbestimmbares Ergebnis darf unter keinen Umstaenden als `0.0` (=
+    "es kommt nachweislich nichts mehr") beim Renderer ankommen.
+    """
+    if ch.metric != "precip_sum_mm" or now_utc is None:
+        return {}
+    from services.weather_change_detection import _precip_remaining
+
+    remaining_mm, ends_at = _precip_remaining(eintrag, now_utc)
+    if remaining_mm is None:
+        return {}
+    ende_offset, _ende_past, ende_weekday = _when_fields(ends_at, now_utc, tz)
+    fenster_offset, _f_past, _f_weekday = _when_fields(
+        eintrag.segment.end_time, now_utc, tz,
+    )
+    return {
+        "remaining_mm": remaining_mm,
+        "remaining_until_time": _fmt_occurred_at(ends_at, tz),
+        "remaining_until_day_offset": ende_offset,
+        "remaining_until_weekday": ende_weekday,
+        "window_end_time": local_fmt(_as_utc(eintrag.segment.end_time), tz),
+        "window_end_day_offset": fenster_offset,
+    }
 
 
 def to_alert_message(
     changes, segments, trip_name, *, tz, stand_at, corridor_hits=None,
-    reference_at=None,
+    reference_at=None, now_utc=None,
 ) -> AlertMessage:
     """WeatherChange-Events → kanonische AlertMessage. source bei Deviation = None.
 
@@ -147,11 +221,23 @@ def to_alert_message(
     Issue #1444 S1: `corridor_hits` (optional, `list[CorridorHit]`) buendelt
     Schwellen-Treffer desselben Laufs in DIESELBE Nachricht (Muster #1088) --
     `changes` kann dabei leer sein (Korridor als einzige Alarmquelle, AC-5).
+
+    Issue #2020 Scheibe 2: `now_utc` ist die REFERENZZEIT des Versands --
+    ohne sie kann niemand entscheiden, welche Stunde noch bevorsteht. Aus ihr
+    entstehen Tagesversatz und Vergangenheits-Kennzeichen jeder Zeitangabe
+    sowie die Restmenge des Niederschlags-Summen-Ereignisses. Sie wird
+    UEBERGEBEN, nie hier von der Systemuhr gelesen (AC-13); `None` laesst die
+    Ausgabe byte-identisch zum Bestand.
     """
     events: list[AlertEvent] = []
     onset_events: list[OnsetShiftEvent] = []
     for ch in changes:
-        match = _trip_segment(_find_segment(segments, ch.segment_id))
+        # Issue #2036 normalisiert auf das `TripSegment` (km, Kennung, Zone);
+        # Issue #2020 Scheibe 2 braucht daneben den ROHEINTRAG, weil Restmenge
+        # und Fensterende aus der Stundenreihe der `SegmentWeatherData`
+        # entstehen -- die das normalisierte Segment nicht mehr traegt.
+        eintrag = _find_segment(segments, ch.segment_id)
+        match = _trip_segment(eintrag)
         km_from = match.start_point.distance_from_start_km
         km_to = match.end_point.distance_from_start_km
         # Issue #2036: Herkunft der Spanne (gemessen vs. Luftlinie) reist mit.
@@ -164,19 +250,25 @@ def to_alert_message(
                 km_from=km_from, km_to=km_to,
                 segment_id=normalize_segment_id(match.segment_id),
                 km_measured=km_measured,
+                now_utc=now_utc,
             ))
             continue
         metric_id = _resolve_metric_id(ch.metric, ch.direction)
         cmp = get_cmp(metric_id)
         if not cmp:
             raise ValueError(f"Leeres cmp für metric_id={metric_id!r}")
+        ev_tz = _tz_for_location(match.start_point, tz)
+        occ_offset, occ_past, occ_weekday = _when_fields(
+            ch.occurred_at, now_utc, ev_tz,
+        )
         events.append(AlertEvent(
             metric_id=metric_id, value_from=ch.old_value, value_to=ch.new_value,
             threshold=ch.threshold, cmp=cmp,
-            occurred_at=_fmt_occurred_at(
-                ch.occurred_at, _tz_for_location(match.start_point, tz)
-            ),
+            occurred_at=_fmt_occurred_at(ch.occurred_at, ev_tz),
             km_from=km_from, km_to=km_to,
+            occurred_day_offset=occ_offset, occurred_is_past=occ_past,
+            occurred_weekday=occ_weekday,
+            **_remaining_fields(eintrag, ch, now_utc, ev_tz),
             # Issue #1744 A1: die Kennung der TATSAECHLICH aufgeloesten Etappe
             # (nicht `ch.segment_id` — `_find_segment` faellt bei nicht
             # aufloesbarer Kennung auf das erste Segment zurueck, und der Alarm

--- a/src/output/renderers/alert/render.py
+++ b/src/output/renderers/alert/render.py
@@ -211,15 +211,112 @@ def _km_str(msg: AlertMessage) -> str:
     return _location_of(msg.events, msg.location_label)
 
 
-def _where_when(e: AlertEvent) -> str:
-    """Ort + Uhrzeit EINES Ereignisses (Issue #1861) — bewusst OHNE
-    `location_label`-Parameter: der Multi-Event-Zweig fuehrt den Ortsnamen
-    bereits als `loc_prefix`, und der Compare-Buendelpfad wird gar nicht erst
-    hier hindurchgeschickt (`segment_id`-Bedingung an der Aufrufstelle)."""
-    when = _location_of((e,))
-    if e.occurred_at:
-        when += f" · {e.occurred_at}"
-    return when
+def _time_with_day(
+    hhmm: str, day_offset: int = 0, is_past: bool = False,
+    *, past_word: str = "seit",
+) -> str:
+    """Issue #2020 Scheibe 2: DER gemeinsame Tageswort-Baustein — typunabhaengig,
+    einer statt zweier.
+
+    Loest den Versatz EXAKT auf, nicht ueber seinen Wahrheitswert: `-1` ist
+    "gestern", nicht "morgen" (genau daran scheiterte `_onset_time_label()`,
+    im Nowcast-Vorwaertsfenster unerreichbar, im Abweichungsalarm der
+    Normalfall). Notation ist die Hausform aus `utils.timezone.
+    format_reference_at`, die die Fusszeile schon heute spricht.
+
+    Am Versandtag (`day_offset == 0`) entfaellt das Tageswort ersatzlos; ein
+    bereits verstrichener Zeitpunkt bekommt stattdessen `past_word`. Das Wort
+    ist Sache der Aufrufstelle, weil beide Ereignisarten es verschieden
+    sprechen: ein Beginn laeuft "seit 15:00", eine Spitze "war 17:00".
+    """
+    if day_offset == -1:
+        tag = f"gestern {hhmm}"
+    elif day_offset < -1:
+        tag = f"vor {-day_offset} Tagen {hhmm}"
+    elif day_offset == 1:
+        tag = f"morgen {hhmm}"
+    elif day_offset > 1:
+        tag = f"in {day_offset} Tagen {hhmm}"
+    else:
+        tag = hhmm
+    return f"{past_word} {tag}" if is_past else tag
+
+
+def _when_suffix(e: AlertEvent) -> str:
+    """Issue #2020 Scheibe 2: der Bedeutungs-Zusatz einer Ereignis-Zeile.
+
+    Eine nackte Uhrzeit sagt nicht, WELCHE Groesse sie meint. Fuer
+    Niederschlags-Summen-Ereignisse (`remaining_mm` gesetzt) traegt die Zeile
+    stattdessen die Blickrichtung — die Uhrzeiten stehen dort in den
+    Restmengen-Zeilen, wo sie hingehoeren; fuer alle uebrigen Metriken bleibt
+    es beim Zeitpunkt des staerksten Werts ("Restmenge" ergibt fuer Wind oder
+    Temperatur keine Aussage).
+    """
+    if e.remaining_mm is not None:
+        return " · mehr Regen als angekündigt"
+    if not e.occurred_at:
+        return ""
+    return " · stärkste Stunde " + _time_with_day(
+        e.occurred_at, e.occurred_day_offset, e.occurred_is_past,
+        past_word="war",
+    )
+
+
+def _mm(value: float) -> str:
+    """Millimeter als glatte Zahl -- die Restmenge ist eine Groessenordnung,
+    keine Messung auf die Nachkommastelle (deshalb steht "~" davor)."""
+    return f"{max(0.0, value):.0f}"
+
+
+def _precip_rows(e: AlertEvent) -> list[tuple[str, str]]:
+    """Issue #2020 Scheibe 2: die beiden Zeilen, die den Alarm nach vorn
+    drehen — was bis jetzt gefallen ist, und was ab jetzt noch kommt.
+
+    Das bereits Gefallene wird als `value_to - remaining_mm` abgeleitet und
+    NICHT zweitgerechnet: zwei getrennt summierte Teilmengen driften
+    auseinander, sobald eine von beiden eine Stunde anders zaehlt.
+
+    Ohne Endzeit kommt nichts mehr. Diese Meldung wird ausdruecklich
+    GESCHRIEBEN und nicht unterdrueckt (PO-Entscheid): mehr Regen als
+    angekuendigt aendert die Lage auch rueckblickend (nasse Ausruestung,
+    Wegzustand, Baeche) -- verschwiegen wuerde nur, wie weit die Aussage
+    reicht, deshalb nennt sie ihr Fensterende.
+    """
+    # KEIN `or 0.0`: beide Aufrufstellen betreten diesen Block nur unter
+    # `e.remaining_mm is not None`, und ein Rueckfall auf 0.0 wuerde genau
+    # die Unterscheidung einebnen, die `_precip_remaining()` aufmacht
+    # (unbestimmbar vs. nachweislich nichts mehr).
+    gefallen = e.value_to - e.remaining_mm
+    rows = [(
+        "Bis jetzt",
+        f"~{_mm(gefallen)} mm gefallen (angekündigt waren {_mm(e.value_from)})",
+    )]
+    if e.remaining_until_time:
+        bis = _time_with_day(e.remaining_until_time, e.remaining_until_day_offset)
+        rows.append((
+            "Ab jetzt",
+            f"noch ~{_mm(e.remaining_mm)} mm, letzter Regen gegen {bis}",
+        ))
+    elif e.window_end_time:
+        ende = _time_with_day(e.window_end_time, e.window_end_day_offset)
+        rows.append((
+            "Ab jetzt",
+            f"kein weiterer Regen bis Tagesende (Fensterende {ende} Ortszeit)",
+        ))
+    else:
+        rows.append(("Ab jetzt", "kein weiterer Regen bis Tagesende"))
+    return rows
+
+
+def _where_when(e: AlertEvent, location_label: str | None = None) -> str:
+    """Ort + Bedeutung/Uhrzeit EINES Ereignisses (Issue #1861).
+
+    Issue #2020 Scheibe 2: `location_label` ist NEU und defaultet -- der
+    Multi-Event-Zweig ruft weiterhin ohne ihn (er fuehrt den Ortsnamen bereits
+    als `loc_prefix`), der Einzel-Datenblock reicht ihn durch, damit beide
+    Zweige denselben Zeit-Baustein benutzen statt zweier Kopien.
+    """
+    return _location_of((e,), location_label) + _when_suffix(e)
 
 
 def _per_event_where_when(evs) -> bool:
@@ -294,10 +391,18 @@ def _onset_shift_where(oe: OnsetShiftEvent) -> str:
     )
 
 
+def _onset_shift_to(oe: OnsetShiftEvent) -> str:
+    """Issue #2020 Scheibe 2: die NEUE Beginn-Uhrzeit mit Tagesbezug und
+    Vergangenheits-Ausweis. EINE Stelle fuer alle drei Ausgabewege (Klartext,
+    HTML-Zeile, Telegram) -- sonst schriebe die Mail "seit 15:00" und die
+    HTML-Tabelle daneben weiterhin ein bevorstehend klingendes "15:00"."""
+    return _time_with_day(oe.to_time, oe.to_day_offset, oe.to_is_past)
+
+
 def _onset_shift_line(oe: OnsetShiftEvent) -> str:
     """Eine Zeile Klartext: Groesse, alte und neue Uhrzeit, Richtungswort."""
     return (
-        f"{_label(oe)}-Beginn: {oe.from_time} → {oe.to_time} "
+        f"{_label(oe)}-Beginn: {oe.from_time} → {_onset_shift_to(oe)} "
         f"({oe.shift_text} · {_onset_shift_where(oe)})"
     )
 
@@ -343,7 +448,8 @@ def _render_email_onset_shift_only(msg: AlertMessage) -> tuple[str, str]:
     rows = [
         _datarow_html(
             f"{_label(oe)}-Beginn · {_onset_shift_where(oe)}",
-            f"{oe.from_time} → {oe.to_time} ({oe.shift_text})", G_DANGER, i == 0,
+            f"{oe.from_time} → {_onset_shift_to(oe)} ({oe.shift_text})",
+            G_DANGER, i == 0,
         )
         for i, oe in enumerate(msg.onset_shift_events)
     ]
@@ -394,8 +500,14 @@ def _onset_time_label(e: OnsetEvent) -> str:
     `onset_time` ist reines "HH:MM" ohne Datum -- bei einem Onset, der ueber
     Mitternacht rutscht, ist "00:23" sonst mehrdeutig (heute Nacht oder in
     ueber 23 Stunden?). Additiv: bei `onset_day_offset == 0` (Normalfall)
-    byte-identisch zu `e.onset_time`."""
-    return f"morgen {e.onset_time}" if e.onset_day_offset else e.onset_time
+    byte-identisch zu `e.onset_time`.
+
+    Issue #2020 Scheibe 2: loest den Versatz ueber den GEMEINSAMEN Baustein
+    `_time_with_day()` auf statt ueber den Wahrheitswert -- vorher wurde jeder
+    Versatz ungleich null zu "morgen", auch `-1`. `OnsetEvent` kennt kein
+    Vergangenheits-Kennzeichen (Radar blickt nach vorn), daher `is_past=False`.
+    """
+    return _time_with_day(e.onset_time, e.onset_day_offset)
 
 
 def _render_email_onset_multi(msg: AlertMessage) -> tuple[str, str]:
@@ -739,11 +851,15 @@ def _datablock_single(e: AlertEvent, location_label: str | None = None) -> list[
     # Issue #1744 A1 (AC-6): DIESELBE Aufloesung wie im Betreff — vorher stand
     # hier ein dritter, eigener km-Bauer (`_km_str_events`), weshalb der
     # Mailkoerper km sprach, waehrend der Betreff schon Segmente sprach.
-    when = _location_of((e,), location_label)
-    if e.occurred_at:
-        when += f" · {e.occurred_at}"
-    row3 = ("Wo & wann", when)
-    return [row1, row2, row3]
+    # Issue #2020 Scheibe 2: derselbe Zeit-/Bedeutungs-Baustein wie im
+    # Mehr-Ereignis-Zweig (`_where_when`) -- keine zweite Kopie.
+    row3 = ("Wo & wann", _where_when(e, location_label))
+    # Issue #2020 Scheibe 2: Niederschlags-Summen-Ereignisse bekommen die
+    # Blickrichtung als eigene Zeilen; alle uebrigen Metriken behalten den
+    # Block unveraendert dreizeilig.
+    if e.remaining_mm is None:
+        return [row1, row2, row3]
+    return [row1, row2, row3, *_precip_rows(e)]
 
 
 def _datarow_html(
@@ -934,7 +1050,8 @@ def render_email(msg: AlertMessage) -> tuple[str, str]:
     for oe in msg.onset_shift_events:
         rows.append(_datarow_html(
             f"{_label(oe)}-Beginn · {_onset_shift_where(oe)}",
-            f"{oe.from_time} → {oe.to_time} ({oe.shift_text})", G_DANGER, not rows,
+            f"{oe.from_time} → {_onset_shift_to(oe)} ({oe.shift_text})",
+            G_DANGER, not rows,
         ))
     for ce in msg.corridor_events:
         rows.append(_datarow_html(_label(ce), _corridor_value_str(ce), G_DANGER, not rows))
@@ -972,7 +1089,12 @@ def render_telegram(msg: AlertMessage) -> str:
     if len(evs) == 1:
         e = evs[0]
         verdict = f"{msg.trip_short} · {km} · {arrow(e)} {_label(e)}"
-        lines = [f"<b>{_esc(verdict)}</b>", _email_line(e)]
+        # Issue #2020 Scheibe 2: Telegram traegt DIESELBEN Saetze wie die
+        # E-Mail (Kanal-Paritaet) -- vorher fehlte hier jede Zeitangabe, der
+        # Kanal konnte den Tagesbezug also gar nicht nennen.
+        lines = [f"<b>{_esc(verdict)}</b>", _email_line(e), _where_when(e)]
+        if e.remaining_mm is not None:
+            lines += [f"{k}: {v}" for k, v in _precip_rows(e)]
     else:
         # Issue #981: Kopfzeilen-Zähler nur über-Schwelle; null → Änderungs-Text.
         over_count = len([e for e in evs if over_thr(e)])
@@ -1047,9 +1169,38 @@ def _sms_token(
         sign = "+" if e.value_to >= e.value_from else "-"
         tok = f"{sign}{_code(e)}{int(round(e.value_to))}"
     if e.occurred_at:
-        tok = tok + f"@{e.occurred_at[:2]}"
+        # Issue #2020 Scheibe 2: liegt der Zeitpunkt an einem anderen Tag,
+        # klebt das Wochentagskuerzel vor die Stunde (`@Do15`) -- dieselbe
+        # Bestandsnotation wie die amtliche Warnung. Ein Zahlensuffix ist
+        # verworfen: "-" ist in der Kurzform bereits dreifach belegt.
+        tag = _sms_day_prefix(e.occurred_day_offset, e.occurred_weekday)
+        tok = tok + f"@{tag}{e.occurred_at[:2]}"
     pos = (location_positions or {}).get(e.location_label or "")
     return f"{pos}:{tok}" if pos else tok
+
+
+def _sms_day_prefix(day_offset: int, weekday: str | None) -> str:
+    """Wochentagskuerzel vor der Stunde -- nur bei Versatz != 0 (am Versandtag
+    entfaellt es ersatzlos, dieselbe Regel wie #1948 S5)."""
+    return (weekday or "") if day_offset else ""
+
+
+def _sms_rest_token(e: AlertEvent) -> str | None:
+    """Issue #2020 Scheibe 2: `Rest{mm}@{HH}` -- die Restmenge ab jetzt und
+    ihr Ende als Kompakt-Token. `None` fuer Metriken ohne Restmenge.
+
+    Ohne Endzeit steht `Rest0` OHNE Zeit-Suffix: die Kurzform verschweigt den
+    Sachverhalt nicht, sie kuerzt ihn nur.
+    """
+    if e.remaining_mm is None:
+        return None
+    tok = f"Rest{int(round(e.remaining_mm))}"
+    if e.remaining_until_time:
+        tag = _sms_day_prefix(
+            e.remaining_until_day_offset, e.remaining_until_weekday,
+        )
+        tok += f"@{tag}{e.remaining_until_time[:2]}"
+    return tok
 
 
 def _render_sms_corridor_only(msg: AlertMessage, limit: int) -> str:
@@ -1164,9 +1315,17 @@ def _render_sms_body(
         # transliteriert (AC-7), kein Trip-Name mehr (AC-5).
         head = f"{_ascii_alert_location(_km_str(msg))}: "
     # Issue #1444 S1 (AC-6): Schwellen-Treffer-Tokens desselben Laufs mit.
-    tokens = (
-        [_sms_token(e, location_positions) for e in evs]
-        + [_sms_onset_shift_token(oe) for oe in msg.onset_shift_events]
+    # Issue #2020 Scheibe 2: das Restmengen-Token steht DIREKT neben dem
+    # Delta-Token desselben Ereignisses -- sonst stuenden bei mehreren
+    # Ereignissen Menge und Rest an unzusammenhaengenden Stellen.
+    tokens: list[str] = []
+    for e in evs:
+        tokens.append(_sms_token(e, location_positions))
+        rest = _sms_rest_token(e)
+        if rest:
+            tokens.append(rest)
+    tokens += (
+        [_sms_onset_shift_token(oe) for oe in msg.onset_shift_events]
         + [_sms_corridor_token(ce) for ce in msg.corridor_events]
     )
 

--- a/src/services/notification_service.py
+++ b/src/services/notification_service.py
@@ -686,10 +686,15 @@ class NotificationService:
             weather[0].segment.start_point.lat,
             weather[0].segment.start_point.lon,
         )
-        stand_at = local_fmt(datetime.now(timezone.utc), alert_tz)
+        # Issue #2020 Scheibe 2: EINE Referenzzeit fuer Stand-Zeile UND
+        # Blickrichtung -- sonst koennte die Fusszeile eine andere Stunde
+        # nennen als die Restmengen-Rechnung.
+        now_utc = datetime.now(timezone.utc)
+        stand_at = local_fmt(now_utc, alert_tz)
         alert_msg = to_alert_message(
             changes, weather, trip.name, tz=alert_tz, stand_at=stand_at,
             corridor_hits=corridor_hits, reference_at=reference_at,
+            now_utc=now_utc,
         )
         return self._dispatch_alert_message(
             alert_msg=alert_msg,

--- a/src/services/segment_weather.py
+++ b/src/services/segment_weather.py
@@ -263,24 +263,18 @@ class SegmentWeatherService:
         # tzinfo gestrippt wird -- ein reines .replace(tzinfo=None) wuerde
         # die lokale Uhrzeit als UTC missdeuten und falsche Stunden
         # zuordnen (analog zu app/models.py:155).
-        start_floor = to_utc(segment.start_time).replace(
-            minute=0, second=0, microsecond=0, tzinfo=None
+        # Issue #2020 Scheibe 2: die Filterung wohnt seither in
+        # `app.day_window.segment_window_points()` -- verhaltensgleich zum
+        # bisherigen Inline-Filter (Bug #806 Exklusiv-Ende, Bug #856
+        # Punkttreffer bei Segmenten unter einer Stunde), aber GETEILT mit
+        # `weather_change_detection._precip_remaining()`. Grund: der
+        # Abweichungsalarm zieht seine Restmenge von der hier gebildeten
+        # Fenster-Gesamtmenge ab; zwei getrennte Filter liessen die Differenz
+        # driften (Befunde F001/F005, s. Docstring dort).
+        from app.day_window import segment_window_points
+        filtered_data = segment_window_points(
+            segment.start_time, segment.end_time, timeseries.data,
         )
-        end_floor = to_utc(segment.end_time).replace(
-            minute=0, second=0, microsecond=0, tzinfo=None
-        )
-        # Bug #806: Randstunde exklusiv am Ende (< end_floor), damit jede Stunde
-        # genau einem Segment gehört (Vermeidung von Widersprüchen bei Start-Punkt-Sampling).
-        # Bug #856: Wenn Start- und Endstunde identisch sind (Segment < 1h, gleiche UTC-Stunde),
-        # würde < end_floor immer False liefern → Fallback auf == start_floor.
-        filtered_data = [
-            dp for dp in timeseries.data
-            if (
-                (dp.ts == start_floor)
-                if start_floor == end_floor
-                else (start_floor <= dp.ts < end_floor)
-            )
-        ]
         from app.models import NormalizedTimeseries as NTS
         filtered_ts = NTS(meta=timeseries.meta, data=filtered_data)
         self._debug.add(f"filtered.points: {len(filtered_data)} (of {len(timeseries.data)})")

--- a/src/services/validator_render_service.py
+++ b/src/services/validator_render_service.py
@@ -103,7 +103,10 @@ def render_alert_preview(
         return _render_nowcast_replay(trip_obj, body.nowcast_frames)
 
     alert_tz = _alert_tz_for_trip(trip_obj)
-    stand_at = local_fmt(datetime.now(timezone.utc), alert_tz)
+    # Issue #2020 Scheibe 2: dieselbe Referenzzeit fuer Stand-Zeile und
+    # Zeitbezug der Vorschau (Muster `notification_service`).
+    now_utc = datetime.now(timezone.utc)
+    stand_at = local_fmt(now_utc, alert_tz)
     has_onset = body.onset is not None
 
     if has_onset:
@@ -147,7 +150,7 @@ def render_alert_preview(
         segments = [_stub_segment(st) for st in body.segment_times]
         msg = to_alert_message(
             changes, segments, trip_obj.name,
-            tz=alert_tz, stand_at=stand_at,
+            tz=alert_tz, stand_at=stand_at, now_utc=now_utc,
         )
 
     subject = render_subject(msg)

--- a/src/services/weather_change_detection.py
+++ b/src/services/weather_change_detection.py
@@ -333,7 +333,8 @@ def _precip_remaining(
     ueber die ganze Reihe. Begruendung steht in
     `segment_weather._aggregate_for_segment()` (:292-308): sonst nennt der
     Alarm eine andere Stunde als das Briefing, und beide Vergleichsseiten
-    rechneten mit verschiedenen Fenstern.
+    rechneten mit verschiedenen Fenstern. Die Endgrenze ist dabei EXKLUSIV
+    (`< seg_end`) -- s. die Begruendung an der Filterzeile unten.
 
     Restmenge = Summe der `precip_1h_mm`-Stundenwerte des Fensters, deren
     Stunde nicht bereits VOLLSTAENDIG vergangen ist. Die angebrochene Stunde
@@ -367,7 +368,19 @@ def _precip_remaining(
             if p.ts is None:
                 continue
             ts = _as_utc(p.ts)
-            if not (seg_start <= ts <= seg_end):
+            # Endgrenze EXKLUSIV -- anders als in `_peak_occurred_at()` oben.
+            # Kein Versehen, sondern die einzige Grenze, die hier stimmen kann:
+            # `new_value` ist `aggregated.precip_sum_mm`, und diese Summe
+            # entsteht in `_aggregate_for_segment()` aus genau
+            # `start_floor <= ts < end_floor` (segment_weather.py:276-282,
+            # Bug #806: jede Stunde gehoert genau EINEM Segment). Die
+            # Projektion rechnet `bereits_gefallen = new_value - remaining` --
+            # zaehlte die Restmenge die Stunde AUF `end_time` mit, waere die
+            # Differenz negativ und die Restmenge groesser als die
+            # Fenster-Gesamtmenge (gemessen: 24 statt 22 mm, beides von AC-2
+            # ausdruecklich verboten). `_peak_occurred_at()` faellt das nicht
+            # auf, weil es nur eine Uhrzeit liefert und nichts verrechnet.
+            if not (seg_start <= ts < seg_end):
                 continue
             # Stunde vollstaendig vergangen -> zaehlt weder zur Restmenge
             # noch zum Ende (ihr Ende liegt bei ts + 1 h).

--- a/src/services/weather_change_detection.py
+++ b/src/services/weather_change_detection.py
@@ -328,13 +328,29 @@ def _precip_remaining(
 
     Geschwisterfunktion von `_peak_occurred_at()` und damit an dieselbe
     BINDENDE Fenster-Invariante gebunden: gerechnet wird ausschliesslich
-    ueber die Stundenwerte INNERHALB des Segmentfensters
-    (`seg_start`/`seg_end`, wie oben), nie ueber den Kalendertag und nie
-    ueber die ganze Reihe. Begruendung steht in
+    ueber die Stundenwerte INNERHALB des Segmentfensters, nie ueber den
+    Kalendertag und nie ueber die ganze Reihe. Begruendung steht in
     `segment_weather._aggregate_for_segment()` (:292-308): sonst nennt der
     Alarm eine andere Stunde als das Briefing, und beide Vergleichsseiten
-    rechneten mit verschiedenen Fenstern. Die Endgrenze ist dabei EXKLUSIV
-    (`< seg_end`) -- s. die Begruendung an der Filterzeile unten.
+    rechneten mit verschiedenen Fenstern.
+
+    🔴 Die Punktmenge kommt aus `day_window.segment_window_points()` -- also
+    aus DERSELBEN Funktion, aus der auch die Fenster-Gesamtmenge
+    (`new_value`) entsteht. Das ist keine Bequemlichkeit, sondern die
+    Bedingung dafuer, dass `bereits_gefallen = new_value - remaining`
+    ueberhaupt eine sinnvolle Zahl sein kann. Ein selbst gebauter
+    Fenstervergleich hat hier bereits ZWEIMAL danebengelegen: einmal an der
+    Endstunde (F001, Restmenge groesser als die Gesamtmenge) und einmal bei
+    Segmenten unter einer Stunde (F005, gar kein Treffer -> "alles gefallen,
+    es kommt nichts mehr", obwohl die volle Menge noch ausstand).
+
+    Ausdruecklich NICHT uebernommen wird der Leerfenster-Rueckfall von
+    `_peak_occurred_at()` (`if not window: window = points`). Fuer eine
+    Uhrzeit ist er harmlos; fuer eine Menge, die gegen `new_value`
+    verrechnet wird, bricht er die Fenster-Invariante -- die Restmenge kaeme
+    dann aus der ganzen Reihe statt aus dem Fenster. Ein leeres Fenster heisst
+    hier deshalb "nicht bestimmbar" (`(None, None)`), nicht "es kommt nichts
+    mehr".
 
     Restmenge = Summe der `precip_1h_mm`-Stundenwerte des Fensters, deren
     Stunde nicht bereits VOLLSTAENDIG vergangen ist. Die angebrochene Stunde
@@ -355,33 +371,23 @@ def _precip_remaining(
     (nicht bestimmbar), nie `(0.0, None)` (s. o.).
     """
     try:
+        from app.day_window import segment_window_points
+
         seg = new_data.segment
         points = getattr(getattr(new_data, "timeseries", None), "data", None) or []
-        seg_start = _as_utc(seg.start_time)
-        seg_end = _as_utc(seg.end_time)
-        now = _as_utc_aware(now_utc)
-        if seg_start is None or seg_end is None or not points:
+        if not points:
             return None, None  # nicht bestimmbar -- KEINE Entwarnung
+        fenster = segment_window_points(seg.start_time, seg.end_time, points)
+        if not fenster:
+            # Die Reihe deckt das Segment nicht ab. KEIN Rueckfall auf die
+            # ganze Reihe (s. Docstring) und keine Entwarnung -- wir wissen
+            # ueber dieses Fenster schlicht nichts.
+            return None, None
+        now = _as_utc_aware(now_utc)
         remaining = 0.0
         ends_at: "datetime | None" = None
-        for p in points:
-            if p.ts is None:
-                continue
+        for p in fenster:
             ts = _as_utc(p.ts)
-            # Endgrenze EXKLUSIV -- anders als in `_peak_occurred_at()` oben.
-            # Kein Versehen, sondern die einzige Grenze, die hier stimmen kann:
-            # `new_value` ist `aggregated.precip_sum_mm`, und diese Summe
-            # entsteht in `_aggregate_for_segment()` aus genau
-            # `start_floor <= ts < end_floor` (segment_weather.py:276-282,
-            # Bug #806: jede Stunde gehoert genau EINEM Segment). Die
-            # Projektion rechnet `bereits_gefallen = new_value - remaining` --
-            # zaehlte die Restmenge die Stunde AUF `end_time` mit, waere die
-            # Differenz negativ und die Restmenge groesser als die
-            # Fenster-Gesamtmenge (gemessen: 24 statt 22 mm, beides von AC-2
-            # ausdruecklich verboten). `_peak_occurred_at()` faellt das nicht
-            # auf, weil es nur eine Uhrzeit liefert und nichts verrechnet.
-            if not (seg_start <= ts < seg_end):
-                continue
             # Stunde vollstaendig vergangen -> zaehlt weder zur Restmenge
             # noch zum Ende (ihr Ende liegt bei ts + 1 h).
             if ts + timedelta(hours=1) <= now:

--- a/src/services/weather_change_detection.py
+++ b/src/services/weather_change_detection.py
@@ -9,7 +9,7 @@ SPEC: docs/specs/modules/weather_change_detection.md v2.0
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 from typing import TYPE_CHECKING, Optional
 
@@ -296,6 +296,93 @@ def _as_utc(ts: "datetime | None") -> "datetime | None":
     Fenstergrenzen können fehlen; der zentrale Guard verlangt ein ``datetime``).
     """
     return _as_utc_aware(ts) if ts is not None else None
+
+
+# --- Issue #2020 Scheibe 2: Restmenge ab Versandzeit + letzte Regenstunde ----
+
+# Mess-Schwelle "hat es ueberhaupt geregnet", KEINE Alarm-Schwelle: gefragt
+# ist, ob eine Stunde noch Regen traegt, nicht ob sie alarmwuerdig ist.
+_PRECIP_MEASURABLE_MM = 0.1
+
+
+def _precip_remaining(
+    new_data: "SegmentWeatherData", now_utc: "datetime",
+) -> "tuple[float | None, datetime | None]":
+    """Issue #2020 Scheibe 2: (Restmenge ab `now_utc`, letzte Regenstunde).
+
+    🔴 ZWEI VERSCHIEDENE Rueckgaben, die nie verwechselt werden duerfen:
+
+    * `None` = **konnte nicht bestimmt werden** (keine Zeitreihe, kaputte
+      Fenstergrenzen, irgendein Fehler). Der Alarm sagt dann ueber die
+      Restmenge GAR NICHTS und faellt auf den "staerkste Stunde"-Kopf
+      zurueck -- richtig, weil er sie nicht kennt.
+    * `0.0` = **bestimmt, und es kommt nachweislich nichts mehr**. Der Alarm
+      sagt das ausdruecklich ("kein weiterer Regen bis Tagesende").
+
+    `0.0` ist also eine positive AUSSAGE, keine Verlegenheit. Wer den
+    Fehlerfall auf `0.0` legt, laesst den Alarm dem Wanderer aus einem
+    technischen Defekt heraus Entwarnung geben -- in genau der Nachricht,
+    deren ganzer Zweck die Vorwaerts-Aussage ist. Der Vergleich mit
+    `_peak_occurred_at()` traegt hier NICHT: dessen `None` laesst nur eine
+    Uhrzeit weg, es behauptet nichts.
+
+    Geschwisterfunktion von `_peak_occurred_at()` und damit an dieselbe
+    BINDENDE Fenster-Invariante gebunden: gerechnet wird ausschliesslich
+    ueber die Stundenwerte INNERHALB des Segmentfensters
+    (`seg_start`/`seg_end`, wie oben), nie ueber den Kalendertag und nie
+    ueber die ganze Reihe. Begruendung steht in
+    `segment_weather._aggregate_for_segment()` (:292-308): sonst nennt der
+    Alarm eine andere Stunde als das Briefing, und beide Vergleichsseiten
+    rechneten mit verschiedenen Fenstern.
+
+    Restmenge = Summe der `precip_1h_mm`-Stundenwerte des Fensters, deren
+    Stunde nicht bereits VOLLSTAENDIG vergangen ist. Die angebrochene Stunde
+    (die, in der `now_utc` liegt) zaehlt VOLL mit -- `precip_1h_mm` ist ein
+    Stundenwert ohne untertaegige Rate, eine anteilige Kuerzung taeuschte
+    eine Genauigkeit vor, die das Modell nicht hergibt; die volle Zaehlung
+    ist die konservative Richtung.
+
+    Letzte Regenstunde = spaeteste dieser noch nicht vergangenen Stunden mit
+    >= `_PRECIP_MEASURABLE_MM`. Bewusst ueber das GESAMTE restliche Fenster,
+    nicht nur ueber die laufende Regenphase: zwei getrennte Phasen im selben
+    Fenster sind ein realer Fall, und eine Meldung, die beim ersten Regenende
+    "nichts mehr" saegt, waere dann falsch. Kein Treffer -> `None` (der
+    Aufrufer sagt dann ausdruecklich "kein weiterer Regen").
+
+    Best-effort wie `_peak_occurred_at()`: wirft nie -- ein Rechen-Detail
+    darf keinen Alarm verschlucken. Der Rueckfall ist aber `(None, None)`
+    (nicht bestimmbar), nie `(0.0, None)` (s. o.).
+    """
+    try:
+        seg = new_data.segment
+        points = getattr(getattr(new_data, "timeseries", None), "data", None) or []
+        seg_start = _as_utc(seg.start_time)
+        seg_end = _as_utc(seg.end_time)
+        now = _as_utc_aware(now_utc)
+        if seg_start is None or seg_end is None or not points:
+            return None, None  # nicht bestimmbar -- KEINE Entwarnung
+        remaining = 0.0
+        ends_at: "datetime | None" = None
+        for p in points:
+            if p.ts is None:
+                continue
+            ts = _as_utc(p.ts)
+            if not (seg_start <= ts <= seg_end):
+                continue
+            # Stunde vollstaendig vergangen -> zaehlt weder zur Restmenge
+            # noch zum Ende (ihr Ende liegt bei ts + 1 h).
+            if ts + timedelta(hours=1) <= now:
+                continue
+            try:
+                mm = float(getattr(p, "precip_1h_mm", None))
+            except (TypeError, ValueError):
+                continue
+            remaining += mm
+            if mm >= _PRECIP_MEASURABLE_MM and (ends_at is None or ts > ends_at):
+                ends_at = ts
+        return remaining, ends_at
+    except Exception:
+        return None, None  # nicht bestimmbar -- KEINE Entwarnung
 
 
 def _peak_occurred_at(

--- a/tests/tdd/test_alert_location_vocabulary.py
+++ b/tests/tdd/test_alert_location_vocabulary.py
@@ -345,6 +345,15 @@ def test_ortsvergleich_aenderungsalarm_nennt_weiterhin_den_ortsnamen():
     Die Erwartungen sind der HEUTIGE Wortlaut, byte-genau. Sie duerfen sich
     durch #1744 nicht bewegen; `location_label` bleibt die erste Stufe der
     Aufloesungsreihenfolge.
+
+    Nachgezogen mit Issue #2020 Scheibe 2: der ZEIT-Teil der "Wo & wann"-Zeile
+    benennt seither seine Groesse ("staerkste Stunde 16:00" statt der nackten
+    "16:00", AC-11) -- eine bewusste Wortlaut-Aenderung dieser Spec, die den
+    geteilten Renderer und damit BEIDE Flaechen trifft (Trip UND Ortsvergleich;
+    eine Zweiteilung des Wortlauts waere ein Verstoss gegen die
+    Teilungs-Invariante). Der von diesem Test bewachte ORTS-Teil ist davon
+    unberuehrt und bleibt byte-genau gepruefte Invariante -- deshalb steht er
+    unten in einer eigenen, unveraenderten Zusicherung.
     """
     from output.renderers.alert.project import to_point_alert_message
     from output.renderers.alert.render import (
@@ -358,7 +367,11 @@ def test_ortsvergleich_aenderungsalarm_nennt_weiterhin_den_ortsnamen():
 
     assert render_subject(msg) == "[Toulon] Toulon · ↑ Böen: 50 km/h→80 km/h"
     assert render_telegram(msg).splitlines()[0] == "<b>Toulon · Toulon · ↑ Böen</b>"
-    assert _wo_und_wann(render_email(msg)[1]) == "Toulon · 16:00"
+    plain = render_email(msg)[1]
+    # Die #1744-Invariante: der Ort steht vorn und ist der Ortsname.
+    assert _wo_ort(plain) == "Toulon"
+    # Der Zeit-Teil in seiner #2020-Fassung (Groesse benannt, Uhrzeit unveraendert).
+    assert _wo_und_wann(plain) == "Toulon · stärkste Stunde 16:00"
 
 
 def test_ortsvergleich_mehrere_orte_nennen_weiterhin_ihre_namen():

--- a/tests/tdd/test_alert_restmenge_und_ende.py
+++ b/tests/tdd/test_alert_restmenge_und_ende.py
@@ -61,8 +61,12 @@ from output.renderers.alert.project import to_alert_message
 from output.renderers.alert.render import (
     _render_sms_body, render_email, render_sms, render_telegram,
 )
+from providers.openmeteo import OpenMeteoProvider
 from services.notification_service import NotificationService
-from services.weather_change_detection import WeatherChangeDetectionService
+from services.segment_weather import SegmentWeatherService
+from services.weather_change_detection import (
+    WeatherChangeDetectionService, _precip_remaining,
+)
 from utils.timezone import local_fmt
 
 # Island: ganzjaehrig UTC+0 -> Ortszeit == Weltzeit (s. Modul-Docstring).
@@ -826,4 +830,205 @@ def test_versandweg_reicht_die_referenzzeit_durch():
         f"Der Versandweg muss die Restmenge ab jetzt zustellen — fehlt sie, "
         f"ist die Referenzzeit unterwegs verloren gegangen und der Alarm "
         f"meldet wieder nur Vergangenheit; bekam:\n{body}"
+    )
+
+
+# --------------------------------------------------------------------------
+# Absicherung kurzer Segmente (kein AC): ein Segment unter einer Stunde darf
+# keine doppelte Falschaussage erzeugen.
+# --------------------------------------------------------------------------
+
+def _zwischensegment(start: datetime, ende: datetime) -> TripSegment:
+    """Ein GEWOEHNLICHES Zwischensegment, kein "Ziel".
+
+    Das Ziel-Segment bekommt in `trip_segments` eine erzwungene
+    Mindestdauer von einer Stunde (:294-311) -- der Kurzsegment-Fall ist ueber
+    `_segment()` oben deshalb gar nicht erreichbar. Zwischensegmente zwischen
+    eng beieinanderliegenden Wegpunkten kennen keine Mindestdauer
+    (`trip_segments.py:220-243`, Bug #856), koennen also durchaus in eine
+    einzige Stunde fallen.
+    """
+    return TripSegment(
+        segment_id="2",
+        start_point=GPXPoint(lat=ISLAND_LAT, lon=ISLAND_LON, elevation_m=800.0,
+                             distance_from_start_km=4.0),
+        end_point=GPXPoint(lat=ISLAND_LAT + 0.01, lon=ISLAND_LON + 0.01,
+                           elevation_m=850.0, distance_from_start_km=5.0),
+        start_time=start, end_time=ende,
+        duration_hours=(ende - start).total_seconds() / 3600.0,
+        distance_km=1.0, ascent_m=50.0, descent_m=0.0,
+    )
+
+
+def _stand_fuer(segment: TripSegment, stunden: dict[int, float],
+                summe: float | None) -> SegmentWeatherData:
+    """Etappen-Datenstand zu EINEM beliebigen Segment (nicht nur zum
+    Tagesfenster-Ziel wie `_data()`)."""
+    return SegmentWeatherData(
+        segment=segment,
+        timeseries=NormalizedTimeseries(
+            meta=ForecastMeta(provider=Provider.OPENMETEO, model="test",
+                              grid_res_km=1.0),
+            data=_punkte(stunden),
+        ),
+        aggregated=SegmentWeatherSummary(temp_max_c=12.0, precip_sum_mm=summe),
+        fetched_at=datetime(TAG.year, TAG.month, TAG.day, 6, 0,
+                            tzinfo=timezone.utc),
+        provider="openmeteo",
+    )
+
+
+def _fenstermenge(segment: TripSegment, stunden: dict[int, float]) -> float:
+    """Die Fenster-Gesamtmenge, wie sie PRODUKTIV entsteht.
+
+    Faehrt das echte `_aggregate_for_segment()` -- kein nachgebauter Filter,
+    kein gesetzter Wert. Genau diese Zahl wird als `WeatherChange.new_value`
+    zur Vergleichsgrundlage, von der die Restmenge abgezogen wird. Der
+    `OpenMeteoProvider` wird nur konstruiert (`.name`/`select_model()` sind
+    rein rechnend); es gibt keinen Netzzugriff.
+    """
+    stand = _stand_fuer(segment, stunden, None)
+    aggregiert = SegmentWeatherService(OpenMeteoProvider())._aggregate_for_segment(
+        segment, stand.timeseries, fetched_at=stand.fetched_at,
+    )
+    return aggregiert.aggregated.precip_sum_mm
+
+
+def test_kurzsegment_unter_einer_stunde_meldet_die_lage_richtig_herum():
+    """Absicherung kurzer Segmente (gehoert zu keinem der 14 ACs — sie
+    schuetzt die Umsetzung von AC-1 und AC-3).
+
+    GIVEN ein Zwischensegment, das VOLLSTAENDIG in eine Stunde faellt
+          (14:10-14:40 UTC), und eine Reihe mit 5 mm exakt um 14:00. Die
+          Fenster-Gesamtmenge wird aus dem ECHTEN `_aggregate_for_segment()`
+          geholt, nicht gesetzt.
+    WHEN  die Nachricht bei Referenzzeit 12:00 gerendert wird — zwei Stunden
+          VOR dem Regen
+    THEN  meldet sie, dass die volle Menge noch aussteht.
+
+    Ohne den Punkttreffer-Sonderfall (`start_floor == end_floor`) matcht kein
+    einziger Datenpunkt: weder 14:00 noch 15:00 liegen in [14:10, 14:40).
+    Die Restmenge waere 0, `bereits_gefallen` = `new_value` — und der Alarm
+    behauptete GLEICHZEITIG "~5 mm gefallen" (obwohl nichts gefallen ist) und
+    "kein weiterer Regen" (obwohl 100 % noch aussteht). Beide Aussagen falsch,
+    beide in derselben Meldung.
+    """
+    reihe = {14: 5.0}
+    segment = _zwischensegment(
+        datetime(TAG.year, TAG.month, TAG.day, 14, 10, tzinfo=timezone.utc),
+        datetime(TAG.year, TAG.month, TAG.day, 14, 40, tzinfo=timezone.utc),
+    )
+    menge = _fenstermenge(segment, reihe)
+    assert menge == 5.0, (
+        f"Fixtur-Schutz: die produktive Fenster-Aggregation muss die "
+        f"14-Uhr-Stunde sehen; bekam {menge!r}"
+    )
+
+    alt = _stand_fuer(segment, reihe, 0.0)
+    neu = _stand_fuer(segment, reihe, menge)
+    changes = WeatherChangeDetectionService(
+        thresholds={"precip_sum_mm": 1.0},
+    ).detect_changes(alt, neu, include_absolute=False)
+    regen = [c for c in changes if c.metric == "precip_sum_mm"]
+    assert regen, f"Fixtur-Schutz: der Detektor muss ausloesen; {changes!r}"
+
+    msg = _nachricht(regen, [neu], now_utc=_uhr(12))
+    _html, plain = render_email(msg)
+    telegram = render_telegram(msg)
+
+    for kanal, text in (("email_plain", plain), ("telegram", telegram)):
+        assert "Ab jetzt: noch ~5 mm, letzter Regen gegen 14:00" in text, (
+            f"{kanal}: Zwei Stunden vor dem Regen steht die VOLLE Menge noch "
+            f"aus; bekam:\n{text}"
+        )
+        assert "Bis jetzt: ~0 mm gefallen" in text, (
+            f"{kanal}: Vor dem Regen darf nichts als gefallen gelten; "
+            f"bekam:\n{text}"
+        )
+        assert "kein weiterer Regen" not in text, (
+            f"{kanal}: Eine Entwarnung waere hier die gefaehrlichste "
+            f"Falschaussage der Meldung — der Regen kommt erst noch; "
+            f"bekam:\n{text}"
+        )
+
+
+# --------------------------------------------------------------------------
+# Absicherung der KOPPLUNG (kein AC): Restmenge und Fenster-Gesamtmenge
+# muessen ueber dieselbe Punktmenge laufen. F001 und F005 waren beide
+# Verletzungen genau dieser einen Invariante — sie gehoert einmal explizit
+# bewacht, statt bei jeder neuen Kante einzeln entdeckt zu werden.
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "zuschnitt",
+    ["tagesfenster_mit_punkt_auf_der_endgrenze", "kurzsegment_unter_einer_stunde",
+     "gewoehnliches_zwischensegment"],
+)
+@pytest.mark.parametrize("stunde", [0, 14, 23], ids=["frueh", "mittendrin", "spaet"])
+def test_restmenge_bleibt_an_die_fenster_gesamtmenge_gekoppelt(zuschnitt, stunde):
+    """Absicherung der Kopplungs-Invariante (gehoert zu keinem der 14 ACs).
+
+    GIVEN drei Segment-Zuschnitte, die je eine andere Fensterkante treffen —
+          Tagesfenster mit einem Datenpunkt EXAKT auf der Endgrenze (Befund
+          F001), ein Segment vollstaendig innerhalb einer Stunde (Befund
+          F005) und ein gewoehnliches Zwischensegment als Normalfall —
+          jeweils gegen DIESELBE Stundenreihe
+    WHEN  `_precip_remaining()` und das echte `_aggregate_for_segment()`
+          ueber diese Reihe laufen, zu drei verschiedenen Referenzzeiten
+    THEN  gilt in jedem Fall `0 <= new_value - remaining <= new_value`.
+
+    Das ist die Invariante hinter der ganzen Funktion: die Projektion bildet
+    `bereits_gefallen = new_value - remaining`. Laufen beide Seiten ueber
+    verschiedene Punktmengen, wird die Differenz negativ (Restmenge zaehlt
+    eine Stunde mit, die in der Gesamtmenge fehlt) oder sie erreicht faelsch-
+    lich die Gesamtmenge (Restmenge findet gar keinen Punkt). Beide Kanten
+    sind in #2020 real aufgetreten — dieser Test faengt kuenftige, ohne dass
+    jemand die konkrete Kante vorher kennen muss.
+    """
+    reihe = {**REIHE_AC1, 20: 2.0}
+    zuschnitte = {
+        # Ziel-Tagesfenster 4-19: Segment-Ende 20:00, und die Reihe traegt
+        # einen Punkt GENAU dort.
+        "tagesfenster_mit_punkt_auf_der_endgrenze": _segment(FENSTER_TAG),
+        "kurzsegment_unter_einer_stunde": _zwischensegment(
+            datetime(TAG.year, TAG.month, TAG.day, 15, 10, tzinfo=timezone.utc),
+            datetime(TAG.year, TAG.month, TAG.day, 15, 40, tzinfo=timezone.utc),
+        ),
+        "gewoehnliches_zwischensegment": _zwischensegment(
+            datetime(TAG.year, TAG.month, TAG.day, 12, 0, tzinfo=timezone.utc),
+            datetime(TAG.year, TAG.month, TAG.day, 17, 0, tzinfo=timezone.utc),
+        ),
+    }
+    segment = zuschnitte[zuschnitt]
+
+    new_value = _fenstermenge(segment, reihe)
+    remaining, _ende = _precip_remaining(
+        _stand_fuer(segment, reihe, new_value), _uhr(stunde),
+    )
+
+    assert new_value, (
+        f"Fixtur-Schutz: jeder Zuschnitt muss Regen im Fenster sehen, sonst "
+        f"pruefte dieser Fall nichts; bekam {new_value!r}"
+    )
+    assert remaining is not None, (
+        f"Fixtur-Schutz: die Restmenge muss bestimmbar sein — `None` hiesse, "
+        f"der Zuschnitt {zuschnitt!r} findet gar kein Fenster"
+    )
+
+    bereits_gefallen = new_value - remaining
+    assert bereits_gefallen >= 0, (
+        f"{zuschnitt} @ {stunde}:00 — bereits gefallen ist NEGATIV "
+        f"({new_value} - {remaining} = {bereits_gefallen}). Die Restmenge "
+        f"zaehlt eine Stunde mit, die in der Fenster-Gesamtmenge fehlt: beide "
+        f"Seiten laufen nicht mehr ueber dieselbe Punktmenge."
+    )
+    assert bereits_gefallen <= new_value, (
+        f"{zuschnitt} @ {stunde}:00 — bereits gefallen ({bereits_gefallen}) "
+        f"uebersteigt die Fenster-Gesamtmenge ({new_value}); die Restmenge "
+        f"({remaining}) ist negativ geworden."
+    )
+    assert remaining <= new_value, (
+        f"{zuschnitt} @ {stunde}:00 — die Restmenge ({remaining}) ist groesser "
+        f"als die gesamte Fenstermenge ({new_value}). Genau so sah Befund "
+        f"F001 aus."
     )

--- a/tests/tdd/test_alert_restmenge_und_ende.py
+++ b/tests/tdd/test_alert_restmenge_und_ende.py
@@ -45,20 +45,23 @@ unveraenderte Hauptrepo-Kopie und meldete falsches Gruen.
 """
 from __future__ import annotations
 
-from datetime import date, datetime, time, timezone
+from datetime import date, datetime, time, timedelta, timezone
 from zoneinfo import ZoneInfo
 
 import pytest
 
+from app.config import Settings
 from app.day_window import resolve_configured_window, window_end_utc_exclusive
 from app.models import (
     ForecastDataPoint, ForecastMeta, GPXPoint, NormalizedTimeseries, Provider,
     SegmentWeatherData, SegmentWeatherSummary, TripSegment,
 )
+from app.trip import Stage, Trip, Waypoint
 from output.renderers.alert.project import to_alert_message
 from output.renderers.alert.render import (
     _render_sms_body, render_email, render_sms, render_telegram,
 )
+from services.notification_service import NotificationService
 from services.weather_change_detection import WeatherChangeDetectionService
 from utils.timezone import local_fmt
 
@@ -615,4 +618,212 @@ def test_unbestimmbare_restmenge_erfindet_keine_entwarnung():
     assert "Rest" not in unbestimmbar["sms"], (
         f"Kurzform darf kein Restmengen-Token erfinden; "
         f"bekam {unbestimmbar['sms']!r}"
+    )
+
+
+# --------------------------------------------------------------------------
+# Absicherung der Fenstergrenze (kein AC): die Stunde AUF `segment.end_time`
+# gehoert nicht mehr ins Fenster — sonst rechnet die Restmenge gegen eine
+# Fenster-Gesamtmenge, die diese Stunde gar nicht enthaelt.
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "regenstunde, gesamtmenge, erwartet, verboten",
+    [
+        # 19:00 ist die LETZTE Stunde des Fensters 4-19 und zaehlt voll mit
+        # (`end_hour` inklusive, ADR-0035) -> sie steckt in der
+        # Fenster-Gesamtmenge (24 mm) UND in der Restmenge.
+        (19, SUMME_AC1 + 2.0, "noch ~24 mm, letzter Regen gegen 19:00", "gegen 17:00"),
+        # 20:00 ist das EXKLUSIVE Segment-Ende. `_aggregate_for_segment()`
+        # filtert `start_floor <= ts < end_floor` (segment_weather.py:276-282,
+        # Bug #806) -- die Stunde fehlt damit in der Fenster-Gesamtmenge, die
+        # deshalb bei 22 mm bleibt. Zaehlte die Restmenge sie trotzdem mit,
+        # ergaebe `new_value - remaining` einen NEGATIVEN Wert und die
+        # Restmenge (24 mm) uebertraefe die Gesamtmenge (22 mm) -- beides
+        # verbietet AC-2 ausdruecklich.
+        (20, SUMME_AC1, "noch ~22 mm, letzter Regen gegen 17:00", "gegen 20:00"),
+    ],
+    ids=["19_uhr_letzte_fensterstunde_zaehlt", "20_uhr_segmentende_zaehlt_nicht"],
+)
+def test_fenstergrenze_trennt_letzte_fensterstunde_vom_segmentende(
+    regenstunde, gesamtmenge, erwartet, verboten,
+):
+    """Absicherung der Fenstergrenze (gehoert zu keinem der 14 ACs — sie
+    schuetzt die Umsetzung von AC-2 und AC-6).
+
+    GIVEN Tagesfenster 4-19 (Segment-Ende 20:00) und die AC-1-Reihe, ergaenzt
+          um 2 mm einmal auf 19:00 (letzte Fensterstunde) und einmal auf
+          20:00 (exakt das Segment-Ende). Die Fenster-Gesamtmenge folgt
+          jeweils derselben Regel, nach der sie produktiv entsteht.
+    WHEN  bei Referenzzeit 10:00 gerendert wird
+    THEN  zaehlt die 19:00-Stunde mit (24 mm / 19:00) und die 20:00-Stunde
+          NICHT (22 mm / 17:00).
+
+    Beide Zeilen zusammen nageln die Grenze von BEIDEN Seiten fest: eine
+    Implementierung mit `<= seg_end` bricht an der zweiten, eine mit
+    `< seg_end - 1h` an der ersten.
+    """
+    reihe = {**REIHE_AC1, regenstunde: 2.0}
+    texte = _texte(reihe, now_utc=_uhr(10), neu=gesamtmenge)
+
+    for kanal, text in _langform(texte):
+        assert f"Ab jetzt: {erwartet}" in text, (
+            f"{kanal}: Regenstunde {regenstunde}:00 -> erwartet {erwartet!r}; "
+            f"bekam:\n{text}"
+        )
+        assert verboten not in text, (
+            f"{kanal}: {verboten!r} zeigt an, dass die Fenstergrenze um eine "
+            f"Stunde verrutscht ist; bekam:\n{text}"
+        )
+        assert "~-" not in text, (
+            f"{kanal}: Keine Teilmenge darf negativ werden — genau das "
+            f"passiert, wenn die Restmenge eine Stunde mitzaehlt, die in der "
+            f"Fenster-Gesamtmenge fehlt; bekam:\n{text}"
+        )
+
+
+# --------------------------------------------------------------------------
+# Absicherung des WIRKORTS (kein AC): der echte Versandweg reicht die
+# Referenzzeit durch. Ohne sie faellt die Ausgabe still auf die alte,
+# rueckwaertsgewandte Fassung zurueck — und genau das faengt kein Test, der
+# `to_alert_message()` direkt aufruft.
+# --------------------------------------------------------------------------
+
+def _trip_fuer_versand() -> Trip:
+    stage = Stage(
+        id="S1", name="Etappe 1", date=TAG,
+        waypoints=[
+            Waypoint(id="W1", name="Start", lat=ISLAND_LAT, lon=ISLAND_LON,
+                     elevation_m=800),
+            Waypoint(id="W2", name="Ziel", lat=ISLAND_LAT + 0.1,
+                     lon=ISLAND_LON + 0.1, elevation_m=900),
+        ],
+    )
+    return Trip(id="trip-2020-wirkort", name="ProbeTrip", stages=[stage])
+
+
+def _settings_nur_email() -> Settings:
+    """`can_send_email() == True`, Telegram und SMS ausdruecklich AUS.
+
+    `smtp_host` zeigt auf eine nicht aufloesbare `.invalid`-Domain (Muster
+    `tests/helpers/alert_log_fixtures.settings_email_only`); zusammen mit dem
+    `mail_sink` unten wird der SMTP-Weg gar nicht erst betreten.
+    """
+    return Settings(
+        smtp_host="dummy.invalid", smtp_user="dummy", smtp_pass="dummy",
+        mail_to="dummy@example.invalid",
+        telegram_bot_token="", telegram_chat_id="",
+        seven_api_key="", sms_to="",
+    )
+
+
+def _lauf_um_jetzt():
+    """Ein Etappen-Datenstand, dessen Fenster um die AKTUELLE Stunde liegt.
+
+    `send_deviation_alert()` liest seine Referenzzeit selbst aus der Systemuhr
+    (so entsteht sie produktiv) — der Test kann sie also nicht setzen und baut
+    stattdessen die Stundenreihe um sie herum. Die Mengen entsprechen exakt
+    dem AC-1-Szenario: 8 mm sind gefallen, 14 mm stehen noch aus.
+
+    Die Stunde, in der "jetzt" liegt, traegt bewusst KEINEN Regen. Damit ist
+    das Ergebnis auch dann stabil, wenn zwischen dem Bau der Reihe hier und
+    dem `datetime.now()` im Dienst ein Stundenwechsel faellt.
+    """
+    jetzt = datetime.now(timezone.utc).replace(minute=0, second=0, microsecond=0)
+    beginn, ende = jetzt - timedelta(hours=2), jetzt + timedelta(hours=4)
+    regen = {jetzt - timedelta(hours=1): 8.0, jetzt + timedelta(hours=1): 10.0,
+             jetzt + timedelta(hours=2): 3.0, jetzt + timedelta(hours=3): 1.0}
+    segment = TripSegment(
+        segment_id="Ziel",
+        start_point=GPXPoint(lat=ISLAND_LAT, lon=ISLAND_LON, elevation_m=800.0,
+                             distance_from_start_km=0.0),
+        end_point=GPXPoint(lat=ISLAND_LAT + 0.1, lon=ISLAND_LON + 0.1,
+                           elevation_m=900.0, distance_from_start_km=9.0),
+        start_time=beginn, end_time=ende, duration_hours=6.0,
+        distance_km=9.0, ascent_m=100.0, descent_m=100.0,
+    )
+    punkte = [
+        ForecastDataPoint(
+            ts=beginn + timedelta(hours=i),
+            t2m_c=12.0, wind10m_kmh=15.0, gust_kmh=25.0,
+            precip_1h_mm=regen.get(beginn + timedelta(hours=i), 0.0),
+        )
+        for i in range(7)
+    ]
+
+    def _stand(summe: float) -> SegmentWeatherData:
+        return SegmentWeatherData(
+            segment=segment,
+            timeseries=NormalizedTimeseries(
+                meta=ForecastMeta(provider=Provider.OPENMETEO, model="test",
+                                  grid_res_km=1.0),
+                data=punkte,
+            ),
+            aggregated=SegmentWeatherSummary(temp_max_c=12.0, precip_sum_mm=summe),
+            fetched_at=jetzt, provider="openmeteo",
+        )
+
+    neu = _stand(SUMME_AC1)
+    changes = WeatherChangeDetectionService().detect_changes(
+        _stand(ANGEKUENDIGT), neu, include_absolute=False,
+    )
+    regen_changes = [c for c in changes if c.metric == "precip_sum_mm"]
+    assert regen_changes, (
+        f"Fixtur-Schutz: der Detektor muss ausloesen; bekam "
+        f"{[c.metric for c in changes]}"
+    )
+    return regen_changes, [neu]
+
+
+def test_versandweg_reicht_die_referenzzeit_durch():
+    """Absicherung des Wirkorts (gehoert zu keinem der 14 ACs — sie schuetzt
+    die Umsetzung von AC-1 an der Stelle, an der sie WIRKT).
+
+    GIVEN eine Niederschlags-Summen-Aenderung, deren Stundenreihe um die
+          aktuelle Stunde liegt (8 mm gefallen, 14 mm stehen aus)
+    WHEN  sie ueber den ECHTEN Versandweg `NotificationService.
+          send_deviation_alert()` laeuft — nicht ueber einen Direktaufruf von
+          `to_alert_message()` — und die Mail ueber die Transport-Naht
+          `mail_sink` abgefangen wird (kein SMTP, kein echter Versand)
+    THEN  traegt der zugestellte Text die vorwaertsgewandte Aussage.
+
+    WARUM DIESER TEST: `to_alert_message()` faellt ohne `now_utc` still auf
+    die alte, rueckwaertsgewandte Fassung zurueck (Regressions-Invariante fuer
+    Bestandsaufrufer). Wer die Uebergabe in `notification_service.py`
+    versehentlich entfernt, bekommt von jedem Test, der die Projektion direkt
+    aufruft, ein gruenes Licht — und der Alarm meldete wieder Vergangenheit,
+    also exakt den Fehler, den diese Scheibe behebt.
+
+    `mail_sink` ersetzt AUSSCHLIESSLICH den Transport: der Text, den es
+    bekommt, ist derselbe `render_email()`-Klartext, den sonst
+    `EmailOutput.send()` verschickt (`notification_service.py:1381/1456-1457`).
+    Der Renderpfad — und damit der Wirkort — wird also echt durchlaufen.
+    """
+    changes, wetter = _lauf_um_jetzt()
+    mails: list[tuple[str, str]] = []
+    ergebnis = NotificationService(
+        settings=_settings_nur_email(), user_id="tdd-2020-wirkort",
+    ).send_deviation_alert(
+        trip=_trip_fuer_versand(), weather=wetter, changes=changes,
+        effective_channels={"email"},
+        mail_sink=lambda subject, body: mails.append((subject, body)),
+    )
+
+    # Fixtur-Schutz: ohne betretenen E-Mail-Kanal waere jede Zusicherung
+    # unten leer -- der Test muesste dann rot sein, nicht still gruen.
+    assert "email" in ergebnis.sent_channels, (
+        f"Fixtur-Schutz: der E-Mail-Kanal muss betreten worden sein; "
+        f"bekam {ergebnis.sent_channels!r}"
+    )
+    assert mails, "Fixtur-Schutz: die Transport-Naht muss eine Mail gesehen haben"
+
+    _betreff, body = mails[-1]
+    assert "Bis jetzt: ~8 mm gefallen (angekündigt waren 5)" in body, (
+        f"Der Versandweg muss die Einordnung des bereits Gefallenen "
+        f"zustellen; bekam:\n{body}"
+    )
+    assert "Ab jetzt: noch ~14 mm" in body, (
+        f"Der Versandweg muss die Restmenge ab jetzt zustellen — fehlt sie, "
+        f"ist die Referenzzeit unterwegs verloren gegangen und der Alarm "
+        f"meldet wieder nur Vergangenheit; bekam:\n{body}"
     )

--- a/tests/tdd/test_alert_restmenge_und_ende.py
+++ b/tests/tdd/test_alert_restmenge_und_ende.py
@@ -157,6 +157,26 @@ def _data(stunden: dict[int, float], summe: float,
     )
 
 
+def _data_ohne_reihe(summe: float,
+                     fenster: tuple[int, int] = FENSTER_TAG) -> SegmentWeatherData:
+    """Ein Etappen-Datenstand OHNE Stundenreihe.
+
+    `SegmentWeatherData.timeseries` ist im DTO ausdruecklich optional
+    ("None bei Provider-Fehler", models.py:543) — das ist also kein
+    konstruierter Sonderfall, sondern der dokumentierte Datenmangel-Zustand
+    des Versandpfads. Dieselbe Lage entsteht beim Vorschau-Stub des
+    Validators (`validator_render_service._stub_segment`, `data=[]`).
+    """
+    return SegmentWeatherData(
+        segment=_segment(fenster),
+        timeseries=None,
+        aggregated=SegmentWeatherSummary(temp_max_c=12.0, precip_sum_mm=summe),
+        fetched_at=datetime(TAG.year, TAG.month, TAG.day, 6, 0,
+                            tzinfo=timezone.utc),
+        provider="openmeteo",
+    )
+
+
 def _aenderungen(stunden: dict[int, float], *, alt: float, neu: float,
                  fenster: tuple[int, int] = FENSTER_TAG,
                  schwelle: float | None = None):
@@ -194,18 +214,8 @@ def _nachricht(changes, segmente, *, now_utc: datetime,
     Stand-Zeile, und der Vergleich sagte nichts ueber die Restmenge aus.
     """
     kwargs = dict(tz=TZ, stand_at=stand_at or local_fmt(now_utc, TZ))
-    # 🔴 RED-ONLY (#2020 Scheibe 2, Phase 5): Dieser Fallback MUSS mit dem
-    # GREEN-Commit entfernt werden. Er existiert AUSSCHLIESSLICH, damit die
-    # Wortlaut-ACs an inhaltlichen Assertions scheitern statt am fehlenden
-    # Parameter `now_utc`. Bleibt er stehen, verdeckt er kuenftig das Fehlen
-    # von `now_utc`, statt es rot zu machen — eine eingebaute Erosionsstelle.
-    try:
-        return to_alert_message(changes, segmente, "Test-Trip",
-                                now_utc=now_utc, **kwargs)
-    except TypeError as exc:  # pragma: no cover - faellt mit dem Fix weg
-        if "now_utc" not in str(exc):
-            raise
-        return to_alert_message(changes, segmente, "Test-Trip", **kwargs)
+    return to_alert_message(changes, segmente, "Test-Trip",
+                            now_utc=now_utc, **kwargs)
 
 
 def _texte(stunden: dict[int, float], *, now_utc: datetime,
@@ -536,3 +546,73 @@ def test_kein_weiterer_regen_wird_auch_in_der_kurzform_gesagt():
         f"'Rest0' traegt kein Zeit-Suffix (es gibt keine Endzeit); bekam {kurz!r}"
     )
     assert len(kurz) <= 160, f"160-Zeichen-Grenze gerissen: {kurz!r}"
+
+
+# --------------------------------------------------------------------------
+# Absicherung der Umsetzung (kein AC): "weiss ich nicht" ist NICHT "kommt
+# nichts mehr". Ein Datenmangel darf keine Entwarnung erfinden.
+# --------------------------------------------------------------------------
+
+def test_unbestimmbare_restmenge_erfindet_keine_entwarnung():
+    """Absicherung zur Datenmangel-Unterscheidung (gehoert zu keinem der 14
+    ACs — sie schuetzt die Umsetzung von AC-3).
+
+    GIVEN denselben Abweichungsalarm wie AC-3 (Referenzzeit 18:15, nach der
+          letzten Regenstunde), einmal MIT vollstaendiger Stundenreihe und
+          einmal mit einem Etappen-Datenstand OHNE Zeitreihe (Provider-Fehler,
+          `SegmentWeatherData.timeseries is None`)
+    WHEN  beide Faelle gerendert werden
+    THEN  sagt NUR der bestimmbare Fall "kein weiterer Regen bis Tagesende"
+          (und in der Kurzform "Rest0"). Der unbestimmbare sagt ueber die
+          Restmenge GAR NICHTS und faellt auf den Bestands-Kopf zurueck —
+          eine Entwarnung aus einem technischen Defekt waere die gefaehrlichste
+          Falschaussage, die diese Nachricht ueberhaupt treffen kann.
+
+    Die Gegenueberstellung ist der Kern: eine Implementierung, die den
+    Fehlerfall auf `0.0` legt, macht beide Faelle textgleich und muss hier
+    brechen.
+    """
+    changes, segmente = _aenderungen(REIHE_AC1, alt=ANGEKUENDIGT, neu=SUMME_AC1)
+    now = _uhr(18, 15)
+
+    def _kanaele(segs):
+        msg = _nachricht(changes, segs, now_utc=now)
+        _html, plain = render_email(msg)
+        return {"email_plain": plain, "telegram": render_telegram(msg),
+                "sms": render_sms(msg, 160)}
+
+    bestimmbar = _kanaele(segmente)
+    unbestimmbar = _kanaele([_data_ohne_reihe(SUMME_AC1)])
+
+    # Gegenprobe zuerst: ohne sie waere der Waechter unten allein dadurch
+    # gruen, dass es den Satz ueberhaupt nicht (mehr) gibt.
+    for kanal, text in _langform(bestimmbar):
+        assert "kein weiterer Regen bis Tagesende" in text, (
+            f"{kanal}: Der BESTIMMBARE Fall muss die Entwarnung ausdruecklich "
+            f"aussprechen (AC-3); bekam:\n{text}"
+        )
+    assert "Rest0" in bestimmbar["sms"], (
+        f"Kurzform des bestimmbaren Falls: {bestimmbar['sms']!r}"
+    )
+
+    for kanal, text in _langform(unbestimmbar):
+        assert text.strip(), f"{kanal}: Die Meldung muss trotzdem rausgehen"
+        # Positiv-Anker: die Meldung ist vollstaendig, nur die Restmengen-
+        # Aussage fehlt — sonst waere dieser Test schon durch eine leere
+        # Nachricht zufrieden.
+        assert "stärkste Stunde" in text, (
+            f"{kanal}: Ohne Restmenge greift der Bestands-Kopf; bekam:\n{text}"
+        )
+        assert "kein weiterer Regen" not in text, (
+            f"{kanal}: Eine unbestimmbare Restmenge darf NICHT als Entwarnung "
+            f"erscheinen — das erfindet aus einem Datenfehler eine Aussage; "
+            f"bekam:\n{text}"
+        )
+        assert "Ab jetzt" not in text and "Bis jetzt" not in text, (
+            f"{kanal}: Ohne bestimmbare Restmenge gibt es keine der beiden "
+            f"Blickrichtungs-Zeilen; bekam:\n{text}"
+        )
+    assert "Rest" not in unbestimmbar["sms"], (
+        f"Kurzform darf kein Restmengen-Token erfinden; "
+        f"bekam {unbestimmbar['sms']!r}"
+    )

--- a/tests/tdd/test_alert_restmenge_und_ende.py
+++ b/tests/tdd/test_alert_restmenge_und_ende.py
@@ -51,7 +51,10 @@ from zoneinfo import ZoneInfo
 import pytest
 
 from app.config import Settings
-from app.day_window import resolve_configured_window, window_end_utc_exclusive
+from app.day_window import (
+    resolve_configured_window, segment_window_points,
+    window_end_utc_exclusive,
+)
 from app.models import (
     ForecastDataPoint, ForecastMeta, GPXPoint, NormalizedTimeseries, Provider,
     SegmentWeatherData, SegmentWeatherSummary, TripSegment,
@@ -1031,4 +1034,86 @@ def test_restmenge_bleibt_an_die_fenster_gesamtmenge_gekoppelt(zuschnitt, stunde
         f"{zuschnitt} @ {stunde}:00 — die Restmenge ({remaining}) ist groesser "
         f"als die gesamte Fenstermenge ({new_value}). Genau so sah Befund "
         f"F001 aus."
+    )
+
+
+# --------------------------------------------------------------------------
+# Absicherung des Leerfenster-Guards (kein AC): deckt die Zeitreihe das
+# Segment gar nicht ab, weiss der Alarm nichts — und sagt dann auch nichts.
+# --------------------------------------------------------------------------
+
+def test_reihe_ohne_ueberlappung_mit_dem_segment_erfindet_keine_entwarnung():
+    """Absicherung des Leerfenster-Guards (gehoert zu keinem der 14 ACs — sie
+    schuetzt die Umsetzung von AC-3).
+
+    GIVEN ein Segment am FOLGETAG (Tagesfenster 4-19 des 21.08.) und eine
+          Stundenreihe, die ausschliesslich den 20.08. abdeckt — die beiden
+          ueberlappen sich zeitlich also nicht. Das Fenster-Aggregat ist
+          trotzdem befuellt: genau so sieht ein Cache-Treffer eines anderen
+          Tages oder ein Segment jenseits des Vorhersagehorizonts aus.
+    WHEN  die Nachricht gerendert wird
+    THEN  sagt sie ueber die Restmenge GAR NICHTS und faellt auf den
+          Bestands-Kopf zurueck.
+
+    `segment_window_points()` liefert hier eine leere Punktmenge. Gaebe der
+    Guard dafuer `0.0` statt `None` zurueck, stuende im Text "kein weiterer
+    Regen bis Tagesende" — eine Entwarnung, die aus einer Datenluecke
+    erfunden waere. Dieselbe Falschaussage wie in F005, nur ueber die dritte
+    Kante derselben Funktion; an dieser Fensterkante ist die Rechnung bereits
+    zweimal gebrochen (F001, F005).
+
+    Geprueft wird der TEXT, nicht der Rueckgabewert: die Zusicherung wirkt
+    dort, wo der Nutzer sie liest.
+    """
+    folgetag = TAG + timedelta(days=1)
+    beginn, ende = _fenstergrenzen(FENSTER_TAG, tag=folgetag)
+    segment = TripSegment(
+        segment_id="Ziel",
+        start_point=GPXPoint(lat=ISLAND_LAT, lon=ISLAND_LON, elevation_m=800.0,
+                             distance_from_start_km=0.0),
+        end_point=GPXPoint(lat=ISLAND_LAT + 0.1, lon=ISLAND_LON + 0.1,
+                           elevation_m=900.0, distance_from_start_km=9.0),
+        start_time=beginn, end_time=ende,
+        duration_hours=(ende - beginn).total_seconds() / 3600.0,
+        distance_km=9.0, ascent_m=100.0, descent_m=100.0,
+    )
+    # Fixtur-Schutz: die Reihe (20.08.) darf das Segment (21.08.) wirklich
+    # nicht schneiden -- sonst pruefte dieser Test einen anderen Fall.
+    assert not segment_window_points(beginn, ende, _punkte(REIHE_AC1)), (
+        "Fixtur-Schutz: Segment und Stundenreihe duerfen sich nicht ueberlappen"
+    )
+
+    alt = _stand_fuer(segment, REIHE_AC1, ANGEKUENDIGT)
+    neu = _stand_fuer(segment, REIHE_AC1, SUMME_AC1)
+    changes = WeatherChangeDetectionService().detect_changes(
+        alt, neu, include_absolute=False,
+    )
+    regen = [c for c in changes if c.metric == "precip_sum_mm"]
+    assert regen, f"Fixtur-Schutz: der Detektor muss ausloesen; {changes!r}"
+
+    msg = _nachricht(regen, [neu], now_utc=_uhr(10))
+    _html, plain = render_email(msg)
+    telegram = render_telegram(msg)
+    sms = render_sms(msg, 160)
+
+    for kanal, text in (("email_plain", plain), ("telegram", telegram)):
+        assert text.strip(), f"{kanal}: Die Meldung muss trotzdem rausgehen"
+        # Positiv-Anker: die Meldung ist vollstaendig, nur die Restmengen-
+        # Aussage fehlt -- sonst waere dieser Test schon durch eine leere
+        # Nachricht zufrieden.
+        assert "stärkste Stunde" in text, (
+            f"{kanal}: Ohne bestimmbare Restmenge greift der Bestands-Kopf; "
+            f"bekam:\n{text}"
+        )
+        assert "kein weiterer Regen" not in text, (
+            f"{kanal}: Eine Zeitreihe, die das Segment nicht abdeckt, ist eine "
+            f"DATENLUECKE — keine Entwarnung. Genau diese Verwechslung war "
+            f"F005; bekam:\n{text}"
+        )
+        assert "Ab jetzt" not in text and "Bis jetzt" not in text, (
+            f"{kanal}: Ohne Punktmenge gibt es keine der beiden "
+            f"Blickrichtungs-Zeilen; bekam:\n{text}"
+        )
+    assert "Rest" not in sms, (
+        f"Kurzform darf kein Restmengen-Token erfinden; bekam {sms!r}"
     )

--- a/tests/tdd/test_alert_restmenge_und_ende.py
+++ b/tests/tdd/test_alert_restmenge_und_ende.py
@@ -1,0 +1,538 @@
+"""TDD RED — Issue #2020, Scheibe 2: der Abweichungsalarm schaut nach VORN.
+
+SPEC: docs/specs/modules/fix_2020_alarm_blickrichtung.md (AC-1 .. AC-7)
+
+GEMESSENER IST-STAND (2026-08-21, dieser Branch): der Alarm nennt fuer eine
+Niederschlags-Summen-Aenderung ausschliesslich Vergangenheit — den Von-/
+Bis-Wert und die staerkste Stunde (`_datablock_single`, render.py:692-723).
+Es fehlen alle drei Bausteine:
+
+1. `WeatherChange` fuehrt weder `remaining_mm` noch `precip_ends_at`
+   (models.py:570 ff.), und `weather_change_detection.py` rechnet nichts
+   dergleichen aus der Stundenreihe.
+2. `to_alert_message()` (project.py:125) kennt keine Referenzzeit `now_utc` —
+   ohne sie kann niemand entscheiden, welche Stunde noch bevorsteht.
+3. `AlertEvent` traegt keine Restmengen-Felder, und kein Renderer setzt die
+   Saetze "Bis jetzt: …"/"Ab jetzt: …" bzw. das Kurzform-Token `Rest{mm}@{HH}`.
+
+PRUEFORT = WIRKORT. Restmenge und Ende entstehen laut Spec im ERKENNUNGSDIENST
+aus der Stundenreihe INNERHALB DES SEGMENTFENSTERS (bindende Invariante,
+Spec-Abschnitt "Implementation Details"). Deshalb faehrt jeder Test hier die
+echte Produktivkette:
+
+    resolve_configured_window()/window_end_utc_exclusive()  -> Fenstergrenzen
+    WeatherChangeDetectionService().detect_changes(...)     -> WeatherChange
+    to_alert_message(...)                                   -> AlertMessage
+    render_email()/render_telegram()/render_sms()           -> die vier Kanaele
+
+Kein Test baut sich eine `WeatherChange` von Hand mit fertigen Werten
+zusammen — das pruefte die Fenster-Invariante (AC-5/AC-6) ueberhaupt nicht.
+
+KEIN MOCK-THEATER (CLAUDE.md, Kern-Schicht): kein `Mock()`/`patch()`/
+`MagicMock`, kein Dateiinhalt-Check als Verhaltensnachweis, kein Netz.
+
+ZEITZONE. Die Etappe haengt bewusst auf Island (`Atlantic/Reykjavik`,
+ganzjaehrig UTC+0, keine Sommerzeit): Ortszeit und Weltzeit sind dort
+zeichengleich, die Uhrzeit-Erwartungen der Spec ("15:00", "17:00") stehen
+damit als LITERAL im Test und werden nicht aus derselben Zeitzonen-Aufloesung
+gezogen, die der Prueling benutzt. Kalendertag und Referenzzeiten sind fest —
+nirgends entscheidet die Systemuhr mit (AC-13).
+
+Pfadregel #1409: der Prueling wird RELATIV ZU DIESER DATEI aufgeloest (ueber
+`tests/conftest.py`, das `<repo>/src` an `sys.path` haengt), nie ueber den
+festen Hauptrepo-Pfad — sonst pruefte dieser Test aus dem Worktree die
+unveraenderte Hauptrepo-Kopie und meldete falsches Gruen.
+"""
+from __future__ import annotations
+
+from datetime import date, datetime, time, timezone
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from app.day_window import resolve_configured_window, window_end_utc_exclusive
+from app.models import (
+    ForecastDataPoint, ForecastMeta, GPXPoint, NormalizedTimeseries, Provider,
+    SegmentWeatherData, SegmentWeatherSummary, TripSegment,
+)
+from output.renderers.alert.project import to_alert_message
+from output.renderers.alert.render import (
+    _render_sms_body, render_email, render_sms, render_telegram,
+)
+from services.weather_change_detection import WeatherChangeDetectionService
+from utils.timezone import local_fmt
+
+# Island: ganzjaehrig UTC+0 -> Ortszeit == Weltzeit (s. Modul-Docstring).
+ISLAND_LAT, ISLAND_LON = 64.13, -21.90
+TZ = ZoneInfo("Atlantic/Reykjavik")
+TAG = date(2026, 8, 20)
+
+# Die Stundenreihe der Spec (AC-1): 13:00=8 · 15:00=10 · 16:00=3 · 17:00=1 mm.
+# Summe im Tagesfenster 4-19 = 22 mm; angekuendigt (letzter Briefing-Stand)
+# waren 5 mm.
+REIHE_AC1 = {13: 8.0, 15: 10.0, 16: 3.0, 17: 1.0}
+SUMME_AC1 = 22.0
+ANGEKUENDIGT = 5.0
+
+# Fenster 4-19 (Default, ADR-0035). `end_hour` zaehlt VOLL mit -> das Fenster
+# endet effektiv um 20:00 Ortszeit (window_end_utc_exclusive, day_window.py:57).
+FENSTER_TAG = (4, 19)
+# Zweites, ausdruecklich genanntes Fenster fuer die Fenstergrenzen-Gegenprobe.
+FENSTER_LANG = (4, 22)
+
+
+# --------------------------------------------------------------------------
+# Fixture-Bausteine — die Fenstergrenzen kommen aus den PRODUKTIVEN Funktionen
+# (`resolve_configured_window`/`window_end_utc_exclusive`), nicht aus getippten
+# Uhrzeiten. Sonst pruefte der Test seine eigene Annahme ueber das Fenster.
+# --------------------------------------------------------------------------
+
+def _fenstergrenzen(fenster: tuple[int, int], *, tag: date = TAG):
+    """(Beginn, effektives Ende) des Tagesfensters als UTC-Zeitstempel."""
+    start_h, end_h = resolve_configured_window(*fenster)
+    beginn = (
+        datetime.combine(tag, time(start_h))
+        .replace(tzinfo=TZ)
+        .astimezone(timezone.utc)
+    )
+    return beginn, window_end_utc_exclusive(tag, end_h, TZ)
+
+
+def _fensterende_text(fenster: tuple[int, int] = FENSTER_TAG) -> str:
+    """"20:00" fuer das Default-Fenster — abgeleitet, nicht getippt."""
+    return local_fmt(_fenstergrenzen(fenster)[1], TZ)
+
+
+def _segment(fenster: tuple[int, int]) -> TripSegment:
+    """Ziel-Etappe, deren Fenster GENAU das Tagesfenster ist — so, wie
+    `_aggregate_for_segment()` es fuer Alarm UND Briefing zuschneidet."""
+    beginn, ende = _fenstergrenzen(fenster)
+    return TripSegment(
+        segment_id="Ziel",
+        start_point=GPXPoint(lat=ISLAND_LAT, lon=ISLAND_LON, elevation_m=800.0,
+                             distance_from_start_km=0.0),
+        end_point=GPXPoint(lat=ISLAND_LAT + 0.1, lon=ISLAND_LON + 0.1,
+                           elevation_m=900.0, distance_from_start_km=9.0),
+        start_time=beginn, end_time=ende,
+        duration_hours=(ende - beginn).total_seconds() / 3600.0,
+        distance_km=9.0, ascent_m=100.0, descent_m=100.0,
+    )
+
+
+def _punkte(stunden: dict[int, float], *, tag: date = TAG):
+    """Volle 24-Stunden-Reihe des Tages; nur die genannten Stunden tragen Regen.
+
+    Bewusst der GANZE Tag: eine Stunde ausserhalb des Fensters muss ueber ihren
+    ZEITSTEMPEL herausfallen (AC-6), nicht dadurch, dass es sie gar nicht gibt.
+    """
+    return [
+        ForecastDataPoint(
+            ts=datetime(tag.year, tag.month, tag.day, h, 0),
+            t2m_c=12.0, wind10m_kmh=15.0, gust_kmh=25.0,
+            precip_1h_mm=stunden.get(h, 0.0),
+        )
+        for h in range(24)
+    ]
+
+
+def _data(stunden: dict[int, float], summe: float,
+          fenster: tuple[int, int] = FENSTER_TAG) -> SegmentWeatherData:
+    """Ein Etappen-Datenstand: Stundenreihe + Fenster-Aggregat.
+
+    `precip_sum_mm` ist die FENSTER-Gesamtsumme (so entsteht sie produktiv in
+    `_aggregate_for_segment()`); die Projektion leitet daraus das bereits
+    Gefallene als `new_value - remaining_mm` ab.
+    """
+    return SegmentWeatherData(
+        segment=_segment(fenster),
+        timeseries=NormalizedTimeseries(
+            meta=ForecastMeta(provider=Provider.OPENMETEO, model="test",
+                              grid_res_km=1.0),
+            data=_punkte(stunden),
+        ),
+        aggregated=SegmentWeatherSummary(temp_max_c=12.0, precip_sum_mm=summe),
+        fetched_at=datetime(TAG.year, TAG.month, TAG.day, 6, 0,
+                            tzinfo=timezone.utc),
+        provider="openmeteo",
+    )
+
+
+def _aenderungen(stunden: dict[int, float], *, alt: float, neu: float,
+                 fenster: tuple[int, int] = FENSTER_TAG,
+                 schwelle: float | None = None):
+    """Der PRODUKTIVE Vergleichslauf. `include_absolute=False` ist der
+    Alarm-Pfad (Issue #816). `schwelle` bildet eine nutzerseitig gesetzte
+    Empfindlichkeit ab (Katalog-Default fuer `precip_sum_mm` ist 10 mm)."""
+    detektor = (
+        WeatherChangeDetectionService(thresholds={"precip_sum_mm": schwelle})
+        if schwelle is not None else WeatherChangeDetectionService()
+    )
+    alt_data = _data(stunden, alt, fenster)
+    neu_data = _data(stunden, neu, fenster)
+    changes = detektor.detect_changes(alt_data, neu_data, include_absolute=False)
+    regen = [c for c in changes if c.metric == "precip_sum_mm"]
+    assert regen, (
+        "Der Detektor muss eine Niederschlags-Summen-Aenderung liefern; "
+        f"bekam {[c.metric for c in changes]}"
+    )
+    return regen, [neu_data]
+
+
+def _uhr(stunde: int, minute: int = 0, *, tag: date = TAG) -> datetime:
+    """Referenzzeit (Ortszeit == UTC auf Island) als UTC-Zeitstempel."""
+    return datetime(tag.year, tag.month, tag.day, stunde, minute,
+                    tzinfo=timezone.utc)
+
+
+def _nachricht(changes, segmente, *, now_utc: datetime,
+               stand_at: str | None = None):
+    """Projektion MIT Referenzzeit.
+
+    `stand_at` ist normalerweise die Ortszeit der Referenzzeit (so entsteht sie
+    produktiv). Wo ZWEI Referenzzeiten gegeneinander verglichen werden (AC-4),
+    setzt der Test ihn fest — sonst unterschieden sich die Texte schon an der
+    Stand-Zeile, und der Vergleich sagte nichts ueber die Restmenge aus.
+    """
+    kwargs = dict(tz=TZ, stand_at=stand_at or local_fmt(now_utc, TZ))
+    # 🔴 RED-ONLY (#2020 Scheibe 2, Phase 5): Dieser Fallback MUSS mit dem
+    # GREEN-Commit entfernt werden. Er existiert AUSSCHLIESSLICH, damit die
+    # Wortlaut-ACs an inhaltlichen Assertions scheitern statt am fehlenden
+    # Parameter `now_utc`. Bleibt er stehen, verdeckt er kuenftig das Fehlen
+    # von `now_utc`, statt es rot zu machen — eine eingebaute Erosionsstelle.
+    try:
+        return to_alert_message(changes, segmente, "Test-Trip",
+                                now_utc=now_utc, **kwargs)
+    except TypeError as exc:  # pragma: no cover - faellt mit dem Fix weg
+        if "now_utc" not in str(exc):
+            raise
+        return to_alert_message(changes, segmente, "Test-Trip", **kwargs)
+
+
+def _texte(stunden: dict[int, float], *, now_utc: datetime,
+           alt: float = ANGEKUENDIGT, neu: float = SUMME_AC1,
+           fenster: tuple[int, int] = FENSTER_TAG,
+           schwelle: float | None = None,
+           stand_at: str | None = None) -> dict[str, str]:
+    """Die vier Kanaltexte aus EINEM Alarm-Lauf — genau die Renderer, die
+    `notification_service._dispatch_alert_message()` aufruft. Premium-SMS
+    bekommt dort denselben `sms_body` wie SMS (`_render_sms_body`)."""
+    changes, segmente = _aenderungen(stunden, alt=alt, neu=neu,
+                                     fenster=fenster, schwelle=schwelle)
+    msg = _nachricht(changes, segmente, now_utc=now_utc, stand_at=stand_at)
+    html, plain = render_email(msg)
+    return {
+        "email_html": html, "email_plain": plain,
+        "telegram": render_telegram(msg),
+        # 160 statt des Default-Limits 140: die Spec bemisst die Kurzform an
+        # der 160-Zeichen-Grenze (AC-7), und ein zu enges Limit wuerde den
+        # Restmengen-Token wegschneiden, bevor er geprueft werden kann.
+        "sms": render_sms(msg, 160),
+        "premium_sms": _render_sms_body(msg, 160),
+    }
+
+
+def _langform(texte: dict[str, str]) -> list[tuple[str, str]]:
+    """(Kanalname, Text) der beiden Langform-Kanaele — E-Mail-Klartext und
+    Telegram muessen dieselben Saetze tragen."""
+    return [("email_plain", texte["email_plain"]), ("telegram", texte["telegram"])]
+
+
+# --------------------------------------------------------------------------
+# AC-1 .. AC-3: dieselbe Stundenreihe, drei Referenzzeiten
+# --------------------------------------------------------------------------
+
+def test_alarm_nennt_restmenge_und_letzten_regen_ab_versandzeit():
+    """AC-1.
+
+    GIVEN Tagesfenster 4-19 (effektives Ende 20:00 Ortszeit) und die
+          Stundenreihe 13:00=8 · 15:00=10 · 16:00=3 · 17:00=1 mm
+          (angekuendigt waren 5 mm)
+    WHEN  die Nachricht bei Referenzzeit 14:30 Ortszeit gerendert wird —
+          nach der 13:00-Stunde, vor der 15:00-Stunde
+    THEN  ist die Hauptaussage vorwaertsgewandt: Kopf "mehr Regen als
+          angekuendigt", "Bis jetzt: ~8 mm gefallen (angekuendigt waren 5)",
+          "Ab jetzt: noch ~14 mm, letzter Regen gegen 17:00".
+    """
+    texte = _texte(REIHE_AC1, now_utc=_uhr(14, 30))
+
+    for kanal, text in _langform(texte):
+        assert "mehr Regen als angekündigt" in text, (
+            f"{kanal}: Der Kopf muss die Blickrichtung nennen "
+            f"('mehr Regen als angekündigt'); bekam:\n{text}"
+        )
+        assert "Bis jetzt: ~8 mm gefallen (angekündigt waren 5)" in text, (
+            f"{kanal}: Einordnung des bereits Gefallenen fehlt; bekam:\n{text}"
+        )
+        assert "Ab jetzt: noch ~14 mm, letzter Regen gegen 17:00" in text, (
+            f"{kanal}: Restmenge ab Versand und ihr Ende fehlen — genau das "
+            f"ist die Hauptaussage dieser Scheibe; bekam:\n{text}"
+        )
+
+    kopfzeile = [z for z in texte["telegram"].splitlines()
+                 if "mehr Regen als angekündigt" in z]
+    assert kopfzeile and "Ziel" in kopfzeile[0], (
+        f"Der Kopf muss weiterhin den Ort nennen ('🏁 Ziel'); bekam {kopfzeile!r}"
+    )
+
+
+def test_frueher_versand_meldet_fast_die_ganze_menge_als_rest():
+    """AC-2.
+
+    GIVEN dieselbe Stundenreihe und dasselbe Fenster wie AC-1
+    WHEN  die Nachricht bei Referenzzeit 10:00 Ortszeit gerendert wird, bevor
+          irgendeine Stunde der Reihe begonnen hat
+    THEN  ist die Restmenge nahe der Fenster-Gesamtmenge (~22 mm), das bereits
+          Gefallene nahe null (~0 mm), und die Endzeit bleibt 17:00 — sie ist
+          eine Eigenschaft der Reihe, nicht der Referenzzeit.
+    """
+    texte = _texte(REIHE_AC1, now_utc=_uhr(10))
+
+    for kanal, text in _langform(texte):
+        assert "Ab jetzt: noch ~22 mm, letzter Regen gegen 17:00" in text, (
+            f"{kanal}: Vor der ersten Regenstunde muss die volle Fenstermenge "
+            f"als Rest stehen; bekam:\n{text}"
+        )
+        assert "Bis jetzt: ~0 mm gefallen (angekündigt waren 5)" in text, (
+            f"{kanal}: Vor der ersten Regenstunde darf nichts gefallen sein; "
+            f"bekam:\n{text}"
+        )
+        assert "~-" not in text, (
+            f"{kanal}: Keine Teilmenge darf negativ werden; bekam:\n{text}"
+        )
+        assert "noch ~23 mm" not in text and "noch ~24 mm" not in text, (
+            f"{kanal}: Die Restmenge darf die Fenster-Gesamtmenge (22 mm) nicht "
+            f"ueberschreiten; bekam:\n{text}"
+        )
+
+
+def test_alarm_nach_dem_letzten_regen_meldet_ehrlich_nichts_mehr():
+    """AC-3.
+
+    GIVEN dieselbe Stundenreihe und dasselbe Fenster wie AC-1 (letzte
+          Regenstunde 17:00)
+    WHEN  die Nachricht bei Referenzzeit 18:15 Ortszeit gerendert wird — nach
+          der letzten Regenstunde, aber vor dem effektiven Fensterende 20:00
+          (der beanstandete Originalfall vom 2026-08-20)
+    THEN  meldet sie "kein weiterer Regen bis Tagesende (Fensterende 20:00
+          Ortszeit)" statt eine Restmenge zu erfinden — und wird trotzdem
+          zugestellt, weil bereits mehr gefallen ist als angekuendigt.
+    """
+    texte = _texte(REIHE_AC1, now_utc=_uhr(18, 15))
+    erwartet = (
+        "Ab jetzt: kein weiterer Regen bis Tagesende "
+        f"(Fensterende {_fensterende_text()} Ortszeit)"
+    )
+
+    for kanal, text in _langform(texte):
+        assert text.strip(), f"{kanal}: Die Meldung darf nicht leer sein"
+        assert erwartet in text, (
+            f"{kanal}: Nach der letzten Regenstunde muss die Meldung ehrlich "
+            f"sagen, dass nichts mehr kommt. Erwartet {erwartet!r}; bekam:\n{text}"
+        )
+        assert "Bis jetzt: ~22 mm gefallen (angekündigt waren 5)" in text, (
+            f"{kanal}: Die Einordnung des bereits Gefallenen bleibt — sie ist "
+            f"der Grund, warum die Meldung zugestellt wird; bekam:\n{text}"
+        )
+        assert "noch ~" not in text, (
+            f"{kanal}: Es darf keine Restmenge erfunden werden; bekam:\n{text}"
+        )
+
+
+# --------------------------------------------------------------------------
+# AC-4 .. AC-6: Rechenregeln der Restmenge
+# --------------------------------------------------------------------------
+
+def test_angebrochene_stunde_zaehlt_voll_und_nicht_anteilig():
+    """AC-4.
+
+    GIVEN eine Referenzzeit mitten in einer angebrochenen Regenstunde
+          (14:20 Ortszeit bei 2,0 mm um 14:00, sonst die AC-1-Reihe)
+    WHEN  die Restmenge berechnet wird
+    THEN  zaehlt die angebrochene Stunde VOLL (2 + 10 + 3 + 1 = 16 mm) — die
+          Reihe ergibt bei 14:00 exakt denselben Wert wie bei 14:20. Eine
+          anteilige Implementierung muss daran brechen.
+    """
+    reihe = {**REIHE_AC1, 14: 2.0}
+    summe = SUMME_AC1 + 2.0
+    # `stand_at` fest auf BEIDEN Seiten: sonst unterschieden sich die Texte
+    # bereits an der Stand-Zeile ("Stand: heute 14:00" gegen "… 14:20"), und
+    # der Vergleich unten koennte selbst nach einer korrekten Implementierung
+    # nie gruen werden. So bleibt der schaerfste Vergleich moeglich — der
+    # GESAMTE Kanaltext —, und der einzige zulaessige Unterschied waere ein
+    # anteilig gekuerzter Restmengenwert. Genau den soll AC-4 verbieten.
+    voll = _texte(reihe, now_utc=_uhr(14, 0), neu=summe, stand_at="14:00")
+    angebrochen = _texte(reihe, now_utc=_uhr(14, 20), neu=summe, stand_at="14:00")
+
+    for kanal, text in _langform(angebrochen):
+        assert "Ab jetzt: noch ~16 mm, letzter Regen gegen 17:00" in text, (
+            f"{kanal}: Die um 14:00 beginnende Stunde (2,0 mm) zaehlt VOLL zur "
+            f"Restmenge (2+10+3+1 = 16 mm); bekam:\n{text}"
+        )
+    for kanal in ("email_plain", "telegram", "sms"):
+        assert voll[kanal] == angebrochen[kanal], (
+            f"{kanal}: Grenzstabilitaet — 14:00 und 14:20 muessen denselben "
+            f"Restmengen-Wert liefern.\n14:00: {voll[kanal]!r}\n"
+            f"14:20: {angebrochen[kanal]!r}"
+        )
+
+
+def test_ende_ist_die_letzte_regenstunde_des_ganzen_fensters():
+    """AC-5.
+
+    GIVEN Tagesfenster 4-19 und zwei getrennte Regenphasen, die BEIDE im
+          Fenster liegen (6:00=1 · 7:00=1 mm, Pause, 16:00=1 · 17:00=1 mm)
+    WHEN  das Ende bei Referenzzeit 10:00 Ortszeit — zwischen den Phasen —
+          berechnet wird
+    THEN  ist das Ende die letzte Regenstunde des GESAMTEN Fensters (17:00),
+          nicht das Ende der ersten Phase (07:00).
+    """
+    reihe = {6: 1.0, 7: 1.0, 16: 1.0, 17: 1.0}
+    # Nutzerseitig empfindlichere Schwelle (1 mm statt Katalog-Default 10 mm) —
+    # sonst loest diese kleine, aber fachlich reale Reihe gar keinen Alarm aus.
+    texte = _texte(reihe, now_utc=_uhr(10), alt=1.0, neu=4.0, schwelle=1.0)
+
+    for kanal, text in _langform(texte):
+        assert "letzter Regen gegen 17:00" in text, (
+            f"{kanal}: Das Ende muss die letzte Regenstunde des Fensters sein "
+            f"(17:00), nicht das Ende der ersten Phase; bekam:\n{text}"
+        )
+        assert "gegen 07:00" not in text, (
+            f"{kanal}: 07:00 ist nur das Ende der ERSTEN Phase — die zweite "
+            f"Phase liegt im selben Fenster; bekam:\n{text}"
+        )
+        assert "Ab jetzt: noch ~2 mm" in text, (
+            f"{kanal}: Beide Stunden der zweiten Phase stehen noch bevor; "
+            f"bekam:\n{text}"
+        )
+
+
+@pytest.mark.parametrize(
+    "fenster, erwartet_rest, erwartet_ende, summe",
+    [
+        (FENSTER_TAG, "noch ~22 mm", "gegen 17:00", SUMME_AC1),
+        (FENSTER_LANG, "noch ~27 mm", "gegen 21:00", SUMME_AC1 + 5.0),
+    ],
+    ids=["fenster_4_19_schliesst_21_uhr_aus", "fenster_4_22_schliesst_21_uhr_ein"],
+)
+def test_restmenge_und_ende_bleiben_im_konfigurierten_tagesfenster(
+    fenster, erwartet_rest, erwartet_ende, summe,
+):
+    """AC-6.
+
+    GIVEN die AC-1-Reihe, ergaenzt um eine Regenstunde um 21:00 (5 mm)
+    WHEN  Restmenge und Ende bei Referenzzeit 10:00 einmal mit Tagesfenster
+          4-19 (effektives Ende 20:00) und einmal mit 4-22 (effektives Ende
+          23:00) berechnet werden
+    THEN  bleiben die Werte bei 4-19 GENAU wie in AC-2 (22 mm / 17:00 — die
+          21:00-Stunde faellt heraus) und aendern sich bei 4-22 fenstertreu
+          (27 mm / 21:00). Eine Implementierung, die global ueber die Reihe
+          summiert, muss mindestens einen der beiden Faelle brechen.
+    """
+    reihe = {**REIHE_AC1, 21: 5.0}
+    texte = _texte(reihe, now_utc=_uhr(10), neu=summe, fenster=fenster)
+
+    for kanal, text in _langform(texte):
+        assert f"Ab jetzt: {erwartet_rest}, letzter Regen {erwartet_ende}" in text, (
+            f"{kanal}: Fenster {fenster} -> erwartet {erwartet_rest!r} / "
+            f"{erwartet_ende!r}; bekam:\n{text}"
+        )
+
+
+def test_regen_nach_fensterende_erscheint_nicht_in_der_meldung():
+    """AC-6 (Gegenprobe zur Fenster-Invariante).
+
+    GIVEN dieselbe erweiterte Reihe (21:00 = 5 mm) und Tagesfenster 4-19
+    WHEN  die Nachricht bei Referenzzeit 10:00 gerendert wird
+    THEN  taucht die 21:00-Stunde nirgends auf — weder als Endzeit noch in der
+          Restmenge. Genau das sieht auch das Briefing fuer diesen Zeitraum
+          nicht (gemeinsames Fenster, Spec-Invariante).
+    """
+    reihe = {**REIHE_AC1, 21: 5.0}
+    texte = _texte(reihe, now_utc=_uhr(10))
+
+    for kanal, text in _langform(texte):
+        # Positivseite ZUERST: ohne sie waere dieser Waechter allein dadurch
+        # gruen, dass es noch gar keine Restmengen-Aussage gibt.
+        assert "Ab jetzt: noch ~22 mm, letzter Regen gegen 17:00" in text, (
+            f"{kanal}: Die Werte muessen mit AC-2 identisch bleiben, obwohl die "
+            f"Reihe eine 21:00-Stunde traegt; bekam:\n{text}"
+        )
+        assert "21:00" not in text, (
+            f"{kanal}: Regen nach dem effektiven Fensterende (20:00) darf die "
+            f"Meldung nicht erreichen; bekam:\n{text}"
+        )
+        assert "noch ~27 mm" not in text, (
+            f"{kanal}: Die 21:00-Stunde darf nicht in die Restmenge fliessen; "
+            f"bekam:\n{text}"
+        )
+
+
+# --------------------------------------------------------------------------
+# AC-7: alle vier Kanaele aus EINER Nachricht
+# --------------------------------------------------------------------------
+
+def test_alle_vier_kanaele_tragen_restmenge_und_ende():
+    """AC-7.
+
+    GIVEN denselben Abweichungsalarm wie AC-1 (Reihe/Fenster/Referenzzeit
+          14:30)
+    WHEN  er in alle vier Kanaele gerendert wird (E-Mail HTML, E-Mail
+          Klartext, Telegram, SMS/Premium-SMS)
+    THEN  tragen E-Mail und Telegram die vollstaendigen Saetze, SMS und
+          Premium-SMS denselben Sachverhalt als Kompakt-Token
+          ("Ziel: R5->22@15 Rest14@17"), und die Kurznachricht bleibt
+          innerhalb der 160-Zeichen-Grenze.
+    """
+    texte = _texte(REIHE_AC1, now_utc=_uhr(14, 30))
+
+    assert "Ab jetzt" in texte["email_html"], (
+        "Die HTML-Fassung ist die Normalfassung und muss dieselbe Aussage "
+        f"tragen; bekam:\n{texte['email_html']}"
+    )
+    for kanal, text in _langform(texte):
+        assert "Ab jetzt: noch ~14 mm, letzter Regen gegen 17:00" in text, (
+            f"{kanal}: vollstaendiger Satz erwartet; bekam:\n{text}"
+        )
+
+    for kanal in ("sms", "premium_sms"):
+        kurz = texte[kanal]
+        assert "Rest14@17" in kurz, (
+            f"{kanal}: Kompakt-Token der Restmenge erwartet ('Rest14@17'); "
+            f"bekam {kurz!r}"
+        )
+        assert "R5->22@15" in kurz, (
+            f"{kanal}: Das bestehende Delta-Token bleibt unveraendert daneben "
+            f"stehen; bekam {kurz!r}"
+        )
+        assert kurz.startswith("Ziel:"), (
+            f"{kanal}: Der Kurzform-Kopf nennt weiterhin den Ort; bekam {kurz!r}"
+        )
+        assert len(kurz) <= 160, (
+            f"{kanal}: 160-Zeichen-Grenze gerissen ({len(kurz)}): {kurz!r}"
+        )
+
+    # Premium-SMS laeuft ueber DENSELBEN `_render_sms_body`-Pfad wie SMS —
+    # nachgewiesen, nicht angenommen: derselbe Text, nicht nur derselbe Inhalt.
+    assert texte["sms"] == texte["premium_sms"], (
+        "SMS und Premium-SMS muessen denselben Text bekommen.\n"
+        f"sms:         {texte['sms']!r}\npremium_sms: {texte['premium_sms']!r}"
+    )
+
+
+def test_kein_weiterer_regen_wird_auch_in_der_kurzform_gesagt():
+    """AC-7 (Kurzform des AC-3-Falls).
+
+    GIVEN die AC-1-Reihe und Referenzzeit 18:15 (nichts kommt mehr)
+    WHEN  die Kurznachricht gebaut wird
+    THEN  steht dort "Rest0" ohne Zeit-Suffix — die Kurzform verschweigt den
+          Sachverhalt nicht, sie kuerzt ihn nur.
+    """
+    kurz = _texte(REIHE_AC1, now_utc=_uhr(18, 15))["sms"]
+
+    assert "Rest0" in kurz, (
+        f"Kurzform muss 'Rest0' melden statt zu schweigen; bekam {kurz!r}"
+    )
+    assert "Rest0@" not in kurz, (
+        f"'Rest0' traegt kein Zeit-Suffix (es gibt keine Endzeit); bekam {kurz!r}"
+    )
+    assert len(kurz) <= 160, f"160-Zeichen-Grenze gerissen: {kurz!r}"

--- a/tests/tdd/test_alert_zeitangaben_tagesbezug.py
+++ b/tests/tdd/test_alert_zeitangaben_tagesbezug.py
@@ -1,0 +1,538 @@
+"""TDD RED — Issue #2020, Scheibe 2: jede Zeitangabe nennt ihre Groesse und
+ihren Tagesbezug.
+
+SPEC: docs/specs/modules/fix_2020_alarm_blickrichtung.md (AC-8 .. AC-14),
+      Abschnitt "Teil 3 — Zeitangaben benennen ihre Groesse und ihren Tagesbezug"
+
+GEMESSENER IST-STAND (2026-08-21, dieser Branch):
+
+1. Die Zeile "Wo & wann" nennt eine NACKTE Uhrzeit (`_datablock_single`,
+   render.py:721 -> "🏁 Ziel · 17:00"). Ob das der Zeitpunkt des staerksten
+   Werts ist, ob er bevorsteht oder laengst vorbei ist, und an welchem Tag er
+   liegt, steht nirgends.
+2. `_onset_time_label()` (render.py:367-374) loest den Tagesversatz nur ueber
+   den WAHRHEITSWERT auf (`f"morgen …" if e.onset_day_offset else …`) — jeder
+   Versatz ungleich null wird "morgen", auch `-1`. Im Nowcast-Vorwaertsfenster
+   unerreichbar, im Abweichungsalarm der Normalfall.
+3. Weder `AlertEvent` noch `OnsetShiftEvent` fuehren einen Tagesversatz oder
+   ein Vergangenheits-Kennzeichen, und `to_alert_message()` kennt keine
+   Referenzzeit `now_utc`, aus der sich beides ableiten liesse.
+
+PRUEFORT = WIRKORT. Tagesversatz und Vergangenheit entstehen laut Spec in der
+PROJEKTION aus der Referenzzeit (`day_offset(now_utc, …)`), der Renderer setzt
+nur die Worte. Deshalb faehrt jeder Test die echte Kette
+`WeatherChangeDetectionService.detect_changes()` -> `to_alert_message()` ->
+Kanal-Renderer, statt sich fertige Modell-Felder von Hand zu setzen: nur so
+ist geprueft, dass der Versatz aus der REFERENZZEIT kommt und nicht aus der
+Systemuhr (AC-13).
+
+KEIN MOCK-THEATER (CLAUDE.md, Kern-Schicht): kein `Mock()`/`patch()`/
+`MagicMock`, kein Dateiinhalt-Check als Verhaltensnachweis, kein Netz.
+`freeze_time` friert ausschliesslich die SYSTEMUHR ein — genau die Groesse,
+von der das Ergebnis laut AC-13 NICHT abhaengen darf.
+
+ZEITZONE/KALENDER. Die Etappe haengt auf Island (`Atlantic/Reykjavik`,
+ganzjaehrig UTC+0): Ortszeit == Weltzeit, die Uhrzeit-Literale stehen damit
+unverfaelscht im Test. Der Ereignistag 2026-08-20 ist ein DONNERSTAG — das
+Kuerzel "Do" fuer AC-10 wird ueber `_de_weekday_short()` aus dem Bestand
+abgeleitet, nicht geraten.
+
+Pfadregel #1409: der Prueling wird RELATIV ZU DIESER DATEI aufgeloest (ueber
+`tests/conftest.py`, das `<repo>/src` an `sys.path` haengt), nie ueber den
+festen Hauptrepo-Pfad.
+"""
+from __future__ import annotations
+
+import dataclasses
+from datetime import date, datetime, time, timedelta, timezone
+from zoneinfo import ZoneInfo
+
+import pytest
+from freezegun import freeze_time
+
+from app.day_window import resolve_configured_window, window_end_utc_exclusive
+from app.models import (
+    ForecastDataPoint, ForecastMeta, GPXPoint, NormalizedTimeseries, Provider,
+    SegmentWeatherData, SegmentWeatherSummary, TripSegment,
+)
+from output.renderers.alert.model import OnsetEvent, OnsetShiftEvent
+from output.renderers.alert.official_alerts import _de_weekday_short, _tag_hour
+from output.renderers.alert.project import to_alert_message
+from output.renderers.alert.render import (
+    _onset_time_label, render_email, render_sms, render_telegram,
+)
+from services.weather_change_detection import WeatherChangeDetectionService
+from utils.timezone import local_fmt
+
+ISLAND_LAT, ISLAND_LON = 64.13, -21.90
+TZ = ZoneInfo("Atlantic/Reykjavik")
+TAG = date(2026, 8, 20)          # Donnerstag (s. Modul-Docstring)
+FENSTER = (4, 19)                # Default-Tagesfenster, ADR-0035
+
+# Die Niederschlags-Reihe der Spec (AC-1): Spitze um 15:00.
+REIHE_REGEN = {13: 8.0, 15: 10.0, 16: 3.0, 17: 1.0}
+SUMME_REGEN = 22.0
+ANGEKUENDIGT = 5.0
+
+
+# --------------------------------------------------------------------------
+# Fixture-Bausteine (dieselbe Bauart wie test_alert_restmenge_und_ende.py --
+# Fenstergrenzen aus den produktiven Funktionen, nicht getippt)
+# --------------------------------------------------------------------------
+
+def _segment() -> TripSegment:
+    start_h, end_h = resolve_configured_window(*FENSTER)
+    beginn = (
+        datetime.combine(TAG, time(start_h))
+        .replace(tzinfo=TZ)
+        .astimezone(timezone.utc)
+    )
+    ende = window_end_utc_exclusive(TAG, end_h, TZ)
+    return TripSegment(
+        segment_id="Ziel",
+        start_point=GPXPoint(lat=ISLAND_LAT, lon=ISLAND_LON, elevation_m=800.0,
+                             distance_from_start_km=0.0),
+        end_point=GPXPoint(lat=ISLAND_LAT + 0.1, lon=ISLAND_LON + 0.1,
+                           elevation_m=900.0, distance_from_start_km=9.0),
+        start_time=beginn, end_time=ende,
+        duration_hours=(ende - beginn).total_seconds() / 3600.0,
+        distance_km=9.0, ascent_m=100.0, descent_m=100.0,
+    )
+
+
+def _punkte(*, regen: dict[int, float] | None = None, boeen_spitze: int | None = None):
+    """24-Stunden-Reihe. `boeen_spitze` legt die Stunde der staerksten Boee."""
+    regen = regen or {}
+    return [
+        ForecastDataPoint(
+            ts=datetime(TAG.year, TAG.month, TAG.day, h, 0),
+            t2m_c=12.0, wind10m_kmh=20.0,
+            gust_kmh=70.0 if h == boeen_spitze else 25.0,
+            precip_1h_mm=regen.get(h, 0.0),
+        )
+        for h in range(24)
+    ]
+
+
+def _data(punkte, **summary) -> SegmentWeatherData:
+    return SegmentWeatherData(
+        segment=_segment(),
+        timeseries=NormalizedTimeseries(
+            meta=ForecastMeta(provider=Provider.OPENMETEO, model="test",
+                              grid_res_km=1.0),
+            data=punkte,
+        ),
+        aggregated=SegmentWeatherSummary(temp_max_c=12.0, **summary),
+        fetched_at=datetime(TAG.year, TAG.month, TAG.day, 6, 0,
+                            tzinfo=timezone.utc),
+        provider="openmeteo",
+    )
+
+
+def _aenderungen(punkte, feld: str, *, alt: float, neu: float):
+    """Der PRODUKTIVE Vergleichslauf (Alarm-Pfad, `include_absolute=False`)."""
+    changes = WeatherChangeDetectionService().detect_changes(
+        _data(punkte, **{feld: alt}), _data(punkte, **{feld: neu}),
+        include_absolute=False,
+    )
+    treffer = [c for c in changes if c.metric == feld]
+    assert treffer, (
+        f"Der Detektor muss eine Aenderung an {feld} liefern; "
+        f"bekam {[c.metric for c in changes]}"
+    )
+    return treffer, [_data(punkte, **{feld: neu})]
+
+
+def _uhr(tag: date, stunde: int, minute: int = 0) -> datetime:
+    return datetime(tag.year, tag.month, tag.day, stunde, minute,
+                    tzinfo=timezone.utc)
+
+
+def _nachricht(changes, segmente, *, now_utc: datetime):
+    """Projektion MIT Referenzzeit.
+
+    RED-Zustand: `to_alert_message()` kennt `now_utc` noch nicht. Der Aufruf
+    faellt dann auf die Bestandsform zurueck, damit die Tests unten an der
+    fehlenden AUSSAGE scheitern und nicht an der Signatur.
+    """
+    kwargs = dict(tz=TZ, stand_at=local_fmt(now_utc, TZ))
+    # 🔴 RED-ONLY (#2020 Scheibe 2, Phase 5): Dieser Fallback MUSS mit dem
+    # GREEN-Commit entfernt werden. Er existiert AUSSCHLIESSLICH, damit die
+    # Wortlaut-ACs an inhaltlichen Assertions scheitern statt am fehlenden
+    # Parameter `now_utc`. Bleibt er stehen, verdeckt er kuenftig das Fehlen
+    # von `now_utc`, statt es rot zu machen — eine eingebaute Erosionsstelle.
+    try:
+        return to_alert_message(changes, segmente, "Test-Trip",
+                                now_utc=now_utc, **kwargs)
+    except TypeError as exc:  # pragma: no cover - faellt mit dem Fix weg
+        if "now_utc" not in str(exc):
+            raise
+        return to_alert_message(changes, segmente, "Test-Trip", **kwargs)
+
+
+def _texte(msg) -> dict[str, str]:
+    html, plain = render_email(msg)
+    return {"email_html": html, "email_plain": plain,
+            "telegram": render_telegram(msg), "sms": render_sms(msg, 160)}
+
+
+def _langform(texte) -> list[tuple[str, str]]:
+    return [("email_plain", texte["email_plain"]), ("telegram", texte["telegram"])]
+
+
+def _boeen_nachricht(*, spitze: int, now_utc: datetime):
+    """Boeen-Aenderung (Nicht-Niederschlags-Metrik) mit Spitze zur Stunde
+    `spitze` — der Fall, fuer den der Kopf "staerkste Stunde" gilt."""
+    changes, segmente = _aenderungen(
+        _punkte(boeen_spitze=spitze), "gust_max_kmh", alt=30.0, neu=70.0,
+    )
+    return _nachricht(changes, segmente, now_utc=now_utc)
+
+
+def _regen_nachricht(*, now_utc: datetime):
+    changes, segmente = _aenderungen(
+        _punkte(regen=REIHE_REGEN), "precip_sum_mm",
+        alt=ANGEKUENDIGT, neu=SUMME_REGEN,
+    )
+    return _nachricht(changes, segmente, now_utc=now_utc)
+
+
+def _nur_bekannte_felder(cls, **felder):
+    """Konstruiert ein Modell mit den Feldern, die es HEUTE schon kennt.
+
+    Die neuen Felder dieser Spec (`to_is_past`, `to_day_offset`) fallen im
+    RED-Zustand weg — der Test scheitert dadurch an der fehlenden AUSSAGE im
+    gerenderten Text statt an der Konstruktion, und wird gruen, sobald die
+    Felder existieren UND der Renderer sie ausspricht.
+    """
+    bekannt = {f.name for f in dataclasses.fields(cls)}
+    return cls(**{k: v for k, v in felder.items() if k in bekannt})
+
+
+def _onset_shift(*, to_is_past: bool) -> OnsetShiftEvent:
+    return _nur_bekannte_felder(
+        OnsetShiftEvent,
+        metric_id="precipitation", from_time="19:00", to_time="15:00",
+        shift_text="4 h früher", km_from=0.0, km_to=9.0, segment_id="Ziel",
+        to_day_offset=0, to_is_past=to_is_past,
+    )
+
+
+def _onset_shift_nachricht(*, to_is_past: bool):
+    from output.renderers.alert.model import AlertMessage
+    return AlertMessage(
+        trip_short="Test-Trip", stand_at="15:30", events=(),
+        onset_shift_events=(_onset_shift(to_is_past=to_is_past),),
+    )
+
+
+# --------------------------------------------------------------------------
+# AC-8: vergangener Beginn wird als vergangen ausgewiesen
+# --------------------------------------------------------------------------
+
+def test_bereits_verstrichener_beginn_wird_als_vergangen_ausgewiesen():
+    """AC-8.
+
+    GIVEN ein Abweichungsalarm, dessen Niederschlagsbeginn zum
+          Versandzeitpunkt bereits verstrichen ist, aber am selben
+          Kalendertag liegt (Beginn 15:00, Versand 15:30 Ortszeit)
+    WHEN  die Alarm-Nachricht gerendert wird
+    THEN  weist die Beginn-Zeile den Zeitpunkt als vergangen aus
+          ("19:00 → seit 15:00 (4 h früher)") statt ihn als bevorstehend zu
+          formulieren; die Gegenprobe mit kuenftigem Beginn traegt "seit" nicht.
+    """
+    vergangen = _texte(_onset_shift_nachricht(to_is_past=True))
+    kuenftig = _texte(_onset_shift_nachricht(to_is_past=False))
+
+    for kanal, text in _langform(vergangen):
+        assert "19:00 → seit 15:00" in text, (
+            f"{kanal}: Ein bereits verstrichener Beginn muss als vergangen "
+            f"formuliert sein ('→ seit 15:00'); bekam:\n{text}"
+        )
+    for kanal, text in _langform(kuenftig):
+        assert "seit" not in text, (
+            f"{kanal}: Ein noch bevorstehender Beginn darf NICHT als vergangen "
+            f"formuliert sein; bekam:\n{text}"
+        )
+
+
+# --------------------------------------------------------------------------
+# AC-9: Tagesbezug in der Langform
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "versandtag, erwartet, verboten",
+    [
+        (TAG + timedelta(days=1), "gestern 17:00", "morgen"),
+        (TAG + timedelta(days=2), "vor 2 Tagen 17:00", "morgen"),
+        (TAG - timedelta(days=1), "morgen 17:00", "gestern"),
+    ],
+    ids=["versatz_minus_1", "versatz_minus_2", "versatz_plus_1"],
+)
+def test_zeitangabe_nennt_den_tag_beim_namen(versandtag, erwartet, verboten):
+    """AC-9.
+
+    GIVEN ein Abweichungsalarm, dessen Zeitpunkt (17:00 Ortszeit am
+          2026-08-20) auf einem anderen Kalendertag liegt als der Versandtag
+    WHEN  die Nachricht in E-Mail oder Telegram gerendert wird
+    THEN  nennt die Zeitangabe den Tag in der Hausnotation aus
+          `format_reference_at`: -1 -> "gestern 17:00", -2 -> "vor 2 Tagen
+          17:00", +1 -> "morgen 17:00". Der -1- und -2-Fall duerfen unter
+          KEINEN Umstaenden "morgen" ergeben (Regression zur Wahrheitswert-
+          Pruefung in render.py:374).
+    """
+    texte = _texte(_boeen_nachricht(spitze=17, now_utc=_uhr(versandtag, 9)))
+
+    for kanal, text in _langform(texte):
+        assert erwartet in text, (
+            f"{kanal}: Versandtag {versandtag} -> erwartet {erwartet!r}; "
+            f"bekam:\n{text}"
+        )
+        assert verboten not in text, (
+            f"{kanal}: {verboten!r} ist hier falsch — der Tagesversatz muss "
+            f"EXAKT aufgeloest werden, nicht ueber seinen Wahrheitswert; "
+            f"bekam:\n{text}"
+        )
+
+
+def test_nowcast_tageswort_loest_den_exakten_versatz_auf():
+    """AC-9 (Gegenprobe im Nowcast-Pfad).
+
+    GIVEN denselben gemeinsamen Tageswort-Baustein, auf den
+          `_onset_time_label()` laut Spec umgestellt wird
+    WHEN  er mit Versatz -1 bzw. +1 aufgerufen wird
+    THEN  ergibt -1 "gestern 15:00" und NICHT "morgen 15:00"; +1 bleibt
+          "morgen 15:00" (Bestandsverhalten, Regressions-Invariante).
+    """
+    def _onset(offset: int) -> OnsetEvent:
+        return _nur_bekannte_felder(
+            OnsetEvent, onset_minutes=30, onset_time="15:00", km_from=0.0,
+            km_to=9.0, is_convective=False, intensity_label="mäßig",
+            source_label="Radar (DWD)", onset_day_offset=offset,
+        )
+
+    gestern = _onset_time_label(_onset(-1))
+    morgen = _onset_time_label(_onset(1))
+
+    assert gestern == "gestern 15:00", (
+        f"Versatz -1 muss 'gestern 15:00' ergeben; bekam {gestern!r} — die "
+        f"Wahrheitswert-Pruefung macht daraus faelschlich 'morgen'"
+    )
+    assert morgen == "morgen 15:00", (
+        f"Versatz +1 bleibt 'morgen 15:00'; bekam {morgen!r}"
+    )
+
+
+# --------------------------------------------------------------------------
+# AC-10: Tagesbezug in der Kurzform
+# --------------------------------------------------------------------------
+
+def test_kurzform_klebt_das_wochentagskuerzel_vor_die_stunde():
+    """AC-10.
+
+    GIVEN denselben Fall wie AC-9 (Ereigniszeit 15:00 am Donnerstag
+          2026-08-20, Versand am Folgetag), gerendert in SMS/Premium-SMS
+    WHEN  die Kurznachricht gebaut wird
+    THEN  klebt das Wochentagskuerzel vor die Stunde des Tokens ("@Do15") —
+          kein Kanal faellt auf ein Zahlensuffix ("@15-1"/"@15+-1") zurueck.
+    """
+    kuerzel = _de_weekday_short(datetime(TAG.year, TAG.month, TAG.day, 15, 0))
+    assert kuerzel == "Do", (
+        f"Fixture-Selbstkontrolle: {TAG} muss ein Donnerstag sein, "
+        f"bekam {kuerzel!r}"
+    )
+
+    sms = render_sms(_regen_nachricht(now_utc=_uhr(TAG + timedelta(days=1), 9)), 160)
+
+    assert f"@{kuerzel}15" in sms, (
+        f"Erwartet das Wochentagskuerzel direkt vor der Stunde ('@{kuerzel}15'); "
+        f"bekam {sms!r}"
+    )
+    for zahlensuffix in ("@15-1", "@15+-1", "15:00-1"):
+        assert zahlensuffix not in sms, (
+            f"Zahlensuffix {zahlensuffix!r} ist verworfen ('-' ist in der "
+            f"Kurzform dreifach belegt); bekam {sms!r}"
+        )
+    assert len(sms) <= 160, f"160-Zeichen-Grenze gerissen: {sms!r}"
+
+
+# --------------------------------------------------------------------------
+# AC-11/AC-12: jede Zeitangabe benennt ihre Groesse
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "versandstunde, erwartet",
+    [(12, "stärkste Stunde 17:00"), (18, "stärkste Stunde war 17:00")],
+    ids=["zeitpunkt_steht_bevor", "zeitpunkt_ist_vorbei"],
+)
+def test_boeen_zeitangabe_nennt_die_staerkste_stunde(versandstunde, erwartet):
+    """AC-11.
+
+    GIVEN eine Wertaenderung EINER Nicht-Niederschlags-Metrik (Windboee) mit
+          Spitzenwert um 17:00 Ortszeit
+    WHEN  die Nachricht vor bzw. nach diesem Zeitpunkt gerendert wird
+    THEN  benennt die Zeile "Wo & wann" die Uhrzeit ausdruecklich als
+          Zeitpunkt des staerksten Werts ("stärkste Stunde 17:00" bzw.
+          "stärkste Stunde war 17:00") — fuer diese Metrikart bleibt die
+          Kopfform bestehen, eine "Restmenge" ergibt fuer Wind keinen Sinn.
+    """
+    texte = _texte(_boeen_nachricht(spitze=17, now_utc=_uhr(TAG, versandstunde)))
+
+    for kanal, text in _langform(texte):
+        assert erwartet in text, (
+            f"{kanal}: erwartet {erwartet!r}; bekam:\n{text}"
+        )
+        assert "Ab jetzt: noch" not in text, (
+            f"{kanal}: Eine Restmengen-Aussage ergibt fuer Boeen keinen Sinn; "
+            f"bekam:\n{text}"
+        )
+
+
+def test_reine_beginn_zeile_traegt_kein_staerkste_stunde():
+    """AC-11 (Gegenprobe).
+
+    GIVEN eine reine Beginn-Verschiebung ohne Wertaenderung
+    WHEN  die Nachricht gerendert wird
+    THEN  kommt sie weiterhin OHNE das Wort "stärkste Stunde" aus — der
+          Beginn ist keine Spitze.
+    """
+    texte = _texte(_onset_shift_nachricht(to_is_past=True))
+
+    for kanal, text in _langform(texte):
+        assert "stärkste Stunde" not in text, (
+            f"{kanal}: Eine Beginn-Zeile darf das Spitzen-Wort nicht tragen; "
+            f"bekam:\n{text}"
+        )
+        assert "-Beginn:" in text, (
+            f"{kanal}: Die Beginn-Zeile muss ihre Groesse weiterhin als "
+            f"Beginn benennen; bekam:\n{text}"
+        )
+
+
+def test_wertaenderung_und_beginn_verschiebung_bleiben_unterscheidbar():
+    """AC-12.
+
+    GIVEN ein Abweichungsalarm, der GLEICHZEITIG eine Wertaenderung (Boeen-
+          Spitze 17:00) und eine Beginn-Verschiebung (auf 15:00) traegt —
+          der Fall aus #2020, bisher von keinem Test abgedeckt
+    WHEN  die Nachricht gerendert wird
+    THEN  stehen beide Zeitangaben mit unterscheidbarer Bedeutung in
+          derselben Nachricht: die eine als "stärkste Stunde", die andere als
+          "-Beginn" — eine Spitzen-Aussage neben einem Beginn um 15:00 ist
+          damit nicht als Widerspruch lesbar.
+    """
+    msg = _boeen_nachricht(spitze=17, now_utc=_uhr(TAG, 12))
+    msg = dataclasses.replace(
+        msg, onset_shift_events=(_onset_shift(to_is_past=False),),
+    )
+    texte = _texte(msg)
+
+    for kanal, text in _langform(texte):
+        assert "stärkste Stunde 17:00" in text, (
+            f"{kanal}: Die Wertaenderung muss ihre Groesse benennen; bekam:\n{text}"
+        )
+        assert "-Beginn: 19:00 → 15:00" in text, (
+            f"{kanal}: Die Beginn-Verschiebung muss daneben stehen und ihre "
+            f"eigene Groesse benennen; bekam:\n{text}"
+        )
+
+
+# --------------------------------------------------------------------------
+# AC-13: Referenzzeit entscheidet, nicht die Systemuhr
+# --------------------------------------------------------------------------
+
+def test_ergebnis_haengt_an_der_referenzzeit_nicht_an_der_systemuhr():
+    """AC-13.
+
+    GIVEN identische Wetterdaten
+    WHEN  dieselbe Nachricht (a) unter ZWEI verschiedenen eingefrorenen
+          Systemzeiten mit derselben expliziten Referenzzeit und (b) mit ZWEI
+          verschiedenen Referenzzeiten gerendert wird
+    THEN  ist (a) byte-identisch — die Systemuhr entscheidet nirgends mit —
+          und (b) unterschiedlich in Tagesbezug UND Restmenge.
+    """
+    # BEIDE Laeufe bekommen dieselbe Referenzzeit — damit ist auch `stand_at`
+    # identisch (es wird in `_nachricht()` aus genau dieser Referenzzeit
+    # abgeleitet, nicht aus der Systemuhr). Der Gesamttext-Vergleich unten ist
+    # deshalb erfuellbar und misst allein die Unabhaengigkeit von der Systemuhr.
+    with freeze_time("2026-09-01 03:00:00"):
+        frueh = _texte(_regen_nachricht(now_utc=_uhr(TAG, 14, 30)))
+    with freeze_time("2027-01-15 22:00:00"):
+        spaet = _texte(_regen_nachricht(now_utc=_uhr(TAG, 14, 30)))
+
+    for kanal in ("email_plain", "telegram", "sms"):
+        assert frueh[kanal] == spaet[kanal], (
+            f"{kanal}: Bei identischer Referenzzeit darf die Systemuhr das "
+            f"Ergebnis nicht veraendern.\n{frueh[kanal]!r}\n{spaet[kanal]!r}"
+        )
+
+    heute = _texte(_regen_nachricht(now_utc=_uhr(TAG, 14, 30)))
+    morgen = _texte(_regen_nachricht(now_utc=_uhr(TAG + timedelta(days=1), 9)))
+
+    for kanal, text in _langform(heute):
+        assert "Ab jetzt: noch ~14 mm" in text, (
+            f"{kanal}: Referenzzeit 14:30 am Ereignistag -> 14 mm Restmenge; "
+            f"bekam:\n{text}"
+        )
+        assert "gestern" not in text, (
+            f"{kanal}: Am Ereignistag gibt es keinen Tagesbezug; bekam:\n{text}"
+        )
+    for kanal, text in _langform(morgen):
+        assert "gestern" in text, (
+            f"{kanal}: Referenzzeit am Folgetag -> Tagesbezug 'gestern'; "
+            f"bekam:\n{text}"
+        )
+        assert "noch ~14 mm" not in text, (
+            f"{kanal}: Am Folgetag ist von der Restmenge nichts mehr uebrig; "
+            f"bekam:\n{text}"
+        )
+
+
+# --------------------------------------------------------------------------
+# AC-14: Waechter gegen Formkollision in der Kurzform
+# --------------------------------------------------------------------------
+
+def test_tagesbezug_und_fensterform_der_amtlichen_warnung_bleiben_unterscheidbar():
+    """AC-14.
+
+    GIVEN zwei Kurzform-Ausschnitte, die im selben Kanal nebeneinander
+          vorkommen koennen: die Tagesbezug-Form dieses Alarms ("@Do15") und
+          die Fensterform der amtlichen Warnung ("Do12-22" bzw. "15:20-17"
+          aus `_tag_hour`)
+    WHEN  ein Waechter beide aus dem ECHTEN Renderer-Code zieht und
+          gegenueberstellt
+    THEN  sind sie strukturell unterscheidbar — und eine spaetere Aenderung
+          der Fensterform (z.B. Umstellung auf HH:MM-HH:MM) macht diesen Test
+          sofort rot, bevor die Verwechselbarkeit erneut in Produktion landet.
+    """
+    tag = datetime(TAG.year, TAG.month, TAG.day, 12, 0)
+    # Bestandsform der amtlichen Warnung, aus dem echten Code gezogen.
+    fenster_voll = f"{_de_weekday_short(tag)}{_tag_hour(tag)}-{_tag_hour(tag.replace(hour=22))}"
+    fenster_minuten = (
+        f"{_tag_hour(tag.replace(hour=15, minute=20))}-{_tag_hour(tag.replace(hour=17))}"
+    )
+    assert (fenster_voll, fenster_minuten) == ("Do12-22", "15:20-17"), (
+        "Die Fensterform der amtlichen Warnung hat sich geaendert. Damit ist "
+        "die Kollisionsanalyse dieser Spec (verworfenes Zahlensuffix '17:00-1') "
+        "neu zu fuehren, BEVOR die Kurzform angepasst wird. "
+        f"Bekam {fenster_voll!r} / {fenster_minuten!r}"
+    )
+
+    sms = render_sms(_regen_nachricht(now_utc=_uhr(TAG + timedelta(days=1), 9)), 160)
+    tagesbezug = [t for t in sms.split() if "@" in t]
+    assert tagesbezug, f"Kein Zeit-Token in der Kurznachricht: {sms!r}"
+
+    for token in tagesbezug:
+        stunde = token.split("@", 1)[1]
+        assert stunde.startswith("Do"), (
+            f"Der Tagesbezug klebt als Wochentagskuerzel vor die Stunde; "
+            f"bekam {token!r} in {sms!r}"
+        )
+        assert "-" not in stunde, (
+            f"Der Tagesbezug darf keine Bindestrich-Form tragen — sie waere "
+            f"von der Fensterform {fenster_minuten!r} nicht mehr zu "
+            f"unterscheiden; bekam {token!r}"
+        )
+        assert stunde not in (fenster_voll, fenster_minuten), (
+            f"Tagesbezug {stunde!r} und Fensterform sind formgleich geworden"
+        )

--- a/tests/tdd/test_alert_zeitangaben_tagesbezug.py
+++ b/tests/tdd/test_alert_zeitangaben_tagesbezug.py
@@ -149,25 +149,10 @@ def _uhr(tag: date, stunde: int, minute: int = 0) -> datetime:
 
 
 def _nachricht(changes, segmente, *, now_utc: datetime):
-    """Projektion MIT Referenzzeit.
-
-    RED-Zustand: `to_alert_message()` kennt `now_utc` noch nicht. Der Aufruf
-    faellt dann auf die Bestandsform zurueck, damit die Tests unten an der
-    fehlenden AUSSAGE scheitern und nicht an der Signatur.
-    """
+    """Projektion MIT Referenzzeit -- fest uebergeben, nie aus der Systemuhr."""
     kwargs = dict(tz=TZ, stand_at=local_fmt(now_utc, TZ))
-    # 🔴 RED-ONLY (#2020 Scheibe 2, Phase 5): Dieser Fallback MUSS mit dem
-    # GREEN-Commit entfernt werden. Er existiert AUSSCHLIESSLICH, damit die
-    # Wortlaut-ACs an inhaltlichen Assertions scheitern statt am fehlenden
-    # Parameter `now_utc`. Bleibt er stehen, verdeckt er kuenftig das Fehlen
-    # von `now_utc`, statt es rot zu machen — eine eingebaute Erosionsstelle.
-    try:
-        return to_alert_message(changes, segmente, "Test-Trip",
-                                now_utc=now_utc, **kwargs)
-    except TypeError as exc:  # pragma: no cover - faellt mit dem Fix weg
-        if "now_utc" not in str(exc):
-            raise
-        return to_alert_message(changes, segmente, "Test-Trip", **kwargs)
+    return to_alert_message(changes, segmente, "Test-Trip",
+                            now_utc=now_utc, **kwargs)
 
 
 def _texte(msg) -> dict[str, str]:


### PR DESCRIPTION
Schließt Scheibe 2 von #2020. Spec: `docs/specs/modules/fix_2020_alarm_blickrichtung.md` (14 ACs, PO-freigegeben 2026-08-21).

## Was sich ändert

Der Regen-Abweichungsalarm meldete bisher ausschließlich Vergangenheit. Der Vorfall vom 2026-08-20, 18:15 Ortszeit: „Niederschlag 7,4 → 29,4 mm, Beginn 19:00 → 15:00" — zu diesem Zeitpunkt war der Regen längst gefallen. Jetzt steht vorn, was noch kommt:

```
🏁 Ziel · mehr Regen als angekündigt
Bis jetzt: ~8 mm gefallen (angekündigt waren 5)
Ab jetzt: noch ~14 mm, letzter Regen gegen 17:00
```

Kommt nichts mehr, sagt die Meldung das ausdrücklich — und wird trotzdem zugestellt (PO-Entscheid: eine deutlich höhere Regenmenge ändert die Lage auch rückblickend). Zusätzlich benennt jede Zeitangabe ihre Größe, trägt ihren Tagesbezug und weist Vergangenes als vergangen aus; die Kurzform bekommt ein `Rest{mm}@{HH}`-Token und Wochentagskürzel.

Alle vier Kanäle. Umsetzt #2050 B-2 („jede Zeitangabe benennt ihre Größe und ihren Tag") und B-1 für den Niederschlags-Δ-Zweig.

## Adversary: VERIFIED

Drei Runden, 20 Punkte belegt, sechs Findings. **Vier davon waren echte Fehler, die kein Testlauf gezeigt hätte** — gefunden allein durch Mutations-Gegenproben:

| Finding | Was es war |
|---|---|
| **F003** (HIGH) | `now_utc` erreichte den Versandweg, aber **kein Test bewachte das**. Entfernt man die Übergabe, fällt die Ausgabe still auf die alte, rückwärtsgewandte Fassung zurück — von ~430 Testfällen wurde keiner rot. Jetzt fährt ein Test `NotificationService.send_deviation_alert()` echt. |
| **F001** | Fenstergrenze musste exklusiv rechnen. `new_value` entsteht in `_aggregate_for_segment()` aus `start_floor <= ts < end_floor`; inklusiv gerechnet wurde `bereits_gefallen = new_value - remaining` **negativ** (24 mm Restmenge bei 22 mm Gesamtmenge). |
| **F005** (CRITICAL) | Segmente unter einer Stunde fanden **keinen einzigen Datenpunkt** → Alarm behauptete „~5 mm gefallen" für Regen, der noch kommt, UND „kein weiterer Regen". Kein Test fing das, weil alle das „Ziel"-Segment nutzen — das einzige mit erzwungener 1h-Mindestdauer. |
| **F006** | Der mit dem F005-Fix neu eingeführte Leerfenster-Guard war selbst unbewacht. |

**F001 und F005 hatten dieselbe Ursache an zwei Kanten:** Restmenge und Gesamtmenge liefen über getrennte Filter. Der Fix zieht die Regel deshalb in **eine** Funktion — `app.day_window.segment_window_points()`, aufgerufen von `_aggregate_for_segment()` **und** `_precip_remaining()`. Dazu bewacht ein Test die Kopplung selbst (`bereits_gefallen` weder negativ noch größer als `new_value`), statt jede Kante einzeln zu entdecken.

Bewusst offengelassen: **F002** (Fehlerzweig strukturell unerreichbar, `ForecastDataPoint.__post_init__` schließt ihn aus) und **F004** (der Ortsvergleich bekommt nur die Wortkonstante, nicht Tagesbezug/Restmenge — Ortsvergleich-Themen sind PO-seitig zurückgestellt, steht jetzt in „Known Limitations").

## Ein Hinweis für den Review

Die Auslagerung der Filterregel berührt `_aggregate_for_segment()` — den **Kernpfad aller Briefings**, nicht nur der Alarme. Verhaltensgleichheit wurde geprüft: gefloorte Grenzen (#1334), Endstunde exklusiv (#806), Punkttreffer bei Segmenten unter 1 h (#856). Die neu hinzukommende `to_utc()`-Normalisierung des Punkt-Zeitstempels ist für jeden erreichbaren Fall ein No-Op, weil `ForecastDataPoint.__post_init__` bereits auf naive UTC normalisiert.

## Tests

- 37 neu (AC-1 … AC-14 plus Absicherungen der vier Findings)
- 1264 Bestandstests der Alarm-Fläche grün, inklusive der 44 Kilometer-Zusicherungen aus #2036 (Rebase-Integration, sechs additiv aufgelöste Konfliktstellen)
- Radar-Alarm-Mail-Validator Exit 0 gegen eine echt zugestellte Staging-Mail (Kennung `0961ba7b` im Betreff verifiziert — der Validator nimmt die neueste Mail des Typs, und mehrere Sitzungen teilen das Postfach)

Beobachtet, nicht als Befund gewertet: ein einmalig roter Lauf in `test_bug_397_output_localtime.py`, zweifach danach grün reproduziert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
