### PR TITLE
docs(#2069): Grenzen von alert-preview im Validator-Protokoll benennen

### DIFF
--- a/.claude/agents/external-validator.md
+++ b/.claude/agents/external-validator.md
@@ -47,9 +47,29 @@ AMBIGUOUS gehst — sie machen interne Logik prüfbar:
   (z.B. `format_metric_value("m", 12240.0) == "12.240 m"`).
 - `POST /api/trips/{id}/alert-preview` mit JSON-Body
   `{"changes":[…WeatherChange…], "segment_times":[{"segment_id":"…","start":"HH:MM","end":"HH:MM"}]}`
-  → `{"html":"…","plain":"…"}` — rendert die Alert-Mail über den
-  Production-Renderer-Pfad, **ohne Versand**. Nützlich für ACs über
-  Alert-Mail-Inhalt, Change-Zeilen-Formatierung, Segment-Bezug.
+  → `{"subject":"…","email_html":"…","email_plain":"…","telegram":"…","sms":"…"}` — rendert den
+  Alarm-Text über die Produktions-Renderer, **ohne Versand**. Nützlich für ACs über
+  Alarm-**Textinhalt** und Change-Zeilen-Formatierung.
+
+  🔴 **NICHT nutzbar für segmentbezogene ACs** (gemessene km-Spanne, Distanz, Höhenmeter,
+  Koordinaten): Der `changes`-Zweig rendert **Stub-Segmente** — `GPXPoint(lat=0.0, lon=0.0)`,
+  `distance_km=0.0`, unvermessen — statt der echten Trip-Segmente; vom Trip werden nur Name und
+  Zeitzone benutzt (`src/services/validator_render_service.py:56,147`, Issue **#2069**). Ein
+  solches Merkmal fehlt in der Antwort **immer**, unabhängig davon, ob die Implementierung stimmt.
+  Wer daraus auf einen Fehler schließt, schreibt ein falsches BROKEN (passiert bei #2036).
+  Gegenprobe für segmentbezogene Merkmale: die Briefing-Vorschau
+  `GET /api/preview/{id}/telegram` bekommt die echten Segmente.
+
+  **Wertebereiche** (falscher Wert → HTTP 500 ohne Stacktrace, sieht aus wie ein defekter
+  Endpoint): `severity` nur `minor|moderate|major`, `direction` nur `increase|decrease`.
+  Unbekannte **Metrik**-Namen werden dagegen sauber mit 422 abgewiesen.
+
+  **Aufbau-Selbstkontrolle, PFLICHT vor der ersten Messung:** Der Trip braucht eine Etappe auf
+  dem **heutigen** Datum, sonst ist die Menge der echten Segment-IDs leer und **jede** erfundene
+  `segment_id` wird still akzeptiert (`"99"` → `"Seg 99"`). Schick zuerst bewusst
+  `"segment_id":"zzz-unbekannt"`: Kommt **kein** `422`, ist der Aufbau ungültig — dann NICHT
+  weitermessen. `segment_id` ist die schlichte Segmentnummer (`"1"`, `"2"`, `"Ziel"`), keine
+  technische Kennung.
 - `GET /api/_validator/detector-thresholds?trip=<id>`
   → `{"config_source":"<from_alert_rules|from_display_config|from_trip_config|defaults>", "effective_detector":"<…>", "thresholds":{…}}`
   — zeigt, welchen Detector-Pfad der `WeatherChangeDetectionService` für diesen


### PR DESCRIPTION
Das Protokoll empfahl POST /api/trips/{id}/alert-preview fuer ACs ueber
"Segment-Bezug" — genau das kann der Endpoint konstruktionsbedingt nicht:
der changes-Zweig rendert Stub-Segmente (lat/lon 0.0, distance_km 0.0,
unvermessen) statt der echten Trip-Segmente. Bei der Staging-Verifikation
zu #2036 fuehrte das dazu, dass ein External Validator AC-1 an drei Trips
als BROKEN meldete, obwohl die Implementierung korrekt ist.

Korrigiert:
- explizite Warnung, dass segmentbezogene Merkmale dort IMMER fehlen,
  samt Gegenprobe ueber die Briefing-Vorschau
- Rueckgabeform aktualisiert (subject/email_html/email_plain/telegram/sms
  statt des veralteten html/plain aus der #221-Spec)
- Wertebereiche fuer severity/direction ergaenzt (falscher Wert -> HTTP 500
  ohne Stacktrace, sieht aus wie ein defekter Endpoint)
- Pflicht-Selbstkontrolle des Messaufbaus: ohne Etappe auf HEUTE wird jede
  erfundene segment_id still akzeptiert

Der Stub selbst ist in #221 so spezifiziert und war fuer den urspruenglichen
Zweck richtig; die Zuschnittsgrenze zieht #2069 nach.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BKka1TpVzqPRzW8duVG3fi
