### PR TITLE
feat(#2051 S1): Ereignis-Ende und -Dauer im Radar-Nowcast

### DIFF
--- a/api/routers/validator.py
+++ b/api/routers/validator.py
@@ -241,6 +241,17 @@ class OnsetPayload(BaseModel):
     # Beginn), additiv und optional -- Muster `segment_id` o. Ohne sie rendert
     # der Vorschauweg die zahlenlose Alt-Form.
     onset_precip_mm: float | None = None
+    # Issue #2051 S1: Ende des Ereignisses ("HH:MM") und sein eigener
+    # Tagesbezug, additiv und optional -- Muster `onset_precip_mm` o. Ohne sie
+    # rendert der Vorschauweg die Ausweichform ohne Ende.
+    event_end_time: str | None = None
+    event_end_day_offset: int = 0
+    # Issue #2051 S1 (Spec v1.1): der R4-Waechter braucht ein EIGENES Feld --
+    # seit der Umkehr auf die Untergrenzen-Form loest ihn die erzeugende Seite
+    # nicht mehr in einem fehlenden Ende auf, er waehlt die Textform. Ohne das
+    # Feld zeigte die Vorschau im Waechterfall die falsche der beiden Formen
+    # und damit nicht mehr das, was der Produktivpfad sendet.
+    event_ongoing_beyond_horizon: bool = False
 
 
 class OfficialAlertPayload(BaseModel):

--- a/docs/context/feat-2051-s1-dauer-und-ende.md
+++ b/docs/context/feat-2051-s1-dauer-und-ende.md
@@ -1,0 +1,306 @@
+# Context: feat-2051-s1-dauer-und-ende
+
+**Issue:** #2051 — „Ereignis als Flaeche liefern: Dauer, raeumliche Ausdehnung, Reichweite der Quelle"
+**Zuschnitt:** ausschliesslich **Scheibe S1** — Dauer und Ende mitliefern. S2 (raeumliche
+Ausdehnung), S3 (Reichweite der Quelle), S4 (`/strecke`-Kommando) bleiben offen; das Ticket
+bleibt als Scheiben-Ticket offen.
+**Erstellt:** 2026-08-21 · Phase 1 (Kontext)
+
+## Request Summary
+
+Der Radar-/Nowcast-Pfad liest heute aus der abgerufenen Frame-Zeitreihe nur den **ersten**
+nassen Zeitpunkt und verwirft den Rest. Der Nutzer erfaehrt, *wann* es anfaengt, aber nicht,
+**wie lange es dauert und wann es endet**. S1 leitet Ende und Dauer des zusammenhaengenden
+nassen Blocks aus **denselben, bereits abgerufenen Frames** ab (kein zusaetzlicher
+Quellenabruf) und liefert sie in allen vier Kanaelen mit.
+
+## Related Files
+
+### Datenpfad (Ableitung)
+
+| Datei | Relevanz |
+|---|---|
+| `src/services/radar_service.py:701` `_derive_result()` | **Kernstelle.** Baut `NowcastResult` aus den Frames. Die Onset-Schleife (`:716-727`) bricht beim ersten nassen Frame mit `break` ab — genau hier faellt die Information ueber Ende/Dauer weg. |
+| `src/services/radar_service.py:197` `_accumulate_precip_mm()` | **Wichtigster Wiederverwendungs-Kandidat.** Von #2046 aus `_derive_result` extrahierter, parametrisierter Rechenkern: Frame-Dedup je Zeitstempel (hoeherer Wert gewinnt), Dauer je Frame aus dem *eigenen* naechsten Nachbarn (`bisect_right` ueber `all_ts_sorted`), Deckel `_MAX_FRAME_COVERAGE`, hartes Fensterende. Genau diese Mechanik braucht auch die Ende-Bestimmung. |
+| `src/services/radar_service.py:134` `NowcastResult` | Traegt `frames` (**vollstaendige Zeitreihe, bereits vorhanden**), `onset_minutes`, `window_precip_mm`, `onset_precip_mm`, `max_rate_mm_h`. Additive, optionale Felder sind hier das etablierte Muster. |
+| `src/services/trip_alert.py:144` `radar_alert_due()` | Auslöse-Gate: `onset <= threshold_min`. |
+| `src/services/trip_alert.py:1349` / `src/services/compare_radar_alert.py:352` | Die **einzigen** zwei Anwender von `RADAR_ONSET_THRESHOLD_MIN` (ADR-0021, Trip + Ortsvergleich teilen den Code). |
+| `src/services/notification_service.py:165` `RadarAlertRequest` | DTO Service → Renderer. Traegt `onset_minutes`, `onset_time`, `onset_day_offset`, `km_from/km_to`, `is_convective`, `intensity_label`, `source_label`, `tz`, `segment_id`, `onset_precip_mm`. **Kein** Ende-/Dauer-Feld. |
+| `src/output/renderers/alert/model.py:38` `OnsetEvent` | Renderer-Modell, gleiche Felderlage. Additive Felder mit Default sind hier Standard (#1041, #1744, #2009, #2046). |
+| `src/output/renderers/alert/project.py:368-398` | Baut das Mehr-Orte-Onset-Buendel (Ortsvergleich) aus `NowcastResult`. |
+
+### Textpfad — alle Stellen, die den Onset ausformulieren
+
+> Die Wirkkette endet **nicht** beim ersten Formatierer. Vollstaendige Liste, per Grep nach
+> `onset_minutes` in den Ausgabe-Modulen erhoben:
+
+| # | Stelle | Kanal / Nachrichtenart | Sichtbarer Text heute |
+|---|---|---|---|
+| 1 | `render.py:352` `_render_subject_onset` | E-Mail-Betreff | `[{trip}] {km} · {label} in {n} Min` |
+| 2 | `render.py:389` `_render_email_onset_multi` | E-Mail, Mehr-Orte-Buendel (Ortsvergleich) | `in {n} Min` |
+| 3 | `render.py:459` `_render_email_onset` | E-Mail, Trip | `{label} in {n} Min` |
+| 4 | `render.py:528` `_render_telegram_onset` | Telegram (rich) | `{trip} · {km} · {label} in {n} Min` |
+| 5 | `render.py:594+` `_render_sms_onset` | SMS · Premium-SMS · Telegram-Kurzstil | `Ziel: R2.5@18:00` bzw. `Ziel: TH@18:00 R2.5` |
+| 6 | `output/renderers/email/starkregen_hint.py:27` `format_starkregen_hint` | **Briefing**-Kurzfristhinweis (#1439) | `{label} ab ca. {HH:MM} (in ~{n} Min).` |
+| 7 | `services/radar_service.py:450` `format_now_text` | **Inbound-Kommando-Antwort** (`trip_command_processor.py:1537`) | `{label} ab ca. {HH:MM} (in ~{n} Min).` |
+
+Stellen 1–5 liegen in `src/output/renderers/alert/render.py` (ADR-0011: ein Backend-Renderer);
+6 und 7 liegen ausserhalb.
+
+## Existing Patterns
+
+1. **Additiv-optionales Feld durch die ganze Kette.** #2046 (`onset_precip_mm`) ist die frische,
+   vollstaendig durchgezogene Blaupause: neues Feld an `NowcastResult` → `RadarAlertRequest` →
+   `OnsetEvent` → Renderer, plus Vorschau-/Testeinspeiseweg (`api/routers/validator.py`,
+   `src/services/validator_render_service.py`). Default `None`, Ausweichform ohne die Angabe.
+   Commit `f9149858`, Spec `docs/specs/modules/fix_2046_onset_menge.md`.
+2. **Eigener Fenstername statt geteilter Konstante.** `_ONSET_PRECIP_WINDOW_MIN = 60` steht
+   bewusst neben `_OVERTAKE_COMPARE_WINDOW_MIN = 60` — gleiche Zahl, verschiedene Bezugspunkte
+   und Zwecke. Eine Ende-/Dauer-Groesse braucht denselben Respekt vor dem Bezugspunkt.
+3. **Frame-Deckung nie global schaetzen.** `_MAX_FRAME_COVERAGE = 15 min` (groebstes
+   Produktivraster) plus Nachbar-Ableitung je Frame. Herleitung: #2020 Adversary-Runden 2/3
+   (F006/F007/F010). Eine globale Kadenz-Schaetzung ist in beide Richtungen verfaelschbar.
+4. **Trip und Ortsvergleich teilen den Code** (ADR-0021). Jede Aenderung am Onset muss in
+   **beiden** Flaechen wirken; Paritaets-Tests existieren (`tests/tdd/test_onset_menge_kanalparitaet.py`).
+5. **Mail-Bauform:** Fakten als Datenzeilen (`_datarow_html`, Label links / Wert rechts,
+   Outlook-Kompatibilitaet), HTML und Klartext aus denselben Label-Wert-Tupeln (ADR-0052).
+
+## Dependencies
+
+- **Upstream:** Frames der Nowcast-Quellen (INCA/GeoSphere, AROME-FR, ICON-D2, ARPAE,
+  Open-Meteo `minutely_15`); Raster 5–15 Min, Horizont bis 180 Min.
+- **Downstream:** alle sieben Textstellen oben; Vorschau-/Validator-Weg
+  (`api/routers/validator.py`, `src/services/validator_render_service.py`); Pydantic-Payload
+  der Vorschau.
+- **Konstanten:** `_NOWCAST_HORIZON_MIN = 180` (`:69`), `RADAR_ONSET_THRESHOLD_MIN = 55`
+  (`:121`), `_DRY_THRESHOLD_MM_H = 0.1`, `_MAX_FRAME_COVERAGE = 15 min`,
+  `_OVERTAKE_COMPARE_WINDOW_MIN = 60`, `_ONSET_PRECIP_WINDOW_MIN = 60`.
+
+## Existing Specs
+
+| Spec | Bezug |
+|---|---|
+| `docs/specs/modules/fix_2046_onset_menge.md` | **Naechster Nachbar** — Mengenangabe ab Ereignisbeginn, dieselbe Kette |
+| `docs/specs/modules/fix_2020_alarm_ausloesung.md` | Mengen-Ueberholung, Herkunft von `_accumulate_precip_mm` |
+| `docs/specs/modules/fix_1945_nowcast_horizon.md` | Anhebung 60 → 180 Min, direkt relevant fuer den offenen PO-Entscheid |
+| `docs/specs/modules/fix_2009_nowcast_vorlauf.md` | Herkunft von `RADAR_ONSET_THRESHOLD_MIN = 55` |
+| `docs/specs/modules/fix_2017_nowcast_messpunkt.md` | Messpunkt am Aufenthaltsort |
+| `docs/specs/modules/radar_nowcast.md` (+ `_inca_fix`, `_icon_d2`, `_france`, `_italy_arpae_fallback`) | Quellen und Raster |
+| `docs/specs/modules/fix_1948_s4_nowcast_sms_zielbild.md` | Zielbild der Onset-Kurznachricht |
+| ADR-0011, ADR-0021, ADR-0046, ADR-0052 | Ein Backend-Renderer · geteilter Code Trip/Compare · Kanal-Schwelle · Mail-Bauform |
+
+## Abstimmung mit Parallelsitzungen (2026-08-21)
+
+| Sitzung | Ergebnis |
+|---|---|
+| `feat-2050-s1-pruefstrecke` (#2050, Phase 6) | **B-1 liegt dort NICHT im Zuschnitt** (ist dort S2, ausdruecklich „Nicht Ziel"). Deren Diff sind zwei reine Testdateien, keine Produktivdatei. Der im Ticket-Body vermutete gemeinsame Bau entfaellt — kein Wartegrund. Angebot: die Pruefstrecke steht S1 danach zur Auslöse-Verifikation offen. |
+| `fix-2020-zeitangaben-wortlaut` (#2020 S2, Phase 5) | Arbeitet im **Δ-/Abweichungszweig**, nicht im Nowcast-Onset-Zweig. Beruehrungspunkte: `_onset_time_label()` (Tagesversatz-Wortlaut, wirkt auch auf den Nowcast-Pfad) und der Δ-Teil von `_render_sms_body`. **Zusage dieser Sitzung: beide Funktionen bleiben unangetastet**, und der Wortlaut fuer das Ereignisende wird uebernommen statt neu erfunden — Langform `letzter Regen gegen HH:MM`, Kurzform `@HH` hinter dem Mengen-Token. Jene Sitzung haengt zusaetzlich an #2036 und meldet sich mit dem endgueltigen Wortlaut, sobald S2 in `main` ist. |
+
+## Risks & Considerations
+
+**R1 — Der Realfall im Ticket stammt nicht aus dem Alarmzweig.** „Regen bei km 10 in 90 Minuten"
+kann aus dem Onset-**Alarm** gar nicht kommen: `radar_alert_due()` deckelt hart bei 55 Min.
+Ungedeckelt bis 180 Min sind dagegen der **Briefing-Kurzfristhinweis** (`format_starkregen_hint`,
+gespeist ueber `src/services/trip_report_scheduler.py:1808-1815`, das den fehlenden Grenzwert
+ausdruecklich als bewusste Entscheidung dokumentiert) und die **Inbound-Kommando-Antwort**
+(`format_now_text`). Vor dem Zuschnitt der Spec ist zu klaeren, welche Nachrichtenart der
+Ausgangsfall war — sonst baut S1 Ende/Dauer in einen Pfad, der den geschilderten Fall nicht
+erzeugt hat. Sicherste Auslegung: **alle sieben Textstellen** bedienen.
+Befund beigesteuert von der Sitzung `intake-2020-scheibe2`.
+
+**R2 — Der offene PO-Entscheid ist anders gelagert als im Ticket beschrieben.** Der Kommentar
+vom 18:35 stellt „Horizont auf 60 Min kappen" gegen „voller Horizont mit Guete-Kennzeichnung".
+Fuer den **Alarm**zweig existiert die Kappung bereits (55 Min) — Option (a) waere dort weitgehend
+wirkungslos. Zugleich wuerde ein Absenken von `_NOWCAST_HORIZON_MIN` auf 60 die Entscheidung aus
+**#1945** zuruecknehmen (dort auf 180 angehoben, weil der 60-Min-Deckel den Alarm praktisch immer
+erst ~8 Min vorher ausloesen liess) und ausserdem `window_precip_mm`/`onset_precip_mm`
+beschneiden. Der Entscheid betrifft also faktisch die **ungedeckelten** Pfade 6 und 7.
+
+**R3 — Tagesfenster vs. Nowcast-Horizont.** #2020 S2 rechnet Restmenge und Ende strikt im
+Tagesfenster der Etappe (`resolve_configured_window`, Default 4–19, effektives Ende 20:00
+Ortszeit — Begruendung `src/services/segment_weather.py:292-308`: sonst nennt der Alarm eine
+andere Stunde als das Briefing). Ein aus Nowcast-Frames abgeleitetes Ende reicht bei 180 Min
+Horizont **regelmaessig** darueber hinaus. Ob S1 das Ende am Fensterende kappt oder darueber
+hinaus nennt, ist eine bewusste Entscheidung und gehoert in die Spec.
+
+**R4 — „Ende" ist bei abgeschnittener Zeitreihe nicht dasselbe wie „Ende des Ereignisses".**
+Wenn der letzte nasse Frame der letzte verfuegbare Frame ist, ist das Ereignis **nicht** zu Ende
+— die Daten sind zu Ende. Beide Faelle duerfen nicht denselben Text erzeugen (verwandt mit S3:
+Reichweite der Quelle als Datum). Dasselbe gilt bei Datenluecken mitten im nassen Block:
+ein einzelner fehlender Frame darf den Block nicht faelschlich beenden.
+
+**R5 — Zeichenbudget SMS/Premium-SMS.** 140 Zeichen GSM-7. Die Kurzform traegt seit #2046
+bereits ein Mengen-Token. Eine zusaetzliche Ende-Angabe muss ins Budget passen oder eine
+Ausweichform haben. Auf der Huette (nur Satellit) ist Premium-SMS die einzige ankommende
+Fassung — die Verdichtung entscheidet dort ueber den Nutzwert.
+
+**R6 — Bevormundungs-Grenze.** Nur Daten ueber das Wetter, keine Rechnungen ueber den Nutzer
+(PO-Ansage, zweifach geschaerft). „Nass bis 16:30" ist erlaubt; „bei Planzeit bist du um 15:40
+bei km 9" ist verboten.
+
+**R7 — Merge-Reihenfolge in `render.py`.** #2036 (Phase 6, noch nicht in `main`) und #2020 S2
+fassen dieselbe Datei an. Vor dem Schreiben an `render.py` auf den jeweils aktuellen Stand
+nachziehen.
+
+## Stand des Worktrees
+
+Branch `feat-2051-s1-dauer-und-ende`, per Vorwaertsspulen auf `origin/main` = `d908160d`
+gezogen (enthaelt #2046). Keine eigenen Commits.
+
+---
+
+# Analysis (Phase 2)
+
+## Type
+
+**Feature** (Issue-Label `enhancement`), Scheibe eines Scheiben-Tickets.
+
+## Korrekturen an Phase 1
+
+- Die sieben Textstellen sind **vollzaehlig**. `_render_email_onset_shift_only` /
+  `_render_sms_onset_shift_only` (`render.py:311-341`) rendern `OnsetShiftEvent` aus dem
+  prognosebasierten Abweichungspfad (#1468, `project.py:115` nimmt `WeatherChange` entgegen) und
+  tragen keine Nowcast-Minutenangabe — anderer Ereignistyp, nicht Teil der Flaeche.
+- **Der Briefing-Pfad (Stelle 6) bekommt kein `NowcastResult`, sondern zwei Skalare.**
+  `starkregen_nowcast: tuple[str, int] | None` (`notification_service.py:110`), gebaut in
+  `trip_report_scheduler.py:1870` als `return (result.intensity_label, result.onset_minutes)`,
+  ausgepackt `:366`, verbraucht von `format_starkregen_hint(intensity_label, onset_minutes, tz)`.
+  Fuer Dauer/Ende muss dort die **Datenform** aufgemacht werden (Tupel erweitern oder durch ein
+  kleines Objekt ersetzen) — vier Stellen statt einer.
+- **Stelle 7 dagegen ist billig:** `format_now_text(result, ...)` bekommt das vollstaendige
+  `NowcastResult` (`radar_service.py:400`).
+- **Zwei Pydantic-Modelle** muessen ein neues Feld kennen: `RadarAlertRequest`
+  (`notification_service.py:165`) und `OnsetPayload` (`api/routers/validator.py:~240`). Bei #2046
+  war genau das der Adversary-Fund F002 — hier vorab bekannt.
+- **Der Nowcast-Pfad kennt heute kein Tagesfenster.** `_derive_result(self, frames, source,
+  now=None)` arbeitet rein auf Frames und einem Zeitpunkt; die Tagesfenster-Tests
+  (`test_onset_respects_configured_day_window.py`, `test_onset_compare_day_window.py`) gehoeren
+  zur prognosebasierten Beginn-Verschiebung (#1468), nicht hierher. Ein Kappen am Tagesfenster
+  waere eine **Neueinfuehrung**, die Trip-Konfiguration bis in den Radar-Dienst durchreichen
+  muesste.
+
+## Technischer Ansatz
+
+Die Onset-Schleife (`radar_service.py:724-729`) laeuft bereits ueber das sortierte Fenster und
+bricht beim ersten nassen Frame ab. Die Blockende-Bestimmung ist dieselbe Schleife **ohne** den
+Abbruch. Der Kern ist die Unterscheidung zweier Faelle — und **beide brauchen keine neue
+Toleranzzahl**:
+
+| Fall | Bedeutung | Behandlung |
+|---|---|---|
+| Frame vorhanden, `precip_mm_h < 0.1` | Quellenaussage „hier hat es aufgehoert" | beendet den Block **real**. Nicht ueberbruecken — sonst verschmelzen zwei getrennte Ereignisse und die Dauer wird ueberschaetzt. |
+| Frame **fehlt** (Raster-Luecke, Drosselung, Ausfall) | keine Beobachtung | Der letzte nasse Frame deckt ohnehin nur bis `min(naechster Frame, +_MAX_FRAME_COVERAGE, Fensterende)`. Luecken bis 15 Min sind damit **implizit** toleriert; groessere Luecken setzen das Ende an der Deckungsgrenze. |
+
+Neuer Helfer als **Geschwister** von `_accumulate_precip_mm`, nicht als dessen Erweiterung
+(dessen Aufgabe ist Summieren in einem bekannten Fenster, nicht Grenzen finden):
+`_derive_wet_block_end(frames, all_ts_sorted, onset_ts, horizon) -> tuple[datetime, bool]`.
+
+**Neue Felder an `NowcastResult`** (additiv, optional, Muster `onset_precip_mm`):
+
+- `event_end_minutes: Optional[int] = None` — Minuten ab jetzt bis Blockende, analog `onset_minutes`.
+- `event_ongoing_beyond_horizon: bool = False` — der **R4-Waechter**: Frames bzw. der 180-Min-Horizont
+  sind ausgegangen, waehrend der letzte bekannte Frame noch nass war. `False` = „das echte Ende ist
+  bekannt", konsistent mit `throttled`/`data_unavailable`.
+
+**Keine** gespeicherte `event_duration_minutes` — sie ist `event_end_minutes - onset_minutes`, ein
+drittes Feld koennte auseinanderlaufen. Downstream braucht `event_end_time` /
+`event_end_day_offset` als Pendants zu `onset_time`/`onset_day_offset`, berechnet ueber
+**dieselbe** Zeitversatz-Logik (#2009-Muster), nicht neu implementiert.
+
+## Affected Files
+
+| Datei | Aenderung | Beschreibung |
+|---|---|---|
+| `src/services/radar_service.py` | MODIFY | Grenz-Helfer, zwei Felder, Verdrahtung in `_derive_result`; Stelle 7 (`format_now_text`) |
+| `src/output/renderers/alert/model.py` | MODIFY | Felder an `OnsetEvent` |
+| `src/services/notification_service.py` | MODIFY | `RadarAlertRequest` (Pydantic), Weitergabe; Aufruf Stelle 6 |
+| `src/services/trip_alert.py` | MODIFY | Ende-Zeit + Tagesversatz berechnen, durchreichen |
+| `src/services/compare_radar_alert.py` | MODIFY | Paritaet Ortsvergleich (ADR-0021) |
+| `src/output/renderers/alert/project.py` | MODIFY | Mehr-Orte-Buendel |
+| `src/output/renderers/alert/render.py` | MODIFY | Textstellen 1–5 |
+| `src/output/renderers/email/starkregen_hint.py` | MODIFY | Stelle 6, Signatur |
+| `src/services/trip_report_scheduler.py` | MODIFY | Datenform des Briefing-Tupels |
+| `api/routers/validator.py` | MODIFY | `OnsetPayload` (Pydantic) |
+| `src/services/validator_render_service.py` | MODIFY | Vorschau-/Replay-Weg |
+| `tests/tdd/…` | CREATE/MODIFY | Blockende inkl. Luecken-Fall, Tagesversatz fuers Ende, Kanalparitaet, SMS-Budget-Grenzfall |
+
+## Scope Assessment
+
+- Dateien: 11 Produktiv + ~10–12 Test
+- Geschaetzte LoC: **~200–240 produktiv**, ~150–220 Tests bei voller Reichweite
+- **Ueber dem 250-LoC-Workflow-Limit** → `loc_limit_override` einplanen
+- Risiko: **MEDIUM**
+
+## Risiken (ueber Phase 1 hinaus)
+
+- **Groesstes inhaltliches Risiko ist R4.** Ohne den `event_ongoing_beyond_horizon`-Waechter
+  behauptet der Text ein festes Ende, obwohl das Ereignis nachweislich ueber den
+  Beobachtungshorizont hinausreicht. Das waere **schlechter als der heutige Zustand**, der ueber
+  das Ende gar nichts behauptet — eine falsche Tatsachenbehauptung, kein Rundungsfehler. Jeder
+  Text-Konsument muss den Waechter pruefen, bevor er ein Ende formuliert.
+- **SMS-Budget nicht aus #2046 fortschreiben.** AC-9 dort prueft das Budget nur fuer den damaligen
+  Token-Umfang. S1 braucht einen **neuen** kombinierten Grenzfall (langer Ortsname + Extremmenge +
+  Ende-Token), keine Annahme, die alte Marge gelte weiter.
+- **Mitternachtsueberlauf asymmetrisch:** Das Ende kann auf den Folgetag fallen, auch wenn der
+  Beginn es nicht tut (Beginn 23:50, Ende 00:40). Eigenes `event_end_day_offset` noetig.
+
+## Reihenfolge
+
+`render.py` wird von drei Vorhaben gleichzeitig angefasst. Empfehlung:
+
+1. **Datenschicht zuerst** (`radar_service.py`, `model.py`, `notification_service.py`,
+   `trip_alert.py`/`compare_radar_alert.py`, Vorschauweg) — keine Abhaengigkeit von `render.py`,
+   kann sofort entstehen.
+2. #2036 (Phase 6) und #2020 S2 (Phase 5) mergen lassen.
+3. Auf beide nachziehen, **dann** die Textstellen 1–5 schreiben.
+
+## Open Questions — gehen mit den ACs zur PO-Freigabe
+
+**(E1) Reichweite.** *Empfehlung: alle sieben Textstellen.* Der Ticket-Text rahmt das Problem als
+„Das Alarmsystem meldet heute einen Punkt" — ein Zuschnitt ohne die Alarmtexte adressiert die
+eigene Problemstellung des Tickets nicht. Vor allem: Stelle 6 ist **E-Mail-only**
+(`renderers/email/`), Stelle 7 ist eine Antwort auf aktive Nachfrage. Ein Zuschnitt auf 6+7
+liesse **SMS und Premium-SMS ohne die Angabe** — und auf der Huette (nur Satellit) ist
+Premium-SMS die einzige ankommende Fassung. Gegenargument, das die Empfehlung nicht kippt: die
+strategische Bewertung riet zu 6+7, um `render.py`-Konflikte und das LoC-Limit zu vermeiden. Der
+Wartezeit-Teil des Arguments traegt nicht — der zu uebernehmende Wortlaut steht bereits fest.
+Falls der PO frueher liefern will, ist „Datenschicht + 6 + 7 jetzt, Alarmtexte als zweite
+Scheibe" der saubere Schnitt.
+
+**(E2) Tagesfenster.** *Empfehlung: NICHT kappen, das echte Ende aus den Frames nennen.* Drei
+Gruende: (a) Der Nowcast-Pfad spricht heute schon ausserhalb des Tagesfensters — `onset_time`
+wird nirgends gekappt, ein Alarm um 19:40 nennt problemlos einen Beginn um 20:35. Nur das *Ende*
+zu kappen waere in sich unstimmig. (b) Die Briefing-Konsistenz-Begruendung aus
+`segment_weather.py:292-308` gilt dem Δ-Alarm, der gegen **Briefing-Zahlen** vergleicht; fuer das
+Nowcast-Ende gibt es keine Briefing-Entsprechung, mit der es sich widersprechen koennte. (c) Ein
+still gekapptes „Ende gegen 20:00" bei Regen bis 22:00 ist eine **falsche Aussage** — dieselbe
+Fehlerklasse wie R4, nur selbst verursacht. Die strategische Bewertung schlug einen Mittelweg vor
+(kappen + Fortsetzungs-Hinweis „haelt ueber das Tagesfenster hinaus an"); der fuehrt einen Begriff
+ein, den der Nowcast sonst nirgends kennt, und erkauft nichts, was das echte Ende nicht auch
+liefert.
+
+**(E3) Horizont — der im Issue offene PO-Entscheid.** *Empfehlung: (b) voller Horizont mit
+Guete-Kennzeichnung; `_NOWCAST_HORIZON_MIN` bleibt bei 180.* Eine Kappung auf 60 wuerde die
+#1945-Entscheidung still zuruecknehmen (dort bewusst 60 → 180, weil der Deckel den Alarm
+praktisch immer erst ~8 Min vorher ausloesen liess). Der **Alarm**zweig waere von der Kappung
+ohnehin kaum betroffen, weil er bereits hart bei 55 Min deckelt; treffen wuerde sie
+`window_precip_mm`, `onset_precip_mm`, den Briefing-Hinweis und die Kommando-Antwort — also
+genau die Pfade, aus denen der geschilderte Realfall stammt. Der
+`event_ongoing_beyond_horizon`-Waechter **ist** bereits die vom PO erwogene Guete-Kennzeichnung.
+
+## Horizont-Drift in Nutzertexten — **gehoert in S1**, als eigenes AC
+
+Seit #1945 (`_NOWCAST_HORIZON_MIN` 60 → 180) sind **zwei** Textstellen nicht nachgezogen worden:
+
+| Stelle | Text heute | Wahrheit |
+|---|---|---|
+| `src/services/radar_service.py:431` (Trockenzweig von `format_now_text`) | „In den naechsten 2 Stunden kein Regen erwartet." | geprueft werden **3 Stunden** |
+| `src/output/renderers/email/starkregen_hint.py:4` (Docstring) | „60-Minuten-Nowcast-Fenster (`NOWCAST_HORIZON_MIN`)" | 180 Minuten |
+
+**Entscheidung:** kein eigenes Issue, kein Sammel-Eintrag — **eigenes AC in dieser Spec**, mit
+Test und eigenem Commit. Begruendung: eine falsche Zahl in nutzersichtbarem Text ist mehr als
+kosmetisch, aber S1 fasst genau diese Funktion ohnehin an; ein eigenes Ticket waere
+Backlog-Inflation, eine stille Nebenreparatur waere ein Nachweis-Loch. Zusaetzlicher Grund: sobald
+der Nass-Zweig derselben Funktion ein bis zu 3 Stunden entferntes Ende nennt, steht die falsche
+„2 Stunden"-Aussage des Trockenzweigs unmittelbar daneben.
+Der Docstring-Teil ist reine Doku und faellt nicht unter das LoC-Limit.

--- a/docs/features/architecture.md
+++ b/docs/features/architecture.md
@@ -407,8 +407,17 @@ Scheibe 3 (#1170). Scheduler: `POST /api/scheduler/compare-alert-checks`, Go-Cro
        nach der Zeit — hinter `TH` bleibt die Stufen-Position frei). Ohne belastbare Zahl
        (`None`, unter 0,1 mm, Daten nicht verfügbar) bleibt die zahlenlose Form
        (`R@18:00`/`TH@18:00`) erhalten; E-Mail- und Telegram-Langform sind unverändert und
-       zeigen weiterhin `intensity_label` als Wort.
-     - `OnsetEvent`-Datenklasse: `onset_minutes`, `onset_time`, `km_from`/`km_to`, `is_convective`, `intensity_label`, `source_label`, `onset_precip_mm` (additiv, #2046 — Menge ab Ereignisbeginn, getrennt von `NowcastResult.window_precip_mm`, das ab „jetzt" misst)
+       zeigen weiterhin `intensity_label` als Wort. **Seit #2051 S1** trägt der Token
+       zusätzlich das Ende des zusammenhängenden nassen Blocks, abgeleitet aus denselben
+       bereits abgerufenen Nowcast-Frames: `@HH:MM` direkt hinter dem Mengen-Token
+       (`R2.5@18:00@20:00`). Reicht der nasse Block über den 180-Min-Horizont hinaus oder
+       bricht die Frame-Zeitreihe ab, wird stattdessen eine belegte Untergrenze angezeigt
+       (` >@HH:MM`, PO-Entscheid 2026-08-22 — kehrt die ursprüngliche Weglass-Entscheidung
+       um). Dieselbe Unterscheidung gilt in der Langform: `letzter Regen gegen HH:MM` bzw.
+       `Regen mindestens bis HH:MM`, in allen sieben Textstellen (E-Mail-Betreff, E-Mail
+       Trip/Mehr-Orte, Telegram rich, SMS/Premium-SMS/Telegram-Kurzstil, Briefing-
+       Kurzfristhinweis, Inbound-Kommando-Antwort).
+     - `OnsetEvent`-Datenklasse: `onset_minutes`, `onset_time`, `km_from`/`km_to`, `is_convective`, `intensity_label`, `source_label`, `onset_precip_mm` (additiv, #2046 — Menge ab Ereignisbeginn, getrennt von `NowcastResult.window_precip_mm`, das ab „jetzt" misst), `event_end_time`/`event_end_day_offset`/`event_ongoing_beyond_horizon` (additiv, #2051 S1 — Ende desselben Ereignisses mit eigenem Tagesbezug, aus `NowcastResult.event_end_minutes`/`.event_ongoing_beyond_horizon` abgeleitet)
      - `AlertMessage.cooldown_display` trägt den dynamischen Cooldown-Text (z.B. „2 Stunden")
      - `src/outputs/radar_alert.py` ist gelöscht — kein separater Inline-Body-Bau mehr
    - **Throttle-Semantik unverändert** (Issue #773): `radar_alert_throttle.json` + `alert_log` auch bei Best-Effort-Versandfehlern

--- a/docs/reference/api_contract.md
+++ b/docs/reference/api_contract.md
@@ -3386,7 +3386,7 @@ S1-Eingangsprotokoll (`src/services/alert_input_capture.py`, siehe
 |------|-----|------|
 | changes | `ChangePayload[]` | Zweig a (Δ-Alarm): rohe Änderungswerte je Etappe (`metric`, `old_value`, `new_value`, `delta`, `threshold`, `severity`, `direction`, `segment_id`) |
 | segment_times | `SegmentTimePayload[]` | Optional bei `changes` — fehlt es, synthetisiert der Endpoint die Etappen-Zeitfenster aus dem geladenen Trip über dieselbe Produktions-Segmentierung wie der Versandpfad (`convert_trip_to_segments`) |
-| onset | `OnsetPayload` \| null | Radar-Onset (Zweig c, Alt-Form vor S2): `onset_minutes`, `onset_time`, `km_from`, `km_to`, `is_convective`, `intensity_label`, `source_label`, `cooldown_display?`, `segment_id?` (additiv seit #1948 S5, AC-15 — ohne Segment-Kennung fiel der Zweig auf den km-Rückfall zurück), `onset_precip_mm?` (additiv seit #2046 — Menge in mm, akkumuliert über 60 Min ab Ereignisbeginn; `None`/fehlend ⇒ SMS-Onset-Token ohne Zahl) |
+| onset | `OnsetPayload` \| null | Radar-Onset (Zweig c, Alt-Form vor S2): `onset_minutes`, `onset_time`, `km_from`, `km_to`, `is_convective`, `intensity_label`, `source_label`, `cooldown_display?`, `segment_id?` (additiv seit #1948 S5, AC-15 — ohne Segment-Kennung fiel der Zweig auf den km-Rückfall zurück), `onset_precip_mm?` (additiv seit #2046 — Menge in mm, akkumuliert über 60 Min ab Ereignisbeginn; `None`/fehlend ⇒ SMS-Onset-Token ohne Zahl), `event_end_time?: string \| null`, `event_end_day_offset?: int = 0`, `event_ongoing_beyond_horizon?: bool = false` (additiv seit #2051 S1 — Ende des zusammenhängenden nassen Blocks mit eigenem Tagesbezug, analog zu `onset_time`/`onset_day_offset`; ohne `event_end_time` rendert der Vorschauweg die Ausweichform ohne Ende; `event_ongoing_beyond_horizon=true` wählt die Untergrenzen-Form `Regen mindestens bis HH:MM` statt `letzter Regen gegen HH:MM`) |
 | official | `OfficialAlertPayload[]` \| null | **NEU (#1948 S2), Zweig b:** amtliche Warnung(en), Feldspiegel von `OfficialAlert` — `source`, `hazard`, `level: int`, `label`, `valid_from?`, `valid_to?`, `url?`, `region_label?`, `dedup_id?`, `segment_ids: string[]` |
 | nowcast_frames | `NowcastFramesPayload` \| null | **NEU (#1948 S2), Zweig c:** Replay eines S1-Nowcast-Mitschnitts — `source`, `frames: [{timestamp, precip_mm_h, is_convective}]`, `km_from`, `km_to`, `segment_id?` (additiv seit #1948 S5, AC-15, analog zu `OnsetPayload`) |
 
@@ -3671,6 +3671,20 @@ function corridorInside(value, min, max) {
 
 ## Changelog
 
+- 2026-08-22: Issue #2051 Scheibe S1 — `OnsetPayload` (Section 22.5, `POST /api/trips/{trip_id}/
+  alert-preview`) bekommt additiv die Felder `event_end_time: string | null`,
+  `event_end_day_offset: int = 0` und `event_ongoing_beyond_horizon: bool = false`. Ende und Dauer
+  des zusammenhängenden nassen Blocks werden aus denselben, bereits abgerufenen Nowcast-Frames
+  abgeleitet (kein zusätzlicher Quellenabruf) und in allen sieben Textstellen mitgenannt: Langform
+  `letzter Regen gegen HH:MM`, Kurzform (SMS/Premium-SMS/Telegram-Kurzstil) `@HH:MM` direkt hinter
+  dem Mengen-Token aus #2046. Reicht der nasse Block über den 180-Min-Horizont hinaus oder bricht
+  die Frame-Zeitreihe ab, ist `event_ongoing_beyond_horizon=true` gesetzt und alle Textstellen
+  rendern stattdessen die belegte Untergrenzen-Form `Regen mindestens bis HH:MM` bzw. ` >@HH:MM`
+  (PO-Entscheid 2026-08-22, v1.1 — kehrt die ursprüngliche Weglass-Entscheidung um). Dieselbe
+  Feld-Erweiterung trägt `RadarAlertRequest` (`notification_service.py`) auf dem Trip-/
+  Ortsvergleich-Versandpfad. Reine additive Feld-Ergänzung, kein Formatwechsel der Antwortstruktur;
+  ohne die neuen Felder rendert der Vorschauweg unverändert die alte Ausweichform ohne Ende. Spec:
+  `docs/specs/modules/feat_2051_s1_dauer_und_ende.md`.
 - 2026-08-22: Issue #2020 Scheibe 2 — der Abweichungsalarm für
   Niederschlags-Summen-Ereignisse schaut nach vorn statt zurück: statt „stärkste
   Stunde war um X" nennt die Ereigniszeile jetzt die ab Versandzeitpunkt noch

--- a/docs/specs/modules/feat_2051_s1_dauer_und_ende.md
+++ b/docs/specs/modules/feat_2051_s1_dauer_und_ende.md
@@ -1,0 +1,547 @@
+---
+entity_id: feat_2051_s1_dauer_und_ende
+type: feature
+created: 2026-08-21
+updated: 2026-08-22
+status: approved
+version: "1.1"
+tags: [alarm, briefing, nowcast, radar, dauer, ende]
+---
+
+# Ereignis-Ende und -Dauer im Nowcast mitliefern — #2051 Scheibe S1
+
+## Approval
+
+- [x] Approved — PO-Freigabe der Acceptance Criteria am 2026-08-21 (v1.0)
+- [x] Approved — PO-Freigabe der geänderten Kriterien AC-5, AC-16 und des
+  neuen AC-20 am 2026-08-22 (v1.1, Umkehr auf die Untergrenzen-Form)
+
+## Purpose
+
+Der Radar-/Nowcast-Pfad liest aus der abgerufenen Frame-Zeitreihe heute nur den
+**ersten** nassen Zeitpunkt (`onset_minutes`) und bricht danach ab — der Rest der
+bereits vorliegenden Zeitreihe wird verworfen. Der Nutzer erfährt, *wann* es
+anfängt, aber nicht, **wie lange es dauert und wann es endet**. Diese Spec
+leitet Ende und Dauer des zusammenhängenden nassen Blocks aus **denselben,
+bereits abgerufenen Frames** ab (kein zusätzlicher Quellenabruf) und liefert
+sie additiv in allen sieben Textstellen mit, die den Ereignisbeginn heute schon
+ausformulieren. S2 (räumliche Ausdehnung), S3 (Reichweite der Quelle) und S4
+(`/strecke`-Kommando) aus Issue #2051 bleiben ausdrücklich außerhalb dieses
+Zuschnitts; das Ticket bleibt als Scheiben-Ticket offen.
+
+## Source
+
+- **File:** `src/services/radar_service.py`
+- **Identifier:** `_derive_result()` (Z. 700-…), neuer Helfer
+  `_derive_wet_block_end()`, `NowcastResult` (Z. 137-190)
+
+Begleitend: `src/output/renderers/alert/model.py` (`OnsetEvent`),
+`src/services/notification_service.py` (`RadarAlertRequest`, Z. 165),
+`src/services/trip_alert.py` (`check_radar_alerts`, Z. 1330-1499),
+`src/services/compare_radar_alert.py` (Z. 352, Ortsvergleich-Pendant),
+`src/output/renderers/alert/project.py` (Z. 368-405, Mehr-Orte-Bündel),
+`src/output/renderers/alert/render.py` (Textstellen 1-5),
+`src/output/renderers/email/starkregen_hint.py` (Textstelle 6),
+`src/services/trip_report_scheduler.py` (Z. 366, 1870, Datenform des
+Briefing-Tupels), `api/routers/validator.py` (`OnsetPayload`),
+`src/services/validator_render_service.py` (Vorschau-/Replay-Weg).
+
+> **Schicht-Hinweis:** Alle Änderungen liegen ausschließlich im Python-Core
+> (`src/services/`, `src/output/`, `api/routers/`) — kein Go-API-, kein
+> Frontend-Anteil.
+
+## Estimated Scope
+
+- **LoC:** ~200-240 produktiv, ~150-220 Tests bei voller Reichweite —
+  **über dem 250-LoC-Workflow-Limit**, `workflow.py set-field
+  loc_limit_override 500` ist vor `/40-tdd-red` einzuplanen.
+- **Files:** 11 Produktivdateien + ~10-12 Testdateien (Neuanlagen + Bestand
+  fortgeschrieben).
+- **Effort:** high.
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `_accumulate_precip_mm` | function (`radar_service.py:200-242`) | Bestehender, aus #2046 extrahierter Rechenkern: Frame-Dedup je Zeitstempel (höherer Wert gewinnt), Dauer je Frame aus dem eigenen nächsten Nachbarn (`bisect_right` über `all_ts_sorted`), Deckel `_MAX_FRAME_COVERAGE` (15 Min), hartes Fensterende. Wird für Summenbildung weiterverwendet, nicht für die neue Grenzfindung. |
+| `NowcastResult.onset_minutes` / `.frames` | fields (`radar_service.py:139,142`) | Bestehende Felder — `frames` trägt bereits die vollständige Zeitreihe, aus der auch das Ende abgeleitet wird. |
+| `_NOWCAST_HORIZON_MIN` | constant (`radar_service.py:69`, Wert 180) | Bleibt unverändert (E3) — Herleitung von #1945, dort bewusst von 60 auf 180 angehoben. |
+| `RADAR_ONSET_THRESHOLD_MIN` | constant (`radar_service.py:121`, Wert 55) | Auslöse-Schwelle des Alarms — von dieser Spec unberührt, nur die Anzeige ändert sich. |
+| `RadarAlertRequest` | DTO (`notification_service.py:165-194`) | Trip-Pfad-Transport; bekommt additiv-optionale Ende-Felder, Muster `onset_precip_mm` (#2046). |
+| `OnsetEvent` | dataclass (`model.py:38-62`) | Renderer-Modell; bekommt dieselben additiven Felder. |
+| `OnsetPayload` | Pydantic-Model (`api/routers/validator.py:~240`) | Vorschau-Payload-Schema — muss das neue Feld kennen, sonst Adversary-Fund wie #2046 F002. |
+| `starkregen_nowcast: tuple[str, int] \| None` | field (`notification_service.py:110`) | Bestehende, zu **enge** Datenform des Briefing-Pfads — muss um Ende/Dauer/Wächter erweitert werden (vier Stellen). |
+| `_onset_time_label()` / Δ-Teil `_render_sms_body` | functions (`render.py`) | Von dieser Spec **nicht** angefasst — Zusage an die Parallelsitzung `fix-2020-zeitangaben-wortlaut` (#2020 S2). |
+
+## Getroffene Entscheidungen (E1-E3, aus Phase 2 — nicht erneut vorlegen)
+
+**E1 — Reichweite: alle sieben Textstellen.** E-Mail-Betreff,
+E-Mail Mehr-Orte-Bündel (Ortsvergleich), E-Mail Trip, Telegram (rich),
+SMS/Premium-SMS/Telegram-Kurzstil, Briefing-Kurzfristhinweis und
+Inbound-Kommando-Antwort bekommen alle die Ende-Angabe. Begründung: Ein
+Zuschnitt ohne die Alarmtexte adressiert die eigene Problemstellung des
+Tickets nicht — dieses rahmt das Problem als „das Alarmsystem meldet heute
+einen Punkt". Ein Zuschnitt auf Briefing-Hinweis + Kommando-Antwort (die
+beiden ungedeckelten Pfade) ließe **SMS und Premium-SMS ohne die Angabe** —
+und auf der Hütte (nur Satellit) ist Premium-SMS der einzige ankommende Kanal.
+
+**E2 — Tagesfenster: nicht kappen.** Das echte, aus den Frames abgeleitete
+Ende wird genannt, auch wenn es über das konfigurierte Tagesfenster
+hinausreicht. Drei Gründe: (a) Der Nowcast-Pfad spricht heute schon außerhalb
+des Tagesfensters — `onset_time` wird nirgends gekappt; nur das Ende zu kappen
+wäre in sich unstimmig. (b) Die Tagesfenster-Konsistenzbegründung aus
+`segment_weather.py:292-308` gilt dem prognosebasierten Δ-Alarm, der gegen
+Briefing-Zahlen vergleicht — für das Nowcast-Ende gibt es keine
+Briefing-Entsprechung, mit der es sich widersprechen könnte. (c) Ein still
+gekapptes „Ende gegen 20:00" bei Regen bis 22:00 wäre eine falsche Aussage —
+dieselbe Fehlerklasse wie R4, nur selbst verursacht.
+
+**E3 — Horizont: `_NOWCAST_HORIZON_MIN` bleibt bei 180.** Keine Kappung auf
+60 — das nähme die #1945-Entscheidung (dort bewusst 60 → 180 angehoben, weil
+der 60-Min-Deckel den Alarm praktisch immer erst ~8 Min vorher auslösen ließ)
+still zurück. Der Alarmzweig wäre von einer Kappung ohnehin kaum betroffen
+(deckelt bereits hart bei 55 Min); getroffen würden `window_precip_mm`,
+`onset_precip_mm`, der Briefing-Hinweis und die Kommando-Antwort — genau die
+Pfade, aus denen der im Ticket geschilderte Realfall stammt. Die vom PO
+erwogene Güte-Kennzeichnung **ist** der `event_ongoing_beyond_horizon`-Wächter
+(s. Implementation Details) — keine zusätzliche Kappung nötig.
+
+## Implementation Details
+
+Die Onset-Schleife (`radar_service.py:724-729`) läuft bereits über das
+sortierte Fenster und bricht beim ersten nassen Frame ab. Die Blockende-
+Bestimmung ist dieselbe Schleife **ohne** den Abbruch, ab dem Beginn-Frame
+weitergeführt. Zwei Fälle, **beide ohne neue Toleranzzahl**:
+
+| Fall | Bedeutung | Behandlung |
+|---|---|---|
+| Frame vorhanden, `precip_mm_h < 0.1` | Quellenaussage „hier hat es aufgehört" | beendet den Block **real** — nicht überbrücken, sonst verschmelzen zwei getrennte Ereignisse und die Dauer wird überschätzt. |
+| Frame **fehlt** (Rasterlücke, Drosselung, Ausfall) | keine Beobachtung | Der letzte nasse Frame deckt ohnehin nur bis `min(nächster Frame, +_MAX_FRAME_COVERAGE, Horizontende)` — dieselbe Nachbar-Deckungslogik wie in `_accumulate_precip_mm`. Lücken bis 15 Min sind damit **implizit** toleriert; größere Lücken setzen das Ende an der Deckungsgrenze, nicht am nächsten wieder nassen Frame danach. |
+
+**Neuer Helfer als Geschwister von `_accumulate_precip_mm`** (nicht dessen
+Erweiterung — dessen Aufgabe ist Summieren in einem bekannten Fenster, nicht
+Grenzen finden):
+
+```
+_derive_wet_block_end(
+    frames: list, all_ts_sorted: list, onset_ts: datetime, horizon: datetime,
+) -> tuple[datetime, bool]
+```
+
+Rückgabe: `(end_ts, ongoing_beyond_horizon)`. Läuft ab `onset_ts` über die
+sortierten Frames im Fenster, endet beim ersten Trockenframe oder an der
+Deckungsgrenze einer Lücke; erreicht die Schleife den Horizont, während der
+letzte bekannte Frame noch nass war, ist `ongoing_beyond_horizon = True` und
+`end_ts` der Horizont selbst (nicht behauptbar als echtes Ende).
+
+**Zwei neue Felder auf `NowcastResult`** (`radar_service.py`, additiv,
+optional, Muster `onset_precip_mm` aus #2046):
+
+```python
+event_end_minutes: Optional[int] = None
+# Issue #2051 S1: Minuten ab jetzt bis zum Ende des zusammenhaengenden nassen
+# Blocks, analog onset_minutes. None wenn onset_minutes None ist.
+event_ongoing_beyond_horizon: bool = False
+# R4-Waechter: die Frames bzw. der 180-Min-Horizont sind ausgegangen, waehrend
+# der letzte bekannte Frame noch nass war. False heisst "das echte Ende ist
+# bekannt" -- konsistent mit throttled/data_unavailable als
+# Beobachtbarkeits-Signal.
+```
+
+**Keine** gespeicherte `event_duration_minutes` — sie ist stets
+`event_end_minutes - onset_minutes`; ein drittes Feld könnte auseinanderlaufen
+und würde bei jedem Konsumenten eine zweite Quelle der Wahrheit schaffen.
+
+**Downstream `event_end_time` / `event_end_day_offset`** als Pendants zu
+`onset_time`/`onset_day_offset`, über **dieselbe** Zeitversatz-Logik
+(#2009-Muster: `_end_dt = now_utc + timedelta(minutes=event_end_minutes)`,
+`local_fmt(_end_dt, tz)` für die Uhrzeit, `day_offset(now_utc, _end_dt, tz)`
+für den Tagesversatz) — nicht neu implementiert. Das ist bewusst
+**asymmetrisch** zum Beginn: Beginn und Ende können unterschiedliche
+Tagesversätze tragen (Beginn 23:50 ohne Versatz, Ende 00:40 mit
+`day_offset=1`).
+
+**Zwei Pydantic-Modelle** brauchen das neue Feld: `RadarAlertRequest`
+(`notification_service.py:165`) und `OnsetPayload`
+(`api/routers/validator.py:~240`). Bei #2046 war genau das der
+Adversary-Fund F002 — hier vorab bekannt, beide Stellen sind im Test-Plan
+gelistet.
+
+**Briefing-Pfad (Textstelle 6) — Datenform muss aufgemacht werden.** Heute
+transportiert `notification_service.py:110`
+`starkregen_nowcast: tuple[str, int] | None` (nur `intensity_label`,
+`onset_minutes`), gebaut in `trip_report_scheduler.py:1870` als
+`return (result.intensity_label, result.onset_minutes)`, ausgepackt `:366`,
+verbraucht von
+`format_starkregen_hint(intensity_label, onset_minutes, *, tz)`. Für Ende und
+Wächter reicht das Tupel nicht mehr — Erweiterung auf ein Tupel mit den
+zusätzlichen Feldern (oder ein kleines Objekt) an allen vier Stellen:
+`notification_service.py:110`, `trip_report_scheduler.py:1870` und `:366`,
+`starkregen_hint.py` (Signatur von `format_starkregen_hint`).
+
+**Wortlaut — von der Parallelsitzung #2020 S2 übernommen, nicht neu
+erfunden:**
+
+- **Langform** (E-Mail-Betreff, E-Mail Trip, E-Mail Mehr-Orte, Telegram rich,
+  Briefing-Hinweis, Kommando-Antwort): `letzter Regen gegen HH:MM`
+- **Kurzform** (SMS/Premium-SMS/Telegram-Kurzstil): `@HH` direkt hinter dem
+  Mengen-Token aus #2046, z. B. `R2.5@18:00@20`.
+- **Langform Untergrenze** (bei gesetztem `event_ongoing_beyond_horizon`,
+  alle sieben Textstellen): `Regen mindestens bis HH:MM`.
+- **Kurzform Untergrenze** (SMS/Premium-SMS/Telegram-Kurzstil, bei gesetztem
+  Wächter): ` >@HH:MM` — ein Leerzeichen, dann `>`, dann das Zeit-Token,
+  z. B. `km 8-8: R2.5@18:00 >@20:00`. Schreibweise vom PO vorgegeben
+  (2026-08-22).
+
+Die Kurzform-Untergrenze trägt eine **absolute Uhrzeit**, keine relative
+Dauer (»+60min«): Die Premium-SMS kommt auf der Hütte über Satellit an, teils
+verzögert — eine relative Angabe würde durch die Zustellverzögerung still
+falsch, eine absolute Uhrzeit bleibt richtig. Dieselbe Begründung trägt schon
+`onset_day_offset` aus #2009.
+
+Das Zeit-Token ist bei der Untergrenze bewusst **minutengenau** (`HH:MM`) und
+nicht nur die Stunde: Die Quellen liefern ein 15-Minuten-Raster (INCA/AROME
+am Karnischen Höhenweg) bzw. 5 Minuten (RADOLAN) — `20:45` auf `20` zu kürzen
+wäre bis zu 45 Minuten daneben. Der PO hat dazu die Briefing-Konvention `%Hh`
+(nur Stunde, `sms_trip.py:753`) angeführt; die gilt dort für die **geplante**
+Etappen-Startzeit, die naturgemäß auf vollen Stunden liegt, nicht für einen
+Messzeitpunkt.
+
+`_onset_time_label()` und der Δ-Teil von `_render_sms_body` bleiben
+**unangetastet** (Zusage an `fix-2020-zeitangaben-wortlaut`).
+
+**Bei gesetztem `event_ongoing_beyond_horizon` rendert jeder der sieben
+Textkonsumenten die Untergrenzen-Form statt der Normalform** — nicht mehr
+die Ausweichform ohne Ende (PO-Entscheid 2026-08-22, kehrt die ursprüngliche
+Entscheidung um). Begründung: `event_end_minutes` ist in beiden
+Wächter-Fällen bereits eine belegte, keine geratene Zahl — im Code verifiziert
+in `_derive_wet_block_end` (`radar_service.py:260-320`): Erreicht die
+Schleife den Horizont, während der letzte bekannte Frame noch nass war
+(`coverage_end >= horizon`), regnet es nachweislich durchgehend bis dorthin;
+bricht die Zeitreihe ab (`next_ts is None`), ist die Untergrenze der letzte
+bekannte nasse Frame plus seine `_MAX_FRAME_COVERAGE`-Deckung. Beides ist eine
+Beobachtung, keine Extrapolation über den Horizont hinaus. Das Weglassen
+(Ursprungsentscheidung) verwarf damit eine wahre, beobachtungsgestützte
+Aussage — die Untergrenzen-Form nennt sie, ohne ein unbekanntes echtes Ende zu
+behaupten (AC-20 grenzt beide Formen textlich voneinander ab). Es ist keine
+neue Rechnung nötig, `event_end_minutes` trägt bereits die richtige Zahl —
+nur die Textform ändert sich.
+
+**Horizont-Drift-Korrektur (gehört in S1, s. u.):** `format_now_text()`
+(`radar_service.py:431`) sagt im Trockenzweig „In den nächsten 2 Stunden kein
+Regen erwartet." — geprüft werden seit #1945 tatsächlich 3 Stunden
+(`_NOWCAST_HORIZON_MIN = 180`). Der Docstring von `starkregen_hint.py:4`
+nennt „60-Minuten-Nowcast-Fenster (`NOWCAST_HORIZON_MIN`)" — der Wert ist
+180. Beide werden in dieser Spec korrigiert (eigenes AC, eigener Commit),
+nicht als separates Ticket oder stille Nebenreparatur.
+
+## Expected Behavior
+
+- **Input:** `NowcastResult` mit gesetztem `onset_minutes` und Frames, die den
+  zusammenhängenden nassen Block ganz oder teilweise abdecken (bis zum
+  Horizont oder bis zum tatsächlichen Ende).
+- **Output:** alle sieben Textstellen tragen zusätzlich eine Ende-Angabe. Bei
+  `event_ongoing_beyond_horizon=False` in der Normalform
+  (`letzter Regen gegen HH:MM` / `@HH:MM`), bei
+  `event_ongoing_beyond_horizon=True` in der Untergrenzen-Form
+  (`Regen mindestens bis HH:MM` / ` >@HH:MM`, PO-Entscheid 2026-08-22).
+  Nur wenn `onset_minutes is None` ist, bleibt der Text unverändert wie heute.
+- **Side effects:** keine — reine additive Feld-Durchreichung plus
+  Renderer-/Formatierungserweiterung. Kein Datenmodell-Bruch (alle neuen
+  Felder optional mit Default), keine Persistenz betroffen, keine Änderung an
+  der Auslöseregel (`radar_alert_due`) oder der #2020-Überholungsprüfung.
+
+## Acceptance Criteria
+
+- **AC-1:** Given eine Frame-Zeitreihe mit einem zusammenhängenden nassen
+  Block (durchgängig `precip_mm_h >= 0.1` von Minute 20 bis Minute 80, danach
+  trocken) / When `_derive_result` daraus `event_end_minutes` ableitet / Then
+  entspricht `event_end_minutes` dem Zeitpunkt des letzten nassen Frames vor
+  dem Trockenübergang (Minute 80), nicht dem Horizontende und nicht dem
+  Beginn.
+  - Test: Unit-Test gegen `_derive_wet_block_end` bzw. `_derive_result` mit
+    konstruierten Frames im 5-Minuten-Raster, `event_end_minutes` gegen den
+    erwarteten Wert geprüft.
+
+- **AC-2:** Given zwei getrennte nasse Blöcke in derselben Frame-Zeitreihe
+  (nass Minute 10-30, trocken Minute 35-50, wieder nass Minute 55-70) / When
+  `_derive_result` Beginn und Ende ableitet / Then endet der Block beim ersten
+  Trockenframe nach Minute 30 — das zweite, spätere Ereignis wird NICHT in
+  `event_end_minutes` eingerechnet, die beiden Ereignisse verschmelzen nicht
+  zu einer überlangen Dauer.
+  - Test: Unit-Test mit den zwei getrennten Blöcken, `event_end_minutes`
+    liegt nahe bei Minute 30, nicht bei Minute 70.
+
+- **AC-3:** Given einen nassen Block, in dem ein einzelner Frame mitten drin
+  fehlt (Raster sonst 10-Minuten-Kadenz, eine Lücke von 10 Minuten — innerhalb
+  der `_MAX_FRAME_COVERAGE`-Deckung von 15 Minuten) / When das Ende abgeleitet
+  wird / Then wird der Block durch die Lücke NICHT fälschlich beendet — das
+  Ende liegt beim letzten tatsächlich nassen Frame nach der Lücke, nicht bei
+  der Lücke selbst.
+  - Test: Unit-Test mit einer 10-Minuten-Datenlücke mitten im nassen Block,
+    `event_end_minutes` zeigt auf den späteren, nach der Lücke liegenden
+    nassen Frame.
+
+- **AC-4:** Given einen nassen Block mit einer Datenlücke von 25 Minuten
+  (größer als `_MAX_FRAME_COVERAGE` = 15 Minuten) mitten drin, gefolgt von
+  einem erneut nassen Frame / When das Ende abgeleitet wird / Then wird das
+  Ende an der Deckungsgrenze des letzten Frames vor der Lücke gesetzt
+  (`Frame-Zeitstempel + 15 Minuten`), NICHT am nach der Lücke wieder nassen
+  Frame — dieselbe Deckungsmechanik wie `_accumulate_precip_mm`, keine neue
+  Toleranzzahl.
+  - Test: Unit-Test mit 25-Minuten-Lücke, `event_end_minutes` exakt
+    `Beginn-Frame-Zeit-des-letzten-Frames-vor-der-Luecke + 15 Min` geprüft.
+
+- **AC-5:** Given eine Frame-Zeitreihe, deren letzter verfügbarer bzw. bis zum
+  180-Minuten-Horizont reichender Frame noch nass ist (kein Trockenframe im
+  gesamten Fenster) / When `_derive_result` das Ergebnis baut und die sieben
+  Textstellen gerendert werden / Then ist `event_ongoing_beyond_horizon=True`,
+  und JEDE der sieben Textstellen nennt das Ende als belegte UNTERGRENZE statt
+  es wegzulassen: Langform `Regen mindestens bis HH:MM`, Kurzform ` >@HH:MM`.
+  Der genannte Zeitpunkt ist der aus `event_end_minutes` abgeleitete — in
+  beiden Wächter-Fällen (Horizont erreicht bzw. Zeitreihe abgebrochen) eine
+  beobachtungsgestützte Untergrenze, keine Schätzung.
+  - Test: Ein Unit-Test gegen `_derive_result` prüft das Flag selbst; je ein
+    Renderer-Test für die Langform (E-Mail Trip), die Kurzform (SMS) und den
+    Briefing-Hinweis prüft die Anwesenheit der Untergrenzen-Form.
+
+- **AC-20:** Given denselben Aufbau wie AC-5 (`event_ongoing_beyond_horizon=True`) /
+  When die sieben Textstellen gerendert werden / Then erscheint in KEINEM der
+  Texte die Normalfall-Formulierung `letzter Regen gegen` bzw. das schmucklose
+  Kurzform-Token `@HH:MM` an der Ende-Position — die Untergrenze darf nicht als
+  bekanntes Ende missverstanden werden. Umgekehrt trägt der Normalfall
+  (`event_ongoing_beyond_horizon=False`) NIE `mindestens` oder `>`.
+  - Test: Unit-Test über beide Zustände, Negativ-Prüfung je Richtung —
+    Wächterfall ohne `letzter Regen gegen`, Normalfall ohne `mindestens`/`>`.
+
+- **AC-6:** Given einen Onset-Alarm mit Beginn um 23:50 Ortszeit (kein
+  Tagesversatz) und einem daraus abgeleiteten Ende um 00:40 des Folgetags /
+  When Beginn und Ende gerendert werden / Then trägt `onset_day_offset=0`
+  während `event_end_day_offset=1` — Beginn und Ende können unterschiedliche
+  Tagesversätze tragen, die Ableitung ist asymmetrisch, nicht vom Beginn
+  kopiert.
+  - Test: Unit-Test mit Frames, die den Übergang über Mitternacht abbilden,
+    beide `day_offset`-Werte einzeln geprüft.
+
+- **AC-7:** Given eine Frame-Zeitreihe mit nassem Block, der über das
+  konfigurierte Tagesfenster der Etappe hinausreicht (z. B. Ende um 22:15 bei
+  einem Tagesfenster-Ende von 20:00) / When das Ende gerendert wird / Then
+  nennt der Text das ECHTE Ende (22:15), OHNE es auf das Tagesfenster zu
+  kappen oder zu unterdrücken.
+  - Test: Unit-Test/Renderer-Test mit einem über 20:00 Ortszeit hinaus nassen
+    Block, gerenderter Text enthält die ungekappte Uhrzeit.
+
+- **AC-8:** Given ein Onset-Alarm mit gesetztem `event_end_minutes` /
+  When der E-Mail-Betreff (`_render_subject_onset`) gerendert wird / Then
+  enthält der Betreff zusätzlich zur Beginn-Angabe die Ende-Angabe im Wortlaut
+  `letzter Regen gegen HH:MM`.
+  - Test: Unit-Test gegen `_render_subject_onset` mit konstruiertem
+    `OnsetEvent`, Substring-Prüfung auf `letzter Regen gegen`.
+
+- **AC-9:** Given denselben Aufbau wie AC-8 / When die E-Mail-Trip-Onset-Zeile
+  (`_render_email_onset`) gerendert wird / Then enthält der Text
+  `letzter Regen gegen HH:MM` zusätzlich zur bestehenden Beginn-Zeile.
+  - Test: Unit-Test gegen `_render_email_onset`, Substring-Prüfung.
+
+- **AC-10:** Given ein Mehr-Orte-Onset-Bündel (Ortsvergleich) mit einem
+  führenden Ort, dessen `NowcastResult` ein gesetztes `event_end_minutes`
+  trägt / When `to_multi_location_onset_alert_message` das Ergebnis baut und
+  `_render_email_onset_multi` rendert / Then enthält der Text
+  `letzter Regen gegen HH:MM` — dieselbe Angabe wie im Trip-Pfad (AC-9), nicht
+  nur eine leere Beginn-Zeile.
+  - Test: Unit-Test über `to_multi_location_onset_alert_message` mit zwei
+    Orts-`NowcastResult`s (führender Ort mit gesetztem Ende), gerenderter
+    E-Mail-Text auf die Ende-Angabe geprüft.
+
+- **AC-11:** Given denselben Aufbau wie AC-8 / When
+  `_render_telegram_onset` (rich) gerendert wird / Then enthält der
+  Telegram-Text `letzter Regen gegen HH:MM` zusätzlich zur Beginn-Angabe.
+  - Test: Unit-Test gegen `_render_telegram_onset`, Substring-Prüfung.
+
+- **AC-12:** Given denselben Aufbau wie AC-8 / When `_render_sms_onset`
+  (SMS, Premium-SMS und Telegram-Kurzstil) gerendert wird / Then enthält der
+  Text zusätzlich zum bestehenden Mengen-Token (#2046) das Kurzform-Token
+  `@HH` für das Ende, unmittelbar hinter dem Mengen-Token — alle drei Kanäle
+  zeigen denselben Text, weil sie denselben gerenderten `sms_body` erhalten.
+  - Test: Unit-Test gegen `_render_sms_onset` mit konstruiertem `OnsetEvent`,
+    Regex-Prüfung auf zwei `@HH:MM`-artige Token in der erwarteten
+    Reihenfolge; ergänzend ein Kanalvergleichstest wie #2046-AC-7.
+
+- **AC-13:** Given ein `starkregen_nowcast`-Tupel mit gesetztem Ende und
+  `event_ongoing_beyond_horizon=False` / When
+  `format_starkregen_hint(...)` den Briefing-Kurzfristhinweis rendert / Then
+  enthält der Text zusätzlich zur Beginn-Angabe `letzter Regen gegen HH:MM`.
+  - Test: Unit-Test gegen `format_starkregen_hint` mit erweiterter
+    Signatur/Datenform, Substring-Prüfung.
+
+- **AC-14:** Given ein `NowcastResult` mit gesetztem `event_end_minutes` /
+  When `format_now_text(result, ...)` als Antwort auf ein Inbound-Kommando
+  gerendert wird / Then enthält der Text zusätzlich zur bestehenden
+  Beginn-Zeile `letzter Regen gegen HH:MM`.
+  - Test: Unit-Test gegen `format_now_text`, Substring-Prüfung.
+
+- **AC-15:** Given denselben Onset-Alarm einmal über den Trip-Pfad
+  (`trip_alert.check_radar_alerts`) und einmal über den Ortsvergleich-Pfad
+  (`compare_radar_alert`) gerendert (ADR-0021, geteilter Code) / When beide
+  Pfade dieselben Frames erhalten / Then trägt die Ende-Angabe in beiden
+  Flächen denselben Wortlaut und denselben Wert — keine Fläche zeigt das Ende,
+  ohne dass es die andere auch täte.
+  - Test: Paritätstest, gespiegelt zu
+    `tests/tdd/test_onset_menge_kanalparitaet.py`, prüft Trip- und
+    Ortsvergleich-Ausgabe auf identische Ende-Angabe.
+
+- **AC-16:** Given ein Onset-Alarm mit langem Ortsnamen (30 Zeichen), einer
+  Extremmenge (`onset_precip_mm=99.9`) UND dem Ende-Untergrenzen-Token
+  (` >@23:59`, `event_ongoing_beyond_horizon=True`) — der Extremfall aus
+  kombiniertem Mengen- und Untergrenzen-Token, ein Zeichen länger als die
+  Normalform und NICHT die alte Marge aus #2046-AC-9 fortgeschrieben / When
+  `render_sms(msg, limit=140)` gerendert wird / Then bleibt der resultierende
+  Text unter 140 GSM-7-Zeichen, ohne dass der harte Schnitt `body[:limit]` im
+  Normalfall greift.
+  - Test: Unit-Test mit 30-Zeichen-Ortsnamen, `onset_precip_mm=99.9` und
+    gesetztem Wächter (Untergrenzen-Token), `len(sms) <= 140` geprüft — reine
+    Längenprüfung, kein Goldstring-Vergleich.
+
+- **AC-17:** Given einen beliebigen der sieben gerenderten Texte mit
+  gesetztem Ende / When der Text auf Formulierungen geprüft wird, die eine
+  Handlungsempfehlung oder eine Position/Uhrzeit-Rechnung über den Nutzer
+  enthalten (z. B. „bei Planzeit bist du um … bei km …") / Then enthält KEINER
+  der sieben Texte eine solche Formulierung — ausschließlich Wetterdaten
+  (Beginn, Ende, Menge, Ort).
+  - Test: Unit-Test über alle sieben Renderer-Ausgaben, Negativ-Prüfung auf
+    eine Liste verbotener Muster (kein Personalpronomen der zweiten Person in
+    Verbindung mit einer Zeit-/Ortsangabe).
+
+- **AC-18:** Given der Trockenzweig von `format_now_text` (kein Regen im
+  gesamten Nowcast-Fenster) / When der Text gerendert wird / Then lautet die
+  Zeitangabe „In den nächsten 3 Stunden kein Regen erwartet." — konsistent mit
+  `_NOWCAST_HORIZON_MIN = 180` seit #1945, nicht mehr „2 Stunden".
+  - Test: Unit-Test gegen `format_now_text` mit einem durchgängig trockenen
+    `NowcastResult`, Substring-Prüfung auf „3 Stunden" und Abwesenheit von
+    „2 Stunden".
+
+- **AC-19:** Given ein `NowcastResult` ohne ableitbares Ende — drei Varianten:
+  (a) `onset_minutes=None` (kein Beginn erkannt), (b) `throttled=True`
+  (Budget-Drosselung), (c) `data_unavailable=True` (echter Fetch-Fehler) /
+  When alle sieben Textstellen wie vor dieser Spec gerendert werden / Then
+  bleiben `event_end_minutes=None` und `event_ongoing_beyond_horizon=False`,
+  und JEDER der sieben Texte rendert exakt wie vor dieser Änderung — additives
+  Feld mit Default, kein Bruch für Alt-Aufrufer.
+  - Test: Regressionslauf der Bestandstests aus dem Test-Plan ohne
+    inhaltliche Anpassung an ihren Fixtures — kein Bestandstest darf allein
+    wegen der neuen Felder rot werden.
+
+## Known Limitations
+
+- **R4 bleibt strukturell:** „Ende" bei abgeschnittener Zeitreihe ist nicht
+  dasselbe wie „Ende des Ereignisses". `event_ongoing_beyond_horizon` macht
+  den Unterschied zwischen „Ende" und „Ende der Beobachtung" jetzt im Text
+  sichtbar — als belegte Untergrenze (`Regen mindestens bis HH:MM` /
+  ` >@HH:MM`) statt als Schweigen —, löst ihn aber weiterhin nicht auf:
+  jenseits von 180 Minuten bleibt das tatsächliche Ende grundsätzlich
+  unbekannt (das wäre S3, „Reichweite der Quelle", explizit außerhalb dieses
+  Zuschnitts).
+- **Abhängigkeit vom Quellenraster.** Wie bei `onset_precip_mm` (#2046)
+  bestimmt die Kadenz der jeweiligen Quelle (5-15 Min) die Präzision der
+  Ende-Angabe; bei gröberem Raster kann das abgeleitete Ende um bis zu
+  `_MAX_FRAME_COVERAGE` (15 Min) von der Wirklichkeit abweichen.
+- **S2 (räumliche Ausdehnung), S3 (Reichweite der Quelle), S4
+  (`/strecke`-Kommando)** aus Issue #2051 bleiben offen — diese Spec deckt
+  ausschließlich S1 (Dauer/Ende).
+
+## Nicht-Ziele
+
+- **Keine Änderung an der Auslöseschwelle** (`RADAR_ONSET_THRESHOLD_MIN = 55`)
+  oder an der #2020-Überholungsprüfung.
+- **Keine Kappung von `_NOWCAST_HORIZON_MIN`** auf 60 (E3) — nähme #1945
+  zurück.
+- **Keine Kappung der Ende-Angabe am Tagesfenster** (E2).
+- **Keine neue Toleranzzahl** für Datenlücken — dieselbe
+  `_MAX_FRAME_COVERAGE`-Deckung wie `_accumulate_precip_mm`.
+- **Keine Änderung an `_onset_time_label()` oder dem Δ-Teil von
+  `_render_sms_body`** — Zusage an `fix-2020-zeitangaben-wortlaut`.
+- **Kein neuer Quellenabruf** — die Ende-Bestimmung nutzt ausschließlich die
+  bereits abgerufenen `frames`.
+- **Keine Handlungsempfehlung im Text** — ausschließlich Wetterdaten (AC-17).
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Additive Feld-Durchreichung entlang einer bestehenden
+  Wirkkette (Muster bereits über `onset_precip_mm`/`onset_day_offset`/
+  `segment_id` etabliert) plus eine reine Renderer-Formaterweiterung. Berührt
+  keine der vier Entscheidungsflächen, die ein neues ADR verlangen würden:
+  ADR-0011 (ein Backend-Renderer) bleibt gültig — alle fünf renderer-seitigen
+  Textstellen liegen weiter in `render.py`; ADR-0021 (geteilter Code
+  Trip/Compare) wird angewendet, nicht verändert (AC-15); ADR-0052
+  (Mail-Bauform, Label-Wert-Tupel) bleibt unangetastet, die Ende-Angabe fügt
+  sich in dieselbe Datenzeilen-Form ein. Kein neuer Kanal, kein neuer
+  Provider, keine Persistenz-Änderung, keine Änderung an der Auslöseregel.
+
+## Reihenfolge
+
+`render.py` wird von drei Vorhaben gleichzeitig angefasst (#2036, #2020 S2,
+diese Spec). Empfohlene Reihenfolge:
+
+1. **Datenschicht zuerst** (`radar_service.py`, `model.py`,
+   `notification_service.py`, `trip_alert.py`/`compare_radar_alert.py`,
+   Vorschauweg) — keine Abhängigkeit von `render.py`, kann sofort entstehen.
+2. #2036 (Phase 6) und #2020 S2 (Phase 5) mergen lassen.
+3. Auf beide nachziehen, **dann** die Textstellen 1-5 in `render.py`
+   schreiben.
+
+## Test-Plan
+
+**Bestehende Tests, die den heutigen ende-losen Text festnageln — laufen
+unverändert grün oder werden am Goldstring fortgeschrieben (AC-19):**
+
+- `tests/tdd/test_alert_sms_onset_zeitpunkt.py`
+- `tests/tdd/test_alert_onset_day_rollover.py`
+- `tests/tdd/test_alert_preview_nowcast_replay.py`
+- `tests/tdd/test_952_onset_alert_fidelity.py`
+- `tests/tdd/test_alert_sms_location_positions.py`
+- `tests/tdd/test_alert_addendum_sms.py`
+- `tests/tdd/test_issue_919_radar_alert_canonical.py`
+- `tests/tdd/test_multi_location_onset_alert.py`
+- `tests/tdd/test_onset_kurzform_menge.py` (#2046)
+- `tests/tdd/test_onset_menge_kanalparitaet.py` (#2046, Muster für AC-15/AC-16)
+
+**Neue Testdateien, benannt nach Verhalten (nicht nach Issue-Nummer):**
+
+- `tests/tdd/test_nowcast_blockende_ableitung.py` — AC-1/AC-2 (Normalfall,
+  getrennte Blöcke).
+- `tests/tdd/test_nowcast_blockende_datenluecke.py` — AC-3/AC-4 (Lücke
+  innerhalb/außerhalb der Deckung).
+- `tests/tdd/test_nowcast_blockende_horizont_waechter.py` — AC-5
+  (`event_ongoing_beyond_horizon`, alle drei geprüften Kanäle; seit v1.1 in
+  umgekehrter Zusicherung: Anwesenheit der Untergrenzen-Form statt
+  Abwesenheit einer Ende-Angabe).
+- `tests/tdd/test_nowcast_blockende_tagesversatz.py` — AC-6 (asymmetrischer
+  Mitternachtsüberlauf).
+- `tests/tdd/test_nowcast_blockende_tagesfenster.py` — AC-7 (ungekapptes
+  Ende).
+- `tests/tdd/test_onset_ende_textstellen.py` — AC-8/AC-9/AC-10/AC-11/AC-12
+  (alle sieben Textstellen, je ein Fall).
+- `tests/tdd/test_onset_ende_briefing_hinweis.py` — AC-13 (Datenform-
+  Erweiterung des Briefing-Tupels).
+- `tests/tdd/test_onset_ende_kommando_antwort.py` — AC-14
+  (`format_now_text`).
+- `tests/tdd/test_onset_ende_kanalparitaet.py` — AC-15 (Trip ↔ Ortsvergleich).
+- `tests/tdd/test_onset_ende_sms_budget.py` — AC-16 (kombinierter
+  Zeichen-Grenzfall).
+- `tests/tdd/test_onset_texte_keine_bevormundung.py` — AC-17.
+- `tests/tdd/test_nowcast_horizont_drift_text.py` — AC-18 (Trockenzweig
+  „3 Stunden").
+- `tests/tdd/test_onset_ende_untergrenze_abgrenzung.py` — AC-20 (Abgrenzung
+  Untergrenze ↔ bekanntes Ende, beide Richtungen).
+
+## Changelog
+
+- 2026-08-21: Initial spec created (#2051 Scheibe S1, Ereignis-Ende und
+  -Dauer im Nowcast).
+- 2026-08-22: v1.1 — AC-5 umgekehrt (PO-Entscheid): bei gesetztem
+  Horizont-Wächter wird das Ende als belegte Untergrenze genannt
+  (`Regen mindestens bis HH:MM` / ` >@HH:MM`) statt weggelassen. Neu AC-20
+  (Abgrenzung Untergrenze ↔ bekanntes Ende). AC-16 auf den längeren
+  Extremfall nachgezogen. Nebenbefund #2063 (Onset-Uhrzeit eine Minute zu
+  früh) bewusst außerhalb dieses Zuschnitts.

--- a/src/output/renderers/alert/model.py
+++ b/src/output/renderers/alert/model.py
@@ -107,6 +107,30 @@ class OnsetEvent:
     # Erst dann darf die Ortsangabe die km-Spanne statt der Segmentnummer
     # zeigen -- eine aus Luftlinie geschaetzte Zahl nie (AC-13).
     km_measured: bool = False
+    # Issue #2051 S1: additiv, optional (Muster `onset_precip_mm`/
+    # `onset_day_offset` o.). Ende desselben Ereignisses als reines "HH:MM"
+    # — Quelle `NowcastResult.event_end_minutes`. `None` heisst "es gibt
+    # keines" (kein Beginn erkannt, keine Frames); die Ende-Angabe entfaellt
+    # dann ersatzlos. Gesetzt von den BEIDEN Onset-Pfaden (Trip UND
+    # Ortsvergleich-Buendel, ADR-0021) ueber die geteilte Fassung
+    # `project.event_end_display`.
+    event_end_time: str | None = None
+    # Issue #2051 S1: Tagesbezug des Endes, analog `onset_day_offset` — aber
+    # BEWUSST eigenstaendig aus dem Ende-Zeitpunkt abgeleitet und nicht vom
+    # Beginn kopiert: Beginn 23:50 (Versatz 0) und Ende 00:40 (Versatz 1)
+    # liegen an verschiedenen Kalendertagen.
+    event_end_day_offset: int = 0
+    # Issue #2051 S1 (Spec v1.1, PO-Entscheid 2026-08-22): der R4-Waechter
+    # `NowcastResult.event_ongoing_beyond_horizon` — die Frames bzw. der
+    # 180-Min-Horizont sind ausgegangen, waehrend der letzte bekannte Frame
+    # noch nass war. `event_end_time` traegt dann trotzdem eine BELEGTE Zahl;
+    # dieses Feld waehlt nur ihre Textform: `True` → Untergrenze
+    # ("Regen mindestens bis HH:MM" / " >@HH:MM"), `False` → bekanntes Ende
+    # ("letzter Regen gegen HH:MM" / "@HH:MM"). Die beiden Formen sagen
+    # Gegensaetzliches und duerfen nie ineinander rutschen (AC-20); deshalb
+    # entscheidet AUSSCHLIESSLICH dieses Feld darueber, an EINER Stelle je
+    # Textform (`_onset_end_suffix` / `_sms_onset_ende`).
+    event_ongoing_beyond_horizon: bool = False
 
 
 @dataclass(frozen=True)

--- a/src/output/renderers/alert/project.py
+++ b/src/output/renderers/alert/project.py
@@ -34,6 +34,39 @@ logger = logging.getLogger("alert_project")
 COMPARE_RADAR_SOURCE = "compare-radar"
 
 
+def event_end_display(
+    now_utc: datetime, nowcast, tz,
+) -> tuple[str | None, int, bool]:
+    """Anzeigefassung des Ereignis-Endes (Issue #2051 S1):
+    `("HH:MM", Versatz, Untergrenze?)`.
+
+    EINE Fassung fuer BEIDE Onset-Pfade (Trip-Radar-Alarm und
+    Ortsvergleich-Buendel, ADR-0021) — zwei Kopien dieser vier Zeilen wuerden
+    genau so auseinanderlaufen wie die Uhrzeit-/Tagesbezugs-Ableitung des
+    Beginns es koennte.
+
+    `(None, 0, False)` heisst "es gibt kein Ende" — das Nowcast-Ergebnis
+    traegt keines (kein Beginn erkannt, keine Frames).
+
+    Das dritte Feld ist der R4-Waechter `event_ongoing_beyond_horizon`. Seit
+    dem PO-Entscheid vom 2026-08-22 (Spec v1.1) unterdrueckt er die
+    Ende-Angabe NICHT mehr, sondern waehlt ihre FORM: `True` heisst "der
+    genannte Zeitpunkt ist eine belegte Untergrenze, kein bekanntes Ende".
+    Er reist deshalb GEMEINSAM mit der Uhrzeit — eine Textstelle, die nur die
+    Uhrzeit bekaeme, wuerde eine Untergrenze als bekanntes Ende ausgeben und
+    damit das Gegenteil der Datenlage behaupten (AC-20).
+
+    Der Tagesversatz stammt aus dem ENDE-Zeitpunkt, nicht vom Beginn: Beginn
+    23:50 und Ende 00:40 liegen an verschiedenen Kalendertagen.
+    """
+    end_minutes = getattr(nowcast, "event_end_minutes", None)
+    if end_minutes is None:
+        return None, 0, False
+    ongoing = bool(getattr(nowcast, "event_ongoing_beyond_horizon", False))
+    end_dt = now_utc + timedelta(minutes=end_minutes)
+    return local_fmt(end_dt, tz), day_offset(now_utc, end_dt, tz), ongoing
+
+
 def _resolve_metric_id(field: str, direction: str) -> str:
     """summary_field → catalog metric_id, disambiguiert per Richtung.
 
@@ -507,6 +540,7 @@ def to_multi_location_onset_alert_message(
         # eine gemeinsame Zone waere fuer alle bis auf einen still falsch.
         loc_tz = _tz_for_location(loc, tz)
         onset_dt = now + timedelta(minutes=nc.onset_minutes)
+        _end_time, _end_offset, _end_ongoing = event_end_display(now, nc, loc_tz)
         events.append(OnsetEvent(
             onset_minutes=nc.onset_minutes, onset_time=local_fmt(onset_dt, loc_tz),
             km_from=0.0, km_to=0.0, is_convective=nc.is_convective,
@@ -519,6 +553,17 @@ def to_multi_location_onset_alert_message(
             # dieser Pfad sein OnsetEvent selbst baut (ADR-0021: Trip und
             # Ortsvergleich teilen die Ausgabe).
             onset_precip_mm=nc.onset_precip_mm,
+            # Issue #2051 S1: Ende und sein EIGENER Tagesbezug in DERSELBEN
+            # Ortszone wie der Beginn (`loc_tz`) -- ein Buendel kann Orte in
+            # verschiedenen Zonen tragen. Geteilte Fassung `event_end_display`,
+            # dieselbe, die der Trip-Pfad benutzt (ADR-0021).
+            event_end_time=_end_time,
+            event_end_day_offset=_end_offset,
+            # Issue #2051 S1 (Spec v1.1): der R4-Waechter waehlt die TEXTFORM
+            # des Endes (Untergrenze vs. bekanntes Ende) und muss den Renderer
+            # deshalb erreichen -- er darf nicht mehr stromaufwaerts in einem
+            # fehlenden Ende aufgeloest werden (AC-5/AC-20).
+            event_ongoing_beyond_horizon=_end_ongoing,
         ))
     trip_short = (
         ", ".join(name for name, _loc, _nc in valid_groups)

--- a/src/output/renderers/alert/render.py
+++ b/src/output/renderers/alert/render.py
@@ -479,7 +479,12 @@ def _render_subject_onset(msg: AlertMessage) -> str:
     e = msg.events[0]
     label = "Gewitter" if e.is_convective else "Regen"
     km = _km_str_onset(e)
-    return f"[{msg.trip_short}] {km} · {label} in {e.onset_minutes} Min"
+    # Issue #2051 S1: das Ende additiv HINTER der Beginn-Angabe -- ohne
+    # behauptbares Ende bleibt der Betreff byte-identisch (AC-19).
+    return (
+        f"[{msg.trip_short}] {km} · {label} in {e.onset_minutes} Min"
+        f"{_onset_end_suffix(e)}"
+    )
 
 
 def _distinct_source_labels(msg: AlertMessage) -> str:
@@ -510,6 +515,45 @@ def _onset_time_label(e: OnsetEvent) -> str:
     return _time_with_day(e.onset_time, e.onset_day_offset)
 
 
+def _onset_end_suffix(e: OnsetEvent) -> str:
+    """Issue #2051 S1: Langform-Ende-Angabe als anhaengbares Stueck oder LEER,
+    wenn es gar kein Ende gibt (`event_end_time is None` -- kein Beginn
+    erkannt, keine Frames; dann faellt die Angabe ersatzlos weg).
+
+    ZWEI Formen, entschieden allein am R4-Waechter
+    `event_ongoing_beyond_horizon` (Spec v1.1, PO-Entscheid 2026-08-22):
+
+      * Waechter NICHT gesetzt -> ` · letzter Regen gegen HH:MM`. Die Quelle
+        hat den Trockenuebergang beobachtet, das Ende ist bekannt.
+      * Waechter gesetzt -> ` · Regen mindestens bis HH:MM`. Die Zeitreihe
+        bzw. der 180-Min-Horizont ist ausgegangen, waehrend es noch regnete:
+        die Zahl ist eine BELEGTE Untergrenze, aber kein bekanntes Ende.
+
+    Die beiden Saetze sagen Gegensaetzliches ("hoert um HH:MM auf" vs. "hoert
+    bis HH:MM nicht auf"). Sie entstehen deshalb hier in EINEM Ausdruck mit
+    genau einer Weiche -- zwei getrennte Zweige, die je einen ganzen Satz
+    bauen, koennten unbemerkt beide dieselbe Form schreiben (AC-20).
+
+    Der Tagesbezug wird eigenstaendig aus `event_end_day_offset` gebildet und
+    NICHT vom Beginn kopiert: Beginn 23:50 (Versatz 0) und Ende 00:40
+    (Versatz 1) liegen an verschiedenen Kalendertagen. Aufgeloest ueber
+    DENSELBEN gemeinsamen Baustein `_time_with_day()`, den #2020 Scheibe 2
+    eingefuehrt hat -- `_onset_time_label` (o.) selbst bleibt unangetastet
+    (Zusage an `fix-2020-zeitangaben-wortlaut`).
+
+    Die Fuge ` · ` gehoert bewusst zum Rueckgabewert: alle drei Langform-
+    Stellen (Betreff, E-Mail, Telegram) reihen ihre Angaben mit diesem
+    Trenner, und so bleibt der Bestandstext ohne Ende ohne haengendes
+    Trennzeichen."""
+    ende = getattr(e, "event_end_time", None)
+    if not ende:
+        return ""
+    ende = _time_with_day(ende, getattr(e, "event_end_day_offset", 0))
+    if getattr(e, "event_ongoing_beyond_horizon", False):
+        return f" · Regen mindestens bis {ende}"
+    return f" · letzter Regen gegen {ende}"
+
+
 def _render_email_onset_multi(msg: AlertMessage) -> tuple[str, str]:
     """Bündel-Zweig (Issue #1041 Slice 1a): je Ort eine Zeile mit Onset-Zeit
     und Intensität (Muster `loc_prefix`, render_email:328-333).
@@ -523,7 +567,11 @@ def _render_email_onset_multi(msg: AlertMessage) -> tuple[str, str]:
         (
             f"{e.location_label} · {'Gewitter/Hagel' if e.is_convective else 'Regen'} "
             f"in {e.onset_minutes} Min",
-            f"ab {_onset_time_label(e)} · {e.intensity_label}",
+            # Issue #2051 S1: das Ende JE ORT aus dessen eigenem Event -- ein
+            # Buendel kann Orte mit verschiedenen Ende-Zeiten tragen. Ohne
+            # behauptbares Ende bleibt die Zeile byte-identisch (AC-19).
+            f"ab {_onset_time_label(e)}{_onset_end_suffix(e)} · "
+            f"{e.intensity_label}",
         )
         for e in msg.events
     ]
@@ -596,7 +644,10 @@ def _render_email_onset(msg: AlertMessage) -> tuple[str, str]:
     km = _km_str_onset(e)
 
     data_rows = [
-        ("Wo & wann", f"{km} · ab {_onset_time_label(e)}"),
+        # Issue #2051 S1: Beginn und Ende gehoeren in DIESELBE "Wo & wann"-
+        # Zeile -- eine eigene Datenzeile nur fuer das Ende waere im
+        # Ende-losen Normalfall eine leere Zeile (ADR-0052, Label-Wert-Form).
+        ("Wo & wann", f"{km} · ab {_onset_time_label(e)}{_onset_end_suffix(e)}"),
         ("Intensität", e.intensity_label),
         ("Quelle", e.source_label),
     ]
@@ -662,7 +713,12 @@ def _render_telegram_onset(msg: AlertMessage) -> str:
     label = "Gewitter" if e.is_convective else "Regen"
     km = _km_str_onset(e)
     first = f"<b>{_esc(f'{msg.trip_short} · {km} · {label} in {e.onset_minutes} Min')}</b>"
-    second = f"{_onset_time_label(e)} · {e.intensity_label} · {e.source_label}"
+    # Issue #2051 S1: das Ende additiv HINTER der Beginn-Zeit, vor Intensitaet
+    # und Quelle -- ohne behauptbares Ende byte-identisch wie bisher (AC-19).
+    second = (
+        f"{_onset_time_label(e)}{_onset_end_suffix(e)} · "
+        f"{e.intensity_label} · {e.source_label}"
+    )
     # Issue #2018 (AC-B3): die Bezugszeile steht als EIGENE Zeile zwischen Kopf
     # und Detailtext -- bei `None` bleibt der Text unveraendert.
     if msg.addendum_reference:
@@ -708,6 +764,39 @@ def _sms_onset_menge(value: float | None) -> str | None:
     return _fmt_num("R", value)
 
 
+def _sms_onset_ende(e: OnsetEvent) -> str:
+    """Issue #2051 S1: das Ende-Token der Kurznachricht oder leer.
+
+    Dieselbe Zeitform wie das Beginn-Token (`_sms_onset_time`: Stunde ohne
+    fuehrende Null, Tages-Suffix `+1` beim Mitternachts-Ueberlauf) -- zwei
+    benachbarte Zeit-Token in unterschiedlicher Granularitaet waeren eine
+    eigene Fehlerquelle. Ohne Ende (`event_end_time is None`) bleibt das
+    Token leer und die Kurzform ist byte-identisch zu #2046 -- kein
+    haengendes `@`.
+
+    ZWEI Formen, entschieden allein am R4-Waechter (Spec v1.1, Schreibweise
+    vom PO vorgegeben 2026-08-22):
+
+      * nicht gesetzt -> `@HH:MM` direkt am Beginn-Token (`R2.5@18:00@20:00`)
+      * gesetzt       -> ` >@HH:MM`, also Leerzeichen, `>`, Zeit-Token
+        (`R2.5@18:00 >@20:00`) -- die Untergrenzen-Form.
+
+    Hier haengt an EINEM Zeichen die Bedeutung: `>` fehlt, und aus "regnet
+    mindestens bis" wird "hoert auf um". Auf der Huette am Karnischen
+    Hoehenweg kommt nur die Premium-SMS an, die denselben `sms_body` traegt --
+    es gibt dort keinen zweiten Kanal, der die Aussage richtigstellt. Das
+    Praefix wird deshalb an dieser einen Stelle gebildet und dem gemeinsamen
+    Zeit-Token nur vorangestellt (AC-20)."""
+    ende = getattr(e, "event_end_time", None)
+    if not ende:
+        return ""
+    praefix = " >" if getattr(e, "event_ongoing_beyond_horizon", False) else ""
+    return (
+        f"{praefix}@"
+        f"{_sms_onset_time(ende, getattr(e, 'event_end_day_offset', 0))}"
+    )
+
+
 def _render_sms_onset(msg: AlertMessage, limit: int = 140) -> str:
     """Issue #1948 S4: die Nowcast-/Onset-Kurznachricht nennt einen ZEITPUNKT
     (`TH@15:40`) statt eines Countdowns (`TH!8`) und spricht im Kopf dieselbe
@@ -728,7 +817,12 @@ def _render_sms_onset(msg: AlertMessage, limit: int = 140) -> str:
     ihn mit (AC-10)."""
     e = msg.events[0]
     kuerzel = "TH" if e.is_convective else "R"
-    zeit = _sms_onset_time(e.onset_time, e.onset_day_offset)
+    # Issue #2051 S1: das Ende-Token haengt unmittelbar am Beginn-Token
+    # (`R2.5@18:00@20:00`). Bewusst hier zusammengefasst statt in jedem der
+    # drei Token-Zweige unten: so traegt AUCH der Gewitter-Zweig das Ende an
+    # der Zeit (`TH@18:00@20:00 R2.5`) und nicht hinter der Menge -- sonst
+    # bliebe dort eine stille Luecke.
+    zeit = _sms_onset_time(e.onset_time, e.onset_day_offset) + _sms_onset_ende(e)
     menge = _sms_onset_menge(getattr(e, "onset_precip_mm", None))
     if menge is None:
         token = f"{kuerzel}@{zeit}"

--- a/src/output/renderers/email/starkregen_hint.py
+++ b/src/output/renderers/email/starkregen_hint.py
@@ -1,8 +1,9 @@
 """Starkregen-Kurzfristhinweis im planmaessigen Trip-Briefing (Issue #1439).
 
 Nutzt den bereits produktiven `RadarNowcastService` (#656) fuer eine kurze
-Hinweiszeile im planmaessigen Briefing — 60-Minuten-Nowcast-Fenster
-(`NOWCAST_HORIZON_MIN`), keine Tage-vorher-Vorhersage (s. Spec
+Hinweiszeile im planmaessigen Briefing — Nowcast-Fenster
+(`NOWCAST_HORIZON_MIN`, seit #1945 180 Minuten; der Docstring nannte bis
+Issue #2051 S1 faelschlich 60), keine Tage-vorher-Vorhersage (s. Spec
 "Known Limitations").
 
 Bewusst im Briefing-/E-Mail-Renderer-Bereich (nicht unter `renderers/alert/`):
@@ -15,16 +16,41 @@ from datetime import datetime, timedelta, timezone
 from zoneinfo import ZoneInfo
 
 
-def format_starkregen_hint(intensity_label: str, onset_minutes: int, *, tz: ZoneInfo) -> str:
-    """"Starker Regen ab ca. HH:MM (in ~N Min)." — identisches Format wie
-    `RadarNowcastService.format_now_text()` fuer den Starkregen-Zweig, damit
-    E-Mail und Telegram wortgleich sind (Onset-Zeit in Trip-Ortszeit)."""
+def format_starkregen_hint(
+    intensity_label: str, onset_minutes: int, *, tz: ZoneInfo,
+    event_end_minutes: int | None = None,
+    event_ongoing_beyond_horizon: bool = False,
+) -> str:
+    """"Starker Regen ab ca. HH:MM (in ~N Min), letzter Regen gegen HH:MM." —
+    identisches Format wie `RadarNowcastService.format_now_text()` fuer den
+    Starkregen-Zweig, damit E-Mail und Telegram wortgleich sind (beide Zeiten
+    in Trip-Ortszeit).
+
+    Issue #2051 S1: die beiden Ende-Argumente sind additiv und defaultet — ein
+    Aufrufer, der sie nicht uebergibt, bekommt byte-identisch den bisherigen
+    Text. Der R4-Waechter `event_ongoing_beyond_horizon` unterdrueckt die
+    Ende-Angabe seit Spec v1.1 (PO-Entscheid 2026-08-22) NICHT mehr, sondern
+    waehlt ihre Form: gesetzt heisst "die Zeitreihe ist ausgegangen, waehrend
+    es noch regnete" — die Zahl ist eine belegte Untergrenze
+    (`Regen mindestens bis HH:MM`) statt eines bekannten Endes
+    (`letzter Regen gegen HH:MM`). Beide Formen entstehen an dieser einen
+    Stelle mit genau einer Weiche, damit sie nicht ineinander rutschen
+    (AC-20)."""
     from utils.timezone import local_dt
 
     now = datetime.now(timezone.utc)
     onset_time = now + timedelta(minutes=onset_minutes)
     time_str = local_dt(onset_time, tz).strftime("%H:%M")
-    return f"{intensity_label} ab ca. {time_str} (in ~{onset_minutes} Min)."
+    satz = f"{intensity_label} ab ca. {time_str} (in ~{onset_minutes} Min)"
+    if event_end_minutes is not None:
+        end_str = local_dt(
+            now + timedelta(minutes=event_end_minutes), tz,
+        ).strftime("%H:%M")
+        if event_ongoing_beyond_horizon:
+            satz += f", Regen mindestens bis {end_str}"
+        else:
+            satz += f", letzter Regen gegen {end_str}"
+    return satz + "."
 
 
 def render_starkregen_hint_html(hint_text: str) -> str:

--- a/src/services/notification_service.py
+++ b/src/services/notification_service.py
@@ -107,7 +107,10 @@ class TripReportRequest:
     # (intensity_label, onset_minutes) vom Scheduler ermittelt (kein Renderer-
     # Import dort, Architektur-Grenze). None = kein Treffer/Guard aktiv.
     # Die Textformatierung passiert hier im NotificationService.
-    starkregen_nowcast: tuple[str, int] | None = None
+    # Issue #2051 S1: die Datenform traegt zusaetzlich Ende und R4-Waechter
+    # (`event_end_minutes`, `event_ongoing_beyond_horizon`) — das alte
+    # Zwei-Tupel konnte das Ende gar nicht transportieren.
+    starkregen_nowcast: tuple[str, int, int | None, bool] | None = None
 
 
 @dataclass
@@ -200,6 +203,19 @@ class RadarAlertRequest:
     # die Onset-Kurznachricht nennt. Ohne sie bleibt der Versand
     # byte-identisch (zahlenlose Alt-Form).
     onset_precip_mm: float | None = None
+    # Issue #2051 S1: additiv, optional (Muster `onset_precip_mm` o.). Ende
+    # desselben Ereignisses als reines "HH:MM" und sein EIGENER Tagesbezug --
+    # gebildet dort, wo auch `onset_time`/`onset_day_offset` entstehen
+    # (`trip_alert.check_radar_alerts`), damit beide dieselbe Zone benutzen.
+    # `None` heisst "kein Ende ableitbar"; ohne die Felder bleibt der Versand
+    # byte-identisch.
+    event_end_time: str | None = None
+    event_end_day_offset: int = 0
+    # Issue #2051 S1 (Spec v1.1): der R4-Waechter reist MIT der Uhrzeit bis in
+    # den Renderer, weil er dort ueber die Textform entscheidet (Untergrenze
+    # vs. bekanntes Ende, AC-20). Ohne ihn kaeme im Waechterfall die
+    # Normalform an und behauptete ein Ende, das die Daten nicht hergeben.
+    event_ongoing_beyond_horizon: bool = False
 
 
 def build_service_error_email_html(trip_name: str, report_type: str, error_lines: str) -> str:
@@ -379,9 +395,16 @@ class NotificationService:
         if request.starkregen_nowcast is not None:
             from output.renderers.email.starkregen_hint import format_starkregen_hint
 
-            _intensity_label, _onset_minutes = request.starkregen_nowcast
+            (
+                _intensity_label, _onset_minutes,
+                _event_end_minutes, _event_ongoing,
+            ) = request.starkregen_nowcast
             starkregen_hint_text = format_starkregen_hint(
                 _intensity_label, _onset_minutes, tz=request.trip_tz,
+                # Issue #2051 S1: Ende und Waechter aus DEMSELBEN
+                # Nowcast-Ergebnis, das schon Label und Beginn liefert.
+                event_end_minutes=_event_end_minutes,
+                event_ongoing_beyond_horizon=_event_ongoing,
             )
 
         report = self._formatter.format_email(
@@ -1324,6 +1347,10 @@ class NotificationService:
             segment_id=request.segment_id,  # Issue #1744 A1
             onset_day_offset=request.onset_day_offset,  # Issue #2009
             onset_precip_mm=request.onset_precip_mm,  # Issue #2046
+            event_end_time=request.event_end_time,  # Issue #2051 S1
+            event_end_day_offset=request.event_end_day_offset,  # Issue #2051 S1
+            # Issue #2051 S1 (Spec v1.1): waehlt die Ende-Textform im Renderer.
+            event_ongoing_beyond_horizon=request.event_ongoing_beyond_horizon,
         )
         # Issue #1402: kein stiller Rueckfall mehr -- `request.tz` ist seit
         # `RadarAlertRequest` ein Pflichtfeld.

--- a/src/services/radar_service.py
+++ b/src/services/radar_service.py
@@ -188,6 +188,29 @@ class NowcastResult:
     # Beginn -- das Fenster ab jetzt deckt dann fast nur Trockenzeit ab und
     # untertriebe die Menge systematisch. BEWUSST beschreibend: kein Leser in
     # radar_alert_due()/der #2020-Ueberholungsregel.
+    event_end_minutes: Optional[int] = None
+    # Issue #2051 S1: Minuten ab jetzt bis zum Ende des zusammenhaengenden
+    # nassen Blocks, analog `onset_minutes`. `None`, wenn `onset_minutes`
+    # `None` ist -- ohne Beginn gibt es kein Ende, das behauptet werden
+    # koennte. Abgeleitet aus DENSELBEN `frames` (kein zweiter Quellenabruf).
+    # Die DAUER ist stets `event_end_minutes - onset_minutes` und wird
+    # absichtlich NICHT als drittes Feld gespeichert -- eine zweite Quelle der
+    # Wahrheit koennte auseinanderlaufen.
+    event_ongoing_beyond_horizon: bool = False
+    # Issue #2051 S1, R4-Waechter: die Frames bzw. der 180-Min-Horizont sind
+    # ausgegangen, waehrend der letzte bekannte Frame noch nass war. `False`
+    # heisst "das echte Ende ist bekannt" -- konsistent mit
+    # throttled/data_unavailable als Beobachtbarkeits-Signal.
+    #
+    # Bei `True` rendern alle sieben Textstellen die UNTERGRENZEN-Form
+    # (`Regen mindestens bis HH:MM` bzw. ` >@HH:MM`) statt der Normalform
+    # (`letzter Regen gegen HH:MM` / `@HH:MM`) -- Spec-Fassung 1.1,
+    # PO-Entscheid 2026-08-22. Der urspruengliche Entwurf 1.0 liess die
+    # Ende-Angabe hier ersatzlos WEG (Muster #2046 fuer die fehlende Menge);
+    # das verwarf eine wahre Aussage, denn `event_end_minutes` traegt in
+    # beiden Waechter-Faellen eine BEOBACHTETE Zahl -- die Reichweite der
+    # Quelle bzw. den letzten bekannten nassen Frame. Als Untergrenze genannt
+    # behauptet sie kein Ende und unterschlaegt zugleich nichts.
 
 
 def _offline_fixture_active() -> bool:
@@ -240,6 +263,75 @@ def _accumulate_precip_mm(
         duration_h = max(0.0, (frame_end - ts).total_seconds() / 3600.0)
         total += rate * duration_h
     return total
+
+
+def _derive_wet_block_end(
+    frames: list, all_ts_sorted: list, onset_ts: datetime, horizon: datetime,
+) -> tuple[datetime, bool]:
+    """Ende des zusammenhaengenden nassen Blocks ab `onset_ts` (Issue #2051 S1).
+
+    Rueckgabe `(end_ts, ongoing_beyond_horizon)`. Bewusst ein GESCHWISTER von
+    `_accumulate_precip_mm` und nicht dessen Erweiterung: dort wird in einem
+    BEKANNTEN Fenster summiert, hier wird die Fenstergrenze erst gesucht.
+    Dieselbe Deckungsmechanik, KEINE neue Toleranzzahl.
+
+    Die drei Abbruchgruende im Einzelnen:
+      * Trockenframe (`precip_mm_h < _DRY_THRESHOLD_MM_H`): eine
+        QUELLENAUSSAGE "hier hat es aufgehoert" -- der Block endet real, am
+        letzten tatsaechlich nassen Frame. Nicht ueberbruecken, sonst
+        verschmelzen zwei getrennte Ereignisse zu einer ueberlangen Dauer.
+      * Luecke groesser als die Deckung eines Frames (`_MAX_FRAME_COVERAGE`):
+        keine Beobachtung, aber DANACH wieder eine -- das Ende liegt an der
+        Deckungsgrenze, nicht am naechsten wieder nassen Frame.
+      * Deckung reicht bis an den Horizont ODER es folgt gar keine
+        Beobachtung mehr: das echte Ende ist unbekannt (R4) ->
+        `ongoing_beyond_horizon=True`. Der zurueckgegebene Zeitpunkt ist dann
+        nur die Reichweite der Beobachtung -- kein behauptbares Ende, aber
+        eine BELEGTE UNTERGRENZE. Die Textkonsumenten nennen ihn deshalb in
+        der Untergrenzen-Form (`Regen mindestens bis HH:MM` / ` >@HH:MM`)
+        statt ihn wegzulassen (Spec-Fassung 1.1, PO-Entscheid 2026-08-22).
+    """
+    # Dedup je Zeitstempel wie in `_accumulate_precip_mm` (hoeherer Wert
+    # gewinnt) -- sonst entschiede bei Providerwiederholung/Sidecar-Merge die
+    # Reihenfolge darueber, ob ein Zeitpunkt als nass oder trocken gilt.
+    by_ts: dict[datetime, float] = {}
+    for frame in frames:
+        if not (onset_ts <= frame.timestamp <= horizon):
+            continue
+        existing = by_ts.get(frame.timestamp)
+        if existing is None or frame.precip_mm_h > existing:
+            by_ts[frame.timestamp] = frame.precip_mm_h
+
+    last_wet_ts = onset_ts
+    for ts, rate in sorted(by_ts.items()):
+        if rate < _DRY_THRESHOLD_MM_H:
+            return last_wet_ts, False
+        last_wet_ts = ts
+
+        # Deckung DIESES Frames -- dieselbe Rechnung wie in
+        # `_accumulate_precip_mm`: eigener naechster Nachbar aus der
+        # VOLLSTAENDIGEN Frame-Liste, gedeckelt auf `_MAX_FRAME_COVERAGE`, nie
+        # ueber das Fensterende hinaus.
+        coverage_end = min(ts + _MAX_FRAME_COVERAGE, horizon)
+        next_idx = bisect.bisect_right(all_ts_sorted, ts)
+        next_ts = all_ts_sorted[next_idx] if next_idx < len(all_ts_sorted) else None
+
+        if coverage_end >= horizon:
+            # Der Block reicht bis an den Horizont der Quelle.
+            return horizon, True
+        if next_ts is None:
+            # Zeitreihe abgeschnitten, letzter bekannter Frame noch nass.
+            return coverage_end, True
+        if next_ts > coverage_end:
+            # Luecke groesser als die Deckung -- danach folgt zwar wieder eine
+            # Beobachtung, aber die dazwischenliegende Zeit ist unbeobachtet.
+            return coverage_end, False
+
+    # Unerreichbar, solange `all_ts_sorted` aus denselben `frames` stammt: ein
+    # nahtlos anschliessender naechster Frame innerhalb des Fensters ist auch
+    # ein Schleifen-Element. Ohne nassen Frame (leeres Fenster) bleibt der
+    # Beginn selbst das Ende.
+    return last_wet_ts, False
 
 
 class RadarNowcastService:
@@ -428,27 +520,53 @@ class RadarNowcastService:
                 lines.append("Bitte selbst beobachten.")
             else:
                 lines.append(result.intensity_label + ".")
-                lines.append("In den nächsten 2 Stunden kein Regen erwartet.")
+                # Issue #2051 S1 (AC-18): die Stundenzahl haengt am
+                # tatsaechlich geprueften Horizont und ist KEINE zweite,
+                # unabhaengige Zahl -- genau diese Doppelpflege hat die Drift
+                # erzeugt (der Satz sagte "2 Stunden", waehrend #1945 den
+                # Horizont laengst auf 180 Min angehoben hatte).
+                lines.append(
+                    f"In den nächsten {_NOWCAST_HORIZON_MIN // 60} Stunden "
+                    f"kein Regen erwartet."
+                )
         else:
             now = datetime.now(tz=timezone.utc)
-            onset_time = now + timedelta(minutes=result.onset_minutes)
-            if tz is not None:
-                # Issue #1402: local_dt() statt rohem .astimezone(tz) --
-                # geht ueber den zentralen Naiv-Guard (hier zwar bereits
-                # aware, aber konsistent mit dem EINEN Umrechner).
-                from utils.timezone import local_dt
 
-                time_str = local_dt(onset_time, tz).strftime("%H:%M")
-            else:
+            def _hhmm(moment: datetime) -> str:
+                if tz is not None:
+                    # Issue #1402: local_dt() statt rohem .astimezone(tz) --
+                    # geht ueber den zentralen Naiv-Guard (hier zwar bereits
+                    # aware, aber konsistent mit dem EINEN Umrechner).
+                    from utils.timezone import local_dt
+
+                    return local_dt(moment, tz).strftime("%H:%M")
                 # Kein tz uebergeben (Fail-soft-Pfad, Wächter-abgesichert
-                # fuer Produktivcode) -- onset_time ist bereits UTC-aware,
+                # fuer Produktivcode) -- `moment` ist bereits UTC-aware,
                 # NICHT das argumentlose .astimezone() nutzen (deutet sonst
                 # die Prozess-Zeitzone des Servers statt ehrlich UTC).
-                time_str = onset_time.strftime("%H:%M")
-            lines.append(
+                return moment.strftime("%H:%M")
+
+            time_str = _hhmm(now + timedelta(minutes=result.onset_minutes))
+            satz = (
                 f"{result.intensity_label} ab ca. {time_str}"
-                f" (in ~{result.onset_minutes} Min)."
+                f" (in ~{result.onset_minutes} Min)"
             )
+            # Issue #2051 S1 (AC-14): das Ende desselben Ereignisses, aus
+            # DEMSELBEN `now` wie der Beginn abgeleitet. Der R4-Waechter
+            # waehlt seit Spec v1.1 (PO-Entscheid 2026-08-22) die FORM statt
+            # die Angabe zu unterdruecken: bei abgeschnittener Zeitreihe ist
+            # der Zeitpunkt eine belegte Untergrenze, kein bekanntes Ende.
+            # Wortgleich mit `format_starkregen_hint` (dort dieselbe Weiche),
+            # damit E-Mail und Kommando-Antwort keine zwei Dialekte sprechen.
+            if result.event_end_minutes is not None:
+                _end_str = _hhmm(
+                    now + timedelta(minutes=result.event_end_minutes)
+                )
+                if result.event_ongoing_beyond_horizon:
+                    satz += f", Regen mindestens bis {_end_str}"
+                else:
+                    satz += f", letzter Regen gegen {_end_str}"
+            lines.append(satz + ".")
 
         if result.convective_checked is False:
             lines.append("Gewitter-Check nicht verfügbar.")
@@ -813,6 +931,19 @@ class RadarNowcastService:
                 onset_ts + timedelta(minutes=_ONSET_PRECIP_WINDOW_MIN),
             )
 
+        # Issue #2051 S1: Ende des zusammenhaengenden nassen Blocks aus
+        # DERSELBEN `frames`-Liste (kein zweiter Quellenabruf) -- der Nutzer
+        # erfaehrt bisher nur, WANN es anfaengt. Ohne Beginn kein Ende.
+        event_end_minutes: Optional[int] = None
+        event_ongoing_beyond_horizon = False
+        if onset_ts is not None:
+            _end_ts, event_ongoing_beyond_horizon = _derive_wet_block_end(
+                frames, all_ts_sorted, onset_ts, horizon,
+            )
+            event_end_minutes = max(
+                0, round((_end_ts - now).total_seconds() / 60.0)
+            )
+
         # Issue #2020 Adversary-Fund F001: max_rate_mm_h fuer die
         # Ueberholungspruefung MUSS aus demselben Fenster stammen wie
         # window_precip_mm (60 Min compare_window), sonst legitimiert ein
@@ -837,6 +968,8 @@ class RadarNowcastService:
             max_rate_mm_h=compare_window_max_rate_mm_h,
             window_precip_mm=window_precip_mm,
             onset_precip_mm=onset_precip_mm,  # Issue #2046
+            event_end_minutes=event_end_minutes,  # Issue #2051 S1
+            event_ongoing_beyond_horizon=event_ongoing_beyond_horizon,  # #2051 S1
         )
 
 

--- a/src/services/trip_alert.py
+++ b/src/services/trip_alert.py
@@ -1495,6 +1495,17 @@ class TripAlertService:
             # DERSELBEN Zone — eine zweite Herleitung koennte auseinander-
             # laufen und "00:23" wieder mehrdeutig machen.
             _onset_time_str = local_fmt(_onset_dt, tz)
+            # Issue #2051 S1: Ende-Uhrzeit, ihr EIGENER Tagesbezug und der
+            # R4-Waechter ueber die geteilte Fassung, die auch das
+            # Ortsvergleich-Buendel benutzt (ADR-0021). Der Waechter reist
+            # ausdruecklich MIT: er waehlt im Renderer die Textform
+            # (Untergrenze vs. bekanntes Ende, Spec v1.1). Lazy importiert wie
+            # die uebrigen Renderer-Bausteine dieses Pfads.
+            from output.renderers.alert.project import event_end_display
+
+            _end_time_str, _end_day_offset, _end_ongoing = event_end_display(
+                now_utc, result, tz,
+            )
             _radar_request = RadarAlertRequest(
                 onset_minutes=result.onset_minutes,
                 onset_time=_onset_time_str,
@@ -1514,6 +1525,11 @@ class TripAlertService:
                 # liefert (analog `is_convective=result.is_convective`) -- rein
                 # beschreibend, ohne Einfluss auf die Ausloeseregel.
                 onset_precip_mm=result.onset_precip_mm,
+                # Issue #2051 S1: Ende desselben Ereignisses -- beschreibend,
+                # ohne Einfluss auf die Ausloeseregel (wie onset_precip_mm).
+                event_end_time=_end_time_str,
+                event_end_day_offset=_end_day_offset,
+                event_ongoing_beyond_horizon=_end_ongoing,
                 tz=tz,
             )
 

--- a/src/services/trip_report_scheduler.py
+++ b/src/services/trip_report_scheduler.py
@@ -1465,8 +1465,9 @@ class TripReportSchedulerService:
         # Segment-Auswahl/Naehe-Guard/Budget-Gate/Fetch laufen VOR dem Bau des
         # TripReportRequest, damit ein zu weit entferntes Segment oder ein
         # ausgeschoepftes Tagesbudget keinen Nowcast-Call verursacht. Liefert
-        # nur Rohdaten (intensity_label, onset_minutes) — die Textformatierung
-        # (Renderer-Aufruf) passiert im NotificationService (Architektur-Grenze).
+        # nur Rohdaten (intensity_label, onset_minutes, Ende, Waechter) — die
+        # Textformatierung (Renderer-Aufruf) passiert im NotificationService
+        # (Architektur-Grenze).
         starkregen_nowcast = self._build_starkregen_hint(
             trip, segments, datetime.now(timezone.utc), target_date,
         )
@@ -1699,7 +1700,7 @@ class TripReportSchedulerService:
         catchup_prefix: str | None,
         partial_outage_hint: str | None = None,
         render_options: Optional["ReportRenderOptions"] = None,
-        starkregen_nowcast: Optional[Tuple[str, int]] = None,
+        starkregen_nowcast: Optional[Tuple[str, int, Optional[int], bool]] = None,
     ) -> TripReportRequest:
         """Baut das DTO, das an den NotificationService übergeben wird (Issue #1022).
 
@@ -1756,9 +1757,11 @@ class TripReportSchedulerService:
         segments: List[TripSegment],
         now_utc: datetime,
         target_date: Optional[date] = None,
-    ) -> Optional[Tuple[str, int]]:
+    ) -> Optional[Tuple[str, int, Optional[int], bool]]:
         """Starkregen-Kurzfristhinweis (Issue #1439): liefert die Rohdaten
-        (``intensity_label``, ``onset_minutes``) fuer den planmaessigen
+        (``intensity_label``, ``onset_minutes``, seit Issue #2051 S1
+        zusaetzlich ``event_end_minutes`` und
+        ``event_ongoing_beyond_horizon``) fuer den planmaessigen
         Briefing-Pfad, wenn der bereits produktive `RadarNowcastService`
         (#656) fuer den Startpunkt des aktiven/naechsten Segments Starkregen
         innerhalb von `NOWCAST_HORIZON_MIN` erkennt.
@@ -1876,7 +1879,14 @@ class TripReportSchedulerService:
         if result.onset_minutes is None or result.intensity_label != INTENSITY_HEAVY:
             return None
 
-        return (result.intensity_label, result.onset_minutes)
+        # Issue #2051 S1: Ende und R4-Waechter wandern mit -- das alte
+        # Zwei-Tupel konnte das Ende gar nicht transportieren. Rohdaten
+        # bleiben Rohdaten: die Textformatierung passiert weiterhin im
+        # NotificationService (Architektur-Grenze).
+        return (
+            result.intensity_label, result.onset_minutes,
+            result.event_end_minutes, result.event_ongoing_beyond_horizon,
+        )
 
     def _reset_alert_state_after_briefing(self, trip_id: str) -> None:
         """Issue #816 (B): Alert-Melde-Gedächtnis nach Briefing-Versand löschen.

--- a/src/services/validator_render_service.py
+++ b/src/services/validator_render_service.py
@@ -25,7 +25,10 @@ from app.profile import ActivityProfile
 from app.trip import Trip
 from app.user import ComparisonResult, LocationResult, SavedLocation
 from output.renderers.alert.model import AlertMessage, OnsetEvent
-from output.renderers.alert.project import to_alert_message
+from output.renderers.alert.project import (
+    event_end_display,  # Issue #2051 S1
+    to_alert_message,
+)
 from output.renderers.alert.render import (
     render_email,
     render_sms,
@@ -125,6 +128,19 @@ def render_alert_preview(
             # dieser Zweig sowohl den API-Payload (`OnsetPayload`) als auch
             # den Replay-SimpleNamespace bedient -- Muster `segment_id` o.
             onset_precip_mm=getattr(body.onset, "onset_precip_mm", None),
+            # Issue #2051 S1: Ende-Angabe des Payloads, `getattr` aus
+            # demselben Grund wie oben (API-Payload UND Replay-Namespace).
+            event_end_time=getattr(body.onset, "event_end_time", None),
+            event_end_day_offset=getattr(
+                body.onset, "event_end_day_offset", 0,
+            ),
+            # Issue #2051 S1 (Spec v1.1): der R4-Waechter waehlt die
+            # Ende-Textform -- er muss den Renderer auch auf dem Vorschauweg
+            # erreichen, sonst zeigt die Vorschau eine andere Aussage als der
+            # Versand.
+            event_ongoing_beyond_horizon=getattr(
+                body.onset, "event_ongoing_beyond_horizon", False,
+            ),
         )
         msg = AlertMessage(
             trip_short=trip_obj.name,
@@ -251,6 +267,9 @@ def _render_nowcast_replay(trip_obj: Trip, body_nf: Any) -> dict:
 
     alert_tz = _alert_tz_for_trip(trip_obj)
     onset_time = now + timedelta(minutes=result.onset_minutes)
+    _end_time, _end_offset, _end_ongoing = event_end_display(
+        now, result, alert_tz,
+    )
     onset_ns = SimpleNamespace(
         onset_minutes=result.onset_minutes,
         onset_time=local_fmt(onset_time, alert_tz)[-5:],  # "HH:MM"-Anteil
@@ -266,6 +285,13 @@ def _render_nowcast_replay(trip_obj: Trip, body_nf: Any) -> dict:
         # onset_minutes/intensity_label -- der Replay-Weg muss dieselbe Zahl
         # zeigen wie der Produktivpfad (AC-10).
         onset_precip_mm=result.onset_precip_mm,
+        # Issue #2051 S1: Ende aus DEMSELBEN `_derive_result`-Ergebnis, ueber
+        # die geteilte Anzeigefassung -- samt R4-Waechter, der die Textform
+        # waehlt. Der Replay-Weg zeigt damit exakt dasselbe wie der
+        # Produktivpfad.
+        event_end_time=_end_time,
+        event_end_day_offset=_end_offset,
+        event_ongoing_beyond_horizon=_end_ongoing,
     )
     out = render_alert_preview(
         trip_obj, SimpleNamespace(onset=onset_ns, official=None, nowcast_frames=None),

--- a/tests/tdd/test_nowcast_blockende_ableitung.py
+++ b/tests/tdd/test_nowcast_blockende_ableitung.py
@@ -1,0 +1,227 @@
+"""TDD RED — Issue #2051 S1: Ende des zusammenhaengenden nassen Blocks.
+
+SPEC: docs/specs/modules/feat_2051_s1_dauer_und_ende.md — AC-1, AC-2.
+
+Fachlicher Kern: die Onset-Schleife (`_derive_result`) bricht heute beim
+ERSTEN nassen Frame ab; der Rest der bereits abgerufenen Zeitreihe wird
+verworfen. Neu wird aus DENSELBEN Frames zusaetzlich das Ende des
+zusammenhaengenden nassen Blocks abgeleitet (`event_end_minutes`) — ohne
+neuen Quellenabruf.
+
+Zwei Zusicherungen dieser Datei:
+  * AC-1 — ein durchgehend nasser Block endet beim LETZTEN nassen Frame vor
+    dem Trockenuebergang, nicht am Horizont und nicht am Beginn.
+  * AC-2 — ein zweiter, spaeterer Regenblock in derselben Zeitreihe wird
+    NICHT eingerechnet: zwei getrennte Ereignisse duerfen nicht zu einer
+    ueberlangen Dauer verschmelzen.
+
+RED heute: `NowcastResult` kennt das additive Feld `event_end_minutes` noch
+nicht -> `AttributeError` beim Zugriff auf das Ergebnis; der in der Spec
+vorgeschriebene Helfer `_derive_wet_block_end` existiert nicht ->
+`ImportError`.
+
+Mock-frei: echte `RadarFrame`-Objekte durch das echte `_derive_result`, die
+Uhr ist ueber `now=` FEST injiziert (keine Wanduhr). Eigener Cache je
+Service (`cache=RadarNowcastCacheService()`), damit kein prozessweit
+geteilter Zustand zwischen den Faellen wirkt.
+"""
+from __future__ import annotations
+
+import inspect
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from providers.brightsky import RadarFrame
+from services.radar_cache import RadarNowcastCacheService
+from services.radar_service import RadarNowcastService
+
+# Fester Bezugszeitpunkt aller Faelle — keine Wanduhr.
+_NOW = datetime(2026, 8, 21, 12, 0, tzinfo=timezone.utc)
+
+
+def _frames(raster: dict[int, float]) -> list[RadarFrame]:
+    """`{Minutenversatz ab _NOW: Rate mm/h}` -> echte `RadarFrame`-Liste."""
+    return [
+        RadarFrame(timestamp=_NOW + timedelta(minutes=minute), precip_mm_h=rate)
+        for minute, rate in sorted(raster.items())
+    ]
+
+
+def _result(raster: dict[int, float]):
+    """Echtes `_derive_result` mit fest injizierter Uhr."""
+    svc = RadarNowcastService(cache=RadarNowcastCacheService())
+    return svc._derive_result(_frames(raster), "radar", now=_NOW)
+
+
+def _fuenf_minuten_raster(nass_von: int, nass_bis: int, ende: int = 120) -> dict[int, float]:
+    """Durchgehendes 5-Minuten-Raster; nass (1.0 mm/h) im angegebenen
+    Minutenfenster, sonst trocken (0.0 mm/h)."""
+    return {
+        m: (1.0 if nass_von <= m <= nass_bis else 0.0)
+        for m in range(0, ende + 1, 5)
+    }
+
+
+def test_prueling_stammt_aus_diesem_arbeitsbaum():
+    """Vorbedingung (kein AC): der gepruefte Nowcast-Dienst wird RELATIV ZU
+    DIESER Testdatei aufgeloest — sonst pruefte ein Worktree-Lauf still die
+    Datei des Hauptrepos und lieferte falsches Gruen."""
+    from services import radar_service as radar_module
+
+    modul_pfad = Path(inspect.getfile(radar_module)).resolve()
+    arbeitsbaum = Path(__file__).resolve().parents[2]
+    assert modul_pfad.is_relative_to(arbeitsbaum), (
+        f"Prueling stammt nicht aus diesem Arbeitsbaum: {modul_pfad}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-1 — durchgehender Block: Ende am letzten nassen Frame
+# ---------------------------------------------------------------------------
+
+
+def test_ac1_durchgehender_block_endet_am_letzten_nassen_frame():
+    """AC-1 GIVEN eine Frame-Zeitreihe im 5-Minuten-Raster mit einem
+    durchgaengig nassen Block (`precip_mm_h >= 0.1`) von Minute 20 bis
+    Minute 80, danach trocken
+    WHEN `_derive_result` daraus `event_end_minutes` ableitet
+    THEN entspricht `event_end_minutes` dem Zeitpunkt des LETZTEN nassen
+    Frames vor dem Trockenuebergang (Minute 80) — nicht dem Horizontende
+    (180) und nicht dem Beginn (20).
+
+    RED heute: `NowcastResult` kennt `event_end_minutes` nicht."""
+    result = _result(_fuenf_minuten_raster(20, 80))
+
+    assert result.onset_minutes == 20, (
+        f"Vorbedingung verletzt: Beginn nicht bei Minute 20, sondern "
+        f"{result.onset_minutes}"
+    )
+    assert result.event_end_minutes == 80, (
+        f"RED: Blockende muss am letzten nassen Frame (Minute 80) liegen, "
+        f"bekam {result.event_end_minutes!r}"
+    )
+    assert result.event_end_minutes != 180, (
+        "Das Ende darf nicht auf das Horizontende gesetzt werden, solange ein "
+        "Trockenframe im Fenster liegt."
+    )
+    assert result.event_end_minutes != result.onset_minutes, (
+        "Das Ende darf nicht auf den Beginn zurueckfallen — dann waere die "
+        "Dauer strukturell immer null."
+    )
+
+
+def test_ac1_ende_ohne_beginn_bleibt_leer():
+    """AC-1 (Kehrseite) GIVEN eine durchgehend trockene Frame-Zeitreihe
+    (kein Beginn erkannt, `onset_minutes is None`)
+    WHEN `_derive_result` das Ergebnis baut
+    THEN bleibt `event_end_minutes` `None` und der Horizont-Waechter `False`
+    — ohne Beginn gibt es kein Ende, das behauptet werden koennte.
+
+    RED heute: `NowcastResult` kennt die beiden Felder nicht."""
+    result = _result({m: 0.0 for m in range(0, 121, 5)})
+
+    assert result.onset_minutes is None, "Vorbedingung: kein Beginn erwartet"
+    assert result.event_end_minutes is None, (
+        f"Ohne Beginn darf kein Ende entstehen: {result.event_end_minutes!r}"
+    )
+    assert result.event_ongoing_beyond_horizon is False, (
+        "Ohne Beginn darf der Horizont-Waechter nicht anschlagen: "
+        f"{result.event_ongoing_beyond_horizon!r}"
+    )
+
+
+def test_ac1_helfer_derive_wet_block_end_liefert_ende_und_waechter():
+    """AC-1 (Bauform) GIVEN denselben durchgehenden Block
+    WHEN der in der Spec vorgeschriebene Helfer `_derive_wet_block_end(
+    frames, all_ts_sorted, onset_ts, horizon)` direkt aufgerufen wird
+    THEN liefert er das Tupel `(end_ts, ongoing_beyond_horizon)` mit dem
+    Zeitstempel des letzten nassen Frames und `False`.
+
+    Der Helfer ist bewusst ein GESCHWISTER von `_accumulate_precip_mm`
+    (Summieren in bekanntem Fenster) und nicht dessen Erweiterung —
+    Grenzenfinden ist eine andere Aufgabe.
+
+    RED heute: der Helfer existiert nicht (`ImportError`)."""
+    from services.radar_service import _derive_wet_block_end
+
+    frames = _frames(_fuenf_minuten_raster(20, 80))
+    all_ts_sorted = sorted({f.timestamp for f in frames})
+    onset_ts = _NOW + timedelta(minutes=20)
+    horizon = _NOW + timedelta(minutes=180)
+
+    end_ts, ongoing = _derive_wet_block_end(frames, all_ts_sorted, onset_ts, horizon)
+
+    assert end_ts == _NOW + timedelta(minutes=80), (
+        f"Helfer liefert das falsche Blockende: {end_ts!r}"
+    )
+    assert ongoing is False, (
+        f"Ein im Fenster beendeter Block darf den Waechter nicht setzen: "
+        f"{ongoing!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-2 — zwei getrennte Bloecke verschmelzen nicht
+# ---------------------------------------------------------------------------
+
+
+def _zwei_bloecke() -> dict[int, float]:
+    """Nass 10-30, trocken 35-50, wieder nass 55-70 (5-Minuten-Raster)."""
+    raster = {m: 0.0 for m in range(0, 121, 5)}
+    for m in range(10, 31, 5):
+        raster[m] = 1.0
+    for m in range(55, 71, 5):
+        raster[m] = 1.0
+    return raster
+
+
+def test_ac2_zwei_getrennte_bloecke_verschmelzen_nicht():
+    """AC-2 GIVEN zwei getrennte nasse Bloecke in DERSELBEN Zeitreihe
+    (nass Minute 10-30, trocken Minute 35-50, wieder nass Minute 55-70)
+    WHEN `_derive_result` Beginn und Ende ableitet
+    THEN endet der Block beim ersten Trockenuebergang nach Minute 30 — das
+    zweite, spaetere Ereignis wird NICHT eingerechnet.
+
+    Ein Zusammenziehen wuerde die Dauer ueberschaetzen (60 statt 20 Minuten)
+    und dem Nutzer durchgehenden Regen behaupten, wo die Quelle eine
+    Trockenphase zeigt.
+
+    RED heute: `NowcastResult` kennt `event_end_minutes` nicht."""
+    result = _result(_zwei_bloecke())
+
+    assert result.onset_minutes == 10, (
+        f"Vorbedingung: Beginn bei Minute 10 erwartet, bekam "
+        f"{result.onset_minutes}"
+    )
+    assert result.event_end_minutes == 30, (
+        f"RED: das Ende des ERSTEN Blocks muss bei Minute 30 liegen, bekam "
+        f"{result.event_end_minutes!r}"
+    )
+    assert result.event_end_minutes < 55, (
+        f"Das Ende reicht in den zweiten, unabhaengigen Block hinein "
+        f"({result.event_end_minutes!r}) — die beiden Ereignisse sind "
+        f"verschmolzen."
+    )
+    assert result.event_ongoing_beyond_horizon is False, (
+        "Ein durch einen Trockenframe beendeter Block ist ein BEKANNTES Ende "
+        "— der Horizont-Waechter darf nicht anschlagen."
+    )
+
+
+def test_ac2_dauer_ergibt_sich_aus_beginn_und_ende():
+    """AC-2 (abgeleitete Dauer) GIVEN denselben Aufbau
+    WHEN die Dauer als `event_end_minutes - onset_minutes` gebildet wird
+    THEN ergibt sie 20 Minuten (nicht 60) — und es gibt KEIN gespeichertes
+    `event_duration_minutes`-Feld, das als zweite Quelle der Wahrheit
+    auseinanderlaufen koennte (Spec, Implementation Details).
+
+    RED heute: `NowcastResult` kennt `event_end_minutes` nicht."""
+    result = _result(_zwei_bloecke())
+
+    assert result.event_end_minutes - result.onset_minutes == 20, (
+        f"Dauer falsch: {result.onset_minutes} -> {result.event_end_minutes!r}"
+    )
+    assert not hasattr(result, "event_duration_minutes"), (
+        "Kein gespeichertes Dauer-Feld: die Dauer ist stets die Differenz "
+        "aus Beginn und Ende (Spec: keine zweite Quelle der Wahrheit)."
+    )

--- a/tests/tdd/test_nowcast_blockende_datenluecke.py
+++ b/tests/tdd/test_nowcast_blockende_datenluecke.py
@@ -1,0 +1,184 @@
+"""TDD RED — Issue #2051 S1: Datenluecken beim Ableiten des Blockendes.
+
+SPEC: docs/specs/modules/feat_2051_s1_dauer_und_ende.md — AC-3, AC-4.
+
+Fachlicher Kern: ein FEHLENDER Frame ist keine Quellenaussage "hier hat es
+aufgehoert", sondern schlicht keine Beobachtung. Die Ende-Bestimmung benutzt
+deshalb DIESELBE Deckungsmechanik wie `_accumulate_precip_mm` (Rechenkern aus
+#2046/#2020) und KEINE neue Toleranzzahl:
+
+  * Luecke <= `_MAX_FRAME_COVERAGE` (15 Min) -> die Deckung des letzten
+    Frames reicht ueber die Luecke; der Block laeuft weiter (AC-3).
+  * Luecke > 15 Min -> das Ende wird an der Deckungsgrenze gesetzt
+    (`letzter Frame vor der Luecke + 15 Min`), NICHT am nach der Luecke
+    wieder nassen Frame (AC-4).
+
+RED heute: `NowcastResult` kennt das additive Feld `event_end_minutes` noch
+nicht -> `AttributeError` beim Zugriff auf das Ergebnis.
+
+Mock-frei: echte `RadarFrame`-Objekte durch das echte `_derive_result`, Uhr
+ueber `now=` FEST injiziert (keine Wanduhr), eigener Cache je Service.
+"""
+from __future__ import annotations
+
+import inspect
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from providers.brightsky import RadarFrame
+from services.radar_cache import RadarNowcastCacheService
+from services.radar_service import _MAX_FRAME_COVERAGE, RadarNowcastService
+
+_NOW = datetime(2026, 8, 21, 12, 0, tzinfo=timezone.utc)
+
+# Deckung EINES Frames in Minuten — bewusst aus der Produktivkonstante
+# gelesen, nicht als zweite 15 danebengeschrieben (sonst waere die Zusicherung
+# gegen eine Kopie der Zahl gestellt statt gegen die gueltige).
+_DECKUNG_MIN = int(_MAX_FRAME_COVERAGE.total_seconds() // 60)
+
+
+def _frames(raster: dict[int, float]) -> list[RadarFrame]:
+    """`{Minutenversatz ab _NOW: Rate mm/h}` -> echte `RadarFrame`-Liste.
+
+    Ein Minutenversatz, der NICHT im Wörterbuch steht, ist eine echte
+    Datenluecke — es entsteht kein Frame dafuer."""
+    return [
+        RadarFrame(timestamp=_NOW + timedelta(minutes=minute), precip_mm_h=rate)
+        for minute, rate in sorted(raster.items())
+    ]
+
+
+def _result(raster: dict[int, float]):
+    svc = RadarNowcastService(cache=RadarNowcastCacheService())
+    return svc._derive_result(_frames(raster), "radar", now=_NOW)
+
+
+def test_prueling_stammt_aus_diesem_arbeitsbaum():
+    """Vorbedingung (kein AC): der gepruefte Nowcast-Dienst wird RELATIV ZU
+    DIESER Testdatei aufgeloest — sonst pruefte ein Worktree-Lauf still die
+    Datei des Hauptrepos."""
+    from services import radar_service as radar_module
+
+    modul_pfad = Path(inspect.getfile(radar_module)).resolve()
+    arbeitsbaum = Path(__file__).resolve().parents[2]
+    assert modul_pfad.is_relative_to(arbeitsbaum), (
+        f"Prueling stammt nicht aus diesem Arbeitsbaum: {modul_pfad}"
+    )
+
+
+def test_deckungskonstante_ist_fuenfzehn_minuten():
+    """Vorbedingung (kein AC): die beiden Faelle unten sind nur dann
+    aussagekraeftig, wenn die Deckung eines Frames 15 Minuten betraegt — die
+    10-Minuten-Luecke liegt darunter, die 25-Minuten-Luecke darueber."""
+    assert _DECKUNG_MIN == 15, (
+        f"Testaufbau haengt an _MAX_FRAME_COVERAGE == 15 Min, ist aber "
+        f"{_DECKUNG_MIN} Min — die Luecken-Faelle muessen nachgezogen werden."
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-3 — Luecke INNERHALB der Deckung beendet den Block nicht
+# ---------------------------------------------------------------------------
+
+
+def _luecke_innerhalb_der_deckung() -> dict[int, float]:
+    """5-Minuten-Raster, nass ab Minute 20; der Frame bei Minute 35 FEHLT
+    (10 Minuten Abstand zwischen den vorhandenen Frames 30 und 40), danach
+    weiter nass bis Minute 50, ab Minute 55 trocken."""
+    raster = {m: 0.0 for m in range(0, 121, 5)}
+    for m in (20, 25, 30, 40, 45, 50):
+        raster[m] = 1.0
+    del raster[35]
+    return raster
+
+
+def test_ac3_zehn_minuten_luecke_beendet_den_block_nicht():
+    """AC-3 GIVEN einen nassen Block, in dem ein einzelner Frame mitten drin
+    fehlt (5-Minuten-Raster, dadurch 10 Minuten Abstand zwischen den
+    vorhandenen Frames bei Minute 30 und 40 — innerhalb der
+    `_MAX_FRAME_COVERAGE`-Deckung von 15 Minuten)
+    WHEN das Ende abgeleitet wird
+    THEN wird der Block durch die Luecke NICHT faelschlich beendet: das Ende
+    liegt beim letzten tatsaechlich nassen Frame NACH der Luecke (Minute 50),
+    nicht bei der Luecke selbst (Minute 30).
+
+    Ein fehlender Frame ist keine Beobachtung — ihn wie einen Trockenframe zu
+    behandeln wuerde die Dauer systematisch zu kurz melden.
+
+    RED heute: `NowcastResult` kennt `event_end_minutes` nicht."""
+    result = _result(_luecke_innerhalb_der_deckung())
+
+    assert result.onset_minutes == 20, (
+        f"Vorbedingung: Beginn bei Minute 20 erwartet, bekam "
+        f"{result.onset_minutes}"
+    )
+    assert result.event_end_minutes == 50, (
+        f"RED: eine 10-Minuten-Luecke liegt innerhalb der Deckung und darf den "
+        f"Block nicht beenden — erwartet Minute 50, bekam "
+        f"{result.event_end_minutes!r}"
+    )
+    assert result.event_end_minutes != 30, (
+        "Der Block wurde an der Datenluecke beendet — eine fehlende "
+        "Beobachtung ist keine Trockenmeldung."
+    )
+    assert result.event_ongoing_beyond_horizon is False, (
+        "Der Block endet an einem Trockenframe im Fenster — der "
+        "Horizont-Waechter darf nicht anschlagen."
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-4 — Luecke GROESSER als die Deckung setzt das Ende an der Deckungsgrenze
+# ---------------------------------------------------------------------------
+
+
+def _luecke_groesser_als_deckung() -> dict[int, float]:
+    """Nass bei 20/25/30, dann 25 Minuten ohne jeden Frame, ab Minute 55
+    wieder nass (55/60), ab Minute 65 trocken."""
+    raster = {m: 0.0 for m in range(0, 121, 5)}
+    for m in range(35, 55, 5):
+        del raster[m]
+    for m in (20, 25, 30, 55, 60):
+        raster[m] = 1.0
+    return raster
+
+
+def test_ac4_luecke_groesser_als_die_deckung_endet_an_der_deckungsgrenze():
+    """AC-4 GIVEN einen nassen Block mit einer Datenluecke von 25 Minuten
+    (groesser als `_MAX_FRAME_COVERAGE` = 15 Minuten) zwischen dem letzten
+    nassen Frame bei Minute 30 und dem naechsten Frame bei Minute 55, der
+    wieder nass ist
+    WHEN das Ende abgeleitet wird
+    THEN wird das Ende an der Deckungsgrenze des letzten Frames vor der
+    Luecke gesetzt (Minute 30 + 15 = Minute 45) — NICHT am nach der Luecke
+    wieder nassen Frame (Minute 55) und nicht am Frame selbst (Minute 30).
+
+    Dieselbe Deckungsmechanik wie `_accumulate_precip_mm`, keine neue
+    Toleranzzahl: ein einzelner Frame darf nie fuer mehr Zeit einstehen, als
+    das groebste Produktivraster hergibt.
+
+    RED heute: `NowcastResult` kennt `event_end_minutes` nicht."""
+    result = _result(_luecke_groesser_als_deckung())
+
+    assert result.onset_minutes == 20, (
+        f"Vorbedingung: Beginn bei Minute 20 erwartet, bekam "
+        f"{result.onset_minutes}"
+    )
+    assert result.event_end_minutes == 30 + _DECKUNG_MIN, (
+        f"RED: das Ende muss an der Deckungsgrenze liegen "
+        f"(Minute 30 + {_DECKUNG_MIN} = {30 + _DECKUNG_MIN}), bekam "
+        f"{result.event_end_minutes!r}"
+    )
+    assert result.event_end_minutes != 55, (
+        "Der Block wurde ueber die Luecke hinweg bis zum naechsten nassen "
+        "Frame gestreckt — 25 Minuten ohne Beobachtung sind kein Regen."
+    )
+    assert result.event_end_minutes != 30, (
+        "Das Ende wurde auf den letzten Frame gesetzt statt auf dessen "
+        "Deckungsgrenze — die Deckung eines Frames reicht 15 Minuten weit."
+    )
+    assert result.event_ongoing_beyond_horizon is False, (
+        "Eine Deckungsgrenze ist ein bekanntes Ende innerhalb des Fensters — "
+        "der Horizont-Waechter gilt nur fuer Bloecke, die den Horizont "
+        "erreichen."
+    )

--- a/tests/tdd/test_nowcast_blockende_horizont_waechter.py
+++ b/tests/tdd/test_nowcast_blockende_horizont_waechter.py
@@ -1,0 +1,402 @@
+"""TDD RED — Issue #2051 S1: Horizont-Waechter `event_ongoing_beyond_horizon`.
+
+SPEC: docs/specs/modules/feat_2051_s1_dauer_und_ende.md — AC-5 (vollstaendig).
+
+Fachlicher Kern (R4): "Ende" bei abgeschnittener Zeitreihe ist NICHT dasselbe
+wie "Ende des Ereignisses". Wenn der letzte bekannte Frame noch nass ist —
+weil die Frames ausgegangen sind oder der 180-Minuten-Horizont erreicht ist —
+ist das echte Ende unbekannt. Der Waechter macht das sichtbar.
+
+Spec-Fassung 1.1 (PO-Entscheid 2026-08-22) kehrt die urspruengliche Behandlung
+UM: statt die Ende-Angabe wegzulassen, nennt jede der sieben Textstellen das
+Ende als belegte UNTERGRENZE. `event_end_minutes` traegt in beiden
+Waechter-Faellen bereits eine beobachtete, keine geratene Zahl — sie
+wegzulassen verwarf eine wahre Aussage. Die Untergrenzen-Form nennt sie, ohne
+ein unbekanntes echtes Ende zu behaupten:
+
+  * Langform: `Regen mindestens bis HH:MM` (statt `letzter Regen gegen HH:MM`)
+  * Kurzform: ` >@HH:MM` (statt `@HH:MM`), also `R@18:30 >@21:00`
+
+Diese Datei deckt AC-5 vollstaendig ab:
+  * das Flag selbst in `_derive_result` (beide Auspraegungen: Frames enden
+    mitten im Fenster / Block reicht bis zum Horizont),
+  * Langform E-Mail-Trip (`_render_email_onset` ueber `render_email`) — und
+    zwar mit einem Ergebnis aus `_derive_result` ueber echte Frames, also
+    ueber die gesamte Naht Ableitung -> `event_end_display` -> Renderer,
+  * Kurzform SMS (`_render_sms_onset` ueber `render_sms`),
+  * Briefing-Kurzfristhinweis (`format_starkregen_hint`).
+
+Jeder Renderer-Fall traegt seine GEGENFASSUNG im selben Test: ohne gesetzten
+Waechter MUSS die NORMALFORM erscheinen und die Untergrenzen-Form fehlen.
+Ohne diese Kontrolle bestuende ein Renderer, der pauschal immer "mindestens"
+schreibt, die Pruefung ebenfalls — die textliche Abgrenzung beider Formen ist
+der ganze Grund fuer die Aenderung (AC-20).
+
+RED heute: der Code ist auf Spec-Stand 1.0 und laesst die Ende-Angabe bei
+gesetztem Waechter ERSATZLOS weg (`event_end_display` -> `(None, 0)`,
+`format_starkregen_hint` -> Satz ohne Ende). Die Untergrenzen-Form gibt es
+noch nirgends.
+
+Mock-frei: echte `RadarFrame`/`NowcastResult`-Objekte durch die echten
+Renderer. Die Uhr ist im Ableitungsteil ueber `now=` injiziert; im
+Renderer-Teil ueber `freeze_time` festgestellt, weil der Buendel-Konstruktor
+`onset_time` selbst aus `datetime.now()` bildet.
+"""
+from __future__ import annotations
+
+import inspect
+import re
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+from freezegun import freeze_time
+
+from output.renderers.alert.project import to_multi_location_onset_alert_message
+from output.renderers.alert.render import render_email, render_sms
+from output.renderers.email.starkregen_hint import format_starkregen_hint
+from providers.brightsky import RadarFrame
+from services.radar_cache import RadarNowcastCacheService
+from services.radar_service import (
+    _NOWCAST_HORIZON_MIN, NowcastResult, RadarNowcastService,
+)
+
+_NOW = datetime(2026, 8, 21, 12, 0, tzinfo=timezone.utc)
+
+# Renderer-Teil: 18:00 Ortszeit Wien (= 16:00 UTC im Sommer). Beginn 18:30
+# (+30 Min), bekanntes Ende 19:30 (+90 Min), Untergrenze am Horizont 21:00
+# (+180 Min). Die beiden Ende-Zeitpunkte sind BEWUSST verschieden: so faellt
+# auf, wenn eine Fassung die Zahl der anderen zeigt.
+_TZ = ZoneInfo("Europe/Vienna")
+_FROZEN_UTC = "2026-08-21 16:00:00+00:00"
+# Dieselbe Sekunde als Objekt — Fensterbezug fuer die Frame-Zeitreihen des
+# Langform-Tests, der den Waechter aus der ECHTEN Ableitung bezieht.
+_FROZEN_NOW = datetime(2026, 8, 21, 16, 0, tzinfo=timezone.utc)
+_ENDE_TEXT = "letzter Regen gegen 19:30"
+_UNTERGRENZE_TEXT = "Regen mindestens bis 21:00"
+# Kurzform-Untergrenze (Spec v1.1): Leerzeichen, `>`, dann das Zeit-Token.
+_UNTERGRENZE_TOKEN = " >@21:00"
+# Ende-Token OHNE vorangestelltes `>`: genau die Form, die im Waechterfall
+# NICHT stehen darf, weil sie ein bekanntes Ende behauptet. Der Lookbehind
+# trennt sie vom Untergrenzen-Token, das dieselbe Uhrzeit traegt.
+_BLANKES_ENDE_RE = re.compile(r"(?<!>)@21:00")
+
+_UNSET = object()  # Sentinel: neue Felder nur setzen, wenn ausdruecklich verlangt.
+
+
+def _frames(raster: dict[int, float]) -> list[RadarFrame]:
+    return [
+        RadarFrame(timestamp=_NOW + timedelta(minutes=minute), precip_mm_h=rate)
+        for minute, rate in sorted(raster.items())
+    ]
+
+
+def _result(raster: dict[int, float]):
+    svc = RadarNowcastService(cache=RadarNowcastCacheService())
+    return svc._derive_result(_frames(raster), "radar", now=_NOW)
+
+
+def _abgeleitetes_ergebnis(raster: dict[int, float]) -> NowcastResult:
+    """Wie `_result`, aber mit `_FROZEN_NOW` als Bezugspunkt — so passen die
+    abgeleiteten Minutenwerte zu der Uhr, die die Renderer sehen."""
+    svc = RadarNowcastService(cache=RadarNowcastCacheService())
+    frames = [
+        RadarFrame(timestamp=_FROZEN_NOW + timedelta(minutes=minute),
+                   precip_mm_h=rate)
+        for minute, rate in sorted(raster.items())
+    ]
+    return svc._derive_result(frames, "radar", now=_FROZEN_NOW)
+
+
+def _nowcast(*, event_end_minutes: object = _UNSET,
+             event_ongoing_beyond_horizon: object = _UNSET) -> NowcastResult:
+    """Ein `NowcastResult` mit gesetztem Beginn; die neuen Felder werden NUR
+    uebergeben, wenn ein Aufrufer sie ausdruecklich setzt (Muster
+    `test_onset_kurzform_menge.py`) — so bleiben Vergleichsfassungen ohne die
+    Felder unabhaengig vom Modell-Erweiterungsstand."""
+    fields = dict(
+        onset_minutes=30, intensity_label="Starker Regen", source="radar",
+        is_convective=False,
+    )
+    if event_end_minutes is not _UNSET:
+        fields["event_end_minutes"] = event_end_minutes
+    if event_ongoing_beyond_horizon is not _UNSET:
+        fields["event_ongoing_beyond_horizon"] = event_ongoing_beyond_horizon
+    return NowcastResult(**fields)
+
+
+def _alert_message(nc: NowcastResult):
+    """Einzel-Ort-Buendel -> `location_label is None` -> derselbe
+    Einzel-Onset-Renderpfad, den auch der Trip-Radar-Alarm benutzt
+    (ADR-0021: Trip und Ortsvergleich teilen die Ausgabe)."""
+    return to_multi_location_onset_alert_message(
+        [("Sillian", nc)], tz=_TZ, stand_at="17:55",
+    )
+
+
+def test_prueling_stammt_aus_diesem_arbeitsbaum():
+    """Vorbedingung (kein AC): Nowcast-Dienst und Alarm-Renderer werden
+    RELATIV ZU DIESER Testdatei aufgeloest — sonst pruefte ein Worktree-Lauf
+    still die Dateien des Hauptrepos."""
+    from output.renderers.alert import render as render_module
+    from services import radar_service as radar_module
+
+    arbeitsbaum = Path(__file__).resolve().parents[2]
+    for modul in (radar_module, render_module):
+        modul_pfad = Path(inspect.getfile(modul)).resolve()
+        assert modul_pfad.is_relative_to(arbeitsbaum), (
+            f"Prueling stammt nicht aus diesem Arbeitsbaum: {modul_pfad}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-5 (a) — das Flag in `_derive_result`
+# ---------------------------------------------------------------------------
+
+
+def test_ac5_block_bis_zum_horizont_setzt_den_waechter():
+    """AC-5 GIVEN eine Frame-Zeitreihe, die vom Beginn (Minute 20) bis zum
+    180-Minuten-Horizont durchgehend nass ist (kein Trockenframe im gesamten
+    Fenster)
+    WHEN `_derive_result` das Ergebnis baut
+    THEN ist `event_ongoing_beyond_horizon=True` — das echte Ende liegt
+    jenseits der Reichweite der Quelle und ist nicht behauptbar.
+
+    RED heute: `NowcastResult` kennt das Feld nicht."""
+    raster = {m: (1.0 if m >= 20 else 0.0)
+              for m in range(0, _NOWCAST_HORIZON_MIN + 1, 5)}
+
+    result = _result(raster)
+
+    assert result.onset_minutes == 20, (
+        f"Vorbedingung: Beginn bei Minute 20, bekam {result.onset_minutes}"
+    )
+    assert result.event_ongoing_beyond_horizon is True, (
+        "RED: ein bis zum Horizont nasser Block muss den Waechter setzen, "
+        f"bekam {result.event_ongoing_beyond_horizon!r}"
+    )
+
+
+def test_ac5_ende_am_horizont_wird_nicht_ueber_den_horizont_hinaus_behauptet():
+    """AC-5 (Wert) GIVEN denselben bis zum Horizont nassen Block
+    WHEN das Ende abgeleitet wird
+    THEN ist `event_end_minutes` der Horizont selbst (180 Minuten) und nicht
+    groesser — die Quelle reicht nicht weiter, ein spaeterer Zeitpunkt waere
+    erfunden.
+
+    RED heute: `NowcastResult` kennt `event_end_minutes` nicht."""
+    raster = {m: (1.0 if m >= 20 else 0.0)
+              for m in range(0, _NOWCAST_HORIZON_MIN + 1, 5)}
+
+    result = _result(raster)
+
+    assert result.event_end_minutes == _NOWCAST_HORIZON_MIN, (
+        f"RED: erwartet den Horizont ({_NOWCAST_HORIZON_MIN} Min) als Ende, "
+        f"bekam {result.event_end_minutes!r}"
+    )
+
+
+def test_ac5_abgeschnittene_zeitreihe_setzt_den_waechter():
+    """AC-5 (zweite Auspraegung) GIVEN eine Zeitreihe, deren LETZTER
+    verfuegbarer Frame (Minute 90) noch nass ist und nach der keine
+    Beobachtung mehr folgt (Quelle liefert nicht bis zum Horizont)
+    WHEN `_derive_result` das Ergebnis baut
+    THEN ist `event_ongoing_beyond_horizon=True` — auch hier ist das echte
+    Ende unbekannt, obwohl der Horizont gar nicht erreicht wurde. Der
+    Unterschied zur Deckungsgrenze aus AC-4: dort folgt NACH der Luecke
+    wieder eine Beobachtung, hier folgt gar keine mehr.
+
+    RED heute: `NowcastResult` kennt das Feld nicht."""
+    raster = {m: (1.0 if m >= 20 else 0.0) for m in range(0, 91, 5)}
+
+    result = _result(raster)
+
+    assert result.onset_minutes == 20, (
+        f"Vorbedingung: Beginn bei Minute 20, bekam {result.onset_minutes}"
+    )
+    assert result.event_ongoing_beyond_horizon is True, (
+        "RED: eine abgeschnittene, bis zuletzt nasse Zeitreihe muss den "
+        f"Waechter setzen, bekam {result.event_ongoing_beyond_horizon!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-5 (b) — Langform E-Mail (Trip-Onset-Renderpfad)
+# ---------------------------------------------------------------------------
+
+
+@freeze_time(_FROZEN_UTC)
+def test_ac5_email_langform_nennt_die_untergrenze_bei_gesetztem_waechter():
+    """AC-5 (v1.1) GIVEN einen Onset-Alarm, dessen `NowcastResult` den Waechter
+    gesetzt hat (`event_ongoing_beyond_horizon=True`, Ende-Wert der Horizont
+    = 21:00 Ortszeit)
+    WHEN die Langform-E-Mail (`render_email` -> `_render_email_onset`)
+    gerendert wird
+    THEN nennt sie das Ende als belegte Untergrenze
+    (`Regen mindestens bis 21:00`) und NICHT als bekanntes Ende
+    (`letzter Regen gegen`) — Gegenfassung im selben Test: ohne gesetzten
+    Waechter steht dort die Normalform und kein `mindestens`.
+
+    DIESER Test bewacht die NAHT: sein `NowcastResult` kommt nicht von Hand,
+    sondern aus `_derive_result` ueber echte Frames — also durch denselben
+    Ableitungsweg, den der Produktivpfad nimmt
+    (`_derive_wet_block_end` -> `_derive_result` -> `event_end_display` in
+    `project.py` -> Renderer). Klemmt man den Waechter an der QUELLE fest,
+    wird er rot. Die beiden Geschwister-Tests (SMS, Briefing) setzen die
+    Felder weiterhin direkt und pruefen nur den Renderer-Wortlaut
+    (Adversary-Fund F001, 2026-08-22).
+
+    RED heute: der Code laesst die Ende-Angabe bei gesetztem Waechter
+    ersatzlos weg (`event_end_display` -> `(None, 0)`)."""
+    # Durchgehend nass ab Minute 30 bis an den Horizont -> Waechter gesetzt,
+    # Ende = Horizont (180 Min = 21:00 Ortszeit).
+    mit_waechter = _abgeleitetes_ergebnis(
+        {m: (5.0 if m >= 30 else 0.0)
+         for m in range(0, _NOWCAST_HORIZON_MIN + 1, 5)}
+    )
+    # Nass von Minute 30 bis 90, danach trocken -> die Quelle sagt selbst, wo
+    # es aufhoert: bekanntes Ende bei 90 Min (19:30 Ortszeit).
+    ohne_waechter = _abgeleitetes_ergebnis(
+        {m: (5.0 if 30 <= m <= 90 else 0.0)
+         for m in range(0, _NOWCAST_HORIZON_MIN + 1, 5)}
+    )
+
+    # Vorbedingung deckt BEWUSST nur die Zeitpunkte ab, NICHT den Waechter:
+    # der ist die zu pruefende Zusicherung. Stuende er hier, schluege eine
+    # Klemme an der Quelle schon in der Vorbedingung fehl und der Nachweis,
+    # dass sie bis in den TEXT durchschlaegt, bliebe ungefuehrt.
+    assert (mit_waechter.onset_minutes, mit_waechter.event_end_minutes) == (
+        30, _NOWCAST_HORIZON_MIN), (
+        f"Vorbedingung: die Ableitung muss aus diesen Frames Beginn 30 und "
+        f"Ende {_NOWCAST_HORIZON_MIN} ergeben, bekam "
+        f"{mit_waechter.onset_minutes!r}/{mit_waechter.event_end_minutes!r}"
+    )
+    assert (ohne_waechter.onset_minutes, ohne_waechter.event_end_minutes) == (
+        30, 90), (
+        f"Vorbedingung: die Gegenfassung muss ein Ende bei 90 Min ergeben, "
+        f"bekam {ohne_waechter.onset_minutes!r}/"
+        f"{ohne_waechter.event_end_minutes!r}"
+    )
+
+    _, plain_waechter = render_email(_alert_message(mit_waechter))
+    _, plain_bekannt = render_email(_alert_message(ohne_waechter))
+
+    assert _ENDE_TEXT in plain_bekannt, (
+        f"Gegenfassung: bei bekanntem Ende muss die Langform "
+        f"{_ENDE_TEXT!r} nennen: {plain_bekannt!r}"
+    )
+    assert "mindestens" not in plain_bekannt, (
+        f"Gegenfassung: bei bekanntem Ende darf keine Untergrenzen-Form "
+        f"stehen: {plain_bekannt!r}"
+    )
+    assert _UNTERGRENZE_TEXT in plain_waechter, (
+        f"RED: bei gesetztem Horizont-Waechter muss die Langform die "
+        f"Untergrenze {_UNTERGRENZE_TEXT!r} nennen: {plain_waechter!r}"
+    )
+    assert "letzter Regen gegen" not in plain_waechter, (
+        f"Bei gesetztem Horizont-Waechter darf kein bekanntes Ende behauptet "
+        f"werden: {plain_waechter!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-5 (c) — Kurzform SMS
+# ---------------------------------------------------------------------------
+
+
+@freeze_time(_FROZEN_UTC)
+def test_ac5_sms_kurzform_traegt_die_untergrenze_bei_gesetztem_waechter():
+    """AC-5 (v1.1) GIVEN denselben Aufbau
+    WHEN die Kurznachricht (`render_sms` -> `_render_sms_onset`) gerendert
+    wird
+    THEN traegt sie bei gesetztem Waechter das Untergrenzen-Token ` >@21:00`
+    — Leerzeichen, `>`, dann das minutengenaue Zeit-Token (Schreibweise vom PO
+    vorgegeben, Spec v1.1) — und NICHT das blanke `@21:00` der Normalform.
+    Gegenfassung im selben Test: ohne Waechter steht das blanke Ende-Token
+    und kein `>`.
+
+    Kurzweg mit Absicht: die Felder werden hier direkt gesetzt, geprueft wird
+    allein der Renderer-Wortlaut. Die NAHT zwischen Ableitung und Renderer
+    bewacht `test_ac5_email_langform_nennt_die_untergrenze_bei_gesetztem_waechter`,
+    dessen Ergebnis aus echten Frames ueber `_derive_result` stammt.
+
+    Die frueher hier stehende `@`-Zaehlung traegt nicht mehr: beide Formen
+    tragen zwei `@`. Geprueft wird deshalb die FORM des Ende-Tokens
+    ausdruecklich, per Regex mit Lookbehind — sonst waere `>@` und `@` an der
+    Ende-Position ununterscheidbar.
+
+    RED heute: der Code laesst das Ende-Token bei gesetztem Waechter
+    ersatzlos weg (`event_end_display` -> `(None, 0)`)."""
+    mit_waechter = _nowcast(event_end_minutes=_NOWCAST_HORIZON_MIN,
+                            event_ongoing_beyond_horizon=True)
+    ohne_waechter = _nowcast(event_end_minutes=90,
+                             event_ongoing_beyond_horizon=False)
+
+    sms_waechter = render_sms(_alert_message(mit_waechter))
+    sms_bekannt = render_sms(_alert_message(ohne_waechter))
+
+    assert "@19:30" in sms_bekannt and ">" not in sms_bekannt, (
+        f"Gegenfassung: bei bekanntem Ende traegt die Kurznachricht das "
+        f"blanke Ende-Token '@19:30' ohne '>': {sms_bekannt!r}"
+    )
+    assert _UNTERGRENZE_TOKEN in sms_waechter, (
+        f"RED: bei gesetztem Horizont-Waechter muss die Kurznachricht das "
+        f"Untergrenzen-Token {_UNTERGRENZE_TOKEN!r} tragen: {sms_waechter!r}"
+    )
+    assert _BLANKES_ENDE_RE.search(sms_waechter) is None, (
+        f"Der Ende-Zeitpunkt steht ohne vorangestelltes '>' in der "
+        f"Kurznachricht und behauptet damit ein bekanntes Ende: "
+        f"{sms_waechter!r}"
+    )
+    assert "18:30" in sms_waechter, (
+        f"Das Beginn-Token darf nicht verdraengt werden: {sms_waechter!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-5 (d) — Briefing-Kurzfristhinweis
+# ---------------------------------------------------------------------------
+
+
+@freeze_time(_FROZEN_UTC)
+def test_ac5_briefing_hinweis_nennt_die_untergrenze_bei_gesetztem_waechter():
+    """AC-5 (v1.1) GIVEN den Briefing-Kurzfristhinweis mit gesetztem Waechter
+    WHEN `format_starkregen_hint(...)` rendert
+    THEN nennt der Hinweis das Ende als Untergrenze
+    (`Regen mindestens bis 21:00`) statt es wegzulassen, und NICHT als
+    bekanntes Ende — Gegenfassung im selben Test: mit
+    `event_ongoing_beyond_horizon=False` steht `letzter Regen gegen 19:30` da
+    und kein `mindestens`.
+
+    Kurzweg mit Absicht (wie beim SMS-Fall): `format_starkregen_hint` bekommt
+    die Werte direkt, geprueft wird der Wortlaut. Die Naht zur Ableitung
+    bewacht der Langform-Test.
+
+    RED heute: `format_starkregen_hint` unterdrueckt die Ende-Angabe bei
+    gesetztem Waechter vollstaendig (`starkregen_hint.py:41`)."""
+    text_waechter = format_starkregen_hint(
+        "Starker Regen", 30, tz=_TZ,
+        event_end_minutes=_NOWCAST_HORIZON_MIN,
+        event_ongoing_beyond_horizon=True,
+    )
+    text_bekannt = format_starkregen_hint(
+        "Starker Regen", 30, tz=_TZ,
+        event_end_minutes=90, event_ongoing_beyond_horizon=False,
+    )
+
+    assert _ENDE_TEXT in text_bekannt, (
+        f"Gegenfassung: bei bekanntem Ende muss der Briefing-Hinweis "
+        f"{_ENDE_TEXT!r} nennen: {text_bekannt!r}"
+    )
+    assert "mindestens" not in text_bekannt, (
+        f"Gegenfassung: bei bekanntem Ende darf keine Untergrenzen-Form "
+        f"stehen: {text_bekannt!r}"
+    )
+    assert _UNTERGRENZE_TEXT in text_waechter, (
+        f"RED: bei gesetztem Horizont-Waechter muss der Briefing-Hinweis die "
+        f"Untergrenze {_UNTERGRENZE_TEXT!r} nennen: {text_waechter!r}"
+    )
+    assert "letzter Regen gegen" not in text_waechter, (
+        f"Bei gesetztem Horizont-Waechter darf der Briefing-Hinweis kein "
+        f"bekanntes Ende behaupten: {text_waechter!r}"
+    )

--- a/tests/tdd/test_nowcast_blockende_tagesfenster.py
+++ b/tests/tdd/test_nowcast_blockende_tagesfenster.py
@@ -1,0 +1,167 @@
+"""TDD RED — Issue #2051 S1: das Ende wird NICHT am Tagesfenster gekappt.
+
+SPEC: docs/specs/modules/feat_2051_s1_dauer_und_ende.md — AC-7 (Entscheid E2).
+
+Fachlicher Kern: der Nowcast-Pfad spricht heute schon ausserhalb des
+konfigurierten Tagesfensters — `onset_time` wird nirgends gekappt. Nur das
+ENDE zu kappen waere in sich unstimmig, und ein still auf 20:00 gekapptes
+"letzter Regen gegen 20:00" bei Regen bis 22:15 waere eine FALSCHE Aussage
+(dieselbe Fehlerklasse wie R4, nur selbst verursacht).
+
+Aufbau: jetzt ist 19:45 Ortszeit (Wien), der Regen beginnt 20:05 und endet
+22:15 — beides jenseits eines Tagesfenster-Endes von 20:00, beides innerhalb
+des 180-Minuten-Nowcast-Horizonts.
+
+RED heute: `NowcastResult` kennt `event_end_minutes` nicht (`AttributeError`
+bzw. `TypeError` beim Konstruktor).
+
+Mock-frei: echte `RadarFrame`/`NowcastResult`-Objekte durch die echten
+Renderer; Uhr per `now=` bzw. `freeze_time` festgestellt.
+"""
+from __future__ import annotations
+
+import inspect
+import re
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+from freezegun import freeze_time
+
+from output.renderers.alert.project import to_multi_location_onset_alert_message
+from output.renderers.alert.render import render_email, render_sms
+from providers.brightsky import RadarFrame
+from services.radar_cache import RadarNowcastCacheService
+from services.radar_service import NowcastResult, RadarNowcastService
+
+# 19:45 Ortszeit Wien am 2026-08-21 (CEST = UTC+2) -> 17:45 UTC.
+_TZ = ZoneInfo("Europe/Vienna")
+_NOW = datetime(2026, 8, 21, 17, 45, tzinfo=timezone.utc)
+_FROZEN_UTC = "2026-08-21 17:45:00+00:00"
+
+# Bezugsgroesse der Zusicherung: ein typisches Tagesfenster-Ende, hinter dem
+# das echte Ende (22:15) liegt. Die Ableitung darf diese Grenze gar nicht
+# kennen.
+_TAGESFENSTER_ENDE = "20:00"
+
+_UNSET = object()
+
+
+def _frames(raster: dict[int, float]) -> list[RadarFrame]:
+    return [
+        RadarFrame(timestamp=_NOW + timedelta(minutes=minute), precip_mm_h=rate)
+        for minute, rate in sorted(raster.items())
+    ]
+
+
+def _result(raster: dict[int, float]):
+    svc = RadarNowcastService(cache=RadarNowcastCacheService())
+    return svc._derive_result(_frames(raster), "radar", now=_NOW)
+
+
+def _nowcast(*, event_end_minutes: object = _UNSET) -> NowcastResult:
+    """Beginn in 20 Minuten (20:05 Ortszeit)."""
+    fields = dict(
+        onset_minutes=20, intensity_label="Starker Regen", source="radar",
+        is_convective=False,
+    )
+    if event_end_minutes is not _UNSET:
+        fields["event_end_minutes"] = event_end_minutes
+    return NowcastResult(**fields)
+
+
+def test_prueling_stammt_aus_diesem_arbeitsbaum():
+    """Vorbedingung (kein AC): Nowcast-Dienst und Alarm-Renderer werden
+    RELATIV ZU DIESER Testdatei aufgeloest."""
+    from output.renderers.alert import render as render_module
+    from services import radar_service as radar_module
+
+    arbeitsbaum = Path(__file__).resolve().parents[2]
+    for modul in (radar_module, render_module):
+        modul_pfad = Path(inspect.getfile(modul)).resolve()
+        assert modul_pfad.is_relative_to(arbeitsbaum), (
+            f"Prueling stammt nicht aus diesem Arbeitsbaum: {modul_pfad}"
+        )
+
+
+def test_ac7_ableitung_reicht_ueber_das_tagesfenster_hinaus():
+    """AC-7 (Vorstufe) GIVEN eine Frame-Zeitreihe mit nassem Block von
+    Minute 20 (20:05 Ortszeit) bis Minute 150 (22:15 Ortszeit), also weit
+    ueber ein Tagesfenster-Ende von 20:00 hinaus
+    WHEN das Ende abgeleitet wird
+    THEN steht `event_end_minutes` bei 150 — die Ableitung kennt das
+    Tagesfenster nicht und kappt nichts.
+
+    RED heute: `NowcastResult` kennt `event_end_minutes` nicht."""
+    raster = {m: (1.0 if 20 <= m <= 150 else 0.0) for m in range(0, 181, 5)}
+
+    result = _result(raster)
+
+    assert result.onset_minutes == 20, (
+        f"Vorbedingung: Beginn bei Minute 20, bekam {result.onset_minutes}"
+    )
+    assert result.event_end_minutes == 150, (
+        f"RED: ungekapptes Ende bei Minute 150 erwartet, bekam "
+        f"{result.event_end_minutes!r}"
+    )
+    assert result.event_ongoing_beyond_horizon is False, (
+        "Der Block endet an einem Trockenframe innerhalb des Fensters — das "
+        "Ende ist bekannt, der Horizont-Waechter darf nicht anschlagen."
+    )
+
+
+@freeze_time(_FROZEN_UTC)
+def test_ac7_langform_nennt_das_echte_ende_ohne_kappung():
+    """AC-7 GIVEN einen Onset-Alarm, dessen Ende (22:15 Ortszeit) ueber das
+    konfigurierte Tagesfenster-Ende (20:00) hinausreicht
+    WHEN die Langform-E-Mail gerendert wird
+    THEN nennt der Text das ECHTE Ende (22:15), OHNE es auf das Tagesfenster
+    zu kappen und ohne es zu unterdruecken.
+
+    RED heute: `NowcastResult` kennt `event_end_minutes` nicht (`TypeError`)."""
+    msg = to_multi_location_onset_alert_message(
+        [("Sillian", _nowcast(event_end_minutes=150))],
+        tz=_TZ, stand_at="19:45",
+    )
+
+    _, plain = render_email(msg)
+
+    assert "letzter Regen gegen 22:15" in plain, (
+        f"RED: das ungekappte Ende 22:15 fehlt im Langform-Text: {plain!r}"
+    )
+    assert f"letzter Regen gegen {_TAGESFENSTER_ENDE}" not in plain, (
+        f"Das Ende wurde still auf das Tagesfenster-Ende "
+        f"{_TAGESFENSTER_ENDE} gekappt — das waere eine falsche Aussage: "
+        f"{plain!r}"
+    )
+
+
+@freeze_time(_FROZEN_UTC)
+def test_ac7_kurzform_nennt_das_echte_ende_ohne_kappung():
+    """AC-7 (Kurzform) GIVEN denselben Aufbau
+    WHEN die Kurznachricht gerendert wird
+    THEN nennt auch sie die Stunde des echten Endes (22), nicht die des
+    Tagesfenster-Endes (20) — geprueft ueber die Stunden der beiden
+    Zeit-Token, damit die Zusicherung unabhaengig davon haelt, ob die
+    Kurzform `@HH:MM` oder `@HH` schreibt.
+
+    RED heute: `NowcastResult` kennt `event_end_minutes` nicht (`TypeError`)."""
+    msg = to_multi_location_onset_alert_message(
+        [("Sillian", _nowcast(event_end_minutes=150))],
+        tz=_TZ, stand_at="19:45",
+    )
+
+    sms = render_sms(msg)
+    stunden = re.findall(r"@(\d{1,2})", sms)
+
+    assert len(stunden) == 2, (
+        f"RED: erwartet zwei Zeit-Token (Beginn und Ende) in der "
+        f"Kurznachricht, bekam {stunden!r}: {sms!r}"
+    )
+    assert stunden[0] == "20", (
+        f"Vorbedingung: das Beginn-Token gehoert zur Stunde 20: {sms!r}"
+    )
+    assert stunden[1] == "22", (
+        f"Das Ende-Token nennt nicht die echte Ende-Stunde 22 — offenbar auf "
+        f"das Tagesfenster gekappt: {sms!r}"
+    )

--- a/tests/tdd/test_nowcast_blockende_tagesversatz.py
+++ b/tests/tdd/test_nowcast_blockende_tagesversatz.py
@@ -1,0 +1,178 @@
+"""TDD RED — Issue #2051 S1: asymmetrischer Tagesversatz von Beginn und Ende.
+
+SPEC: docs/specs/modules/feat_2051_s1_dauer_und_ende.md — AC-6.
+
+Fachlicher Kern: `onset_time`/`event_end_time` sind reines "HH:MM" ohne
+Datum. Beginn und Ende koennen auf VERSCHIEDENE Kalendertage fallen (Beginn
+23:50 ohne Versatz, Ende 00:40 am Folgetag). Der Tagesversatz des Endes muss
+deshalb aus dem ENDE-Zeitpunkt abgeleitet werden (#2009-Muster:
+`day_offset(now_utc, _end_dt, tz)`) — vom Beginn kopiert waere er still
+falsch, und "00:40" ohne Tagesbezug ist mehrdeutig (heute Nacht oder in ueber
+23 Stunden?).
+
+RED heute: `NowcastResult` kennt `event_end_minutes` nicht (`TypeError` beim
+Konstruktor), `OnsetEvent` kennt `event_end_time`/`event_end_day_offset`
+nicht (`AttributeError`).
+
+Mock-frei: echte `RadarFrame`/`NowcastResult`/`OnsetEvent`-Objekte durch die
+echte Projektion. Die Uhr steht fest — im Ableitungsteil per `now=`,
+im Projektionsteil per `freeze_time`, weil der Buendel-Konstruktor
+`onset_time` selbst aus `datetime.now()` bildet.
+"""
+from __future__ import annotations
+
+import inspect
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+from freezegun import freeze_time
+
+from output.renderers.alert.project import to_multi_location_onset_alert_message
+from providers.brightsky import RadarFrame
+from services.radar_cache import RadarNowcastCacheService
+from services.radar_service import NowcastResult, RadarNowcastService
+
+# 23:40 Ortszeit Wien am 2026-08-21 (CEST = UTC+2) -> 21:40 UTC.
+_TZ = ZoneInfo("Europe/Vienna")
+_NOW = datetime(2026, 8, 21, 21, 40, tzinfo=timezone.utc)
+_FROZEN_UTC = "2026-08-21 21:40:00+00:00"
+
+_UNSET = object()
+
+
+def _frames(raster: dict[int, float]) -> list[RadarFrame]:
+    return [
+        RadarFrame(timestamp=_NOW + timedelta(minutes=minute), precip_mm_h=rate)
+        for minute, rate in sorted(raster.items())
+    ]
+
+
+def _result(raster: dict[int, float]):
+    svc = RadarNowcastService(cache=RadarNowcastCacheService())
+    return svc._derive_result(_frames(raster), "radar", now=_NOW)
+
+
+def _nowcast(*, event_end_minutes: object = _UNSET) -> NowcastResult:
+    """Beginn in 10 Minuten (23:50 Ortszeit); die neuen Felder nur auf
+    ausdruecklichen Wunsch setzen (Sentinel-Muster)."""
+    fields = dict(
+        onset_minutes=10, intensity_label="Starker Regen", source="radar",
+        is_convective=False,
+    )
+    if event_end_minutes is not _UNSET:
+        fields["event_end_minutes"] = event_end_minutes
+    return NowcastResult(**fields)
+
+
+def test_prueling_stammt_aus_diesem_arbeitsbaum():
+    """Vorbedingung (kein AC): Nowcast-Dienst und Projektion werden RELATIV
+    ZU DIESER Testdatei aufgeloest — sonst pruefte ein Worktree-Lauf still
+    die Dateien des Hauptrepos."""
+    from output.renderers.alert import project as project_module
+    from services import radar_service as radar_module
+
+    arbeitsbaum = Path(__file__).resolve().parents[2]
+    for modul in (radar_module, project_module):
+        modul_pfad = Path(inspect.getfile(modul)).resolve()
+        assert modul_pfad.is_relative_to(arbeitsbaum), (
+            f"Prueling stammt nicht aus diesem Arbeitsbaum: {modul_pfad}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-6 (a) — die Ableitung ueber Mitternacht
+# ---------------------------------------------------------------------------
+
+
+def test_ac6_block_ueber_mitternacht_wird_vollstaendig_abgeleitet():
+    """AC-6 (Vorstufe) GIVEN Frames, die den Uebergang ueber Mitternacht
+    abbilden (jetzt 23:40 Ortszeit; nass von 23:50 bis 00:40 des Folgetags,
+    danach trocken)
+    WHEN `_derive_result` Beginn und Ende ableitet
+    THEN steht der Beginn bei 10 Minuten und das Ende bei 60 Minuten — die
+    Ableitung stolpert nicht ueber die Tagesgrenze.
+
+    RED heute: `NowcastResult` kennt `event_end_minutes` nicht."""
+    raster = {m: (1.0 if 10 <= m <= 60 else 0.0) for m in range(0, 121, 5)}
+
+    result = _result(raster)
+
+    assert result.onset_minutes == 10, (
+        f"Vorbedingung: Beginn bei Minute 10, bekam {result.onset_minutes}"
+    )
+    assert result.event_end_minutes == 60, (
+        f"RED: Ende bei Minute 60 (00:40 Ortszeit) erwartet, bekam "
+        f"{result.event_end_minutes!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-6 (b) — Beginn und Ende tragen VERSCHIEDENE Tagesversaetze
+# ---------------------------------------------------------------------------
+
+
+@freeze_time(_FROZEN_UTC)
+def test_ac6_beginn_ohne_versatz_ende_mit_versatz():
+    """AC-6 GIVEN einen Onset-Alarm mit Beginn um 23:50 Ortszeit (kein
+    Tagesversatz) und einem daraus abgeleiteten Ende um 00:40 des Folgetags
+    WHEN Beginn und Ende in das Renderer-Modell projiziert werden
+    THEN traegt `onset_day_offset=0`, waehrend `event_end_day_offset=1` ist —
+    der Tagesversatz des Endes ist eigenstaendig aus dem Ende-Zeitpunkt
+    abgeleitet, NICHT vom Beginn kopiert.
+
+    RED heute: `NowcastResult` kennt `event_end_minutes` nicht (`TypeError`)
+    und `OnsetEvent` kennt `event_end_day_offset` nicht."""
+    msg = to_multi_location_onset_alert_message(
+        [("Sillian", _nowcast(event_end_minutes=60))],
+        tz=_TZ, stand_at="23:40",
+    )
+    event = msg.events[0]
+
+    assert event.onset_time == "23:50", (
+        f"Vorbedingung: Beginn 23:50 Ortszeit erwartet, bekam "
+        f"{event.onset_time!r}"
+    )
+    assert event.onset_day_offset == 0, (
+        f"Der Beginn liegt noch am heutigen Tag: {event.onset_day_offset!r}"
+    )
+    assert event.event_end_time == "00:40", (
+        f"RED: Ende-Uhrzeit 00:40 Ortszeit erwartet, bekam "
+        f"{getattr(event, 'event_end_time', None)!r}"
+    )
+    assert event.event_end_day_offset == 1, (
+        f"RED: das Ende liegt am Folgetag — erwartet Tagesversatz 1, bekam "
+        f"{getattr(event, 'event_end_day_offset', None)!r}"
+    )
+    assert event.event_end_day_offset != event.onset_day_offset, (
+        "Der Tagesversatz des Endes ist offenbar vom Beginn kopiert — die "
+        "Ableitung muss asymmetrisch sein."
+    )
+
+
+@freeze_time(_FROZEN_UTC)
+def test_ac6_ende_am_selben_tag_traegt_keinen_versatz():
+    """AC-6 (Gegenprobe) GIVEN denselben Beginn um 23:50 Ortszeit, aber ein
+    Ende bereits um 23:55 (5 Minuten spaeter, derselbe Kalendertag)
+    WHEN Beginn und Ende projiziert werden
+    THEN tragen BEIDE den Tagesversatz 0 — der Ende-Versatz ist nicht
+    pauschal 1, sondern haengt am tatsaechlichen Zeitpunkt.
+
+    Ohne diese Gegenprobe waere ein fest verdrahtetes `event_end_day_offset=1`
+    von der Zusicherung oben nicht zu unterscheiden.
+
+    RED heute: `NowcastResult` kennt `event_end_minutes` nicht (`TypeError`)."""
+    msg = to_multi_location_onset_alert_message(
+        [("Sillian", _nowcast(event_end_minutes=15))],
+        tz=_TZ, stand_at="23:40",
+    )
+    event = msg.events[0]
+
+    assert event.event_end_time == "23:55", (
+        f"RED: Ende-Uhrzeit 23:55 Ortszeit erwartet, bekam "
+        f"{getattr(event, 'event_end_time', None)!r}"
+    )
+    assert event.event_end_day_offset == 0, (
+        f"Ein Ende am selben Kalendertag darf keinen Tagesversatz tragen: "
+        f"{getattr(event, 'event_end_day_offset', None)!r}"
+    )

--- a/tests/tdd/test_nowcast_horizont_drift_text.py
+++ b/tests/tdd/test_nowcast_horizont_drift_text.py
@@ -1,0 +1,136 @@
+"""TDD RED — Issue #2051 S1: Horizont-Drift im Trockenzweig von
+`format_now_text`.
+
+SPEC: docs/specs/modules/feat_2051_s1_dauer_und_ende.md — AC-18.
+
+Fachlicher Kern: der Trockenzweig sagt heute "In den nächsten 2 Stunden kein
+Regen erwartet." — geprueft werden seit #1945 aber 3 Stunden
+(`_NOWCAST_HORIZON_MIN = 180`). Die Aussage ist damit zu KURZ gegriffen: der
+Nutzer bekommt eine Entwarnung fuer zwei Stunden, obwohl die Quelle drei
+Stunden abgedeckt hat. Zwei Zusicherungen:
+
+  * der Text nennt "3 Stunden" und nicht mehr "2 Stunden",
+  * die Zahl ist an `_NOWCAST_HORIZON_MIN` GEKOPPELT und nicht als zweite,
+    unabhaengige Zahl danebengeschrieben — sonst driftet sie beim naechsten
+    Mal genauso auseinander. Nachgewiesen wird das, indem die Konstante zur
+    LAUFZEIT veraendert wird und der Text mitwandern muss; ein Vergleich
+    gegen die selbst ausgerechnete Zahl waere von einem hart getippten `3`
+    ununterscheidbar.
+
+RED heute: der Trockenzweig sagt "2 Stunden" -> beide Zusicherungen
+schlagen fehl (fehlender bzw. verbotener Substring).
+
+Mock-frei: echtes `NowcastResult` durch den echten Formatierer, eigener
+Cache je Service.
+"""
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+from services.radar_cache import RadarNowcastCacheService
+from services.radar_service import (
+    INTENSITY_DRY, NowcastResult, RadarNowcastService,
+)
+
+_TZ = ZoneInfo("Europe/Vienna")
+
+
+def _trockenes_ergebnis() -> NowcastResult:
+    """Kein Regen im gesamten Nowcast-Fenster: kein Beginn, kein Ausfall,
+    keine Drosselung — der reine Trockenzweig."""
+    return NowcastResult(
+        onset_minutes=None, intensity_label=INTENSITY_DRY, source="radar",
+    )
+
+
+def _text(result: NowcastResult) -> str:
+    svc = RadarNowcastService(cache=RadarNowcastCacheService())
+    return svc.format_now_text(result, tz=_TZ, include_source=False)
+
+
+def test_prueling_stammt_aus_diesem_arbeitsbaum():
+    """Vorbedingung (kein AC): der geprueste Formatierer wird RELATIV ZU
+    DIESER Testdatei aufgeloest — sonst pruefte ein Worktree-Lauf still die
+    Datei des Hauptrepos."""
+    from services import radar_service as radar_module
+
+    modul_pfad = Path(inspect.getfile(radar_module)).resolve()
+    arbeitsbaum = Path(__file__).resolve().parents[2]
+    assert modul_pfad.is_relative_to(arbeitsbaum), (
+        f"Prueling stammt nicht aus diesem Arbeitsbaum: {modul_pfad}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-18 — der Trockenzweig nennt 3 Stunden
+# ---------------------------------------------------------------------------
+
+
+def test_ac18_trockenzweig_nennt_drei_stunden():
+    """AC-18 GIVEN den Trockenzweig von `format_now_text` (kein Regen im
+    gesamten Nowcast-Fenster)
+    WHEN der Text gerendert wird
+    THEN lautet die Zeitangabe "In den nächsten 3 Stunden kein Regen
+    erwartet." — konsistent mit `_NOWCAST_HORIZON_MIN = 180` seit #1945,
+    nicht mehr "2 Stunden".
+
+    RED heute: der Zweig sagt "In den nächsten 2 Stunden kein Regen
+    erwartet."."""
+    text = _text(_trockenes_ergebnis())
+
+    assert "In den nächsten 3 Stunden kein Regen erwartet." in text, (
+        f"RED: der Trockenzweig nennt nicht die tatsaechlich geprueften "
+        f"3 Stunden: {text!r}"
+    )
+    assert "2 Stunden" not in text, (
+        f"Die veraltete 2-Stunden-Aussage steht noch im Text — sie entwarnt "
+        f"fuer eine kuerzere Spanne, als die Quelle abgedeckt hat: {text!r}"
+    )
+
+
+def test_ac18_stundenzahl_haengt_am_horizont_und_nicht_an_einer_kopie(monkeypatch):
+    """AC-18 (Kopplung) GIVEN denselben Trockenzweig
+    WHEN `_NOWCAST_HORIZON_MIN` ZUR LAUFZEIT auf einen anderen Wert gesetzt
+    wird (120 bzw. 240 Minuten)
+    THEN wandert die Stundenzahl im Text mit (2 bzw. 4 Stunden) — der Text
+    liest die Konstante, statt eine zweite, unabhaengig gepflegte Zahl zu
+    tragen. Genau diese Doppelpflege hat die heutige Drift erzeugt.
+
+    Der Beleg MUSS ueber eine Veraenderung der Konstante laufen. Ein Test, der
+    die erwartete Zahl selbst aus `_NOWCAST_HORIZON_MIN` ausrechnet und dann
+    nur den fertigen String vergleicht, ist bei 180 Min von einem hart
+    getippten `3` im Produktivcode ununterscheidbar (Adversary-Fund F002,
+    2026-08-22: genau diese Mutation blieb gruen).
+
+    Gepatcht wird die MODUL-Referenz (`radar_service._NOWCAST_HORIZON_MIN`),
+    weil der Formatierer die Konstante bei jedem Aufruf ueber den
+    Modul-Namensraum aufloest (`radar_service.py:519`) — waere sie beim Import
+    an einen lokalen Namen gebunden, ginge der Patch ins Leere und der Test
+    waere derselbe wertlose Nachweis in neuer Form.
+
+    RED heute: der Text nennt 2 statt 3 Stunden."""
+    from services import radar_service as radar_module
+
+    assert radar_module._NOWCAST_HORIZON_MIN == 180, (
+        f"Vorbedingung: Ist-Horizont 180 Min (seit #1945), ist aber "
+        f"{radar_module._NOWCAST_HORIZON_MIN} Min."
+    )
+    assert "In den nächsten 3 Stunden" in _text(_trockenes_ergebnis()), (
+        "Vorbedingung: der Ist-Horizont muss den AC-18-Wortlaut ergeben."
+    )
+
+    for horizont_min, erwartete_stunden in ((120, 2), (240, 4)):
+        monkeypatch.setattr(radar_module, "_NOWCAST_HORIZON_MIN", horizont_min)
+
+        text = _text(_trockenes_ergebnis())
+
+        assert (
+            f"In den nächsten {erwartete_stunden} Stunden kein Regen erwartet."
+            in text
+        ), (
+            f"RED: bei einem Horizont von {horizont_min} Min muss der Text "
+            f"{erwartete_stunden} Stunden nennen — er tut es nicht, die Zahl "
+            f"ist also nicht an die Konstante gekoppelt: {text!r}"
+        )

--- a/tests/tdd/test_onset_ende_briefing_hinweis.py
+++ b/tests/tdd/test_onset_ende_briefing_hinweis.py
@@ -1,0 +1,148 @@
+"""TDD RED — Issue #2051 S1: Ende-Angabe im Briefing-Kurzfristhinweis.
+
+SPEC: docs/specs/modules/feat_2051_s1_dauer_und_ende.md — AC-13.
+
+Fachlicher Kern: der Briefing-Kurzfristhinweis (Textstelle 6) transportiert
+heute nur `intensity_label` und `onset_minutes` — die Datenform
+(`starkregen_nowcast: tuple[str, int] | None`) ist fuer Ende und Waechter zu
+eng. `format_starkregen_hint` bekommt die beiden zusaetzlichen Angaben
+additiv als Schluesselwort-Argumente:
+
+    format_starkregen_hint(
+        intensity_label, onset_minutes, *, tz,
+        event_end_minutes=None, event_ongoing_beyond_horizon=False,
+    )
+
+Additiv und defaultet: ein Alt-Aufrufer, der die neuen Argumente nicht
+uebergibt, bekommt byte-identisch den heutigen Text (AC-19).
+
+RED heute: `format_starkregen_hint` kennt die beiden Argumente nicht
+-> `TypeError: unexpected keyword argument`; `NowcastResult` kennt die
+Quellfelder nicht -> `TypeError` beim Konstruktor.
+
+Mock-frei: echte Funktion, echte `NowcastResult`-Objekte; die Uhr steht per
+`freeze_time` fest, weil `format_starkregen_hint` intern `datetime.now()`
+liest.
+"""
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+from freezegun import freeze_time
+
+from output.renderers.email.starkregen_hint import format_starkregen_hint
+from services.radar_service import NowcastResult
+
+# 18:00 Ortszeit Wien (= 16:00 UTC im Sommer): Beginn 18:30 (+30 Min),
+# Ende 19:30 (+90 Min).
+_TZ = ZoneInfo("Europe/Vienna")
+_FROZEN_UTC = "2026-08-21 16:00:00+00:00"
+_BEGINN_TEXT = "Starker Regen ab ca. 18:30 (in ~30 Min)"
+_ENDE_TEXT = "letzter Regen gegen 19:30"
+
+_UNSET = object()
+
+
+def _nowcast(**kw) -> NowcastResult:
+    """`NowcastResult` mit gesetztem Beginn; neue Felder nur auf
+    ausdruecklichen Wunsch (Sentinel-Muster)."""
+    fields = dict(
+        onset_minutes=30, intensity_label="Starker Regen", source="radar",
+        is_convective=False,
+    )
+    fields.update({k: v for k, v in kw.items() if v is not _UNSET})
+    return NowcastResult(**fields)
+
+
+def test_prueling_stammt_aus_diesem_arbeitsbaum():
+    """Vorbedingung (kein AC): der geprueste Briefing-Baustein wird RELATIV
+    ZU DIESER Testdatei aufgeloest — sonst pruefte ein Worktree-Lauf still
+    die Datei des Hauptrepos."""
+    from output.renderers.email import starkregen_hint as hint_module
+
+    modul_pfad = Path(inspect.getfile(hint_module)).resolve()
+    arbeitsbaum = Path(__file__).resolve().parents[2]
+    assert modul_pfad.is_relative_to(arbeitsbaum), (
+        f"Prueling stammt nicht aus diesem Arbeitsbaum: {modul_pfad}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-13 — der Hinweis nennt zusaetzlich das Ende
+# ---------------------------------------------------------------------------
+
+
+@freeze_time(_FROZEN_UTC)
+def test_ac13_briefing_hinweis_nennt_das_ende():
+    """AC-13 GIVEN ein Nowcast-Ergebnis mit gesetztem Ende
+    (`event_end_minutes=90`) und `event_ongoing_beyond_horizon=False`
+    WHEN `format_starkregen_hint(...)` den Briefing-Kurzfristhinweis rendert
+    THEN enthaelt der Text ZUSAETZLICH zur bestehenden Beginn-Angabe die
+    Ende-Angabe im Wortlaut `letzter Regen gegen HH:MM`.
+
+    RED heute: `format_starkregen_hint` kennt die erweiterte Datenform nicht
+    (`TypeError: unexpected keyword argument`)."""
+    text = format_starkregen_hint(
+        "Starker Regen", 30, tz=_TZ,
+        event_end_minutes=90, event_ongoing_beyond_horizon=False,
+    )
+
+    assert _BEGINN_TEXT in text, (
+        f"Die bestehende Beginn-Angabe darf nicht verlorengehen: {text!r}"
+    )
+    assert _ENDE_TEXT in text, (
+        f"RED: Ende-Angabe {_ENDE_TEXT!r} fehlt im Briefing-Hinweis: {text!r}"
+    )
+
+
+@freeze_time(_FROZEN_UTC)
+def test_ac13_ohne_ende_bleibt_die_heutige_form_byte_identisch():
+    """AC-13 (Alt-Aufrufer, AC-19) GIVEN denselben Hinweis OHNE ableitbares
+    Ende (`event_end_minutes=None`)
+    WHEN er einmal mit den neuen Argumenten und einmal ganz ohne sie
+    gerendert wird
+    THEN sind beide Texte byte-identisch und tragen KEINE Ende-Angabe — die
+    Erweiterung ist additiv und defaultet, kein Bruch fuer Alt-Aufrufer.
+
+    RED heute: der Aufruf mit den neuen Argumenten schlaegt mit `TypeError`
+    fehl."""
+    mit_none = format_starkregen_hint(
+        "Starker Regen", 30, tz=_TZ,
+        event_end_minutes=None, event_ongoing_beyond_horizon=False,
+    )
+    ohne_argumente = format_starkregen_hint("Starker Regen", 30, tz=_TZ)
+
+    assert mit_none == ohne_argumente, (
+        "Ein ungesetztes Ende darf den Hinweistext nicht anfassen.\n"
+        f"  mit None       = {mit_none!r}\n"
+        f"  ohne Argumente = {ohne_argumente!r}"
+    )
+    assert "letzter Regen gegen" not in mit_none, (
+        f"Ohne ableitbares Ende darf keines behauptet werden: {mit_none!r}"
+    )
+
+
+@freeze_time(_FROZEN_UTC)
+def test_ac13_ende_stammt_aus_dem_nowcast_ergebnis():
+    """AC-13 (Datenform) GIVEN ein `NowcastResult`, das Beginn UND Ende
+    traegt
+    WHEN seine Felder — so wie der Briefing-Pfad sie transportiert — an
+    `format_starkregen_hint` durchgereicht werden
+    THEN erscheint dieselbe Ende-Angabe im Hinweistext: die Angabe stammt aus
+    dem Nowcast-Ergebnis, nicht aus einer zweiten Quelle.
+
+    RED heute: `NowcastResult` kennt die beiden Felder nicht (`TypeError`)."""
+    nc = _nowcast(event_end_minutes=90, event_ongoing_beyond_horizon=False)
+
+    text = format_starkregen_hint(
+        nc.intensity_label, nc.onset_minutes, tz=_TZ,
+        event_end_minutes=nc.event_end_minutes,
+        event_ongoing_beyond_horizon=nc.event_ongoing_beyond_horizon,
+    )
+
+    assert _ENDE_TEXT in text, (
+        f"RED: das Ende aus dem NowcastResult kommt im Briefing-Hinweis nicht "
+        f"an: {text!r}"
+    )

--- a/tests/tdd/test_onset_ende_kanalparitaet.py
+++ b/tests/tdd/test_onset_ende_kanalparitaet.py
@@ -1,0 +1,479 @@
+"""TDD RED — Issue #2051 Scheibe S1: die Ende-Angabe erreicht BEIDE Flaechen —
+Trip UND Ortsvergleich — mit demselben Wortlaut und demselben Wert.
+
+SPEC: docs/specs/modules/feat_2051_s1_dauer_und_ende.md — AC-15.
+
+Warum das zaehlt (ADR-0021, geteilter Code Trip/Ortsvergleich): Trip und
+Ortsvergleich bauen ihr `OnsetEvent` an ZWEI verschiedenen Stellen —
+`trip_alert.check_radar_alerts()` ueber `RadarAlertRequest` und
+`project.to_multi_location_onset_alert_message()` ueber das `NowcastResult`.
+Wird das neue Ende-Feld nur an einer der beiden Stellen durchgereicht,
+entsteht in der anderen eine stille Luecke. Genau diese Fehlerklasse fand der
+Adversary bei #2046 (F001).
+
+Gespiegelt zu `tests/tdd/test_onset_menge_kanalparitaet.py`.
+
+Mock-frei: DIESELBEN echten Radar-Frames (feste absolute Zeitstempel, keine
+Wanduhr-Ableitung je Aufruf) laufen durch BEIDE echten Produktivpfade —
+echter `RadarNowcastService` -> echtes `NowcastResult` -> echter
+Alarm-Service -> echter `NotificationService` -> echter Telegram-Transport ->
+Nutzlast am Draht eines lokalen Aufzeichnungs-Servers. Kein `Mock()`,
+kein `patch()` von Verhalten, kein externes Netz, kein echter SMS-Versand.
+
+Beide Flaechen laufen auf DENSELBEN Koordinaten (Atlantic/Reykjavik,
+ganzjaehrig UTC+0): der Ortsvergleich loest die Zeitzone JE ORT auf, der
+Trip ueber seine Wegpunkte — mit verschiedenen Orten waeren die Uhrzeiten
+zulaessig verschieden und der Vergleich wertlos.
+
+RED-Ursache: `NowcastResult` kennt `event_end_minutes` noch nicht, keiner der
+beiden Pfade reicht ein Ende durch — in BEIDEN Texten fehlt
+`letzter Regen gegen HH:MM` bzw. das zweite Kurzform-Zeit-Token.
+"""
+from __future__ import annotations
+
+import dataclasses
+import http.server
+import json
+import re
+import shutil
+import socket
+import threading
+from datetime import datetime, time, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+import output.channels.telegram as tg_module
+from app.config import Settings
+from app.loader import save_location, save_trip
+from app.models import TripReportConfig
+from app.user import SavedLocation
+
+from tests.helpers.briefing_zeiten import briefing_zeiten_fuer_trip
+from tests.helpers.compare_briefings import write_compare_briefings
+from tests.helpers.nowcast_gate_fixtures import (
+    TRIP_LAT, TRIP_LON, TRIP_ZONE, clean_uid, fresh_uid, make_trip,
+    quiet_window_elsewhere, radar_service, reset_radar_cache,
+)
+
+# Langform-Wortlaut (#2020 S2), mit gefangener Uhrzeit.
+_LANGFORM_RE = re.compile(r"letzter Regen gegen (\d{1,2}:\d{2})")
+# Kurzform: Beginn-Token, unmittelbar gefolgt vom MINUTENGENAUEN Ende-Token
+# (`@HH:MM`). Kein optionaler Minutenteil: die Spec ist an dieser Stelle
+# uneinheitlich, den Ausschlag gibt AC-16 (dort, wo die exakte Laenge zaehlt,
+# budgetiert sie `@23:59`) sowie die Konsistenz mit dem Beginn-Token aus #2046
+# (`R2.5@18:00`). Die Toleranz NICHT wiederherstellen — ein Ausdruck, der
+# `@20` und `@20:00` gleichermassen annimmt, bewacht keines der beiden
+# Formate.
+_KURZFORM_RE = re.compile(
+    r"@(?P<beginn>\d{1,2}:\d{2})@(?P<ende>\d{1,2}:\d{2})\b"
+)
+
+# Nasser Block: +20 bis +80 Minuten im 10-Minuten-Raster, danach TROCKEN.
+# Das erwartete Ende ist damit von Hand hergeleitet (letzter nasser Frame vor
+# dem Trockenuebergang) und NICHT aus der Implementierung abgeschrieben.
+ONSET_MIN = 20          # < RADAR_ONSET_THRESHOLD_MIN (55) -> der Alarm feuert
+ENDE_MIN = 80
+TROCKEN_MIN = 90
+RATE_MM_H = 3.0
+
+
+class _FesterNasserBlock:
+    """Echter, aufrufbarer `frame_source` (kein Mock) mit EINMALIG
+    festgelegten, absoluten Zeitstempeln.
+
+    Absolut statt "relativ zu jetzt bei jedem Aufruf": beide Flaechen werden
+    im selben Test nacheinander gefahren; eine Wanduhr-Ableitung je Aufruf
+    verschoebe die Frames zwischen den beiden Laeufen und der Paritaets-
+    Vergleich maesse die Uhr statt der Verdrahtung.
+
+    Liefert fuer JEDE Koordinate denselben Satz — beide Flaechen sehen damit
+    nachweislich dieselben Frames.
+    """
+
+    def __init__(self) -> None:
+        self.start = datetime.now(timezone.utc).replace(microsecond=0)
+        self.calls: list[tuple[float, float]] = []
+
+    @property
+    def erwartetes_ende_utc(self) -> datetime:
+        return self.start + timedelta(minutes=ENDE_MIN)
+
+    def __call__(self, lat: float, lon: float) -> list:
+        from providers.brightsky import RadarFrame
+
+        self.calls.append((lat, lon))
+        frames = [
+            RadarFrame(
+                timestamp=self.start + timedelta(minutes=m),
+                precip_mm_h=RATE_MM_H, is_convective=False,
+            )
+            for m in range(ONSET_MIN, ENDE_MIN + 1, 10)
+        ]
+        frames.append(RadarFrame(
+            timestamp=self.start + timedelta(minutes=TROCKEN_MIN),
+            precip_mm_h=0.0, is_convective=False,
+        ))
+        return frames
+
+
+# ---------------------------------------------------------------------------
+# Echter lokaler Telegram-Bot-API-Stub (kein Mock)
+# ---------------------------------------------------------------------------
+
+
+def _free_port() -> int:
+    probe = socket.socket()
+    probe.bind(("", 0))
+    port = probe.getsockname()[1]
+    probe.close()
+    return port
+
+
+class _TelegramStub:
+    def __init__(self) -> None:
+        self.sent: list[dict] = []
+        sent = self.sent
+        counter = {"mid": 5000}
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def do_POST(self):  # noqa: N802
+                length = int(self.headers.get("Content-Length", 0))
+                try:
+                    payload = json.loads(self.rfile.read(length).decode())
+                except ValueError:
+                    payload = {}
+                sent.append(payload)
+                counter["mid"] += 1
+                body = json.dumps(
+                    {"ok": True, "result": {"message_id": counter["mid"]}}
+                ).encode()
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, *args):  # noqa: D401
+                pass
+
+        self.port = _free_port()
+        self._server = http.server.HTTPServer(("127.0.0.1", self.port), Handler)
+        threading.Thread(target=self._server.serve_forever, daemon=True).start()
+
+    @property
+    def base_url(self) -> str:
+        return f"http://127.0.0.1:{self.port}"
+
+    def stop(self) -> None:
+        self._server.shutdown()
+
+
+@pytest.fixture()
+def telegram_stub():
+    stub = _TelegramStub()
+    yield stub
+    stub.stop()
+
+
+def _telegram_only_settings(marke: str) -> Settings:
+    """Nur Telegram sendebereit — E-Mail, SMS und Premium-SMS ausdruecklich
+    AUS. Jedes weggelassene Feld faellt bei pydantic still auf die Prod-`.env`
+    des Arbeitsverzeichnisses zurueck (#1477).
+
+    `telegram_test_chat_id` ist Pflicht fuer die Herkunftssperre des
+    Telegram-Kanals aus einem Nicht-Prod-Checkout (#1476)."""
+    return Settings(
+        smtp_host=None, smtp_user=None, smtp_pass=None, mail_to=None,
+        telegram_bot_token=f"test-token-2051-{marke}",
+        telegram_chat_id="99999", telegram_test_chat_id="99999",
+        sms_gateway_url="", seven_api_key="", seven_sandbox_key="",
+        sms_to="", sms_from=None,
+        premium_sms_reply_to=None, premium_sms_reply_at=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Die beiden echten Produktivpfade
+# ---------------------------------------------------------------------------
+
+
+def _text_vom_trip_pfad(frames, telegram_stub, monkeypatch, *, stil: str) -> str:
+    """Faehrt `TripAlertService.check_radar_alerts()` — den einzigen
+    Produktivpfad, der im Trip-Betrieb einen `RadarAlertRequest` baut — und
+    gibt den Text zurueck, der am Draht ankam."""
+    from services.trip_alert import TripAlertService
+
+    monkeypatch.setattr(tg_module, "TELEGRAM_API_BASE", telegram_stub.base_url)
+
+    uid, trip_id = fresh_uid(f"2051-par-trip-{stil}"), f"trip-2051-par-{stil}"
+    clean_uid(uid)
+    reset_radar_cache()
+    try:
+        quiet_from, quiet_to = quiet_window_elsewhere(zone=TRIP_ZONE)
+        trip = make_trip(
+            trip_id, cooldown_minutes=0, quiet_from=quiet_from, quiet_to=quiet_to,
+        )
+        # Etappen-Startzeit auf "gerade eben" setzen, damit zu JEDER Tageszeit
+        # ein Segment aktiv ist. Noetig, weil `app.loader.save_trip` die
+        # Ankunftszeiten beim Speichern NEU rechnet (Compute-on-Save, #802):
+        # die 00:00-23:59-Spanne aus `make_trip()` ueberlebt den Roundtrip
+        # nicht, aus ihr wird die Naismith-Gehzeit ab der Stage-Startzeit
+        # (Vorgabe 08:00). Ein abends laufender Test faende danach kein
+        # aktives Segment mehr und maesse die Segment-Auswahl statt der
+        # Ende-Durchreichung. Mitternachts-Klemme: vor 00:15 Ortszeit bleibt
+        # es bei 00:00, sonst rutschte der Start auf den Vortag.
+        lokal = datetime.now(timezone.utc).astimezone(TRIP_ZONE)
+        start = max(
+            lokal - timedelta(minutes=15),
+            lokal.replace(hour=0, minute=0, second=0, microsecond=0),
+        )
+        trip.stages[0] = dataclasses.replace(
+            trip.stages[0], start_time=time(start.hour, start.minute),
+        )
+        morgen, abend = briefing_zeiten_fuer_trip(trip)
+        trip.report_config = TripReportConfig(
+            trip_id=trip_id, send_email=False, send_sms=False,
+            send_telegram=True, send_premium_sms=False,
+            alert_on_changes=True, telegram_style=stil,
+            morning_time=morgen, evening_time=abend,
+        )
+        # Der PRODUKTIVE Speicherer: nur er schreibt `telegram_style` mit, und
+        # `check_radar_alerts()` liest den Trip von Platte zurueck.
+        save_trip(trip, user_id=uid)
+
+        svc = TripAlertService(
+            settings=_telegram_only_settings(f"trip-{stil}"), throttle_hours=0,
+            user_id=uid, radar_service=radar_service(frames),
+        )
+        vorher = len(telegram_stub.sent)
+        sent = svc.check_radar_alerts()
+
+        assert sent == 1, (
+            f"Voraussetzung: genau EIN Trip-Radar-Alarm erwartet, war {sent}. "
+            f"Nowcast-Abrufe: {frames.calls!r}"
+        )
+        neu = telegram_stub.sent[vorher:]
+        assert len(neu) == 1, (
+            f"Erwartet genau EINE Trip-Nachricht am Draht: {neu!r}"
+        )
+        return neu[0].get("text") or ""
+    finally:
+        clean_uid(uid)
+
+
+def _compare_users_root() -> Path:
+    """Funktion statt Konstante (#1595): `get_data_root()` liefert erst zur
+    Laufzeit die von der Test-Fixture gesetzte Basis."""
+    from app.loader import get_data_root
+
+    return get_data_root() / "users"
+
+
+def _text_vom_ortsvergleich_pfad(frames, telegram_stub, monkeypatch, *, stil: str) -> str:
+    """Faehrt `CompareRadarAlertService.check_all_compare_presets()` — den
+    Ortsvergleich-Produktivpfad, der sein `OnsetEvent` ueber
+    `to_multi_location_onset_alert_message()` selbst baut."""
+    from services.compare_radar_alert import CompareRadarAlertService
+
+    monkeypatch.setattr(tg_module, "TELEGRAM_API_BASE", telegram_stub.base_url)
+
+    uid = fresh_uid(f"2051-par-cmp-{stil}")
+    preset_id = f"cp-2051-par-{stil}"
+    clean_uid(uid)
+    reset_radar_cache()
+    try:
+        # DIESELBEN Koordinaten wie der Trip (Atlantic/Reykjavik, UTC+0) —
+        # sonst waeren die Uhrzeiten zulaessig verschieden.
+        save_location(
+            SavedLocation(
+                id="loc-2051", name="Reykjavik-Paritaet",
+                lat=TRIP_LAT, lon=TRIP_LON, elevation_m=100,
+            ),
+            user_id=uid,
+        )
+        write_compare_briefings(_compare_users_root() / uid, [{
+            "id": preset_id,
+            "name": preset_id,
+            "user_id": uid,
+            "location_ids": ["loc-2051"],
+            # Aktiver Zeitplan noetig (#1467 S2 AG6), sonst gilt das Preset als
+            # pausiert und schweigt in allen Alarm-Pfaden.
+            "schedule": "daily",
+            "weekday": 4,
+            "profil": "ALLGEMEIN",
+            "hour_from": 9,
+            "hour_to": 16,
+            "empfaenger": ["gregor-test@henemm.com"],
+            "letzter_versand": None,
+            "top_ort_letzter_versand": None,
+            "created_at": "2026-08-21T00:00:00Z",
+            "radar_alert_enabled": True,
+            "send_telegram": True,
+            "display_config": {"telegram_style": stil},
+        }])
+
+        svc = CompareRadarAlertService(
+            settings=_telegram_only_settings(f"cmp-{stil}"), user_id=uid,
+            radar_service=radar_service(frames),
+        )
+        vorher = len(telegram_stub.sent)
+        sent = svc.check_all_compare_presets()
+
+        assert sent == 1, (
+            f"Voraussetzung: genau EIN Ortsvergleich-Radar-Alarm erwartet, "
+            f"war {sent}. Nowcast-Abrufe: {frames.calls!r}"
+        )
+        neu = telegram_stub.sent[vorher:]
+        assert len(neu) == 1, (
+            f"Erwartet genau EINE Ortsvergleich-Nachricht am Draht: {neu!r}"
+        )
+        return neu[0].get("text") or ""
+    finally:
+        clean_uid(uid)
+        d = _compare_users_root() / uid
+        if d.exists():
+            shutil.rmtree(d, ignore_errors=True)
+
+
+def _minuten(hhmm: str) -> int:
+    stunde, _, minute = hhmm.partition(":")
+    return int(stunde) * 60 + (int(minute) if minute else 0)
+
+
+def _abstand_minuten(a: str, b: str) -> int:
+    """Abstand zweier `HH:MM`-Angaben in Minuten, ueber Mitternacht hinweg."""
+    roh = abs(_minuten(a) - _minuten(b))
+    return min(roh, 24 * 60 - roh)
+
+
+# Die beiden Laeufe liegen Sekundenbruchteile auseinander; springt dazwischen
+# die Minute um, unterscheiden sich die aus "Minuten ab jetzt" zurueck-
+# gerechneten Uhrzeiten um genau 1 Minute. Groesser darf der Abstand nicht
+# sein — das waere ein echter Wertunterschied zwischen den Flaechen.
+_WANDUHR_TOLERANZ_MIN = 1
+
+
+# ---------------------------------------------------------------------------
+# AC-15 — Langform: Trip und Ortsvergleich nennen dasselbe Ende
+# ---------------------------------------------------------------------------
+
+
+def test_ac15_langform_traegt_in_beiden_flaechen_dasselbe_ende(
+    telegram_stub, monkeypatch,
+):
+    """AC-15 GIVEN DIESELBEN Radar-Frames (nasser Block +20 bis +80 Minuten,
+    danach trocken) einmal ueber den Trip-Pfad
+    (`trip_alert.check_radar_alerts`) und einmal ueber den
+    Ortsvergleich-Pfad (`compare_radar_alert.check_all_compare_presets`),
+    beide auf denselben Koordinaten und im reichen Telegram-Stil
+    WHEN beide Alarme tatsaechlich abgesetzt werden
+    THEN traegt die Ende-Angabe in BEIDEN Flaechen denselben Wortlaut
+    (`letzter Regen gegen HH:MM`) und denselben Wert — keine Flaeche zeigt
+    das Ende, ohne dass es die andere auch taete.
+
+    Zusaetzlich wird der Wert gegen das aus den Frames HERGELEITETE Ende
+    (Beginn + 80 Min) geprueft, nicht nur die beiden Flaechen gegeneinander:
+    zwei gleich falsche Angaben waeren sonst gruen.
+
+    RED heute: `NowcastResult` kennt `event_end_minutes` nicht — beide Texte
+    nennen ueberhaupt kein Ende."""
+    frames = _FesterNasserBlock()
+
+    trip_text = _text_vom_trip_pfad(frames, telegram_stub, monkeypatch, stil="rich")
+    cmp_text = _text_vom_ortsvergleich_pfad(
+        frames, telegram_stub, monkeypatch, stil="rich",
+    )
+
+    trip_treffer = _LANGFORM_RE.search(trip_text)
+    cmp_treffer = _LANGFORM_RE.search(cmp_text)
+    fehlend = [
+        name for name, t in (("Trip", trip_treffer), ("Ortsvergleich", cmp_treffer))
+        if t is None
+    ]
+    assert not fehlend, (
+        f"RED: diese Flaeche(n) nennen kein Ende: {fehlend}\n"
+        f"  Trip          = {trip_text!r}\n  Ortsvergleich = {cmp_text!r}"
+    )
+
+    erwartet = frames.erwartetes_ende_utc.astimezone(TRIP_ZONE).strftime("%H:%M")
+    for name, treffer, text in (
+        ("Trip", trip_treffer, trip_text),
+        ("Ortsvergleich", cmp_treffer, cmp_text),
+    ):
+        assert _abstand_minuten(treffer.group(1), erwartet) <= _WANDUHR_TOLERANZ_MIN, (
+            f"{name} nennt {treffer.group(1)} statt des aus den Frames "
+            f"hergeleiteten Endes {erwartet}: {text!r}"
+        )
+
+    assert _abstand_minuten(
+        trip_treffer.group(1), cmp_treffer.group(1)
+    ) <= _WANDUHR_TOLERANZ_MIN, (
+        "Trip und Ortsvergleich nennen verschiedene Ende-Uhrzeiten:\n"
+        f"  Trip          = {trip_treffer.group(1)}\n"
+        f"  Ortsvergleich = {cmp_treffer.group(1)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-15 — Kurzform: dieselbe Zusicherung fuer den einzigen Satelliten-Kanal
+# ---------------------------------------------------------------------------
+
+
+def test_ac15_kurzform_traegt_in_beiden_flaechen_dasselbe_ende_token(
+    telegram_stub, monkeypatch,
+):
+    """AC-15 (Kurzform) GIVEN denselben Aufbau, aber beide Flaechen im
+    Telegram-KURZSTIL — dem Stil, der denselben `sms_body` traegt, den SMS
+    und Premium-SMS bekommen
+    WHEN beide Alarme abgesetzt werden
+    THEN traegt das minutengenaue Ende-Token (`@HH:MM`) in BEIDEN Flaechen
+    denselben Wert.
+
+    Warum eigens geprueft: die Kurzform ist ein anderer Codepfad als die
+    Langform (`_render_sms_onset` statt `_render_telegram_onset`), und auf der
+    Huette am Karnischen Hoehenweg kommt NUR Premium-SMS an — eine Angabe,
+    die den Kurzpfad einer Flaeche nicht erreicht, erreicht dort niemanden.
+
+    Minutengenau, nicht `@HH`: den Ausschlag gibt AC-16 (dort budgetiert die
+    Spec `@23:59`) und die Konsistenz mit dem Beginn-Token aus #2046. Der
+    Ausdruck laesst deshalb bewusst KEINEN optionalen Minutenteil zu.
+
+    RED heute: `NowcastResult` kennt `event_end_minutes` nicht — in beiden
+    Texten steht nur EIN Zeit-Token."""
+    frames = _FesterNasserBlock()
+
+    trip_text = _text_vom_trip_pfad(
+        frames, telegram_stub, monkeypatch, stil="kurzform",
+    )
+    cmp_text = _text_vom_ortsvergleich_pfad(
+        frames, telegram_stub, monkeypatch, stil="kurzform",
+    )
+
+    trip_treffer = _KURZFORM_RE.search(trip_text)
+    cmp_treffer = _KURZFORM_RE.search(cmp_text)
+    fehlend = [
+        name for name, t in (("Trip", trip_treffer), ("Ortsvergleich", cmp_treffer))
+        if t is None
+    ]
+    assert not fehlend, (
+        f"RED: diese Flaeche(n) tragen kein Ende-Token: {fehlend}\n"
+        f"  Trip          = {trip_text!r}\n  Ortsvergleich = {cmp_text!r}"
+    )
+
+    erwartet = frames.erwartetes_ende_utc.astimezone(TRIP_ZONE).strftime("%H:%M")
+    for name, treffer, text in (
+        ("Trip", trip_treffer, trip_text),
+        ("Ortsvergleich", cmp_treffer, cmp_text),
+    ):
+        assert _abstand_minuten(treffer.group("ende"), erwartet) <= _WANDUHR_TOLERANZ_MIN, (
+            f"{name} nennt das Ende {treffer.group('ende')!r} statt des aus "
+            f"den Frames hergeleiteten Endes {erwartet}: {text!r}"
+        )
+
+    assert _abstand_minuten(
+        trip_treffer.group("ende"), cmp_treffer.group("ende"),
+    ) <= _WANDUHR_TOLERANZ_MIN, (
+        "Trip und Ortsvergleich tragen verschiedene Ende-Token:\n"
+        f"  Trip          = {trip_treffer.group('ende')!r}\n"
+        f"  Ortsvergleich = {cmp_treffer.group('ende')!r}"
+    )

--- a/tests/tdd/test_onset_ende_kommando_antwort.py
+++ b/tests/tdd/test_onset_ende_kommando_antwort.py
@@ -1,0 +1,145 @@
+"""TDD RED — Issue #2051 S1: Ende-Angabe in der Inbound-Kommando-Antwort.
+
+SPEC: docs/specs/modules/feat_2051_s1_dauer_und_ende.md — AC-14.
+
+Fachlicher Kern: `format_now_text` ist die Antwort auf das Inbound-Kommando
+(Textstelle 7) und einer der beiden ungedeckelten Pfade — genau der Pfad, aus
+dem der im Ticket geschilderte Realfall stammt. Sie nennt heute nur den
+Beginn und muss zusaetzlich das Ende im Wortlaut `letzter Regen gegen HH:MM`
+nennen.
+
+RED heute: `NowcastResult` kennt `event_end_minutes` /
+`event_ongoing_beyond_horizon` nicht -> `TypeError` beim Konstruktor.
+
+Mock-frei: echte `NowcastResult`-Objekte durch den echten Formatierer; die
+Uhr steht per `freeze_time` fest, weil `format_now_text` intern
+`datetime.now()` liest. Eigener Cache je Service, damit kein prozessweit
+geteilter Zustand mitwirkt.
+"""
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+from freezegun import freeze_time
+
+from services.radar_cache import RadarNowcastCacheService
+from services.radar_service import (
+    _NOWCAST_HORIZON_MIN, NowcastResult, RadarNowcastService,
+)
+
+# 18:00 Ortszeit Wien (= 16:00 UTC im Sommer): Beginn 18:30 (+30 Min),
+# Ende 19:30 (+90 Min).
+_TZ = ZoneInfo("Europe/Vienna")
+_FROZEN_UTC = "2026-08-21 16:00:00+00:00"
+_BEGINN_TEXT = "Starker Regen ab ca. 18:30 (in ~30 Min)"
+_ENDE_TEXT = "letzter Regen gegen 19:30"
+
+_UNSET = object()
+
+
+def _nowcast(*, event_end_minutes: object = _UNSET,
+             event_ongoing_beyond_horizon: object = _UNSET) -> NowcastResult:
+    """`NowcastResult` mit gesetztem Beginn; die neuen Felder nur auf
+    ausdruecklichen Wunsch setzen (Sentinel-Muster) — so bleibt die
+    Vergleichsfassung ohne die Felder unabhaengig vom Erweiterungsstand."""
+    fields = dict(
+        onset_minutes=30, intensity_label="Starker Regen", source="radar",
+        is_convective=False,
+    )
+    if event_end_minutes is not _UNSET:
+        fields["event_end_minutes"] = event_end_minutes
+    if event_ongoing_beyond_horizon is not _UNSET:
+        fields["event_ongoing_beyond_horizon"] = event_ongoing_beyond_horizon
+    return NowcastResult(**fields)
+
+
+def _text(result: NowcastResult) -> str:
+    svc = RadarNowcastService(cache=RadarNowcastCacheService())
+    return svc.format_now_text(result, tz=_TZ, include_source=False)
+
+
+def test_prueling_stammt_aus_diesem_arbeitsbaum():
+    """Vorbedingung (kein AC): der geprueste Formatierer wird RELATIV ZU
+    DIESER Testdatei aufgeloest — sonst pruefte ein Worktree-Lauf still die
+    Datei des Hauptrepos."""
+    from services import radar_service as radar_module
+
+    modul_pfad = Path(inspect.getfile(radar_module)).resolve()
+    arbeitsbaum = Path(__file__).resolve().parents[2]
+    assert modul_pfad.is_relative_to(arbeitsbaum), (
+        f"Prueling stammt nicht aus diesem Arbeitsbaum: {modul_pfad}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-14 — die Kommando-Antwort nennt das Ende
+# ---------------------------------------------------------------------------
+
+
+@freeze_time(_FROZEN_UTC)
+def test_ac14_kommando_antwort_nennt_das_ende():
+    """AC-14 GIVEN ein `NowcastResult` mit gesetztem `event_end_minutes`
+    (90 Minuten -> 19:30 Ortszeit)
+    WHEN `format_now_text(result, tz=...)` als Antwort auf ein
+    Inbound-Kommando gerendert wird
+    THEN enthaelt der Text ZUSAETZLICH zur bestehenden Beginn-Zeile
+    `letzter Regen gegen 19:30`.
+
+    RED heute: `NowcastResult` kennt `event_end_minutes` nicht
+    (`TypeError`)."""
+    text = _text(_nowcast(event_end_minutes=90,
+                          event_ongoing_beyond_horizon=False))
+
+    assert _BEGINN_TEXT in text, (
+        f"Die bestehende Beginn-Zeile darf nicht verlorengehen: {text!r}"
+    )
+    assert _ENDE_TEXT in text, (
+        f"RED: Ende-Angabe {_ENDE_TEXT!r} fehlt in der Kommando-Antwort: "
+        f"{text!r}"
+    )
+
+
+@freeze_time(_FROZEN_UTC)
+def test_ac14_ohne_ende_bleibt_die_heutige_antwort_byte_identisch():
+    """AC-14 (Alt-Fall, AC-19) GIVEN ein `NowcastResult` ohne ableitbares
+    Ende (`event_end_minutes=None`)
+    WHEN die Kommando-Antwort einmal mit gesetztem `None` und einmal ganz
+    ohne das Feld gerendert wird
+    THEN sind beide Texte byte-identisch und tragen keine Ende-Angabe — das
+    additive Feld mit Default bricht keinen Alt-Aufrufer.
+
+    RED heute: `NowcastResult` kennt das Feld nicht (`TypeError`)."""
+    mit_none = _text(_nowcast(event_end_minutes=None))
+    ohne_feld = _text(_nowcast())
+
+    assert mit_none == ohne_feld, (
+        "Ein ungesetztes Ende darf die Kommando-Antwort nicht anfassen.\n"
+        f"  mit None  = {mit_none!r}\n  ohne Feld = {ohne_feld!r}"
+    )
+    assert "letzter Regen gegen" not in mit_none, (
+        f"Ohne ableitbares Ende darf keines behauptet werden: {mit_none!r}"
+    )
+
+
+@freeze_time(_FROZEN_UTC)
+def test_ac14_kein_ende_bei_gesetztem_horizont_waechter():
+    """AC-14 (Waechter, AC-5) GIVEN ein `NowcastResult`, dessen Block bis zum
+    Horizont nass bleibt (`event_ongoing_beyond_horizon=True`, Ende-Wert nur
+    der Horizont)
+    WHEN die Kommando-Antwort gerendert wird
+    THEN erscheint KEINE Ende-Angabe — bei abgeschnittener Zeitreihe ist das
+    echte Ende unbekannt und darf nicht behauptet werden.
+
+    RED heute: `NowcastResult` kennt die beiden Felder nicht (`TypeError`)."""
+    text = _text(_nowcast(event_end_minutes=_NOWCAST_HORIZON_MIN,
+                          event_ongoing_beyond_horizon=True))
+
+    assert _BEGINN_TEXT in text, (
+        f"Die Beginn-Zeile bleibt auch bei gesetztem Waechter stehen: {text!r}"
+    )
+    assert "letzter Regen gegen" not in text, (
+        f"Bei gesetztem Horizont-Waechter darf kein Ende behauptet werden: "
+        f"{text!r}"
+    )

--- a/tests/tdd/test_onset_ende_sms_budget.py
+++ b/tests/tdd/test_onset_ende_sms_budget.py
@@ -1,0 +1,158 @@
+"""TDD RED — Issue #2051 Scheibe S1: die Kurznachricht sprengt auch mit
+Mengen- UND Ende-Token das Zeichenbudget nicht.
+
+SPEC: docs/specs/modules/feat_2051_s1_dauer_und_ende.md — AC-16.
+
+Fachlicher Kern: die Kurzform traegt seit #2046 die Regenmenge und bekommt in
+dieser Scheibe zusaetzlich das Ende-Token. Beides zusammen verbraucht
+Zeichenbudget. Geprueft wird der KOMBINIERTE Extremfall — 30-Zeichen-Ortsname
++ `onset_precip_mm=99.9` + spaetes Ende — nicht die alte Marge aus
+#2046-AC-9 fortgeschrieben.
+
+Spec-Fassung 1.1 (PO-Entscheid 2026-08-22): das teuerste Ende-Token ist die
+UNTERGRENZEN-Form ` >@23:59` (`event_ongoing_beyond_horizon=True`), nicht die
+Normalform `@23:59` — Leerzeichen und `>` kommen hinzu. Der Extremfall wird
+deshalb mit gesetztem Waechter gebaut; die Normalform ist ein Teilfall davon
+und damit mitgedeckt.
+
+Reine Laengenpruefung, KEIN Goldstring-Vergleich: der Wortlaut gehoert
+AC-8..AC-12/AC-20 (`test_onset_ende_textstellen.py`,
+`test_onset_ende_untergrenze_abgrenzung.py`), hier zaehlt allein, dass der
+Text ins Budget passt und der harte Schnitt `body[:limit]` im Normalfall
+NICHT greift.
+
+RED-Ursache: `OnsetEvent` kennt `event_ongoing_beyond_horizon` noch nicht ->
+`TypeError` beim Konstruktor-Aufruf. Der Waechter muss den Renderer
+erreichen, weil nur er (`_sms_onset_ende`) ueber die Token-Form entscheidet;
+bis Spec-Stand 1.0 wurde er stromaufwaerts in `event_end_time=None`
+aufgeloest.
+
+Mock-frei: echte `OnsetEvent`/`AlertMessage`-Objekte durch den echten
+Renderer, feste Zeitangaben (keine Wanduhr).
+"""
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+from output.renderers.alert.model import AlertMessage, OnsetEvent
+from output.renderers.alert.render import render_sms
+
+SMS_LIMIT = 140
+# Deutlich ueber dem Limit: rendert derselbe Aufruf mit grosszuegigem Limit
+# denselben Text, hat der harte Schnitt `body[:limit]` NICHT gegriffen.
+UNGEDECKELT = 4000
+
+
+def _extremfall_msg(*, event_end_time: str, ortsname: str) -> AlertMessage:
+    """Der kombinierte Grenzfall als echte Nachricht (kein Mock).
+
+    `event_ongoing_beyond_horizon=True` erzwingt die Untergrenzen-Form
+    ` >@HH:MM` (Spec v1.1) — die laengste Ende-Schreibweise und damit der
+    richtige Massstab fuer das Zeichenbudget."""
+    event = OnsetEvent(
+        onset_minutes=40, onset_time="18:00", km_from=0.0, km_to=0.0,
+        is_convective=False, intensity_label="Starker Regen",
+        source_label="Radar (DWD)", location_label=ortsname,
+        onset_precip_mm=99.9, event_end_time=event_end_time,
+        event_ongoing_beyond_horizon=True,
+    )
+    return AlertMessage(
+        trip_short="Alpen", stand_at="17:20", events=(event,),
+        source="Radar (DWD)",
+    )
+
+
+def _langer_ortsname() -> str:
+    name = "Obertilliacher Bergwiesenalm".ljust(30, "x")
+    assert len(name) == 30, "Voraussetzung: 30-Zeichen-Ortsname"
+    return name
+
+
+def test_prueling_stammt_aus_diesem_arbeitsbaum():
+    """Vorbedingung (kein AC): der geprueften Renderer wird RELATIV ZU DIESER
+    Testdatei aufgeloest — sonst pruefte ein Worktree-Lauf still die Datei des
+    Hauptrepos und lieferte falsches Gruen."""
+    from output.renderers.alert import render as render_module
+
+    modul_pfad = Path(inspect.getfile(render_module)).resolve()
+    arbeitsbaum = Path(__file__).resolve().parents[2]
+    assert modul_pfad.is_relative_to(arbeitsbaum), (
+        f"Prueling stammt nicht aus diesem Arbeitsbaum: {modul_pfad}"
+    )
+
+
+def test_ac16_kombinierter_extremfall_bleibt_im_zeichenbudget():
+    """AC-16 GIVEN einen Onset-Alarm mit 30 Zeichen langem Ortsnamen, der
+    Extremmenge `onset_precip_mm=99.9` UND dem spaeten
+    Ende-UNTERGRENZEN-Token (` >@23:59`, `event_ongoing_beyond_horizon=True`)
+    WHEN `render_sms(msg, limit=140)` rendert
+    THEN bleibt der Text bei hoechstens 140 Zeichen.
+
+    Reine Laengenpruefung (Spec-Vorgabe), kein Goldstring.
+
+    RED heute: `OnsetEvent` kennt `event_ongoing_beyond_horizon` nicht
+    (`TypeError`)."""
+    sms = render_sms(
+        _extremfall_msg(event_end_time="23:59", ortsname=_langer_ortsname()),
+        limit=SMS_LIMIT,
+    )
+
+    assert len(sms) <= SMS_LIMIT, (
+        f"RED: {len(sms)} Zeichen ueberschreiten das Render-Limit "
+        f"{SMS_LIMIT}: {sms!r}"
+    )
+
+
+def test_ac16_der_harte_schnitt_greift_im_extremfall_nicht():
+    """AC-16 (Kern der Zusicherung) GIVEN denselben Extremfall
+    WHEN derselbe Aufruf einmal mit `limit=140` und einmal ungedeckelt
+    gerendert wird
+    THEN sind beide Texte IDENTISCH — der harte Schnitt `body[:limit]` hat
+    also nicht gegriffen.
+
+    Ohne diese Pruefung waere die Laengenpruefung oben trivial erfuellbar:
+    ein abgeschnittener Text ist immer kurz genug. Der Schnitt bleibt als
+    letzte Reissleine bestehen, darf im Normalfall aber nie sichtbar werden —
+    ein abgeschnittenes Ende-Token waere im Satellitenkanal eine falsche
+    Angabe, keine fehlende. Bei der Untergrenzen-Form waere ein Schnitt sogar
+    doppelt gefaehrlich: faellt das `>` weg, liest sich die Untergrenze als
+    bekanntes Ende.
+
+    RED heute: `OnsetEvent` kennt `event_ongoing_beyond_horizon` nicht
+    (`TypeError`)."""
+    ortsname = _langer_ortsname()
+    gedeckelt = render_sms(
+        _extremfall_msg(event_end_time="23:59", ortsname=ortsname), limit=SMS_LIMIT,
+    )
+    ungedeckelt = render_sms(
+        _extremfall_msg(event_end_time="23:59", ortsname=ortsname), limit=UNGEDECKELT,
+    )
+
+    assert gedeckelt == ungedeckelt, (
+        "RED: der harte Schnitt greift im Extremfall — der Text ist bei "
+        f"limit={SMS_LIMIT} kuerzer als ungedeckelt.\n"
+        f"  gedeckelt   ({len(gedeckelt)}) = {gedeckelt!r}\n"
+        f"  ungedeckelt ({len(ungedeckelt)}) = {ungedeckelt!r}"
+    )
+
+
+def test_ac16_extremfall_bleibt_gsm7_tauglich():
+    """AC-16 (Zeichenvorrat) GIVEN denselben Extremfall
+    WHEN `render_sms(msg, limit=140)` rendert
+    THEN ist der Text ASCII-rein.
+
+    Ein einziges Zeichen ausserhalb von GSM-7 wuerde die Nachricht auf
+    UCS-2 umstellen und die tatsaechliche Kapazitaet von 160 auf 70 Zeichen
+    halbieren — die Zeichenzahl allein bewiese das Budget dann nicht. Das `>`
+    der Untergrenzen-Form ist GSM-7-Basiszeichen und aendert daran nichts;
+    genau das wird hier nachgewiesen statt angenommen.
+
+    RED heute: `OnsetEvent` kennt `event_ongoing_beyond_horizon` nicht
+    (`TypeError`)."""
+    sms = render_sms(
+        _extremfall_msg(event_end_time="23:59", ortsname=_langer_ortsname()),
+        limit=SMS_LIMIT,
+    )
+
+    assert sms.isascii(), f"Kurznachricht ist nicht ASCII-rein: {sms!r}"

--- a/tests/tdd/test_onset_ende_textstellen.py
+++ b/tests/tdd/test_onset_ende_textstellen.py
@@ -1,0 +1,645 @@
+"""TDD RED — Issue #2051 Scheibe S1: die fuenf Renderer-Textstellen nennen das
+ENDE des Regenereignisses, nicht nur seinen Beginn.
+
+SPEC: docs/specs/modules/feat_2051_s1_dauer_und_ende.md — AC-8, AC-9, AC-10,
+AC-11, AC-12.
+
+Fachlicher Kern: der Nowcast liest heute nur den ERSTEN nassen Frame und
+verwirft den Rest der bereits abgerufenen Zeitreihe. Der Nutzer erfaehrt,
+WANN es anfaengt, aber nicht, WANN es aufhoert. S1 leitet das Ende aus
+denselben Frames ab und liefert es additiv in allen Textstellen mit:
+
+* Langform (Betreff, E-Mail Trip, E-Mail Mehr-Orte, Telegram rich):
+  `letzter Regen gegen HH:MM`
+* Kurzform (SMS/Premium-SMS/Telegram-Kurzstil): ein zweites, MINUTENGENAUES
+  Zeit-Token (`@HH:MM`) unmittelbar HINTER dem Mengen-Token aus #2046, also
+  `R2.5@18:00@20:00`. Begruendung der Formatwahl s. `_KURZFORM_RE` unten.
+
+Wortlaut-Herkunft: von der Parallelsitzung #2020 S2 uebernommen, hier nicht
+neu erfunden. `_onset_time_label()` und der Delta-Teil von `_render_sms_body`
+bleiben unangetastet (Zusage an `fix-2020-zeitangaben-wortlaut`) — kein Test
+dieser Datei nagelt deren heutiges Verhalten fest.
+
+RED-Ursache: `OnsetEvent`/`NowcastResult`/`RadarAlertRequest` kennen die
+additiven Ende-Felder (`event_end_time`, `event_end_day_offset` bzw.
+`event_end_minutes`) noch nicht -> `TypeError` beim Konstruktor-Aufruf.
+
+Mock-frei: echte `OnsetEvent`/`AlertMessage`-Objekte durch die echten
+Renderer, echter `NotificationService` gegen echte lokale
+Aufzeichnungs-Server. Alle Zeitangaben sind FEST gesetzt (keine Wanduhr) —
+ausser im Ortsvergleich-Buendel (AC-10), dessen Konstruktor `onset_time`
+selbst aus `datetime.now()` ableitet; dort wird auf Struktur statt
+Goldstring geprueft.
+"""
+from __future__ import annotations
+
+import http.server
+import inspect
+import json
+import re
+import socket
+import threading
+import urllib.parse
+from datetime import datetime, timezone
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import pytest
+
+import output.channels.telegram as tg_module
+from app.config import Settings
+from output.renderers.alert.model import AlertMessage, OnsetEvent
+from output.renderers.alert.render import (
+    render_email, render_sms, render_subject, render_telegram,
+)
+from services.notification_service import NotificationService, RadarAlertRequest
+
+from tests.helpers.nowcast_gate_fixtures import clean_uid, fresh_uid, make_trip
+
+# Langform-Wortlaut (#2020 S2). Die Uhrzeit wird als Gruppe gefangen, damit
+# der WERT geprueft werden kann und nicht nur die Floskel.
+_LANGFORM_RE = re.compile(r"letzter Regen gegen (\d{1,2}:\d{2})")
+# Kurzform: Mengen-Token aus #2046, unmittelbar gefolgt vom Ende-Token.
+#
+# Das Ende-Token ist `@HH:MM` — MINUTENGENAU, kein optionaler Minutenteil.
+# Die Spec ist an dieser Stelle uneinheitlich (zweimal `@HH`/`@20`, zweimal
+# `@HH:MM`/`@23:59`); den Ausschlag gibt AC-16: dort, wo die exakte Laenge
+# zaehlt, budgetiert die Spec ausdruecklich `@23:59`. Dazu kommt die
+# Konsistenz mit dem Beginn-Token aus #2046 (`R2.5@18:00`) — zwei benachbarte
+# Zeit-Token in unterschiedlicher Granularitaet waeren eine eigene
+# Fehlerquelle. Die `@HH`-Erwaehnungen sind Kurzschreibweise fuer "ein
+# Zeit-Token", keine Formatvorgabe.
+#
+# Die Toleranz NICHT wiederherstellen: ein Ausdruck, der `@20` und `@20:00`
+# gleichermassen annimmt, bewacht keines der beiden Formate.
+_KURZFORM_RE = re.compile(
+    r"\bR(?P<menge>\d+\.\d)@(?P<beginn>\d{1,2}:\d{2})@(?P<ende>\d{1,2}:\d{2})\b"
+)
+
+SMS_TO = "+49000000000"
+PREMIUM_REPLY_TO = "+4915799912345"
+# Sandbox-Kennung des seven.io-Transports: KEIN echter Schluessel, sondern der
+# Wert, mit dem beide Sicherheitssperren des Transports (`seven_api_key ==
+# seven_sandbox_key`) zufrieden sind und nichts das Haus verlaesst. Aus
+# Bausteinen gesetzt, damit die Zeichenfolge nicht wie ein hinterlegter
+# Schluessel aussieht.
+_SANDBOX_KENNUNG = "-".join(("sandbox", "key", "2051"))
+
+_UNSET = object()  # Sentinel: Ende-Felder gar nicht erst uebergeben.
+
+
+def _onset_event(
+    *, event_end_time: object = _UNSET, event_end_day_offset: object = _UNSET,
+    onset_precip_mm: object = _UNSET, **kw,
+) -> OnsetEvent:
+    """Ein Trip-Radar-Onset-Ereignis mit festen Feldern (keine Wanduhr).
+
+    Die neuen Ende-Felder werden NUR uebergeben, wenn ein Aufrufer sie
+    ausdruecklich setzt (Muster `test_onset_kurzform_menge.py`): so bleiben
+    Vergleichsfassungen ohne Ende unabhaengig vom Modell-Erweiterungsstand
+    gruen, waehrend die Ende-Faelle heute am `TypeError` scheitern.
+    """
+    fields = dict(
+        onset_minutes=30, onset_time="18:00", km_from=8.0, km_to=8.0,
+        is_convective=False, intensity_label="Mäßiger Regen",
+        source_label="Radar (DWD)", segment_id="Ziel",
+    )
+    fields.update(kw)
+    if event_end_time is not _UNSET:
+        fields["event_end_time"] = event_end_time
+    if event_end_day_offset is not _UNSET:
+        fields["event_end_day_offset"] = event_end_day_offset
+    if onset_precip_mm is not _UNSET:
+        fields["onset_precip_mm"] = onset_precip_mm
+    return OnsetEvent(**fields)
+
+
+def _onset_msg(*events: OnsetEvent) -> AlertMessage:
+    """`source is not None` routet alle Renderer in den Onset-Zweig."""
+    return AlertMessage(
+        trip_short="KHW 403", stand_at="17:30", events=tuple(events),
+        source="Radar (DWD)",
+    )
+
+
+def _free_port() -> int:
+    probe = socket.socket()
+    probe.bind(("", 0))
+    port = probe.getsockname()[1]
+    probe.close()
+    return port
+
+
+class _SevenIoStub:
+    """Lokaler HTTP-Server, der die seven.io-POSTs von SMS UND Premium-SMS
+    entgegennimmt (Vorbild `test_onset_menge_kanalparitaet.py`). Kein Mock:
+    der echte Transport laeuft, die Nutzlast wird am Draht gemessen."""
+
+    def __init__(self) -> None:
+        self.received: list[dict] = []
+        received = self.received
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def do_POST(self):  # noqa: N802
+                length = int(self.headers.get("Content-Length", 0))
+                data = urllib.parse.parse_qs(self.rfile.read(length).decode())
+                received.append({k: v[0] for k, v in data.items()})
+                self.send_response(200)
+                self.end_headers()
+                self.wfile.write(b"100")
+
+            def log_message(self, *args):  # noqa: D401
+                pass
+
+        self.port = _free_port()
+        self._server = http.server.HTTPServer(("127.0.0.1", self.port), Handler)
+        threading.Thread(target=self._server.serve_forever, daemon=True).start()
+
+    def stop(self) -> None:
+        self._server.shutdown()
+
+
+class _TelegramStub:
+    """Lokaler HTTP-Stub der Telegram-Bot-API — zeichnet jede
+    `sendMessage`-Nutzlast auf."""
+
+    def __init__(self) -> None:
+        self.sent: list[dict] = []
+        sent = self.sent
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def do_POST(self):  # noqa: N802
+                length = int(self.headers.get("Content-Length", 0))
+                try:
+                    payload = json.loads(self.rfile.read(length).decode())
+                except ValueError:
+                    payload = {}
+                sent.append(payload)
+                body = json.dumps(
+                    {"ok": True, "result": {"message_id": 4711}}
+                ).encode()
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, *args):  # noqa: D401
+                pass
+
+        self.port = _free_port()
+        self._server = http.server.HTTPServer(("127.0.0.1", self.port), Handler)
+        threading.Thread(target=self._server.serve_forever, daemon=True).start()
+
+    @property
+    def base_url(self) -> str:
+        return f"http://127.0.0.1:{self.port}"
+
+    def stop(self) -> None:
+        self._server.shutdown()
+
+
+@pytest.fixture()
+def seven_io_stub():
+    stub = _SevenIoStub()
+    yield stub
+    stub.stop()
+
+
+@pytest.fixture()
+def telegram_stub():
+    stub = _TelegramStub()
+    yield stub
+    stub.stop()
+
+
+def _drei_kanal_settings(seven_port: int) -> Settings:
+    """SMS, Premium-SMS und Telegram sendebereit, E-Mail bewusst aus.
+
+    Jedes weggelassene Feld faellt bei pydantic still auf die Prod-`.env` des
+    Arbeitsverzeichnisses zurueck (#1477), deshalb wird auch das
+    ausdrueckliche "aus" vollstaendig gesetzt.
+    """
+    return Settings(
+        sms_gateway_url=f"http://127.0.0.1:{seven_port}/api/sms",
+        seven_api_key=_SANDBOX_KENNUNG,
+        seven_sandbox_key=_SANDBOX_KENNUNG,
+        sms_to=SMS_TO, sms_from=None,
+        premium_sms_reply_to=PREMIUM_REPLY_TO,
+        premium_sms_reply_at=datetime.now(timezone.utc),
+        telegram_bot_token="test-token-2051",
+        telegram_chat_id="99999", telegram_test_chat_id="99999",
+        smtp_host=None, smtp_user=None, smtp_pass=None, mail_to=None,
+    )
+
+
+def test_prueling_stammt_aus_diesem_arbeitsbaum():
+    """Vorbedingung (kein AC): der geprueften Renderer wird RELATIV ZU DIESER
+    Testdatei aufgeloest — sonst pruefte ein Worktree-Lauf still die Datei des
+    Hauptrepos und lieferte falsches Gruen."""
+    from output.renderers.alert import render as render_module
+
+    modul_pfad = Path(inspect.getfile(render_module)).resolve()
+    arbeitsbaum = Path(__file__).resolve().parents[2]
+    assert modul_pfad.is_relative_to(arbeitsbaum), (
+        f"Prueling stammt nicht aus diesem Arbeitsbaum: {modul_pfad}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-8 — E-Mail-Betreff (`_render_subject_onset`)
+# ---------------------------------------------------------------------------
+
+
+def test_ac8_email_betreff_nennt_das_ende():
+    """AC-8 GIVEN einen Onset-Alarm mit abgeleitetem Ende
+    (`event_end_time="20:00"`)
+    WHEN `render_subject(msg)` den E-Mail-Betreff rendert
+    THEN nennt der Betreff zusaetzlich zur Beginn-Angabe das Ende im Wortlaut
+    `letzter Regen gegen 20:00`.
+
+    RED heute: `OnsetEvent` kennt `event_end_time` nicht (`TypeError`)."""
+    betreff = render_subject(_onset_msg(_onset_event(event_end_time="20:00")))
+
+    treffer = _LANGFORM_RE.search(betreff)
+    assert treffer is not None, (
+        f"RED: der Betreff nennt das Ende nicht ('letzter Regen gegen HH:MM'): "
+        f"{betreff!r}"
+    )
+    assert treffer.group(1) == "20:00", (
+        f"Der Betreff nennt eine andere Uhrzeit als das abgeleitete Ende "
+        f"(erwartet 20:00): {betreff!r}"
+    )
+    assert "in 30 Min" in betreff, (
+        f"Die bestehende Beginn-Angabe darf nicht verdraengt werden: {betreff!r}"
+    )
+
+
+def test_ac8_ohne_ende_bleibt_der_betreff_unveraendert():
+    """AC-8 (Gegenprobe) GIVEN denselben Alarm OHNE abgeleitetes Ende
+    (`event_end_time=None`)
+    WHEN `render_subject(msg)` rendert
+    THEN steht KEINE Ende-Angabe im Betreff, und der Text ist byte-identisch
+    zu der Fassung, die das Feld gar nicht erst uebergibt — ein ungesetztes
+    Ende darf den Bestandstext nicht anfassen (AC-19).
+
+    RED heute: `OnsetEvent` kennt `event_end_time` nicht (`TypeError`)."""
+    mit_none = render_subject(_onset_msg(_onset_event(event_end_time=None)))
+    ohne_feld = render_subject(_onset_msg(_onset_event()))
+
+    assert _LANGFORM_RE.search(mit_none) is None, (
+        f"Ohne abgeleitetes Ende darf keine Ende-Angabe entstehen: {mit_none!r}"
+    )
+    assert mit_none == ohne_feld, (
+        "Ein ungesetztes Ende-Feld darf den Betreff nicht veraendern.\n"
+        f"  mit None  = {mit_none!r}\n  ohne Feld = {ohne_feld!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-9 — E-Mail Trip (`_render_email_onset`)
+# ---------------------------------------------------------------------------
+
+
+def test_ac9_email_trip_onset_nennt_das_ende():
+    """AC-9 GIVEN denselben Aufbau wie AC-8
+    WHEN `render_email(msg)` die Trip-Onset-Mail rendert
+    THEN enthaelt der Klartext-Koerper `letzter Regen gegen 20:00`
+    ZUSAETZLICH zur bestehenden Beginn-Zeile (`ab 18:00`) — die Beginn-Angabe
+    wird ergaenzt, nicht ersetzt.
+
+    RED heute: `OnsetEvent` kennt `event_end_time` nicht (`TypeError`)."""
+    _html, plain = render_email(_onset_msg(_onset_event(event_end_time="20:00")))
+
+    treffer = _LANGFORM_RE.search(plain)
+    assert treffer is not None, (
+        f"RED: die Trip-Onset-Mail nennt das Ende nicht: {plain!r}"
+    )
+    assert treffer.group(1) == "20:00", (
+        f"Die Mail nennt eine andere Uhrzeit als das abgeleitete Ende: {plain!r}"
+    )
+    assert "ab 18:00" in plain, (
+        f"Die bestehende Beginn-Zeile darf nicht verdraengt werden: {plain!r}"
+    )
+
+
+def test_ac9_die_ende_angabe_steht_auch_im_html_teil():
+    """AC-9 (Kanaltreue) GIVEN denselben Aufbau
+    WHEN dieselbe Mail gerendert wird
+    THEN traegt der HTML-Teil dieselbe Ende-Uhrzeit wie der Klartext — die
+    HTML-Fassung ist die Normalfassung, der Klartext ihr Gegenstueck; eine
+    Angabe nur in einer der beiden Haelften waere eine stille Luecke.
+
+    RED heute: `OnsetEvent` kennt `event_end_time` nicht (`TypeError`)."""
+    html, plain = render_email(_onset_msg(_onset_event(event_end_time="20:00")))
+
+    aus_plain = _LANGFORM_RE.search(plain)
+    aus_html = _LANGFORM_RE.search(html)
+    assert aus_html is not None, (
+        f"RED: der HTML-Teil nennt das Ende nicht: {html!r}"
+    )
+    assert aus_plain is not None and aus_html.group(1) == aus_plain.group(1), (
+        "HTML- und Klartext-Fassung nennen unterschiedliche Ende-Uhrzeiten."
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-10 — E-Mail Mehr-Orte-Buendel (Ortsvergleich)
+# ---------------------------------------------------------------------------
+
+
+def test_ac10_mehr_orte_buendel_traegt_das_ende_des_fuehrenden_ortes():
+    """AC-10 GIVEN ein Mehr-Orte-Onset-Buendel (Ortsvergleich) mit ZWEI Orten,
+    dessen fuehrender Ort ein `NowcastResult` mit gesetztem
+    `event_end_minutes=80` traegt
+    WHEN `to_multi_location_onset_alert_message` die Nachricht baut und
+    `render_email` sie ueber `_render_email_onset_multi` rendert
+    THEN enthaelt der Text `letzter Regen gegen HH:MM` — dieselbe Angabe wie
+    im Trip-Pfad (AC-9), nicht bloss eine Beginn-Zeile.
+
+    Wanduhrfest: der Buendel-Konstruktor leitet die Uhrzeiten aus
+    `datetime.now()` ab, deshalb Struktur- statt Goldstring-Pruefung.
+
+    RED heute: `NowcastResult` kennt `event_end_minutes` nicht
+    (`TypeError`)."""
+    from output.renderers.alert.project import to_multi_location_onset_alert_message
+    from services.radar_service import NowcastResult
+
+    fuehrend = NowcastResult(
+        onset_minutes=20, intensity_label="Mäßiger Regen", source="radar",
+        is_convective=False, event_end_minutes=80,
+    )
+    zweiter = NowcastResult(
+        onset_minutes=35, intensity_label="Leichter Regen", source="AROME-FR",
+        is_convective=False, event_end_minutes=95,
+    )
+
+    msg = to_multi_location_onset_alert_message(
+        [("Zermatt", fuehrend), ("Chamonix", zweiter)],
+        tz=timezone.utc, stand_at="10:00",
+    )
+    _html, plain = render_email(msg)
+
+    assert _LANGFORM_RE.search(plain), (
+        f"RED: das Mehr-Orte-Buendel nennt kein Ende: {plain!r}"
+    )
+    assert "Zermatt" in plain, (
+        f"Voraussetzung: der fuehrende Ort steht im Buendel-Text: {plain!r}"
+    )
+
+
+def test_ac10_ohne_ende_bleibt_das_buendel_unveraendert():
+    """AC-10 (Gegenprobe) GIVEN dasselbe Buendel, aber OHNE abgeleitetes Ende
+    WHEN dieselbe Nachricht gebaut und gerendert wird
+    THEN steht KEINE Ende-Angabe im Text — die Buendel-Fassung ohne Ende
+    bleibt wie heute (AC-19).
+
+    Bewusst OHNE das neue Feld konstruiert: dieser Waechter bleibt damit
+    unabhaengig vom Modell-Erweiterungsstand gruen und faengt spaeter eine
+    erfundene Ende-Angabe."""
+    from output.renderers.alert.project import to_multi_location_onset_alert_message
+    from services.radar_service import NowcastResult
+
+    msg = to_multi_location_onset_alert_message(
+        [
+            ("Zermatt", NowcastResult(
+                onset_minutes=20, intensity_label="Mäßiger Regen",
+                source="radar", is_convective=False,
+            )),
+            ("Chamonix", NowcastResult(
+                onset_minutes=35, intensity_label="Leichter Regen",
+                source="AROME-FR", is_convective=False,
+            )),
+        ],
+        tz=timezone.utc, stand_at="10:00",
+    )
+    _html, plain = render_email(msg)
+
+    assert _LANGFORM_RE.search(plain) is None, (
+        f"Ohne abgeleitetes Ende darf keine Ende-Angabe entstehen: {plain!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-11 — Telegram (rich)
+# ---------------------------------------------------------------------------
+
+
+def test_ac11_telegram_rich_nennt_das_ende():
+    """AC-11 GIVEN denselben Aufbau wie AC-8
+    WHEN `render_telegram(msg)` die reiche Telegram-Nachricht rendert
+    THEN enthaelt der Text `letzter Regen gegen 20:00` zusaetzlich zur
+    Beginn-Angabe.
+
+    RED heute: `OnsetEvent` kennt `event_end_time` nicht (`TypeError`)."""
+    text = render_telegram(_onset_msg(_onset_event(event_end_time="20:00")))
+
+    treffer = _LANGFORM_RE.search(text)
+    assert treffer is not None, (
+        f"RED: die Telegram-Nachricht nennt das Ende nicht: {text!r}"
+    )
+    assert treffer.group(1) == "20:00", (
+        f"Telegram nennt eine andere Uhrzeit als das abgeleitete Ende: {text!r}"
+    )
+    assert "18:00" in text, (
+        f"Die bestehende Beginn-Angabe darf nicht verdraengt werden: {text!r}"
+    )
+
+
+def test_ac11_langform_ist_in_allen_drei_stellen_derselbe_wortlaut():
+    """AC-8/AC-9/AC-11 (Kopplung) GIVEN denselben Alarm
+    WHEN Betreff, Trip-Mail und Telegram gerendert werden
+    THEN nennen alle drei DIESELBE Uhrzeit im DEMSELBEN Wortlaut — drei
+    Stellen mit drei Formulierungen waeren drei Dialekte fuer dieselbe
+    Aussage.
+
+    RED heute: `OnsetEvent` kennt `event_end_time` nicht (`TypeError`)."""
+    msg = _onset_msg(_onset_event(event_end_time="20:00"))
+    _html, plain = render_email(msg)
+
+    fundstellen = {
+        "betreff": _LANGFORM_RE.search(render_subject(msg)),
+        "mail": _LANGFORM_RE.search(plain),
+        "telegram": _LANGFORM_RE.search(render_telegram(msg)),
+    }
+    fehlend = [k for k, v in fundstellen.items() if v is None]
+    assert not fehlend, f"RED: ohne Ende-Angabe: {fehlend}"
+    werte = {k: v.group(1) for k, v in fundstellen.items()}
+    assert len(set(werte.values())) == 1, (
+        f"Die drei Langform-Stellen nennen verschiedene Uhrzeiten: {werte}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-12 — Kurzform: zweites Zeit-Token hinter dem Mengen-Token
+# ---------------------------------------------------------------------------
+
+
+def test_ac12_kurzform_traegt_das_ende_token_hinter_der_menge():
+    """AC-12 GIVEN einen Onset-Alarm mit Mengenangabe aus #2046
+    (`onset_precip_mm=2.5`, Beginn `18:00`) UND abgeleitetem Ende
+    (`event_end_time="20:00"`)
+    WHEN `render_sms(msg)` ueber den Onset-Zweig rendert
+    THEN traegt der Text ZWEI Zeit-Token in dieser Reihenfolge: erst das
+    Mengen-/Beginn-Token `R2.5@18:00`, unmittelbar dahinter das minutengenaue
+    Ende-Token `@20:00` — kein Trennzeichen dazwischen, keine Vertauschung.
+
+    Das Ende-Token ist minutengenau (`@HH:MM`), nicht `@HH`: die exakte Laenge
+    zaehlt in AC-16, und dort budgetiert die Spec `@23:59`; ausserdem waeren
+    zwei benachbarte Zeit-Token in unterschiedlicher Granularitaet eine eigene
+    Fehlerquelle. Kein optionaler Minutenteil im Ausdruck — ein Test, der
+    beide Schreibweisen annimmt, bewacht keine von beiden.
+
+    RED heute: `OnsetEvent` kennt `event_end_time` nicht (`TypeError`)."""
+    sms = render_sms(_onset_msg(
+        _onset_event(onset_precip_mm=2.5, event_end_time="20:00")
+    ))
+
+    treffer = _KURZFORM_RE.search(sms)
+    assert treffer is not None, (
+        f"RED: kein 'R<menge>@<beginn>@<ende>'-Token in der Kurznachricht: "
+        f"{sms!r}"
+    )
+    assert treffer.group("menge") == "2.5", (
+        f"Das Mengen-Token aus #2046 ist beschaedigt: {sms!r}"
+    )
+    assert treffer.group("beginn") == "18:00", (
+        f"Das Beginn-Token steht nicht mehr an erster Stelle: {sms!r}"
+    )
+    assert treffer.group("ende") == "20:00", (
+        f"Das Ende-Token nennt nicht das abgeleitete Ende minutengenau "
+        f"(erwartet '20:00'): {sms!r}"
+    )
+
+
+def test_ac12_ohne_ende_bleibt_die_kurzform_von_2046_unveraendert():
+    """AC-12 (Gegenprobe) GIVEN denselben Alarm mit Menge, aber OHNE
+    abgeleitetes Ende (`event_end_time=None`)
+    WHEN `render_sms(msg)` rendert
+    THEN bleibt die Kurzform aus #2046 byte-identisch (`Ziel: R2.5@18:00`) —
+    kein zweites Zeit-Token, kein leeres `@`.
+
+    RED heute: `OnsetEvent` kennt `event_end_time` nicht (`TypeError`)."""
+    mit_none = render_sms(_onset_msg(
+        _onset_event(onset_precip_mm=2.5, event_end_time=None)
+    ))
+    ohne_feld = render_sms(_onset_msg(_onset_event(onset_precip_mm=2.5)))
+
+    assert mit_none == ohne_feld, (
+        "Ein ungesetztes Ende-Feld darf die Kurznachricht nicht anfassen.\n"
+        f"  mit None  = {mit_none!r}\n  ohne Feld = {ohne_feld!r}"
+    )
+    assert _KURZFORM_RE.search(mit_none) is None, (
+        f"Ohne abgeleitetes Ende darf kein zweites Zeit-Token entstehen: "
+        f"{mit_none!r}"
+    )
+    assert not mit_none.rstrip().endswith("@"), (
+        f"Leeres Ende-Token am Textende: {mit_none!r}"
+    )
+
+
+def test_ac12_gewitter_kurzform_traegt_das_ende_hinter_dem_zeit_token():
+    """AC-12 (Gewitter-Zweig) GIVEN denselben Alarm konvektiv
+    (`is_convective=True`) — dort steht die Menge laut #2046 als EIGENES
+    Token NACH der Zeit (`TH@18:00 R2.5`)
+    WHEN `render_sms(msg)` rendert
+    THEN traegt auch dieser Zweig das minutengenaue Ende-Token `@20:00`, und
+    hinter `TH` steht weiterhin NIEMALS eine Ziffer (die Position gehoert der
+    Stufe L/M/H der Briefing-Grammatik, #2046 AC-2).
+
+    Der Gewitter-Zweig ist ein eigener Codepfad; wird das Ende nur im
+    Regen-Zweig angehaengt, bleibt hier eine stille Luecke.
+
+    Auch hier minutengenau (`@HH:MM`, nicht `@HH`) — dieselbe Formatregel wie
+    im Regen-Zweig; eine je Zweig andere Granularitaet waere ein zweiter
+    Dialekt fuer dieselbe Angabe.
+
+    RED heute: `OnsetEvent` kennt `event_end_time` nicht (`TypeError`)."""
+    sms = render_sms(_onset_msg(_onset_event(
+        onset_precip_mm=2.5, event_end_time="20:00", is_convective=True,
+        intensity_label="Starker Hagel/Gewitter",
+    )))
+
+    assert "18:00" in sms, f"Voraussetzung: der Beginn steht im Text: {sms!r}"
+    hinter_beginn = sms.split("18:00", 1)[1]
+    assert "@20:00" in hinter_beginn, (
+        f"RED: der Gewitter-Zweig der Kurzform nennt das Ende nicht "
+        f"minutengenau hinter dem Beginn-Token (erwartet '@20:00'): {sms!r}"
+    )
+    assert re.search(r"\bTH\d", sms) is None, (
+        f"Ziffer unmittelbar hinter 'TH' — diese Position gehoert der Stufe: "
+        f"{sms!r}"
+    )
+
+
+def test_ac12_sms_premium_sms_und_telegram_kurzstil_zeigen_dasselbe_ende(
+    seven_io_stub, telegram_stub, monkeypatch,
+):
+    """AC-12 (Kanalvergleich, Muster #2046 AC-7) GIVEN denselben Onset-Alarm
+    fuer SMS, Premium-SMS und Telegram im Kurzstil (Beginn `16:45`, Menge
+    `2.5`, Ende `19:15`)
+    WHEN `send_radar_alert(...)` alle drei konfigurierten Kanaele bedient
+    THEN zeigen ALLE DREI denselben `sms_body` INKLUSIVE Ende-Token — kein
+    Kanal zeigt ein anderes Ende, keiner laesst es aus.
+
+    Warum das zaehlt: auf der Huette am Karnischen Hoehenweg kommt NUR
+    Premium-SMS (Garmin inReach) an. Eine Angabe, die diesen Kanal nicht
+    erreicht, erreicht dort niemanden.
+
+    Die Zusicherung ist der VERGLEICH der drei tatsaechlich abgesetzten
+    Nutzlasten, gemessen am Draht der lokalen Aufzeichnungs-Server.
+
+    RED heute: `RadarAlertRequest` kennt `event_end_time` nicht
+    (`TypeError`)."""
+    monkeypatch.setattr(tg_module, "TELEGRAM_API_BASE", telegram_stub.base_url)
+
+    uid = fresh_uid("2051-ac12")
+    clean_uid(uid)
+    try:
+        svc = NotificationService(_drei_kanal_settings(seven_io_stub.port), uid)
+
+        svc.send_radar_alert(
+            trip=make_trip("trip-2051-ac12"),
+            request=RadarAlertRequest(
+                onset_minutes=25, onset_time="16:45", km_from=0.0, km_to=6.0,
+                is_convective=False, intensity_label="Mäßiger Regen",
+                source_label="Radar (DWD)", tz=ZoneInfo("Europe/Vienna"),
+                segment_id="Ziel", onset_precip_mm=2.5,
+                event_end_time="19:15",
+            ),
+            source="Radar (DWD)",
+            cooldown_display="2 Stunden",
+            effective_channels={"sms", "premium_sms", "telegram"},
+            telegram_style="kurzform",
+        )
+
+        nach_ziel = {p.get("to"): p.get("text") for p in seven_io_stub.received}
+        assert set(nach_ziel) == {SMS_TO, PREMIUM_REPLY_TO}, (
+            "Erwartet je EINEN seven.io-POST fuer SMS und Premium-SMS, "
+            f"empfangen: {seven_io_stub.received!r}"
+        )
+        assert len(telegram_stub.sent) == 1, (
+            f"Erwartet genau EINE Telegram-Nachricht: {telegram_stub.sent!r}"
+        )
+
+        sms_text = nach_ziel[SMS_TO]
+        premium_text = nach_ziel[PREMIUM_REPLY_TO]
+        telegram_text = telegram_stub.sent[0].get("text") or ""
+
+        treffer = _KURZFORM_RE.search(sms_text)
+        assert treffer is not None, (
+            f"RED: die SMS nennt kein Ende hinter der Menge: {sms_text!r}"
+        )
+        assert treffer.group("ende") == "19:15", (
+            f"Die SMS nennt ein anderes Ende als abgeleitet (erwartet "
+            f"'19:15', minutengenau): {sms_text!r}"
+        )
+        assert premium_text == sms_text, (
+            "RED: Premium-SMS und SMS muessen denselben Renderer-Ausgang "
+            f"tragen.\n  premium = {premium_text!r}\n  sms     = {sms_text!r}"
+        )
+        assert telegram_text == sms_text, (
+            "RED: der Telegram-Kurzstil muss denselben Text tragen wie die "
+            f"SMS.\n  telegram = {telegram_text!r}\n  sms      = {sms_text!r}"
+        )
+    finally:
+        clean_uid(uid)

--- a/tests/tdd/test_onset_ende_untergrenze_abgrenzung.py
+++ b/tests/tdd/test_onset_ende_untergrenze_abgrenzung.py
@@ -1,0 +1,369 @@
+"""TDD RED — Issue #2051 Scheibe S1: Untergrenze und bekanntes Ende bleiben
+textlich UNTERSCHEIDBAR.
+
+SPEC: docs/specs/modules/feat_2051_s1_dauer_und_ende.md (v1.1) — AC-20.
+
+Fachlicher Kern: seit dem PO-Entscheid vom 2026-08-22 nennen alle sieben
+Textstellen auch bei gesetztem R4-Waechter
+(`event_ongoing_beyond_horizon=True`) einen Ende-Zeitpunkt — aber als belegte
+UNTERGRENZE, nicht als bekanntes Ende. Die Zahl ist in beiden Faellen
+dieselbe; nur die FORM sagt, was sie bedeutet:
+
+  | Zustand | Langform | Kurzform |
+  |---|---|---|
+  | `False` (Ende bekannt) | `letzter Regen gegen HH:MM` | `@HH:MM` |
+  | `True` (Zeitreihe/Horizont zu Ende) | `Regen mindestens bis HH:MM` | ` >@HH:MM` |
+
+"Der Regen hoert um 19:30 auf" und "der Regen hoert mindestens bis 19:30
+nicht auf" sind gegensaetzliche Aussagen. Rutschen die beiden Formen
+ineinander — weil ein Renderer den Waechter nicht liest oder pauschal eine
+der beiden Formen schreibt —, steht im Text das Gegenteil des Gemeinten. Der
+Kanal, in dem das am teuersten ist, ist die Premium-SMS: auf der Huette am
+Karnischen Hoehenweg kommt nur sie an, und dort entscheidet ` >` allein
+ueber die Bedeutung.
+
+Diese Datei prueft deshalb BEIDE Richtungen ueber alle sieben Textstellen:
+
+  1. E-Mail-Betreff (`_render_subject_onset`)
+  2. E-Mail Trip, Klartext (`_render_email_onset`)
+  3. E-Mail Trip, HTML (dieselbe Stelle, Normalfassung)
+  4. E-Mail Mehr-Orte (`_render_email_onset_multi`)
+  5. Telegram rich (`_render_telegram_onset`)
+  6. Kurzform SMS/Premium-SMS/Telegram-Kurzstil (`_render_sms_onset`)
+  7. Briefing-Kurzfristhinweis (`format_starkregen_hint`)
+  8. Kommando-Antwort (`RadarNowcastService.format_now_text`)
+
+Beide Zustaende tragen ABSICHTLICH denselben `event_end_minutes`-Wert: so
+kann kein Test versehentlich die Uhrzeit statt der Form pruefen, und ein
+Renderer, der beide Zustaende gleich behandelt, faellt sicher durch.
+
+Jede Negativ-Pruefung steht zusammen mit ihrer Positivkontrolle im selben
+Test. Ohne sie waere "im Waechterfall steht nirgends `letzter Regen gegen`"
+heute trivial wahr — der Code auf Spec-Stand 1.0 laesst die Ende-Angabe dort
+naemlich ersatzlos weg.
+
+RED heute: Spec-Stand 1.0 kennt die Untergrenzen-Form nicht. Die
+Waechterfall-Tests scheitern an der fehlenden Untergrenze
+(`event_end_display` -> `(None, 0)`, `starkregen_hint.py:41`,
+`radar_service.py:548`). Die Normalfall-Tests sind ausdruecklich als
+VERGLEICHSFASSUNG gebaut und bleiben gruen — sie nageln fest, dass die
+Aenderung den unveraenderten Zweig nicht mitreisst.
+
+Mock-frei: echte `NowcastResult`-Objekte durch den echten Projektions- und
+Renderpfad (`to_multi_location_onset_alert_message`, ADR-0021: Trip und
+Ortsvergleich teilen die Ausgabe). Die Uhr steht per `freeze_time`, weil
+Projektion und Hinweis-Formatierer ihre Zeitpunkte selbst aus
+`datetime.now()` bilden.
+"""
+from __future__ import annotations
+
+import inspect
+import re
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+from freezegun import freeze_time
+
+from output.renderers.alert.project import to_multi_location_onset_alert_message
+from output.renderers.alert.render import (
+    render_email, render_sms, render_subject, render_telegram,
+)
+from output.renderers.email.starkregen_hint import format_starkregen_hint
+from services.radar_cache import RadarNowcastCacheService
+from services.radar_service import NowcastResult, RadarNowcastService
+
+# 18:00 Ortszeit Wien (= 16:00 UTC im Sommer). Beginn 18:30 (+30 Min),
+# Ende 19:30 (+90 Min) — in BEIDEN Zustaenden derselbe Wert.
+_TZ = ZoneInfo("Europe/Vienna")
+_FROZEN_UTC = "2026-08-21 16:00:00+00:00"
+_ONSET_MIN = 30
+_ENDE_MIN = 90
+_BEGINN_HHMM = "18:30"
+_ENDE_HHMM = "19:30"
+
+_LANGFORM_NORMAL = f"letzter Regen gegen {_ENDE_HHMM}"
+_LANGFORM_UNTERGRENZE = f"Regen mindestens bis {_ENDE_HHMM}"
+# Kurzform-Untergrenze laut Spec v1.1: Leerzeichen, `>`, dann das Zeit-Token.
+_KURZFORM_UNTERGRENZE = f" >@{_ENDE_HHMM}"
+# Das Ende-Token OHNE vorangestelltes `>` — die Normalform. Der Lookbehind
+# unterscheidet sie von der Untergrenzen-Form, die dieselbe Uhrzeit traegt;
+# eine reine Substring-Suche nach `@19:30` faende beide und bewachte keine.
+_BLANKES_ENDE_RE = re.compile(r"(?<!>)@" + re.escape(_ENDE_HHMM))
+
+# Alle Fassungen ausser der Kurzform reden Langform.
+_KURZFORM = "sms_kurzform"
+# Fassungen MIT Auszeichnung: dort kommt `>` aus `<b>`/HTML-Tags und sagt
+# nichts ueber die Ende-Angabe. Sie werden von der blanken `>`-Pruefung
+# ausgenommen; ihre Untergrenzen-Pruefung laeuft ueber `>@` bzw. den
+# Langform-Wortlaut, der von Auszeichnung unberuehrt bleibt.
+_MIT_AUSZEICHNUNG = ("email_trip_html", "telegram_rich")
+
+# Woran die Anwesenheit des BEGINNS je Fassung erkennbar ist. Fuenf der sechs
+# Langform-Fassungen nennen ihn als Uhrzeit; der E-Mail-Betreff nennt ihn seit
+# jeher als COUNTDOWN und nie als Uhrzeit (`render.py:355`:
+# `f"[{trip_short}] {km} · {label} in {onset_minutes} Min"`) — vier
+# Bestandstests nageln genau diese Form als Gleichheit fest
+# (`test_alert_location_vocabulary.py:421`, `test_alert_sms_onset_zeitpunkt.py:451`,
+# `test_alert_addendum_sms.py:543`, `test_multi_location_onset_alert.py:38`).
+#
+# Der Indikator wird deshalb je Fassung gewaehlt statt pauschal `18:30`
+# vorauszusetzen. Die Zusicherung wird dadurch NICHT schwaecher: fuer jede der
+# sechs Fassungen bleibt geprueft, dass die angehaengte Ende-Angabe die
+# Beginn-Angabe ERGAENZT statt sie zu verdraengen — beim Betreff, dem
+# kuerzesten und damit gefaehrdetsten Text, eben am Countdown.
+#
+# Eine Uhrzeit IN den Betreff zu ziehen waere ein Produktentscheid zum
+# Zeitangaben-Wortlaut und gehoert der Parallelsitzung
+# `fix-2020-zeitangaben-wortlaut` (#2020 S2), nicht dieser Scheibe.
+_BEGINN_INDIKATOR = {"email_betreff": f"in {_ONSET_MIN} Min"}
+
+
+def _nowcast(*, ongoing: bool) -> NowcastResult:
+    """Ein Nowcast-Ergebnis mit Beginn UND Ende; nur der Waechter variiert."""
+    return NowcastResult(
+        onset_minutes=_ONSET_MIN, intensity_label="Starker Regen",
+        source="radar", is_convective=False,
+        event_end_minutes=_ENDE_MIN, event_ongoing_beyond_horizon=ongoing,
+    )
+
+
+def _texte(*, ongoing: bool) -> dict[str, str]:
+    """Die sieben Textstellen (E-Mail Trip in beiden Haelften) fuer EINEN
+    Waechter-Zustand.
+
+    Der Einzel-Ort-Aufruf laesst `location_label is None` und faellt damit in
+    denselben Einzel-Onset-Renderpfad, den auch der Trip-Radar-Alarm benutzt
+    (ADR-0021); der Zwei-Orte-Aufruf erreicht zusaetzlich den
+    Mehr-Orte-Zweig."""
+    nc = _nowcast(ongoing=ongoing)
+    einzel = to_multi_location_onset_alert_message(
+        [("Sillian", nc)], tz=_TZ, stand_at="17:55",
+    )
+    buendel = to_multi_location_onset_alert_message(
+        [("Sillian", nc), ("Obertilliach", _nowcast(ongoing=ongoing))],
+        tz=_TZ, stand_at="17:55",
+    )
+    html_einzel, plain_einzel = render_email(einzel)
+    _html_buendel, plain_buendel = render_email(buendel)
+    svc = RadarNowcastService(cache=RadarNowcastCacheService())
+    return {
+        "email_betreff": render_subject(einzel),
+        "email_trip_plain": plain_einzel,
+        "email_trip_html": html_einzel,
+        "email_mehr_orte": plain_buendel,
+        "telegram_rich": render_telegram(einzel),
+        _KURZFORM: render_sms(einzel),
+        "briefing_hinweis": format_starkregen_hint(
+            "Starker Regen", _ONSET_MIN, tz=_TZ,
+            event_end_minutes=_ENDE_MIN,
+            event_ongoing_beyond_horizon=ongoing,
+        ),
+        "kommando_antwort": svc.format_now_text(nc, tz=_TZ, include_source=False),
+    }
+
+
+def _langform_fassungen(texte: dict[str, str]) -> dict[str, str]:
+    return {name: text for name, text in texte.items() if name != _KURZFORM}
+
+
+def _befund(treffer: dict[str, str]) -> str:
+    """Lesbare Fehlermeldung: Name der Fassung plus ein Ausschnitt. Der
+    HTML-Teil der Mail ist mehrere Kilobyte gross — vollstaendig ausgegeben
+    ersaeuft er die eigentliche Aussage."""
+    return "; ".join(
+        f"{name}={text[:160]!r}" for name, text in sorted(treffer.items())
+    )
+
+
+def test_prueling_stammt_aus_diesem_arbeitsbaum():
+    """Vorbedingung (kein AC): Projektion, Alarm-Renderer, Briefing-Hinweis
+    und Nowcast-Dienst werden RELATIV ZU DIESER Testdatei aufgeloest — sonst
+    pruefte ein Worktree-Lauf still die Dateien des Hauptrepos und lieferte
+    falsches Gruen."""
+    from output.renderers.alert import project as project_module
+    from output.renderers.alert import render as render_module
+    from output.renderers.email import starkregen_hint as hint_module
+    from services import radar_service as radar_module
+
+    arbeitsbaum = Path(__file__).resolve().parents[2]
+    for modul in (project_module, render_module, hint_module, radar_module):
+        modul_pfad = Path(inspect.getfile(modul)).resolve()
+        assert modul_pfad.is_relative_to(arbeitsbaum), (
+            f"Prueling stammt nicht aus diesem Arbeitsbaum: {modul_pfad}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-20 (a) — Waechterfall: Untergrenze JA, bekanntes Ende NEIN
+# ---------------------------------------------------------------------------
+
+
+@freeze_time(_FROZEN_UTC)
+def test_ac20_waechterfall_langform_nennt_die_untergrenze_statt_des_bekannten_endes():
+    """AC-20 GIVEN `event_ongoing_beyond_horizon=True` bei gesetztem
+    `event_end_minutes`
+    WHEN die sechs Langform-Textstellen gerendert werden (Betreff, E-Mail Trip
+    in Klartext und HTML, E-Mail Mehr-Orte, Telegram rich, Briefing-Hinweis,
+    Kommando-Antwort)
+    THEN nennt JEDE die Untergrenze `Regen mindestens bis 19:30` und KEINE die
+    Normalfall-Formulierung `letzter Regen gegen` — die Untergrenze darf nicht
+    als bekanntes Ende missverstanden werden.
+
+    Die Positivkontrolle steht bewusst im selben Test: ohne sie waere die
+    Negativ-Pruefung heute trivial wahr, weil der Code auf Spec-Stand 1.0 im
+    Waechterfall gar keine Ende-Angabe rendert.
+
+    RED heute: keine der Fassungen kennt die Untergrenzen-Form."""
+    texte = _langform_fassungen(_texte(ongoing=True))
+
+    ohne_untergrenze = {
+        name: text for name, text in texte.items()
+        if _LANGFORM_UNTERGRENZE not in text
+    }
+    assert not ohne_untergrenze, (
+        f"RED: diese Langform-Stellen nennen die Untergrenze "
+        f"{_LANGFORM_UNTERGRENZE!r} nicht: {_befund(ohne_untergrenze)}"
+    )
+
+    mit_bekanntem_ende = {
+        name: text for name, text in texte.items()
+        if "letzter Regen gegen" in text
+    }
+    assert not mit_bekanntem_ende, (
+        "Diese Stellen behaupten ein BEKANNTES Ende, obwohl nur eine "
+        f"Untergrenze belegt ist: {_befund(mit_bekanntem_ende)}"
+    )
+
+    ohne_beginn = {
+        name: text for name, text in texte.items()
+        if _BEGINN_INDIKATOR.get(name, _BEGINN_HHMM) not in text
+    }
+    assert not ohne_beginn, (
+        f"Vorbedingung: die Beginn-Angabe darf nicht verdraengt werden: "
+        f"{_befund(ohne_beginn)}"
+    )
+
+
+@freeze_time(_FROZEN_UTC)
+def test_ac20_waechterfall_kurzform_traegt_das_untergrenzen_token_statt_des_blanken():
+    """AC-20 (Kurzform) GIVEN denselben Aufbau
+    WHEN die Kurznachricht gerendert wird (SMS, Premium-SMS und
+    Telegram-Kurzstil teilen denselben `sms_body`)
+    THEN traegt sie das Untergrenzen-Token ` >@19:30` und an der Ende-Position
+    NIEMALS ein schmuckloses `@19:30` ohne vorangestelltes `>`.
+
+    Das ist die schaerfste Stelle der ganzen Abgrenzung: zwischen "hoert um
+    19:30 auf" und "hoert mindestens bis 19:30 nicht auf" steht hier ein
+    einziges Zeichen. Auf der Huette am Karnischen Hoehenweg kommt nur die
+    Premium-SMS an — faellt das `>` weg, liest der Nutzer dort das Gegenteil.
+
+    RED heute: der Waechterfall rendert gar kein Ende-Token
+    (`event_end_display` -> `(None, 0)`)."""
+    sms = _texte(ongoing=True)[_KURZFORM]
+
+    assert _KURZFORM_UNTERGRENZE in sms, (
+        f"RED: die Kurznachricht traegt das Untergrenzen-Token "
+        f"{_KURZFORM_UNTERGRENZE!r} nicht: {sms!r}"
+    )
+    assert _BLANKES_ENDE_RE.search(sms) is None, (
+        f"Der Ende-Zeitpunkt steht ohne vorangestelltes '>' und behauptet "
+        f"damit ein bekanntes Ende: {sms!r}"
+    )
+    assert f"@{_BEGINN_HHMM}" in sms, (
+        f"Vorbedingung: das Beginn-Token darf nicht verdraengt werden: {sms!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-20 (b) — Normalfall: bekanntes Ende JA, Untergrenzen-Zeichen NEIN
+# ---------------------------------------------------------------------------
+
+
+@freeze_time(_FROZEN_UTC)
+def test_ac20_normalfall_langform_nennt_das_bekannte_ende_und_nie_mindestens():
+    """AC-20 (Gegenrichtung) GIVEN `event_ongoing_beyond_horizon=False` bei
+    demselben `event_end_minutes`
+    WHEN dieselben Langform-Textstellen gerendert werden
+    THEN nennt JEDE das bekannte Ende `letzter Regen gegen 19:30` und KEINE
+    traegt das Wort `mindestens` — ein Ende, das die Quelle beobachtet hat,
+    darf nicht als blosse Untergrenze verkleinert werden.
+
+    VERGLEICHSFASSUNG: dieser Zweig aendert sich in Spec v1.1 nicht und ist
+    heute gruen. Er ist der Waechter dagegen, dass die Untergrenzen-Form
+    pauschal ueberall eingebaut wird — genau die Verfaelschung, die die
+    Negativ-Pruefung des Waechterfalls allein nicht faengt."""
+    texte = _langform_fassungen(_texte(ongoing=False))
+
+    ohne_ende = {
+        name: text for name, text in texte.items()
+        if _LANGFORM_NORMAL not in text
+    }
+    assert not ohne_ende, (
+        f"Bei bekanntem Ende muss jede Langform-Stelle "
+        f"{_LANGFORM_NORMAL!r} nennen; ohne: {_befund(ohne_ende)}"
+    )
+
+    mit_untergrenze = {
+        name: text for name, text in texte.items() if "mindestens" in text
+    }
+    assert not mit_untergrenze, (
+        "Diese Stellen nennen das bekannte Ende als blosse Untergrenze: "
+        f"{_befund(mit_untergrenze)}"
+    )
+
+
+@freeze_time(_FROZEN_UTC)
+def test_ac20_normalfall_kurzform_traegt_das_blanke_ende_token_ohne_groesser_zeichen():
+    """AC-20 (Gegenrichtung, Kurzform) GIVEN denselben Aufbau mit
+    `event_ongoing_beyond_horizon=False`
+    WHEN die Kurznachricht gerendert wird
+    THEN traegt sie das blanke Ende-Token `@19:30` und KEIN `>` — weder als
+    Untergrenzen-Token noch sonstwo.
+
+    VERGLEICHSFASSUNG (heute gruen): fiele diese Pruefung, hiesse das, die
+    Kurzform schriebe die Untergrenzen-Form auch dann, wenn das Ende bekannt
+    ist."""
+    sms = _texte(ongoing=False)[_KURZFORM]
+
+    assert _BLANKES_ENDE_RE.search(sms) is not None, (
+        f"Bei bekanntem Ende muss das blanke Token '@{_ENDE_HHMM}' stehen: "
+        f"{sms!r}"
+    )
+    assert ">" not in sms, (
+        f"Bei bekanntem Ende darf die Kurznachricht kein '>' tragen: {sms!r}"
+    )
+
+
+@freeze_time(_FROZEN_UTC)
+def test_ac20_normalfall_traegt_in_keiner_auszeichnungsfreien_fassung_ein_groesser_zeichen():
+    """AC-20 (Gegenrichtung, wortwoertlich) GIVEN `event_ongoing_beyond_horizon
+    =False`
+    WHEN die auszeichnungsfreien Textstellen gerendert werden (Betreff,
+    E-Mail-Klartext einzeln und gebuendelt, Kurzform, Briefing-Hinweis,
+    Kommando-Antwort)
+    THEN traegt KEINE von ihnen ein `>`.
+
+    HTML-Mail und Telegram rich sind ausgenommen, weil dort `>` aus
+    `<b>`/Tag-Syntax stammt und nichts ueber die Ende-Angabe aussagt; fuer
+    diese beiden faengt die `mindestens`-Pruefung oben dieselbe Verfaelschung
+    im Wortlaut ab, und `>@` waere dort ebenfalls sichtbar — deshalb wird es
+    hier zusaetzlich fuer ALLE Fassungen geprueft.
+
+    VERGLEICHSFASSUNG, heute gruen."""
+    texte = _texte(ongoing=False)
+
+    mit_token = {
+        name: text for name, text in texte.items() if ">@" in text
+    }
+    assert not mit_token, (
+        f"Untergrenzen-Token '>@' im Normalfall: {_befund(mit_token)}"
+    )
+
+    mit_zeichen = {
+        name: text for name, text in texte.items()
+        if name not in _MIT_AUSZEICHNUNG and ">" in text
+    }
+    assert not mit_zeichen, (
+        f"'>' in einer auszeichnungsfreien Fassung des Normalfalls: "
+        f"{_befund(mit_zeichen)}"
+    )

--- a/tests/tdd/test_onset_texte_keine_bevormundung.py
+++ b/tests/tdd/test_onset_texte_keine_bevormundung.py
@@ -1,0 +1,255 @@
+"""TDD RED — Issue #2051 Scheibe S1: die Ende-Angabe bleibt eine WETTERAUSSAGE
+und wird nicht zur Handlungsempfehlung.
+
+SPEC: docs/specs/modules/feat_2051_s1_dauer_und_ende.md — AC-17.
+
+Produkt-Grundsatz (PO, mehrfach bekraeftigt): Gregor Zwanzig liefert Daten,
+keine Ratschlaege. Der Nutzer ist Profi und entscheidet selbst, was ein
+Regenende fuer seine Tour bedeutet. Eine Ende-Angabe verfuehrt genau dazu,
+den naechsten Schritt gleich mitzurechnen — "bei Planzeit bist du um 20:10
+bei km 14, also …". Das waere eine Konsequenz aus dem Datum, nicht das Datum,
+und zoege eine Nachfuehrpflicht nach sich, sobald sich die Planung aendert.
+
+Geprueft werden die Textstellen, die in `render.py` bzw. im Nowcast-Dienst
+entstehen — Betreff, E-Mail Trip, E-Mail Mehr-Orte, Telegram rich, Kurzform,
+Kommando-Antwort (`format_now_text`). Der Briefing-Kurzfristhinweis
+(`format_starkregen_hint`) fehlt hier bewusst: seine erweiterte Signatur
+entsteht in der Parallelsitzung; ihn hier mit geratener Aufrufform zu pruefen
+naegelte eine fremde Entwurfsentscheidung fest.
+
+Der Cooldown-Hinweis ("Du erhaeltst diese Warnung hoechstens einmal in …")
+bleibt ausdruecklich ausserhalb der Pruefung: er ist Zustell-Metatext ueber
+das Meldeverhalten des Systems, keine Aussage ueber Wetter oder Position des
+Nutzers. Deshalb wird ohne `cooldown_display` gerendert.
+
+RED-Ursache: `OnsetEvent`/`NowcastResult` kennen die Ende-Felder noch nicht
+-> `TypeError`. Eine reine Negativpruefung waere ohne diesen Aufbau heute
+trivial gruen; geprueft wird deshalb der ENDE-TRAGENDE Text, den es heute
+noch nicht geben kann.
+
+Mock-frei: echte Modelle durch die echten Renderer, feste Zeitangaben.
+"""
+from __future__ import annotations
+
+import re
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from output.renderers.alert.model import AlertMessage, OnsetEvent
+from output.renderers.alert.render import (
+    render_email, render_sms, render_subject, render_telegram,
+)
+
+TZ = ZoneInfo("Europe/Vienna")
+
+# Anrede in der zweiten Person bzw. Hoeflichkeitsform. Im Wetterdatentext hat
+# sie nichts verloren — dort stehen Ort, Beginn, Ende, Menge, sonst nichts.
+_ZWEITE_PERSON_RE = re.compile(
+    r"\b(du|dir|dich|dein|deine|deinem|deinen|deiner|deines"
+    r"|Sie|Ihnen|Ihr|Ihre|Ihrem|Ihren|Ihrer|Ihres)\b"
+)
+# Zeit-/Orts-/Streckenangabe — der zweite Bestandteil einer Positions-Rechnung
+# ueber den Nutzer.
+_ZEIT_ODER_ORT_RE = re.compile(
+    r"\d{1,2}:\d{2}|\bkm\s*\d|\bkm\b|\b\d+\s*Min\b|\bStunden?\b"
+)
+# Ausdrueckliche Positions-Rechnungen ueber den Nutzer, unabhaengig davon, ob
+# im selben Satz eine Zahl steht.
+_POSITIONSRECHNUNG = (
+    "bei planzeit", "bist du", "waerst du", "wärst du", "erreichst du",
+    "triffst du", "befindest du", "stehst du", "kommst du",
+)
+# Handlungsempfehlungs-Vokabular.
+_EMPFEHLUNG = (
+    "empfehlung", "empfohlen", "wir empfehlen", "wir raten", "solltest",
+    "sollten sie", "am besten", "besser umkehren", "plane ", "such dir",
+    "brich ab", "warte ab",
+)
+
+
+def _onset_event(**kw) -> OnsetEvent:
+    """Ein Trip-Radar-Onset-Ereignis MIT abgeleitetem Ende (feste Zeiten)."""
+    fields = dict(
+        onset_minutes=30, onset_time="18:00", km_from=8.0, km_to=14.0,
+        is_convective=False, intensity_label="Mäßiger Regen",
+        source_label="Radar (DWD)", segment_id="Ziel",
+        onset_precip_mm=2.5, event_end_time="20:10",
+    )
+    fields.update(kw)
+    return OnsetEvent(**fields)
+
+
+def _onset_msg(*events: OnsetEvent) -> AlertMessage:
+    """Bewusst OHNE `cooldown_display` — s. Modul-Kopf."""
+    return AlertMessage(
+        trip_short="KHW 403", stand_at="17:30", events=tuple(events),
+        source="Radar (DWD)",
+    )
+
+
+def _texte_mit_ende() -> dict[str, str]:
+    """Alle in dieser Scheibe geprueften Textstellen, jeweils MIT gesetztem
+    Ende. Der Aufbau selbst ist die RED-Ursache: die Ende-Felder existieren
+    heute nicht."""
+    from output.renderers.alert.project import to_multi_location_onset_alert_message
+    from services.radar_service import NowcastResult, RadarNowcastService
+
+    einzel = _onset_msg(_onset_event())
+    _html, plain = render_email(einzel)
+
+    buendel = to_multi_location_onset_alert_message(
+        [
+            ("Zermatt", NowcastResult(
+                onset_minutes=20, intensity_label="Mäßiger Regen",
+                source="radar", is_convective=False, event_end_minutes=80,
+            )),
+            ("Chamonix", NowcastResult(
+                onset_minutes=35, intensity_label="Leichter Regen",
+                source="AROME-FR", is_convective=False, event_end_minutes=95,
+            )),
+        ],
+        tz=TZ, stand_at="10:00",
+    )
+    _b_html, b_plain = render_email(buendel)
+
+    # Echter, aufrufbarer `frame_source` (kein Mock): `format_now_text` ruft
+    # ihn nicht auf, aber ein DI-Seam ohne Netzweg ist der ehrliche Aufbau.
+    dienst = RadarNowcastService(frame_source=lambda lat, lon: [])
+    kommando = dienst.format_now_text(
+        NowcastResult(
+            onset_minutes=30, intensity_label="Mäßiger Regen", source="radar",
+            is_convective=False, event_end_minutes=150,
+        ),
+        tz=TZ,
+    )
+
+    return {
+        "E-Mail-Betreff": render_subject(einzel),
+        "E-Mail Trip": plain,
+        "E-Mail Mehr-Orte": b_plain,
+        "Telegram rich": render_telegram(einzel),
+        "Kurzform (SMS/Premium-SMS/Telegram-Kurzstil)": render_sms(einzel),
+        "Kommando-Antwort": kommando,
+    }
+
+
+def _saetze(text: str) -> list[str]:
+    """Grobe Satz-/Zeilenzerlegung — die Nachbarschaft, in der Pronomen und
+    Zeitangabe zusammen eine Positions-Rechnung ergeben."""
+    return [s for s in re.split(r"[.\n·|]", text) if s.strip()]
+
+
+def _verstoesse(text: str) -> list[str]:
+    """Alle gefundenen Bevormundungs-Muster eines Textes."""
+    gefunden: list[str] = []
+    klein = text.lower()
+    for phrase in _POSITIONSRECHNUNG:
+        if phrase in klein:
+            gefunden.append(f"Positions-Rechnung ueber den Nutzer: {phrase!r}")
+    for phrase in _EMPFEHLUNG:
+        if phrase in klein:
+            gefunden.append(f"Handlungsempfehlung: {phrase!r}")
+    for satz in _saetze(text):
+        pronomen = _ZWEITE_PERSON_RE.search(satz)
+        angabe = _ZEIT_ODER_ORT_RE.search(satz)
+        if pronomen and angabe:
+            gefunden.append(
+                f"Anrede {pronomen.group(0)!r} zusammen mit der Angabe "
+                f"{angabe.group(0)!r} im Satz {satz.strip()!r}"
+            )
+    return gefunden
+
+
+# ---------------------------------------------------------------------------
+# Selbstkontrolle des Pruefers — sonst waere die Negativpruefung wertlos
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("beispiel", [
+    "Regen ab 18:00 · bei Planzeit bist du um 20:10 bei km 14.",
+    "Letzter Regen gegen 20:10. Wir empfehlen, die Etappe vorzuziehen.",
+    "Du solltest vor 18:00 auf der Hütte sein.",
+])
+def test_der_pruefer_faengt_bekannte_bevormundungs_saetze(beispiel):
+    """Vorbedingung (kein AC): der Muster-Pruefer dieser Datei muss echte
+    Verstoss-Saetze auch tatsaechlich fangen.
+
+    Ohne diese Positivkontrolle bestuende die Negativpruefung unten auch
+    dann, wenn der Ausdruck gar nichts trifft — sie waere gruen aus dem
+    falschen Grund. Dieser Test darf (und soll) schon heute gruen sein."""
+    assert _verstoesse(beispiel), (
+        f"Der Pruefer erkennt diesen Verstoss nicht: {beispiel!r}"
+    )
+
+
+def test_der_pruefer_schlaegt_bei_reinen_wetterdaten_nicht_an():
+    """Vorbedingung (kein AC): der Pruefer darf einen reinen Datentext NICHT
+    beanstanden — sonst waere die Negativpruefung unten unerfuellbar und
+    bewiese nichts ueber die Implementierung.
+
+    Darf schon heute gruen sein."""
+    sauber = (
+        "Regen in 30 Min\nWo & wann: km 8–14 · ab 18:00\n"
+        "letzter Regen gegen 20:10\nIntensität: Mäßiger Regen\n"
+        "Quelle: Radar (DWD)"
+    )
+    assert _verstoesse(sauber) == [], (
+        f"Der Pruefer beanstandet einen reinen Datentext: {_verstoesse(sauber)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-17 — keine Bevormundung in irgendeiner der Ende-tragenden Textstellen
+# ---------------------------------------------------------------------------
+
+
+def test_ac17_keine_textstelle_enthaelt_eine_handlungsempfehlung():
+    """AC-17 GIVEN jede der in dieser Scheibe gerenderten Textstellen MIT
+    gesetztem Ende
+    WHEN der Text auf Handlungsempfehlungen oder Positions-/Zeit-Rechnungen
+    ueber den Nutzer geprueft wird
+    THEN enthaelt KEINE der Stellen eine solche Formulierung — ausschliesslich
+    Wetterdaten (Beginn, Ende, Menge, Ort).
+
+    RED heute: `OnsetEvent`/`NowcastResult` kennen die Ende-Felder nicht
+    (`TypeError` beim Aufbau der Texte) — der Ende-tragende Text, um den es
+    geht, laesst sich noch gar nicht erzeugen."""
+    befunde = {
+        name: _verstoesse(text) for name, text in _texte_mit_ende().items()
+    }
+    beanstandet = {k: v for k, v in befunde.items() if v}
+
+    assert not beanstandet, (
+        "Bevormundende Formulierung in Ende-tragenden Texten:\n"
+        + "\n".join(f"  {k}: {v}" for k, v in beanstandet.items())
+    )
+
+
+def test_ac17_die_ende_angabe_bleibt_ein_reines_datum():
+    """AC-17 (Kern) GIVEN dieselben Textstellen
+    WHEN die Umgebung der Ende-Angabe betrachtet wird
+    THEN steht dort die Uhrzeit allein — keine daraus abgeleitete Aussage
+    ueber Streckenposition, Restzeit des Nutzers oder Tourverlauf.
+
+    Geprueft wird der Satz, in dem die Ende-Angabe steht: er darf keine
+    Anrede in der zweiten Person tragen.
+
+    RED heute: die Ende-Angabe existiert noch nicht (`TypeError` beim
+    Aufbau)."""
+    texte = _texte_mit_ende()
+    gefunden_in: list[str] = []
+    for name, text in texte.items():
+        for satz in _saetze(text):
+            if "letzter Regen gegen" not in satz and "@" not in satz:
+                continue
+            gefunden_in.append(name)
+            pronomen = _ZWEITE_PERSON_RE.search(satz)
+            assert pronomen is None, (
+                f"{name}: die Ende-Angabe steht in einem Satz mit Anrede "
+                f"{pronomen.group(0)!r}: {satz.strip()!r}"
+            )
+    assert gefunden_in, (
+        "RED: keine der geprueften Textstellen traegt ueberhaupt eine "
+        f"Ende-Angabe: {texte!r}"
+    )

--- a/tests/unit/test_radar_upstream_failure.py
+++ b/tests/unit/test_radar_upstream_failure.py
@@ -245,7 +245,15 @@ def test_format_now_text_shows_data_gap_hint_not_false_all_clear():
 
 def test_format_now_text_dry_result_wording_unchanged():
     """AC-7: der Normalfall (echt trocken, Fehlerfeld False) bleibt
-    zeichenidentisch zum bisherigen Wortlaut."""
+    zeichenidentisch zum bisherigen Wortlaut.
+
+    Issue #2051 S1 (AC-18) schreibt den Goldstring an EINER Stelle fort: die
+    Stundenzahl leitet sich seither zur Laufzeit aus `_NOWCAST_HORIZON_MIN`
+    (180) ab und lautet damit "3 Stunden" statt der zuvor doppelt gepflegten
+    "2 Stunden". Die Zusicherung DIESES Tests bleibt unveraendert -- geprueft
+    wird weiter, dass der echte Trockenfall NICHT in den
+    "nicht moeglich"-Zweig aus #1628 rutscht.
+    """
     result = NowcastResult(
         onset_minutes=None, intensity_label="Kein Niederschlag",
         source="minutely_15", frames=[], data_unavailable=False,
@@ -255,7 +263,7 @@ def test_format_now_text_dry_result_wording_unchanged():
     text = svc.format_now_text(result, include_source=False)
 
     assert text == (
-        "Kein Niederschlag.\nIn den nächsten 2 Stunden kein Regen erwartet."
+        "Kein Niederschlag.\nIn den nächsten 3 Stunden kein Regen erwartet."
     ), f"AC-7: Normalfall-Wortlaut darf sich nicht aendern, tatsaechlich: {text!r}"
 
 


### PR DESCRIPTION
Schließt einen Teil von #2051 (Scheibe S1 — Ereignis-Ende und -Dauer). Das Ticket bleibt offen: S2 (räumliche Ausdehnung), S3 (Reichweite der Quelle) und S4 (`/strecke`-Kommando) sind unberührt.

## Was sich ändert

Der Radar-Nowcast las aus der abgerufenen Frame-Zeitreihe bisher nur den **ersten** nassen Zeitpunkt und verwarf den Rest. Der Nutzer erfuhr, *wann* es anfängt, aber nicht, wann es aufhört. Diese Scheibe leitet Ende und Dauer des zusammenhängenden nassen Blocks aus **denselben, bereits abgerufenen Frames** ab — kein zusätzlicher Quellenabruf — und liefert sie in allen sieben Textstellen mit.

| Fall | Langform | Kurzform (SMS / Premium-SMS / Telegram-Kurzstil) |
|---|---|---|
| Ende bekannt | `letzter Regen gegen HH:MM` | `R2.5@18:00@20:00` |
| Ende jenseits der Reichweite | `Regen mindestens bis HH:MM` | `R2.5@18:00 >@20:00` |

Reicht der Regen über die Reichweite der Quelle hinaus (`event_ongoing_beyond_horizon`), wird eine **belegte Untergrenze** genannt statt eines behaupteten Endes. Der Zeitpunkt ist in beiden Wächter-Fällen beobachtungsgestützt: entweder regnet es nachweislich durchgehend bis an den 180-Minuten-Horizont, oder die Zeitreihe bricht ab, während der letzte bekannte Frame noch nass war — dann ist die Untergrenze dieser Frame plus seine Deckung.

Die Ursprungsfassung ließ die Angabe in diesem Fall ganz weg. Der PO hat das am 2026-08-22 umgekehrt (Spec v1.1), weil Schweigen eine wahre Aussage verwirft.

**Dazu die Horizont-Drift aus #1945:** Der Trockenzweig sagte „In den nächsten 2 Stunden kein Regen erwartet", geprüft werden aber seit #1945 tatsächlich 180 Minuten. Die Zahl leitet sich jetzt **zur Laufzeit** aus `_NOWCAST_HORIZON_MIN` ab — eine getippte Kopie wäre vom Kopplungstest nicht unterscheidbar gewesen.

## Entscheidungen

- **Alle sieben Textstellen**, nicht nur die ungedeckelten Pfade. Ein Zuschnitt ohne die Alarmtexte ließe SMS und Premium-SMS ohne die Angabe — auf der Hütte (nur Satellit) ist Premium-SMS der einzige ankommende Kanal.
- **Kein Kappen am Tagesfenster.** Ein still gekapptes „Ende gegen 20:00" bei Regen bis 22:00 wäre eine falsche Aussage.
- **Absolute Uhrzeit, nicht relative Dauer.** Die Premium-SMS kommt über Satellit teils verzögert an; `+60min` wird dadurch still falsch, `20:00` bleibt richtig. Dieselbe Begründung trägt schon `onset_day_offset` aus #2009.
- **Minutengenau, nicht nur die Stunde.** Die Quellen liefern ein 15-Minuten-Raster (INCA/AROME) bzw. 5 Minuten (RADOLAN) — `20:45` auf `20` zu kürzen wäre bis zu 45 Minuten daneben.

## Prüfung

**Tests:** 67 Scheiben-Tests + 162 Bestandstests grün. Alle neuen Felder additiv mit Default; kein Bestandstest musste in seinen Fixtures angepasst werden. Einzige Ausnahme: `tests/unit/test_radar_upstream_failure.py` zieht einen Goldstring von „2 Stunden" auf „3 Stunden" nach (AC-18) — seine eigentliche Zusicherung bleibt unverändert.

**Adversary:** drei Runden. Runde 1 BROKEN (4 Findings), Runde 2 BROKEN (1 kritisches Finding), Runde 3 VERIFIED. Alle sieben Pflicht-Mutationen wurden von Tests gefangen.

Zwei Befunde sind erwähnenswert, weil sie kein Testlauf gezeigt hätte:

- **Ein Kopplungstest prüfte nicht, was er behauptete.** Er sollte sicherstellen, dass die Stundenzahl an `_NOWCAST_HORIZON_MIN` hängt statt eine zweite, separat gepflegte Zahl zu sein — genau die Doppelpflege, die den Ursprungsfehler erzeugt hatte. Er rechnete die Erwartung aber selbst aus und verglich nur das Ergebnis; ein hart getipptes `3` wäre durchgekommen. Er setzt den Horizont jetzt versuchsweise auf 120 und 240 Minuten.
- **Ein Rebase-Versuch hätte #2020 S2 und Teile von #2036 stillschweigend zurückgedreht** — inklusive der Wächter-Testdatei (1119 Zeilen), weshalb alle Tests grün blieben. Diese Fassung ist deshalb **neu auf `origin/main` aufgebaut**: `git diff origin/main --diff-filter=D` ist leer, beide Wächter-Testdateien sind vorhanden, `_time_with_day`/`_when_suffix`/`_sms_rest_token` und `km_measured`/`measured_segment_km`/`persist_backfill` sind belegt im Code.

**Zusagen an Parallelsitzungen eingehalten:** `_onset_time_label()` und der Δ-Teil von `_render_sms_body` sind unverändert (#2020 S2), `compare_radar_alert.py` ist unverändert — der Ortsvergleich bekommt das Ende über die geteilte Fassung `event_end_display()` (ADR-0021).

## Nicht enthalten

**#2063** — die Onset-Uhrzeit ist in rund jedem zweiten Alarm eine Minute zu früh (`local_fmt` schneidet Sekunden ab, statt zu runden). Bei dieser Arbeit gefunden, bewusst außerhalb des Zuschnitts: andere Ursache, eigene Tests nötig, und die betroffene Uhrzeit gehörte zum Fundzeitpunkt der Parallelsitzung #2020 S2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DuF4pfYEzKQSKCxS3DHfZ4
