### PR TITLE
docs(#2042): Gehzeit folgt gemessener Wegstrecke -- Vertrag nachgezogen

### DIFF
--- a/docs/reference/api_contract.md
+++ b/docs/reference/api_contract.md
@@ -1015,9 +1015,13 @@ zu unterscheiden von `0.0` (gültiger Startwert). Wird beim GPX-Import aus dem
 Original-Trackpunkt (`GPXPoint.distance_from_start_km`) übernommen oder nachträglich per
 Track-Auflösung (`src/services/track_resolution.py`) einmalig additiv zurückgeschrieben,
 wenn genau ein GPX-Track im Bestand des Nutzers alle Wegpunkte der Etappe innerhalb 10 m
-enthält. Speist ausschließlich die Alarm-Ortsangabe (`km A-B` statt `Segment N`,
-`renderers/alert/segments.py::format_alert_location`) — kein Einfluss auf Naismith-Gehzeiten
-(rechnen weiterhin auf Luftlinie, #2042). Muss im Go-Modell existieren, da sonst der erste
+enthält. Speist die Alarm-Ortsangabe (`km A-B` statt `Segment N`,
+`renderers/alert/segments.py::format_alert_location`) **und seit #2042 die Naismith-Gehzeiten**:
+Die Gehzeit je Abschnitt beruht auf der Differenz der gemessenen Strecken zweier
+aufeinanderfolgender Wegpunkte statt auf deren Luftlinie. Der Rückfall auf Luftlinie gilt
+**je Abschnitt**, nicht je Etappe — er greift, wenn einer der beiden Wegpunkte keine gemessene
+Strecke trägt oder die Differenz negativ wäre. Etappen ohne gemessene Strecke rechnen damit
+unverändert wie zuvor. Muss im Go-Modell existieren, da sonst der erste
 Editor-Save (`SaveTrip`) den beim Import gesetzten Wert wieder verwirft (Präzedenzfall
 `suggestion_reason`).
 
@@ -3671,6 +3675,21 @@ function corridorInside(value, min, max) {
 
 ## Changelog
 
+- 2026-08-22: Issue #2042 — Ankunftszeiten folgen der **gemessenen Wegstrecke** statt der
+  Luftlinie: `ComputeStageArrivals` (`internal/model/naismith.go`) und
+  `compute_stage_arrivals` (`src/core/naismith.py`) rechnen die Gehzeit je Abschnitt aus der
+  Differenz der `distance_from_start_km` zweier aufeinanderfolgender Wegpunkte. **Kein neues
+  Feld, keine Migration** — die Größe existiert seit #2036, sie wird nur nicht mehr ignoriert.
+  Rückfall auf Luftlinie gilt **je Abschnitt**, nicht je Etappe: er greift, wenn einer der
+  beiden Wegpunkte keine gemessene Strecke trägt oder die Differenz negativ wäre. Etappen ohne
+  gemessene Strecke liefern damit byte-identische Zeiten wie zuvor. **Nutzersichtbar:** Auf
+  vermessenen Etappen rücken `arrival_calculated` und die daraus abgeleiteten Zeitfenster nach
+  hinten — gemessen Faktor 1,17–1,59 gegenüber der Luftlinie; die Zeiten waren vorher
+  systematisch zu früh. Python/Go-Parität durch je einen Paritätstest gedeckt
+  (`test_ac5_paritaet_erwartungswerte_fuer_die_go_seite`,
+  `TestArrivals_2042_ParityWithPython`) — auf Staging ist sie strukturell nicht beobachtbar,
+  weil kein API-Pfad Pythons Berechnung unabhängig von Go exponiert. Spec:
+  `docs/specs/modules/fix_2042_gehzeit_wegstrecke.md`.
 - 2026-08-22: Issue #2051 Scheibe S1 — `OnsetPayload` (Section 22.5, `POST /api/trips/{trip_id}/
   alert-preview`) bekommt additiv die Felder `event_end_time: string | null`,
   `event_end_day_offset: int = 0` und `event_ongoing_beyond_horizon: bool = false`. Ende und Dauer

--- a/docs/specs/fast/mess-2070-khw-track.md
+++ b/docs/specs/fast/mess-2070-khw-track.md
@@ -1,0 +1,29 @@
+# Mini-Spec: #2070 KHW-Trip gegen die Track-Auflösung messen
+
+## Was ändert sich
+
+- Nichts am Produktivcode. Reine **Read-only-Messung** gegen den Prod-Stand.
+- Je Etappe des KHW-Trips (`KHW 403`, user `henning`) wird `resolve_stage_track_km()`
+  (`src/services/track_resolution.py`, `DEFAULT_TOLERANCE_M = 10.0`) aufgerufen.
+- Ergebnis als Tabelle ans Issue #2070: *Etappe · Datum · auflösbar ja/nein · km-Spanne ·
+  größter gemessener Wegpunkt-Abstand in m · Grund*.
+
+## Was darf sich nicht ändern
+
+- **Der Prod-Trip-Bestand.** Gemessen wird gegen eine Kopie im Session-Scratchpad,
+  `resolve_stage_track_km()` direkt — **nie** `backfill_stage_distances(persist=True)`.
+- Der GPX-Bestand unter `/var/lib/gregor/users/henning/gpx/` bleibt unangetastet.
+- Keine Änderung an der Trip-Konfiguration des PO.
+- Die Auflösungslogik selbst wird nicht angefasst (das ist #2036 / #2073).
+
+## Manuelle Test-Schritte
+
+1. Prod-Daten (Trip-JSON + GPX-Verzeichnis) read-only ins Scratchpad kopieren.
+2. Messskript gegen die Kopie laufen lassen.
+3. md5-Summen des Prod-GPX-Bestands vor/nach der Messung vergleichen — müssen identisch sein.
+4. Tabelle ans Issue #2070 hängen.
+
+## Inline-Test
+
+- [ ] Gegenprobe: Prod-GPX-Bestand nach der Messung unverändert (md5 aller Dateien)
+- [ ] Gegenprobe: Prod-Trip-JSON nach der Messung unverändert (md5)


### PR DESCRIPTION
Der API-Vertrag behauptete an der Stelle zu distance_from_start_km woertlich
das Gegenteil des ausgelieferten Verhaltens: "kein Einfluss auf
Naismith-Gehzeiten (rechnen weiterhin auf Luftlinie, #2042)". Seit c684d053
(PR #2072, live 2026-08-22) speist die gemessene Strecke genau diese Gehzeiten.

- Abschnitt distance_from_start_km korrigiert: Rueckfall auf Luftlinie gilt je
  ABSCHNITT, nicht je Etappe -- greift bei fehlender Strecke an einem der
  beiden Wegpunkte oder bei negativer Differenz.
- Changelog-Eintrag #2042 mit der nutzersichtbaren Folge (Faktor 1,17-1,59
  spaetere Ankunftszeiten auf vermessenen Etappen) und der Paritaets-Deckung.
- Mini-Spec der #2070-Messung abgelegt (Read-only-Messung, 13/13 Etappen).

Zwei weitere Luftlinien-Fundstellen geprueft und bewusst unveraendert
gelassen (architecture.md:282, api_contract:3737) -- beide betreffen die
Alarm-Ortsangabe aus #2036, nicht die Gehzeit.

tests/test_api_contract_drift.py gruen.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0181wwuV7pcBsEYPQ4sQkEiE
