### PR TITLE
fix(#2050 S2b): laufendes Ereignis wird als laufend gemeldet (B-1)

### DIFF
--- a/docs/context/fix-2050-s2b-laufendes-ereignis.md
+++ b/docs/context/fix-2050-s2b-laufendes-ereignis.md
@@ -1,0 +1,162 @@
+# Context: fix-2050-s2b-laufendes-ereignis
+
+Issue #2050, Scheibe **S2b** — Szenario 1, Anforderung **B-1**.
+Erstellt 2026-08-22. Vorgaenger: S1 (Pruefstrecke) und S2a (Waechter Szenarien 2+3), beide geliefert.
+Stand nach Rebase auf `origin/main` inkl. Merge `5e92e053` (#2020 Scheibe 2).
+
+## Request Summary
+
+Laeuft ein Niederschlags-/Gewitterereignis zum Zeitpunkt des Alarmlaufs **bereits**, darf die
+Nachricht es nicht als bevorstehend melden ("Regen in 8 Min"). Sie muss es als laufend ausweisen
+und das **Ende** nennen statt des Beginns — oder gar nicht ausloesen.
+
+## Ursache (an Produktionsdaten belegt)
+
+Zwei unabhaengig belegte Fakten ergeben zusammen den Defekt:
+
+1. **Der Filter verwirft die laufende Viertelstunde.**
+   `src/services/radar_service.py:712` — `window = [f for f in frames if f.timestamp >= now and ...]`.
+   Frames tragen den **Slot-Start** als Zeitstempel (15-Min-Raster: `:00/:15/:30/:45`). Das Frame,
+   das die *aktuelle* Viertelstunde beschreibt, liegt damit immer vor `now` und faellt heraus.
+   `onset_minutes` (`:719-727`) wird ausschliesslich aus diesem `window` gebildet, danach
+   `max(0, round(delta))` — ein "laeuft bereits" ist strukturell nicht darstellbar.
+
+2. **Der Alarmtakt macht die Zahl konstant.**
+   Cron `:07,:22,:37,:52` gegen Raster `:00/:15/:30/:45` ⇒ das verworfene Frame ist stets genau
+   **7 Minuten alt**, das naechste stets genau **8 Minuten** entfernt. "in 8 Min" ist deshalb nicht
+   der gemessene Wert, sondern der **einzige moegliche** Wert, wenn der Regen gerade laeuft.
+   Der Vorfall vom 21.08. 18:37 zeigt exakt diese Zahl.
+
+**Empirischer Beleg** (Prod-Mitschnitt, 2026-08-22): Datei
+`/var/lib/gregor/debug/alert_input/nowcast/46.6843_12.4937_inca_20260822T071602783389.json` —
+`captured_at = 07:16:02`, erstes Frame `timestamp = 07:15:00`. Das Frame der laufenden
+Viertelstunde ist vorhanden und wird verworfen.
+
+Der Mitschnitt wird von `_capture_nowcast_frames()` (`radar_service.py:918-935`, #1948 S1)
+**vor** `_derive_result` geschrieben — die Rohdaten des Vorfalls waeren dort sichtbar gewesen.
+Aufbewahrung: 50 Dateien je Ort (`alert_input_capture.py:38-44`), reicht keine 24 Stunden;
+der Mitschnitt vom 21.08. ist bereits geloescht. Der Nachweis haengt nicht daran, weil der
+Defekt in jedem Lauf strukturell sichtbar ist.
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `src/services/radar_service.py:697-760` | `_derive_result` — Ursprung von `onset_minutes`, Filter + Klemme |
+| `src/services/radar_service.py:137-190` | `NowcastResult` — Datenmodell, kennt keinen Laufend-Zustand |
+| `src/services/radar_service.py:121` | `RADAR_ONSET_THRESHOLD_MIN = 55` — Meldeschwelle (gehoert zu A-1, **nicht** zu dieser Scheibe) |
+| `src/services/radar_service.py:69` | `_NOWCAST_HORIZON_MIN = 180` — Sichtfenster |
+| `src/services/radar_service.py:918-935` | `_capture_nowcast_frames` — Roh-Mitschnitt vor der Auswertung |
+| `src/services/trip_alert.py:145,1365,1382` | `radar_alert_due`, Nowcast-Aufruf, `_onset_dt = now + onset_minutes` |
+| `src/services/radar_alert_service.py:34-72` | Baut `OnsetEvent` aus `onset_minutes` |
+| `src/services/compare_radar_alert.py:62-73,342` | Ortsvergleich: Dedup/Identity, kein eigener Text |
+| `src/output/renderers/alert/model.py:72-110` | `OnsetEvent` — kennt kein Laufend-/Ende-Feld |
+| `src/output/renderers/alert/render.py:497` | `_onset_time_label` — der B-1-Wirkort |
+| `src/output/renderers/alert/project.py:360-430` | Ortsvergleich-Projektion, speist dieselben Renderer |
+| `src/output/renderers/email/starkregen_hint.py:27` | Trip-Briefing, Kurzfrist-Zusatzzeile |
+| `src/services/validator_render_service.py:100-270` | Replay-Weg, ruft die Renderer unveraendert auf |
+| `tests/helpers/alarm_pruefstrecke.py` | Pruefstrecke aus S1 — Einspeisung + vier Kanaele |
+
+## Wirkkette "in X Min" — sechs Formatierer
+
+| Ort | Kanal | Form heute |
+|---|---|---|
+| `render.py:376` `_render_subject_onset` | Betreff (alle Kanaele) | `in {onset_minutes} Min` |
+| `render.py:~525` `_render_email_onset_multi` | E-Mail Buendel/Ortsvergleich | `in {onset_minutes} Min` |
+| `render.py:~599` `_render_email_onset` | E-Mail Ein-Ort | `ab {_onset_time_label(e)}` |
+| `render.py:~665` `_render_telegram_onset` | Telegram (rich) | `in {onset_minutes} Min` |
+| `email/starkregen_hint.py:27` | Trip-Briefing E-Mail | `ab ca. HH:MM (in ~N Min)` |
+| `radar_service.py:450` `format_now_text` | `/jetzt`-Antwort (On-Demand) | `(in ~N Min)` |
+
+`_render_sms_onset` nutzt seit #1948 S4 die **Zeitpunkt-Form** (`R@18:45`).
+Telegram-Kurzform (`notification_service.py:1494`) und Premium-SMS
+(`output/channels/premium_sms.py:19-21`) senden diesen SMS-Text unveraendert weiter.
+
+🔴 **Wichtige Praezisierung:** Die Zeitpunkt-Form macht SMS/Premium-SMS/Telegram-Kurzform
+**nicht** konform. `R@18:45` stammt aus demselben falschen `onset_minutes` und behauptet bei
+laufendem Regen ebenso einen Beginn in der Zukunft — nur anders formuliert. Der Defekt sitzt
+**unterhalb** der Formatierer. Alle vier Kanaele sind betroffen.
+
+## Der Stand nach #2020 Scheibe 2 (Merge `5e92e053`)
+
+Zwei Befunde, die den Zuschnitt bestimmen:
+
+1. **Die neuen Ende-/Restmengen-Felder haengen am falschen Ereignistyp.**
+   `remaining_mm`, `remaining_until_time`, `remaining_until_day_offset`, `remaining_until_weekday`,
+   `window_end_time`, `window_end_day_offset` sitzen an **`AlertEvent`** (`model.py:50-70`) — dem
+   Vorhersage-/Abweichungspfad. **`OnsetEvent`** (`model.py:72-110`, der Radar-Pfad) hat sie nicht.
+   Der Zuschnitt von S2b schrumpft dadurch **nicht**; es gibt aber ein fertiges Vorbild fuer
+   Benennung, Defaults und die Trennung "Projektion rechnet, Renderer setzt Worte".
+
+2. **Die zu brechende Annahme steht jetzt ausformuliert im Code.**
+   `_onset_time_label` (`render.py:497-511`) traegt den Kommentar:
+   *"`OnsetEvent` kennt kein Vergangenheits-Kennzeichen (Radar blickt nach vorn), daher
+   `is_past=False`."* Genau diese Praemisse ist falsch und ist der Kern von B-1. Der gemeinsame
+   Baustein `_time_with_day(zeit, offset, is_past=...)` existiert bereits und wird von beiden
+   Pfaden genutzt — der Laufend-Fall kann darauf aufsetzen statt einen eigenen Formatierer zu bauen.
+
+## Existing Patterns
+
+- **Pruefstrecke (S1):** `AlarmPruefstrecke(user_id=..., settings=...)`,
+  `lauf(at=, zweig="radar"|"deviation"|"official", trip=, radar_service=, ...)` →
+  `AlarmPruefstreckeLauf(triggered_count, mail, telegram, sms, premium_sms)`.
+  Uhr ausschliesslich ueber `freeze_time(at)`. Kontinuitaet zwischen Laeufen kommt vom
+  Datentraeger unter `get_data_dir(user_id)`, nicht von der Instanz.
+- **Frame-Einspeisung:** eigener `RadarNowcastService` mit DI-Naht `frame_source=`, uebergeben
+  als `radar_service=` (Muster aus S2a, Waechter 1).
+- **Szenario-Waechter (S2a):** `tests/tdd/test_alarm_szenario_*.py` — `_uid()` mit uuid-Suffix,
+  `_trip()`-Fabrik, `_stand(stunde)`-Wetterfabrik, ein Test je AC, Belege an der Wirkstelle
+  gelesen (nicht am Aufrufer).
+- **Additive Modell-Erweiterung** (#2009, #2046, #2036, #2020 S2): neues Feld mit Default, in der
+  Projektion gerechnet, im Renderer nur Worte gesetzt — Normalfall byte-identisch.
+- **Zeitpunkt-Form statt Countdown** ist im SMS-Zweig etabliert (#1948 S4) — Vorbild fuer die
+  Formulierung des Laufend-Falls.
+
+## Dependencies
+
+- **Upstream:** Frame-Quellen (Brightsky/RADOLAN, GeoSphere INCA, AROME-FR-HD, ICON-D2, ARPAE,
+  Open-Meteo `minutely_15`). Keine Quelle wird mit `past_minutes`/`past_hours`/`start_date`
+  abgefragt; die Vergangenheit reicht genau so weit wie der laufende Rasterslot.
+- **Downstream:** `trip_alert.py` (Trip-Alarme), `compare_radar_alert.py` (Ortsvergleich),
+  `trip_report_scheduler.py` (Briefing-Zusatzzeile), `validator_render_service.py` (Replay),
+  alle vier Kanal-Renderer.
+
+## Existing Specs
+
+- `docs/specs/modules/alarm_pruefstrecke.md` — S1, die Pruefstrecke.
+- `docs/specs/modules/alarm_szenarien_waechter_2_3.md` — S2a, Szenarien 2 und 3.
+- **Keine Spec zu B-1 / "laufendes Ereignis"** — S2b braucht eine neue.
+
+## ADRs
+
+Keine ADR zur Vorwarnzeit-Untergrenze und keine zum Laufend-Fall. `RADAR_ONSET_THRESHOLD_MIN`
+und `_NOWCAST_HORIZON_MIN` sind reine Code-Konstanten. Es wird also **keine** dokumentierte
+Entscheidung zurueckgenommen. Beruehrte Entscheidungsflaeche: ADR-0052 (Warnmail-Nowcast-Bauform),
+ADR-0056 (rollierender Alarm-Anker) — vor der Spec gegenlesen.
+
+## Risks & Considerations
+
+- **R1 — Offene Produktfrage (PO-Entscheid).** Szenario 1 laesst zwei Ergebnisse zu: "als laufend
+  melden mit Ende" **oder** "gar nicht ausloesen". Gehoert in die AC-Freigabe, nicht in eine
+  technische Vorentscheidung.
+- **R2 — Quellenreichweite.** Keine Quelle wird nach Vergangenheit gefragt. Die Erkennung
+  "laeuft bereits" kann sich daher nur auf den laufenden Rasterslot stuetzen (max. 15 Min
+  zurueck), nicht auf einen laengeren Rueckblick. Ein Ereignis, das vor mehr als einer
+  Viertelstunde begann und noch laeuft, ist aus dem Nowcast allein nicht als "seit X laufend"
+  belegbar — nur als "laeuft jetzt". Das begrenzt, was B-1 ueberhaupt zusichern kann.
+- **R3 — "Ende" ist im Nowcast-Fenster nicht immer bestimmbar.** Das Sichtfenster endet nach
+  180 Min (INCA liefert real ~11 Frames ≈ 165 Min). Regnet es bis ueber den Horizont hinaus,
+  gibt es kein Ende zu nennen — der Fall braucht eine eigene Aussage, sonst entsteht wieder eine
+  stille Falschbehauptung.
+- **R4 — Testmasse.** Rund 15 Testdateien nageln den Wortlaut "in X Min" fest, weitere ~15
+  haengen an `format_starkregen_hint`/`format_now_text`. Eine Wortlautaenderung zieht breite
+  Testanpassung nach sich; das LoC-Budget ist entsprechend zu planen
+  (`loc_limit_override` produktiv, `test_loc_limit_override` fuer Tests).
+- **R5 — Abgrenzung.** `format_now_text` bedient `/jetzt` (On-Demand-Abfrage), nicht den
+  proaktiven Alarm. Ob B-1 den Pfad mitmeint, ist in der Spec zu entscheiden. Ebenso liegt die
+  55-Minuten-Meldeschwelle bei **A-1**, nicht bei B-1 — nicht mitverschieben.
+- **R6 — Kurze Zeitfenster im Test.** Das Ziel-Segment hat einen erzwungenen 1-Stunden-Boden
+  (`src/services/trip_segments.py:376-393`), Zwischensegmente nicht (`:242-306`). Ein
+  "Regen laeuft schon"-Szenario baut man ueber ein Zwischensegment.
+- **R7 — Nicht nur Regen.** `OnsetEvent.is_convective` deckt Gewitter/Hagel mit ab. Ein laufendes
+  Gewitter faellt unter dieselbe Anforderung; die Spec darf nicht auf Niederschlag verengen.

--- a/docs/context/fix-2050-s2b-laufendes-ereignis.md
+++ b/docs/context/fix-2050-s2b-laufendes-ereignis.md
@@ -160,3 +160,121 @@ ADR-0056 (rollierender Alarm-Anker) — vor der Spec gegenlesen.
   "Regen laeuft schon"-Szenario baut man ueber ein Zwischensegment.
 - **R7 — Nicht nur Regen.** `OnsetEvent.is_convective` deckt Gewitter/Hagel mit ab. Ein laufendes
   Gewitter faellt unter dieselbe Anforderung; die Spec darf nicht auf Niederschlag verengen.
+
+---
+
+# Analysis
+
+## Type
+
+**Bug** (nutzersichtbares Fehlverhalten mit Vorfallbeleg vom 21.08.), geschnitten als Scheibe des
+Enhancement-Tickets #2050.
+
+## Die tragende Erkenntnis
+
+Der gesamte Radar-Zweig setzt an **vier unabhaengigen Stellen** voraus, dass ein Radar-Ereignis in
+der **Zukunft** liegt. Diese Praemisse steht seit dem Merge von #2020 S2 sogar ausformuliert im
+Code (`render.py:497-511`: *"`OnsetEvent` kennt kein Vergangenheits-Kennzeichen (Radar blickt nach
+vorn)"*). B-1 bricht genau diese Praemisse — und jede der vier Stellen muss mitziehen, sonst
+ueberlebt der Defekt dort still weiter.
+
+Alle vier haengen am selben Ausdruck `onset_minutes is not None`:
+
+| # | Stelle | Verhalten bei `already_running=True, onset_minutes=None` | Schwere |
+|---|---|---|---|
+| 1 | `trip_alert.py:145-148` `radar_alert_due` | liefert `False` ⇒ **gar kein Alarm**, Renderer nie erreicht | sperrt den Fall komplett |
+| 2 | `compare_radar_alert.py:64-79` `_identity_inputs` | `onset_at=None` ⇒ `_times_overlap` (`alert_gate.py:490-512`) findet nie einen Kandidaten ⇒ **Entdopplung wird stiller No-Op** | wirkt, sieht aber funktionsfaehig aus |
+| 3 | `trip_alert.py:1382` / `project.py:509-511` | `now + timedelta(minutes=None)` ⇒ **Absturz** | laut |
+| 4 | `project.py:494` | filtert laufende Orte vor dem `OnsetEvent`-Bau heraus ⇒ **Ortsvergleich schweigt** | still |
+
+🔴 Nr. 2 ist der gefaehrlichste Punkt: Ein Test, der nur "laeuft UND regnet weiter" baut, sieht
+davon nichts — dort ist `onset_minutes` gesetzt und alles verhaelt sich normal. Der Fall wird nur
+sichtbar, wenn das Ereignis **innerhalb der laufenden Viertelstunde endet**. Dieselbe Fehlerfamilie
+wie dreimal zuvor in diesem Ticket: ein Zweig wirkt grün, weil die Bedingung ihn nie erreicht.
+
+## Affected Files
+
+| Datei | Aenderung | Beschreibung |
+|---|---|---|
+| `src/services/radar_service.py` | MODIFY | Erkennung im `_derive_result`; `NowcastResult` um Laufend-Kennzeichen + Ende erweitern; `format_now_text` (`/jetzt`) |
+| `src/output/renderers/alert/model.py` | MODIFY | `OnsetEvent` additiv um Laufend-Kennzeichen + Ende-Zeit + Tagesversatz |
+| `src/output/renderers/alert/render.py` | MODIFY | geteilter Helfer neben `_onset_time_label`; Verzweigung in allen Onset-Formatierern (E-Mail einzeln/Buendel, Telegram-Langform, Betreff, SMS-Token) |
+| `src/services/trip_alert.py` | MODIFY | `radar_alert_due` (:145), Zeitableitung + Dedup-Identitaet (:1382), `RadarAlertRequest`-Bau (:1498) |
+| `src/services/compare_radar_alert.py` | MODIFY | `_identity_inputs` (:64-79) |
+| `src/output/renderers/alert/project.py` | MODIFY | Filter (:494) und Zeitableitung (:509-511) im Compare-Buendel |
+| `src/services/notification_service.py` | MODIFY | `RadarAlertRequest`: `onset_minutes` optional, neue Felder durchreichen |
+| `src/services/radar_alert_service.py` | MODIFY? | Aufrufer beim Implementieren per Grep klaeren — moeglicherweise Legacy/Preview |
+| `src/output/renderers/email/starkregen_hint.py` | MODIFY | Briefing-Kurzfristzeile |
+| `src/services/validator_render_service.py` | MODIFY? | Replay-Payload-Schema, nur falls es die Felder tragen muss |
+| `docs/specs/modules/alarm_szenario_laufendes_ereignis.md` | CREATE | Spec dieser Scheibe |
+| `tests/tdd/test_alarm_szenario_laufendes_ereignis.py` | CREATE | Waechter nach S2a-Muster ueber die Pruefstrecke |
+
+## Scope Assessment
+
+- Dateien: 10-12 (davon 2 neu)
+- LoC produktiv: ~180-260 ⇒ **`loc_limit_override` auf 300** noetig (Default 250)
+- LoC Test: ~150-250 ⇒ `test_loc_limit_override` vorsorglich setzen
+- Risk Level: **MEDIUM-HIGH** — kritischer Alarmpfad, aber ausschliesslich additiv; der Normalfall
+  (Ereignis liegt wirklich in der Zukunft) bleibt unveraendert und ist als Regressions-Invariante
+  pruefbar.
+
+## Technical Approach (Empfehlung)
+
+**Gewaehlt: den Laufend-Zustand erkennen und durchreichen** — nicht: die Ausloesung unterdruecken.
+
+1. **Erkennung** in `_derive_result` (`radar_service.py:~700`), wo Frames, Fenster und `now` bereits
+   zusammenliegen. Ein Ereignis laeuft, wenn das Frame, dessen Gueltigkeitsintervall `now` enthaelt,
+   ueber der Trockenschwelle liegt. Die Vorwaerts-Konvention ist keine Neuerfindung: die
+   Mengenrechnung `_accumulate_precip_mm` (`radar_service.py:200-242`, `_MAX_FRAME_COVERAGE`)
+   rechnet heute schon so. Damit werden Ausloeseentscheidung und Mengenrechnung deckungsgleich.
+2. **Ende** = erstes trockenes Frame nach der laufenden nassen Strecke. Regnet es bis ueber den
+   Sichthorizont hinaus (INCA real ~165 Min), gibt es **kein** Ende zu nennen — dann wird das
+   ausdruecklich gesagt, statt eine Dauer zu erfinden.
+3. **`onset_minutes` bleibt unangetastet.** Es behaelt seine Rolle als Torwaechter und
+   Dedup-Bestandteil; der Laufend-Zustand liegt additiv daneben. Das haelt die Gate-Kette, an der
+   #2065 parallel arbeitet, aus dem Spiel.
+4. **Die vier Stellen aus der Tabelle ziehen mit** — jede einzeln als Akzeptanzkriterium, sonst
+   bewacht sie kein Test (Praezedenz: `onset_precip_mm` musste bei #2046 an denselben Stellen
+   nachgezogen werden).
+5. **Renderer**: ein geteilter Helfer neben `_onset_time_label`, aufgesetzt auf den bestehenden
+   Baustein `_time_with_day(zeit, offset, is_past=)`. Alle vier Kanaele verzweigen an ihrer
+   vorhandenen Stelle. **Pflicht, nicht Kuer:** ohne Textaenderung liest der Nutzer sonst
+   "Regen in 0 Min" — der Fix waere schlimmer als der Bug.
+
+**Verworfen: Ausloesung unterdruecken** ("gar nicht melden", von Szenario 1 ausdruecklich erlaubt).
+Begruendung: widerspricht dem Produktgrundsatz *NUR Daten, keine Bevormundung* — ob ein bereits
+laufender Regen fuer ihn wichtig ist, entscheidet der Wanderer; ein stiller Nicht-Alarm ist zudem
+von einem technischen Ausfall nicht unterscheidbar (Anforderung D-2 verlangt fuer jede
+Unterdrueckung einen benannten Grund). **Diese Wahl ist die eine echte PO-Entscheidung dieser
+Scheibe** und wird bei der AC-Freigabe vorgelegt.
+
+## Flut-Gegenprobe
+
+Kein neues Risiko. `check_nowcast_gate` (`alert_gate.py:140-184`) ist ein reiner Cooldown auf der
+Trip-/Preset-Kennung, laeuft **vor** `radar_alert_due` und ist von `onset_minutes` unabhaengig. Ein
+durchregnender Nachmittag loest daher hoechstens im Cooldown-Takt aus, nicht alle 15 Minuten. Die
+Entdopplung wirkt als zweite Sperre — aber erst, wenn Punkt 2 der Tabelle behoben ist.
+
+## Selbst entschieden (keine PO-Fragen)
+
+- **`/jetzt` ist im Scope.** Die Sofort-Abfrage macht dieselbe Falschaussage aus derselben
+  Datenbasis; sie auszunehmen hiesse, den Bug halb zu beheben.
+- **Kein Ende absehbar ⇒ genau das sagen**, keine erfundene Mindestdauer.
+- **Gewitter ist eingeschlossen**, nicht nur Niederschlag (`is_convective`).
+- **Die 55-Minuten-Meldeschwelle bleibt unberuehrt** — sie gehoert zu Anforderung A-1, nicht zu B-1.
+
+## Open Questions
+
+- [ ] **PO:** Laeuft der Regen beim Alarmlauf bereits — melden (mit Angabe, bis wann er anhaelt)
+      oder in diesem Fall gar nichts schicken? *Empfehlung: melden.*
+- [ ] **Beim Implementieren zu klaeren:** Hat `radar_alert_service.py:build_onset_alert_message`
+      noch produktive Aufrufer, oder ist es Legacy/Preview? (Grep auf Aufrufer.)
+- [ ] **Beim Implementieren zu klaeren:** Traegt das Replay-Payload-Schema
+      (`validator_render_service.py`) die neuen Felder, oder reicht Durchreichen?
+
+## Ungeprueft geblieben (bewusst offengelegt)
+
+Welche Intervall-Konvention die drei Datenquellen **extern** zusichern, ist aus dem Code nicht
+belegbar. Wir uebernehmen die Konvention, nach der die App bereits ihre Mengen rechnet. Das ist
+in sich konsistent, aber eine Annahme — nachpruefbar nur ueber einen Live-Abgleich von
+Frame-Zeitstempel gegen tatsaechliche Messzeit.

--- a/docs/specs/modules/alarm_szenario_laufendes_ereignis.md
+++ b/docs/specs/modules/alarm_szenario_laufendes_ereignis.md
@@ -1,0 +1,289 @@
+---
+entity_id: alarm_szenario_laufendes_ereignis
+type: bugfix
+created: 2026-08-22
+updated: 2026-08-22
+status: draft
+workflow: fix-2050-s2b-laufendes-ereignis
+version: "1.0"
+tags: [alarm, radar, nowcast, rendering]
+---
+
+# Laufendes Regen-/Gewitterereignis wird als laufend gemeldet (Scheibe S2b, Issue #2050)
+
+## Approval
+
+- [x] Approved — Product Owner, 2026-08-22 ("go"). Produktentscheidung: melden mit Ende;
+      Variante "gar nicht melden" verworfen.
+
+## Purpose
+
+Läuft ein Regen- oder Gewitterereignis zum Zeitpunkt des Alarmlaufs bereits, meldet Gregor es
+heute fälschlich als bevorstehend ("Regen in 8 Min") statt als laufend. Ursache: Der Radar-Zweig
+geht an vier unabhängigen Stellen davon aus, dass ein Ereignis in der Zukunft liegt (Vorfall vom
+21.08., Prod-Mitschnitt belegt). Diese Scheibe stellt das Ereignis als bereits laufend dar, nennt
+das voraussichtliche Ende — oder sagt ausdrücklich, dass keines im Sichtfenster erkennbar ist —
+und stellt sicher, dass der Alarm dabei weiterhin verschickt wird, entdoppelt bleibt und über
+alle vier Kanäle sowie im Ortsvergleich korrekt erscheint.
+
+## Source
+
+- **File:** `src/services/radar_service.py` (`_derive_result`, `NowcastResult`, `format_now_text`)
+- **Identifier:** `class NowcastResult`, `def _derive_result`
+
+> Schicht: Python-Core (`src/services/`, `src/output/renderers/`) — kein Go-/Frontend-Anteil.
+> Betroffen sind Domain-Logik (Radar-Nowcast, Trip- und Ortsvergleichs-Alarme) und deren
+> Text-Renderer für alle vier Kanäle.
+
+## Estimated Scope
+
+- **LoC:** produktiv ~180-260 (⇒ `loc_limit_override` auf 300 nötig, Standardlimit 250), Tests
+  ~150-250 (⇒ `test_loc_limit_override` vorsorglich setzen)
+- **Files:** 10-12 (davon 2 neu: diese Spec, ein neuer Wächter-Testfile)
+- **Effort:** high
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `src/services/radar_service.py::_derive_result` (`:700-`) | function | Ursprung von `onset_minutes`; hier entsteht die Laufend-Erkennung, wo Frames/Fenster/`now` bereits zusammenliegen |
+| `src/services/radar_service.py::NowcastResult` (`:137-190`) | dataclass | Trägt die neuen additiven Roh-Felder für Laufend-Zustand und Ende |
+| `src/services/radar_service.py::format_now_text` (`:~430-451`) | method | `/jetzt`-Antwort — muss dieselbe Laufend-Aussage tragen |
+| `src/output/renderers/alert/model.py::OnsetEvent` (`:72-110`) | dataclass | Renderer-Vertrag; additive Felder analog `AlertEvent.remaining_until_time`/`window_end_time` (`:60-69`, Vorbild aus #2020 S2) |
+| `src/output/renderers/alert/render.py::_time_with_day` (`:214-`) | function | Geteilter Tageswort-Baustein, den der neue Laufend-/Ende-Formatierer wiederverwendet statt einen eigenen zu bauen |
+| `src/output/renderers/alert/render.py::_onset_time_label` (`:497-511`) | function | Trägt heute den fälschlichen Kommentar "Radar blickt nach vorn, daher `is_past=False`" — die zu brechende Prämisse |
+| `src/output/renderers/alert/render.py` (`_render_subject_onset:474`, `_render_email_onset_multi:513`, `_render_email_onset`, `_render_telegram_onset:660`, `_render_sms_onset:711`) | function | Alle sechs Formatierer der Wirkkette "in X Min" — jeder muss verzweigen |
+| `src/services/trip_alert.py::radar_alert_due` (`:145-148`) | function | Bruchstelle 1 — liefert heute `False` bei `onset_minutes is None`, sperrt den Alarm komplett |
+| `src/services/trip_alert.py` (`:1382`, `:~1498`) | code | Bruchstelle 3 — Zeitableitung `now_utc + timedelta(minutes=result.onset_minutes)` stürzt bei `None` ab; `RadarAlertRequest`-Bau muss neue Felder durchreichen |
+| `src/services/compare_radar_alert.py::_identity_inputs` (`:64-79`) | function | Bruchstelle 2 — `onset_at=None` macht die Entdopplung zum stillen No-Op |
+| `src/output/renderers/alert/project.py` (`:494`, `:509-511`) | code | Bruchstelle 4 — Ortsvergleich-Filter `nc.onset_minutes is not None` wirft laufende Orte vor dem `OnsetEvent`-Bau heraus |
+| `src/output/renderers/email/starkregen_hint.py::format_starkregen_hint` (`:18-27`) | function | Trip-Briefing-Kurzfristzeile, dieselbe "ab ca. HH:MM"-Aussage |
+| `src/services/notification_service.py::RadarAlertRequest` | dataclass | `onset_minutes` wird optional, neue Felder müssen durchgereicht werden |
+| `tests/helpers/alarm_pruefstrecke.py::AlarmPruefstrecke.lauf` | function | Prüfstrecke aus S1 — alle Wächter dieser Scheibe fahren ausschließlich darüber, kein eigener Aufbau der Auslöseentscheidung |
+| `docs/specs/modules/alarm_szenarien_waechter_2_3.md` | reference | Vorgänger-Scheibe S2a — Ton, Wächter-Muster und Fixture-Vorbilder (`_uid()`, `_trip()`, `frozen_active_window()`) |
+
+## Implementation Details
+
+**1. Erkennung** in `_derive_result`: Ein Ereignis läuft, wenn das Frame, dessen 15-Minuten-Slot
+`now` enthält, über der Trockenschwelle liegt (Vorwärts-Konvention, wie sie `_accumulate_precip_mm`
+für die Mengenrechnung bereits verwendet — keine neue Annahme, siehe "Offengelegte Annahme"
+unten). `onset_minutes` bleibt unangetastet: Es behält seine Rolle als Torwächter und
+Dedup-Bestandteil. Der Laufend-Zustand (`already_running: bool`) liegt additiv daneben und wird
+unabhängig davon gesetzt, ob `onset_minutes` (weil der Regen in ein künftiges Frame hinein
+andauert) noch einen Wert trägt oder `None` ist (weil der Regen innerhalb der laufenden
+Viertelstunde endet).
+
+**2. Ende:** das erste trockene Frame nach der laufenden nassen Strecke, als Minutenwert
+(`running_until_minutes`) auf `NowcastResult`, nur gesetzt wenn `already_running`. Reicht der
+Regen bis über den tatsächlichen Datenhorizont der Quelle hinaus (INCA liefert real ~165 Min,
+nicht die vollen 180), bleibt `running_until_minutes` `None` und stattdessen wird die reale
+Reichweite der Quelle als `nowcast_horizon_minutes` gesetzt — damit der Renderer "kein Ende
+erkennbar (bis HH:MM)" sagen kann, ohne eine Dauer zu erfinden.
+
+**3. `OnsetEvent`** (Renderer-Vertrag) bekommt dieselben Informationen als Klartext-Felder,
+gebaut über den bestehenden Baustein `_time_with_day`: `already_running: bool = False`,
+`running_until_time: str | None = None`, `running_until_day_offset: int = 0`,
+`horizon_time: str | None = None`, `horizon_day_offset: int = 0`. Namensgebung analog zum
+fertigen Vorbild `AlertEvent.remaining_until_time`/`window_end_time` aus #2020 Scheibe 2 — dort
+ist dieselbe Unterscheidung "Ende bestimmbar" vs. "nur Fenster-Reichweite nennbar" bereits gelöst.
+
+**4. Renderer:** ein geteilter Helfer neben `_onset_time_label`, der bei `already_running=True`
+"läuft bereits" plus Ende-Aussage statt der Beginn-Angabe liefert. Alle sechs Formatierer der
+Wirkkette (Betreff, E-Mail Einzelort/Bündel, Telegram-Langform, SMS-Token, `/jetzt`,
+Briefing-Kurzfristzeile) verzweigen an ihrer bestehenden Stelle. Telegram-Kurzform und
+Premium-SMS senden den SMS-Text unverändert weiter (bestehendes Muster seit #1948 S4) und
+erhalten die Aussage damit automatisch mit.
+
+**5. Die vier Bruchstellen** (`radar_alert_due`, `_identity_inputs`, die Zeitableitung in
+`trip_alert.py`/`project.py`, der Ortsvergleich-Filter in `project.py`) müssen den
+`already_running`-Fall explizit behandeln statt implizit über `onset_minutes is not None` zu
+entscheiden — sonst bleibt der Fix auf halbem Weg stehen (Präzedenz: `onset_precip_mm` musste bei
+#2046 an denselben Stellen nachgezogen werden).
+
+**Offengelegte Annahme:** Welche Intervall-Konvention die Datenquellen (Brightsky/RADOLAN,
+GeoSphere INCA, AROME-FR-HD, ICON-D2, ARPAE, Open-Meteo `minutely_15`) *extern* zusichern, ist aus
+dem Code nicht belegbar. Die Erkennung übernimmt die Konvention, nach der die App ihre
+Mengenrechnung bereits heute betreibt (ein Frame mit Zeitstempel T gilt vorwärts für das
+Intervall ab T) — das ist in sich konsistent, aber eine Annahme, nicht extern zugesichert.
+
+## Expected Behavior
+
+- **Input:** Radar-Frames aus `_fetch_frames_with_fallback`, `now` (injizierbar über `_now_fn`),
+  Sichtfenster `_NOWCAST_HORIZON_MIN`.
+- **Output:** `NowcastResult` mit den additiven Feldern `already_running`,
+  `running_until_minutes`, `nowcast_horizon_minutes`; daraus abgeleitet ein `OnsetEvent` mit
+  `already_running`, `running_until_time`/`_day_offset`, `horizon_time`/`_day_offset`; darauf
+  aufbauend Alarmtexte über alle vier Kanäle, die "läuft bereits" statt einer Beginn-Angabe
+  zeigen.
+- **Side effects:** keine neuen — Alarmversand, Cooldown-Buchung und Alarmprotokoll laufen über
+  dieselben bestehenden Schreibwege wie heute; lediglich der `already_running`-Fall darf dabei
+  nicht mehr stumm herausfallen.
+
+## Acceptance Criteria
+
+- **AC-1:** Given ein Regen- oder Gewitterereignis läuft im Zielsegment bereits, wenn der
+  Alarmlauf prüft (das den aktuellen Rasterslot deckende Frame liegt über der
+  Trockenschwelle), When der Alarmlauf die Nachricht baut, Then meldet die Nachricht das
+  Ereignis als bereits laufend ("läuft bereits") statt mit einer Beginn-Angabe ("in X Min").
+  - Test: `AlarmPruefstrecke.lauf(zweig="radar", ...)` mit Frames, die den aktuellen Rasterslot
+    als nass ausweisen; der Alarminhalt (mind. ein Kanal) enthält die Laufend-Formulierung und
+    NICHT "in {N} Min".
+
+- **AC-2:** Given im Zielsegment regnet es zum Prüfzeitpunkt noch nicht, aber ein künftiges
+  Frame im Sichtfenster liegt über der Trockenschwelle (unveränderter Normalfall), When der
+  Alarmlauf die Nachricht baut, Then bleibt der Wortlaut unverändert wie bisher (Beginn-Angabe
+  mit Minuten bzw. Uhrzeit) — byte-identisch zum bisherigen Verhalten.
+  - Test: `AlarmPruefstrecke.lauf(zweig="radar", ...)` mit trockenem Startframe und nassem
+    Frame erst später; der Alarminhalt enthält weiterhin "in {N} Min" bzw. die bestehende
+    Beginn-Uhrzeit-Form, unverändert zum Vor-Fix-Verhalten (Regressions-Invariante).
+
+- **AC-3:** Given ein konvektives Ereignis (Gewitter) läuft im Zielsegment bereits, When der
+  Alarmlauf die Nachricht baut, Then wird auch das laufende Gewitter als bereits laufend
+  gemeldet — nicht nur laufender Regen.
+  - Test: wie AC-1, aber mit `is_convective=True`-Frame; der Alarminhalt trägt die
+    Laufend-Formulierung für das Gewitter-Kürzel/-Wort statt einer Beginn-Angabe.
+
+- **AC-4:** Given ein laufendes Ereignis, das innerhalb des Sichtfensters wieder aufhört (ein
+  späteres Frame ist trocken), When die Nachricht gebaut wird, Then nennt die Nachricht den
+  Zeitpunkt, bis zu dem das Ereignis voraussichtlich anhält.
+  - Test: Frames mit nassem aktuellem Slot und einem trockenen Frame vor Ende des Sichtfensters;
+    der Alarminhalt enthält eine konkrete Uhrzeit als Ende-Angabe.
+
+- **AC-5:** Given ein laufendes Ereignis, das bis über die tatsächliche Reichweite der
+  Radarquelle hinaus anhält (kein Frame im gesamten verfügbaren Datenbestand ist mehr trocken),
+  When die Nachricht gebaut wird, Then sagt die Nachricht ausdrücklich, dass kein Ende im
+  Sichtfenster erkennbar ist, und nennt die Reichweite des Sichtfensters (Uhrzeit) — ohne eine
+  Dauer zu erfinden.
+  - Test: Frames durchgängig nass bis zum letzten verfügbaren Frame; der Alarminhalt enthält
+    eine "kein Ende erkennbar"-Formulierung samt der Uhrzeit des letzten verfügbaren Frames,
+    aber KEINE erfundene Enddauer.
+
+- **AC-6:** Given ein laufendes Ereignis an einem einzelnen Ort/Trip, When die Alarm-E-Mail
+  gerendert wird, Then sagt die E-Mail "läuft bereits" statt "ab ca. HH:MM (in ~N Min)".
+  - Test: `lauf.mail` aus dem Prüfstrecken-Ergebnis von AC-1 auf die Laufend-Formulierung
+    prüfen; die alte Beginn-Form fehlt.
+
+- **AC-7:** Given dasselbe laufende Ereignis, When die Telegram-Langform gerendert wird, Then
+  sagt sie ebenfalls "läuft bereits" statt "in X Min".
+  - Test: `lauf.telegram` aus AC-1 auf dieselbe Laufend-Formulierung prüfen.
+
+- **AC-8:** Given dasselbe laufende Ereignis, When SMS und Premium-SMS gerendert werden, Then
+  macht die heutige Zeitpunkt-Form (`R@HH:MM`) den Laufend-Fall kenntlich (z. B. eigenes
+  Kürzel/Präfix), statt weiterhin unverändert einen künftigen Beginn zu behaupten — innerhalb
+  des bestehenden Zeichenbudgets.
+  - Test: `lauf.sms` und `lauf.premium_sms` aus AC-1 enthalten die Laufend-Kennzeichnung und
+    NICHT die unveränderte `R@HH:MM`-Form für einen Beginn in der Zukunft; Zeichenlänge bleibt
+    innerhalb des bestehenden SMS-Limits.
+
+- **AC-9:** Given dasselbe laufende Ereignis, When die Telegram-Kurzform gerendert wird, Then
+  trägt sie denselben Laufend-Text wie die SMS (geerbtes Verhalten seit #1948 S4).
+  - Test: bei `telegram_style="kurzform"` (Trip-Fixture nach S2a-Vorbild) den Telegram-Inhalt
+    aus dem Prüfstrecken-Ergebnis auf dieselbe Laufend-Kennzeichnung wie AC-8 prüfen.
+
+- **AC-10:** Given der Regen läuft und hört noch innerhalb der laufenden Viertelstunde auf (kein
+  künftiges Frame im Sichtfenster ist nass, ein künftiger Beginn ist also nicht bestimmbar),
+  When der Alarmlauf prüft, ob ausgelöst wird, Then wird TROTZDEM ein Alarm verschickt (heute
+  fällt der Alarm in genau diesem Fall ersatzlos aus, weil `radar_alert_due` bei
+  `onset_minutes is None` `False` liefert).
+  - Test: Frames mit nassem aktuellem Slot und ausschließlich trockenen künftigen Frames (kein
+    Frame erfüllt die Schwelle); `AlarmPruefstreckeLauf.triggered_count == 1`.
+
+- **AC-11:** Given ein laufendes Ereignis hat bereits einen Alarm ausgelöst, und die Lage ist
+  beim zweiten Prüflauf kurz danach unverändert (weiterhin laufend, weiterhin kein künftiger
+  Beginn bestimmbar), When der zweite Prüflauf durchläuft, Then wird KEIN zweiter Alarm
+  verschickt — die Entdopplung erkennt das laufende Ereignis als bereits gemeldet, statt bei
+  `onset_minutes is None` stillschweigend jede Entdopplung zu unterlassen.
+  - Test: zwei aufeinanderfolgende `AlarmPruefstrecke.lauf(zweig="radar", ...)`-Aufrufe mit
+    identischen, durchgängig laufenden Eingangsdaten (Muster aus AC-10); erster Lauf
+    `triggered_count == 1`, zweiter Lauf `triggered_count == 0`.
+  - 🔴 **Pflicht zur Wirksamkeit dieses Wächters:** Die Sperrzeit muss für diesen Test
+    ausgeschaltet sein (`trip.alert_cooldown_minutes = 0`, Muster aus S2a). Sonst verhindert
+    schon der Cooldown die zweite Nachricht, der Test wird aus dem falschen Grund grün und
+    misst die Entdopplung überhaupt nicht. Gegenprobe für den Adversary: Wird die
+    Entdopplungs-Zeitableitung verfälscht, MUSS dieser Test rot werden — bleibt er grün,
+    entscheidet in Wahrheit der Cooldown und der Wächter ist wertlos.
+
+- **AC-12:** Given ein Ortsvergleich mit mehreren Orten, von denen an mindestens einem Ort das
+  Ereignis bereits läuft (ohne bestimmbaren künftigen Beginn) und an einem anderen Ort ein
+  künftiger Beginn vorliegt, When das Bündel gebaut wird, Then erscheint der laufende Ort in der
+  Sammelnachricht mit der Laufend-Aussage, statt vor dem Nachrichtenbau herauszufallen.
+  - Test: Ortsvergleichs-Bündel mit zwei Orten (einer laufend ohne `onset_minutes`, einer mit
+    künftigem Beginn) über den Compare-Zweig der Prüfstrecke bauen; die Sammelnachricht enthält
+    Zeilen für BEIDE Orte, die laufende Zeile trägt die Laufend-Formulierung.
+
+- **AC-13:** Given ein laufendes Ereignis, für das kein künftiger Beginn bestimmbar ist
+  (`onset_minutes` ist `None`), When die Zeitableitung für Dedup-Identität und Alarmversand
+  rechnet, Then stürzt der Lauf NICHT ab und die Nachricht wird trotzdem korrekt mit der
+  Laufend-Aussage gebaut.
+  - Test: derselbe Eingangsfall wie AC-10/AC-11 läuft ohne Exception durch
+    `AlarmPruefstrecke.lauf(...)`; das Ergebnis enthält gültige Kanal-Inhalte für alle vier
+    Kanäle.
+
+- **AC-14:** Given ein Nutzer fragt per Telegram-Befehl `/jetzt` die aktuelle Regenlage ab,
+  während das Ereignis am abgefragten Ort bereits läuft, When die Antwort gebaut wird, Then
+  meldet die Antwort das Ereignis als bereits laufend statt mit einer Beginn-Angabe
+  ("ab ca. HH:MM (in ~N Min)").
+  - Test: `RadarNowcastService.format_now_text(...)` (bzw. der zugrundeliegende
+    `NowcastResult` mit `already_running=True`) direkt aufrufen; der Antworttext enthält die
+    Laufend-Formulierung und nicht die Beginn-Form.
+
+- **AC-15:** Given das planmäßige Trip-Briefing enthält die Starkregen-Kurzfristzeile für ein
+  Ereignis, das zum Zeitpunkt der Briefing-Erstellung bereits läuft, When die Zeile gerendert
+  wird, Then weist sie das Ereignis als bereits laufend aus statt mit der Beginn-Form
+  "ab ca. HH:MM (in ~N Min)".
+  - Test: `format_starkregen_hint(...)` mit einem `already_running=True`-Eingang aufrufen; der
+    Rückgabetext enthält die Laufend-Formulierung.
+
+## Known Limitations
+
+- **Nicht Teil dieser Scheibe:** die 55-Minuten-Meldeschwelle (`RADAR_ONSET_THRESHOLD_MIN`,
+  gehört zu Anforderung A-1) und die Sperrzeit-/Überholungslogik von `check_nowcast_gate`
+  (Issue #2065, läuft parallel in einer anderen Session — dort ist Anforderung A-3 gemessen
+  verletzt, unabhängig vom Laufend-Fall dieser Scheibe).
+- **Beim Implementieren zu klären, nicht vorab entschieden:** ob
+  `radar_alert_service.py::build_onset_alert_message` noch einen produktiven Aufrufer im
+  Alarm-Versandpfad hat. Ein Grep zeigt aktuell nur `scripts/send_gate_test_mails.py` und
+  `api/routers/debug.py` als Aufrufer — beides Debug-/Test-Werkzeuge, kein Treffer in
+  `trip_alert.py`. Trifft das beim Implementieren erneut zu, muss die Funktion die neuen
+  `OnsetEvent`-Felder nicht zwingend selbst befüllen (Default `already_running=False` reicht für
+  Debug-Zwecke); ist doch ein produktiver Aufrufer vorhanden, zieht er mit.
+- **Beim Implementieren zu klären:** ob das Replay-Payload-Schema in
+  `validator_render_service.py` die neuen Felder explizit tragen muss oder ob reines
+  Durchreichen der `NowcastResult`/`OnsetEvent`-Instanz genügt.
+- **R2 aus der Analyse bleibt bestehen:** Keine Datenquelle wird nach Vergangenheit gefragt
+  (kein `past_minutes`/`past_hours`/`start_date`-Parameter). Die Erkennung "läuft bereits" stützt
+  sich daher ausschließlich auf den aktuellen Rasterslot (max. 15 Minuten Rückblick), nicht auf
+  einen längeren Rückblick — ein Ereignis, das vor mehr als einer Viertelstunde begann und noch
+  läuft, ist aus dem Nowcast allein nicht als "seit X laufend" belegbar, nur als "läuft jetzt".
+  Diese Scheibe zusichert entsprechend "läuft bereits", nicht "seit HH:MM".
+- Rund 15 Testdateien nageln heute den Wortlaut "in X Min" fest (Regressionsschutz für AC-2),
+  weitere ~15 hängen an `format_starkregen_hint`/`format_now_text` — eine Wortlautänderung im
+  Laufend-Zweig zieht KEINE Anpassung dieser Bestandstests nach sich, solange der
+  Normalfall-Zweig (Ereignis liegt wirklich in der Zukunft) byte-identisch bleibt.
+
+## Nicht Ziel
+
+- Die 55-Minuten-Meldeschwelle (`RADAR_ONSET_THRESHOLD_MIN`) — Anforderung A-1, andere Scheibe.
+- Die Sperrzeit-/Überholungslogik von `check_nowcast_gate` — Issue #2065, parallele Session.
+- Ein "seit HH:MM läuft es schon"-Rückblick über mehr als eine Viertelstunde — aus den
+  verfügbaren Nowcast-Quellen nicht belegbar (s. Known Limitations, R2).
+- Die Option, den Alarm beim Laufend-Fall gar nicht zu verschicken — vom Product Owner
+  ausdrücklich verworfen (widerspräche dem Produktgrundsatz NUR Daten, keine Bevormundung, und
+  ein stiller Nicht-Alarm wäre von einem technischen Ausfall nicht unterscheidbar).
+- Die verbleibenden Alarm-Szenarien aus #2050 außer Szenario 1/Anforderung B-1 (spätere Scheiben).
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Rein additive Modellerweiterung (neue Felder mit Default auf `NowcastResult`
+  und `OnsetEvent`, byte-identischer Normalfall) nach dem bereits etablierten Muster aus
+  #2009/#2046/#2036/#2020 S2 — kein neues Datenmodell, keine neue Route, keine Rücknahme einer
+  bestehenden Architekturentscheidung. Berührt, aber nicht zurückgenommen: ADR-0052
+  (Warnmail-Nowcast-Bauform) und ADR-0056 (rollierender Alarm-Anker) — beide bleiben in Kraft,
+  diese Scheibe ändert nur, WELCHER Text bei WELCHEM Zustand gerendert wird, nicht die
+  Bauform/den Anker-Mechanismus selbst.
+
+## Changelog
+
+- 2026-08-22: Initial spec created (Scheibe S2b aus #2050, Anforderung B-1, verdichtet aus
+  `docs/context/fix-2050-s2b-laufendes-ereignis.md`).

--- a/docs/specs/modules/alarm_szenario_laufendes_ereignis.md
+++ b/docs/specs/modules/alarm_szenario_laufendes_ereignis.md
@@ -234,6 +234,53 @@ Intervall ab T) — das ist in sich konsistent, aber eine Annahme, nicht extern 
   - Test: `format_starkregen_hint(...)` mit einem `already_running=True`-Eingang aufrufen; der
     Rückgabetext enthält die Laufend-Formulierung.
 
+## Nachtrag 2026-08-22: Abhängigkeit von #2051 S1 und Wortlaut-Entscheid
+
+Nach der Freigabe dieser Spec stellte sich heraus, dass **Issue #2051 Scheibe S1**
+(`feat-2051-s1-dauer-und-ende`, PR #2074) die **Ende-Aussage bereits gebaut hat** — inklusive
+`NowcastResult.event_end_minutes`, `event_ongoing_beyond_horizon`, `_derive_wet_block_end()`,
+geteilter Anzeigefassung und Verzweigung in allen sechs Formatierern.
+
+**Folgen für diese Scheibe:**
+
+1. **Der Ende-Wortlaut wird NICHT hier erfunden**, sondern von #2051 S1 übernommen:
+   | Fall | Langform | Kurznachricht |
+   |---|---|---|
+   | Ende bekannt | `letzter Regen gegen HH:MM` | `R2.5@18:00@20:00` — zweites Zeit-Token **ohne** `>` |
+   | kein Ende absehbar | `Regen mindestens bis HH:MM` | `R2.5@18:00 >@20:00` — Leerzeichen, `>`, Zeit-Token |
+   | kein Ende ableitbar | Angabe entfällt | `R2.5@18:00` |
+   | Gewitter | wie oben | `TH@18:00@20:00 R2.5` |
+
+   🔴 Das `>` ist **kein** Schmuck: `@20:00` heisst „hört um 20:00 auf", ` >@20:00` heisst „hört
+   frühestens um 20:00 auf". Gegensätzliche Aussagen — beim einen kann man danach loslaufen,
+   beim anderen weiss man nur, dass es vorher nicht aufhört. Alle Zeit-Token sind
+   **minutengenau** (INCA/AROME liefern im 15-Minuten-Raster; `20:45` auf `20` zu kürzen wäre
+   bis zu 45 Minuten daneben).
+
+   Der PO hatte bei der Freigabe dieser Spec einen abweichenden Wortlaut ausgewählt
+   (`endet voraussichtlich HH:MM` / `kein Ende im Sichtfenster (bis HH:MM)`), ohne zu wissen,
+   dass er am selben Tag für #2051 S1 bereits eine andere Fassung derselben Aussage freigegeben
+   hatte. **PO-Entscheid 2026-08-22 nach Vorlage des Konflikts: die #2051-Fassung gilt.**
+   Begründung: dort bereits breiter verdrahtet und vom Vorhersage-Pfad mitbenutzt
+   (`render.py:298`) — eine Sprache im Produkt statt zweier.
+
+2. **Reihenfolge:** #2051 S1 wird zuerst gemerged, danach rebast diese Scheibe darauf.
+   Die Ende-Rechnung wird **nicht nachgebaut**, sondern deren `event_end_*`-Felder genutzt.
+
+3. **Was hier echte, eigene Arbeit bleibt:** `already_running` existiert auf deren Branch nicht.
+   Vor allem: deren `event_end_minutes` ist per Definition `None`, sobald `onset_minutes`
+   `None` ist (dort AC-19, freigegeben, getestet, Adversary-geprüft — auf Anfrage bewusst nicht
+   aufgeweicht). Genau der Fall dieser Scheibe fällt dort also heraus: **Ereignis läuft jetzt
+   und endet noch in der laufenden Viertelstunde** — kein künftiger Beginn, aber ein
+   bestimmbares Ende. Dazu die vier Stellen, die Zukunft voraussetzen (AC-10 bis AC-13),
+   die bei #2051 S1 unangetastet bleiben.
+
+4. **Fremdbefund, nicht Teil dieser Scheibe:** Issue **#2063** — die Onset-Uhrzeit ist in etwa
+   jedem zweiten Lauf eine Minute zu früh, weil `local_fmt` (`src/utils/timezone.py:133`)
+   Sekunden abschneidet statt zu runden. Betrifft jede über diesen Weg gebildete Uhrzeit,
+   Ende-Angaben eingeschlossen. Scheitert ein Wächter dieser Scheibe an genau einer Minute,
+   ist das die erste Spur — **nicht** ein Anlass, eine Zusicherung aufzuweichen.
+
 ## Known Limitations
 
 - **Nicht Teil dieser Scheibe:** die 55-Minuten-Meldeschwelle (`RADAR_ONSET_THRESHOLD_MIN`,

--- a/src/output/renderers/alert/model.py
+++ b/src/output/renderers/alert/model.py
@@ -131,6 +131,14 @@ class OnsetEvent:
     # entscheidet AUSSCHLIESSLICH dieses Feld darueber, an EINER Stelle je
     # Textform (`_onset_end_suffix` / `_sms_onset_ende`).
     event_ongoing_beyond_horizon: bool = False
+    # Issue #2050 S2b: das Ereignis laeuft zum Meldezeitpunkt BEREITS. Additiv,
+    # Default aus -> der Normalfall (Ereignis liegt in der Zukunft) bleibt
+    # byte-identisch. Ersetzt in jeder Textform die BEGINN-Angabe ("in 8 Min"
+    # / "ab 12:15" / das `@HH:MM`-Zeittoken) durch den Zustand; die
+    # ENDE-Angabe kommt unveraendert aus den `event_end_*`-Feldern oben --
+    # bewusst KEIN zweites Ende-Feld daneben, sonst gaebe es zwei Wahrheiten
+    # ueber denselben Zeitpunkt.
+    already_running: bool = False
 
 
 @dataclass(frozen=True)

--- a/src/output/renderers/alert/project.py
+++ b/src/output/renderers/alert/project.py
@@ -523,8 +523,14 @@ def to_multi_location_onset_alert_message(
     normalized = [
         (g[0], g[1], g[2]) if len(g) == 3 else (g[0], None, g[1]) for g in groups
     ]
+    # Issue #2050 S2b: ein Ort, an dem es GERADE regnet, gehoert in das
+    # Buendel -- auch wenn kein kuenftiger Beginn bestimmbar ist. Bis hierher
+    # entschied allein `onset_minutes is not None`, und damit fiel genau der
+    # laufende Ort still heraus, bevor sein `OnsetEvent` ueberhaupt gebaut
+    # wurde (Bruchstelle 4).
     valid_groups = [
-        (name, loc, nc) for name, loc, nc in normalized if nc.onset_minutes is not None
+        (name, loc, nc) for name, loc, nc in normalized
+        if nc.onset_minutes is not None or getattr(nc, "already_running", False)
     ]
     if not valid_groups:
         raise ValueError(
@@ -539,10 +545,18 @@ def to_multi_location_onset_alert_message(
         # Zone bilden — ein Buendel kann Orte in verschiedenen Zonen tragen,
         # eine gemeinsame Zone waere fuer alle bis auf einen still falsch.
         loc_tz = _tz_for_location(loc, tz)
-        onset_dt = now + timedelta(minutes=nc.onset_minutes)
+        # Issue #2050 S2b: laeuft das Ereignis bereits und ist kein kuenftiger
+        # Beginn bestimmbar, ist der Bezugszeitpunkt JETZT -- `timedelta(
+        # minutes=None)` waere ein Absturz (Bruchstelle 3). `onset_minutes`
+        # faellt dann auf 0 zurueck; gelesen wird es in diesem Fall nirgends,
+        # weil jede Textform auf `already_running` verzweigt.
+        _laufend = getattr(nc, "already_running", False)
+        onset_dt = now + timedelta(minutes=nc.onset_minutes or 0)
         _end_time, _end_offset, _end_ongoing = event_end_display(now, nc, loc_tz)
         events.append(OnsetEvent(
-            onset_minutes=nc.onset_minutes, onset_time=local_fmt(onset_dt, loc_tz),
+            already_running=_laufend,
+            onset_minutes=nc.onset_minutes or 0,
+            onset_time=local_fmt(onset_dt, loc_tz),
             km_from=0.0, km_to=0.0, is_convective=nc.is_convective,
             intensity_label=nc.intensity_label, source_label=nc.source,
             location_label=location_name if multi else None,

--- a/src/output/renderers/alert/render.py
+++ b/src/output/renderers/alert/render.py
@@ -482,7 +482,7 @@ def _render_subject_onset(msg: AlertMessage) -> str:
     # Issue #2051 S1: das Ende additiv HINTER der Beginn-Angabe -- ohne
     # behauptbares Ende bleibt der Betreff byte-identisch (AC-19).
     return (
-        f"[{msg.trip_short}] {km} · {label} in {e.onset_minutes} Min"
+        f"[{msg.trip_short}] {km} · {label} {_onset_wann_kopf(e)}"
         f"{_onset_end_suffix(e)}"
     )
 
@@ -513,6 +513,34 @@ def _onset_time_label(e: OnsetEvent) -> str:
     Vergangenheits-Kennzeichen (Radar blickt nach vorn), daher `is_past=False`.
     """
     return _time_with_day(e.onset_time, e.onset_day_offset)
+
+
+def _onset_wann_kopf(e: OnsetEvent) -> str:
+    """Kopfzeilen-Form: "in 8 Min" -- oder "laeuft bereits" (Issue #2050 S2b).
+
+    EINE Weiche fuer Betreff, E-Mail-H1/-Buendelzeile und Telegram-Kopf: die
+    vier Stellen sagten denselben Satz in vier Kopien, und genau so entstand
+    B-1 an vier Stellen gleichzeitig. Die Ende-Angabe haengt unveraendert
+    ueber `_onset_end_suffix()` dahinter."""
+    if getattr(e, "already_running", False):
+        return "läuft bereits"
+    return f"in {e.onset_minutes} Min"
+
+
+def _onset_wann_zeile(e: OnsetEvent, *, praefix: str = "") -> str:
+    """Detailzeilen-Form: der ZEITPUNKT -- oder "laeuft bereits" (#2050 S2b).
+
+    Getrennt von `_onset_wann_kopf`, weil die Detailzeile den ZEITPUNKT nennt
+    und die Kopfzeile die RESTZEIT; im Laufend-Fall fallen beide zusammen.
+
+    `praefix` gehoert der Aufrufstelle: die E-Mail schreibt "ab 15:40", die
+    Telegram-Langform nennt die Uhrzeit nackt ("15:40"). Ein hier fest
+    eingebautes "ab " hat genau diesen Unterschied eingeebnet und
+    `test_alert_sms_onset_zeitpunkt::test_ac10` rot gemacht -- im
+    Laufend-Fall entfaellt das Praefix mit der Uhrzeit zusammen."""
+    if getattr(e, "already_running", False):
+        return "läuft bereits"
+    return f"{praefix}{_onset_time_label(e)}"
 
 
 def _onset_end_suffix(e: OnsetEvent) -> str:
@@ -566,11 +594,11 @@ def _render_email_onset_multi(msg: AlertMessage) -> tuple[str, str]:
     data_rows = [
         (
             f"{e.location_label} · {'Gewitter/Hagel' if e.is_convective else 'Regen'} "
-            f"in {e.onset_minutes} Min",
+            f"{_onset_wann_kopf(e)}",
             # Issue #2051 S1: das Ende JE ORT aus dessen eigenem Event -- ein
             # Buendel kann Orte mit verschiedenen Ende-Zeiten tragen. Ohne
             # behauptbares Ende bleibt die Zeile byte-identisch (AC-19).
-            f"ab {_onset_time_label(e)}{_onset_end_suffix(e)} · "
+            f"{_onset_wann_zeile(e, praefix='ab ')}{_onset_end_suffix(e)} · "
             f"{e.intensity_label}",
         )
         for e in msg.events
@@ -640,14 +668,15 @@ def _render_email_onset(msg: AlertMessage) -> tuple[str, str]:
     e = msg.events[0]
     label = "Gewitter" if e.is_convective else "Regen"
     badge_text = "Radar-Nowcast"
-    h1 = f"{label} in {e.onset_minutes} Min"
+    h1 = f"{label} {_onset_wann_kopf(e)}"
     km = _km_str_onset(e)
 
     data_rows = [
         # Issue #2051 S1: Beginn und Ende gehoeren in DIESELBE "Wo & wann"-
         # Zeile -- eine eigene Datenzeile nur fuer das Ende waere im
         # Ende-losen Normalfall eine leere Zeile (ADR-0052, Label-Wert-Form).
-        ("Wo & wann", f"{km} · ab {_onset_time_label(e)}{_onset_end_suffix(e)}"),
+        ("Wo & wann",
+         f"{km} · {_onset_wann_zeile(e, praefix='ab ')}{_onset_end_suffix(e)}"),
         ("Intensität", e.intensity_label),
         ("Quelle", e.source_label),
     ]
@@ -712,11 +741,11 @@ def _render_telegram_onset(msg: AlertMessage) -> str:
     e = msg.events[0]
     label = "Gewitter" if e.is_convective else "Regen"
     km = _km_str_onset(e)
-    first = f"<b>{_esc(f'{msg.trip_short} · {km} · {label} in {e.onset_minutes} Min')}</b>"
+    first = f"<b>{_esc(f'{msg.trip_short} · {km} · {label} {_onset_wann_kopf(e)}')}</b>"
     # Issue #2051 S1: das Ende additiv HINTER der Beginn-Zeit, vor Intensitaet
     # und Quelle -- ohne behauptbares Ende byte-identisch wie bisher (AC-19).
     second = (
-        f"{_onset_time_label(e)}{_onset_end_suffix(e)} · "
+        f"{_onset_wann_zeile(e)}{_onset_end_suffix(e)} · "
         f"{e.intensity_label} · {e.source_label}"
     )
     # Issue #2018 (AC-B3): die Bezugszeile steht als EIGENE Zeile zwischen Kopf
@@ -824,7 +853,20 @@ def _render_sms_onset(msg: AlertMessage, limit: int = 140) -> str:
     # bliebe dort eine stille Luecke.
     zeit = _sms_onset_time(e.onset_time, e.onset_day_offset) + _sms_onset_ende(e)
     menge = _sms_onset_menge(getattr(e, "onset_precip_mm", None))
-    if menge is None:
+    if getattr(e, "already_running", False):
+        # Issue #2050 S2b (PO-Entscheid 2026-08-22): `now` steht dort, wo
+        # sonst das Beginn-Zeittoken stuende -- ENGLISCH wie die ganze
+        # Kurzform (`R` = Rain, `TH` = Thunder). Die Ende-Grammatik aus #2051
+        # haengt unveraendert dahinter (`now@20:00` bekanntes Ende,
+        # `now >@20:00` Untergrenze), damit es nur EINE Ende-Form gibt.
+        ende = _sms_onset_ende(e)
+        if menge is None:
+            token = f"{kuerzel} now{ende}"
+        elif kuerzel == "TH":
+            token = f"TH now{ende} R{menge}"
+        else:
+            token = f"R{menge} now{ende}"
+    elif menge is None:
         token = f"{kuerzel}@{zeit}"
     elif kuerzel == "TH":
         # Issue #2046: im Gewitter-Fall steht die Menge als EIGENES Token NACH

--- a/src/output/renderers/email/starkregen_hint.py
+++ b/src/output/renderers/email/starkregen_hint.py
@@ -17,9 +17,10 @@ from zoneinfo import ZoneInfo
 
 
 def format_starkregen_hint(
-    intensity_label: str, onset_minutes: int, *, tz: ZoneInfo,
+    intensity_label: str, onset_minutes: int | None, *, tz: ZoneInfo,
     event_end_minutes: int | None = None,
     event_ongoing_beyond_horizon: bool = False,
+    already_running: bool = False,
 ) -> str:
     """"Starker Regen ab ca. HH:MM (in ~N Min), letzter Regen gegen HH:MM." —
     identisches Format wie `RadarNowcastService.format_now_text()` fuer den
@@ -39,9 +40,16 @@ def format_starkregen_hint(
     from utils.timezone import local_dt
 
     now = datetime.now(timezone.utc)
-    onset_time = now + timedelta(minutes=onset_minutes)
-    time_str = local_dt(onset_time, tz).strftime("%H:%M")
-    satz = f"{intensity_label} ab ca. {time_str} (in ~{onset_minutes} Min)"
+    if already_running:
+        # Issue #2050 S2b: laeuft das Ereignis zur Briefing-Erstellung
+        # bereits, ist die Beginn-Angabe eine Falschaussage -- und
+        # `onset_minutes` darf hier `None` sein (kein kuenftiger Beginn
+        # bestimmbar). Die Ende-Angabe unten bleibt unveraendert.
+        satz = f"{intensity_label} läuft bereits"
+    else:
+        onset_time = now + timedelta(minutes=onset_minutes)
+        time_str = local_dt(onset_time, tz).strftime("%H:%M")
+        satz = f"{intensity_label} ab ca. {time_str} (in ~{onset_minutes} Min)"
     if event_end_minutes is not None:
         end_str = local_dt(
             now + timedelta(minutes=event_end_minutes), tz,

--- a/src/services/compare_radar_alert.py
+++ b/src/services/compare_radar_alert.py
@@ -65,9 +65,15 @@ def _identity_inputs(nowcast, now_utc: datetime) -> tuple:
     """Issue #1917 S4b-2: `(Gefahrenklasse, Dringlichkeit, Onset-Zeitpunkt)`
     einer Nowcast-Meldung — EINE Ableitung fuer Pruefung UND Registrierung,
     damit beide Seiten nie auseinanderlaufen koennen."""
+    # Issue #2050 S2b: ohne kuenftigen Beginn, aber mit laufendem Ereignis ist
+    # JETZT der Bezugszeitpunkt. Bliebe `onset_at` hier `None`, faende
+    # `_times_overlap` (`alert_gate.py`) nie einen Kandidaten und die
+    # Entdopplung waere ein stiller No-Op -- funktionsfaehig aussehend, aber
+    # ohne Wirkung (Bruchstelle 2).
     onset_at = (
         now_utc + timedelta(minutes=nowcast.onset_minutes)
-        if nowcast.onset_minutes is not None else None
+        if nowcast.onset_minutes is not None
+        else (now_utc if getattr(nowcast, "already_running", False) else None)
     )
     return (
         resolve_hazard_class(is_convective=nowcast.is_convective),

--- a/src/services/notification_service.py
+++ b/src/services/notification_service.py
@@ -110,7 +110,10 @@ class TripReportRequest:
     # Issue #2051 S1: die Datenform traegt zusaetzlich Ende und R4-Waechter
     # (`event_end_minutes`, `event_ongoing_beyond_horizon`) — das alte
     # Zwei-Tupel konnte das Ende gar nicht transportieren.
-    starkregen_nowcast: tuple[str, int, int | None, bool] | None = None
+    # Issue #2050 S2b: fuenftes Glied `already_running`, und `onset_minutes`
+    # wird optional — ein laufendes Ereignis, das in der laufenden
+    # Viertelstunde endet, hat keinen kuenftigen Beginn.
+    starkregen_nowcast: tuple[str, int | None, int | None, bool, bool] | None = None
 
 
 @dataclass
@@ -172,7 +175,10 @@ class RadarAlertRequest:
     (`TripAlertService.check_radar_alerts`) loest ihn immer ueber
     `tz_for_coords()` auf (nie `None`).
     """
-    onset_minutes: int
+    # Issue #2050 S2b: `None`, wenn das Ereignis bereits laeuft und in der
+    # laufenden Viertelstunde endet -- dann ist kein kuenftiger Beginn
+    # bestimmbar (`already_running` traegt die Aussage).
+    onset_minutes: int | None
     onset_time: str
     km_from: float
     km_to: float
@@ -216,6 +222,11 @@ class RadarAlertRequest:
     # vs. bekanntes Ende, AC-20). Ohne ihn kaeme im Waechterfall die
     # Normalform an und behauptete ein Ende, das die Daten nicht hergeben.
     event_ongoing_beyond_horizon: bool = False
+    # Issue #2050 S2b: das Ereignis laeuft zum Meldezeitpunkt bereits. Additiv,
+    # Default aus. Reist bis in den Renderer, weil dort die BEGINN-Angabe
+    # durch den Zustand ersetzt wird; das Ende kommt weiter aus den
+    # `event_end_*`-Feldern.
+    already_running: bool = False
 
 
 def build_service_error_email_html(trip_name: str, report_type: str, error_lines: str) -> str:
@@ -397,7 +408,7 @@ class NotificationService:
 
             (
                 _intensity_label, _onset_minutes,
-                _event_end_minutes, _event_ongoing,
+                _event_end_minutes, _event_ongoing, _already_running,
             ) = request.starkregen_nowcast
             starkregen_hint_text = format_starkregen_hint(
                 _intensity_label, _onset_minutes, tz=request.trip_tz,
@@ -405,6 +416,9 @@ class NotificationService:
                 # Nowcast-Ergebnis, das schon Label und Beginn liefert.
                 event_end_minutes=_event_end_minutes,
                 event_ongoing_beyond_horizon=_event_ongoing,
+                # Issue #2050 S2b: der Laufend-Zustand ebenfalls aus demselben
+                # Ergebnis -- er entscheidet ueber die BEGINN-Angabe der Zeile.
+                already_running=_already_running,
             )
 
         report = self._formatter.format_email(
@@ -1336,7 +1350,11 @@ class NotificationService:
     ) -> NotificationResult:
         """Radar-Onset-Alert: rendern und über konfigurierte Kanäle versenden."""
         onset_event = OnsetEvent(
-            onset_minutes=request.onset_minutes,
+            # Issue #2050 S2b: ohne kuenftigen Beginn traegt `onset_minutes`
+            # `None` -- der Renderer-Vertrag verlangt eine Zahl, liest sie im
+            # Laufend-Fall aber nirgends (jede Textform verzweigt vorher).
+            onset_minutes=request.onset_minutes or 0,
+            already_running=request.already_running,  # Issue #2050 S2b
             onset_time=request.onset_time,
             km_from=request.km_from,
             km_to=request.km_to,

--- a/src/services/radar_service.py
+++ b/src/services/radar_service.py
@@ -188,11 +188,21 @@ class NowcastResult:
     # Beginn -- das Fenster ab jetzt deckt dann fast nur Trockenzeit ab und
     # untertriebe die Menge systematisch. BEWUSST beschreibend: kein Leser in
     # radar_alert_due()/der #2020-Ueberholungsregel.
+    already_running: bool = False
+    # Issue #2050 S2b: laeuft das Ereignis zum Abfragezeitpunkt BEREITS? True,
+    # wenn das Frame, dessen Deckung `now` enthaelt, ueber der Trockenschwelle
+    # liegt. Additiv NEBEN `onset_minutes`, nicht an dessen Stelle -- der
+    # Beginn behaelt seine Rolle als Torwaechter und Dedup-Bestandteil. Gilt
+    # unabhaengig davon, ob der Regen in ein kuenftiges Frame hineindauert
+    # (`onset_minutes` gesetzt) oder in der laufenden Viertelstunde endet
+    # (`onset_minutes is None`); nur im zweiten Fall traegt S2b zusaetzlich
+    # das Ende bei, weil #2051 es dort per AC-19 offen laesst.
     event_end_minutes: Optional[int] = None
     # Issue #2051 S1: Minuten ab jetzt bis zum Ende des zusammenhaengenden
     # nassen Blocks, analog `onset_minutes`. `None`, wenn `onset_minutes`
     # `None` ist -- ohne Beginn gibt es kein Ende, das behauptet werden
-    # koennte. Abgeleitet aus DENSELBEN `frames` (kein zweiter Quellenabruf).
+    # koennte. AUSNAHME seit #2050 S2b: laeuft das Ereignis bereits, ist das
+    # Ende auch ohne Beginn bestimmbar (Deckungsgrenze des laufenden Frames). Abgeleitet aus DENSELBEN `frames` (kein zweiter Quellenabruf).
     # Die DAUER ist stets `event_end_minutes - onset_minutes` und wird
     # absichtlich NICHT als drittes Feld gespeichert -- eine zweite Quelle der
     # Wahrheit koennte auseinanderlaufen.
@@ -332,6 +342,43 @@ def _derive_wet_block_end(
     # ein Schleifen-Element. Ohne nassen Frame (leeres Fenster) bleibt der
     # Beginn selbst das Ende.
     return last_wet_ts, False
+
+
+def _laufendes_frame(frames: list, now: datetime):
+    """Das Frame, dessen Gueltigkeitsintervall `now` enthaelt, plus dessen
+    Deckungsende -- oder `None` (Issue #2050 S2b, B-1).
+
+    Frames tragen den SLOT-START (15-Min-Raster :00/:15/:30/:45) und gelten
+    VORWAERTS -- dieselbe Konvention, nach der `_accumulate_precip_mm` seit
+    #2020 seine Mengen rechnet. Deshalb liegt das Frame der LAUFENDEN
+    Viertelstunde immer vor `now` und faellt aus dem Zukunftsfenster
+    (`f.timestamp >= now`) heraus; genau daran scheiterte bisher jede Aussage
+    ueber ein bereits laufendes Ereignis.
+
+    Keine neue Toleranzzahl: Dedup je Zeitstempel wie dort ("hoeherer Wert
+    gewinnt"), Deckung bis zum eigenen naechsten Nachbarn, spaetestens nach
+    `_MAX_FRAME_COVERAGE`. Reicht sie nicht bis `now` (Datenluecke), gibt es
+    kein laufendes Bild -- dann `None` statt einer Hochrechnung.
+
+    Rueckgabe: `(timestamp, rate_mm_h, is_convective, deckung_ende)`.
+    """
+    by_ts: dict[datetime, float] = {}
+    konvektiv: dict[datetime, bool] = {}
+    for f in frames:
+        vorhanden = by_ts.get(f.timestamp)
+        if vorhanden is None or f.precip_mm_h > vorhanden:
+            by_ts[f.timestamp] = f.precip_mm_h
+            konvektiv[f.timestamp] = bool(f.is_convective)
+    reihe = sorted(by_ts.items())
+    for i, (ts, rate) in enumerate(reihe):
+        if ts > now:
+            break
+        deckung_ende = ts + _MAX_FRAME_COVERAGE
+        if i + 1 < len(reihe) and reihe[i + 1][0] < deckung_ende:
+            deckung_ende = reihe[i + 1][0]
+        if ts <= now < deckung_ende:
+            return ts, rate, konvektiv[ts], deckung_ende
+    return None
 
 
 class RadarNowcastService:
@@ -509,7 +556,13 @@ class RadarNowcastService:
         """
         lines: list[str] = []
 
-        if result.onset_minutes is None:
+        # Issue #2050 S2b: ein bereits laufendes Ereignis geht in den Zweig
+        # unten, auch wenn kein kuenftiger Beginn bestimmbar ist -- sonst
+        # antwortet `/jetzt` mit der Entwarnung "kein Regen erwartet",
+        # waehrend es regnet.
+        if result.onset_minutes is None and not getattr(
+            result, "already_running", False
+        ):
             if result.data_unavailable:
                 # Issue #1628 S3: bei einem echten Fetch-Fehler ist
                 # `intensity_label` (frames=[] -> "Kein Niederschlag") und der
@@ -546,11 +599,17 @@ class RadarNowcastService:
                 # die Prozess-Zeitzone des Servers statt ehrlich UTC).
                 return moment.strftime("%H:%M")
 
-            time_str = _hhmm(now + timedelta(minutes=result.onset_minutes))
-            satz = (
-                f"{result.intensity_label} ab ca. {time_str}"
-                f" (in ~{result.onset_minutes} Min)"
-            )
+            if getattr(result, "already_running", False):
+                # Issue #2050 S2b: kein Beginn, sondern der Zustand. Die
+                # Ende-Angabe unten haengt unveraendert dahinter -- eine
+                # zweite Ende-Weiche waere eine zweite Wahrheit.
+                satz = f"{result.intensity_label} läuft bereits"
+            else:
+                time_str = _hhmm(now + timedelta(minutes=result.onset_minutes))
+                satz = (
+                    f"{result.intensity_label} ab ca. {time_str}"
+                    f" (in ~{result.onset_minutes} Min)"
+                )
             # Issue #2051 S1 (AC-14): das Ende desselben Ereignisses, aus
             # DEMSELBEN `now` wie der Beginn abgeleitet. Der R4-Waechter
             # waehlt seit Spec v1.1 (PO-Entscheid 2026-08-22) die FORM statt
@@ -846,17 +905,32 @@ class RadarNowcastService:
                 onset_ts = frame.timestamp
                 break
 
+        # Issue #2050 S2b: laeuft das Ereignis JETZT? Das entscheidende Frame
+        # liegt per Konstruktion VOR `now` und ist in `window` nicht enthalten.
+        _laufend = _laufendes_frame(frames, now)
+        already_running = bool(
+            _laufend is not None and _laufend[1] >= _DRY_THRESHOLD_MM_H
+        )
+
         # Max rate im 180-Min-Nowcast-Fenster -- speist NUR intensity_label
         # (Anzeige). NICHT die Ueberholungspruefung: das NowcastResult-Feld
         # max_rate_mm_h wird weiter unten separat aus dem 60-Min-Vergleichs-
         # fenster gebildet (Adversary-Fund F001, 2026-08-21), damit Raten-
         # und Mengenfenster deckungsgleich sind.
+        #
+        # Issue #2050 S2b: das LAUFENDE Frame zaehlt fuer die Anzeige mit.
+        # Ohne es bliebe von einem Ereignis, das in der laufenden
+        # Viertelstunde endet, "Kein Niederschlag" uebrig -- der Alarm saehe
+        # den Satz "Kein Niederschlag laeuft bereits" und liefe in der
+        # NIEDRIGSTEN Dringlichkeitsstufe, waehrend es schuettet.
         max_rate = max((f.precip_mm_h for f in window), default=0.0)
+        if already_running:
+            max_rate = max(max_rate, _laufend[1])
 
         # Convective flag: any wet frame in window with convective indicator
         is_convective = any(
             f.is_convective for f in window if f.precip_mm_h >= _DRY_THRESHOLD_MM_H
-        )
+        ) or bool(already_running and _laufend[2])
 
         intensity_label = self.intensity_to_text(max_rate, is_convective=is_convective)
 
@@ -943,6 +1017,23 @@ class RadarNowcastService:
             event_end_minutes = max(
                 0, round((_end_ts - now).total_seconds() / 60.0)
             )
+        elif already_running:
+            # Issue #2050 S2b: genau die Luecke, die AC-19 von #2051 offen
+            # laesst ("ohne Beginn kein Ende") -- das Ereignis laeuft, hoert
+            # aber in der laufenden Viertelstunde auf, ein kuenftiger Beginn
+            # ist deshalb nicht bestimmbar. Der nasse Block besteht dann aus
+            # dem laufenden Frame, dessen ZEITSTEMPEL per Konstruktion in der
+            # Vergangenheit liegt. Genannt wird darum seine DECKUNGSGRENZE --
+            # dieselbe Konvention, die der Untergrenzen-Zweig von #2051 schon
+            # verwendet. Der Frame-Zeitstempel waere eine Aussage ueber die
+            # Vergangenheit im Gewand einer Auskunft ueber die Zukunft: der
+            # Wanderer stuende im Regen und laese, dass er vorbei ist.
+            _end_ts, event_ongoing_beyond_horizon = _derive_wet_block_end(
+                frames, all_ts_sorted, _laufend[0], horizon,
+            )
+            event_end_minutes = max(
+                0, round((max(_end_ts, _laufend[3]) - now).total_seconds() / 60.0)
+            )
 
         # Issue #2020 Adversary-Fund F001: max_rate_mm_h fuer die
         # Ueberholungspruefung MUSS aus demselben Fenster stammen wie
@@ -968,6 +1059,7 @@ class RadarNowcastService:
             max_rate_mm_h=compare_window_max_rate_mm_h,
             window_precip_mm=window_precip_mm,
             onset_precip_mm=onset_precip_mm,  # Issue #2046
+            already_running=already_running,  # Issue #2050 S2b
             event_end_minutes=event_end_minutes,  # Issue #2051 S1
             event_ongoing_beyond_horizon=event_ongoing_beyond_horizon,  # #2051 S1
         )

--- a/src/services/trip_alert.py
+++ b/src/services/trip_alert.py
@@ -143,9 +143,17 @@ class AlertCheckRunResult:
 
 
 def radar_alert_due(result: object, threshold_min: int) -> bool:
-    """Return True when rain onset is within threshold_min minutes."""
+    """Return True when rain onset is within threshold_min minutes.
+
+    Issue #2050 S2b: ein BEREITS LAUFENDES Ereignis loest ebenfalls aus. Bis
+    hierher entschied allein `onset_minutes`, und endete der Regen innerhalb
+    der laufenden Viertelstunde, gab es keinen Beginn mehr in der Zukunft --
+    der Alarm fiel ersatzlos aus, obwohl es gerade regnete (Bruchstelle 1).
+    """
     onset = getattr(result, "onset_minutes", None)
-    return onset is not None and onset <= threshold_min
+    if onset is not None and onset <= threshold_min:
+        return True
+    return bool(getattr(result, "already_running", False))
 
 
 def _trip_telegram_style(trip: "Trip") -> str:
@@ -1379,7 +1387,12 @@ class TripAlertService:
             if not radar_alert_due(result, radar_service_mod.RADAR_ONSET_THRESHOLD_MIN):
                 continue
 
-            _onset_dt = now_utc + timedelta(minutes=result.onset_minutes)
+            # Issue #2050 S2b: ohne kuenftigen Beginn (laufendes Ereignis, das
+            # in der laufenden Viertelstunde endet) waere `timedelta(
+            # minutes=None)` ein Absturz. Bezugszeitpunkt ist dann JETZT --
+            # dieser Wert traegt die Ereignis-Identitaet (Entdopplung) und den
+            # Briefing-Vergleich, beide brauchen einen Zeitpunkt (Bruchstelle 3).
+            _onset_dt = now_utc + timedelta(minutes=result.onset_minutes or 0)
 
 
             # Briefing-Vergleich (Issue #818 AC-1/AC-2/AC-3)
@@ -1508,6 +1521,7 @@ class TripAlertService:
             )
             _radar_request = RadarAlertRequest(
                 onset_minutes=result.onset_minutes,
+                already_running=result.already_running,  # Issue #2050 S2b
                 onset_time=_onset_time_str,
                 onset_day_offset=day_offset(now_utc, _onset_dt, tz),
                 km_from=active.start_point.distance_from_start_km,

--- a/src/services/trip_report_scheduler.py
+++ b/src/services/trip_report_scheduler.py
@@ -1700,7 +1700,9 @@ class TripReportSchedulerService:
         catchup_prefix: str | None,
         partial_outage_hint: str | None = None,
         render_options: Optional["ReportRenderOptions"] = None,
-        starkregen_nowcast: Optional[Tuple[str, int, Optional[int], bool]] = None,
+        starkregen_nowcast: Optional[
+            Tuple[str, Optional[int], Optional[int], bool, bool]
+        ] = None,  # Issue #2050 S2b: fuenftes Glied `already_running`
     ) -> TripReportRequest:
         """Baut das DTO, das an den NotificationService übergeben wird (Issue #1022).
 
@@ -1757,11 +1759,13 @@ class TripReportSchedulerService:
         segments: List[TripSegment],
         now_utc: datetime,
         target_date: Optional[date] = None,
-    ) -> Optional[Tuple[str, int, Optional[int], bool]]:
+    ) -> Optional[Tuple[str, Optional[int], Optional[int], bool, bool]]:
         """Starkregen-Kurzfristhinweis (Issue #1439): liefert die Rohdaten
         (``intensity_label``, ``onset_minutes``, seit Issue #2051 S1
         zusaetzlich ``event_end_minutes`` und
-        ``event_ongoing_beyond_horizon``) fuer den planmaessigen
+        ``event_ongoing_beyond_horizon``, seit #2050 S2b ``already_running``;
+        ``onset_minutes`` ist seither optional, weil ein laufendes Ereignis
+        ohne kuenftigen Beginn auskommt) fuer den planmaessigen
         Briefing-Pfad, wenn der bereits produktive `RadarNowcastService`
         (#656) fuer den Startpunkt des aktiven/naechsten Segments Starkregen
         innerhalb von `NOWCAST_HORIZON_MIN` erkennt.
@@ -1876,16 +1880,28 @@ class TripReportSchedulerService:
             logger.warning(f"Starkregen-Kurzfristhinweis: Nowcast fehlgeschlagen fuer {trip.id}: {e}")
             return None
 
-        if result.onset_minutes is None or result.intensity_label != INTENSITY_HEAVY:
+        # Issue #2050 S2b: ein bereits LAUFENDES Ereignis hat keinen kuenftigen
+        # Beginn, wenn es in der laufenden Viertelstunde endet -- an dieser
+        # Bedingung brach der Briefing-Hinweis fuer genau diesen Fall ab,
+        # bevor irgendetwas geprueft wurde. Die STAERKE-Schwelle bleibt
+        # unangetastet: sie liest seit S2b auch das laufende Frame mit, ein
+        # laufender Starkregen erfuellt sie also aus eigener Kraft.
+        if result.intensity_label != INTENSITY_HEAVY:
+            return None
+        if result.onset_minutes is None and not result.already_running:
             return None
 
         # Issue #2051 S1: Ende und R4-Waechter wandern mit -- das alte
         # Zwei-Tupel konnte das Ende gar nicht transportieren. Rohdaten
         # bleiben Rohdaten: die Textformatierung passiert weiterhin im
         # NotificationService (Architektur-Grenze).
+        # Issue #2050 S2b: `already_running` als fuenftes Glied. Ohne es kaeme
+        # der Laufend-Zustand am Formatierer nie an -- der Renderer-Zweig
+        # waere gebaut und unerreichbar.
         return (
             result.intensity_label, result.onset_minutes,
             result.event_end_minutes, result.event_ongoing_beyond_horizon,
+            result.already_running,
         )
 
     def _reset_alert_state_after_briefing(self, trip_id: str) -> None:

--- a/src/services/validator_render_service.py
+++ b/src/services/validator_render_service.py
@@ -141,6 +141,13 @@ def render_alert_preview(
             event_ongoing_beyond_horizon=getattr(
                 body.onset, "event_ongoing_beyond_horizon", False,
             ),
+            # Issue #2050 S2b: der Laufend-Zustand entscheidet ueber die
+            # BEGINN-Angabe ("laeuft bereits" statt "in N Min") und muss den
+            # Renderer deshalb auch hier erreichen. Der Vorschauweg ist das,
+            # womit beim Ausrollen geprueft wird -- zeigte er eine andere
+            # Aussage als der Versand, pruefte die Verifikation etwas, das so
+            # nie beim Nutzer ankommt, und meldete gruen (AC-14b).
+            already_running=getattr(body.onset, "already_running", False),
         )
         msg = AlertMessage(
             trip_short=trip_obj.name,
@@ -259,19 +266,26 @@ def _render_nowcast_replay(trip_obj: Trip, body_nf: Any) -> dict:
     svc = RadarNowcastService()
     now = datetime.now(timezone.utc)
     result = svc._derive_result(frames, body_nf.source, now=now)
-    if result.onset_minutes is None:
+    # Issue #2050 S2b: ein bereits laufendes Ereignis IST ein Ereignis, auch
+    # ohne kuenftigen Beginn -- sonst meldete die Vorschau "kein Onset",
+    # waehrend der Versandweg alarmiert (AC-14b).
+    if result.onset_minutes is None and not result.already_running:
         return {
             "onset_detected": False, "subject": None, "email_html": None,
             "email_plain": None, "telegram": None, "sms": None,
         }
 
     alert_tz = _alert_tz_for_trip(trip_obj)
-    onset_time = now + timedelta(minutes=result.onset_minutes)
+    onset_time = now + timedelta(minutes=result.onset_minutes or 0)
     _end_time, _end_offset, _end_ongoing = event_end_display(
         now, result, alert_tz,
     )
     onset_ns = SimpleNamespace(
-        onset_minutes=result.onset_minutes,
+        onset_minutes=result.onset_minutes or 0,
+        # Issue #2050 S2b: aus DEMSELBEN `_derive_result`-Ergebnis wie alles
+        # andere -- die Vorschau sagt damit "laeuft bereits", wo der Versand
+        # es sagt.
+        already_running=result.already_running,
         onset_time=local_fmt(onset_time, alert_tz)[-5:],  # "HH:MM"-Anteil
         km_from=body_nf.km_from, km_to=body_nf.km_to,
         is_convective=result.is_convective,

--- a/tests/tdd/test_alarm_szenario_laufendes_ereignis.py
+++ b/tests/tdd/test_alarm_szenario_laufendes_ereignis.py
@@ -1,6 +1,8 @@
 """Issue #2050 Scheibe S2b — Waechter: laufendes Regen-/Gewitterereignis.
 
 SPEC: docs/specs/modules/alarm_szenario_laufendes_ereignis.md (AC-1..AC-15)
+Zusaetzlich AC-11b: Gegenrichtung zu AC-11 (Befund der Parallelsession #2065,
+`alert_gate.py:489-494`) -- die Entdopplung darf keinen NEUEN Alarm fressen.
 
 Laeuft ein Ereignis zum Zeitpunkt des Alarmlaufs BEREITS, meldet Gregor es
 heute als bevorstehend ("Regen in 8 Min"): `_derive_result` filtert
@@ -16,19 +18,30 @@ MagicMock: Frames ueber die DI-Naht `frame_source=` eines echten
 Transport (lokale Stubs der Pruefstrecke) bzw. `mail_sink`. Kein echter Versand.
 
 WORTLAUT-VERTRAG dieser Scheibe (GREEN zieht nach). Die Herkunft ist bewusst
-getrennt ausgewiesen -- das eine ist Freigabe, das andere Entwurfsentscheidung:
+getrennt ausgewiesen -- Freigabe ist nicht dasselbe wie Entwurfsentscheidung:
 
-  * VOM PRODUCT OWNER bei der Freigabe ausgewaehlt (verbindlich, steht so
-    nicht in der Spec): E-Mail/Telegram-Langform/Betreff/`/jetzt`/
-    Briefing-Zeile melden "Regen laeuft bereits" statt einer Beginn-Angabe,
-    das Ende als "endet voraussichtlich HH:MM"; ist im verfuegbaren
-    Datenbestand kein Ende erkennbar, steht dort "kein Ende im Sichtfenster
-    (bis HH:MM)" mit der Uhrzeit des LETZTEN verfuegbaren Frames -- ohne
-    erfundene Dauer.
-  * EIGENE WAHL dieser Scheibe (keine PO-Vorlage, weil kein Beispieltext
-    vorlag): die Kurznachricht (SMS/Premium-SMS/Telegram-Kurzform) ersetzt
-    `R@HH:MM` durch `R>HH:MM` bzw. `TH>HH:MM` ("laeuft, bis"); der
-    `@`-Beginn-Marker verschwindet, das Zeichenbudget bleibt gewahrt.
+  * LAUFEND-AUSSAGE, vom Product Owner bei der S2b-Freigabe ausgewaehlt:
+    E-Mail/Telegram-Langform/Betreff/`/jetzt`/Briefing-Zeile melden
+    "Regen laeuft bereits" statt einer Beginn-Angabe.
+  * ENDE-AUSSAGE aus #2051 S1, PO-Entscheid 2026-08-22 (unser urspruenglicher
+    Wortlaut ist zurueckgezogen). Nachgelesen im Quelltext
+    `render.py::_onset_end_suffix`/`_sms_onset_ende` auf
+    `origin/feat-2051-s1-dauer-und-ende`. ZWEI Formen, entschieden allein am
+    R4-Waechter `event_ongoing_beyond_horizon` -- bekanntes Ende
+    (Trockenuebergang beobachtet, unsere Lage A): ` · letzter Regen gegen
+    HH:MM`, Kurznachricht `@HH:MM` direkt angehaengt (`R2.5@18:00@20:00`);
+    Untergrenze (Zeitreihe/Horizont ausgegangen, Lage B): ` · Regen
+    mindestens bis HH:MM`, Kurznachricht ` >@HH:MM`.
+  * LAUFEND-MARKER der Kurznachricht, PO-Entscheid 2026-08-22 (verbindlich):
+    das Wort `now` steht dort, wo sonst der Beginn stuende, danach
+    unveraendert die Ende-Grammatik -- `R2.0 now@12:45` bei bekanntem Ende,
+    `R2.0 now >@14:30` bei der Untergrenze, `TH now@12:45` beim Gewitter.
+
+🔴 Die Kurznachricht (SMS, Premium-SMS, Telegram-Kurzform) ist ENGLISCH --
+`R` = Rain, `TH` = Thunder, und deshalb `now` statt "jetzt". Nur die
+Langformen (E-Mail, Telegram-Langform) sprechen Deutsch. Jedes neue Wort in
+der Kurzform ist englisch, auch wenn dieselbe Aussage in der E-Mail deutsch
+lautet: Langform `letzter Regen gegen 12:30`, Kurzform `R2.0 now@12:30`.
 """
 from __future__ import annotations
 
@@ -44,7 +57,9 @@ from app.loader import save_trip
 from output.renderers.alert.project import to_multi_location_onset_alert_message
 from output.renderers.alert.render import render_email, render_telegram
 from services.radar_cache import reset_shared_radar_cache_for_tests
-from services.radar_service import NowcastResult, RadarNowcastService
+from services.radar_service import (
+    INTENSITY_DRY, NowcastResult, RadarNowcastService,
+)
 
 from tests.helpers.alarm_pruefstrecke import AlarmPruefstrecke
 from tests.tdd.test_952_onset_alert_fidelity import _clean_user
@@ -62,17 +77,32 @@ _AT_LAUF = _AT + timedelta(minutes=7)    # 10:07 UTC = 12:07 Ortszeit
 # Sommerzeit (UTC+2). LITERALE -- bewusst nicht aus derselben Zonenaufloesung
 # gezogen, die der Pruefling benutzt.
 TZ_ORT = ZoneInfo("Europe/Paris")
-ENDE_LOKAL = "12:45"       # Slot +45 Min: erstes trockenes Frame (Lage A)
-HORIZONT_LOKAL = "14:30"   # Slot +150 Min: letztes verfuegbares Frame (Lage B)
-BEGINN_LOKAL = "12:30"     # Slot +30 Min: kuenftiger Beginn (Lage E)
+# Die beiden Ende-Zeiten sind an der GEMERGTEN Ableitung
+# `_derive_wet_block_end()` (#2051 S1) gemessen, nicht aus der Lage
+# geschaetzt -- sie folgen zwei verschiedenen Konventionen, und das ist dort
+# Absicht: bei bekanntem Ende zaehlt das letzte NASSE Frame, bei der
+# Untergrenze die Reichweite seiner Deckung.
+ENDE_LOKAL = "12:30"       # Lage A: letztes nasses Frame (Slot +30)
+HORIZONT_LOKAL = "14:45"   # Lage B: Deckungsende des letzten Frames (Slot +150 +15)
+BEGINN_LOKAL = "12:45"     # Lage E: kuenftiger Beginn (Slot +45)
 
-# PO-Wortlaut (Freigabe): "Regen läuft bereits" / "endet voraussichtlich
-# HH:MM" / "kein Ende im Sichtfenster (bis HH:MM)".
-LAEUFT = "läuft bereits"
-ENDE_FORM = f"endet voraussichtlich {ENDE_LOKAL}"
-KEIN_ENDE = "kein Ende im Sichtfenster"
-# Eigene Wahl (keine PO-Vorlage): Laufend-Token der Kurznachricht.
-SMS_LAUFEND = "R>"
+LAEUFT = "läuft bereits"                             # S2b-Freigabe
+# Ende-Wortlaut aus #2051 S1 (PO-Entscheid 2026-08-22), Lage A = bekanntes
+# Ende, Lage B = belegte Untergrenze.
+ENDE_WORTLAUT = "letzter Regen gegen"          # Ende bekannt (Lage A)
+ENDE_FORM = f"{ENDE_WORTLAUT} {ENDE_LOKAL}"
+UNTERGRENZE_WORTLAUT = "Regen mindestens bis"  # kein Ende absehbar (Lage B)
+UNTERGRENZE_FORM = f"{UNTERGRENZE_WORTLAUT} {HORIZONT_LOKAL}"
+# Kurznachricht: `@HH:MM` = "hoert um HH:MM auf", ` >@HH:MM` = "hoert
+# fruehestens um HH:MM auf". Das `>` traegt die Bedeutung, es ist kein
+# Trennzeichen (`render.py::_sms_onset_ende`). Lage B laeuft ebenfalls, traegt
+# also zusaetzlich den `now`-Marker.
+SMS_UNTERGRENZE = f"now >@{HORIZONT_LOKAL}"
+# Kurznachricht (ENGLISCH): `now` an der Stelle des Beginns, danach die
+# Ende-Grammatik aus #2051. `12:15` waere der falsche kuenftige Beginn, den
+# die Laufend-Kurznachricht nicht mehr behaupten darf.
+SMS_LAUFEND = f"now@{ENDE_LOKAL}"
+SMS_FALSCHER_BEGINN = "@12:15"
 # Die Beginn-Angabe ("in 8 Min"). Negative Vorschau, damit der Cooldown-Satz
 # ("... hoechstens einmal in 30 Minuten") nicht als Beginn-Angabe zaehlt.
 _BEGINN_MIN = re.compile(r"in \d+ Min(?![a-zäöüA-Z])")
@@ -97,15 +127,22 @@ def _uid(tag: str) -> str:
 
 
 def _quelle(*, nass_bis: int, nass_von: int = 0, konvektiv: bool = False,
-            gesamt: int = 11):
-    """Frames im 15-Min-Raster ab `_SLOT`; die Slots `[nass_von, nass_bis)`
-    liegen ueber der Trockenschwelle (`_DRY_THRESHOLD_MM_H`, 0,1 mm/h)."""
+            gesamt: int = 11, ab=None, rate: float = 2.0):
+    """Frames im 15-Min-Raster ab `ab` (Default `_SLOT`); die Slots
+    `[nass_von, nass_bis)` liegen ueber der Trockenschwelle
+    (`_DRY_THRESHOLD_MM_H`, 0,1 mm/h) mit `rate` mm/h.
+
+    `ab`/`rate` sind Vorbelegungen fuer AC-11b (zweite, eigenstaendige Lage zu
+    einem spaeteren Rasterslot) -- die Defaults halten alle uebrigen Lagen
+    unveraendert."""
+    anker = _SLOT if ab is None else ab
+
     def _frames(lat: float, lon: float) -> list:
         from providers.brightsky import RadarFrame
         return [
             RadarFrame(
-                timestamp=_SLOT + timedelta(minutes=15 * k),
-                precip_mm_h=2.0 if nass_von <= k < nass_bis else 0.0,
+                timestamp=anker + timedelta(minutes=15 * k),
+                precip_mm_h=rate if nass_von <= k < nass_bis else 0.0,
                 is_convective=konvektiv and nass_von <= k < nass_bis,
             )
             for k in range(gesamt)
@@ -130,9 +167,22 @@ def _laeuft_endet_im_slot():
     return _quelle(nass_bis=1)
 
 
-# Lage E: Normalfall -- jetzt trocken, Beginn erst Slot +30 Min.
+# Lage E: Normalfall -- jetzt trocken, Beginn erst Slot +45 Min. (Bewusst
+# NICHT Slot +30: dort faellt der kuenftige Beginn auf dieselbe Ortszeit wie
+# das Ende der Lage A, und ein Literal haette zwei Bedeutungen.)
 def _erst_spaeter():
-    return _quelle(nass_von=2, nass_bis=5)
+    return _quelle(nass_von=3, nass_bis=6)
+
+
+# Lage F (AC-11b): zweite, eigenstaendige Lage 75 Min spaeter -- eigener
+# Rasterslot, jetzt trocken, Beginn erst +23 Min und mit 12 mm/h deutlich
+# staerker als die 2 mm/h der ersten Lage.
+_SLOT2 = _SLOT + timedelta(minutes=75)        # 11:15 UTC
+_AT_LAUF2 = _SLOT2 + timedelta(minutes=7)     # 11:22 UTC, derselbe Cron-Versatz
+
+
+def _neue_lage_spaeter():
+    return _quelle(nass_von=2, nass_bis=5, ab=_SLOT2, rate=12.0)
 
 
 def _radar(quelle) -> RadarNowcastService:
@@ -232,11 +282,27 @@ def test_ac3_laufendes_gewitter_wird_ebenfalls_als_laufend_gemeldet():
 
 
 def test_ac4_laufendes_ereignis_nennt_das_voraussichtliche_ende():
-    """AC-4: das erste trockene Frame nach der laufenden nassen Strecke liegt
-    bei Slot +45 Min -> die Nachricht nennt diesen Zeitpunkt als Ende."""
-    text = _kanaltext(_test_lauf("ac4", _laeuft_mit_ende()))
+    """AC-4: auf die laufende nasse Strecke folgt bei Slot +45 Min ein
+    trockenes Frame -- der Trockenuebergang ist damit BEOBACHTET und das Ende
+    bekannt. Genannt wird das letzte NASSE Frame (Slot +30), so leitet
+    `_derive_wet_block_end()` (#2051 S1, gemergt) es ab; an dieser Ableitung
+    ist der Erwartungswert gemessen, nicht aus der Lage geschaetzt.
+
+    Gegenrichtung mitgeprueft (Muster #2051 AC-20): weder die Langform
+    "Regen mindestens bis" noch das Kurznachrichten-Praefix ` >` duerfen
+    vorkommen. Beide sagen "hoert FRUEHESTENS um 12:45 auf" -- die Umkehrung.
+    Ohne diese Haelfte waere ein Renderer, der IMMER die Untergrenzen-Form
+    baut, hier wie in AC-5 gruen."""
+    lauf = _test_lauf("ac4", _laeuft_mit_ende())
+    text = _kanaltext(lauf) + "\n" + "\n".join(lauf.sms)
     assert ENDE_FORM in text, (
-        f"AC-4: das Ende ({ENDE_FORM!r}, erstes trockenes Frame) fehlt.\n{text}"
+        f"AC-4: das bekannte Ende ({ENDE_FORM!r}, letztes nasses Frame) "
+        f"fehlt.\n{text}"
+    )
+    assert UNTERGRENZE_WORTLAUT not in text and " >" not in text, (
+        f"AC-4: die Untergrenzen-Form ({UNTERGRENZE_WORTLAUT!r} bzw. ` >`) "
+        f"behauptet, das Ende sei UNBEKANNT -- hier ist der Trockenuebergang "
+        f"aber beobachtet.\n{text}"
     )
 
 
@@ -245,11 +311,22 @@ def test_ac5_kein_ende_im_datenbestand_wird_ausdruecklich_gesagt():
     ausdruecklich, dass kein Ende erkennbar ist, und nennt die Reichweite
     (Uhrzeit des letzten Frames) -- OHNE eine Dauer zu erfinden."""
     lauf = _test_lauf("ac5", _laeuft_ohne_ende())
-    text = _kanaltext(lauf)
-    erwartet = f"{KEIN_ENDE} (bis {HORIZONT_LOKAL})"   # PO-Wortlaut
-    assert erwartet in text, (
-        f"AC-5: {erwartet!r} fehlt -- Aussage samt Reichweite (letztes "
-        f"verfuegbares Frame), triggered_count={lauf.triggered_count}.\n{text}"
+    text = _kanaltext(lauf) + "\n" + "\n".join(lauf.sms)
+    assert SMS_UNTERGRENZE in text, (
+        f"AC-5: die Kurznachricht muss die Untergrenzen-Form "
+        f"{SMS_UNTERGRENZE!r} tragen -- ohne das `>` liest der Wanderer "
+        f"'hoert um {HORIZONT_LOKAL} auf' statt 'fruehestens'.\n{text}"
+    )
+    assert UNTERGRENZE_FORM in text, (
+        f"AC-5: {UNTERGRENZE_FORM!r} fehlt -- die Zeitreihe ist ausgegangen, "
+        f"waehrend es noch regnete, die Uhrzeit des letzten verfuegbaren "
+        f"Frames ist damit belegte Untergrenze und kein Ende "
+        f"(triggered_count={lauf.triggered_count}).\n{text}"
+    )
+    assert ENDE_WORTLAUT not in text, (
+        f"AC-5: die Form des BEKANNTEN Endes ('letzter Regen gegen') darf hier "
+        f"nicht stehen -- sie behauptet einen beobachteten Trockenuebergang, "
+        f"den es im Datenbestand nicht gibt.\n{text}"
     )
     assert not _BEGINN_MIN.search(text), (
         f"AC-5: es darf KEINE erfundene Dauer im Text stehen.\n{text}"
@@ -284,9 +361,10 @@ def test_ac7_telegram_langform_sagt_laeuft_bereits():
 
 
 def test_ac8_kurznachricht_kennzeichnet_den_laufend_fall():
-    """AC-8: SMS und Premium-SMS ersetzen die Beginn-Zeitpunkt-Form `R@HH:MM`
-    durch die Laufend-Form `R>HH:MM` -- der `@`-Beginn-Marker verschwindet,
-    das Zeichenbudget (140) bleibt gewahrt."""
+    """AC-8: SMS und Premium-SMS behaupten keinen kuenftigen Beginn mehr. Das
+    Ende steht in der #2051-Form (`@HH:MM`, bekanntes Ende -- Lage A hat den
+    Trockenuebergang beobachtet), davor der Laufend-Marker. Zeichenbudget
+    (140) bleibt gewahrt."""
     lauf = _test_lauf("ac8", _laeuft_mit_ende())
     assert lauf.sms and lauf.premium_sms, (
         f"AC-8 Vorbedingung: sms={lauf.sms!r} premium_sms={lauf.premium_sms!r}"
@@ -294,11 +372,17 @@ def test_ac8_kurznachricht_kennzeichnet_den_laufend_fall():
     for kanal, texte in (("sms", lauf.sms), ("premium_sms", lauf.premium_sms)):
         text = "\n".join(texte)
         assert SMS_LAUFEND in text, (
-            f"AC-8 ({kanal}): Kennzeichnung {SMS_LAUFEND!r} fehlt.\n{text}"
+            f"AC-8 ({kanal}): Laufend-Marker samt Ende-Token {SMS_LAUFEND!r} "
+            f"fehlt.\n{text}"
         )
-        assert "@" not in text, (
-            f"AC-8 ({kanal}): 'R@HH:MM' behauptet weiter einen kuenftigen "
-            f"Beginn.\n{text}"
+        assert SMS_FALSCHER_BEGINN not in text, (
+            f"AC-8 ({kanal}): {SMS_FALSCHER_BEGINN!r} behauptet weiter einen "
+            f"kuenftigen Beginn -- das naechste kuenftige Frame.\n{text}"
+        )
+        assert " >" not in text, (
+            f"AC-8 ({kanal}): ` >` ist in der #2051-Grammatik die "
+            f"UNTERGRENZEN-Form. Lage A hat ein beobachtetes Ende -- hier "
+            f"waere sie eine Falschaussage.\n{text}"
         )
         assert all(len(t) <= 140 for t in texte), (
             f"AC-8 ({kanal}): Zeichenbudget 140 gerissen: {[len(t) for t in texte]}"
@@ -314,8 +398,9 @@ def test_ac9_telegram_kurzform_erbt_den_laufend_text_der_sms():
     assert SMS_LAUFEND in text, (
         f"AC-9: die Kurzform traegt {SMS_LAUFEND!r} nicht wie die SMS.\n{text}"
     )
-    assert "@" not in text, (
-        f"AC-9: die Kurzform behauptet weiter einen kuenftigen Beginn.\n{text}"
+    assert SMS_FALSCHER_BEGINN not in text, (
+        f"AC-9: die Kurzform behauptet weiter einen kuenftigen Beginn "
+        f"({SMS_FALSCHER_BEGINN!r}).\n{text}"
     )
 
 
@@ -394,6 +479,76 @@ def test_ac11_unveraenderte_laufende_lage_loest_kein_zweites_mal_aus():
     )
 
 
+def test_ac11b_neues_ereignis_nach_laufendem_wird_nicht_als_wiederholung_unterdrueckt():
+    """AC-11b: die GEGENRICHTUNG zu AC-11 -- die gefaehrlichere, weil ihr
+    Schaden ein AUSBLEIBENDER Alarm ist (Befund #2065).
+
+    `check_event_identity_gate` vergleicht Punkt gegen Punkt und wertet eine
+    Differenz bis `NOWCAST_HORIZON_MIN` (180 Min) als Duplikat
+    (`alert_gate.py:489-494`). Der Laufend-Fall bucht mit `now_utc` einen
+    Punkt, den es vorher gar nicht gab -- eine 75 Min spaeter aufziehende,
+    EIGENSTAENDIGE Lage liegt damit im Duplikat-Fenster und darf trotzdem
+    nicht verschluckt werden. Sie kommt ueber die Eskalationspruefung durch
+    (V2, `alert_gate.py:669` -- "muss IMMER durchkommen"): 12 mm/h gegen
+    2 mm/h ist eine echte Verschaerfung. Sperrzeit wieder aus; den
+    Identitaets-Gate beruehrt das nicht (der Radar-Pfad ruft ihn OHNE
+    `cooldown_minutes` auf, sein Fenster bleibt 180 Min)."""
+    uid = _uid("ac11b")
+    trip = _ohne_sperrzeit(uid, _aufbau(uid, "ac11b"))
+    lat, lon = trip.stages[0].waypoints[0].lat, trip.stages[0].waypoints[0].lon
+
+    # Konstruktions-Gegenprobe: beide Laeufe sehen die Lage, die sie sollen.
+    with freeze_time(_AT_LAUF):
+        reset_shared_radar_cache_for_tests()
+        lage1 = _radar(_laeuft_endet_im_slot()).get_nowcast(lat, lon)
+    with freeze_time(_SLOT):
+        reset_shared_radar_cache_for_tests()
+        lage1_am_slotstart = _radar(_laeuft_endet_im_slot()).get_nowcast(lat, lon)
+    with freeze_time(_AT_LAUF2):
+        reset_shared_radar_cache_for_tests()
+        lage2 = _radar(_neue_lage_spaeter()).get_nowcast(lat, lon)
+    reset_shared_radar_cache_for_tests()
+    assert lage1.onset_minutes is None and lage1_am_slotstart.onset_minutes == 0, (
+        f"AC-11b Konstruktion: Lauf 1 muss die LAUFENDE Lage ohne kuenftigen "
+        f"Beginn sehen (onset={lage1.onset_minutes}, am Slot-Start "
+        f"{lage1_am_slotstart.onset_minutes})."
+    )
+    assert lage2.onset_minutes == 23 and not getattr(lage2, "already_running", False), (
+        f"AC-11b Konstruktion: Lauf 2 muss eine NEUE Lage mit kuenftigem "
+        f"Beginn sehen, nicht dieselbe laufende (onset={lage2.onset_minutes})."
+    )
+    assert lage2.max_rate_mm_h >= 10.0, (
+        f"AC-11b Konstruktion: Lauf 2 muss deutlich staerker sein als Lauf 1 "
+        f"-- sonst traegt die Eskalation nicht (war {lage2.max_rate_mm_h})."
+    )
+
+    # Positivkontrolle auf frischem Datentraeger: die zweite Lage ist FUER SICH
+    # alarmwuerdig. Ohne sie waere eine Stille unten nicht von "diese Lage
+    # loest generell nicht aus" unterscheidbar.
+    kontrolle = _uid("ac11b-ctrl")
+    trip_k = _ohne_sperrzeit(kontrolle, _aufbau(kontrolle, "ac11b-ctrl"))
+    lauf_k = _lauf(kontrolle, trip_k, _neue_lage_spaeter(), at=_AT_LAUF2)
+    assert lauf_k.triggered_count == 1, (
+        f"AC-11b Positivkontrolle: die zweite Lage muss allein ausloesen "
+        f"(war {lauf_k.triggered_count})."
+    )
+
+    strecke = AlarmPruefstrecke(user_id=uid, settings=_settings_all_channels())
+    lauf1 = _lauf(uid, trip, _laeuft_endet_im_slot(), strecke=strecke)
+    assert lauf1.triggered_count == 1, (
+        f"AC-11b Vorbedingung: Lauf 1 muss ausloesen und die Ereignis-"
+        f"Identitaet buchen -- ohne diese Buchung prueft der zweite Lauf "
+        f"nichts (war {lauf1.triggered_count})."
+    )
+
+    lauf2 = _lauf(uid, trip, _neue_lage_spaeter(), at=_AT_LAUF2, strecke=strecke)
+    assert lauf2.triggered_count == 1, (
+        f"AC-11b: die neue, eigenstaendige und staerkere Lage darf NICHT als "
+        f"Wiederholung des laufenden Ereignisses unterdrueckt werden "
+        f"(war {lauf2.triggered_count})."
+    )
+
+
 def test_ac12_ortsvergleich_buendel_traegt_den_laufenden_ort_mit():
     """AC-12: ein Buendel aus einem laufenden Ort (ohne bestimmbaren
     kuenftigen Beginn) und einem Ort mit kuenftigem Beginn -- der laufende
@@ -403,7 +558,7 @@ def test_ac12_ortsvergleich_buendel_traegt_den_laufenden_ort_mit():
         onset_minutes=None, intensity_label="Starker Regen", source="radar",
     )
     laufend.already_running = True
-    laufend.running_until_minutes = 38
+    laufend.event_end_minutes = 23   # Feldname aus #2051 S1 (gemergt)
     kuenftig = NowcastResult(
         onset_minutes=25, intensity_label="Leichter Regen", source="radar",
     )
@@ -441,6 +596,55 @@ def test_ac13_laufender_fall_ohne_kuenftigen_beginn_liefert_alle_vier_kanaele():
     )
 
 
+def test_ac13b_staerke_im_laufend_fall_entspricht_dem_laufenden_bild():
+    """AC-13b: die Staerke des LAUFENDEN Bildes darf nicht verlorengehen.
+
+    `max_rate`/`is_convective` entstehen heute nur aus dem Zukunftsfenster
+    (`f.timestamp >= now`) -- im Laufend-Fall ohne kuenftigen Regen bleibt
+    davon "Kein Niederschlag" uebrig. Folgen: der sinnlose Satz "Kein
+    Niederschlag laeuft bereits" (gegen AC-13, "gueltige Kanal-Inhalte"), ein
+    laufendes Gewitter ohne Gewitter-Kennzeichen (gegen AC-3) und die
+    NIEDRIGSTE Dringlichkeitsstufe, waehrend es schuettet -- was ueber die
+    Eskalationspruefung auf AC-11b zurueckwirkt.
+
+    Referenz sind DIESELBEN Frames am Slot-Start, wo das nasse Frame im
+    Zukunftsfenster liegt und heute schon ein Regen-Label ergibt: aus dem
+    Pruefling selbst, aber aus einem Moment ohne strittiges Verhalten."""
+    uid = _uid("ac13b")
+    trip = _aufbau(uid, "ac13b")
+    lat, lon = trip.stages[0].waypoints[0].lat, trip.stages[0].waypoints[0].lon
+    with freeze_time(_SLOT):
+        reset_shared_radar_cache_for_tests()
+        referenz = _radar(_laeuft_endet_im_slot()).get_nowcast(lat, lon)
+    with freeze_time(_AT_LAUF):
+        reset_shared_radar_cache_for_tests()
+        laufend = _radar(_laeuft_endet_im_slot()).get_nowcast(lat, lon)
+        reset_shared_radar_cache_for_tests()
+        gewitter = _radar(_quelle(nass_bis=1, konvektiv=True)).get_nowcast(lat, lon)
+    reset_shared_radar_cache_for_tests()
+
+    assert referenz.intensity_label != INTENSITY_DRY, (
+        f"AC-13b Konstruktion: am Slot-Start muss dieselbe Lage ein "
+        f"Regen-Label ergeben (war {referenz.intensity_label!r})."
+    )
+    assert laufend.intensity_label == referenz.intensity_label, (
+        f"AC-13b: dieselben Frames, nur {_AT_LAUF - _SLOT} spaeter gemessen -- "
+        f"die Staerke darf nicht auf {laufend.intensity_label!r} umkippen, "
+        f"waehrend das laufende Frame {referenz.intensity_label!r} zeigt."
+    )
+    assert gewitter.is_convective, (
+        "AC-13b: ein LAUFENDES Gewitter muss konvektiv bleiben -- sonst "
+        "verliert die Nachricht das Gewitter-Kennzeichen (AC-3)."
+    )
+
+    lauf = _lauf(uid, trip, _laeuft_endet_im_slot())
+    text = _kanaltext(lauf)
+    assert INTENSITY_DRY not in text, (
+        f"AC-13b: '{INTENSITY_DRY}' darf in einer Laufend-Meldung nicht "
+        f"stehen -- das ist kein gueltiger Kanal-Inhalt.\n{text}"
+    )
+
+
 def test_ac14_jetzt_antwort_meldet_das_laufende_ereignis_als_laufend():
     """AC-14: `/jetzt` (`format_now_text`) macht dieselbe Falschaussage aus
     derselben Datenbasis -- heute steht dort bei laufendem Ereignis ohne
@@ -448,8 +652,11 @@ def test_ac14_jetzt_antwort_meldet_das_laufende_ereignis_als_laufend():
     result = NowcastResult(
         onset_minutes=None, intensity_label="Starker Regen", source="radar",
     )
+    # Feldnamen aus #2051 S1 (gemergt): das Ende heisst `event_end_minutes`,
+    # der Untergrenzen-Waechter `event_ongoing_beyond_horizon`. S2b legt nur
+    # `already_running` daneben -- kein zweites Ende-Feld.
     result.already_running = True
-    result.running_until_minutes = 38   # 10:07 + 38 Min = 10:45 UTC = 12:45 Ortszeit
+    result.event_end_minutes = 23   # 10:07 + 23 Min = 10:30 UTC = 12:30 Ortszeit
     with freeze_time(_AT_LAUF):
         text = RadarNowcastService().format_now_text(
             result, tz=TZ_ORT, include_source=False,
@@ -471,7 +678,7 @@ def test_ac15_briefing_kurzfristzeile_weist_das_ereignis_als_laufend_aus():
         try:
             text = format_starkregen_hint(
                 "Starker Regen", None, tz=TZ_ORT,
-                already_running=True, running_until_minutes=38,
+                already_running=True, event_end_minutes=23,
             )
         except TypeError as e:
             text = f"<TypeError: {e}>"

--- a/tests/tdd/test_alarm_szenario_laufendes_ereignis.py
+++ b/tests/tdd/test_alarm_szenario_laufendes_ereignis.py
@@ -1,0 +1,482 @@
+"""Issue #2050 Scheibe S2b — Waechter: laufendes Regen-/Gewitterereignis.
+
+SPEC: docs/specs/modules/alarm_szenario_laufendes_ereignis.md (AC-1..AC-15)
+
+Laeuft ein Ereignis zum Zeitpunkt des Alarmlaufs BEREITS, meldet Gregor es
+heute als bevorstehend ("Regen in 8 Min"): `_derive_result` filtert
+`f.timestamp >= now` und verwirft damit das Frame der laufenden Viertelstunde
+(Frames tragen den Slot-Start im Raster :00/:15/:30/:45, der Cron laeuft
+:07/:22/:37/:52 -- "in 8 Min" ist deshalb nicht der gemessene, sondern der
+einzig moegliche Wert).
+
+Alle Kanal-Waechter fahren ueber die `AlarmPruefstrecke` (S1) gegen die ECHTE
+Ausloeseentscheidung (`check_radar_alerts()`) -- kein Mock()/patch()/
+MagicMock: Frames ueber die DI-Naht `frame_source=` eines echten
+`RadarNowcastService`, Kanaltexte ueber den echten Telegram-/seven.io-
+Transport (lokale Stubs der Pruefstrecke) bzw. `mail_sink`. Kein echter Versand.
+
+WORTLAUT-VERTRAG dieser Scheibe (GREEN zieht nach). Die Herkunft ist bewusst
+getrennt ausgewiesen -- das eine ist Freigabe, das andere Entwurfsentscheidung:
+
+  * VOM PRODUCT OWNER bei der Freigabe ausgewaehlt (verbindlich, steht so
+    nicht in der Spec): E-Mail/Telegram-Langform/Betreff/`/jetzt`/
+    Briefing-Zeile melden "Regen laeuft bereits" statt einer Beginn-Angabe,
+    das Ende als "endet voraussichtlich HH:MM"; ist im verfuegbaren
+    Datenbestand kein Ende erkennbar, steht dort "kein Ende im Sichtfenster
+    (bis HH:MM)" mit der Uhrzeit des LETZTEN verfuegbaren Frames -- ohne
+    erfundene Dauer.
+  * EIGENE WAHL dieser Scheibe (keine PO-Vorlage, weil kein Beispieltext
+    vorlag): die Kurznachricht (SMS/Premium-SMS/Telegram-Kurzform) ersetzt
+    `R@HH:MM` durch `R>HH:MM` bzw. `TH>HH:MM` ("laeuft, bis"); der
+    `@`-Beginn-Marker verschwindet, das Zeichenbudget bleibt gewahrt.
+"""
+from __future__ import annotations
+
+import re
+import uuid
+from datetime import timedelta
+from zoneinfo import ZoneInfo
+
+import pytest
+from freezegun import freeze_time
+
+from app.loader import save_trip
+from output.renderers.alert.project import to_multi_location_onset_alert_message
+from output.renderers.alert.render import render_email, render_telegram
+from services.radar_cache import reset_shared_radar_cache_for_tests
+from services.radar_service import NowcastResult, RadarNowcastService
+
+from tests.helpers.alarm_pruefstrecke import AlarmPruefstrecke
+from tests.tdd.test_952_onset_alert_fidelity import _clean_user
+from tests.tdd.test_alarm_pruefstrecke_selbstschutz import (
+    _AT, _radar_trip, _settings_all_channels, _write_premium_profile,
+)
+
+# `_AT` (10:00 UTC) taugt als Laufzeitpunkt NICHT: dort faellt `now` genau auf
+# den Slot-Start, `f.timestamp >= now` behielte das Frame und der Defekt waere
+# unsichtbar. Der Versatz +7 Min bildet den echten Cron-Takt ab.
+_SLOT = _AT                              # 10:00 UTC -- Beginn des laufenden Slots
+_AT_LAUF = _AT + timedelta(minutes=7)    # 10:07 UTC = 12:07 Ortszeit
+
+# Ortszeit der Etappe: Korsika (42.20/9.10) -> Europe/Paris, am 2026-04-05
+# Sommerzeit (UTC+2). LITERALE -- bewusst nicht aus derselben Zonenaufloesung
+# gezogen, die der Pruefling benutzt.
+TZ_ORT = ZoneInfo("Europe/Paris")
+ENDE_LOKAL = "12:45"       # Slot +45 Min: erstes trockenes Frame (Lage A)
+HORIZONT_LOKAL = "14:30"   # Slot +150 Min: letztes verfuegbares Frame (Lage B)
+BEGINN_LOKAL = "12:30"     # Slot +30 Min: kuenftiger Beginn (Lage E)
+
+# PO-Wortlaut (Freigabe): "Regen läuft bereits" / "endet voraussichtlich
+# HH:MM" / "kein Ende im Sichtfenster (bis HH:MM)".
+LAEUFT = "läuft bereits"
+ENDE_FORM = f"endet voraussichtlich {ENDE_LOKAL}"
+KEIN_ENDE = "kein Ende im Sichtfenster"
+# Eigene Wahl (keine PO-Vorlage): Laufend-Token der Kurznachricht.
+SMS_LAUFEND = "R>"
+# Die Beginn-Angabe ("in 8 Min"). Negative Vorschau, damit der Cooldown-Satz
+# ("... hoechstens einmal in 30 Minuten") nicht als Beginn-Angabe zaehlt.
+_BEGINN_MIN = re.compile(r"in \d+ Min(?![a-zäöüA-Z])")
+
+_ANGELEGT: list[str] = []
+
+
+@pytest.fixture(autouse=True)
+def _aufraeumen():
+    """Jeder Test raeumt die von ihm angelegten `user_id`-Ablagen ab —
+    Datentraeger und Test-Postfach werden mit Parallelsessions geteilt."""
+    _ANGELEGT.clear()
+    yield
+    for uid in _ANGELEGT:
+        _clean_user(uid)
+
+
+def _uid(tag: str) -> str:
+    uid = f"tdd-2050-s2b-{tag}-{uuid.uuid4().hex[:6]}"
+    _ANGELEGT.append(uid)
+    return uid
+
+
+def _quelle(*, nass_bis: int, nass_von: int = 0, konvektiv: bool = False,
+            gesamt: int = 11):
+    """Frames im 15-Min-Raster ab `_SLOT`; die Slots `[nass_von, nass_bis)`
+    liegen ueber der Trockenschwelle (`_DRY_THRESHOLD_MM_H`, 0,1 mm/h)."""
+    def _frames(lat: float, lon: float) -> list:
+        from providers.brightsky import RadarFrame
+        return [
+            RadarFrame(
+                timestamp=_SLOT + timedelta(minutes=15 * k),
+                precip_mm_h=2.0 if nass_von <= k < nass_bis else 0.0,
+                is_convective=konvektiv and nass_von <= k < nass_bis,
+            )
+            for k in range(gesamt)
+        ]
+    return _frames
+
+
+# Lage A: laeuft und hoert im Sichtfenster auf (Ende = Slot +45 Min).
+def _laeuft_mit_ende(konvektiv: bool = False):
+    return _quelle(nass_bis=3, konvektiv=konvektiv)
+
+
+# Lage B: laeuft ueber den verfuegbaren Datenbestand hinaus (kein Ende).
+def _laeuft_ohne_ende():
+    return _quelle(nass_bis=11)
+
+
+# Lage C: laeuft, hoert aber IN der laufenden Viertelstunde auf -- KEIN
+# kuenftiges Frame ist nass, ein kuenftiger Beginn ist nicht bestimmbar
+# (`onset_minutes is None`). NUR diese Lage erreicht die Bruchstellen 1-3.
+def _laeuft_endet_im_slot():
+    return _quelle(nass_bis=1)
+
+
+# Lage E: Normalfall -- jetzt trocken, Beginn erst Slot +30 Min.
+def _erst_spaeter():
+    return _quelle(nass_von=2, nass_bis=5)
+
+
+def _radar(quelle) -> RadarNowcastService:
+    return RadarNowcastService(frame_source=quelle)
+
+
+def _aufbau(uid: str, tag: str, **flags):
+    """Nutzer (Premium-Profil fuer den vierten Kanal) + Trip mit allen vier
+    Kanaelen. Aufbau unter der gestellten Uhr, weil `save_trip()` die
+    Ankunftszeiten beim Schreiben neu rechnet (Compute-on-Save, #802)."""
+    _clean_user(uid)
+    _write_premium_profile(uid, _AT)
+    with freeze_time(_AT):
+        return _radar_trip(
+            uid, f"trip-2050-s2b-{tag}", send_email=True, send_telegram=True,
+            send_sms=True, send_premium_sms=True, **flags,
+        )
+
+
+def _ohne_sperrzeit(uid: str, trip):
+    """Sperrzeit aus (`alert_cooldown_minutes = 0`). PFLICHT fuer den
+    Entdopplungs-Waechter: `check_radar_alerts()` liest den Trip vom
+    Datentraeger, der Wert muss also mitgespeichert werden."""
+    trip.alert_cooldown_minutes = 0
+    with freeze_time(_AT):
+        save_trip(trip, user_id=uid)
+    return trip
+
+
+def _lauf(uid: str, trip, quelle, *, at=_AT_LAUF, strecke=None):
+    s = strecke or AlarmPruefstrecke(user_id=uid, settings=_settings_all_channels())
+    return s.lauf(at=at, zweig="radar", trip=trip, radar_service=_radar(quelle))
+
+
+def _mailtext(lauf) -> str:
+    return "\n".join(f"{betreff}\n{koerper}" for betreff, koerper in lauf.mail)
+
+
+def _kanaltext(lauf) -> str:
+    """Betreff + Mailkoerper + Telegram-Text eines Laufs, zusammengelegt."""
+    return _mailtext(lauf) + "\n" + "\n".join(lauf.telegram)
+
+
+def _test_lauf(tag: str, quelle, **flags):
+    """Ein Prueflauf auf eigener `user_id` (Aufraeumen per Fixture)."""
+    uid = _uid(tag)
+    return _lauf(uid, _aufbau(uid, tag, **flags), quelle)
+
+
+def test_ac1_laufendes_ereignis_wird_als_laufend_gemeldet():
+    """AC-1: das den aktuellen Rasterslot deckende Frame ist nass -> die
+    Nachricht meldet "laeuft bereits" statt einer Beginn-Angabe."""
+    lauf = _test_lauf("ac1", _laeuft_mit_ende())
+    assert lauf.triggered_count == 1, (
+        f"AC-1 Vorbedingung: der Lauf muss ausloesen -- sonst prueft der "
+        f"Wortlaut nichts (war {lauf.triggered_count})."
+    )
+    text = _kanaltext(lauf)
+    assert LAEUFT in text, f"AC-1: {LAEUFT!r} fehlt.\n{text}"
+    assert not _BEGINN_MIN.search(text), (
+        f"AC-1: kein Kanal darf einen kuenftigen Beginn behaupten.\n{text}"
+    )
+
+
+def test_ac2_kuenftiger_beginn_bleibt_unveraendert_bei_der_beginn_angabe():
+    """AC-2: Regressions-Invariante -- BEWUSST von Anfang an GRUEN. Liegt das
+    Ereignis wirklich in der Zukunft (jetzt trocken, nasses Frame erst Slot
+    +30 Min), bleibt der bisherige Wortlaut unveraendert."""
+    lauf = _test_lauf("ac2", _erst_spaeter())
+    assert lauf.triggered_count == 1, (
+        f"AC-2 Vorbedingung: der Normalfall muss ausloesen "
+        f"(war {lauf.triggered_count})."
+    )
+    text = _kanaltext(lauf)
+    assert _BEGINN_MIN.search(text), (
+        f"AC-2: der Normalfall MUSS die Beginn-Angabe 'in N Min' behalten.\n{text}"
+    )
+    assert BEGINN_LOKAL in text, f"AC-2: Beginn-Uhrzeit {BEGINN_LOKAL} fehlt.\n{text}"
+    assert LAEUFT not in text, (
+        f"AC-2: ein kuenftiger Beginn darf NICHT als laufend erscheinen.\n{text}"
+    )
+
+
+def test_ac3_laufendes_gewitter_wird_ebenfalls_als_laufend_gemeldet():
+    """AC-3: dieselbe Lage konvektiv -- auch das laufende Gewitter wird als
+    laufend gemeldet, nicht nur laufender Regen (`is_convective`)."""
+    lauf = _test_lauf("ac3", _laeuft_mit_ende(konvektiv=True))
+    text = _kanaltext(lauf)
+    assert "Gewitter" in text, (
+        f"AC-3 Vorbedingung: die Lage muss als Gewitter erkannt sein "
+        f"(triggered_count={lauf.triggered_count}).\n{text}"
+    )
+    assert LAEUFT in text, f"AC-3: das laufende GEWITTER zeigt {LAEUFT!r} nicht.\n{text}"
+    assert not _BEGINN_MIN.search(text), (
+        f"AC-3: kein Kanal darf einen kuenftigen Gewitterbeginn behaupten.\n{text}"
+    )
+
+
+def test_ac4_laufendes_ereignis_nennt_das_voraussichtliche_ende():
+    """AC-4: das erste trockene Frame nach der laufenden nassen Strecke liegt
+    bei Slot +45 Min -> die Nachricht nennt diesen Zeitpunkt als Ende."""
+    text = _kanaltext(_test_lauf("ac4", _laeuft_mit_ende()))
+    assert ENDE_FORM in text, (
+        f"AC-4: das Ende ({ENDE_FORM!r}, erstes trockenes Frame) fehlt.\n{text}"
+    )
+
+
+def test_ac5_kein_ende_im_datenbestand_wird_ausdruecklich_gesagt():
+    """AC-5: alle verfuegbaren Frames sind nass -> die Nachricht sagt
+    ausdruecklich, dass kein Ende erkennbar ist, und nennt die Reichweite
+    (Uhrzeit des letzten Frames) -- OHNE eine Dauer zu erfinden."""
+    lauf = _test_lauf("ac5", _laeuft_ohne_ende())
+    text = _kanaltext(lauf)
+    erwartet = f"{KEIN_ENDE} (bis {HORIZONT_LOKAL})"   # PO-Wortlaut
+    assert erwartet in text, (
+        f"AC-5: {erwartet!r} fehlt -- Aussage samt Reichweite (letztes "
+        f"verfuegbares Frame), triggered_count={lauf.triggered_count}.\n{text}"
+    )
+    assert not _BEGINN_MIN.search(text), (
+        f"AC-5: es darf KEINE erfundene Dauer im Text stehen.\n{text}"
+    )
+
+
+def test_ac6_alarm_mail_sagt_laeuft_bereits_statt_ab_uhrzeit():
+    """AC-6: der E-Mail-Zweig (Einzelort) verliert die Beginn-Form
+    "ab HH:MM"/"in N Min" und traegt stattdessen die Laufend-Aussage."""
+    lauf = _test_lauf("ac6", _laeuft_mit_ende())
+    assert lauf.mail, f"AC-6 Vorbedingung: keine E-Mail ({lauf.triggered_count})."
+    text = _mailtext(lauf)
+    assert LAEUFT in text, f"AC-6: die E-Mail sagt nicht {LAEUFT!r}.\n{text}"
+    assert "ab 12:15" not in text, (
+        f"AC-6: die E-Mail behauptet weiterhin einen Beginn ('ab 12:15' -- das "
+        f"naechste kuenftige Frame).\n{text}"
+    )
+    assert not _BEGINN_MIN.search(text), (
+        f"AC-6: die E-Mail traegt weiterhin die Beginn-Angabe.\n{text}"
+    )
+
+
+def test_ac7_telegram_langform_sagt_laeuft_bereits():
+    """AC-7: derselbe Lauf, Telegram-Langform (rich) -- dieselbe Aussage."""
+    lauf = _test_lauf("ac7", _laeuft_mit_ende())
+    assert lauf.telegram, f"AC-7 Vorbedingung: kein Telegram ({lauf.triggered_count})."
+    text = "\n".join(lauf.telegram)
+    assert LAEUFT in text, f"AC-7: Telegram sagt nicht {LAEUFT!r}.\n{text}"
+    assert not _BEGINN_MIN.search(text), (
+        f"AC-7: Telegram traegt weiterhin die Beginn-Angabe.\n{text}"
+    )
+
+
+def test_ac8_kurznachricht_kennzeichnet_den_laufend_fall():
+    """AC-8: SMS und Premium-SMS ersetzen die Beginn-Zeitpunkt-Form `R@HH:MM`
+    durch die Laufend-Form `R>HH:MM` -- der `@`-Beginn-Marker verschwindet,
+    das Zeichenbudget (140) bleibt gewahrt."""
+    lauf = _test_lauf("ac8", _laeuft_mit_ende())
+    assert lauf.sms and lauf.premium_sms, (
+        f"AC-8 Vorbedingung: sms={lauf.sms!r} premium_sms={lauf.premium_sms!r}"
+    )
+    for kanal, texte in (("sms", lauf.sms), ("premium_sms", lauf.premium_sms)):
+        text = "\n".join(texte)
+        assert SMS_LAUFEND in text, (
+            f"AC-8 ({kanal}): Kennzeichnung {SMS_LAUFEND!r} fehlt.\n{text}"
+        )
+        assert "@" not in text, (
+            f"AC-8 ({kanal}): 'R@HH:MM' behauptet weiter einen kuenftigen "
+            f"Beginn.\n{text}"
+        )
+        assert all(len(t) <= 140 for t in texte), (
+            f"AC-8 ({kanal}): Zeichenbudget 140 gerissen: {[len(t) for t in texte]}"
+        )
+
+
+def test_ac9_telegram_kurzform_erbt_den_laufend_text_der_sms():
+    """AC-9: bei `telegram_style="kurzform"` traegt Telegram denselben
+    Kurznachrichten-Text wie die SMS (geerbtes Verhalten seit #1948 S4)."""
+    lauf = _test_lauf("ac9", _laeuft_mit_ende(), telegram_style="kurzform")
+    assert lauf.telegram, f"AC-9 Vorbedingung: kein Telegram ({lauf.triggered_count})."
+    text = "\n".join(lauf.telegram)
+    assert SMS_LAUFEND in text, (
+        f"AC-9: die Kurzform traegt {SMS_LAUFEND!r} nicht wie die SMS.\n{text}"
+    )
+    assert "@" not in text, (
+        f"AC-9: die Kurzform behauptet weiter einen kuenftigen Beginn.\n{text}"
+    )
+
+
+def test_ac10_ereignis_endet_in_der_laufenden_viertelstunde_loest_trotzdem_aus():
+    """AC-10: nasser aktueller Slot, ausschliesslich TROCKENE kuenftige
+    Frames -> `onset_minutes is None`. Heute liefert `radar_alert_due()`
+    daran `False` und der Alarm faellt ERSATZLOS aus (Bruchstelle 1).
+
+    Vorgeschaltet die Konstruktions-Gegenprobe: DIESELBEN Frames, einmal zur
+    Cron-Laufzeit 10:07 und einmal exakt auf dem Slot-Start 10:00 gemessen.
+    Ohne sie waere "kein kuenftiger Beginn" nicht von "gar kein Regen"
+    unterscheidbar -- und der Waechter beruehrte den Laufend-Zweig nie."""
+    uid = _uid("ac10")
+    trip = _aufbau(uid, "ac10")
+    lat, lon = trip.stages[0].waypoints[0].lat, trip.stages[0].waypoints[0].lon
+    # Frame-Cache ist ein Prozess-Singleton mit Koordinaten-Schluessel
+    # (TTL 300 s) -- ohne Reset lieferte die zweite Messung die erste zurueck.
+    with freeze_time(_AT_LAUF):
+        reset_shared_radar_cache_for_tests()
+        versteckt = _radar(_laeuft_endet_im_slot()).get_nowcast(lat, lon)
+    with freeze_time(_SLOT):
+        reset_shared_radar_cache_for_tests()
+        sichtbar = _radar(_laeuft_endet_im_slot()).get_nowcast(lat, lon)
+    reset_shared_radar_cache_for_tests()
+    assert versteckt.onset_minutes is None, (
+        f"AC-10 Konstruktion: zur Cron-Laufzeit darf KEIN kuenftiger Beginn "
+        f"bestimmbar sein (war {versteckt.onset_minutes})."
+    )
+    assert sichtbar.onset_minutes == 0, (
+        f"AC-10 Konstruktion: dieselben Frames, gemessen auf dem Slot-Start, "
+        f"muessen das nasse Frame zeigen (onset 0, war {sichtbar.onset_minutes}) "
+        f"-- sonst regnet es gar nicht und der Waechter misst Luft."
+    )
+
+    lauf = _lauf(uid, trip, _laeuft_endet_im_slot())
+    assert lauf.triggered_count == 1, (
+        f"AC-10: das Ereignis laeuft JETZT und endet in der laufenden "
+        f"Viertelstunde -- ein Alarm muss trotzdem raus. War "
+        f"triggered_count={lauf.triggered_count}."
+    )
+
+
+def test_ac11_unveraenderte_laufende_lage_loest_kein_zweites_mal_aus():
+    """AC-11: zweiter Prueflauf mit identischer, weiterhin laufender Lage ->
+    kein zweiter Alarm. Die Sperrzeit ist AUSGESCHALTET
+    (`alert_cooldown_minutes = 0`), sonst waere der Test aus dem falschen
+    Grund gruen und wuerde die Entdopplung ueberhaupt nicht messen. Die
+    Kontrolle auf frischem Datentraeger zeigt, dass die Stille aus dem
+    gebuchten Zustand kommt, nicht aus den Eingangsdaten."""
+    uid, kontrolle = _uid("ac11"), _uid("ac11-ctrl")
+    trip = _ohne_sperrzeit(uid, _aufbau(uid, "ac11"))
+    assert trip.alert_cooldown_minutes == 0, (
+        "AC-11 Vorbedingung: die Sperrzeit MUSS aus sein, sonst misst der "
+        "Waechter den Cooldown statt der Entdopplung."
+    )
+    strecke = AlarmPruefstrecke(user_id=uid, settings=_settings_all_channels())
+    lauf1 = _lauf(uid, trip, _laeuft_endet_im_slot(), strecke=strecke)
+    assert lauf1.triggered_count == 1, (
+        f"AC-11 Vorbedingung: Lauf 1 muss ausloesen und die Ereignis-Identitaet "
+        f"buchen (war {lauf1.triggered_count})."
+    )
+
+    at2 = _AT_LAUF + timedelta(minutes=15)
+    lauf2 = _lauf(uid, trip, _laeuft_endet_im_slot(), at=at2, strecke=strecke)
+    assert lauf2.triggered_count == 0, (
+        f"AC-11: dasselbe laufende Ereignis darf kein zweites Mal gemeldet "
+        f"werden (war {lauf2.triggered_count})."
+    )
+
+    trip_k = _ohne_sperrzeit(kontrolle, _aufbau(kontrolle, "ac11-ctrl"))
+    lauf_k = _lauf(kontrolle, trip_k, _laeuft_endet_im_slot(), at=at2)
+    assert lauf_k.triggered_count == 1, (
+        f"AC-11 Gegenprobe: dieselben Eingangsdaten zum selben Zeitpunkt OHNE "
+        f"Lauf 1 muessen ausloesen -- sonst kommt die Stille oben nicht von der "
+        f"Entdopplung (war {lauf_k.triggered_count})."
+    )
+
+
+def test_ac12_ortsvergleich_buendel_traegt_den_laufenden_ort_mit():
+    """AC-12: ein Buendel aus einem laufenden Ort (ohne bestimmbaren
+    kuenftigen Beginn) und einem Ort mit kuenftigem Beginn -- der laufende
+    Ort faellt heute VOR dem `OnsetEvent`-Bau aus dem Filter
+    (`nc.onset_minutes is not None`, Bruchstelle 4)."""
+    laufend = NowcastResult(
+        onset_minutes=None, intensity_label="Starker Regen", source="radar",
+    )
+    laufend.already_running = True
+    laufend.running_until_minutes = 38
+    kuenftig = NowcastResult(
+        onset_minutes=25, intensity_label="Leichter Regen", source="radar",
+    )
+    with freeze_time(_AT_LAUF):
+        msg = to_multi_location_onset_alert_message(
+            [("Laufend-Ort", laufend), ("Zukunft-Ort", kuenftig)],
+            tz=TZ_ORT, stand_at="12:07",
+        )
+        _html, plain = render_email(msg)
+        text = f"{plain}\n{render_telegram(msg)}"
+    assert "Zukunft-Ort" in text, (
+        f"AC-12 Vorbedingung: der Ort mit kuenftigem Beginn muss im Buendel "
+        f"stehen.\n{text}"
+    )
+    assert "Laufend-Ort" in text, (
+        f"AC-12: der laufende Ort darf NICHT vor dem Nachrichtenbau "
+        f"herausfallen.\n{text}"
+    )
+    assert LAEUFT in text, f"AC-12: Laufend-Aussage fehlt.\n{text}"
+
+
+def test_ac13_laufender_fall_ohne_kuenftigen_beginn_liefert_alle_vier_kanaele():
+    """AC-13: derselbe Eingangsfall wie AC-10/AC-11 laeuft ohne Exception
+    durch (`now + timedelta(minutes=None)` stuerzt ab, sobald Bruchstelle 1
+    faellt) und liefert gueltige Inhalte auf allen vier Kanaelen."""
+    lauf = _test_lauf("ac13", _laeuft_endet_im_slot())
+    assert lauf.mail and lauf.telegram and lauf.sms and lauf.premium_sms, (
+        f"AC-13: alle vier Kanaele muessen Inhalt tragen: mail={lauf.mail!r} "
+        f"telegram={lauf.telegram!r} sms={lauf.sms!r} "
+        f"premium_sms={lauf.premium_sms!r}"
+    )
+    assert LAEUFT in _kanaltext(lauf), (
+        f"AC-13: die Nachricht muss trotz fehlendem kuenftigen Beginn die "
+        f"Laufend-Aussage tragen.\n{_kanaltext(lauf)}"
+    )
+
+
+def test_ac14_jetzt_antwort_meldet_das_laufende_ereignis_als_laufend():
+    """AC-14: `/jetzt` (`format_now_text`) macht dieselbe Falschaussage aus
+    derselben Datenbasis -- heute steht dort bei laufendem Ereignis ohne
+    kuenftigen Beginn die Entwarnung "kein Regen erwartet"."""
+    result = NowcastResult(
+        onset_minutes=None, intensity_label="Starker Regen", source="radar",
+    )
+    result.already_running = True
+    result.running_until_minutes = 38   # 10:07 + 38 Min = 10:45 UTC = 12:45 Ortszeit
+    with freeze_time(_AT_LAUF):
+        text = RadarNowcastService().format_now_text(
+            result, tz=TZ_ORT, include_source=False,
+        )
+    assert LAEUFT in text, f"AC-14: die /jetzt-Antwort sagt nicht {LAEUFT!r}.\n{text}"
+    assert ENDE_LOKAL in text, f"AC-14: das Ende ({ENDE_LOKAL}) fehlt.\n{text}"
+    assert "kein Regen erwartet" not in text, f"AC-14: Entwarnung.\n{text}"
+
+
+def test_ac15_briefing_kurzfristzeile_weist_das_ereignis_als_laufend_aus():
+    """AC-15: `format_starkregen_hint` traegt heute unbedingt die Beginn-Form
+    "ab ca. HH:MM (in ~N Min)"; der Laufend-Eingang muss stattdessen die
+    Laufend-Aussage liefern. Der `TypeError` der noch fehlenden Signatur wird
+    in den Text gefaltet, damit der Test an der ASSERTION scheitert und die
+    Ursache im Fehlerbericht sichtbar bleibt."""
+    from output.renderers.email.starkregen_hint import format_starkregen_hint
+
+    with freeze_time(_AT_LAUF):
+        try:
+            text = format_starkregen_hint(
+                "Starker Regen", None, tz=TZ_ORT,
+                already_running=True, running_until_minutes=38,
+            )
+        except TypeError as e:
+            text = f"<TypeError: {e}>"
+    assert LAEUFT in text, (
+        f"AC-15: die Briefing-Zeile weist das Ereignis nicht als {LAEUFT!r} "
+        f"aus.\n{text}"
+    )
+    assert ENDE_LOKAL in text, f"AC-15: das Ende ({ENDE_LOKAL}) fehlt.\n{text}"

--- a/tests/tdd/test_alarm_szenario_laufendes_ereignis.py
+++ b/tests/tdd/test_alarm_szenario_laufendes_ereignis.py
@@ -85,6 +85,13 @@ TZ_ORT = ZoneInfo("Europe/Paris")
 ENDE_LOKAL = "12:30"       # Lage A: letztes nasses Frame (Slot +30)
 HORIZONT_LOKAL = "14:45"   # Lage B: Deckungsende des letzten Frames (Slot +150 +15)
 BEGINN_LOKAL = "12:45"     # Lage E: kuenftiger Beginn (Slot +45)
+# Lage C endet IN der laufenden Viertelstunde. Genannt wird die Deckungsgrenze
+# des laufenden Frames (Slot +15), NICHT sein Zeitstempel (Slot +0) -- der
+# laege VOR dem Pruefzeitpunkt 12:07 und waere eine Aussage ueber die
+# Vergangenheit im Gewand einer Auskunft ueber die Zukunft.
+LAGE_C_ENDE_LOKAL = "12:15"
+LAGE_C_FRAME_LOKAL = "12:00"
+PRUEFZEIT_MIN = 12 * 60 + 7   # 12:07 Ortszeit, in Minuten seit Mitternacht
 
 LAEUFT = "läuft bereits"                             # S2b-Freigabe
 # Ende-Wortlaut aus #2051 S1 (PO-Entscheid 2026-08-22), Lage A = bekanntes
@@ -303,6 +310,45 @@ def test_ac4_laufendes_ereignis_nennt_das_voraussichtliche_ende():
         f"AC-4: die Untergrenzen-Form ({UNTERGRENZE_WORTLAUT!r} bzw. ` >`) "
         f"behauptet, das Ende sei UNBEKANNT -- hier ist der Trockenuebergang "
         f"aber beobachtet.\n{text}"
+    )
+
+
+def test_ac4b_ende_in_der_laufenden_viertelstunde_liegt_nach_dem_pruefzeitpunkt():
+    """AC-4b: endet das laufende Ereignis IN der laufenden Viertelstunde, ist
+    das genannte Ende die Deckungsgrenze des laufenden Frames (12:15) und
+    NICHT dessen Zeitstempel (12:00).
+
+    Die eigentliche Zusicherung ist nicht die Zahl, sondern ihre Lage: die
+    genannte Zeit muss NACH dem Pruefzeitpunkt (12:07) liegen. Sonst liest
+    der Wanderer, waehrend er im Regen steht, dass der Regen vorbei sei --
+    eine Aussage ueber die Vergangenheit im Gewand einer Auskunft ueber die
+    Zukunft. Die Konvention ist nicht neu: der Untergrenzen-Zweig aus
+    #2051 S1 nennt ebenfalls die Deckungsgrenze (Lage B, 14:45 statt 14:30).
+
+    Beide Richtungen: dreht jemand auf den Frame-Zeitstempel zurueck, faellt
+    dieser Test -- ueber die Zahl UND ueber den Lagevergleich."""
+    lauf = _test_lauf("ac4b", _laeuft_endet_im_slot())
+    text = _kanaltext(lauf) + "\n" + "\n".join(lauf.sms)
+    assert f"{ENDE_WORTLAUT} {LAGE_C_ENDE_LOKAL}" in text, (
+        f"AC-4b: erwartet {ENDE_WORTLAUT!r} mit der Deckungsgrenze "
+        f"{LAGE_C_ENDE_LOKAL} (triggered_count={lauf.triggered_count}).\n{text}"
+    )
+    assert LAGE_C_FRAME_LOKAL not in text, (
+        f"AC-4b: {LAGE_C_FRAME_LOKAL} ist der Zeitstempel des laufenden "
+        f"Frames und liegt VOR dem Pruefzeitpunkt -- als Ende genannt sagt er "
+        f"dem Wanderer, der Regen sei vorbei, waehrend es regnet.\n{text}"
+    )
+    assert f"now@{LAGE_C_ENDE_LOKAL}" in text, (
+        f"AC-4b: die Kurznachricht muss dieselbe Deckungsgrenze tragen "
+        f"('now@{LAGE_C_ENDE_LOKAL}').\n{text}"
+    )
+    treffer = re.search(rf"{ENDE_WORTLAUT} (\d{{1,2}}):(\d{{2}})", text)
+    assert treffer, f"AC-4b: keine Ende-Uhrzeit im Text gefunden.\n{text}"
+    genannt = int(treffer.group(1)) * 60 + int(treffer.group(2))
+    assert genannt > PRUEFZEIT_MIN, (
+        f"AC-4b: das genannte Ende ({treffer.group(0)!r}) liegt VOR dem "
+        f"Pruefzeitpunkt 12:07 -- ein Ende in der Vergangenheit ist keine "
+        f"Auskunft ueber ein laufendes Ereignis.\n{text}"
     )
 
 

--- a/tests/tdd/test_alarm_szenario_laufendes_ereignis.py
+++ b/tests/tdd/test_alarm_szenario_laufendes_ereignis.py
@@ -47,7 +47,7 @@ from __future__ import annotations
 
 import re
 import uuid
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 from zoneinfo import ZoneInfo
 
 import pytest
@@ -190,6 +190,31 @@ _AT_LAUF2 = _SLOT2 + timedelta(minutes=7)     # 11:22 UTC, derselbe Cron-Versatz
 
 def _neue_lage_spaeter():
     return _quelle(nass_von=2, nass_bis=5, ab=_SLOT2, rate=12.0)
+
+
+def _quelle_jetzt(*, laufend: bool, rate: float = 10.0):
+    """Dieselben Lagen wie oben, aber am RASTER DER WANDUHR ausgerichtet --
+    fuer die zwei Ketten-Waechter (AC-11c, AC-15b), die ueber Bausteine
+    laufen, die ihre eigene Uhr benutzen und sich nicht einfrieren lassen.
+
+    `laufend=True` -> nur der aktuelle Slot ist nass (Lage C: laeuft, kein
+    kuenftiger Beginn). `laufend=False` -> der aktuelle Slot ist trocken, der
+    Regen beginnt in einem der naechsten Frames (Positivkontrolle).
+    Faellt die Wanduhr genau auf eine Rastergrenze, deckt das Frame `now`
+    weiterhin ab (`ts <= now < ts + 15 Min`) -- die Lage bleibt dieselbe."""
+    def _frames(lat: float, lon: float) -> list:
+        from providers.brightsky import RadarFrame
+        jetzt = datetime.now(timezone.utc)
+        slot = jetzt.replace(
+            minute=(jetzt.minute // 15) * 15, second=0, microsecond=0,
+        )
+        nass = (lambda k: k == 0) if laufend else (lambda k: 1 <= k <= 3)
+        return [
+            RadarFrame(timestamp=slot + timedelta(minutes=15 * k),
+                       precip_mm_h=rate if nass(k) else 0.0)
+            for k in range(11)
+        ]
+    return _frames
 
 
 def _radar(quelle) -> RadarNowcastService:
@@ -509,7 +534,18 @@ def test_ac11_unveraenderte_laufende_lage_loest_kein_zweites_mal_aus():
         f"buchen (war {lauf1.triggered_count})."
     )
 
-    at2 = _AT_LAUF + timedelta(minutes=15)
+    # 🔴 +5 Min, NICHT +15: die Spec verlangt fuer Lauf 2 eine UNVERAENDERTE
+    # Lage ("weiterhin laufend, weiterhin kein kuenftiger Beginn"). Bei +15
+    # Min deckt der Slot 10:15 die Pruefzeit ab -- und der ist in Lage C
+    # TROCKEN, das Ereignis waere dann wirklich vorbei. Lauf 2 schwiege dann
+    # aus Mangel an Lage statt wegen der Entdopplung, und dieser Waechter
+    # waere wertlos. Bitte nicht "aufraeumend" zurueckdrehen.
+    #
+    # Gefunden hat das die Positivkontrolle unten, nicht der Haupttest: Sie
+    # laeuft auf frischem Datentraeger, wo es keine Entdopplung gibt, die
+    # etwas unterdruecken koennte -- und loeste trotzdem nicht aus. Ohne sie
+    # waere AC-11 gruen gewesen, waehrend die Entdopplung unbewacht blieb.
+    at2 = _AT_LAUF + timedelta(minutes=5)
     lauf2 = _lauf(uid, trip, _laeuft_endet_im_slot(), at=at2, strecke=strecke)
     assert lauf2.triggered_count == 0, (
         f"AC-11: dasselbe laufende Ereignis darf kein zweites Mal gemeldet "
@@ -593,6 +629,81 @@ def test_ac11b_neues_ereignis_nach_laufendem_wird_nicht_als_wiederholung_unterdr
         f"Wiederholung des laufenden Ereignisses unterdrueckt werden "
         f"(war {lauf2.triggered_count})."
     )
+
+
+def test_ac11c_ortsvergleich_meldet_dasselbe_laufende_ereignis_nicht_zweimal():
+    """AC-11c: die Entdopplung des ORTSVERGLEICHS (Adversary-Fund F001).
+
+    AC-11/AC-11b bewachen sie nur auf der Trip-Seite -- die Pruefstrecke kennt
+    keinen Compare-Zweig. `compare_radar_alert._identity_inputs` war damit
+    unbewacht: Ohne den Laufend-Zweig bliebe `onset_at` dort `None`, und
+    `_times_overlap` faende NIE einen Kandidaten. Die Entdopplung waere ein
+    stiller No-Op -- sie saehe funktionsfaehig aus und wirkte nie.
+
+    Direkt gegen `CompareRadarAlertService` (Muster AC-12), Sperrzeit AUS
+    (`alert_cooldown_minutes = 0`), damit nicht sie statt der Entdopplung
+    entscheidet. Positivkontrolle auf frischem Zustand: sonst waere ein
+    schweigender zweiter Lauf nicht von "diese Lage loest generell nicht aus"
+    zu unterscheiden."""
+    from app.loader import save_location
+    from services.compare_radar_alert import CompareRadarAlertService
+
+    from tests.tdd.test_compare_radar_alert import (
+        _CoordFrameSource, _clean_user as _clean_compare_user, _location,
+        _radar_preset, _settings_email_capable_dummy, _write_preset_file,
+    )
+
+    lat, lon = 46.0207, 7.7491
+
+    def _lauf(uid: str) -> list:
+        """Ein Prueflauf wie ein Cron-Tick: frische Instanz, eigener Mail-Abgriff."""
+        reset_shared_radar_cache_for_tests()
+        mails: list = []
+        CompareRadarAlertService(
+            settings=_settings_email_capable_dummy(), user_id=uid,
+            radar_service=_radar(_CoordFrameSource(
+                {(lat, lon): _quelle_jetzt(laufend=True, rate=2.0)(lat, lon)},
+            )),
+            mail_sink=lambda subject, body: mails.append((subject, body)),
+        ).check_all_compare_presets()
+        return mails
+
+    def _aufbau_preset(uid: str) -> None:
+        _clean_compare_user(uid)
+        save_location(_location("loc-s2b", "Zermatt-S2b", lat, lon), user_id=uid)
+        preset = _radar_preset(
+            f"cp-{uid}", ["loc-s2b"], ["gregor-test@henemm.com"],
+        )
+        preset["alert_cooldown_minutes"] = 0
+        _write_preset_file(uid, [preset])
+
+    uid, kontrolle = _uid("ac11c"), _uid("ac11c-ctrl")
+    try:
+        _aufbau_preset(uid)
+        erste = _lauf(uid)
+        assert len(erste) == 1, (
+            f"AC-11c Vorbedingung: der erste Lauf muss die laufende Lage melden "
+            f"und ihre Ereignis-Identitaet buchen (war {len(erste)} Mails)."
+        )
+        assert LAEUFT in erste[0][1], (
+            f"AC-11c Vorbedingung: die Ortsvergleich-Mail muss die "
+            f"Laufend-Aussage tragen.\n{erste[0][1]}"
+        )
+
+        zweite = _lauf(uid)
+        assert zweite == [], (
+            f"AC-11c: dasselbe laufende Ereignis darf im Ortsvergleich kein "
+            f"zweites Mal gemeldet werden (war {len(zweite)} Mails)."
+        )
+
+        _aufbau_preset(kontrolle)
+        assert len(_lauf(kontrolle)) == 1, (
+            "AC-11c Positivkontrolle: dieselbe Lage auf frischem Zustand MUSS "
+            "melden -- sonst kommt die Stille oben nicht von der Entdopplung."
+        )
+    finally:
+        _clean_compare_user(uid)
+        _clean_compare_user(kontrolle)
 
 
 def test_ac12_ortsvergleich_buendel_traegt_den_laufenden_ort_mit():
@@ -712,6 +823,61 @@ def test_ac14_jetzt_antwort_meldet_das_laufende_ereignis_als_laufend():
     assert "kein Regen erwartet" not in text, f"AC-14: Entwarnung.\n{text}"
 
 
+def test_ac14b_vorschau_sagt_dasselbe_wie_der_versand():
+    """AC-14b: der Vorschau-/Replay-Weg (`/alert-preview`, Frame-Mitschnitt)
+    muss fuer den Laufend-Fall DIESELBE Aussage liefern wie der Versand.
+
+    Betrieblicher Grund, kein aesthetischer: Mit dieser Vorschau wird beim
+    Ausrollen geprueft. Zeigte sie etwas anderes als der Versandweg, pruefte
+    die Staging-Verifikation eine Aussage, die so nie beim Nutzer ankommt --
+    und meldete gruen. #2051 musste dort ihre Ende-Felder aus genau diesem
+    Grund nachziehen; dieser Waechter haelt fest, dass es beim naechsten Feld
+    nicht wieder vergessen wird.
+
+    Beide Seiten laufen ueber DIESELBEN Frames (Lage C)."""
+    from types import SimpleNamespace
+
+    from services.validator_render_service import _render_nowcast_replay
+
+    uid = _uid("ac14b")
+    trip = _aufbau(uid, "ac14b")
+    lat, lon = trip.stages[0].waypoints[0].lat, trip.stages[0].waypoints[0].lon
+    body = SimpleNamespace(
+        source="radar", km_from=0.0, km_to=8.0, segment_id="1",
+        frames=[
+            SimpleNamespace(
+                timestamp=f.timestamp.isoformat(),
+                precip_mm_h=f.precip_mm_h, is_convective=f.is_convective,
+            )
+            for f in _laeuft_endet_im_slot()(lat, lon)
+        ],
+    )
+    with freeze_time(_AT_LAUF):
+        reset_shared_radar_cache_for_tests()
+        vorschau = _render_nowcast_replay(trip, body)
+    reset_shared_radar_cache_for_tests()
+
+    assert vorschau["onset_detected"], (
+        "AC-14b: die Vorschau meldet 'kein Onset', waehrend der Versandweg "
+        "alarmiert -- ein laufendes Ereignis IST ein Ereignis."
+    )
+    vorschau_text = "\n".join(
+        str(vorschau.get(k) or "") for k in ("subject", "email_plain", "telegram")
+    )
+    versand = _kanaltext(_lauf(uid, trip, _laeuft_endet_im_slot()))
+    for aussage in (LAEUFT, f"{ENDE_WORTLAUT} {LAGE_C_ENDE_LOKAL}"):
+        assert aussage in versand, (
+            f"AC-14b Vorbedingung: der VERSAND muss {aussage!r} tragen.\n{versand}"
+        )
+        assert aussage in vorschau_text, (
+            f"AC-14b: die Vorschau sagt {aussage!r} nicht -- sie zeigt damit "
+            f"etwas anderes als der Versand.\n{vorschau_text}"
+        )
+    assert not _BEGINN_MIN.search(vorschau_text), (
+        f"AC-14b: die Vorschau behauptet einen kuenftigen Beginn.\n{vorschau_text}"
+    )
+
+
 def test_ac15_briefing_kurzfristzeile_weist_das_ereignis_als_laufend_aus():
     """AC-15: `format_starkregen_hint` traegt heute unbedingt die Beginn-Form
     "ab ca. HH:MM (in ~N Min)"; der Laufend-Eingang muss stattdessen die
@@ -733,3 +899,66 @@ def test_ac15_briefing_kurzfristzeile_weist_das_ereignis_als_laufend_aus():
         f"aus.\n{text}"
     )
     assert ENDE_LOKAL in text, f"AC-15: das Ende ({ENDE_LOKAL}) fehlt.\n{text}"
+
+
+def test_ac15b_briefing_kette_stellt_die_laufend_zeile_wirklich_zu(monkeypatch):
+    """AC-15b: dieselbe Zusicherung wie AC-15, aber an der WIRKSTELLE
+    (Adversary-Fund F002).
+
+    AC-15 ruft den Formatierer direkt auf und bewies deshalb nur, dass der
+    Renderer-Zweig gebaut ist -- nicht, dass ihn je etwas erreicht. Tat es
+    nicht: `_build_starkregen_hint` brach bei `onset_minutes is None` ab,
+    fuehrte `already_running` nicht im Rohdaten-Tupel, und die Aufrufstelle
+    im NotificationService uebergab den Parameter nie. Drei Huerden
+    hintereinander, jede fuer sich ausreichend -- dieselbe Familie wie der
+    stille Ausstieg im Vorschau-Weg.
+
+    Dieser Waechter faehrt die ECHTE Kette (Scheduler -> Rohdaten-Tupel ->
+    NotificationService -> Renderer) ueber den produktiven Briefing-Pfad. Der
+    Nowcast kommt aus der echten Ableitung ueber die DI-Naht `frame_source`,
+    nur der Netzzugriff ist ersetzt.
+
+    Positivkontrolle zuerst: der kuenftige Beginn muss ueber DIESELBE Kette
+    eine Zeile erzeugen -- sonst vergleicht der Hauptfall zwei leere
+    Briefings."""
+    from tests.tdd.test_starkregen_kurzfristhinweis import (
+        _ReportRecorder, _active_trip, _run_briefing,
+    )
+
+    # Die ECHTE `get_nowcast`-Implementierung, nur mit gestellter Frame-
+    # Quelle -- vor dem Patchen gebunden, sonst riefe sie sich selbst auf.
+    _echte_get_nowcast = RadarNowcastService.get_nowcast
+
+    def _kette(quelle):
+        def _mit_frames(self, lat, lon, elevation_m=None, priority="user_briefing"):
+            reset_shared_radar_cache_for_tests()
+            return _echte_get_nowcast(
+                RadarNowcastService(frame_source=quelle), lat, lon,
+                elevation_m=elevation_m, priority=priority,
+            )
+        return _mit_frames
+
+    def _briefingtext(quelle) -> str:
+        monkeypatch.setattr(RadarNowcastService, "get_nowcast", _kette(quelle))
+        recorder = _ReportRecorder()
+        recorder.install(monkeypatch)
+        _outcome, bericht = _run_briefing(
+            recorder, _uid("ac15b"), _active_trip(f"trip-s2b-{uuid.uuid4().hex[:6]}"),
+        )
+        return bericht.email_plain
+
+    kontrolle = _briefingtext(_quelle_jetzt(laufend=False))
+    assert _BEGINN_MIN.search(kontrolle) or "ab ca." in kontrolle, (
+        f"AC-15b Positivkontrolle: der kuenftige Beginn muss ueber die Kette "
+        f"eine Kurzfristzeile erzeugen -- sonst prueft der Hauptfall zwei "
+        f"leere Briefings.\n{kontrolle}"
+    )
+
+    laufend = _briefingtext(_quelle_jetzt(laufend=True))
+    assert LAEUFT in laufend, (
+        f"AC-15b: die Briefing-Kurzfristzeile erreicht den Laufend-Fall nicht "
+        f"-- der Renderer-Zweig ist gebaut, aber unerreichbar.\n{laufend}"
+    )
+    assert not _BEGINN_MIN.search(laufend) and "ab ca." not in laufend, (
+        f"AC-15b: die Zeile behauptet weiterhin einen kuenftigen Beginn.\n{laufend}"
+    )


### PR DESCRIPTION
Schliesst Anforderung **B-1** aus #2050 (Szenario 1): Laeuft ein Regen-/Gewitterereignis beim Alarmlauf bereits, meldet Gregor es nicht mehr als bevorstehend.

## Die Ursache, an Produktionsdaten belegt

Frames tragen den **Slot-Start** (Raster :00/:15/:30/:45), der Alarm-Cron laeuft **:07/:22/:37/:52**. Der Filter `f.timestamp >= now` (`radar_service.py`) verwarf damit **immer** das Frame der laufenden Viertelstunde — es ist stets genau 7 Minuten alt. Das naechste Frame wurde zum "Beginn" erklaert und ist stets genau 8 Minuten entfernt.

**"in 8 Min" war deshalb kein Messwert, sondern der einzig moegliche Wert**, wenn es gerade regnet. Der Vorfall vom 21.08. 18:37 zeigt exakt diese Zahl.

Beleg: Prod-Mitschnitt vom 22.08., `captured_at 07:16:02`, erstes Frame `07:15:00`.

## Vier Stellen setzten Zukunft voraus

| Stelle | Verhalten vorher |
|---|---|
| `radar_alert_due` | laufender Regen, der in derselben Viertelstunde endet ⇒ **gar kein Alarm** |
| Entdopplungs-Zeitableitung | ohne Vergleichszeitpunkt ⇒ **stiller No-Op** |
| Ortsvergleich-Filter | laufende Orte fielen vor dem Nachrichtenbau heraus |
| zwei Zeitableitungen | **Absturz** ohne kuenftigen Beginn |

## Zusaetzlich behoben, beim Bauen gefunden

- Die **Staerke** kippte im Laufend-Fall auf "Kein Niederschlag" — der Text waere "Kein Niederschlag laeuft bereits" gewesen, der Alarm in der niedrigsten Dringlichkeitsstufe.
- Der **Vorschau-/Replay-Weg** stieg bei fehlendem Beginn still mit `onset_detected=False` aus. Vorschau und Versand haetten sich widersprochen — und die Staging-Abnahme haette gruen gemeldet, ohne etwas zu beweisen.
- Die **Briefing-Kurzfristzeile** erreichte den Laufend-Fall in Produktion **nie** (Adversary-Fund F002): Der Scheduler brach vorher ab, das Rohdaten-Tupel trug den Zustand nicht, die Aufrufstelle uebergab ihn nicht. Der Renderer-Zweig war gebaut und unerreichbar.

## Abgrenzung zu #2051 S1

Die Ende-Rechnung wird **genutzt, nicht nachgebaut**. Genau ein neues Feld im Datenmodell (`already_running`); die Deckungsgrenze greift ausschliesslich dort, wo deren AC-19 `event_end_minutes` auf `None` laesst. AC-4 belegt, dass deren Ableitung unangetastet bleibt.

Wortlaut per PO-Entscheid aus #2051 (**eine** Sprache im Produkt). Kurzform-Marker `now` — die Kurznachricht ist englisch.

## Nachweise

- **21 Waechter** gruen, **425 Bestandstests** ohne Regression
- **Adversary VERIFIED** nach zwei Runden und 23 Mutationen. Runde 1 war BROKEN mit zwei CRITICAL — beide an der Wirkstelle behoben und per Mutation gegengeprueft
- **Mail-Gate:** Modus-Matrix 41 gruen; Briefing- und Radar-Validator je Exit 0 gegen **echt zugestellte** Mail (Kennzeichen `S2BA7E05E`), die den Laufend-Text traegt:
  ```
  Betreff: 🏁 Ziel · Regen läuft bereits · letzter Regen gegen 14:45
  Wo & wann: 🏁 Ziel · läuft bereits · letzter Regen gegen 14:45
  ```

## Nicht im Scope

Die 55-Minuten-Meldeschwelle (Anforderung A-1) · die Sperrzeit-/Ueberholungslogik (#2065) · ein Rueckblick "laeuft seit HH:MM" (aus den Nowcast-Quellen nicht belegbar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgQcZCpyGAA4zVKYFZV1Nj