### PR TITLE
fix(#2073 Scheibe 1): Track-Aufloesung prueft Ergebnisgleichheit statt Dateianzahl

### DIFF
--- a/docs/context/fix-2073-ergebnisgleichheit.md
+++ b/docs/context/fix-2073-ergebnisgleichheit.md
@@ -1,0 +1,130 @@
+# Context: fix-2073-ergebnisgleichheit (Issue #2073, Scheibe 1)
+
+## Request Summary
+
+`resolve_stage_track_km()` gibt auf, sobald **mehr als eine** GPX-Datei innerhalb der Toleranz auf
+die Wegpunkte einer Etappe passt. Geprüft wird damit die **Anzahl der Dateien**, nicht ob die
+Kandidaten zu **verschiedenen Kilometerwerten** führen. Scheibe 1 stellt die Regel auf
+Ergebnisgleichheit um: liefern alle Kandidaten praktisch dieselbe Wegstrecke, darf die Auflösung
+sich entscheiden; nur bei wirklich abweichenden Ergebnissen bleibt `None`.
+
+Scheibe 2 (Sichtbarkeit des stillen Fehlschlags) ist **nicht** Teil dieses Workflows — PO-Entscheid
+2026-08-22: nach der KHW-Tour.
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `src/services/track_resolution.py:59-98` | `resolve_stage_track_km()` — die zu ändernde Regel (`:92-95` bricht bei zweitem Treffer ab) |
+| `src/services/track_resolution.py:38-56` | `_match_track()` — Vollständigkeitsregel (AC-12), bleibt unverändert |
+| `src/services/track_resolution.py:109-178` | `backfill_stage_distances()` — Aufrufer, Read-Modify-Write via `save_trip` |
+| `tests/tdd/test_track_resolution_legacy_trip.py` | 11 Tests; `test_ac11_zwei_gleichwertige_treffer_liefern_kein_ergebnis` bewacht heute die alte Regel |
+| `tests/fixtures/data_root/users/default/gpx/` | 4 versionierte GR221-GPX (Tag 1–4), Basis aller Fixtures |
+| `docs/specs/modules/fix_2036_alarm_kilometer_ortsangabe.md` | Quelle von AC-11/AC-12 und der 10-m-Schwelle |
+| `src/core/gpx_parser.py:137-159` | `_extract_points()` — `distance_from_start_km` kumuliert ab Track-Anfang, `round(..., 4)` |
+| `src/app/models.py:364,382` | `GPXPoint.distance_from_start_km` (float, Default `0.0`), `GPXTrack.points` |
+
+## Existing Patterns
+
+- **Alles oder nichts je Track** (`_match_track`): ein einziger Wegpunkt > 10 m abseits verwirft den
+  ganzen Kandidaten. Diese Regel ist unstrittig und bleibt.
+- **Fail-soft**: jeder Fehler in `backfill_stage_distances` lässt den Trip unverändert — eine
+  fehlende Kilometerangabe ist ein Schönheitsfehler, ein ausgefallener Alarm nicht.
+- **Prozess-Sperre** `_failed_lookups`: erfolglose Suchen werden je `(user_id, trip_id, stage_id)`
+  gemerkt, damit nicht jeder Alarmlauf den ganzen GPX-Bestand neu parst.
+- **Deterministische Reihenfolge**: `sorted(directory.glob("*.gpx"))` — die Kandidatenliste ist
+  reproduzierbar, eine Auswahl daraus ist kein Zufall.
+
+## Dependencies
+
+- **Upstream:** `core.gpx_parser.parse_gpx`, `utils.geo.haversine_km`, `app.loader.get_data_dir` /
+  `save_trip`.
+- **Downstream:** `TripAlertService._resolve_alert_segment` (`trip_alert.py:1165-1168`) und
+  `TripReportSchedulerService._convert_trip_to_segments` (`trip_report_scheduler.py:1983-1990`).
+  Von dort über `TripSegment.distance_measured` → `renderers/alert/project.py:244,359` →
+  `renderers/alert/segments.py::format_alert_location()`, das bei `km_measured=True` `km A-B`
+  statt `Segment N` zeigt. Betrifft #2036 (Ortsangabe) und #2042 (Ankunftszeiten).
+
+## Existing Specs
+
+- `docs/specs/modules/fix_2036_alarm_kilometer_ortsangabe.md` — **AC-11** (Eindeutigkeit),
+  **AC-12** (Vollständigkeit), Abschnitt „Festgelegte Schwellenwerte" (10 m Zuordnungstoleranz,
+  Rundung der Anzeige auf **ganze Kilometer**). AC-11 kennt die Möglichkeit gleicher Ergebnisse
+  noch nicht — genau das ist die Lücke von #2073.
+
+## Messung am Produktivbestand (2026-08-22)
+
+Gemessen mit dem echten GPX-Bestand `/var/lib/gregor/users/henning/gpx/` (20 Dateien) gegen die
+Etappen-Wegpunkte der Produktivtrips „GR221 Mallorca" (4 Etappen) und „KHW 403" (13 Etappen).
+Verfahren identisch zu `_match_track`: je Wegpunkt der nächstgelegene Trackpunkt, Toleranz 10 m.
+
+### Befund 1 — die Ticket-Prämisse trifft in einem Punkt nicht zu
+
+Das Ticket nennt die zwei getrennten Aufzeichnungen von Mallorca Tag 2 als Fall, den ein reiner
+Prüfsummen-Vergleich weiterhin verwerfen würde. **Gemessen passt die zweite Aufzeichnung gar nicht
+auf die Wegpunkte:** ihr schlechtester Wegpunkt liegt **111,1 m** ab und wird bereits von der
+Vollständigkeitsregel (AC-12) ausgesiebt, bevor die Eindeutigkeitsregel überhaupt greift.
+
+| Etappe | Treffer ≤ 10 m | nächstbester verworfener Kandidat |
+|---|---|---|
+| Mallorca Tag 1 | **2** (Original + `test.gpx`, beide 0,0 m) | 4.672,6 m (Tag 2) |
+| Mallorca Tag 2 | 1 (0,0 m) | **111,1 m** (zweite Aufzeichnung vom 2026-02-14) |
+| Mallorca Tag 3 | 1 (0,0 m) | 8.780,3 m |
+| Mallorca Tag 4 | 1 (0,0 m) | 6.088,6 m |
+| KHW 403, alle 13 Etappen | je 1 (0,0 m) | mindestens **4.732,6 m** |
+
+### Befund 2 — der real auftretende Mehrdeutigkeitsfall ist die byte-identische Dublette
+
+Mallorca Tag 1 ist die einzige gemessene Etappe mit zwei Treffern: das Original und `test.gpx`
+(byte-identische Kopie, 62.893 Bytes, gleiche md5-Größe). Beide liefern **identische** km-Werte:
+
+```
+2026-01-17_..._Tag 1_ von Valldemossa nach Deià.gpx   km = [0.0, 2.9345, 6.1364, 9.6067]
+test.gpx                                              km = [0.0, 2.9345, 6.1364, 9.6067]
+-> maximale Abweichung: 0,0 m  (Etappenspanne 9,61 km)
+```
+
+Nach heutiger Regel fällt Mallorca Tag 1 damit auf `Segment N` zurück, obwohl es nichts zu raten
+gibt. Das ist der Fall, den Scheibe 1 auflösen muss.
+
+### Befund 3 — die Trennschärfe ist dreifach belegt
+
+| Größenordnung | Beispiel | max. km-Abweichung zwischen Kandidaten |
+|---|---|---|
+| identisches Ergebnis | Dublette Mallorca Tag 1 | **0,0 m** |
+| dieselbe Strecke, andere Aufzeichnung | Mallorca Tag 2, 2026-01-17 vs. 2026-02-14 | **bis 144 m** (9,390 vs. 9,246 km) |
+| andere Etappe | jede Nachbaretappe | **Kilometer** |
+
+Zwischen 0 m und 144 m liegen mehr als eine Größenordnung Luft. Eine Schwelle in der Größenordnung
+der bereits festgelegten Zuordnungstoleranz (10 m) trennt sicher.
+
+### Wirkung auf die laufende Tour
+
+**KHW 403 gewinnt durch Scheibe 1 heute keine Etappe** — alle 13 Etappen haben seit der
+Dublettenlöschung aus #2070 genau einen Treffer. Der Fix ist dort Vorsorge: eine erneut hochgeladene
+Kopie eines KHW-Tracks würde die Etappe künftig nicht mehr ausfallen lassen. Unmittelbar wirksam ist
+er für „GR221 Mallorca" Tag 1.
+
+## Risks & Considerations
+
+- **Der bewachende Test kippt.** `test_ac11_zwei_gleichwertige_treffer_liefern_kein_ergebnis` kopiert
+  dieselbe Fixture-Datei zweimal und erwartet `None`. Genau dieses Verhalten wird abgeschafft. Der
+  Test muss auf zwei Kandidaten mit **wirklich abweichenden** Ergebnissen umgestellt werden, sonst
+  verliert AC-11 seinen Wächter ersatzlos. Die Regel darf nicht stillschweigend entfallen — nur ihr
+  Auslöser ändert sich.
+- **Vollständige Schleife statt Früh-Abbruch.** Für den Ergebnisvergleich müssen alle Kandidaten
+  gesammelt werden; der heutige `return None` bei zwei Treffern (`:94-95`) entfällt. Der Alarmlauf
+  hat eine Zeitobergrenze (Kommentar bei `_failed_lookups`), der Bestand umfasst 20 Dateien — im
+  gemessenen Fall parst die Schleife ohnehin fast alle, der Mehraufwand ist begrenzt.
+- **Mehr als zwei Kandidaten.** Passen drei Dateien, von denen zwei gleich und eine abweichend ist,
+  muss `None` herauskommen. Ergebnisgleichheit muss also für **alle** Kandidaten gelten, nicht nur
+  für ein Paar.
+- **Welcher Kandidat gewinnt?** Bei Ergebnisgleichheit ist die Wahl fachlich beliebig, aber sie darf
+  nicht zufällig sein — `sorted(...)` gibt eine stabile Reihenfolge vor.
+- **Relative Schwelle wäre die schlechtere Wahl.** 1 % einer 9,6-km-Etappe sind 96 m und würden
+  echte Wegunterschiede durchwinken; bei einer 1-km-Etappe wären es 10 m. Die Größe, um die es hier
+  geht, ist ein Ortsabstand, keine Proportion.
+- **Keine Schema-Änderung.** Scheibe 1 fasst weder Datenmodell noch Persistenz an; der
+  Rückschreibweg (`save_trip`, Read-Modify-Write) bleibt unberührt.
+- **`test.gpx` bleibt liegen.** Der im Ticket genannte Aufräum-Rest wird durch Scheibe 1
+  gegenstandslos, aber nicht gelöscht — Produktivdaten des PO werden nicht angefasst.

--- a/docs/specs/modules/fix_2073_track_ergebnisgleichheit.md
+++ b/docs/specs/modules/fix_2073_track_ergebnisgleichheit.md
@@ -1,0 +1,328 @@
+---
+entity_id: fix_2073_track_ergebnisgleichheit
+type: bugfix
+created: 2026-08-22
+updated: 2026-08-22
+status: draft
+version: "1.0"
+tags: [gpx, track-resolution, alarm]
+workflow: fix-2073-ergebnisgleichheit
+---
+
+# Track-Auflösung: Ergebnisgleichheit statt Dateianzahl als Eindeutigkeitsregel
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+`resolve_stage_track_km()` gibt heute auf, sobald **mehr als eine** GPX-Datei innerhalb der
+Zuordnungstoleranz auf die Wegpunkte einer Etappe passt (Früh-Abbruch bei zweitem Treffer). Geprüft
+wird damit die **Anzahl der Kandidaten**, nicht ob sie zu **verschiedenen** Kilometerwerten führen.
+Eine byte-identische Dublette derselben GPX-Datei unter zwei Namen liefert dieselben Werte wie ein
+einziger Kandidat, wird aber wie ein echter Widerspruch behandelt und die Etappe fällt unnötig auf
+`Segment N` zurück (real gemessen: „GR221 Mallorca" Tag 1, Original + `test.gpx`). Diese Spec stellt
+die Regel auf **Ergebnisgleichheit** um: liefern alle Kandidaten praktisch dieselbe Wegstrecke, darf
+die Auflösung sich entscheiden; nur bei wirklich abweichenden Ergebnissen bleibt `None`.
+
+## Source
+
+- **File:** `src/services/track_resolution.py`
+- **Identifier:** `resolve_stage_track_km()` (:59-98)
+
+> **Schicht-Hinweis:** Python-Core / Domain-Backend (`src/services/`). Kein Go- und kein
+> Frontend-Anteil — reine Auflösungslogik innerhalb einer bestehenden Funktion, kein neues
+> Datenfeld, keine Schema-Änderung.
+
+## Estimated Scope
+
+- **LoC:** ~50–70 Produktivcode
+- **Files:** 2 (`src/services/track_resolution.py`, `tests/tdd/test_track_resolution_legacy_trip.py`)
+- **Effort:** medium — kleiner Funktionsumfang, aber die Umstellung von „ein Treffer" auf
+  „mehrere Treffer paarweise vergleichen" verändert die Kernlogik einer bewachten Funktion, deren
+  Bestandstests (AC-11 aus #2036) mit umgeschrieben werden müssen, ohne ihren Wächter-Zweck zu
+  verlieren.
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `src/services/track_resolution.py` (`_match_track`) | module | Vollständigkeitsregel je Kandidat (AC-12 aus #2036) — bleibt unverändert, liefert weiterhin `Dict[waypoint_id, km]` oder `None` je Track |
+| `src/services/track_resolution.py` (`DEFAULT_TOLERANCE_M`) | module | Bereits festgelegte 10-m-Zuordnungstoleranz — die neue Ergebnisgleichheits-Schwelle wird von dieser Konstante abgeleitet, keine zweite freie Zahl |
+| `src/services/track_resolution.py` (`backfill_stage_distances`) | module | Aufrufer von `resolve_stage_track_km`; Read-Modify-Write-Rückschreibweg bleibt unangetastet |
+| `src/services/trip_segments.py` (`stage_measured_distances`, :150-151) | module | Wendet dieselbe Etappenstart-Normierung bereits auf dem Weg zum Nutzer an — Vorbild für die Normierung im Vergleich |
+| `src/core/gpx_parser.py` (`GPXPoint.distance_from_start_km`, :155) | module | Liefert die rohe, ab Track-Anfang kumulierte Distanz je Trackpunkt — Grundlage der Normierung |
+| `docs/specs/modules/fix_2036_alarm_kilometer_ortsangabe.md` | spec | Vorgänger-Spec, Quelle von AC-11 (Eindeutigkeit), AC-12 (Vollständigkeit) und der 10-m-Toleranz |
+
+## Implementation Details
+
+**Auflösungsreihenfolge in `resolve_stage_track_km()` (ersetzt :82-98):**
+
+1. **Kein Früh-Abbruch mehr.** Die Schleife über `sorted(directory.glob("*.gpx"))` läuft
+   vollständig durch; jeder Kandidat, der `_match_track()` besteht, wird in `matches` gesammelt
+   (statt bei `len(matches) > 1` sofort `None` zurückzugeben).
+2. **Normierung vor dem Vergleich.** Für jeden Kandidaten wird die Ergebnis-Liste
+   `[km_wp1, km_wp2, ...]` in Etappen-Reihenfolge auf den ersten Wegpunkt normiert:
+   `norm[i] = roh[i] - roh[0]`. Dieselbe Normierung wendet `stage_measured_distances`
+   (`trip_segments.py:150-151`) ohnehin auf dem Weg zum Nutzer an.
+3. **Ergebnisgleichheit paarweise, nicht gegen einen Referenzkandidaten.** Zwei Kandidaten gelten
+   als ergebnisgleich, wenn für JEDEN Wegpunkt `|norm_A[i] - norm_B[i]| <= 10 m` (0,01 km) gilt.
+   Die Prüfung läuft über **alle** Kandidatenpaare (bei `n` Kandidaten: alle `n·(n-1)/2` Paare).
+   Referenzvergleich gegen einen einzelnen Kandidaten würde die effektive Toleranz bei einer
+   Kette knapp-innerhalb-Kandidaten stillschweigend verdoppeln (A~B, B~C, aber A und C 18 m
+   auseinander) — deshalb paarweise.
+4. **Sind alle Kandidaten paarweise ergebnisgleich**, wird das Ergebnis des **ersten** Kandidaten
+   in `sorted(...)`-Reihenfolge zurückgegeben — mit seinen **rohen**, unnormierten Werten (wie
+   bisher; die Normierung ist ausschließlich ein Vergleichs-Hilfsmittel, kein Rückgabeformat).
+5. **Sonst** (mindestens ein Paar überschreitet die Schwelle, oder `len(matches) == 0`) liefert
+   die Funktion weiterhin `None`.
+6. `_match_track()` (die Vollständigkeitsregel, AC-12 aus #2036) wird **nicht** angefasst — sie
+   entscheidet weiterhin unverändert, ob ein einzelner Kandidat überhaupt in `matches` landet.
+7. Die Ergebnisgleichheits-Schwelle wird als benannte Konstante geführt, die aus
+   `DEFAULT_TOLERANCE_M` abgeleitet ist (z. B. `RESULT_EQUALITY_TOLERANCE_M = DEFAULT_TOLERANCE_M`)
+   — es gibt bewusst nur EINE 10-m-Zahl im Modul, keine zweite, frei geratene Größe.
+
+**Warum normierte statt roher Werte verglichen werden:** `distance_from_start_km` kumuliert ab dem
+Anfang des jeweiligen GPX-**Tracks** (`gpx_parser.py:155`), nicht ab dem Etappenstart. Eine
+Einzeletappen-GPX beginnt bei 0 km, eine durchlaufende Gesamt-Tour-GPX kann für dieselbe physische
+Etappe bei z. B. 50 km beginnen. Roh verglichen wären beide „verschieden", obwohl sie dem Nutzer
+identische Kilometerwerte zeigen würden: `trip_segments.py:150-151` normiert ohnehin auf den
+Etappenstart, und die ausgelieferten Segmente tragen ausschließlich diese normierten Werte
+(`trip_segments.py:299-305`, `km_start = measured[i]`). Der rohe Absolutwert ist nirgends
+nutzersichtbar — Go transportiert ihn nur (`internal/model/trip.go:99`), kein Frontend zeigt ihn.
+Genau der Fall „Einzeletappe UND Gesamt-GPX" ist das Leitbeispiel aus AC-11 der Vorgänger-Spec, das
+diese Scheibe löst.
+
+**Warum 10 m und nicht relativ:** Am Produktivbestand gemessen (`docs/context/fix-2073-ergebnisgleichheit.md`,
+Befund 3): der einzige real auftretende Gleichheitsfall liegt bei **0,0 m** Abweichung, der nächste
+denkbare Abweichungsfall (dieselbe Strecke, andere Aufzeichnung) bei **144 m**, fremde Etappen liegen
+im Kilometerbereich auseinander. 10 m ist bereits als „derselbe Punkt" festgelegt
+(`DEFAULT_TOLERANCE_M`, Vorgänger-Spec „Festgelegte Schwellenwerte") — es kommt keine zweite, frei
+geratene Zahl ins Modul. Eine relative Schwelle wäre schlechter: 1 % einer 9,6-km-Etappe sind 96 m
+und würden echte Wegunterschiede durchwinken, bei einer 1-km-Etappe wären es nur 10 m. Die
+verglichene Größe ist ein Ortsabstand, keine Proportion.
+
+**Warum paarweise statt gegen einen Referenzkandidaten:** Bei einer harten Schwelle ist Gleichheit
+nicht transitiv. Liegt B 9 m über A und C 9 m unter A, bestehen beide den Referenzvergleich gegen A,
+liegen aber 18 m auseinander — ein Referenzvergleich würde die effektive Toleranz stillschweigend
+verdoppeln. Bei A~B, B~C, A≁C ist `None` die ehrliche Antwort, weil kein einziges gemeinsames
+Ergebnis alle drei Kandidaten gleichzeitig beschreibt.
+
+## Expected Behavior
+
+- **Input:** Eine Etappe mit Wegpunkten und ein GPX-Bestandsverzeichnis, in dem zwei oder mehr
+  Dateien die Vollständigkeitsregel (`_match_track`, AC-12) für diese Etappe erfüllen.
+- **Output:** Sind alle diese Kandidaten paarweise ergebnisgleich (je Wegpunkt ≤ 10 m normierte
+  Abweichung), liefert `resolve_stage_track_km()` ein Ergebnis (die rohen Werte des ersten
+  Kandidaten in `sorted(...)`-Reihenfolge) statt `None`. Weicht mindestens ein Kandidatenpaar
+  wirklich ab, bleibt `None` — unverändert zum heutigen Verhalten.
+- **Side effects:** Keine neuen. `backfill_stage_distances()` schreibt wie bisher additiv über
+  `save_trip` zurück, sobald ein Ergebnis vorliegt.
+
+## Festgelegte Schwellenwerte
+
+| Größe | Wert | Begründung |
+|---|---|---|
+| Ergebnisgleichheits-Toleranz je Wegpunkt | **10 m** (abgeleitet von `DEFAULT_TOLERANCE_M`) | Real gemessener Gleichheitsfall liegt bei 0,0 m, der nächste denkbare Abweichungsfall bei 144 m — mehr als eine Größenordnung Luft; keine zweite freie Zahl im Modul (Kontext-Dokument, Befund 3). |
+| Vergleichsbasis | **normierte** Wegpunkt-Kilometer (`norm[i] = roh[i] - roh[0]`) | Angleicht Track-Ursprünge; identisch zur Etappen-Normierung in `trip_segments.py:150-151`, die dem Nutzer ohnehin angezeigt wird. |
+| Rückgabewert bei Ergebnisgleichheit | **rohe** Werte des ersten Kandidaten in `sorted(...)`-Reihenfolge | Deterministisch, reproduzierbar; die Normierung dient ausschließlich dem Vergleich, nicht der Rückgabe. |
+
+## Acceptance Criteria
+
+- **AC-1:** Given zwei byte-identische GPX-Dateien mit demselben Inhalt liegen unter
+  verschiedenen Namen im GPX-Bestand des Nutzers und beide bestehen die Vollständigkeitsregel für
+  eine Etappe (der real gemessene Fall: „GR221 Mallorca" Tag 1 mit einer zusätzlichen Kopie
+  `test.gpx`) / When die Track-Auflösung für diese Etappe läuft / Then liefert sie ein Ergebnis
+  mit den gemessenen Distanzen — nicht mehr `None`.
+  - Test: Dieselbe GPX-Fixture wird zweimal unter unterschiedlichen Dateinamen in ein
+    `tmp_path`-Verzeichnis kopiert; `resolve_stage_track_km()` liefert für die zugehörige Etappe
+    ein Dict mit den erwarteten Kilometerwerten je Wegpunkt.
+
+- **AC-2:** Given zwei GPX-Kandidaten bestehen beide die Vollständigkeitsregel, sind aber NICHT
+  byte-identisch, und ihre normierten Wegpunkt-Kilometer weichen je Wegpunkt um weniger als 10 m
+  voneinander ab / When die Track-Auflösung läuft / Then liefert sie ein Ergebnis, nicht `None`.
+  - Test: Zwei Kandidaten, bei denen die zweite Datei zwischen zwei Wegpunkten einen minimalen
+    zusätzlichen Trackpunkt trägt (Umweg von wenigen Metern), so dass die normierten
+    Kilometerwerte messbar, aber um weniger als 10 m abweichen — die Dateien sind damit
+    nachweislich **nicht** byte-identisch;
+    `resolve_stage_track_km()` liefert ein Ergebnis. Dieser Test ist der Wirksamkeitsnachweis —
+    ohne ihn wäre „Ergebnisgleichheitsprüfung ersatzlos entfernt" ununterscheidbar vom alten
+    Verhalten, da AC-1 mit byte-identischen Dateien auch bei einer entfernten Prüfung bestünde.
+
+- **AC-3:** Given eine Einzeletappen-GPX und eine durchlaufende Gesamt-Tour-GPX decken dieselbe
+  Etappe ab, ihre rohen Distanzwerte unterscheiden sich aber um einen großen Offset (z. B. +50 km,
+  weil die Gesamt-GPX nicht bei dieser Etappe beginnt) / When die Track-Auflösung läuft / Then
+  liefert sie ein Ergebnis, weil die auf den Etappenstart normierten Werte je Wegpunkt innerhalb
+  von 10 m übereinstimmen.
+  - Test: Neben der Einzeletappen-Fixture wird eine zweite GPX gebaut, die **eine
+    vorangestellte Fremdetappe und danach dieselben Trackpunkte** enthält (die Trackpunkte einer
+    anderen Fixture-Etappe, gefolgt von denen der Zieletappe). `distance_from_start_km` wird von
+    `parse_gpx` beim Parsen kumuliert berechnet (`gpx_parser.py:137-159`) und steht **nicht** in
+    der Datei — der Offset entsteht deshalb ausschließlich durch die vorangestellten Trackpunkte,
+    nicht durch manipulierte Werte. `resolve_stage_track_km()` liefert ein Ergebnis. Das ist das
+    AC-11-Leitbeispiel der Vorgänger-Spec.
+
+- **AC-4:** Given zwei GPX-Kandidaten bestehen beide die Vollständigkeitsregel, aber ihre
+  normierten Wegpunkt-Kilometer weichen an mindestens einem Wegpunkt um deutlich mehr als 10 m
+  voneinander ab (wirklich abweichende Strecken) / When die Track-Auflösung läuft / Then liefert
+  sie `None`, und die nachgelagerte Ortsangabe bleibt `Segment N`.
+  - Test: Zwei Kandidaten, die **beide** die Vollständigkeitsregel bestehen (alle Wegpunkte
+    liegen bei beiden innerhalb von 10 m), deren kumulierte Wegstrecke **zwischen** den
+    Wegpunkten aber auseinanderläuft: die zweite Datei bekommt zwischen zwei Wegpunkten einen
+    eingefügten Umweg von einigen hundert Metern. Das ist der fachlich echte Fall „zwei
+    Wegvarianten zwischen denselben Punkten" und die einzige Konstruktion, die den
+    Ergebnisvergleich überhaupt erreicht — Kandidaten, deren **Wegpunkte** abweichen, werden
+    schon von `_match_track` verworfen (deshalb taugt die zweite Mallorca-Tag-2-Aufzeichnung mit
+    ihren 111 m Wegpunkt-Abstand hier **nicht** als Vorlage, siehe Kontext-Dokument Befund 1).
+    `resolve_stage_track_km()` liefert `None`, und
+    `format_alert_location(None, ..., km_measured=False)` liefert weiterhin `Segment N`. AC-11 der
+    Vorgänger-Spec behält damit seinen Wächter — nur sein Auslöser ändert sich von „Anzahl" auf
+    „Ergebnisunterschied".
+
+- **AC-5:** Given drei GPX-Kandidaten bestehen die Vollständigkeitsregel, wobei Kandidat A und B
+  paarweise ergebnisgleich sind, B und C paarweise ergebnisgleich sind, A und C aber NICHT
+  ergebnisgleich sind (Kette ohne gemeinsames Ergebnis) / When die Track-Auflösung läuft / Then
+  liefert sie `None`.
+  - Test: Drei Kandidaten mit dieser Dreiecks-Konstellation, gebaut nach derselben Technik wie
+    AC-4 (eingefügte Umwege verschiedener Länge zwischen denselben Wegpunkten, so dass A→B und
+    B→C je knapp unter 10 m, A→C aber knapp über 10 m liegen);
+    `resolve_stage_track_km()` liefert `None`. Unterscheidet „paarweise alle" von „nur gegen den
+    ersten Kandidaten verglichen".
+
+- **AC-6:** Given genau ein GPX-Kandidat besteht die Vollständigkeitsregel für eine Etappe / When
+  die Track-Auflösung läuft / Then liefert sie unverändert das Ergebnis dieses einen Kandidaten
+  (Regressionsschutz gegenüber #2036 AC-7).
+  - Test: Der bestehende Test für den Einzeltreffer-Fall (eine GPX-Datei im Bestand) läuft
+    unverändert grün und liefert dieselben Kilometerwerte wie vor dieser Änderung.
+
+- **AC-7:** Given kein GPX-Kandidat im Bestand besteht die Vollständigkeitsregel für eine Etappe /
+  When die Track-Auflösung läuft / Then liefert sie `None`, und die Ortsangabe bleibt byte-identisch
+  `Segment N` (Regressionsschutz #2036 AC-10).
+  - Test: Der bestehende Test für den Kein-Treffer-Fall (unpassende GPX-Datei) läuft unverändert
+    grün; `format_alert_location(None, ..., km_measured=False)` liefert weiterhin exakt
+    `Segment N`.
+
+- **AC-8:** Given eine Etappe enthält einen Wegpunkt, der mehr als 10 m vom nächstgelegenen Punkt
+  eines sonst passenden Tracks abweicht, während andere Kandidaten für dieselbe Etappe die
+  Vollständigkeitsregel erfüllen / When die Track-Zuordnung läuft / Then bleibt die Etappe
+  insgesamt unvermessen — die Vollständigkeitsregel (`_match_track`) verwirft den abweichenden
+  Kandidaten vollständig, bevor er überhaupt in den Ergebnisgleichheits-Vergleich eingeht
+  (Regressionsschutz #2036 AC-12, `_match_track` unangetastet).
+  - Test: Der bestehende AC-12-Test (ein zusätzlicher, 15 m abseits liegender Wegpunkt neben einem
+    sonst exakt passenden Track) läuft unverändert grün und liefert weiterhin `None`.
+
+- **AC-9:** Given zwei oder mehr GPX-Kandidaten sind paarweise ergebnisgleich / When die
+  Track-Auflösung für denselben Bestand mehrfach ausgeführt wird / Then liefert jeder Lauf
+  denselben Rückgabewert (dieselben Kilometerwerte, aus demselben Kandidaten in
+  `sorted(...)`-Reihenfolge).
+  - Test: Dieselbe Kandidatenmenge wird zweimal hintereinander gegen `resolve_stage_track_km()`
+    ausgeführt; beide Rückgaben sind identisch (Dict-Vergleich auf Gleichheit, nicht nur
+    „ist nicht None").
+
+- **AC-10:** Given eine Etappe wird über den bestehenden Rückschreibweg
+  (`backfill_stage_distances`) nachgetragen, nachdem die Track-Auflösung durch Ergebnisgleichheit
+  ein Ergebnis liefert, das vorher `None` gewesen wäre / When die Distanz additiv an den Trip
+  zurückgeschrieben wird / Then landet nur die betroffene Etappe verändert, alle anderen Etappen
+  und vom Python-Loader nicht modellierte (Go-only-)Felder bleiben unverändert erhalten
+  (Regressionsschutz #2036 AC-7).
+  - Test: Ein Trip mit zwei GPX-Dublett-Kandidaten im Bestand (analog AC-1) wird durch
+    `backfill_stage_distances()` geschickt; nach dem Speichern trägt nur die betroffene Etappe die
+    nachgetragene Distanz, alle übrigen Etappen sowie ein zuvor manuell in die JSON-Datei
+    eingefügtes, dem Python-Modell unbekanntes Feld bleiben unverändert.
+
+## Nicht Teil dieser Spec
+
+- **Scheibe 2 (Sichtbarkeit des stillen Fehlschlags)** ist per PO-Entscheid 2026-08-22 auf nach der
+  KHW-Tour verschoben. Der Fehlschlag der Track-Auflösung bleibt in dieser Scheibe weiterhin still
+  (`logger.warning` bei nicht lesbaren Dateien, sonst kein Signal nach außen).
+- **`_match_track()` / die Vollständigkeitsregel** wird nicht verändert — sie bleibt „alles oder
+  nichts je Kandidat" (AC-12 aus #2036).
+- **`test.gpx`** (der im Ticket genannte Aufräum-Rest im Produktivbestand) wird durch diese Spec
+  gegenstandslos, aber nicht gelöscht — Produktivdaten des PO werden nicht angefasst.
+
+## Bestandstests, die grün bleiben müssen
+
+`tests/tdd/test_track_resolution_legacy_trip.py` — insbesondere
+`test_ac7_eindeutiger_track_liefert_die_gemessenen_distanzen`,
+`test_ac10_kein_passender_track_liefert_kein_ergebnis`,
+`test_ac12_wegpunkt_mehr_als_10m_abseits_verhindert_die_zuordnung`,
+`test_ac12_default_toleranz_nimmt_den_exakt_passenden_track_an`,
+`test_ac12_default_toleranz_weist_einen_15m_abseits_liegenden_wegpunkt_ab`,
+`test_ac7_rueckschreiben_erhaelt_go_only_felder`,
+`test_ac7_alarm_pfad_loest_die_nachruestung_aus`,
+`test_ac7_briefing_pfad_loest_die_nachruestung_weiterhin_aus`,
+`test_ac7_zweite_aufloesung_schreibt_nicht_erneut`.
+
+**`test_ac11_zwei_gleichwertige_treffer_liefern_kein_ergebnis` muss umgeschrieben werden** — er
+kopiert heute dieselbe Fixture-Datei zweimal und erwartet `None`. Genau dieses Verhalten wird durch
+AC-1 dieser Spec abgeschafft. Der Test wird auf zwei Kandidaten mit **wirklich abweichenden**
+Ergebnissen umgestellt (Vorbild: AC-4/AC-5 dieser Spec), damit die Eindeutigkeitsregel ihren
+Wächter behält — sie darf nicht ersatzlos entfallen, nur ihr Auslöser ändert sich von „Anzahl" auf
+„Ergebnisunterschied".
+
+## Risiken
+
+1. **Der bewachende Test kippt, wenn er nicht mit umgeschrieben wird.** Ohne Anpassung von
+   `test_ac11_...` verliert die Eindeutigkeitsregel ihren einzigen Nachweis — siehe Abschnitt
+   „Bestandstests, die grün bleiben müssen".
+2. **Vollständige Schleife statt Früh-Abbruch.** Der Alarmlauf hat eine Zeitobergrenze (ADR-0038,
+   120 s), der gemessene GPX-Bestand umfasst 20 Dateien; im real gemessenen Fall parst die
+   Schleife auch heute schon fast alle Dateien, der Mehraufwand ist begrenzt. Entschärft zusätzlich
+   durch die bestehende `_failed_lookups`-Prozess-Sperre (`track_resolution.py:106-107`).
+3. **Referenzvergleich statt paarweise wäre eine stille Verdoppelung der Toleranz.** Muss im
+   Adversary-Dialog aktiv gegengeprüft werden (AC-5).
+4. **Ohne echten Ergebnisunterschied bleibt alles wie heute.** Das ist die Fallback-Garantie
+   (AC-4, AC-7), kein Bug — muss aber als Positivfall geprüft werden, nicht nur impliziter
+   Nebeneffekt.
+
+## Known Limitations
+
+- **Rundungsgrenzfall:** Die Anzeige rundet auf ganze Kilometer. Liegen zwei ergebnisgleiche
+  Kandidaten nahe einer .5-km-Grenze (z. B. 12,497 vs. 12,503 km), kann die Auswahl des ersten
+  Kandidaten in `sorted(...)`-Reihenfolge den angezeigten gerundeten Wert um 1 km verschieben.
+  Bewusst akzeptiert: die Alternative wäre, den bereits eindeutigen Fall wieder zu verwerfen.
+- **Wegpunkt-Stichprobe statt Pfadvergleich:** Ergebnisgleichheit wird an den Wegpunkten geprüft,
+  nicht über den gesamten Trassenverlauf zwischen ihnen. Zwei Aufzeichnungen könnten an den
+  Wegpunkten zusammenfallen und dazwischen abweichen. Kein neues Risiko — AC-12 der Vorgänger-Spec
+  akzeptiert dieselbe Stichprobenlogik bereits für den Einzelkandidaten.
+- **Laufzeit:** Ohne Früh-Abbruch wird bei mehreren Vollständigkeits-Treffern der gesamte
+  GPX-Bestand geparst, statt bei zwei Treffern abzubrechen. Entschärft durch die
+  `_failed_lookups`-Sperre (einmal je `(user_id, trip_id, stage_id)` pro Prozess) und die
+  bestehende Zeitobergrenze je Nutzerlauf (ADR-0038, 120 s, bewacht von
+  `tests/tdd/test_alert_run_deadline.py`). Gemessener Bestand: 20 Dateien.
+- **Scheibe 2 ist NICHT Teil dieser Spec:** Der Fehlschlag der Track-Auflösung bleibt still.
+  Sichtbarmachung am Trip (zweiter Teil von #2073) ist per PO-Entscheid 2026-08-22 auf nach der
+  KHW-Tour verschoben.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Es handelt sich um eine reine Verhaltensänderung innerhalb einer bestehenden
+  Funktion (`resolve_stage_track_km`) — kein neues Datenfeld, keine Schema-Änderung, kein neuer
+  Kanal, keine neue Persistenzentscheidung. Die Eindeutigkeitsregel aus #2036 (AC-11) bleibt
+  inhaltlich bestehen, nur ihr Auslöser wechselt von „Anzahl der Kandidaten" auf „Ergebnisdifferenz
+  zwischen den Kandidaten".
+
+## Nachweisführung
+
+- **AC-1 allein beweist die Wirksamkeit nicht.** Byte-identische Dateien würden auch bei einer
+  fehlerhaft entfernten (statt korrekt umgestellten) Ergebnisgleichheitsprüfung ein Ergebnis
+  liefern. **AC-2 ist der eigentliche Wirksamkeitsnachweis** — echt unterschiedliche, aber
+  innerhalb der Toleranz liegende Kandidaten.
+- **AC-4 ist der Gegenfall zu AC-1/AC-2/AC-3** und existiert, um eine versehentliche
+  „immer-ja"-Logik fangbar zu machen (jede Kombination gilt als ergebnisgleich, wenn die
+  Differenzprüfung fehlt oder invertiert ist). Ohne AC-4 bliebe diese Mutation unsichtbar.
+- **AC-5 ist der Gegenfall zu „Referenzvergleich statt paarweise"** — ein Implementierung, die nur
+  gegen den ersten Kandidaten vergleicht statt alle Paare, besteht AC-1 bis AC-4, aber nicht AC-5.
+- **AC-8 ist der Regressionsnachweis, dass `_match_track` unangetastet bleibt** — eine
+  Implementierung, die versehentlich die Vollständigkeitsregel mit der Ergebnisgleichheitsregel
+  vermischt (z. B. einen 15 m abseits liegenden Wegpunkt über die neue Toleranz durchwinkt),
+  fällt hier auf.
+- Tests lösen ihren Prüfling **relativ zur eigenen Testdatei** auf, nie über den festen
+  Hauptrepo-Pfad, damit sie im Worktree korrekt gegen den lokalen Stand laufen (Muster:
+  `tests/tdd/test_track_resolution_legacy_trip.py`).
+
+## Changelog
+
+- 2026-08-22: Initial spec created

--- a/docs/specs/modules/fix_2073_track_ergebnisgleichheit.md
+++ b/docs/specs/modules/fix_2073_track_ergebnisgleichheit.md
@@ -231,6 +231,26 @@ Ergebnis alle drei Kandidaten gleichzeitig beschreibt.
     nachgetragene Distanz, alle übrigen Etappen sowie ein zuvor manuell in die JSON-Datei
     eingefügtes, dem Python-Modell unbekanntes Feld bleiben unverändert.
 
+- **AC-11:** Given zwei GPX-Kandidaten weichen an ZWEI voneinander unabhängigen Stellen der Etappe
+  ab (zwei getrennte Wegvarianten statt einer einzelnen) / When die Track-Auflösung ihre
+  Ergebnisgleichheit prüft / Then normiert sie auf den **ersten Wegpunkt der Etappe** — denselben
+  Bezugspunkt, den auch die dem Nutzer angezeigte Wegstrecke verwendet
+  (`trip_segments.stage_measured_distances`, `base = values[0]`, :150-151) — und entscheidet damit
+  über genau die Größe, die der Nutzer zu sehen bekommt.
+  - Test: Zwei Kandidaten, deren normierte Wegpunkt-Abweichung **auf den ersten** Wegpunkt bezogen
+    höchstens 10 m beträgt, **auf den letzten** Wegpunkt bezogen aber mehr als 10 m
+    (durchgerechnet: `a` mit +8 m Umweg zwischen G1 und G2, `b` mit +16 m Umweg zwischen G3 und
+    G4 ⇒ Abweichung `b - a` auf den ersten bezogen `[0, -8, -8, +8]` m, auf den letzten bezogen
+    `[-8, -16, -16, 0]` m). `resolve_stage_track_km()` liefert ein Ergebnis. Der Test hält beide
+    Bedingungen zur Laufzeit per Testaufbau-Assertion nach.
+  - **Nachweisführung:** Fängt die Mutation „Bezugspunkt der Normierung gewechselt"
+    (`norm[i] = roh[i] - roh[-1]`). Alle übrigen AC-Tests bauen nur EINEN Umweg an fester Stelle;
+    die Abweichung zwischen zwei solchen Kandidaten ist eine Stufenfunktion mit Extrema an beiden
+    Enden, weshalb die maximale Abweichung dort unabhängig vom gewählten Bezugspunkt ist und die
+    Mutation unsichtbar bliebe. Ein falscher Bezugspunkt liefert keine falschen Kilometerwerte
+    (zurückgegeben werden unverändert die rohen Werte des ersten Kandidaten), aber
+    Fehlklassifikationen in beide Richtungen — fälschlich `None` statt Ergebnis und umgekehrt.
+
 ## Nicht Teil dieser Spec
 
 - **Scheibe 2 (Sichtbarkeit des stillen Fehlschlags)** ist per PO-Entscheid 2026-08-22 auf nach der
@@ -326,3 +346,9 @@ Wächter behält — sie darf nicht ersatzlos entfallen, nur ihr Auslöser ände
 ## Changelog
 
 - 2026-08-22: Initial spec created
+- 2026-08-22: **AC-11 nachgeschärft** (Adversary-Runde, Finding F001, HIGH): die Bindung des
+  Ergebnisvergleichs an denselben Bezugspunkt wie die Nutzer-Anzeige (erster Wegpunkt der Etappe)
+  war zwar unter „Festgelegte Schwellenwerte" als Vergleichsbasis genannt, aber durch kein AC
+  prüfbar gemacht — die Mutation `roh[0]` → `roh[-1]` ließ alle Tests grün, weil sämtliche
+  Fixtures nur eine einzelne Abweichungsstelle bauen. AC-11 schließt die Lücke mit zwei
+  unabhängigen Abweichungsstellen.

--- a/src/services/track_resolution.py
+++ b/src/services/track_resolution.py
@@ -12,10 +12,15 @@ Zwei Regeln machen das Nachtragen belastbar statt raterisch:
   Etappe innerhalb der Toleranz enthaelt. Ein einziger manuell verschobener
   oder ergaenzter Wegpunkt (>10 m abseits) laesst die GANZE Etappe
   unvermessen (AC-12).
-* **Eindeutigkeit** -- passen mehrere Dateien gleichermassen (etwa eine
-  Einzeletappen- UND eine Gesamt-GPX), wird KEINE geraten (AC-11).
+* **Ergebnisgleichheit** -- passen mehrere Dateien, entscheidet nicht ihre
+  ANZAHL, sondern ob sie zu derselben Wegstrecke fuehren: liefern alle
+  Kandidaten je Wegpunkt dieselben (auf den Etappenstart normierten)
+  Kilometer, darf die Aufloesung sich entscheiden; erst bei wirklich
+  abweichenden Ergebnissen wird KEINE geraten (Issue #2073, vorher AC-11 aus
+  #2036: "mehr als eine passende Datei" genuegte fuer den Abbruch, womit eine
+  blosse Kopie derselben Datei die Etappe unnoetig ausfallen liess).
 
-Ohne eindeutigen Treffer liefert die Auflösung ``None``; die Ortsangabe
+Ohne verwertbaren Treffer liefert die Auflösung ``None``; die Ortsangabe
 bleibt dann byte-identisch bei ``Segment N`` (AC-10).
 """
 from __future__ import annotations
@@ -33,6 +38,12 @@ logger = logging.getLogger("track_resolution")
 # 10 m deckt Koordinatenrundung ab und liegt drei Groessenordnungen unter
 # dem Fehlerfall (Spec "Festgelegte Schwellenwerte").
 DEFAULT_TOLERANCE_M = 10.0
+
+# Hoechstabstand, bis zu dem zwei Kandidaten als ergebnisgleich gelten
+# (Issue #2073). Bewusst von der Zuordnungstoleranz ABGELEITET statt neu
+# hingeschrieben: verglichen wird derselbe Ortsabstand, es gibt nur EINE
+# 10-m-Zahl im Modul.
+RESULT_EQUALITY_TOLERANCE_M = DEFAULT_TOLERANCE_M
 
 
 def _match_track(
@@ -56,6 +67,42 @@ def _match_track(
     return result
 
 
+def _normalisiert(hit: Dict[str, float], waypoints: List) -> List[float]:
+    """Wegpunkt-Kilometer eines Kandidaten, auf den Etappenstart normiert.
+
+    ``distance_from_start_km`` kumuliert ab dem Anfang des jeweiligen GPX-
+    Tracks, nicht ab dem Etappenstart: eine Einzeletappen-GPX beginnt bei
+    0 km, eine durchlaufende Gesamt-Tour-GPX fuer dieselbe Etappe z. B. bei
+    50 km. Verglichen wird deshalb dasselbe, was der Nutzer spaeter sieht --
+    ``trip_segments.stage_measured_distances`` (:150-151) normiert genauso.
+    """
+    werte = [hit[wp.id] for wp in waypoints]
+    return [w - werte[0] for w in werte]
+
+
+def _ergebnisse_sind_gleich(
+    matches: List[Dict[str, float]], waypoints: List,
+) -> bool:
+    """Liefern ALLE Kandidaten praktisch dieselbe Wegstrecke (Issue #2073)?
+
+    Geprueft wird PAARWEISE ueber alle ``n*(n-1)/2`` Paare, nicht gegen einen
+    Referenzkandidaten: bei einer harten Schwelle ist Gleichheit nicht
+    transitiv. Laege B 9 m ueber A und C 9 m unter A, bestuenden beide den
+    Referenzvergleich gegen A, laegen aber 18 m auseinander -- das wuerde die
+    Toleranz stillschweigend verdoppeln.
+    """
+    normiert = [_normalisiert(hit, waypoints) for hit in matches]
+    grenze_km = RESULT_EQUALITY_TOLERANCE_M / 1000.0
+    for i in range(len(normiert)):
+        for j in range(i + 1, len(normiert)):
+            if any(
+                abs(a - b) > grenze_km
+                for a, b in zip(normiert[i], normiert[j])
+            ):
+                return False
+    return True
+
+
 def resolve_stage_track_km(
     stage, gpx_dir, tolerance_m: float = DEFAULT_TOLERANCE_M,
 ) -> Optional[Dict[str, float]]:
@@ -67,9 +114,12 @@ def resolve_stage_track_km(
         tolerance_m: Hoechstabstand Wegpunkt <-> Trackpunkt in Metern.
 
     Returns:
-        ``{waypoint_id: distance_from_start_km}`` bei GENAU einem passenden
-        Track, sonst ``None`` (kein Treffer, mehrdeutig, oder mindestens ein
-        Wegpunkt abseits).
+        ``{waypoint_id: distance_from_start_km}``, sobald alle passenden
+        Tracks dieselbe Wegstrecke liefern -- die ROHEN, unnormierten Werte
+        des ersten Kandidaten in ``sorted(...)``-Reihenfolge (die Normierung
+        ist ausschliesslich Vergleichs-Hilfsmittel, kein Rueckgabeformat).
+        Sonst ``None`` (kein Treffer, abweichende Ergebnisse, oder mindestens
+        ein Wegpunkt abseits).
     """
     from core.gpx_parser import parse_gpx
 
@@ -91,10 +141,10 @@ def resolve_stage_track_km(
         hit = _match_track(waypoints, track.points or [], tolerance_m)
         if hit is not None:
             matches.append(hit)
-        if len(matches) > 1:
-            return None  # mehrdeutig -- nicht raten (AC-11)
-    if len(matches) != 1:
+    if not matches:
         return None
+    if not _ergebnisse_sind_gleich(matches, waypoints):
+        return None  # widerspruechliche Ergebnisse -- nicht raten (#2073)
     return matches[0]
 
 

--- a/tests/tdd/test_track_resolution_legacy_trip.py
+++ b/tests/tdd/test_track_resolution_legacy_trip.py
@@ -600,6 +600,11 @@ def _schreibe_gpx(punkte, ziel: Path, name: str = "tdd-2073") -> Path:
 # verschiebt ausschliesslich die kumulierte Wegstrecke ab dieser Stelle.
 _UMWEG_INDEX = 60
 
+# Zweite Umweg-Stelle, ZWISCHEN G3 (Index 281) und G4 (Index 457): gemessen
+# 707 m von G3 und 783 m von G4 entfernt. Erlaubt zwei UNABHAENGIGE
+# Abweichungsstellen in einer Etappe (Issue #2073, Adversary-Finding F001).
+_UMWEG_INDEX_HINTEN = 370
+
 
 def _umweg_punkt(a, b, extra_m: float):
     """Punkt zwischen `a` und `b`, der den Weg um genau `extra_m` verlaengert.
@@ -630,18 +635,23 @@ def _umweg_punkt(a, b, extra_m: float):
     return (a[0] + h, a[1], a[2])
 
 
-def _kandidat_mit_umweg(ziel: Path, extra_m: float) -> Path:
+def _kandidat_mit_umweg(
+    ziel: Path, extra_m: float, *, index: int = _UMWEG_INDEX,
+) -> Path:
     """Tag-1-Track mit einem eingefuegten Umweg von `extra_m` Metern.
 
     Die WEGPUNKTE bleiben unangetastet an ihrem Ort (weiterhin 0,0 m vom
     naechsten Trackpunkt) -- der Kandidat besteht also die
     Vollstaendigkeitsregel und erreicht den Ergebnisvergleich ueberhaupt
     erst. Nur die kumulierte Wegstrecke AB dem Umweg waechst.
+
+    `index` waehlt die Trackpunkt-Stelle, hinter der eingefuegt wird, und
+    damit, welche Wegpunkte der Umweg verschiebt (alle NACH dieser Stelle).
     """
     punkte = _track_punkte(_GPX_TAG1)
     if extra_m > 0.0:
-        p = _umweg_punkt(punkte[_UMWEG_INDEX], punkte[_UMWEG_INDEX + 1], extra_m)
-        punkte = punkte[: _UMWEG_INDEX + 1] + [p] + punkte[_UMWEG_INDEX + 1:]
+        p = _umweg_punkt(punkte[index], punkte[index + 1], extra_m)
+        punkte = punkte[: index + 1] + [p] + punkte[index + 1:]
     return _schreibe_gpx(punkte, ziel, name=f"Tag 1 (+{extra_m:.0f} m)")
 
 
@@ -661,23 +671,31 @@ def _treffer(stage, gpx_pfad):
     )
 
 
-def _normierte_km(stage, gpx_pfad):
+def _normierte_km(stage, gpx_pfad, *, bezug: int = 0):
     """Wegpunkt-Kilometer dieser Datei, auf den Etappenstart normiert
-    (`norm[i] = roh[i] - roh[0]`, wie `trip_segments.py:150-151`)."""
+    (`norm[i] = roh[i] - roh[0]`, wie `trip_segments.py:150-151`).
+
+    `bezug` waehlt den Bezugswegpunkt und ist ausschliesslich fuer AC-11 da:
+    dort wird gegengerechnet, was ein ANDERER Bezugspunkt (der letzte statt
+    der erste Wegpunkt) ergaebe. Produktiv gilt immer `bezug=0`.
+    """
     hit = _treffer(stage, gpx_pfad)
     assert hit is not None, (
         f"Testaufbau: {gpx_pfad.name} besteht die Vollstaendigkeitsregel "
         f"nicht und wuerde den Ergebnisvergleich nie erreichen"
     )
     werte = [hit[wp.id] for wp in stage.waypoints]
-    return [w - werte[0] for w in werte]
+    return [w - werte[bezug] for w in werte]
 
 
-def _abweichung_m(stage, a: Path, b: Path) -> float:
+def _abweichung_m(stage, a: Path, b: Path, *, bezug: int = 0) -> float:
     """Groesste normierte Wegpunkt-Abweichung zwischen zwei Kandidaten (m)."""
     return max(
         abs(x - y)
-        for x, y in zip(_normierte_km(stage, a), _normierte_km(stage, b))
+        for x, y in zip(
+            _normierte_km(stage, a, bezug=bezug),
+            _normierte_km(stage, b, bezug=bezug),
+        )
     ) * 1000.0
 
 
@@ -1079,4 +1097,81 @@ def test_ac10_rueckschreiben_nach_dubletten_aufloesung_erhaelt_go_only_felder():
     assert after.get("multi_day_trend_morning") is True, (
         "Go-only-Feld 'multi_day_trend_morning' beim Zurueckschreiben "
         "verloren -- Replace statt Read-Modify-Write"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-11 — der Vergleich normiert auf DENSELBEN Bezugspunkt wie die Anzeige
+#
+# Adversary-Finding F001 (`docs/artifacts/fix-2073-ergebnisgleichheit/
+# adversary-dialog.md`): die Mutation `werte[0]` -> `werte[-1]` in
+# `_normalisiert` (`track_resolution.py:79-80`) liess ALLE 27 Tests gruen.
+# Grund: jede bisherige Fixture baut genau EINEN Umweg an fester Stelle. Die
+# Abweichung zwischen zwei solchen Kandidaten ist dann eine Stufenfunktion,
+# deren Extrema an beiden Enden liegen -- die maximale Abweichung ist damit
+# unabhaengig davon, auf welches Ende normiert wird. Erst ZWEI unabhaengige
+# Abweichungsstellen trennen die beiden Bezugspunkte.
+# ---------------------------------------------------------------------------
+
+def test_ac11_vergleich_normiert_auf_denselben_bezugspunkt_wie_die_anzeige(
+    tmp_path,
+):
+    """AC-11: Given zwei Kandidaten weichen an ZWEI unabhaengigen Stellen der
+    Etappe voneinander ab / When die Track-Aufloesung ihre Ergebnisgleichheit
+    prueft / Then normiert sie auf den ERSTEN Wegpunkt der Etappe -- denselben
+    Bezugspunkt, den auch die dem Nutzer angezeigte Wegstrecke verwendet
+    (`trip_segments.stage_measured_distances`, `base = values[0]`) -- und
+    liefert hier folglich ein Ergebnis.
+
+    Durchgerechnete Konstellation (`r` = die rohen Werte des unveraenderten
+    Tag-1-Tracks, [0.0, 2.9345, 6.1364, 9.6067] km):
+
+        a-umweg-8m-vorn.gpx      Umweg +8 m zwischen G1 und G2 (Index 60)
+            roh = [r0, r1+8m, r2+8m, r3+8m]
+        b-umweg-16m-hinten.gpx   Umweg +16 m zwischen G3 und G4 (Index 370)
+            roh = [r0, r1,    r2,    r3+16m]
+
+        Abweichung b - a, normiert auf den ERSTEN Wegpunkt (Spec-Formel):
+            [0, -8, -8, +8] m   -> Maximum  8 m <= 10 m -> ergebnisgleich
+        Abweichung b - a, normiert auf den LETZTEN Wegpunkt (Mutation):
+            [-8, -16, -16, 0] m -> Maximum 16 m >  10 m -> NICHT ergebnisgleich
+
+    Der Bezugspunkt kippt die Entscheidung also wirklich. Beide Bedingungen
+    werden unten zur Laufzeit nachgerechnet, damit der Test nicht bei einer
+    stillen Fixture-Drift zufaellig gruen bleibt."""
+    gpx_dir = tmp_path / "gpx"
+    gpx_dir.mkdir()
+    a = _kandidat_mit_umweg(
+        gpx_dir / "a-umweg-8m-vorn.gpx", 8.0, index=_UMWEG_INDEX,
+    )
+    b = _kandidat_mit_umweg(
+        gpx_dir / "b-umweg-16m-hinten.gpx", 16.0, index=_UMWEG_INDEX_HINTEN,
+    )
+
+    stage = _stage1()
+    auf_ersten = _abweichung_m(stage, a, b, bezug=0)
+    auf_letzten = _abweichung_m(stage, a, b, bezug=-1)
+    assert auf_ersten <= 10.0, (
+        f"Testaufbau: auf den ersten Wegpunkt normiert muessen die Kandidaten "
+        f"ergebnisgleich sein, gemessen {auf_ersten:.2f} m"
+    )
+    assert auf_letzten > 10.0, (
+        f"Testaufbau: auf den letzten Wegpunkt normiert muessen sie "
+        f"AUSEINANDERFALLEN, sonst unterscheidet der Test die Bezugspunkte "
+        f"nicht, gemessen {auf_letzten:.2f} m"
+    )
+
+    result = _resolve(stage, gpx_dir)
+
+    assert result is not None, (
+        f"Der Ergebnisvergleich normiert nicht auf den ersten Wegpunkt: auf "
+        f"diesen bezogen liegen die Kandidaten nur {auf_ersten:.1f} m "
+        f"auseinander (ergebnisgleich), auf den letzten bezogen {auf_letzten:.1f} m. "
+        f"Wer auf einem anderen Bezugspunkt vergleicht, klassifiziert etwas "
+        f"anderes als das, was der Nutzer angezeigt bekommt"
+    )
+    assert result["G2"] == pytest.approx(2.9425, abs=0.0015), (
+        f"Zurueckgegeben werden die ROHEN Werte des ersten Kandidaten in "
+        f"sorted()-Reihenfolge (a-umweg-8m-vorn.gpx, G2 = 2,9345 + 8 m): "
+        f"{result!r}"
     )

--- a/tests/tdd/test_track_resolution_legacy_trip.py
+++ b/tests/tdd/test_track_resolution_legacy_trip.py
@@ -17,6 +17,11 @@ RED-VERTRAG: das Modul `services.track_resolution` existiert heute nicht.
 Jeder Import schlaegt mit `ModuleNotFoundError` fehl -- das IST der
 RED-Zustand (die Track-Auflösung ist die zentrale neue Faehigkeit dieser
 Spec, siehe Dependencies-Tabelle "(neu) Track-Auflösungs-Service").
+
+ERWEITERT durch Issue #2073 Scheibe 1 (AC-1 bis AC-10, unten): die
+Eindeutigkeitsregel wird von der ANZAHL passender Dateien auf den
+ERGEBNISUNTERSCHIED zwischen ihnen umgestellt. Spec:
+docs/specs/modules/fix_2073_track_ergebnisgleichheit.md
 """
 from __future__ import annotations
 
@@ -198,26 +203,19 @@ def test_ac10_kein_passender_track_liefert_kein_ergebnis(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# AC-11 — zwei gleichwertige Treffer -> keine Zuordnung (nicht raten)
+# AC-11 (#2036) — UMGESTELLT durch Issue #2073
+#
+# Hier stand `test_ac11_zwei_gleichwertige_treffer_liefern_kein_ergebnis`:
+# zweimal dieselbe Fixture unter verschiedenen Namen, Erwartung `None`.
+# Dieses Verhalten ist seit #2073 Scheibe 1 abgeschafft -- der Test prueft
+# damit veralteten Stand und ist NICHT ersatzlos entfallen, sondern in
+# `test_ac4_kandidaten_mit_abweichenden_ergebnissen_liefern_kein_ergebnis`
+# (unten) umgezogen. Die Regel 'bei Widerspruch wird nicht geraten' bleibt
+# in Kraft; ihr Ausloeser wechselt von 'Anzahl der Dateien' auf
+# 'Ergebnisunterschied zwischen den Kandidaten'. Der byte-identische
+# Dublettenfall von frueher steht jetzt in
+# `test_ac1_byte_identische_dublette_liefert_die_gemessenen_distanzen`.
 # ---------------------------------------------------------------------------
-
-def test_ac11_zwei_gleichwertige_treffer_liefern_kein_ergebnis(tmp_path):
-    """AC-11: Given mehr als eine GPX-Datei passt gleichermassen auf die
-    Wegpunkte einer Etappe (hier: zweimal derselbe Track unter
-    verschiedenen Dateinamen -- wie eine Einzeletappen- UND eine
-    Gesamt-GPX, die dieselben Punkte enthalten) / When die Track-Aufloesung
-    laeuft / Then wird KEINE der Dateien geraten, es gibt kein Ergebnis."""
-    gpx_dir = tmp_path / "gpx"
-    gpx_dir.mkdir()
-    shutil.copyfile(_GPX_TAG1, gpx_dir / "einzeletappe-tag1.gpx")
-    shutil.copyfile(_GPX_TAG1, gpx_dir / "gesamt-tour.gpx")
-
-    stage = _stage1()
-    result = _resolve(stage, gpx_dir)
-
-    assert result is None, (
-        f"Track-Aufloesung raet bei zwei gleichwertigen Treffern: {result!r}"
-    )
 
 
 # ---------------------------------------------------------------------------
@@ -529,3 +527,556 @@ def test_ac7_zweite_aufloesung_schreibt_nicht_erneut():
         "Die zweite Aufloesung hat die Trip-Datei erneut geschrieben"
     )
     assert trip_datei.read_text(encoding="utf-8") == inhalt_nach_erstem
+
+
+# ===========================================================================
+# Issue #2073 Scheibe 1 — Ergebnisgleichheit statt Dateianzahl
+#
+# SPEC:    docs/specs/modules/fix_2073_track_ergebnisgleichheit.md
+# KONTEXT: docs/context/fix-2073-ergebnisgleichheit.md
+#
+# Die Eindeutigkeitsregel prueft heute die ANZAHL der passenden Dateien
+# (Frueh-Abbruch bei zweitem Treffer, `track_resolution.py:94-95`). Kuenftig
+# entscheidet der ERGEBNISUNTERSCHIED: liefern alle Kandidaten normiert
+# dieselbe Wegstrecke (je Wegpunkt <= 10 m), darf die Aufloesung sich
+# entscheiden; erst bei echter Abweichung bleibt es bei `None`.
+#
+# REGRESSIONSSCHUTZ ohne neuen Test (die Bestandstests decken das AC
+# vollstaendig ab, ein Duplikat waere Ballast):
+#   AC-6 (genau ein Kandidat -> unveraendertes Ergebnis)
+#       -> `test_ac7_eindeutiger_track_liefert_die_gemessenen_distanzen`
+#          und `test_ac12_default_toleranz_nimmt_den_exakt_passenden_track_an`
+#   AC-7 (kein Kandidat -> `None`, Ortsangabe byte-identisch `Segment N`)
+#       -> `test_ac10_kein_passender_track_liefert_kein_ergebnis`
+# ===========================================================================
+
+_GPX_TAG4 = _FIXTURE_ROOT / "gpx" / (
+    "2026-01-17_2753228656_Tag 4_ von Tossals Verds nach Lluc.gpx"
+)
+assert _GPX_TAG4.exists(), f"GPX-Fixture fehlt: {_GPX_TAG4}"
+
+_GPX_KOPF = (
+    '<?xml version="1.0" encoding="UTF-8"?>\n'
+    '<gpx version="1.1" creator="tdd-2073" '
+    'xmlns="http://www.topografix.com/GPX/1/1">\n'
+    "  <trk><name>{name}</name><trkseg>\n"
+)
+_GPX_FUSS = "  </trkseg></trk>\n</gpx>\n"
+
+
+def _track_punkte(gpx_pfad):
+    """(lat, lon, ele) je Trackpunkt einer echten GPX-Fixture."""
+    from core.gpx_parser import parse_gpx
+
+    return [
+        (p.lat, p.lon, p.elevation_m if p.elevation_m is not None else 0.0)
+        for p in parse_gpx(gpx_pfad).points
+    ]
+
+
+def _schreibe_gpx(punkte, ziel: Path, name: str = "tdd-2073") -> Path:
+    """Schreibt eine echte, parsebare GPX-Datei aus (lat, lon, ele)-Tupeln.
+
+    KEIN Mock: die Datei geht durch denselben `parse_gpx` wie jeder
+    Produktiv-Track. `distance_from_start_km` steht NICHT in der Datei --
+    `gpx_parser._extract_points` (:137-159) kumuliert sie beim Parsen aus der
+    Geometrie. Ein Kilometer-Unterschied zwischen zwei Kandidaten kann hier
+    also nur ueber den WEGVERLAUF entstehen, nicht ueber gesetzte Werte.
+    """
+    teile = [_GPX_KOPF.format(name=name)]
+    for lat, lon, ele in punkte:
+        teile.append(
+            f'    <trkpt lat="{lat:.8f}" lon="{lon:.8f}">'
+            f"<ele>{ele:.3f}</ele></trkpt>\n"
+        )
+    teile.append(_GPX_FUSS)
+    ziel.write_text("".join(teile), encoding="utf-8")
+    return ziel
+
+
+# Trackpunkt-Index, HINTER dem der Umweg eingefuegt wird: gemessen 957 m von
+# G1, 789 m von G2 und mehrere Kilometer von G3/G4 entfernt -- der eingefuegte
+# Punkt kann also nie der naechstgelegene Punkt eines Wegpunkts werden und
+# verschiebt ausschliesslich die kumulierte Wegstrecke ab dieser Stelle.
+_UMWEG_INDEX = 60
+
+
+def _umweg_punkt(a, b, extra_m: float):
+    """Punkt zwischen `a` und `b`, der den Weg um genau `extra_m` verlaengert.
+
+    Nach Norden versetzt; die Versetzung wird bisektiert, bis
+    |a-P| + |P-b| - |a-b| == extra_m gilt. Kein geratener Wert.
+    """
+    from utils.geo import haversine_km
+
+    basis_m = haversine_km(a[0], a[1], b[0], b[1]) * 1000.0
+
+    def zuwachs(h: float) -> float:
+        p_lat = a[0] + h
+        return (
+            haversine_km(a[0], a[1], p_lat, a[1])
+            + haversine_km(p_lat, a[1], b[0], b[1])
+        ) * 1000.0 - basis_m
+
+    lo, hi = 0.0, 0.01  # 0,01 Grad ~ 1,1 km Versatz ~ 2,2 km Zuwachs
+    assert zuwachs(hi) > extra_m, "Suchintervall zu klein fuer den Umweg"
+    for _ in range(80):
+        mitte = (lo + hi) / 2.0
+        if zuwachs(mitte) < extra_m:
+            lo = mitte
+        else:
+            hi = mitte
+    h = (lo + hi) / 2.0
+    return (a[0] + h, a[1], a[2])
+
+
+def _kandidat_mit_umweg(ziel: Path, extra_m: float) -> Path:
+    """Tag-1-Track mit einem eingefuegten Umweg von `extra_m` Metern.
+
+    Die WEGPUNKTE bleiben unangetastet an ihrem Ort (weiterhin 0,0 m vom
+    naechsten Trackpunkt) -- der Kandidat besteht also die
+    Vollstaendigkeitsregel und erreicht den Ergebnisvergleich ueberhaupt
+    erst. Nur die kumulierte Wegstrecke AB dem Umweg waechst.
+    """
+    punkte = _track_punkte(_GPX_TAG1)
+    if extra_m > 0.0:
+        p = _umweg_punkt(punkte[_UMWEG_INDEX], punkte[_UMWEG_INDEX + 1], extra_m)
+        punkte = punkte[: _UMWEG_INDEX + 1] + [p] + punkte[_UMWEG_INDEX + 1:]
+    return _schreibe_gpx(punkte, ziel, name=f"Tag 1 (+{extra_m:.0f} m)")
+
+
+def _treffer(stage, gpx_pfad):
+    """Distanz je Wegpunkt aus GENAU dieser Datei -- ueber die unveraenderte
+    Vollstaendigkeitsregel des Produktivmoduls (`_match_track`, AC-8).
+
+    Dient ausschliesslich der Nachpruefung des Testaufbaus (bestehen beide
+    Kandidaten die Vollstaendigkeitsregel? wie weit liegen sie normiert
+    auseinander?), nicht als Ersatz fuer die zu pruefende Zusicherung.
+    """
+    from core.gpx_parser import parse_gpx
+    from services.track_resolution import _match_track
+
+    return _match_track(
+        list(stage.waypoints), parse_gpx(gpx_pfad).points or [], 10.0
+    )
+
+
+def _normierte_km(stage, gpx_pfad):
+    """Wegpunkt-Kilometer dieser Datei, auf den Etappenstart normiert
+    (`norm[i] = roh[i] - roh[0]`, wie `trip_segments.py:150-151`)."""
+    hit = _treffer(stage, gpx_pfad)
+    assert hit is not None, (
+        f"Testaufbau: {gpx_pfad.name} besteht die Vollstaendigkeitsregel "
+        f"nicht und wuerde den Ergebnisvergleich nie erreichen"
+    )
+    werte = [hit[wp.id] for wp in stage.waypoints]
+    return [w - werte[0] for w in werte]
+
+
+def _abweichung_m(stage, a: Path, b: Path) -> float:
+    """Groesste normierte Wegpunkt-Abweichung zwischen zwei Kandidaten (m)."""
+    return max(
+        abs(x - y)
+        for x, y in zip(_normierte_km(stage, a), _normierte_km(stage, b))
+    ) * 1000.0
+
+
+# ---------------------------------------------------------------------------
+# AC-1 — byte-identische Dublette liefert ein Ergebnis (der real gemessene Fall)
+# ---------------------------------------------------------------------------
+
+def test_ac1_byte_identische_dublette_liefert_die_gemessenen_distanzen(tmp_path):
+    """AC-1: Given zwei byte-identische GPX-Dateien liegen unter
+    verschiedenen Namen im Bestand und bestehen beide die
+    Vollstaendigkeitsregel (der am Produktivbestand gemessene Fall: 'GR221
+    Mallorca' Tag 1, Original + `test.gpx`, beide 0,0 m Abweichung) / When
+    die Track-Aufloesung laeuft / Then liefert sie die gemessenen Distanzen
+    statt `None`.
+
+    RED heute: der Frueh-Abbruch bei zweitem Treffer
+    (`track_resolution.py:94-95`) zaehlt Dateien, nicht Ergebnisse."""
+    gpx_dir = tmp_path / "gpx"
+    gpx_dir.mkdir()
+    shutil.copyfile(_GPX_TAG1, gpx_dir / "einzeletappe.gpx")
+    shutil.copyfile(_GPX_TAG1, gpx_dir / "kopie-derselben-datei.gpx")
+    assert (gpx_dir / "einzeletappe.gpx").read_bytes() == (
+        gpx_dir / "kopie-derselben-datei.gpx"
+    ).read_bytes(), "Testaufbau: die Kopien sind nicht byte-identisch"
+
+    stage = _stage1()
+    result = _resolve(stage, gpx_dir)
+
+    assert result is not None, (
+        "Zwei byte-identische Kandidaten liefern dieselbe Wegstrecke -- es "
+        "gibt nichts zu raten, trotzdem faellt die Etappe auf 'Segment N'"
+    )
+    assert set(result.keys()) == {"G1", "G2", "G3", "G4"}, f"Keys: {result.keys()}"
+    assert result["G1"] == pytest.approx(0.0, abs=0.01)
+    assert result["G2"] == pytest.approx(2.9345, abs=0.01)
+    assert result["G3"] == pytest.approx(6.1364, abs=0.01)
+    assert result["G4"] == pytest.approx(9.6067, abs=0.01)
+
+
+# ---------------------------------------------------------------------------
+# AC-2 — WIRKSAMKEITSNACHWEIS: verschiedene Dateien, gleiches Ergebnis
+# ---------------------------------------------------------------------------
+
+def test_ac2_nicht_identische_kandidaten_innerhalb_der_toleranz_liefern_ergebnis(
+    tmp_path,
+):
+    """AC-2: Given zwei NICHT byte-identische Kandidaten bestehen beide die
+    Vollstaendigkeitsregel und ihre normierten Wegpunkt-Kilometer weichen um
+    weniger als 10 m voneinander ab / When die Track-Aufloesung laeuft /
+    Then liefert sie ein Ergebnis.
+
+    Der eigentliche Wirksamkeitsnachweis der Spec: eine Implementierung, die
+    die Eindeutigkeitspruefung ersatzlos ENTFERNT statt sie umzustellen,
+    besteht AC-1 (byte-identisch) genauso -- hier aber liegt echte, gemessene
+    Differenz zwischen den Dateien, die unterhalb der Schwelle bleiben muss.
+
+    Konstruktion: `b` traegt zwischen zwei Wegpunkten einen eingefuegten
+    Umweg von 3 m. Gemessen ergibt das normierte Wegpunkt-Differenzen von
+    exakt 3,0 m an G2/G3/G4 (G1 liegt vor dem Umweg, Differenz 0,0 m)."""
+    gpx_dir = tmp_path / "gpx"
+    gpx_dir.mkdir()
+    a = _kandidat_mit_umweg(gpx_dir / "a-original.gpx", 0.0)
+    b = _kandidat_mit_umweg(gpx_dir / "b-umweg-3m.gpx", 3.0)
+
+    stage = _stage1()
+    assert a.read_bytes() != b.read_bytes(), (
+        "Testaufbau: die Kandidaten muessen sich unterscheiden, sonst prueft "
+        "dieser Test dasselbe wie AC-1"
+    )
+    abweichung = _abweichung_m(stage, a, b)
+    assert 0.0 < abweichung < 10.0, (
+        f"Testaufbau: die Abweichung muss messbar > 0 und sicher < 10 m sein, "
+        f"gemessen {abweichung:.2f} m"
+    )
+
+    result = _resolve(stage, gpx_dir)
+
+    assert result is not None, (
+        f"Zwei Kandidaten mit nur {abweichung:.2f} m normierter Abweichung "
+        f"gelten weiterhin als widerspruechlich"
+    )
+    assert result["G2"] == pytest.approx(2.9345, abs=0.01)
+
+
+# ---------------------------------------------------------------------------
+# AC-3 — Einzeletappe + durchlaufende Gesamt-Tour (das AC-11-Leitbeispiel)
+# ---------------------------------------------------------------------------
+
+def test_ac3_gesamt_tour_gpx_mit_grossem_offset_liefert_ein_ergebnis(tmp_path):
+    """AC-3: Given eine Einzeletappen-GPX und eine durchlaufende
+    Gesamt-Tour-GPX decken dieselbe Etappe ab, ihre ROHEN Distanzwerte
+    unterscheiden sich aber um einen grossen Offset / When die
+    Track-Aufloesung laeuft / Then liefert sie ein Ergebnis, weil die auf den
+    Etappenstart normierten Werte je Wegpunkt innerhalb von 10 m
+    uebereinstimmen.
+
+    Die Gesamt-GPX entsteht aus einer vorangestellten FREMDETAPPE (Tag 4,
+    Tossals Verds -> Lluc) plus den Trackpunkten der Zieletappe. Der Offset
+    entsteht damit ausschliesslich aus der Geometrie -- `parse_gpx` kumuliert
+    `distance_from_start_km` beim Parsen (`gpx_parser.py:137-159`), er laesst
+    sich nicht in die Datei schreiben.
+
+    Warum Tag 4 und nicht Tag 2: Tag 2 BEGINNT auf dem Zielwegpunkt G4 von
+    Tag 1 (Deia, identische Koordinaten) -- ein vorangestellter Tag-2-Punkt
+    wuerde die Naechster-Punkt-Suche fuer G4 gewinnen und einen falschen
+    Kilometerwert liefern. Tag 4 liegt gemessen mindestens 14,7 km von JEDEM
+    Wegpunkt der Etappe 1 entfernt. Der Test prueft das aktiv nach: die
+    normierte Abweichung beider Kandidaten muss unter 10 m bleiben -- haette
+    die Fremdetappe die Naechster-Punkt-Suche irgendwo gewonnen, spraenge
+    dieser Wert in den Kilometerbereich.
+
+    RED heute: zwei Treffer -> Frueh-Abbruch."""
+    gpx_dir = tmp_path / "gpx"
+    gpx_dir.mkdir()
+    einzel = _schreibe_gpx(
+        _track_punkte(_GPX_TAG1), gpx_dir / "a-einzeletappe.gpx", "Etappe 1",
+    )
+    gesamt = _schreibe_gpx(
+        _track_punkte(_GPX_TAG4) + _track_punkte(_GPX_TAG1),
+        gpx_dir / "b-gesamtstrecke.gpx",
+        "GR221 durchlaufend",
+    )
+
+    stage = _stage1()
+    roh_gesamt = _treffer(stage, gesamt)
+    assert roh_gesamt is not None and roh_gesamt["G1"] > 30.0, (
+        f"Testaufbau: die Gesamt-GPX muss die Etappe mit einem grossen "
+        f"Roh-Offset fuehren, gemessen {roh_gesamt and roh_gesamt['G1']} km"
+    )
+    abweichung = _abweichung_m(stage, einzel, gesamt)
+    assert abweichung < 10.0, (
+        f"Testaufbau: normiert muessen beide dasselbe liefern, gemessen "
+        f"{abweichung:.2f} m -- die vorangestellte Fremdetappe hat vermutlich "
+        f"die Naechster-Punkt-Suche eines Wegpunkts gewonnen"
+    )
+
+    result = _resolve(stage, gpx_dir)
+
+    assert result is not None, (
+        "Einzeletappen- und Gesamtstrecken-GPX liefern dem Nutzer identische "
+        "(normierte) Kilometer, werden aber als Widerspruch behandelt"
+    )
+    assert result["G2"] == pytest.approx(2.9345, abs=0.01), (
+        f"Zurueckgegeben werden die ROHEN Werte des ersten Kandidaten in "
+        f"sorted()-Reihenfolge (a-einzeletappe.gpx): {result!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-4 — der Waechter aus #2036 AC-11, umgestellt auf ERGEBNISUNTERSCHIED
+#
+# Vorgaenger: `test_ac11_zwei_gleichwertige_treffer_liefern_kein_ergebnis`. Er
+# kopierte dieselbe Fixture zweimal und erwartete `None`. Genau dieses
+# Verhalten schafft AC-1 dieser Spec ab -- der Test prueft damit veraltetes
+# Verhalten und ist hierher umgezogen. Die REGEL bleibt bestehen, nur ihr
+# AUSLOESER wechselt von "Anzahl der Dateien" auf "Ergebnisunterschied"
+# (Issue #2073).
+# ---------------------------------------------------------------------------
+
+def test_ac4_kandidaten_mit_abweichenden_ergebnissen_liefern_kein_ergebnis(tmp_path):
+    """AC-4: Given zwei Kandidaten bestehen BEIDE die Vollstaendigkeitsregel,
+    ihre normierten Wegpunkt-Kilometer weichen aber an mindestens einem
+    Wegpunkt deutlich mehr als 10 m voneinander ab / When die
+    Track-Aufloesung laeuft / Then liefert sie `None` und die nachgelagerte
+    Ortsangabe bleibt `Segment N`.
+
+    Konstruktion: zwei Wegvarianten zwischen denselben Punkten -- `b` traegt
+    zwischen zwei Wegpunkten einen Umweg von 400 m. Beide Kandidaten treffen
+    JEDEN Wegpunkt mit 0,0 m, erreichen also den Ergebnisvergleich; gemessen
+    liegen sie normiert rund 400 m auseinander.
+
+    Nicht verwendbar waere die zweite Mallorca-Tag-2-Aufzeichnung aus dem
+    Ticket: ihr schlechtester Wegpunkt liegt 111 m ab und sie wird schon von
+    `_match_track` verworfen (Kontext-Dokument, Befund 1).
+
+    Faengt die Mutation 'Ergebnisgleichheitspruefung fehlt oder ist
+    invertiert' -- also jede 'immer-ja'-Logik."""
+    gpx_dir = tmp_path / "gpx"
+    gpx_dir.mkdir()
+    a = _kandidat_mit_umweg(gpx_dir / "a-original.gpx", 0.0)
+    b = _kandidat_mit_umweg(gpx_dir / "b-umweg-400m.gpx", 400.0)
+
+    stage = _stage1()
+    abweichung = _abweichung_m(stage, a, b)
+    assert abweichung > 10.0, (
+        f"Testaufbau: die Kandidaten muessen wirklich abweichen, gemessen "
+        f"{abweichung:.2f} m"
+    )
+
+    result = _resolve(stage, gpx_dir)
+
+    assert result is None, (
+        f"Track-Aufloesung raet bei {abweichung:.1f} m Ergebnisunterschied "
+        f"zwischen zwei Kandidaten: {result!r}"
+    )
+
+    from output.renderers.alert.segments import format_alert_location
+
+    text = format_alert_location(None, ["1"], 0.0, 2.93, km_measured=False)
+    assert text == "Segment 1", f"Ortsangabe nicht byte-identisch: {text!r}"
+
+
+# ---------------------------------------------------------------------------
+# AC-5 — Kette ohne gemeinsames Ergebnis (paarweise, nicht gegen eine Referenz)
+# ---------------------------------------------------------------------------
+
+def test_ac5_kette_ohne_gemeinsames_ergebnis_liefert_kein_ergebnis(tmp_path):
+    """AC-5: Given drei Kandidaten, bei denen A~B und B~C ergebnisgleich
+    sind, A und C aber NICHT / When die Track-Aufloesung laeuft / Then
+    liefert sie `None`.
+
+    Durchgerechnete Konstellation (Umweg-Zuwachs gegenueber dem
+    Original-Track, gemessen an den normierten Wegpunkt-Kilometern G2/G3/G4;
+    G1 liegt vor dem Umweg und ist bei allen dreien identisch):
+
+        a-referenz-umweg-9m.gpx    +9 m   (G4 = 9,6157 km)
+        b-ohne-umweg.gpx           +0 m   (G4 = 9,6067 km)
+        c-umweg-18m.gpx           +18 m   (G4 = 9,6247 km)
+
+        |a - b| =  9,0 m  <= 10 m   ergebnisgleich
+        |a - c| =  9,0 m  <= 10 m   ergebnisgleich
+        |b - c| = 18,0 m  >  10 m   NICHT ergebnisgleich
+
+    Die Datei-Reihenfolge ist Absicht: `sorted()` stellt den MITTLEREN
+    Kandidaten (a) nach vorn. Eine Implementierung, die alle Kandidaten nur
+    gegen den ERSTEN vergleicht statt paarweise, findet damit zweimal
+    'gleich' und liefert ein Ergebnis -- obwohl kein einziger Wert alle drei
+    Kandidaten beschreibt. Genau diese Mutation faengt dieser Test; AC-1 bis
+    AC-4 wuerden sie durchwinken."""
+    gpx_dir = tmp_path / "gpx"
+    gpx_dir.mkdir()
+    a = _kandidat_mit_umweg(gpx_dir / "a-referenz-umweg-9m.gpx", 9.0)
+    b = _kandidat_mit_umweg(gpx_dir / "b-ohne-umweg.gpx", 0.0)
+    c = _kandidat_mit_umweg(gpx_dir / "c-umweg-18m.gpx", 18.0)
+
+    stage = _stage1()
+    ab = _abweichung_m(stage, a, b)
+    ac = _abweichung_m(stage, a, c)
+    bc = _abweichung_m(stage, b, c)
+    assert ab <= 10.0 and ac <= 10.0 and bc > 10.0, (
+        f"Testaufbau: die Dreiecks-Konstellation ist nicht hergestellt "
+        f"(|a-b|={ab:.2f} m, |a-c|={ac:.2f} m, |b-c|={bc:.2f} m)"
+    )
+    assert sorted(p.name for p in gpx_dir.glob("*.gpx"))[0] == a.name, (
+        "Testaufbau: der MITTLERE Kandidat muss zuerst kommen, sonst "
+        "unterscheidet der Test 'paarweise' nicht von 'gegen den ersten'"
+    )
+
+    result = _resolve(stage, gpx_dir)
+
+    assert result is None, (
+        f"Track-Aufloesung liefert ein Ergebnis, obwohl zwei Kandidaten "
+        f"{bc:.1f} m auseinanderliegen -- gegen den ersten Kandidaten "
+        f"verglichen statt paarweise: {result!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-8 — die Vollstaendigkeitsregel siebt VOR dem Ergebnisvergleich aus
+#
+# REGRESSIONSSCHUTZ, heute wie nachher gruen (`_match_track` bleibt
+# unangetastet). Die bestehenden AC-12-Tests pruefen denselben 15-m-Wegpunkt
+# mit nur EINER Datei im Bestand; die Reihenfolge-Zusicherung "verworfen,
+# BEVOR er in den Ergebnisvergleich eingeht" ist erst mit mehreren
+# Kandidaten beobachtbar -- deshalb dieser Zusatz statt eines Duplikats.
+# ---------------------------------------------------------------------------
+
+def test_ac8_abseits_liegender_wegpunkt_verwirft_kandidaten_vor_dem_vergleich(
+    tmp_path,
+):
+    """AC-8: Given eine Etappe enthaelt einen Wegpunkt mehr als 10 m abseits
+    des sonst passenden Tracks, waehrend mehrere Kandidaten fuer dieselbe
+    Etappe im Bestand liegen / When die Track-Zuordnung laeuft / Then bleibt
+    die Etappe unvermessen -- die Vollstaendigkeitsregel verwirft die
+    Kandidaten, bevor die Ergebnisgleichheit ueberhaupt geprueft wird.
+
+    Faengt die Mutation 'Vollstaendigkeits- und Ergebnisgleichheitsregel
+    vermischt' (ein 15 m abseits liegender Wegpunkt wird ueber die neue
+    10-m-Ergebnistoleranz durchgewunken)."""
+    import dataclasses
+
+    from app.trip import Waypoint
+
+    gpx_dir = tmp_path / "gpx"
+    gpx_dir.mkdir()
+    shutil.copyfile(_GPX_TAG1, gpx_dir / "a-einzeletappe.gpx")
+    shutil.copyfile(_GPX_TAG1, gpx_dir / "b-dublette.gpx")
+
+    stage = _stage1()
+    off_track_wp = Waypoint(
+        id="G2b", name="Manuell ergaenzt", lat=39.726311746676245,
+        lon=2.624463, elevation_m=800,
+    )
+    waypoints = list(stage.waypoints)
+    waypoints.insert(2, off_track_wp)
+    stage_with_extra = dataclasses.replace(stage, waypoints=waypoints)
+
+    result = _resolve(stage_with_extra, gpx_dir)
+
+    assert result is None, (
+        f"Ein 15 m abseits liegender Wegpunkt wird durchgewunken, sobald "
+        f"mehrere Kandidaten im Bestand liegen: {result!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-9 — Reproduzierbarkeit: derselbe Bestand liefert denselben Kandidaten
+# ---------------------------------------------------------------------------
+
+def test_ac9_wiederholte_aufloesung_liefert_denselben_ersten_kandidaten(tmp_path):
+    """AC-9: Given zwei ergebnisgleiche, aber NICHT identische Kandidaten /
+    When die Track-Aufloesung fuer denselben Bestand mehrfach laeuft / Then
+    liefert jeder Lauf denselben Rueckgabewert -- die ROHEN Werte des ersten
+    Kandidaten in `sorted()`-Reihenfolge.
+
+    Nur mit unterschiedlichen Kandidatenwerten ist 'derselbe Kandidat
+    gewinnt' ueberhaupt beobachtbar: `b` traegt einen 3-m-Umweg, seine Werte
+    ab G2 liegen also 3 m ueber denen von `a` (G4: 9,6097 statt 9,6067 km).
+    Kommt `b`s Wert heraus, ist die Auswahl nicht die dokumentierte."""
+    gpx_dir = tmp_path / "gpx"
+    gpx_dir.mkdir()
+    _kandidat_mit_umweg(gpx_dir / "a-original.gpx", 0.0)
+    _kandidat_mit_umweg(gpx_dir / "b-umweg-3m.gpx", 3.0)
+
+    stage = _stage1()
+    erster = _resolve(stage, gpx_dir)
+    zweiter = _resolve(stage, gpx_dir)
+
+    assert erster is not None, "Ergebnisgleiche Kandidaten liefern kein Ergebnis"
+    assert erster == zweiter, (
+        f"Zwei Laeufe ueber denselben Bestand liefern verschiedene Werte: "
+        f"{erster!r} vs. {zweiter!r}"
+    )
+    # a-original.gpx kommt in sorted()-Reihenfolge zuerst -> seine ROHEN
+    # Werte (ohne Umweg) muessen herauskommen, nicht die von b (+3 m).
+    assert erster["G4"] == pytest.approx(9.6067, abs=0.0015), (
+        f"Nicht der erste Kandidat in sorted()-Reihenfolge hat gewonnen: "
+        f"{erster!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-10 — der Rueckschreibweg bleibt additiv (Read-Modify-Write, nie Replace)
+# ---------------------------------------------------------------------------
+
+def test_ac10_rueckschreiben_nach_dubletten_aufloesung_erhaelt_go_only_felder():
+    """AC-10: Given eine Etappe wird ueber `backfill_stage_distances()`
+    nachgetragen, nachdem die Track-Aufloesung durch Ergebnisgleichheit ein
+    Ergebnis liefert, das vorher `None` gewesen waere / When die Distanz
+    additiv zurueckgeschrieben wird / Then traegt nur die betroffene Etappe
+    die nachgetragene Distanz -- alle uebrigen Etappen und ein dem
+    Python-Modell unbekanntes (Go-only-)Feld bleiben unveraendert.
+
+    RED heute: die zwei Dubletten im Bestand lassen die Aufloesung `None`
+    liefern, es wird gar nichts nachgetragen."""
+    import dataclasses
+
+    from app.loader import get_data_dir, load_trip_from_dict, save_trip
+    from services.track_resolution import backfill_stage_distances
+
+    user = "tdd-2073-ac10"
+    heute = date(2026, 8, 26)
+
+    gpx_dir = get_data_dir(user) / "gpx"
+    gpx_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(_GPX_TAG1, gpx_dir / "einzeletappe.gpx")
+    shutil.copyfile(_GPX_TAG1, gpx_dir / "kopie-derselben-datei.gpx")
+
+    data = json.loads(_TRIP_JSON.read_text(encoding="utf-8"))
+    trip = load_trip_from_dict(data)
+    stage1 = dataclasses.replace(trip.stages[0], date=heute)
+    trip = dataclasses.replace(trip, stages=[stage1] + list(trip.stages[1:]))
+    assert all(
+        wp.distance_from_start_km is None for wp in trip.stages[0].waypoints
+    ), "Testaufbau: Etappe 1 muss unvermessen starten"
+    pfad = save_trip(trip, user_id=user)
+
+    # Zustand nach einem Go-Schreibvorgang nachstellen (Feld, das der
+    # Python-Loader nicht modelliert -- bei Replace waere es danach weg).
+    persisted = json.loads(pfad.read_text(encoding="utf-8"))
+    persisted["multi_day_trend_morning"] = True
+    pfad.write_text(json.dumps(persisted, indent=2), encoding="utf-8")
+
+    ergaenzt = backfill_stage_distances(trip, user, heute)
+
+    assert ergaenzt.stages[0].waypoints[1].distance_from_start_km == \
+        pytest.approx(2.9345, abs=0.01), (
+            "Die Nachruestung hat bei zwei ergebnisgleichen Kandidaten nichts "
+            "eingetragen"
+        )
+
+    after = json.loads(pfad.read_text(encoding="utf-8"))
+    assert after["stages"][0]["waypoints"][1]["distance_from_start_km"] == \
+        pytest.approx(2.9345, abs=0.01), "Distanz nicht persistiert"
+    for wp in after["stages"][1]["waypoints"]:
+        assert wp.get("distance_from_start_km") is None, (
+            f"Etappe 2 hat unerwuenscht eine Distanz erhalten: {wp}"
+        )
+    assert after.get("multi_day_trend_morning") is True, (
+        "Go-only-Feld 'multi_day_trend_morning' beim Zurueckschreiben "
+        "verloren -- Replace statt Read-Modify-Write"
+    )


### PR DESCRIPTION
Schließt #2073 Scheibe 1. (Scheibe 2 — Sichtbarkeit des stillen Fehlschlags — ist per PO-Entscheid auf nach der KHW-Tour verschoben.)

## Problem

`resolve_stage_track_km()` brach ab, sobald **mehr als eine** GPX-Datei innerhalb der Toleranz auf die Wegpunkte einer Etappe passte. Geprüft wurde damit die **Anzahl der Dateien**, nicht ob sie zu verschiedenen Kilometerwerten führen. Eine byte-identische Kopie derselben Aufzeichnung ließ die Etappe unnötig auf `Segment N` zurückfallen — bei #2070 traf das 3 von 13 KHW-Etappen.

## Lösung

Alle passenden Kandidaten werden gesammelt und **paarweise** verglichen. Sind sie ergebnisgleich (je Wegpunkt ≤ 10 m), wird das Ergebnis des ersten Kandidaten in `sorted(...)`-Reihenfolge geliefert; nur bei wirklich abweichenden Ergebnissen bleibt `None`.

**Verglichen wird der auf den Etappenstart normierte Wert**, nicht der rohe. Der rohe kumuliert ab Track-Anfang; was der Nutzer sieht, normiert `stage_measured_distances` (`trip_segments.py:150-151`) ohnehin auf den Etappenstart. Damit löst sich zusätzlich das Leitbeispiel aus AC-11 von #2036: Einzeletappen-GPX gegen durchlaufende Gesamt-Tour-GPX.

**Schwelle 10 m, abgeleitet von `DEFAULT_TOLERANCE_M`** — keine zweite freie Zahl im Modul. Am Produktivbestand gemessen: Gleichheitsfall 0,0 m, nächster Abweichungsfall 144 m, fremde Etappen im Kilometerbereich.

## Korrektur der Ticket-Prämisse

Das Ticket nennt die zwei getrennten Mallorca-Tag-2-Aufzeichnungen als Fall, den ein Prüfsummen-Vergleich nicht abdecken würde. **Gemessen passt die zweite Aufzeichnung gar nicht**: ihr schlechtester Wegpunkt liegt 111 m ab und wird bereits von der Vollständigkeitsregel (AC-12) verworfen, bevor die Eindeutigkeitsregel greift. Der real auftretende Mehrdeutigkeitsfall ist die byte-identische Dublette. Details: `docs/context/fix-2073-ergebnisgleichheit.md`, Befund 1–3.

## Adversary

Zwei Runden, 12 Mutationen geprüft.

- **Runde 1: BROKEN.** Die Bezugspunkt-Mutation (`werte[0]` → `werte[-1]`) blieb ungefangen, weil jede Fixture nur eine Abweichungsstelle konstruierte.
- **Fix:** neuer Wächter AC-11 mit zwei unabhängigen Abweichungsstellen — auf den ersten Wegpunkt normiert 8 m (gleich), auf den letzten 16 m (ungleich). Die Bezugspunktwahl kippt die Entscheidung nachweislich.
- **Runde 2: VERIFIED.** Alle 11 ACs mit Code-Referenz bestätigt.
- Nebenbefund F002 (Grenzwert exakt 10,000 m unbewacht) → #1199, kein Defekt.

## Umfang

- `src/services/track_resolution.py`: +57 LoC (Limit 250). `_match_track` unangetastet.
- 28 Tests grün. Keine Schema-Änderung, kein Go-/Frontend-Anteil.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FNAFz1zGpqNtpwzkP7daW9
