### PR TITLE
fix(#2065): quantitative Verschaerfung ueberholt die Radar-Sperrzeit

### DIFF
--- a/docs/adr/0021-shared-deviation-alert-engine.md
+++ b/docs/adr/0021-shared-deviation-alert-engine.md
@@ -252,3 +252,31 @@ dieser Scheibe (Scheibe 2, #1169).
   Architekturprinzip — derselbe geteilte Baustein, nur mit einem dritten,
   eng umgrenzten Ausgang. Details:
   `docs/specs/modules/alert_nachtragsmeldung.md`.
+
+- **Nachtrag (Issue #2065, 2026-08-22):** die feste Reihenfolge Ruhezeit →
+  **Sperrzeit** → Tages-Obergrenze bekommt an genau EINER Stufe eine
+  Ausnahme: eine **quantitativ deutliche Verschärfung überholt die
+  Sperrzeit**. Anlass war ein gemessener Fall — ein Radar-Alarm über ~10 mm
+  bucht 120 Minuten Sperre, 90 Minuten später schweigt eine auf ~27,5 mm
+  verdreifachte Lage mit Protokollgrund `cooldown`. „Deutlich schlimmer" ist
+  quantitativ definiert (`radar_overtakes_cooldown()`: Menge ≥ 2,0 × zuletzt
+  gemeldete Menge UND ≥ 2,0 mm im 60-Minuten-Vergleichsfenster) und lebt
+  **nicht** im geteilten Baustein: `check_nowcast_gate()` bleibt in Signatur
+  UND Verhalten unverändert, den Vergleich führt allein der Trip-Zweig
+  (`trip_alert.py::check_radar_alerts`) durch, nachdem das Gate `cooldown`
+  gemeldet hat. **Ruhezeit und Tages-Obergrenze bleiben unbrechbar** — die
+  Ruhezeit per PO-Entscheid (#1955), die Tages-Obergrenze wird im
+  Durchbruchspfad ausdrücklich ERNEUT geprüft, weil die Kette bisher schon an
+  der Sperrzeit kurzschloss. Weil die dreistufige Schwere-Skala bei 4 mm/h
+  sättigt, reist dieselbe Mengen-Feststellung als optionales
+  `quantitative_escalation` in `check_event_identity_gate()` mit; ohne diese
+  zweite Hälfte wechselte nur der Protokollgrund von `cooldown` auf
+  `event_duplicate` und der Alarm bliebe trotzdem aus. Der **Ortsvergleich
+  bekommt diese Ausnahme NICHT**: er ist PO-seitig zurückgestellt, und die
+  Ausnahme braucht eine Vergleichsbasis (die zuletzt gemeldete Menge im
+  `ThrottleStore`), die im Ortsvergleich niemand schreibt. Genau deshalb liegt
+  der Vergleich im Trip-Pfad statt im geteilten Gate — so bleibt
+  `compare_radar_alert.py` unberührt, ohne Signatur-Passagiere und ohne toten
+  Default. Eine spätere Übernahme in den Ortsvergleich wäre eine eigene,
+  spezifizierte Entscheidung. Details:
+  `docs/specs/modules/fix_2065_verschaerfung_ueberholt_sperre.md`.

--- a/docs/context/fix-2065-verschaerfung-durchbricht-sperrzeit.md
+++ b/docs/context/fix-2065-verschaerfung-durchbricht-sperrzeit.md
@@ -1,0 +1,180 @@
+# Context: fix-2065-verschaerfung-durchbricht-sperrzeit
+
+Erhoben am 2026-08-22 fuer Issue #2065. Alle Zeilenangaben gegen `origin/main` @ `5e92e053`.
+
+## Request Summary
+
+Eine sich deutlich verschaerfende Wetterlage erreicht den Nutzer nicht, weil die Sperrzeit
+des vorangegangenen Alarms sie aufhaelt. Das verletzt Anforderung **A-3** aus #2050
+(„Eine Verschaerfung ueberholt jede Sperre") und ist dort **Szenario 4**.
+
+Gemessen auf der Alarm-Pruefstrecke (#2050 S2a) gegen die echte Ausloeseentscheidung
+`TripAlertService.check_radar_alerts()`: Lauf 1 (11 mm/h, ~10 mm) loest aus und bucht
+120 Min Sperrzeit; Lauf 3 nach 90 Min (30 mm/h, ~27,5 mm) schweigt mit Protokollgrund
+`cooldown`.
+
+## Kernbefund 1 — die Sperre steht vor der Eskalationspruefung
+
+Die Gate-Kette des Trip-Radar-Zweigs laeuft in dieser Reihenfolge:
+
+| # | Stufe | Ort | Kennt Verschaerfung? |
+|---|---|---|---|
+| 1 | Ruhezeit | `alert_gate.py:170-175` (in `check_nowcast_gate`) | nein — soll sie auch nicht (#1955) |
+| 2 | **Sperrzeit** | `alert_gate.py:177-181` | **nein** |
+| 3 | Tages-Obergrenze | `alert_gate.py:183-188` | nein |
+| 4 | Briefing-Ueberholung | `trip_alert.py:1410-1414` | **ja** (Menge gegen Menge, #2020 S1) |
+| 5 | Entdopplung / Ereignis-Identitaet | `trip_alert.py:1540` → `alert_gate.py:617-692` | **ja** (Stufenvergleich, #1467 S4b) |
+
+`check_nowcast_gate()` (`alert_gate.py:140-190`) nimmt **keinen Parameter entgegen, ueber den
+es von einer Verschaerfung erfahren koennte** — es kennt nur Zeit, Ruhezeit und Zaehler. Der
+Aufrufer bricht bei `not gate.allowed` mit `continue` ab (`trip_alert.py:1279-1300`), Stufe 4
+und 5 werden nie erreicht.
+
+## Kernbefund 2 — Umsortieren allein wuerde den gemessenen Fall NICHT beheben
+
+Naheliegende Lesart: „Stufe 5 kann Verschaerfung, sie kommt nur zu spaet — also umsortieren."
+Das traegt nicht. Die vorhandene Eskalationspruefung vergleicht auf der **dreistufigen**
+Skala `LOW`/`MODERATE`/`HIGH` (`alert_urgency.exceeds`, `alert_urgency.py:65-72`). Fuer Radar
+entsteht die Stufe aus `intensity_to_text` (`radar_service.py:279-296`), und die **saettigt
+bei 4,0 mm/h** (`HEAVY_RAIN_THRESHOLD_MM_H`, `radar_service.py:78`):
+
+| Lauf | Rate | `intensity_label` | `severity` |
+|---|---|---|---|
+| 1 | 11 mm/h | `Starker Regen` | `HIGH` |
+| 3 | 30 mm/h | `Starker Regen` | `HIGH` |
+
+`exceeds("HIGH", "HIGH")` ist `False`. Die bestehende Leiter ist oben zu und kann eine
+Verdreifachung nicht sehen. **Eine quantitative Vergleichsbasis muss neu dazu; sie laesst
+sich nicht aus dem Bestand borgen.**
+
+## Kernbefund 3 — die Vergleichsbasis (C-3) hat eine PO-freigegebene Praezedenz
+
+Anforderung C-3 („Die Vergleichsbasis ist definiert und protokolliert") ist fuer die
+**Briefing**-Ueberholung bereits beantwortet, entschieden am 2026-08-21 (#2020 F008):
+
+```
+_overtaking = (
+    _briefing_announced
+    and result.window_precip_mm >= _briefing_precip * _BRIEFING_OVERTAKE_FACTOR   # 2,0
+    and result.window_precip_mm >= _OVERTAKE_MIN_ABSOLUTE_MM                       # 2,0 mm
+)
+```
+`trip_alert.py:1410-1414`, Konstanten `:88` und `:99`.
+
+Entscheidend ist die **Messgrundlage**: verglichen wird **Menge gegen Menge**
+(`window_precip_mm` = akkumulierte mm im 60-Min-Vergleichsfenster ab `now`,
+`_OVERTAKE_COMPARE_WINDOW_MIN = 60`, `radar_service.py:84`, Rechnung `:779-800`) — bewusst
+**nicht** ueber eine Spitzenrate. Begruendung im Code (`trip_alert.py:80-99`): anhaltender,
+nicht-spitzer Regen (3,9 mm/h ueber 50 Min = 3,575 mm gegen 1,0 mm Ankuendigung, 3,6-fach)
+wurde von der alten Ratenschwelle ausgesperrt, obwohl er die Ankuendigung real ueberholte.
+
+Diese Regel rechnet den gemessenen #2065-Fall korrekt durch:
+`27,5 mm >= 10 mm × 2,0` ✓ und `27,5 mm >= 2,0 mm` ✓ → Alarm.
+
+Zur Abgrenzung: `max_rate_mm_h` (`radar_service.py:158-180`) ist seit #2020/F008 **rein
+beschreibend, ohne Leser in der Alarmregel**; `intensity_label` entsteht dagegen aus der Max-Rate
+im **180-Min**-Nowcast-Fenster (`radar_service.py:731-743`) — drei verschiedene Groessen, die
+nicht verwechselt werden duerfen.
+
+## Kernbefund 4 — die zuletzt gemeldete MENGE wird heute nirgends gespeichert
+
+| Ablage | Datei | Inhalt | taugt als Vergleichsbasis? |
+|---|---|---|---|
+| `ThrottleStore` | `data/users/<uid>/throttle_state.json` | `{scope: {key: ISO-Zeitstempel}}` | **nein** — nur Zeitstempel (`throttle_store.py:67-87`) |
+| Tageszaehler | `alert_daily_count.json` | `{zones: {zone: {date, count}}}` | nein |
+| Ereignis-Identitaet | `alert_state/<entity_id>.json` | u.a. `severity` (LOW/MODERATE/HIGH) | nur grob — saettigt (Kernbefund 2) |
+| Abweichungs-Register (#816) | `alert_state/<entity_id>.json`, Schluessel `<metric>:<segment_id>` | `last_reported_value: float` | Vorbild fuer die Bauform, aber anderer Alarmtyp |
+
+Es fehlt also genau ein Wert: die zuletzt **gemeldete** `window_precip_mm` je
+(`throttle_scope`, `throttle_key`). Der natuerliche Buchungsort ist `record_nowcast_sent()`
+(`alert_gate.py:386-400`) — dort werden Tageszaehler und Sperrzeit heute schon gemeinsam und
+**nur nach erfolgreicher Zustellung** gebucht (F001-Symmetrie), und beide Flaechen
+(Trip + Ortsvergleich) laufen darueber.
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `src/services/alert_gate.py` | `check_nowcast_gate` (:140), `record_nowcast_sent` (:386), `check_event_identity_gate` (:617) — geteilter Baustein Trip+Vergleich |
+| `src/services/trip_alert.py` | Radar-Zweig: Gate-Aufruf :1269, Briefing-Ueberholung :1410, Entdopplung :1540, Buchung :1637 |
+| `src/services/throttle_store.py` | Sperrzeit-Persistenz; muesste die gemeldete Menge mittragen |
+| `src/services/radar_service.py` | `NowcastResult.window_precip_mm` (:137-190), Fensterrechnung (:779-800), Intensitaets-Schwellen (:78, :279-296) |
+| `src/services/alert_urgency.py` | 3-Stufen-Skala + `exceeds` — erklaert, warum der Bestand nicht reicht |
+| `src/services/compare_radar_alert.py` | zweiter Produktiv-Aufrufer von `check_nowcast_gate` (:169) — Ortsvergleich, **zurueckgestellt** |
+| `src/services/alert_daily_limit.py` | Tages-Obergrenze inkl. Reserve-Mechanik `_FORECAST_CHANGE_RESERVE` (:88) |
+| `src/services/user_tier.py` | `daily_alert_limit` (:45): premium → `None` (kein Limit), standard → 4, free → 2 |
+| `tests/helpers/alarm_pruefstrecke.py` | Zeitreihen-Harness (#2050 S1): `AlarmPruefstrecke(user_id, settings, throttle_hours=2)`, `.lauf(at=, zweig=, trip=, radar_service=)` → `AlarmPruefstreckeLauf(triggered_count, mail, telegram, sms, premium_sms)` |
+| `tests/tdd/test_alarm_szenario_briefing_ueberholung_zeitreihe.py` | Helfer `_uid/_dauerregen/_radar/_briefing_anker/_aufbau/_settings_all_channels/_clean_user`; die ausgelassene AC-3-Stelle ist ab :270 dokumentiert |
+
+## Existing Patterns
+
+- **Ueberholung als UND-Verknuepfung** (Faktor **und** absolute Untergrenze), damit die Regel
+  fuer feste Vergleichsbasis in beiden Groessen monoton bleibt — `trip_alert.py:1405-1414`.
+- **Buchen nur nach Zustellung** (F001-Symmetrie): `record_nowcast_sent` /
+  `record_event_identity` stehen hinter dem Versand, nicht davor.
+- **Benannte Konstante statt Hartverdrahtung** fuer jede Schwelle (ADR-0021-Muster, #2009).
+- **Geteilter Baustein mit `context_label`-Parameter** statt zweier Kopien fuer Trip/Vergleich.
+
+## Existing Specs & ADRs
+
+| Quelle | Kernaussage | Bedeutung hier |
+|---|---|---|
+| **ADR-0021**, Nachtrag (`docs/adr/0021-shared-deviation-alert-engine.md:106-112`) | Die Reihenfolge **Ruhezeit → Sperrzeit → Tages-Obergrenze** ist als geteilter Baustein festgeschrieben, fuer Trip **und** Ortsvergleich | Eine Ausnahme in dieser Kette ist eine Aenderung an einer dokumentierten Entscheidung → **datierter ADR-Nachtrag noetig** (Praezedenz: der S4b-Nachtrag, bewacht von `test_ac21_adr_0021_traegt_einen_datierten_s4b_nachtrag`) |
+| **ADR-0009** Alarme als Abweichungs-Waechter | Alarme messen Abweichung, nicht absolute Schwellen | Stuetzt die Bauform „gegen die zuletzt gemeldete Lage", nicht „ab X mm" |
+| `docs/specs/modules/rework_1467_s3_nowcast.md` | Spec der geteilten Gate-Kette | Muss den neuen Zweig mitfuehren |
+| `docs/specs/modules/rework_1467_s4b_entdopplung.md` | Ereignis-Identitaet inkl. V2-Eskalation | Erklaert die bestehende, saettigende Stufenpruefung |
+| `docs/specs/modules/alarm_pruefstrecke.md`, `alarm_szenarien_waechter_2_3.md` | Harness + Szenarien 2/3 | Der rote Test haengt hier an |
+
+## Dependencies
+
+- **Upstream:** `NowcastResult.window_precip_mm` (Radar-Dienst), `ThrottleStore`,
+  `alert_daily_limit`, `AlertStateService`.
+- **Downstream (Aufrufer, die eine Signaturaenderung sehen):**
+  `trip_alert.py:1269` (Trip-Radar) und `compare_radar_alert.py:169` (Ortsvergleich-Radar).
+  Der Ortsvergleich ist PO-seitig zurueckgestellt → die Erweiterung muss dort **wirkungslos**
+  bleiben (optionaler Parameter, Default „keine Verschaerfungsinformation").
+
+## Betroffene Tests
+
+| Datei | Relevanz |
+|---|---|
+| `tests/tdd/test_alert_gate.py` | `test_ac11_ruhezeit_stoppt_vor_der_sperrzeit_pruefung` (:88), `test_ac11_sperrzeit_stoppt_vor_der_tages_obergrenze` (:129), `test_ac11_freie_bahn_wird_durchgelassen` (:163) bewachen die Reihenfolge; `test_ac20_…signatur_bleibt_ohne_cooldown_parameter` (:1045) zeigt, dass Signaturen hier bewacht werden |
+| `tests/tdd/test_alarm_szenario_briefing_ueberholung_zeitreihe.py` | Heimat der Helfer; die ausgelassene AC-3-Stelle |
+| `tests/tdd/test_alarm_pruefstrecke_selbstschutz.py` | patcht `check_nowcast_gate` (:304-310) — reagiert auf Signaturaenderungen |
+| `tests/tdd/test_ruhezeit_und_zaehler_folgen_der_ortszone.py` | Zonenfuehrung durch dieselbe Kette |
+| `tests/tdd/test_issue_1088_official_alert_triggers.py` | prueft die Aufrufreihenfolge `check_nowcast_gate` → `check_event_identity_gate` → Versand (:788-822) |
+
+## Risks & Considerations
+
+1. **Alarmflut statt Schweigen.** Die Fehlerrichtung kippt: eine zu weiche Ueberholungsregel
+   macht aus der Sperrzeit eine Attrappe. Die absolute Untergrenze ist der Schutz dagegen und
+   darf nicht entfallen.
+2. **Kettenreaktion.** Wenn jeder durchgebrochene Alarm die neue Vergleichsbasis hochsetzt,
+   braucht die naechste Verschaerfung wieder den Faktor — das bremst von selbst. Nur wenn die
+   Basis **nicht** mitgefuehrt wird, entsteht Wiederholungsgefahr. Muss AC-gedeckt sein.
+3. **Ruhezeit bleibt unangetastet** (#1955, PO-Ablehnung) — die Ausnahme darf ausdruecklich
+   **nicht** an Stufe 1 vorbei.
+4. **Ortsvergleich zurueckgestellt** — Signaturaenderung ja, Verhaltensaenderung dort nein.
+5. **Schema-Aenderung an `throttle_state.json`**: Bestandsdaten muessen weiterlesbar bleiben
+   (Read-Modify-Write, alter Reinstring als gueltiger Eintrag). `throttle_store.py` faellt
+   unter die Schema-Backup-Regel.
+6. **ADR-0021 nicht still zuruecknehmen** — datierter Nachtrag ist Pflicht.
+7. **Tageslimit ist tierabhaengig**: `premium → None`. Fuer den PO ist die Tageslimit-Haelfte
+   von A-3 heute wirkungslos; die akute Luecke ist eindeutig die Sperrzeit.
+8. **Ueberschneidung mit #2050 S2b** (Parallelsitzung): dort wird `trip_alert.py:1382`
+   (`_onset_dt`-Berechnung) angefasst. Abgesprochen 2026-08-22: **#2065 zuerst**, S2b rebast
+   darauf.
+
+## Offene Entscheidung fuer die Spec
+
+A-3 nennt **drei** Sperren (Sperrzeit, Tageslimit, Entdopplung), #2065 misst nur die Sperrzeit.
+Zuschnitt-Optionen: nur Sperrzeit · Sperrzeit + Tageslimit (beide liegen in derselben Funktion,
+Zusatzaufwand gering; Tageslimit ist zugleich Szenario 7 / D-3) · alle drei. Empfehlung und
+Begruendung gehoeren in die Analyse-Phase.
+
+## Nebenbefund
+
+#2050 nennt als Herkunft von Szenario 4 die Nummer **#1445** — dort steht aber „MeteoAlarm via
+MQTT-Stream". Fuer Szenario 4 existiert also **kein** dokumentierter historischer Vorfall; der
+einzige Beleg ist die Messung aus #2050 S2a. Kein Handlungsbedarf, nur zur Einordnung der
+Behauptung „jedes Szenario ist einmal wirklich passiert".

--- a/docs/context/fix-2065-verschaerfung-durchbricht-sperrzeit.md
+++ b/docs/context/fix-2065-verschaerfung-durchbricht-sperrzeit.md
@@ -178,12 +178,161 @@ werden, nicht nur die ADR.
    (`_onset_dt`-Berechnung) angefasst. Abgesprochen 2026-08-22: **#2065 zuerst**, S2b rebast
    darauf.
 
-## Offene Entscheidung fuer die Spec
+---
 
-A-3 nennt **drei** Sperren (Sperrzeit, Tageslimit, Entdopplung), #2065 misst nur die Sperrzeit.
-Zuschnitt-Optionen: nur Sperrzeit · Sperrzeit + Tageslimit (beide liegen in derselben Funktion,
-Zusatzaufwand gering; Tageslimit ist zugleich Szenario 7 / D-3) · alle drei. Empfehlung und
-Begruendung gehoeren in die Analyse-Phase.
+# Analysis (Phase 2, 2026-08-22)
+
+## Type
+
+**Bug.** Nutzersichtbares Fehlverhalten: ein Alarm ueber eine deutliche Verschaerfung bleibt aus.
+
+## Befund A — hinter der Sperrzeit steht eine ZWEITE Wand (GEMESSEN)
+
+Der wichtigste Analyse-Ertrag, unabhaengig zweifach hergeleitet (eigene Messung + Challenger)
+und **empirisch belegt**, nicht nur gerechnet. Aufruf der echten Entdopplung mit der
+Konstellation der Pruefstrecke (Lauf 1 meldet bei T+5 mit `HIGH`, Lauf 3 prueft 90 Min spaeter
+bei T+95 mit `HIGH`):
+
+```
+Lauf 3 (HIGH gegen HIGH):       allowed=False  reason='event_duplicate'
+Gegenprobe (Eintrag MODERATE):  allowed=True   reason=None
+```
+
+Die **Gegenprobe ist der Beweis, dass die Eskalationsstelle erreicht wird** — ohne sie koennte
+„blockiert" auch heissen, der Zweig sei gar nicht ausgewertet worden.
+
+Rechenweg (`alert_gate.py:458-467`, `:489-494`, `:601-614`, `NOWCAST_HORIZON_MIN = 180`,
+`radar_service.py:69`):
+
+| Schritt | Wert | Ergebnis |
+|---|---|---|
+| Zeitabstand der Ereigniszeitpunkte | 90 Min ≤ 180 Min | Treffer im Register |
+| Eskalation `exceeds("HIGH","HIGH")` | `2 > 2` | False |
+| V1-Ausnahme `_covers_materially_more` | abgedeckt bis T+275, noetig T+365 | greift nicht |
+| **Ergebnis** | | `REASON_EVENT_DUPLICATE` |
+
+**Konsequenz:** Ein Fix, der nur die Sperrzeit oeffnet, macht den roten Test **nicht** gruen —
+er wechselt nur den Protokollgrund von `cooldown` auf `event_duplicate`. Die Zuschnitt-Option
+„nur Sperrzeit" ist damit nicht eine schwaechere Variante, sondern **keine Loesung**.
+
+Beide Sperren scheitern an **derselben** Ursache: einer Schwere-Skala, die bei 4 mm/h zumacht.
+Das ist eine Ursache, nicht zwei — und deshalb ein Fix, nicht zwei.
+
+## Befund B — die Menge existiert zum Zeitpunkt der Sperrpruefung noch nicht
+
+`check_nowcast_gate` laeuft in `trip_alert.py:1269`, der Nowcast-Abruf erst in `:1365`. Die
+Groesse, an der Verschaerfung gemessen wird (`window_precip_mm`), entsteht also **nach** dem
+Gate. Ein gesperrter Lauf holt heute gar keine Daten (`continue` bei `:1303`).
+
+Daraus folgt zwingend: im Sperrzeit-Fall muss **zusaetzlich** abgerufen werden. Keine Bauform
+kommt daran vorbei. Kosten: Prueftakt 15 Min (`scheduler.go`), Sperrzeit-Vorgabe 2 h,
+Radar-Cache-TTL 300 s (`radar_cache.py:67`) → bis zu **7 zusaetzliche Abrufe je Sperrfenster
+und Tour**, gegen ein Tagesbudget von 9000 (`forecast_budget.py:40`). Unkritisch, gehoert aber
+in den PR benannt. Die Invariante „genau EIN `get_nowcast` je Trip" (`trip_alert.py:1305`,
+#1329) bleibt gewahrt, wenn der Sperrzeit-Fall in denselben Abruf laeuft statt einen zweiten
+auszuloesen.
+
+## Befund C — ein zweiter Schreiber teilt sich den Sperrzeit-Topf
+
+`trip_report_scheduler.py:1574` bucht dieselbe `radar`-Sperre fuer den Kurzfristhinweis im
+Briefing — **ohne** Mengenangabe. Die Vergleichsbasis kann also legitim fehlen. Regel:
+**fehlende Vergleichsbasis ⇒ kein Durchbruch** (konservativ). Das ist die richtige
+Fehlerrichtung — Alarmflut zu vermeiden wiegt schwerer als Durchlaessigkeit, und ein Durchbruch
+ohne Vergleichsbasis waere ein Durchbruch ohne Nachweis.
+
+## Technischer Ansatz (Entscheidung)
+
+**Eine geteilte Vergleichsfunktion, zwei Wirkorte.** Die Definition von „deutlich schlimmer"
+existiert genau **einmal** (Anforderung C-3) und wird an beiden blockierenden Stellen benutzt:
+
+| # | Baustein | Wirkung |
+|---|---|---|
+| 1 | Neuer Helfer in `alert_gate.py`, Nachbarschaft `record_nowcast_sent` | Vergleicht aktuelle Menge gegen gespeicherte Vergleichsbasis. Faktor **und** absolute Untergrenze, UND-verknuepft — Muster der Briefing-Ueberholung, aber **eigene benannte Konstanten** (andere Vergleichsbasis) |
+| 2 | `trip_alert.py::check_radar_alerts` | Bei `gate.reason == REASON_COOLDOWN` **kein sofortiges `continue`** mehr: in den Abruf laufen, dann den Helfer befragen. Kein Treffer → unveraendert unterdruecken (Protokollgrund bleibt `cooldown`) |
+| 3 | `check_event_identity_gate` | Optionaler Parameter, der die quantitative Verschaerfung in den **bestehenden ersten Eskalationszweig** (`alert_gate.py:669`) einspeist — ODER-verknuepft mit `exceeds(...)`. Struktur „Eskalation zuerst" bleibt unangetastet |
+| 4 | `ThrottleStore` | Eintrag von reinem ISO-String auf `{"at": …, "precip_mm": …}` erweitern; alter Reinstring bleibt gueltig lesbar (`_parse`, `throttle_store.py:161-172`). Neue Lesemethode statt Ueberladung von `last_sent` (15+ Aufrufer) |
+| 5 | `record_nowcast_sent` | Optionaler Mengen-Parameter, durchgereicht an `.record()`. Buchung weiterhin **nur nach erfolgreicher Zustellung** (F001-Symmetrie) |
+
+**`check_nowcast_gate` bleibt in Signatur und Verhalten unveraendert.** Damit bleiben die drei
+Ordnungstests (`test_alert_gate.py:88/129/163`) und der Ortsvergleich (`compare_radar_alert.py`)
+unberuehrt — der Helfer taucht dort schlicht nicht im Aufrufgraphen auf. Das ist die sauberste
+Erfuellung der PO-Rueckstellung: keine Signatur-Passagiere, kein toter Default.
+
+**Verworfen:**
+- *Gates umsortieren* — behebt den gemessenen Fall nicht (Befund A und Kernbefund 2).
+- *Vergleich in `check_nowcast_gate` selbst* — zoege den Speicherzugriff in den geteilten
+  Baustein und beruehrte Ortsvergleich und Ordnungstests am falschen Ort.
+- *Die bestehende `LOW/MODERATE/HIGH`-Leiter um eine vierte Stufe erweitern* — aendert die
+  Bedeutung einer Groesse, die an vielen Stellen gelesen wird (Kanal-Schwellen ADR-0046,
+  amtliche Warnstufen), fuer einen lokalen Zweck. Grosse Flaeche, kleiner Ertrag.
+
+## Verfall der Vergleichsbasis
+
+Die Vergleichsbasis lebt **im selben Eintrag** wie der Sperrzeit-Zeitstempel und wird bei jeder
+erfolgreichen Zustellung ueberschrieben. Keine zweite Uhr. Gelesen wird sie ohnehin nur, solange
+die Sperre laeuft.
+
+Fehlerrichtung, die das bewusst in Kauf nimmt: nach einem durchgebrochenen 27,5-mm-Alarm braucht
+die naechste Verschaerfung im selben Fenster den vollen Faktor **gegen 27,5 mm**, nicht mehr
+gegen die alten 10 mm. Das ist erwuenschtes Selbstbremsen und genau der Schutz gegen die
+Kettenreaktion aus Risk 2 — keine Luecke.
+
+## Zuschnitt (Entscheidung)
+
+**Sperrzeit + Entdopplung. Tageslimit NICHT.**
+
+- *Sperrzeit* — der gemessene Fall.
+- *Entdopplung* — **zwingend**, sonst wird der rote Test nicht gruen (Befund A). Nicht
+  Scope-Ausweitung, sondern Teil derselben Ursache.
+- *Tageslimit* — bewusst ausgelassen, mit Begruendung: bei `tier=premium` ohnehin `None`
+  (`user_tier.py:45-64`), also fuer den akuten Fall wirkungslos; es ist als Szenario 7 /
+  Anforderung D-3 bereits eigener Scheibe S3 in #2050 zugeordnet; und die Kette bricht bei
+  Sperrzeit ab, bevor das Tageslimit ueberhaupt geprueft wurde.
+
+**Wichtig und AC-pflichtig:** Weil `check_nowcast_gate` bei Sperrzeit kurzschliesst, wurde das
+Tageslimit im Ueberholungsfall **noch nie geprueft**. Der Durchbruch darf es nicht stillschweigend
+mit ueberspringen — im Override-Pfad ist es erneut zu pruefen und bleibt hartes Stop. Sonst
+raeumte dieser Fix eine zweite Sperre ab, ohne es zu sagen.
+
+A-3 wird damit **teilweise** erfuellt (zwei von drei Sperren). Das gehoert so in die Spec — nicht
+als „A-3 erledigt" verbuchen.
+
+## Scope Assessment
+
+| | |
+|---|---|
+| Produktivdateien | 4 (`alert_gate.py`, `trip_alert.py`, `throttle_store.py`, ggf. Konstanten) |
+| Geschaetzte LoC (Produktivcode) | ~+140 / −20 — **eng am 250er-Limit**, Doku zaehlt nicht mit |
+| Testdateien | Zeitreihen-Szenario (neu), `test_alert_gate.py`, `test_throttle_store.py`, `test_nowcast_suppression_logging.py` |
+| Doku | ADR-0021 datierter Nachtrag · `docs/specs/modules/rework_1467_s3_nowcast.md` Nachtrag |
+| Risiko | **HIGH** — kritischer Alarmpfad, geteilter Baustein, Schema-Aenderung |
+
+## Umsetzungsreihenfolge
+
+1. `throttle_store.py`: Schema-Erweiterung + Rueckwaerts-Lesbarkeit, Roundtrip-Test.
+2. `alert_gate.py`: Vergleichs-Helfer + benannte Konstanten + Mengen-Parameter an
+   `record_nowcast_sent` + optionaler Eskalations-Parameter am Entdopplungs-Gate.
+3. ADR-0021-Nachtrag und Spec-Nachtrag (inkl. Satz, **warum** der Ortsvergleich nicht mitkommt).
+4. `trip_alert.py`: Kontrollfluss im Sperrzeit-Fall, Weitergabe an beide Wirkorte, erneute
+   Tageslimit-Pruefung im Override-Pfad.
+5. Zeitreihen-Szenario auf der Pruefstrecke (Reproduktion 11 → 30 mm/h).
+6. Protokoll-Test fuer den neuen Durchbruchsgrund.
+
+## Adversary-Schwerpunkte (fuer spaeter vormerken)
+
+- Fehlende Vergleichsbasis (`precip_mm=None` durch den Briefing-Schreiber, Befund C) muss
+  **konservativ** entscheiden — gezielt mutieren.
+- Untergrenze entfernen → muss rot werden. Faktor verfaelschen → muss rot werden.
+- Der Entdopplungs-Zweig: pruefen, dass die Gegenprobe den Zweig auch **erreicht** (siehe die
+  MODERATE-Gegenprobe oben) — sonst beweist ein gruener Test nichts.
+- Ruhezeit muss weiterhin **unbrechbar** sein (#1955).
+- Tageslimit im Override-Pfad muss weiterhin greifen.
+
+## Open Questions
+
+Keine blockierenden. Die im Ticket offen gelassene Vergleichsbasis-Frage (C-3) ist durch die
+PO-freigegebene Praezedenz aus #2020 F008 beantwortet; die konkreten Schwellenwerte gehen als
+ACs auf Deutsch in die Spec und werden dort freigegeben.
 
 ## Nebenbefund
 

--- a/docs/context/fix-2065-verschaerfung-durchbricht-sperrzeit.md
+++ b/docs/context/fix-2065-verschaerfung-durchbricht-sperrzeit.md
@@ -143,6 +143,19 @@ Es fehlt also genau ein Wert: die zuletzt **gemeldete** `window_precip_mm` je
 | `tests/tdd/test_alarm_pruefstrecke_selbstschutz.py` | patcht `check_nowcast_gate` (:304-310) — reagiert auf Signaturaenderungen |
 | `tests/tdd/test_ruhezeit_und_zaehler_folgen_der_ortszone.py` | Zonenfuehrung durch dieselbe Kette |
 | `tests/tdd/test_issue_1088_official_alert_triggers.py` | prueft die Aufrufreihenfolge `check_nowcast_gate` → `check_event_identity_gate` → Versand (:788-822) |
+| `tests/tdd/test_nowcast_briefing_overtake.py` | die Briefing-Ueberholung aus #2020 S1 — Einzelaufrufe ohne Sperrzeit-Gedaechtnis; muss unveraendert gruen bleiben |
+| `tests/tdd/test_nowcast_suppression_logging.py` | prueft die `alert_log`-Eintraege bei Gate-Abweisung — ein neuer Durchbruchsgrund beruehrt sie |
+
+Ergaenzungen zur Pruefstrecke: `Zweig = Literal["deviation", "official", "radar"]`
+(`alarm_pruefstrecke.py:40`); Zeit ausschliesslich ueber `freeze_time(at)` in `lauf()` (`:162`),
+`now_utc=` ist bewusst nicht durchgereicht. Weitere Helfer in der Szenario-Datei:
+`_kurze_spitze(rate_mm_h)` (:96-108) und `_gelesene_briefing_werte(uid, trip, seit)` (:60-79) —
+letzterer liest die Vergleichswerte aus `alert_log.read_undelivered()`, statt sie
+nachzurechnen.
+
+Die feste Reihenfolge ist zusaetzlich in `docs/specs/modules/rework_1467_s3_nowcast.md:12-20`
+niedergeschrieben (Abbruch bei der ersten greifenden Stufe) — die Spec muss also mitgezogen
+werden, nicht nur die ADR.
 
 ## Risks & Considerations
 

--- a/docs/specs/modules/fix_2065_verschaerfung_ueberholt_sperre.md
+++ b/docs/specs/modules/fix_2065_verschaerfung_ueberholt_sperre.md
@@ -3,7 +3,7 @@ entity_id: fix_2065_verschaerfung_ueberholt_sperre
 type: module
 created: 2026-08-22
 updated: 2026-08-22
-status: draft
+status: approved
 workflow: fix-2065-verschaerfung-durchbricht-sperrzeit
 version: "1.0"
 tags: [alarm, nowcast, sperrzeit, entdopplung]
@@ -13,7 +13,7 @@ tags: [alarm, nowcast, sperrzeit, entdopplung]
 
 ## Approval
 
-- [ ] Approved
+- [x] Approved — PO ("approved"), 2026-08-22
 
 ## Purpose
 

--- a/docs/specs/modules/fix_2065_verschaerfung_ueberholt_sperre.md
+++ b/docs/specs/modules/fix_2065_verschaerfung_ueberholt_sperre.md
@@ -1,0 +1,294 @@
+---
+entity_id: fix_2065_verschaerfung_ueberholt_sperre
+type: module
+created: 2026-08-22
+updated: 2026-08-22
+status: draft
+workflow: fix-2065-verschaerfung-durchbricht-sperrzeit
+version: "1.0"
+tags: [alarm, nowcast, sperrzeit, entdopplung]
+---
+
+# Verschärfung überholt die Radar-Sperrzeit (Issue #2065)
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Eine sich deutlich verschärfende Regenlage erreicht den Nutzer heute nicht, wenn ein
+vorangegangener Radar-Alarm noch eine laufende Sperrzeit hält — gemessen: 11 mm/h (~10 mm)
+lösen aus und buchen 120 Minuten Sperre, 90 Minuten später schweigt eine auf 30 mm/h
+(~27,5 mm) verdreifachte Lage mit Protokollgrund `cooldown`. Das verletzt Anforderung **A-3**
+aus #2050 ("Eine Verschärfung überholt jede Sperre", dort Szenario 4). Diese Spec führt eine
+eigenständige, quantitative Überholungsprüfung ein, die an **beiden** Stellen wirkt, an denen
+der gemessene Fall heute scheitert: der Sperrzeit selbst und der dahinterliegenden
+Entdopplung.
+
+## Source
+
+- **File:** `src/services/alert_gate.py` (neuer Vergleichs-Helfer, Erweiterung
+  `record_nowcast_sent`, optionaler Parameter `check_event_identity_gate`)
+- **File:** `src/services/trip_alert.py` (`TripAlertService.check_radar_alerts`,
+  Kontrollfluss im Sperrzeit-Fall)
+- **File:** `src/services/throttle_store.py` (`ThrottleStore`, Schema-Erweiterung)
+- **Identifier:** `check_nowcast_gate` (unverändert), neuer Helfer (Arbeitstitel
+  `_radar_overtakes_cooldown` bzw. äquivalent), `check_event_identity_gate`
+
+Schicht: ausschließlich Python-Core (`src/services/`). Kein Go-, kein Frontend-Anteil.
+
+## Estimated Scope
+
+- **LoC:** ~+140 / −20 (Produktivcode) — eng am 250-LoC-Standardlimit des Workflows;
+  Doku (ADR-Nachtrag, Spec-Nachtrag) zählt dort nicht mit. Ggf. `loc_limit_override` nötig.
+- **Files:** 4 Produktivdateien (`alert_gate.py`, `trip_alert.py`, `throttle_store.py`,
+  ggf. eine Konstanten-Stelle)
+- **Effort:** high
+- **Risiko:** HIGH — kritischer Alarmpfad, geteilter Baustein (Trip + Ortsvergleich),
+  Schema-Änderung an Bestandsdaten
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `src/services/alert_gate.py::check_nowcast_gate` | function | Bleibt in Signatur UND Verhalten unverändert — der neue Helfer taucht dort nicht im Aufrufgraphen auf |
+| `src/services/alert_gate.py::record_nowcast_sent` | function | Bekommt einen optionalen Mengen-Parameter, gebucht weiterhin nur nach erfolgreicher Zustellung (F001-Symmetrie) |
+| `src/services/alert_gate.py::check_event_identity_gate` | function | Bekommt einen optionalen Eskalations-Parameter, der in den bestehenden ersten Eskalationszweig (`:669`, `exceeds(...)`) einspeist |
+| `src/services/throttle_store.py::ThrottleStore` | class | Eintragsformat erweitert sich um die zuletzt gemeldete Menge, alter Reinstring bleibt lesbar |
+| `src/services/radar_service.py::NowcastResult.window_precip_mm` | attribute | Die quantitative Vergleichsgröße (60-Min-Vergleichsfenster ab `now`), dieselbe Größe wie bei der Briefing-Überholung |
+| `src/services/alert_daily_limit.py::is_allowed`/`increment` | function | Erneute Tageslimit-Prüfung im Override-Pfad (AC-7) — Lesen vor dem Abruf, Buchen nur nach Zustellung |
+| `src/services/alert_urgency.py::exceeds` | function | Bestehende Eskalationsprüfung, mit der der neue Parameter ODER-verknüpft wird |
+| `src/services/compare_radar_alert.py` | module | Zweiter Aufrufer von `check_nowcast_gate` — bleibt unberührt (Ortsvergleich zurückgestellt) |
+| `docs/adr/0021-shared-deviation-alert-engine.md` | doc | Trägt die feste Reihenfolge Ruhezeit→Sperrzeit→Tages-Obergrenze fest — die Ausnahme braucht einen datierten Nachtrag |
+| `docs/specs/modules/rework_1467_s3_nowcast.md` | doc | Spec der geteilten Gate-Kette — muss den neuen Zweig mitführen |
+| `tests/helpers/alarm_pruefstrecke.py::AlarmPruefstrecke` | test helper | Zeitreihen-Harness, auf dem der Kernfall (AC-1) reproduziert wird |
+
+## Implementation Details
+
+**Eine geteilte Vergleichsfunktion, zwei Wirkorte** — die Definition von "deutlich
+schlimmer" (Anforderung C-3) existiert genau einmal und wird an beiden blockierenden
+Stellen benutzt, die den gemessenen Fall verursachen (Kernbefund 1 + Befund A der
+Analyse, `docs/context/fix-2065-verschaerfung-durchbricht-sperrzeit.md`).
+
+**1. Neuer Vergleichs-Helfer in `alert_gate.py`**, in Nachbarschaft von `record_nowcast_sent`
+(`alert_gate.py:386`). Vergleicht die aktuelle Menge (`window_precip_mm`) gegen die
+gespeicherte Vergleichsbasis (Baustein 4). UND-verknüpft, Muster identisch zur
+PO-freigegebenen Briefing-Überholung (`trip_alert.py:1410-1414`, F008/#2020), aber mit
+**eigenen benannten Konstanten** — andere Vergleichsbasis (letzte gemeldete Menge statt
+Briefing-Ankündigung), daher eigenständig nachziehbar:
+
+```
+Faktor: 2,0            (Arbeitsname: _COOLDOWN_OVERTAKE_FACTOR)
+Absolute Untergrenze: 2,0 mm  (Arbeitsname: _COOLDOWN_OVERTAKE_MIN_ABSOLUTE_MM)
+```
+
+Fehlt die Vergleichsbasis (kein gespeicherter Wert — Befund C, s. u.), liefert der Helfer
+`False` (kein Durchbruch, konservativ).
+
+Der gemessene #2065-Fall rechnet damit durch: `27,5 mm >= 10,08 mm × 2,0` (✓) und
+`27,5 mm >= 2,0 mm` (✓) → Durchbruch. Diese beiden Zahlen sind der Regler, den der PO bei
+der Freigabe verstellen kann.
+
+**2. `trip_alert.py::check_radar_alerts` — Kontrollfluss im Sperrzeit-Fall.** Bei
+`gate.reason == alert_log.REASON_COOLDOWN` kein sofortiges `continue` mehr
+(bisher `trip_alert.py:1281-1303`): stattdessen in den Nowcast-Abruf laufen (derselbe
+Abruf wie im freien Fall, keine zweite `get_nowcast`-Anfrage — die Invariante "genau EIN
+Abruf je Trip", `trip_alert.py:1305`, #1329, bleibt gewahrt), dann den Helfer aus Baustein 1
+befragen. Kein Treffer → unverändert unterdrücken, Protokollgrund bleibt `cooldown`.
+Treffer → weiterlaufen wie im ungesperrten Fall, inklusive erneuter Tageslimit-Prüfung
+(Baustein 5) und der bestehenden Briefing-Überholungsprüfung (`:1410-1414`, unverändert).
+
+**3. `check_event_identity_gate` — optionaler Eskalations-Parameter.** Die quantitative
+Verschärfung speist in den bestehenden ERSTEN Eskalationszweig
+(`alert_gate.py:669`, `if alert_urgency.exceeds(severity, match["severity"])`) ein, ODER-
+verknüpft mit der bestehenden Prüfung. Struktur "Eskalation zuerst, dann V1-Ausnahme, dann
+Unterdrückung" (`:641-692`) bleibt unangetastet. Notwendig, weil die dreistufige
+Schwere-Skala (`LOW`/`MODERATE`/`HIGH`) bei 4 mm/h sättigt
+(`HEAVY_RAIN_THRESHOLD_MM_H`, `radar_service.py:78`) und `exceeds("HIGH","HIGH")` für
+11 mm/h gegen 30 mm/h `False` liefert — gemessen belegt (Befund A der Analyse): ohne diesen
+Baustein bleibt der rote Kerntest rot, der Protokollgrund wechselt nur von `cooldown` auf
+`event_duplicate`.
+
+**4. `ThrottleStore` — Schema-Erweiterung.** Eintrag von reinem ISO-String
+(`{scope: {key: iso_timestamp}}`) auf `{scope: {key: {"at": iso_timestamp,
+"precip_mm": float|null}}}`. Alter Reinstring bleibt gültig lesbar — neue Lesemethode
+(Arbeitstitel `last_sent_with_precip`) statt Überladung von `last_sent()` (15+ Aufrufer,
+`throttle_store.py:67`). `_parse()` (`:160-170`) unterscheidet beim Lesen zwischen
+altem String-Format und neuem Objekt-Format; `record()` (`:84`) schreibt ausschließlich
+das neue Format. Read-Modify-Write bleibt erhalten (`_update()`, `:117-158`), kein Replace.
+
+**5. `record_nowcast_sent` — optionaler Mengen-Parameter**, durchgereicht an
+`.record()` des `ThrottleStore`. Buchung weiterhin ausschließlich NACH erfolgreicher
+Zustellung (F001-Symmetrie, unverändert aus `alert_gate.py:395`).
+
+**`check_nowcast_gate` bleibt in Signatur UND Verhalten unverändert.** Der neue Helfer
+taucht in seinem Aufrufgraphen nicht auf — damit bleiben die drei Ordnungstests
+(`test_alert_gate.py:88/129/163`) und der Ortsvergleich (`compare_radar_alert.py`)
+unberührt. Das ist die sauberste Erfüllung der PO-Rückstellung des Ortsvergleichs: keine
+Signatur-Passagiere, kein toter Default.
+
+**Verworfen** (aus der Analyse übernommen, nicht erneut zu prüfen):
+- *Gates umsortieren* — behebt den gemessenen Fall nicht (die Entdopplung dahinter kennt
+  dieselbe sättigende Skala, Befund A).
+- *Vergleich in `check_nowcast_gate` selbst* — zöge den Speicherzugriff in den geteilten
+  Baustein und beträfe Ortsvergleich und Ordnungstests am falschen Ort.
+- *Die bestehende `LOW/MODERATE/HIGH`-Leiter um eine vierte Stufe erweitern* — ändert die
+  Bedeutung einer an vielen Stellen gelesenen Größe (Kanal-Schwellen ADR-0046, amtliche
+  Warnstufen) für einen lokalen Zweck.
+
+**Was NICHT dazugehört:**
+- Tageslimit-Durchbruch (Szenario 7 / Anforderung D-3, eigene Scheibe #2050 S3) — bei
+  `tier=premium` gilt ohnehin kein Limit (`user_tier.py:45`), für den akuten Fall wirkungslos.
+- Ruhezeit-Ausnahme — bewusst NICHT: Ruhezeit bleibt unbrechbar (#1955, PO-Ablehnung).
+- Szenario 1 "Regen läuft schon" (#2050 S2b, kollidiert mit #2020 S2, eigene Scheibe).
+- Ortsvergleich — bleibt in Verhalten UND Signatur unverändert (s. o.).
+
+**A-3 wird durch diese Spec nur TEILWEISE erfüllt** (zwei von drei Sperren: Sperrzeit und
+Entdopplung — nicht das Tageslimit). Das ist keine vollständige Erfüllung von A-3 und darf
+nicht als solche verbucht werden.
+
+## Expected Behavior
+
+- **Input:** laufende Radar-Sperrzeit (`ThrottleStore`, Scope `radar`, Schlüssel `trip.id`)
+  mit gespeicherter Vergleichsmenge; aktueller Nowcast-Abruf für denselben Trip.
+- **Output:** bei ausreichender Verschärfung (Faktor UND absolute Untergrenze erfüllt,
+  Tageslimit noch nicht erschöpft) ein zugestellter Alarm über alle konfigurierten Kanäle;
+  sonst unverändert Stille mit Protokollgrund `cooldown`.
+- **Side effects:** ein zusätzlicher `get_nowcast`-Abruf während laufender Sperrzeit (bisher
+  fand dort gar kein Abruf statt); bei Durchbruch Fortschreibung der Vergleichsbasis auf die
+  neue, höhere Menge (Selbstbremsung); bei gescheiterter Zustellung KEINE Fortschreibung
+  (F001-Symmetrie, AC-10).
+
+## Acceptance Criteria
+
+- **AC-1:** Given eine laufende Sperrzeit aus einem vorangegangenen Alarm über ~10 mm
+  (11 mm/h), When 90 Minuten später eine Lage mit ~27,5 mm (30 mm/h) im selben Sperrfenster
+  geprüft wird, Then geht ein Alarm über alle konfigurierten Kanäle raus.
+  - Test: Zeitreihe auf `AlarmPruefstrecke` (Lauf 1: 11 mm/h auslösend, Lauf 3 nach
+    90 Minuten: 30 mm/h) — `triggered_count >= 1`, alle vier Kanal-Listen nicht leer.
+
+- **AC-2:** Given eine laufende Sperrzeit, When die Lage im Vergleich zur letzten
+  Meldung unverändert bleibt, Then bleibt die Unterdrückung bestehen und das Protokoll
+  weist als Grund `cooldown` aus.
+  - Test: zweiter Lauf mit identischer Eingangslage innerhalb des Sperrfensters —
+    `triggered_count == 0`, `alert_log.read_undelivered()` liefert einen Eintrag mit
+    `gate_reason == alert_log.REASON_COOLDOWN`.
+
+- **AC-3:** Given eine Verschärfung, die den Faktor erreicht, aber deren Gesamtmenge unter
+  der absoluten Untergrenze bleibt, When der Vergleich läuft, Then bricht die Sperre NICHT
+  durch.
+  - Test: Vergleichsbasis so niedrig gewählt, dass Faktor 2,0 rechnerisch erfüllt ist
+    (z. B. 0,5 mm × 2,0 = 1,0 mm erreicht), die tatsächliche Menge aber unter 2,0 mm bleibt
+    (z. B. 1,8 mm) — `triggered_count == 0`.
+
+- **AC-4:** Given eine Menge über der absoluten Untergrenze, aber ohne den geforderten
+  Faktor gegenüber der Vergleichsbasis, When der Vergleich läuft, Then bricht die Sperre
+  NICHT durch.
+  - Test: Vergleichsbasis so gewählt, dass die neue Menge über 2,0 mm liegt, aber unter dem
+    2,0-fachen der Vergleichsbasis (z. B. Basis 10 mm, neue Menge 15 mm) —
+    `triggered_count == 0`.
+
+- **AC-5:** Given die Verschärfung erfüllt Faktor und absolute Untergrenze, When der Alarm
+  geprüft wird, Then wirkt der Durchbruch AUCH an der Entdopplung — der protokollierte
+  Grund ist NICHT `event_duplicate`, der Alarm kommt tatsächlich an.
+  - Test: derselbe Lauf wie AC-1, zusätzlich geprüft, dass der zugestellte Alarm nicht mit
+    `alert_log.REASON_EVENT_DUPLICATE` unterdrückt wurde (Begründung: Befund A der
+    Analyse — ohne diesen Baustein wechselt nur der Protokollgrund, der Alarm bliebe aus).
+
+- **AC-6:** Given die Ruhezeit ist aktiv, When selbst eine extreme Verschärfung geprüft
+  wird, Then bleibt der Alarm aus und das Protokoll weist `quiet_hours` als Grund aus.
+  - Test: Lauf mit `now` innerhalb der konfigurierten Ruhezeit und einer Verschärfung weit
+    über Faktor und Untergrenze — `triggered_count == 0`, Protokollgrund
+    `alert_log.REASON_QUIET_HOURS` (PO-Ablehnung #1955, unbrechbar).
+
+- **AC-7:** Given ein Nutzer mit endlichem Tagesbudget, dessen Budget bereits erschöpft
+  ist, When eine Verschärfung vorliegt, die Faktor und Untergrenze erfüllt, Then bleibt der
+  Alarm aus und das Protokoll weist `daily_limit` als Grund aus.
+  - Test: Nutzer-Tier mit endlichem Limit, Tageszähler auf das Limit gesetzt, Verschärfung
+    wie in AC-1 — `triggered_count == 0`, Protokollgrund `alert_log.REASON_DAILY_LIMIT`.
+    Begründung: die Kette schließt heute bei Sperrzeit kurz, das Tageslimit wurde für den
+    Überholungsfall also nie geprüft; der Durchbruch darf es nicht stillschweigend
+    mit-überspringen.
+
+- **AC-8:** Given die Sperre wurde von einem zweiten Schreiber ohne Mengenangabe gebucht
+  (Kurzfristhinweis im Briefing, `trip_report_scheduler.py:1574`), sodass keine
+  Vergleichsbasis existiert, When eine beliebig starke Lage geprüft wird, Then bricht die
+  Sperre NICHT durch und das Protokoll weist `cooldown` als Grund aus.
+  - Test: Sperre über den Pfad ohne Mengenangabe gebucht, anschließend Lauf mit einer
+    Lage, die Faktor und Untergrenze gegen eine hypothetische Basis deutlich überschritte —
+    `triggered_count == 0`, Protokollgrund `cooldown` (konservative Fehlerrichtung:
+    Alarmflut zu vermeiden wiegt schwerer als Durchlässigkeit ohne Nachweis).
+
+- **AC-9:** Given ein Alarm ist im selben Sperrfenster bereits einmal durchgebrochen und
+  hat die Vergleichsbasis auf die höhere Menge fortgeschrieben, When dieselbe (nicht weiter
+  verschärfte) Menge erneut geprüft wird, Then bricht der Alarm NICHT ein zweites Mal durch.
+  - Test: Lauf 1 (auslösend) → Lauf 2 (Durchbruch, z. B. 27,5 mm) → Lauf 3 mit
+    unveränderten 27,5 mm im selben Sperrfenster — `triggered_count == 0` bei Lauf 3
+    (Selbstbremsung, Schutz gegen Wiederholungs-Kettenreaktion).
+
+- **AC-10:** Given ein Durchbruchsfall, bei dem die Zustellung scheitert (kein
+  erreichbarer Kanal / Zustellfehler), When der Lauf abgeschlossen ist, Then wird die
+  Vergleichsbasis NICHT fortgeschrieben.
+  - Test: Durchbruchslage wie AC-1, aber ohne zustellbaren Kanal — anschließend gelesene
+    Vergleichsbasis unverändert gegenüber dem Stand vor dem Lauf (F001-Symmetrie).
+
+- **AC-11:** Given ein `throttle_state.json` im alten Format (Eintrag = reiner
+  ISO-Zeitstempel ohne Mengenangabe), When ein Lauf gegen diese Datei prüft, Then bleibt
+  die Sperrzeit unverändert wirksam, die Datei bleibt lesbar und es geht kein Bestandsdatum
+  verloren.
+  - Test: Roundtrip mit vorbereiteter Alt-Datei (reiner String-Eintrag) — `is_throttled()`
+    liefert weiterhin korrekt `True`/`False`, ein anschließendes `record()` überschreibt
+    nur den geänderten Schlüssel, alle anderen Bestandseinträge bleiben unangetastet
+    (Read-Modify-Write, nie Replace).
+
+- **AC-12:** Given der Ortsvergleich-Radarpfad (`compare_radar_alert.py`), When diese
+  Änderung ausgeliefert ist, Then verhält er sich unverändert — weder Signatur- noch
+  Verhaltensänderung an seinem Aufrufgraphen über `check_nowcast_gate`.
+  - Test: bestehende Ortsvergleich-Nowcast-Tests laufen unverändert grün; zusätzlich ein
+    Signatur-Wächter, der belegt, dass `check_nowcast_gate` keine neuen Parameter ohne
+    Default entgegennimmt.
+
+- **AC-13:** Given ein Lauf mit laufender Sperrzeit, When die Überholungsentscheidung
+  getroffen wird (Durchbruch ODER Unterdrückung), Then protokolliert der Lauf sowohl die
+  gelesene Vergleichsbasis als auch die aktuell gemessene Menge.
+  - Test: Protokolleintrag (Durchbruchsfall wie AC-1 und Unterdrückungsfall wie AC-2) auf
+    Vorhandensein beider Werte prüfen — nachvollziehbar, gegen welche Basis entschieden
+    wurde.
+
+- **AC-14:** Given diese Änderung ist umgesetzt, When `docs/adr/0021-shared-deviation-alert-engine.md`
+  gelesen wird, Then trägt es einen datierten Nachtrag, der die Ausnahme beschreibt UND
+  begründet, warum der Ortsvergleich sie nicht bekommt; zusätzlich trägt
+  `docs/specs/modules/rework_1467_s3_nowcast.md` einen entsprechenden Nachtrag.
+  - Test: `# doc-compliance-test`, analog `test_ac21_adr_0021_traegt_einen_datierten_s4b_nachtrag`
+    (`tests/tdd/test_alert_gate.py:1067`) — Nachtrag mit Bezug auf `#2065` in beiden Dateien,
+    nach dem letzten bestehenden Nachtrag (#2018, 2026-08-21) einsortiert.
+
+## Known Limitations
+
+- **Budget-Mehrkosten:** bis zu 7 zusätzliche Nowcast-Abrufe je Sperrfenster und Tour
+  (Prüftakt 15 Min, Sperrzeit-Vorgabe 2 h, Radar-Cache-TTL 300 s), gegen ein Tagesbudget von
+  9000 (`forecast_budget.py:40`). Unkritisch in der Größenordnung, aber real und im PR zu
+  nennen.
+- **Fehlende Vergleichsbasis beim zweiten Schreiber:** `trip_report_scheduler.py:1574`
+  bucht dieselbe `radar`-Sperre ohne Mengenangabe (Kurzfristhinweis im Briefing) — in
+  diesem Fall bleibt der Durchbruch strukturell unmöglich (AC-8), auch bei real starker
+  Verschärfung.
+- **A-3 aus #2050 wird nur TEILWEISE erfüllt** — zwei von drei Sperren (Sperrzeit,
+  Entdopplung), NICHT das Tageslimit (eigene Scheibe #2050 S3 / Anforderung D-3).
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** ADR-0021 (Nachtrag)
+- **Rationale:** ADR-0021 schreibt die feste Reihenfolge Ruhezeit → Sperrzeit →
+  Tages-Obergrenze als geteilten Baustein für Trip UND Ortsvergleich fest. Diese Spec führt
+  eine Ausnahme in dieser Kette ein (quantitative Verschärfung überholt die Sperrzeit) —
+  das ist eine Änderung an einer dokumentierten Entscheidung und braucht deshalb einen
+  datierten ADR-Nachtrag (Präzedenz: der S4b-Nachtrag zu #1467), der zusätzlich begründet,
+  warum der Ortsvergleich diese Ausnahme NICHT bekommt (PO-Rückstellung, s. `docs/context/
+  fix-2065-verschaerfung-durchbricht-sperrzeit.md`, Abschnitt „Dependencies").
+
+## Changelog
+
+- 2026-08-22: Initial spec created (aus `docs/context/fix-2065-verschaerfung-durchbricht-sperrzeit.md`,
+  Analyse-Phase 2026-08-22).

--- a/docs/specs/modules/rework_1467_s3_nowcast.md
+++ b/docs/specs/modules/rework_1467_s3_nowcast.md
@@ -469,9 +469,33 @@ ausgelieferten Code + gezielt gesetzte Zustandsdateien (Rezept aus S2 AG5/AG6), 
   Compare-eigene Zweitfassung fortzuführen. Kein neues Architekturprinzip, nur konsequente
   Anwendung des bestehenden auf den letzten noch abweichenden Pfad.
 
+## Nachträge
+
+- **Nachtrag (Issue #2065, 2026-08-22):** die feste Reihenfolge des Bausteins bleibt
+  Ruhezeit → Sperrzeit → Tages-Obergrenze, und `check_nowcast_gate()` bleibt in
+  Signatur UND Verhalten unverändert. Neu ist, was der **Trip-Zweig** mit dem
+  Ergebnis `REASON_COOLDOWN` macht: er hält nicht mehr sofort an, sondern holt den
+  Nowcast (weiterhin **genau EIN** `get_nowcast`-Abruf je Trip, #1329) und prüft mit
+  `alert_gate.radar_overtakes_cooldown()`, ob die gemessene Menge die zuletzt
+  gemeldete deutlich übersteigt (≥ 2,0-fach UND ≥ 2,0 mm im 60-Minuten-Fenster).
+  Kein Treffer → unverändert Stille mit Protokollgrund `cooldown`. Treffer → der Lauf
+  läuft weiter wie im ungesperrten Fall, **inklusive erneuter Prüfung der
+  Tages-Obergrenze** (sie wurde wegen des Abbruchs an der Sperrzeit nie erreicht) und
+  mit derselben Mengen-Feststellung als `quantitative_escalation` an
+  `check_event_identity_gate()`. Die Vergleichsbasis ist die zuletzt gemeldete Menge
+  im `ThrottleStore` (`{"at": iso, "precip_mm": float|null}`, Alt-Einträge als reiner
+  ISO-String bleiben lesbar); sie wird — wie die Sperrzeit selbst — ausschließlich
+  NACH erfolgreicher Zustellung fortgeschrieben (`record_nowcast_sent(precip_mm=…)`,
+  F001-Symmetrie). **Ruhezeit (#1955) und Tages-Obergrenze bleiben unbrechbar.** Der
+  **Ortsvergleich-Nowcast bleibt unverändert** — er schreibt keine Vergleichsmenge und
+  bekommt die Ausnahme nicht (PO-Rückstellung). Details:
+  `docs/specs/modules/fix_2065_verschaerfung_ueberholt_sperre.md`, ADR-0021-Nachtrag
+  vom selben Tag.
+
 ## Changelog
 
 - 2026-08-08: Initiale Spec. Vier Änderungen (a)–(d) nach PO-Entscheidungen E1–E4
   (`docs/context/rework-1467-s3-nowcast.md`) zugeschnitten, geteilter Baustein von Anfang an
   mit beiden Nowcast-Pfaden verdrahtet (Abweichung von der Strategie-Agent-Empfehlung, Analyse
   E1). Zeilenangaben gegen den Ist-Stand vom 2026-08-08 verifiziert.
+- 2026-08-22: Nachtrag zu Issue #2065 (Verschärfung überholt die Sperrzeit im Trip-Zweig).

--- a/src/services/alert_gate.py
+++ b/src/services/alert_gate.py
@@ -391,13 +391,75 @@ def record_nowcast_sent(
     now: datetime,
     zone: ZoneInfo,
     throttle_store: Optional[ThrottleStore] = None,
+    precip_mm: Optional[float] = None,
 ) -> None:
     """Tageszaehler und Sperrzeit buchen — NUR nach erfolgreicher Zustellung.
     #1726: `zone` ist PFLICHT; wer hier eine andere uebergibt als
     `check_nowcast_gate()`, fuellt einen anderen Zaehler als den geprueften.
+
+    Issue #2065: `precip_mm` ist die gemeldete Menge und wird zur
+    Vergleichsbasis der naechsten Ueberholungspruefung
+    (`radar_overtakes_cooldown`). Sie wird — wie die Sperrzeit selbst —
+    ausschliesslich NACH erfolgreicher Zustellung fortgeschrieben
+    (F001-Symmetrie); wer sie weglaesst, hinterlaesst keine Basis.
     """
     alert_daily_limit.increment(user_id, now, zone)
-    _resolve_store(user_id, throttle_store).record(throttle_scope, throttle_key, now)
+    _resolve_store(user_id, throttle_store).record(
+        throttle_scope, throttle_key, now, precip_mm=precip_mm,
+    )
+
+
+# Issue #2065: Definition von "deutlich schlimmer" fuer die Sperrzeit-
+# Ueberholung. Muster identisch zur PO-freigegebenen Briefing-Ueberholung
+# (`trip_alert.py`, F008/#2020), aber mit EIGENEN Konstanten: die
+# Vergleichsbasis ist eine andere (zuletzt GEMELDETE Menge statt
+# Briefing-Ankuendigung), beide Regler sind deshalb eigenstaendig nachziehbar.
+_COOLDOWN_OVERTAKE_FACTOR = 2.0
+_COOLDOWN_OVERTAKE_MIN_ABSOLUTE_MM = 2.0
+
+
+def radar_overtakes_cooldown(
+    *, basis_mm: Optional[float], menge_mm: Optional[float],
+) -> bool:
+    """Ueberholt diese Lage die laufende Sperrzeit? (Issue #2065)
+
+    UND-verknuepft: die Menge muss das `_COOLDOWN_OVERTAKE_FACTOR`-fache der
+    zuletzt gemeldeten Menge erreichen UND fuer sich genommen ueber
+    `_COOLDOWN_OVERTAKE_MIN_ABSOLUTE_MM` liegen. Ohne die absolute
+    Untergrenze verdoppelte sich auch ein Nieselregen "deutlich".
+
+    Fehlt die Vergleichsbasis (kein gespeicherter Wert — z.B. Sperre vom
+    Kurzfristhinweis im Briefing gebucht), gibt es keinen Durchbruch: ein
+    Durchbruch ohne Nachweis waere die gefaehrlichere Fehlerrichtung
+    (Alarmflut), die Stille hier die konservative.
+
+    🔴 Bewusst NICHT in `check_nowcast_gate()`: der Vergleich lebt im
+    Trip-Pfad. Der geteilte Baustein bliebe sonst nicht in Signatur UND
+    Verhalten unveraendert und der PO-zurueckgestellte Ortsvergleich bekaeme
+    die Ausnahme still mit.
+    """
+    if basis_mm is None or menge_mm is None:
+        return False
+    return (
+        menge_mm >= basis_mm * _COOLDOWN_OVERTAKE_FACTOR
+        and menge_mm >= _COOLDOWN_OVERTAKE_MIN_ABSOLUTE_MM
+    )
+
+
+def last_nowcast_precip_mm(
+    *,
+    user_id: str,
+    throttle_scope: str,
+    throttle_key: str,
+    throttle_store: Optional[ThrottleStore] = None,
+) -> Optional[float]:
+    """Die zuletzt gemeldete Menge zu dieser Sperre — die Vergleichsbasis der
+    Ueberholungspruefung (Issue #2065). `None`, wenn der Eintrag aus dem
+    Alt-Format stammt oder ohne Mengenangabe gebucht wurde."""
+    _, precip_mm = _resolve_store(user_id, throttle_store).last_sent_with_precip(
+        throttle_scope, throttle_key,
+    )
+    return precip_mm
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -626,6 +688,7 @@ def check_event_identity_gate(
     window_start: Optional[datetime] = None,
     window_end: Optional[datetime] = None,
     cooldown_minutes: Optional[int] = None,
+    quantitative_escalation: bool = False,
 ) -> GateResult:
     """Darf diese Meldung raus, oder ist sie ein quellenuebergreifendes
     Duplikat einer bereits gemeldeten Meldung (Issue #1467 Scheibe S4b-1)?
@@ -647,7 +710,15 @@ def check_event_identity_gate(
     Verschaerfung (hoehere Dringlichkeit) muss IMMER durchkommen, auch wenn
     ihr Zeitfenster das bereits abgedeckte NICHT wesentlich erweitert
     (AC-10) -- das ist die Absicherung gegen die gefaehrlichste
-    Fehlerrichtung "Alarm bleibt aus"."""
+    Fehlerrichtung "Alarm bleibt aus".
+
+    Issue #2065: `quantitative_escalation` ist eine bereits vom Aufrufer
+    getroffene MENGEN-Feststellung, ODER-verknuepft mit der bestehenden
+    Stufenpruefung. Notwendig, weil die dreistufige Skala
+    LOW/MODERATE/HIGH bei 4 mm/h saettigt: eine Verdreifachung von 11 auf
+    30 mm/h ist zweimal `HIGH`, `exceeds("HIGH","HIGH")` also False — die
+    Verschaerfung ist an dieser Stelle strukturell unsichtbar. Vorbelegt mit
+    `False`: kein Bestandsaufrufer aendert sein Verhalten."""
     if hazard_class is None:
         return _ALLOWED
 
@@ -666,7 +737,7 @@ def check_event_identity_gate(
     new_source = "nowcast" if point_at is not None else "official"
     addendum_direction = match["source"] == "official" and new_source == "nowcast"
 
-    if alert_urgency.exceeds(severity, match["severity"]):
+    if quantitative_escalation or alert_urgency.exceeds(severity, match["severity"]):
         # V2 — struktureller erster Zweig, bricht IMMER durch. In der
         # Nachtrags-Richtung geht DIESELBE Zustellung raus, nur als Nachtrag
         # statt als zweiter voller Alarm (AC-A1); sonst unveraendert.

--- a/src/services/throttle_store.py
+++ b/src/services/throttle_store.py
@@ -49,7 +49,9 @@ class ThrottleStore:
       belegt; eine Wiederverwendung ließe die beiden Alarmarten einander
       gegenseitig unterdrücken.
 
-    Struktur der Datei: ``{scope: {key: iso_timestamp}}``.
+    Struktur der Datei: ``{scope: {key: {"at": iso, "precip_mm": float|null}}}``
+    (Issue #2065). Bestandseintraege im Alt-Format ``{scope: {key: iso}}``
+    bleiben lesbar.
     """
 
     def __init__(self, user_id: str, data_dir: Optional[Path] = None) -> None:
@@ -68,6 +70,18 @@ class ThrottleStore:
         data = self._load()
         return self._parse(data.get(scope, {}).get(key))
 
+    def last_sent_with_precip(
+        self, scope: str, key: str
+    ) -> tuple[Optional[datetime], Optional[float]]:
+        """Zeitpunkt UND zuletzt gemeldete Menge (Issue #2065).
+
+        Bewusst eine EIGENE Lesemethode statt einer Ueberladung von
+        `last_sent()`: dessen 15+ Aufrufer erwarten ein `datetime`, nicht ein
+        Paar. Bei einem Alt-Eintrag (reiner ISO-String, keine Mengenangabe)
+        ist die Menge `None` — der Aufrufer entscheidet konservativ."""
+        raw = self._load().get(scope, {}).get(key)
+        return self._parse(raw), self._parse_precip(raw)
+
     def is_throttled(
         self, scope: str, key: str, cooldown_minutes: Optional[int], now: datetime
     ) -> bool:
@@ -81,8 +95,19 @@ class ThrottleStore:
             return False
         return now - last < timedelta(minutes=cooldown_minutes)
 
-    def record(self, scope: str, key: str, now: datetime) -> None:
-        self._update(lambda data: data.setdefault(scope, {}).__setitem__(key, now.isoformat()))
+    def record(
+        self, scope: str, key: str, now: datetime,
+        precip_mm: Optional[float] = None,
+    ) -> None:
+        """Issue #2065: geschrieben wird ausschliesslich das neue Format
+        `{"at": iso, "precip_mm": float|null}`. Aufrufer ohne Mengenangabe
+        (z.B. der Kurzfristhinweis im Briefing) hinterlassen `null` — daraus
+        entsteht spaeter keine Vergleichsbasis."""
+        eintrag = {
+            "at": now.isoformat(),
+            "precip_mm": float(precip_mm) if precip_mm is not None else None,
+        }
+        self._update(lambda data: data.setdefault(scope, {}).__setitem__(key, eintrag))
 
     def clear(self, scope: str, key: str) -> None:
         def _op(data: dict) -> None:
@@ -159,6 +184,10 @@ class ThrottleStore:
 
     @staticmethod
     def _parse(raw: object) -> Optional[datetime]:
+        # Issue #2065: zwei Eintragsformen -- Bestandsdaten tragen den reinen
+        # ISO-String, neue Eintraege ein Objekt mit `at` und `precip_mm`.
+        if isinstance(raw, dict):
+            raw = raw.get("at")
         if not raw or not isinstance(raw, str):
             return None
         try:
@@ -168,6 +197,17 @@ class ThrottleStore:
         if dt.tzinfo is None:
             dt = dt.replace(tzinfo=timezone.utc)
         return dt
+
+    @staticmethod
+    def _parse_precip(raw: object) -> Optional[float]:
+        """Menge aus einem Eintrag — `None` fuer Alt-Eintraege (reiner
+        String) und fuer neue Eintraege ohne Mengenangabe (Issue #2065)."""
+        if not isinstance(raw, dict):
+            return None
+        wert = raw.get("precip_mm")
+        if isinstance(wert, bool) or not isinstance(wert, (int, float)):
+            return None
+        return float(wert)
 
     # --- Migration (lazy, idempotent, beim ersten Zugriff pro Nutzer) ---
 

--- a/src/services/trip_alert.py
+++ b/src/services/trip_alert.py
@@ -23,6 +23,8 @@ from services.alert_gate import (
     check_event_identity_gate,
     check_nowcast_gate,
     check_official_alert_gate,
+    last_nowcast_precip_mm,
+    radar_overtakes_cooldown,
     record_event_identity,
     record_nowcast_sent,
     resolve_hazard_class,
@@ -1176,6 +1178,30 @@ class TripAlertService:
         trip = backfill_stage_distances(trip, self._user_id, today)
         return resolve_current_segment(trip, now_utc, today)
 
+    def _protokolliere_radar_unterdrueckung(
+        self, trip: "Trip", gate_reason: Optional[str], effective_channels,
+    ) -> None:
+        """Unterdrueckungs-Protokoll des Radar-Zweigs (Issue #2065 zieht die
+        bestehende Fassung hierher, weil der Sperrzeit-Fall jetzt an mehreren
+        Stellen enden kann).
+
+        Absicherung je Trip, nicht um den Stapellauf: scheitert der
+        Protokoll-Eintrag EINES Trips, verlieren sonst ALLE weiteren Trips
+        dieses Nutzers ihren Radar-Alarm (Muster `fix_1479`)."""
+        try:
+            alert_log.append_suppressed_entry(
+                self._user_id, entity_id=trip.id, entity_type="trip",
+                reason=alert_log.REASON_NOWCAST, gate_reason=gate_reason,
+                effective_channels=effective_channels,
+            )
+        except Exception as e:
+            logger.error(
+                "Radar alert: Unterdrueckungs-Protokoll fuer Trip %s "
+                "fehlgeschlagen (%s) — der Alarm blieb aus (Grund: %s), "
+                "nur der Protokoll-Eintrag fehlt.",
+                trip.id, e, gate_reason,
+            )
+
     def check_radar_alerts(self) -> int:
         """
         Check all trips for radar-based alerts using segment-aware logic (Issue #822).
@@ -1286,7 +1312,16 @@ class TripAlertService:
                 zone=anchor_tz(trip, now_utc),
                 throttle_store=self._throttle_store,
             )
-            if not gate.allowed:
+            # Issue #2065: die SPERRZEIT ist die einzige Stufe der Kette, die
+            # eine quantitative Verschaerfung ueberholen darf. Der Lauf haelt
+            # deshalb hier nicht mehr an, sondern holt die Daten und
+            # entscheidet weiter unten gegen die zuletzt gemeldete Menge.
+            # Ruhezeit (#1955, unbrechbar) und Tages-Obergrenze bleiben
+            # unveraendert harte Stops.
+            _sperrzeit_offen = (
+                not gate.allowed and gate.reason == alert_log.REASON_COOLDOWN
+            )
+            if not gate.allowed and not _sperrzeit_offen:
                 logger.debug(
                     f"Radar alert suppressed ({gate.reason}) for trip {trip.id}"
                 )
@@ -1295,19 +1330,9 @@ class TripAlertService:
                 # Trips dieses Nutzers ihren Radar-Alarm (Muster `fix_1479`).
                 # Breite Klausel + laute Meldung mit Kennung, wie beim
                 # Nowcast-Abruf ein paar Zeilen weiter unten.
-                try:
-                    alert_log.append_suppressed_entry(
-                        self._user_id, entity_id=trip.id, entity_type="trip",
-                        reason=alert_log.REASON_NOWCAST, gate_reason=gate.reason,
-                        effective_channels=effective_channels,
-                    )
-                except Exception as e:
-                    logger.error(
-                        "Radar alert: Unterdrueckungs-Protokoll fuer Trip %s "
-                        "fehlgeschlagen (%s) — der Alarm blieb aus (Grund: %s), "
-                        "nur der Protokoll-Eintrag fehlt.",
-                        trip.id, e, gate.reason,
-                    )
+                self._protokolliere_radar_unterdrueckung(
+                    trip, gate.reason, effective_channels,
+                )
                 continue
 
             # Genau EIN get_nowcast-Call pro Trip (Budget, #1329) — seit
@@ -1353,6 +1378,10 @@ class TripAlertService:
                     "uebrigen Trips dieses Nutzers laufen weiter.",
                     trip.id, e,
                 )
+                if _sperrzeit_offen:
+                    self._protokolliere_radar_unterdrueckung(
+                        trip, gate.reason, effective_channels,
+                    )
                 continue
             lat = _pos.lat
             lon = _pos.lon
@@ -1375,7 +1404,78 @@ class TripAlertService:
                 )
             except Exception as e:
                 logger.error(f"Radar nowcast failed for trip {trip.id}: {e}")
+                if _sperrzeit_offen:
+                    self._protokolliere_radar_unterdrueckung(
+                        trip, gate.reason, effective_channels,
+                    )
                 continue
+
+            # Issue #2065: die gemessene Menge wird HIER festgehalten --
+            # `result` traegt weiter unten die NotificationResult, die
+            # Vergleichsbasis der naechsten Runde muss aber aus DIESEM Abruf
+            # stammen.
+            _menge_mm = result.window_precip_mm
+
+            # Issue #2065: Ueberholungs-Entscheidung gegen die zuletzt
+            # gemeldete Menge. Bewusst VOR dem Ausloese-Guard
+            # (`radar_alert_due`): so bekommt jeder Lauf, der AN DER SPERRZEIT
+            # haengenbleibt, weiterhin seinen Protokoll-Eintrag mit Grund
+            # `cooldown` — unabhaengig davon, ob die Lage alarmwuerdig waere.
+            #
+            # 🔴 Nach einem erfolgreichen Durchbruch gilt das NICHT mehr, und
+            # das ist Absicht: der Durchgang ist dann nicht mehr gesperrt und
+            # verhaelt sich ab hier wie ein freier Lauf. Scheitert er
+            # anschliessend am Ausloese-Guard (`radar_alert_due`) oder am
+            # Doppel-Alarm-Guard, bleibt er genauso still wie ein freier Lauf
+            # in derselben Lage — „nicht alarmwuerdig" ist in diesem System
+            # kein Unterdrueckungs-Ereignis und bekommt keinen `alert_log`-
+            # Eintrag. Ein `cooldown`-Eintrag waere dort schlicht falsch: die
+            # Sperrzeit hat diesen Lauf ja gerade NICHT unterdrueckt. Die
+            # Entscheidung selbst bleibt ueber die `logger.info`-Zeile weiter
+            # unten nachvollziehbar (AC-13, beide Ausgaenge). Festgenagelt in
+            # `tests/tdd/test_radar_cooldown_overtake.py`
+            # (`test_f001_durchbruch_ohne_ausloeser_verhaelt_sich_wie_ein_freier_lauf`).
+            _ueberholt_sperrzeit = False
+            if _sperrzeit_offen:
+                _basis_mm = last_nowcast_precip_mm(
+                    user_id=self._user_id, throttle_scope=_RADAR_THROTTLE_SCOPE,
+                    throttle_key=trip.id, throttle_store=self._throttle_store,
+                )
+                _ueberholt_sperrzeit = radar_overtakes_cooldown(
+                    basis_mm=_basis_mm, menge_mm=_menge_mm,
+                )
+                # Beide Zahlen in EINER Zeile, damit im Nachhinein
+                # nachvollziehbar ist, GEGEN WAS entschieden wurde -- fuer
+                # beide Ausgaenge (Durchbruch und Stille).
+                logger.info(
+                    "Radar alert: Sperrzeit-Ueberholung fuer Trip %s geprueft — "
+                    "Vergleichsbasis %s mm, gemessene Menge %.1f mm: %s",
+                    trip.id,
+                    "unbekannt" if _basis_mm is None else f"{_basis_mm:.1f}",
+                    _menge_mm,
+                    "Durchbruch" if _ueberholt_sperrzeit else "Sperrzeit bleibt",
+                )
+                if not _ueberholt_sperrzeit:
+                    self._protokolliere_radar_unterdrueckung(
+                        trip, gate.reason, effective_channels,
+                    )
+                    continue
+                # Die Tages-Obergrenze wurde wegen des Abbruchs an der
+                # Sperrzeit nie geprueft (feste Reihenfolge, ADR-0021) -- der
+                # Durchbruch darf sie nicht stillschweigend mit-ueberspringen.
+                # Rein lesend; gebucht wird weiterhin erst nach Zustellung.
+                if not alert_daily_limit.is_allowed(
+                    self._user_id, now_utc, anchor_tz(trip, now_utc),
+                    reason="nowcast",
+                ):
+                    logger.debug(
+                        "Radar alert suppressed (Tages-Obergrenze nach "
+                        "Sperrzeit-Durchbruch) for trip %s", trip.id,
+                    )
+                    self._protokolliere_radar_unterdrueckung(
+                        trip, alert_log.REASON_DAILY_LIMIT, effective_channels,
+                    )
+                    continue
 
             # Issue #2009: EINE geteilte Schwelle statt zweier Literale
             # (ADR-0021). Bewusst ueber die Modul-Referenz gelesen, nicht als
@@ -1574,6 +1674,11 @@ class TripAlertService:
                     [_radar_request.segment_id] if _radar_request.segment_id else []
                 ),
                 severity=_radar_urgency, now=now_utc, point_at=_onset_dt,
+                # Issue #2065: dieselbe Mengen-Feststellung, die schon die
+                # Sperrzeit ueberholt hat -- die Stufenskala saettigt bei
+                # 4 mm/h und kann die Verschaerfung nicht sehen. Ohne diese
+                # Haelfte bliebe der Alarm aus, nur mit anderem Grund.
+                quantitative_escalation=_ueberholt_sperrzeit,
             )
             if not _identity_gate.allowed:
                 logger.debug(
@@ -1669,6 +1774,10 @@ class TripAlertService:
                 throttle_key=trip.id, now=datetime.now(timezone.utc),
                 zone=anchor_tz(trip, now_utc),
                 throttle_store=self._throttle_store,
+                # Issue #2065: Vergleichsbasis der naechsten Runde --
+                # Selbstbremsung, die naechste Verschaerfung muss den vollen
+                # Faktor gegen DIESE Menge erreichen.
+                precip_mm=_menge_mm,
             )
             # Issue #1467 S4b-1 (AC-2/AC-3, F001-Symmetrie): NUR nach
             # erfolgreicher Zustellung -- ein spaeterer amtlicher Alarm

--- a/tests/tdd/test_alert_gate.py
+++ b/tests/tdd/test_alert_gate.py
@@ -1889,3 +1889,123 @@ def test_2018_normalfall_ohne_kaputten_eintrag_loggt_keine_warnung(caplog):
         )
     finally:
         clean_uid(uid)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Issue #2065 — Verschaerfung ueberholt die Radar-Sperrzeit
+# SPEC: docs/specs/modules/fix_2065_verschaerfung_ueberholt_sperre.md
+#
+# Der Ortsvergleich ist PO-seitig zurueckgestellt: die Ausnahme wirkt
+# ausschliesslich im Trip-Pfad. Konstruktiv abgesichert dadurch, dass der neue
+# Vergleichs-Helfer im Aufrufgraphen von `check_nowcast_gate` gar nicht
+# vorkommt — das Gate bleibt in Signatur UND Verhalten unveraendert (AC-12).
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def test_ac12_2065_check_nowcast_gate_bekommt_keinen_pflichtparameter_dazu():
+    """AC-12 (Regressionswaechter, HEUTE SCHON GRUEN — kein RED-Nachweis).
+
+    GIVEN den Ortsvergleich-Radarpfad (`compare_radar_alert.py`), der
+    `check_nowcast_gate` als zweiter Produktiv-Aufrufer benutzt, WHEN die
+    #2065-Aenderung ausgeliefert ist, THEN nimmt das Gate keine neuen
+    Parameter OHNE Vorgabewert entgegen — weder eine Verschaerfungsangabe noch
+    eine Vergleichsbasis wandert nachtraeglich in den geteilten Baustein.
+
+    Geprueft wird die Menge der PFLICHT-Parameter (ohne Default), nicht die
+    Gesamtsignatur: ein rein optionaler Zusatz bliebe erlaubt, ein neuer
+    Pflichtparameter braeche jeden Bestandsaufrufer. Zusaetzlich wird
+    ausdruecklich verboten, dass eine Mengen-/Basis-Angabe ueberhaupt in
+    dieser Signatur auftaucht (auch nicht mit Default) — der Speicherzugriff
+    gehoert laut Spec NICHT in den geteilten Baustein."""
+    import inspect
+
+    from services.alert_gate import check_nowcast_gate
+
+    params = inspect.signature(check_nowcast_gate).parameters
+    pflicht = {
+        name for name, p in params.items()
+        if p.default is inspect.Parameter.empty
+        and p.kind not in (p.VAR_POSITIONAL, p.VAR_KEYWORD)
+    }
+    erwartet = {
+        "user_id", "throttle_scope", "throttle_key", "cooldown_minutes",
+        "quiet_from", "quiet_to", "context_label", "now", "zone",
+    }
+    assert pflicht == erwartet, (
+        f"check_nowcast_gate hat seine PFLICHT-Parameter veraendert: "
+        f"neu={sorted(pflicht - erwartet)!r}, entfallen={sorted(erwartet - pflicht)!r} "
+        f"(voller Parametersatz: {sorted(params)!r})"
+    )
+    verbotene = {
+        n for n in params
+        if "precip" in n or "overtake" in n or "ueberhol" in n
+        or "verschaerf" in n or "escalat" in n or "eskalat" in n
+    }
+    assert not verbotene, (
+        f"check_nowcast_gate darf keine Verschaerfungs-/Mengenangabe kennen — "
+        f"der Vergleich lebt im Trip-Pfad, nicht im geteilten Baustein: "
+        f"{sorted(verbotene)!r}"
+    )
+
+
+def test_ac14_2065_adr_0021_und_s3_spec_tragen_einen_datierten_nachtrag():
+    """AC-14. ``# doc-compliance-test`` (Ausnahme von der Dateiinhalt-Regel,
+    CLAUDE.md; Vorbild `test_ac21_adr_0021_traegt_einen_datierten_s4b_nachtrag`).
+
+    GIVEN ADR-0021 schreibt die feste Reihenfolge Ruhezeit -> Sperrzeit ->
+    Tages-Obergrenze als geteilten Baustein fuer Trip UND Ortsvergleich fest,
+    WHEN #2065 eine Ausnahme in diese Kette einfuehrt, THEN traegt ADR-0021
+    einen DATIERTEN Nachtrag mit Bezug auf '#2065' — einsortiert NACH dem
+    letzten bestehenden Nachtrag (#2018) — der die Ausnahme beschreibt UND
+    begruendet, warum der Ortsvergleich sie nicht bekommt; zusaetzlich traegt
+    `docs/specs/modules/rework_1467_s3_nowcast.md` (die Spec der geteilten
+    Gate-Kette) einen entsprechenden Nachtrag.
+
+    Eine dokumentierte Entscheidung wird nie still zurueckgenommen.
+
+    RED heute: beide Nachtraege fehlen."""
+    import re
+    from pathlib import Path
+
+    wurzel = Path(__file__).resolve().parents[2]
+
+    adr = (wurzel / "docs" / "adr" / "0021-shared-deviation-alert-engine.md").read_text(
+        encoding="utf-8"
+    )
+    treffer = re.search(r"Nachtrag \(Issue #2065, (\d{4}-\d{2}-\d{2})\)", adr)
+    assert treffer is not None, (
+        "ADR-0021 muss einen Nachtrag im Format der bestehenden tragen: "
+        "'**Nachtrag (Issue #2065, JJJJ-MM-TT):**'"
+    )
+    pos_2018 = adr.find("Nachtrag (Issue #2018")
+    assert pos_2018 != -1, "Der bestehende #2018-Nachtrag darf nicht verschwinden"
+    assert treffer.start() > pos_2018, (
+        f"Der #2065-Nachtrag muss NACH dem #2018-Nachtrag stehen "
+        f"(Reihenfolge = Chronologie; pos_2018={pos_2018}, "
+        f"pos_2065={treffer.start()})"
+    )
+    absatz = adr[treffer.start():]
+    naechster = absatz.find("\n- **Nachtrag (", 1)
+    if naechster != -1:
+        absatz = absatz[:naechster]
+    assert "Ortsvergleich" in absatz, (
+        "Der #2065-Nachtrag muss ausdruecklich begruenden, warum der "
+        "ORTSVERGLEICH die Ausnahme NICHT bekommt."
+    )
+    assert "Sperrzeit" in absatz, (
+        "Der #2065-Nachtrag muss benennen, welche Stufe der Kette die Ausnahme "
+        "betrifft (Sperrzeit)."
+    )
+
+    spec = (wurzel / "docs" / "specs" / "modules" / "rework_1467_s3_nowcast.md").read_text(
+        encoding="utf-8"
+    )
+    assert "#2065" in spec, (
+        "Die Spec der geteilten Gate-Kette (rework_1467_s3_nowcast.md) muss den "
+        "neuen Zweig mitfuehren — sonst beschreibt sie eine Kette, die es so "
+        "nicht mehr gibt."
+    )
+    spec_absatz = spec[spec.find("#2065"):][:1200]
+    assert re.search(r"\d{4}-\d{2}-\d{2}", spec_absatz), (
+        "Der #2065-Nachtrag in rework_1467_s3_nowcast.md muss DATIERT sein."
+    )

--- a/tests/tdd/test_compare_radar_alert_event_identity.py
+++ b/tests/tdd/test_compare_radar_alert_event_identity.py
@@ -842,11 +842,14 @@ def _parameter_form(fn) -> list[tuple[str, str, bool]]:
 def test_ac17_signaturen_des_geteilten_bausteins_bleiben_unveraendert():
     """AC-17: Diese Scheibe verdrahtet den bestehenden Baustein nur an zwei
     NEUEN Aufrufstellen — `check_event_identity_gate`, `record_event_identity`
-    und `resolve_hazard_class` behalten ihre S4b-1-Signatur unveraendert (kein
-    neuer Parameter, keine geaenderte Uebergabeart, kein neuer Default).
+    und `resolve_hazard_class` bekommen fuer Compare KEINEN Parameter dazu und
+    keine geaenderte Uebergabeart.
 
-    Regressionstest — heute schon gruen; er faellt erst, wenn jemand den
-    geteilten Baustein fuer Compare „passend macht" statt ihn zu benutzen."""
+    Regressionstest — er faellt, sobald jemand den geteilten Baustein fuer
+    Compare „passend macht" statt ihn zu benutzen. Die Listen sind ein
+    EXAKTER Vergleich: auch eine Erweiterung fuer einen anderen Aufrufer
+    faellt hier auf und muss — wie unten fuer #2065 geschehen — mit
+    Begruendung eingetragen werden."""
     from services.alert_gate import (
         check_event_identity_gate, record_event_identity, resolve_hazard_class,
     )
@@ -862,6 +865,13 @@ def test_ac17_signaturen_des_geteilten_bausteins_bleiben_unveraendert():
         ("window_start", "KEYWORD_ONLY", True),
         ("window_end", "KEYWORD_ONLY", True),
         ("cooldown_minutes", "KEYWORD_ONLY", True),
+        # Issue #2065, 2026-08-22: zulaessig, weil TRIP-seitig und rein
+        # optional — Vorgabewert `False`, den kein Compare-Aufrufer setzt.
+        # Der Ortsvergleich verhaelt sich damit unveraendert; die Ausnahme
+        # „Verschaerfung ueberholt die Sperrzeit" wirkt ausschliesslich im
+        # Trip-Zweig (ADR-0021-Nachtrag vom selben Tag, Abschnitt „warum der
+        # Ortsvergleich sie NICHT bekommt").
+        ("quantitative_escalation", "KEYWORD_ONLY", True),
     ], f"check_event_identity_gate: {_parameter_form(check_event_identity_gate)!r}"
 
     assert _parameter_form(record_event_identity) == [

--- a/tests/tdd/test_official_alert_cooldown_entkopplung.py
+++ b/tests/tdd/test_official_alert_cooldown_entkopplung.py
@@ -93,7 +93,14 @@ def _aenderungsalarm_zugestellt_um(user_id: str, vor_minuten: int) -> datetime:
 
 
 def _sperrzeit_eintrag(user_id: str):
-    return (read_throttle_state(user_id).get(SCOPE_TRIP) or {}).get(TRIP)
+    """Issue #2065: der Eintrag traegt seit dieser Aenderung die zuletzt
+    gemeldete Menge mit (`{"at": iso, "precip_mm": float|null}`). Gelesen
+    wird deshalb ueber die oeffentliche Store-Schnittstelle, die BEIDE
+    Formate kennt — die Zusicherung dieses Tests ist "es steht ein neuerer
+    Zeitpunkt drin", nicht "die Datei sieht so und so aus"."""
+    from services.throttle_store import ThrottleStore
+
+    return ThrottleStore(user_id).last_sent(SCOPE_TRIP, TRIP)
 
 
 # ═══════════ AC-4 (Kernfall): Eskalation kommt trotz Sperrzeit an ═══════════
@@ -196,7 +203,7 @@ def test_ac5_amtlicher_alarm_schreibt_weiterhin_in_den_trip_sperrzeit_topf(nutze
     assert nachher != vorher, (
         f"Der Eintrag muss NEU sein, nicht der vorbelegte: vorher={vorher!r}, "
         f"nachher={nachher!r}")
-    assert datetime.fromisoformat(nachher) > vorher_moment, (
+    assert nachher > vorher_moment, (
         f"Der neue Eintrag muss nach {vorher_moment} liegen, steht auf {nachher!r}")
 
 

--- a/tests/tdd/test_radar_cooldown_overtake.py
+++ b/tests/tdd/test_radar_cooldown_overtake.py
@@ -1,0 +1,798 @@
+"""TDD RED — Issue #2065: eine Verschaerfung ueberholt die Radar-Sperrzeit.
+
+SPEC: docs/specs/modules/fix_2065_verschaerfung_ueberholt_sperre.md
+(AC-1 bis AC-10 und AC-13; AC-11 liegt in `test_throttle_store.py`,
+AC-12/AC-14 in `test_alert_gate.py`.)
+
+Gemessener Ausgangsbefund (Analyse 2026-08-22): Lauf 1 mit 11 mm/h (~10,08 mm
+im 60-Min-Vergleichsfenster) loest aus und bucht 120 Min Sperrzeit; 90 Minuten
+spaeter schweigt eine auf 30 mm/h (~27,5 mm) verdreifachte Lage mit
+Protokollgrund `cooldown`. Hinter der Sperrzeit steht eine ZWEITE Wand: die
+Entdopplung vergleicht auf der dreistufigen Skala LOW/MODERATE/HIGH, die bei
+4 mm/h saettigt — `exceeds("HIGH","HIGH")` ist False (AC-5).
+
+Alle Zeitreihen laufen ueber `AlarmPruefstrecke` (#2050 S1) gegen die ECHTE
+Ausloeseentscheidung `TripAlertService.check_radar_alerts()`. Kein
+Mock()/patch()/MagicMock: echter `RadarNowcastService` an seiner DI-Naht
+`frame_source=`, echte Zustandsdateien unter `get_data_dir(user_id)`,
+Unterdrueckungsgrund ueber `alert_log.read_undelivered()`.
+
+BEWUSST OHNE BRIEFING-ANKER: ohne `save_dated()`-Schnappschuss ist
+`_briefing_announced` False (`trip_alert.py:1400`) und die Briefing-
+Ueberholung faellt als Entscheidungsgrund komplett aus. Waere ein Anker
+gesetzt, koennte die Stille in AC-3/AC-4 auch von IHR kommen — die geprueften
+Bedingungen waeren dann nie die wirksamen.
+
+Keine Wanduhr: alle Zeitpunkte haengen an `_AT` (gestellte Uhr).
+
+MENGEN-HERLEITUNG (`window_precip_mm`, `radar_service.py:765-805`):
+`_accumulate_precip_mm` gibt jedem Frame die Dauer bis zum naechsten Frame,
+gedeckelt auf `_MAX_FRAME_COVERAGE` (15 Min) und nie ueber das Fensterende
+(`now + _OVERTAKE_COMPARE_WINDOW_MIN`, 60 Min) hinaus.
+
+* `_dauerregen(r)`  — Frames bei +5/+20/+35/+50 -> 15+15+15+10 = 55 Min
+  Deckung -> `r * 55/60` mm. 11 mm/h -> 10,083 mm; 30 mm/h -> 27,5 mm.
+* `_kurze_spitze(r)` — Frames bei +5 (r) und +15 (0,0) -> 10 Min Deckung
+  -> `r * 10/60` mm.
+
+Jede benutzte Menge wird zusaetzlich am ECHTEN Nowcast-Ergebnis GEMESSEN
+(`_gemessene_menge`), nicht nur gerechnet.
+"""
+from __future__ import annotations
+
+import logging
+import re
+import uuid
+from datetime import datetime, timedelta
+
+from freezegun import freeze_time
+
+from services import alert_log
+from services.radar_cache import reset_shared_radar_cache_for_tests
+
+from tests.helpers.alarm_pruefstrecke import AlarmPruefstrecke
+from tests.tdd.test_952_onset_alert_fidelity import _clean_user
+from tests.tdd.test_alarm_pruefstrecke_selbstschutz import (
+    _AT, _radar_trip, _settings_all_channels, _write_premium_profile, _write_tier,
+)
+from tests.tdd.test_alarm_szenario_briefing_ueberholung_zeitreihe import (
+    _dauerregen, _kurze_spitze, _radar,
+)
+
+# Die beiden Werte des gemessenen #2065-Falls.
+BASIS_RATE_MM_H = 11.0          # -> ~10,08 mm Vergleichsbasis
+VERSCHAERFT_RATE_MM_H = 30.0    # -> ~27,5 mm, Faktor 2,73 gegen die Basis
+BASIS_MM = 11.0 * 55 / 60
+VERSCHAERFT_MM = 30.0 * 55 / 60
+
+
+def _uid(tag: str) -> str:
+    return f"tdd-2065-{tag}-{uuid.uuid4().hex[:6]}"
+
+
+def _rate_dauerregen(mm: float) -> float:
+    """Rate, die als Dauerregen genau `mm` im Vergleichsfenster ergibt."""
+    return mm * 60.0 / 55.0
+
+
+def _rate_spitze(mm: float) -> float:
+    """Rate, die als 10-Minuten-Spitze genau `mm` im Vergleichsfenster ergibt."""
+    return mm * 60.0 / 10.0
+
+
+def _aufbau(uid: str, tag: str, *, tier: str = "premium", **flags):
+    """Nutzer + Trip mit allen vier Kanaelen (sofern nicht anders verlangt).
+    Kein Briefing-Anker (s. Moduldoku)."""
+    _clean_user(uid)
+    if tier == "premium":
+        _write_premium_profile(uid, _AT)
+    else:
+        _write_tier(uid, tier)
+    kanaele = {
+        "send_email": True, "send_telegram": True,
+        "send_sms": True, "send_premium_sms": True,
+    }
+    kanaele.update(flags)
+    with freeze_time(_AT):
+        trip = _radar_trip(uid, f"trip-2065-{tag}", **kanaele)
+    return trip
+
+
+def _gemessene_menge(trip, quelle, at: datetime) -> float:
+    """`window_precip_mm` aus einem ECHTEN Nowcast-Abruf — die Zahl, mit der
+    der Prueflauf spaeter rechnet, nicht eine im Test nachgerechnete.
+
+    Der Frame-Cache ist ein PROZESS-Singleton mit Koordinaten-Schluessel
+    (TTL 300 s): ohne Reset liefert der naechste Abruf die Frames dieses
+    zurueck (#2050 S1, Falle 2 der Pruefstrecke). Die Koordinaten duerfen von
+    denen des Prueflings abweichen — die Frame-Quelle ignoriert sie."""
+    lat, lon = trip.stages[0].waypoints[0].lat, trip.stages[0].waypoints[0].lon
+    with freeze_time(at):
+        reset_shared_radar_cache_for_tests()
+        ergebnis = _radar(quelle).get_nowcast(lat, lon)
+        reset_shared_radar_cache_for_tests()
+    return ergebnis.window_precip_mm
+
+
+def _gruende(uid: str, trip, seit: datetime) -> set:
+    """Alle Nicht-Zustellungs-Gruende, die der PRUEFLING selbst protokolliert
+    hat (`alert_log.read_undelivered()`) — kein Dateiinhalt-Check, kein
+    zweiter Lesepfad im Testkoerper."""
+    vorfaelle = alert_log.read_undelivered(
+        uid, entity_id=trip.id, entity_type="trip", since=seit,
+    )
+    return {g for v in vorfaelle for g in v.reasons}
+
+
+def _zahlen(text: str) -> list:
+    return [float(z) for z in re.findall(r"\d+[.,]\d+", text.replace(",", "."))]
+
+
+def _entscheidungszeile(caplog, basis: float, menge: float, tol: float = 0.06):
+    """Die Protokollzeile der Ueberholungsentscheidung: EINE Zeile aus
+    `trip_alert`, die BEIDE Groessen traegt — gelesene Vergleichsbasis UND
+    aktuell gemessene Menge (AC-13).
+
+    Geprueft wird auf ZAHLEN mit Nachkommastelle, nicht auf Wortlaut: die
+    Formulierung ist Sache der Implementierung, die beiden Werte sind es
+    nicht. `tol=0.06` laesst Rundung auf eine Nachkommastelle zu (10,083 ->
+    "10.1"), nicht aber auf ganze Zahlen — eine ganzzahlige Angabe verloere
+    genau die Nachvollziehbarkeit, um die es hier geht."""
+    for rec in caplog.records:
+        if rec.name != "trip_alert":
+            continue
+        text = rec.getMessage()
+        gefunden = _zahlen(text)
+        if any(abs(z - basis) <= tol for z in gefunden) and any(
+            abs(z - menge) <= tol for z in gefunden
+        ):
+            return text
+    return None
+
+
+# ───────────────────────────── AC-1 / AC-5 ───────────────────────────────────
+
+
+def test_ac1_verschaerfung_ueberholt_die_laufende_sperrzeit_auf_allen_kanaelen():
+    """AC-1. GIVEN eine laufende Sperrzeit aus einem Alarm ueber ~10 mm
+    (11 mm/h), WHEN 90 Minuten spaeter im selben Sperrfenster eine Lage mit
+    ~27,5 mm (30 mm/h) geprueft wird, THEN geht ein Alarm ueber ALLE vier
+    konfigurierten Kanaele raus.
+
+    RED heute: `check_nowcast_gate` prueft die Sperrzeit unbedingt vor jeder
+    Verschaerfungsbewertung und kennt keine Ausnahme -> `triggered_count == 0`,
+    Protokollgrund `cooldown`."""
+    uid = _uid("ac1")
+    try:
+        trip = _aufbau(uid, "ac1")
+        assert abs(_gemessene_menge(trip, _dauerregen(BASIS_RATE_MM_H), _AT)
+                   - BASIS_MM) < 0.01
+        assert abs(_gemessene_menge(trip, _dauerregen(VERSCHAERFT_RATE_MM_H), _AT)
+                   - VERSCHAERFT_MM) < 0.01
+
+        strecke = AlarmPruefstrecke(user_id=uid, settings=_settings_all_channels())
+        lauf1 = strecke.lauf(
+            at=_AT, zweig="radar", trip=trip,
+            radar_service=_radar(_dauerregen(BASIS_RATE_MM_H)),
+        )
+        assert lauf1.triggered_count == 1, (
+            f"AC-1 Vorbedingung: Lauf 1 (~{BASIS_MM:.2f} mm) muss ausloesen und "
+            f"dabei Sperrzeit UND Vergleichsbasis buchen "
+            f"(war {lauf1.triggered_count})."
+        )
+
+        at3 = _AT + timedelta(minutes=90)
+        lauf3 = strecke.lauf(
+            at=at3, zweig="radar", trip=trip,
+            radar_service=_radar(_dauerregen(VERSCHAERFT_RATE_MM_H)),
+        )
+        assert lauf3.triggered_count == 1, (
+            f"AC-1: ~{VERSCHAERFT_MM:.2f} mm gegen eine Vergleichsbasis von "
+            f"~{BASIS_MM:.2f} mm (Faktor {VERSCHAERFT_MM / BASIS_MM:.2f}) muessen "
+            f"die laufende Sperrzeit ueberholen. War "
+            f"triggered_count={lauf3.triggered_count}, protokollierte Gruende: "
+            f"{_gruende(uid, trip, at3)!r}"
+        )
+        assert lauf3.mail and lauf3.telegram and lauf3.sms and lauf3.premium_sms, (
+            f"AC-1: alle vier Kanaele muessen Inhalt tragen: mail={lauf3.mail!r} "
+            f"telegram={lauf3.telegram!r} sms={lauf3.sms!r} "
+            f"premium_sms={lauf3.premium_sms!r}"
+        )
+    finally:
+        _clean_user(uid)
+
+
+def test_ac5_der_durchbruch_wirkt_auch_an_der_entdopplung():
+    """AC-5. GIVEN dieselbe Verschaerfung wie in AC-1, WHEN der Alarm geprueft
+    wird, THEN wirkt der Durchbruch AUCH an der Entdopplung — der Alarm kommt
+    an und wurde NICHT mit `event_duplicate` unterdrueckt.
+
+    Die Vorbedingung wird POSITIV nachgewiesen: nach Lauf 1 traegt das
+    Ereignis-Register einen Eintrag mit `severity == "HIGH"`. Weil die Skala
+    bei 4 mm/h saettigt (`HEAVY_RAIN_THRESHOLD_MM_H`), ist auch die
+    verdreifachte Lage wieder `HIGH` — `alert_urgency.exceeds("HIGH","HIGH")`
+    ist False, die bestehende Eskalationspruefung kann die Verschaerfung also
+    strukturell nicht sehen. Ohne diesen Nachweis koennte ein gruener Test
+    nicht zwischen 'die Entdopplung wurde ueberholt' und 'die Entdopplung war
+    gar nicht geladen' unterscheiden (Befund A der Analyse).
+
+    RED heute: der Lauf schweigt schon an der Sperrzeit."""
+    uid = _uid("ac5")
+    try:
+        trip = _aufbau(uid, "ac5")
+        strecke = AlarmPruefstrecke(user_id=uid, settings=_settings_all_channels())
+        lauf1 = strecke.lauf(
+            at=_AT, zweig="radar", trip=trip,
+            radar_service=_radar(_dauerregen(BASIS_RATE_MM_H)),
+        )
+        assert lauf1.triggered_count == 1, "AC-5 Vorbedingung: Lauf 1 muss ausloesen"
+
+        from services.alert_state import AlertStateService
+        register = AlertStateService(uid).load(trip.id)
+        stufen = [
+            eintrag.get("severity") for schluessel, eintrag in register.items()
+            if schluessel.startswith("event_identity:") and isinstance(eintrag, dict)
+        ]
+        assert stufen == ["HIGH"], (
+            f"AC-5 Vorbedingung: Lauf 1 muss GENAU EINEN Ereignis-Eintrag mit "
+            f"Stufe HIGH registriert haben — sonst kann die Entdopplung den "
+            f"zweiten Lauf gar nicht blockieren und der Test bewacht nichts. "
+            f"Registriert: {stufen!r}"
+        )
+
+        at3 = _AT + timedelta(minutes=90)
+        lauf3 = strecke.lauf(
+            at=at3, zweig="radar", trip=trip,
+            radar_service=_radar(_dauerregen(VERSCHAERFT_RATE_MM_H)),
+        )
+        gruende = _gruende(uid, trip, at3)
+        assert alert_log.REASON_EVENT_DUPLICATE not in gruende, (
+            f"AC-5: die Verschaerfung darf nicht an der ENTDOPPLUNG haengen "
+            f"bleiben (Stufenvergleich HIGH gegen HIGH). Gruende: {gruende!r}"
+        )
+        assert lauf3.triggered_count == 1, (
+            f"AC-5: der Alarm muss tatsaechlich ankommen, nicht nur einen "
+            f"anderen Unterdrueckungsgrund bekommen. War "
+            f"triggered_count={lauf3.triggered_count}, Gruende: {gruende!r}"
+        )
+    finally:
+        _clean_user(uid)
+
+
+# ─────────────────────────────── AC-2 ────────────────────────────────────────
+
+
+def test_ac2_unveraenderte_lage_bleibt_mit_grund_sperrzeit_unterdrueckt():
+    """AC-2 (Regressionswaechter, HEUTE SCHON GRUEN). GIVEN eine laufende
+    Sperrzeit, WHEN die Lage gegenueber der letzten Meldung unveraendert
+    bleibt, THEN bleibt die Unterdrueckung bestehen und das Protokoll weist
+    `cooldown` aus.
+
+    Bewacht die gefaehrlichste Fehlerrichtung dieser Aenderung: aus der
+    Sperrzeit darf keine Attrappe werden."""
+    uid = _uid("ac2")
+    try:
+        trip = _aufbau(uid, "ac2")
+        strecke = AlarmPruefstrecke(user_id=uid, settings=_settings_all_channels())
+        lauf1 = strecke.lauf(
+            at=_AT, zweig="radar", trip=trip,
+            radar_service=_radar(_dauerregen(BASIS_RATE_MM_H)),
+        )
+        assert lauf1.triggered_count == 1, "AC-2 Vorbedingung: Lauf 1 muss ausloesen"
+
+        at2 = _AT + timedelta(minutes=30)
+        lauf2 = strecke.lauf(
+            at=at2, zweig="radar", trip=trip,
+            radar_service=_radar(_dauerregen(BASIS_RATE_MM_H)),
+        )
+        assert lauf2.triggered_count == 0, (
+            f"AC-2: unveraenderte Lage darf die Sperre NICHT durchbrechen "
+            f"(war {lauf2.triggered_count})."
+        )
+        gruende = _gruende(uid, trip, at2)
+        assert alert_log.REASON_COOLDOWN in gruende, (
+            f"AC-2: der Protokollgrund muss die SPERRZEIT "
+            f"({alert_log.REASON_COOLDOWN!r}) bleiben. Gefunden: {gruende!r}"
+        )
+    finally:
+        _clean_user(uid)
+
+
+# ──────────────────────────── AC-3 / AC-4 ────────────────────────────────────
+
+
+def test_ac3_faktor_erreicht_aber_unter_der_absoluten_untergrenze(caplog):
+    """AC-3. GIVEN eine Verschaerfung, die den Faktor 2,0 erreicht, deren
+    Gesamtmenge aber unter der absoluten Untergrenze von 2,0 mm bleibt, WHEN
+    der Vergleich laeuft, THEN bricht die Sperre NICHT durch.
+
+    Konstruktion so gewaehlt, dass GENAU EINE Bedingung entscheidet: Basis
+    0,8 mm (4,8 mm/h als 10-Min-Spitze — dieselbe Intensitaetsstufe wie der
+    Ausloesefall, aber winzige Menge), neue Menge 1,9 mm. Faktor:
+    1,9 / 0,8 = 2,375 — LOCKER erfuellt. Absolute Untergrenze: 1,9 < 2,0 —
+    allein sie verhindert den Durchbruch. Entfiele die Untergrenze, muss
+    dieser Test rot werden.
+
+    RED heute: der Lauf schweigt zwar auch, fuehrt die Ueberholungspruefung
+    aber gar nicht erst aus — deshalb wird zusaetzlich die
+    Entscheidungs-Protokollzeile (AC-13) verlangt, die heute fehlt."""
+    uid = _uid("ac3")
+    basis_mm, neue_mm = 0.8, 1.9
+    try:
+        trip = _aufbau(uid, "ac3")
+        gemessen_basis = _gemessene_menge(
+            trip, _kurze_spitze(_rate_spitze(basis_mm)), _AT,
+        )
+        gemessen_neu = _gemessene_menge(
+            trip, _kurze_spitze(_rate_spitze(neue_mm)), _AT,
+        )
+        assert abs(gemessen_basis - basis_mm) < 0.01, (
+            f"AC-3 Testkonstruktion: Basis erwartet {basis_mm} mm, gemessen "
+            f"{gemessen_basis} mm."
+        )
+        assert abs(gemessen_neu - neue_mm) < 0.01, (
+            f"AC-3 Testkonstruktion: neue Menge erwartet {neue_mm} mm, gemessen "
+            f"{gemessen_neu} mm."
+        )
+        assert gemessen_neu >= gemessen_basis * 2.0, (
+            f"AC-3 Testkonstruktion: die FAKTOR-Bedingung muss erfuellt sein, "
+            f"sonst entscheidet wieder sie statt der absoluten Untergrenze "
+            f"({gemessen_neu} < {gemessen_basis * 2.0})."
+        )
+        assert gemessen_neu < 2.0, (
+            f"AC-3 Testkonstruktion: die Menge muss UNTER der absoluten "
+            f"Untergrenze liegen ({gemessen_neu})."
+        )
+
+        strecke = AlarmPruefstrecke(user_id=uid, settings=_settings_all_channels())
+        lauf1 = strecke.lauf(
+            at=_AT, zweig="radar", trip=trip,
+            radar_service=_radar(_kurze_spitze(_rate_spitze(basis_mm))),
+        )
+        assert lauf1.triggered_count == 1, (
+            f"AC-3 Vorbedingung: Lauf 1 muss ausloesen und {basis_mm} mm als "
+            f"Vergleichsbasis buchen (war {lauf1.triggered_count})."
+        )
+
+        at2 = _AT + timedelta(minutes=30)
+        caplog.clear()
+        with caplog.at_level(logging.DEBUG, logger="trip_alert"):
+            lauf2 = strecke.lauf(
+                at=at2, zweig="radar", trip=trip,
+                radar_service=_radar(_kurze_spitze(_rate_spitze(neue_mm))),
+            )
+        assert lauf2.triggered_count == 0, (
+            f"AC-3: {neue_mm} mm erfuellen zwar den Faktor gegen {basis_mm} mm, "
+            f"bleiben aber unter der absoluten Untergrenze von 2,0 mm — kein "
+            f"Durchbruch erlaubt. War triggered_count={lauf2.triggered_count}."
+        )
+        assert alert_log.REASON_COOLDOWN in _gruende(uid, trip, at2), (
+            f"AC-3: die Stille muss die SPERRZEIT als Grund behalten. Gefunden: "
+            f"{_gruende(uid, trip, at2)!r}"
+        )
+        assert _entscheidungszeile(caplog, basis_mm, neue_mm) is not None, (
+            f"AC-3: die Ueberholungspruefung muss nachweislich GELAUFEN sein — "
+            f"ohne die Entscheidungszeile mit Basis {basis_mm} und Menge "
+            f"{neue_mm} (AC-13) bewiese die Stille nur, dass die Kette wie "
+            f"bisher vor dem Vergleich kurzschliesst."
+        )
+    finally:
+        _clean_user(uid)
+
+
+def test_ac4_menge_ueber_der_untergrenze_aber_ohne_faktor(caplog):
+    """AC-4. GIVEN eine Menge deutlich ueber der absoluten Untergrenze, aber
+    ohne den geforderten Faktor 2,0 gegenueber der Vergleichsbasis, WHEN der
+    Vergleich laeuft, THEN bricht die Sperre NICHT durch.
+
+    Spiegelbild zu AC-3: hier entscheidet ALLEIN der Faktor. Basis ~10,08 mm
+    (11 mm/h), neue Menge 15,0 mm — 15,0 liegt siebeneinhalbfach ueber der
+    absoluten Untergrenze (2,0 mm), aber unter dem Doppelten der Basis
+    (20,17 mm). Entfiele der Faktor, muss dieser Test rot werden."""
+    uid = _uid("ac4")
+    neue_mm = 15.0
+    try:
+        trip = _aufbau(uid, "ac4")
+        gemessen_neu = _gemessene_menge(
+            trip, _dauerregen(_rate_dauerregen(neue_mm)), _AT,
+        )
+        assert abs(gemessen_neu - neue_mm) < 0.01, (
+            f"AC-4 Testkonstruktion: erwartet {neue_mm} mm, gemessen {gemessen_neu}."
+        )
+        assert gemessen_neu >= 2.0, (
+            "AC-4 Testkonstruktion: die absolute Untergrenze muss LOCKER "
+            "erfuellt sein, sonst entscheidet wieder sie statt des Faktors."
+        )
+        assert gemessen_neu < BASIS_MM * 2.0, (
+            f"AC-4 Testkonstruktion: die FAKTOR-Bedingung muss verfehlt sein "
+            f"({gemessen_neu} >= {BASIS_MM * 2.0})."
+        )
+
+        strecke = AlarmPruefstrecke(user_id=uid, settings=_settings_all_channels())
+        lauf1 = strecke.lauf(
+            at=_AT, zweig="radar", trip=trip,
+            radar_service=_radar(_dauerregen(BASIS_RATE_MM_H)),
+        )
+        assert lauf1.triggered_count == 1, "AC-4 Vorbedingung: Lauf 1 muss ausloesen"
+
+        at2 = _AT + timedelta(minutes=30)
+        caplog.clear()
+        with caplog.at_level(logging.DEBUG, logger="trip_alert"):
+            lauf2 = strecke.lauf(
+                at=at2, zweig="radar", trip=trip,
+                radar_service=_radar(_dauerregen(_rate_dauerregen(neue_mm))),
+            )
+        assert lauf2.triggered_count == 0, (
+            f"AC-4: {neue_mm} mm gegen eine Basis von ~{BASIS_MM:.2f} mm "
+            f"erreichen den Faktor 2,0 NICHT — kein Durchbruch erlaubt. War "
+            f"triggered_count={lauf2.triggered_count}."
+        )
+        assert alert_log.REASON_COOLDOWN in _gruende(uid, trip, at2), (
+            f"AC-4: die Stille muss die SPERRZEIT als Grund behalten. Gefunden: "
+            f"{_gruende(uid, trip, at2)!r}"
+        )
+        assert _entscheidungszeile(caplog, BASIS_MM, neue_mm) is not None, (
+            f"AC-4: die Ueberholungspruefung muss nachweislich gelaufen sein "
+            f"(Entscheidungszeile mit Basis ~{BASIS_MM:.2f} und Menge "
+            f"{neue_mm}, AC-13)."
+        )
+    finally:
+        _clean_user(uid)
+
+
+# ──────────────────────────── AC-6 / AC-7 ────────────────────────────────────
+
+
+def test_ac6_ruhezeit_bleibt_auch_fuer_extreme_verschaerfung_unbrechbar():
+    """AC-6 (Regressionswaechter, HEUTE SCHON GRUEN). GIVEN die Ruhezeit ist
+    aktiv, WHEN selbst eine extreme Verschaerfung geprueft wird, THEN bleibt
+    der Alarm aus und das Protokoll weist `quiet_hours` aus.
+
+    PO-Ablehnung #1955: die Ruhezeit bleibt unbrechbar. Das Ruhefenster
+    (13:00–14:00 Ortszeit, Europe/Paris) liegt so, dass Lauf 1 um 12:00
+    Ortszeit noch AUSSERHALB liegt und ausloesen kann — sonst gaebe es weder
+    Sperrzeit noch Vergleichsbasis und der Test bewachte eine leere Lage."""
+    uid = _uid("ac6")
+    try:
+        trip = _aufbau(uid, "ac6")
+        trip.alert_quiet_from = "13:00"
+        trip.alert_quiet_to = "14:00"
+        with freeze_time(_AT):
+            from app.loader import save_trip
+            save_trip(trip, user_id=uid)
+
+        strecke = AlarmPruefstrecke(user_id=uid, settings=_settings_all_channels())
+        lauf1 = strecke.lauf(
+            at=_AT, zweig="radar", trip=trip,
+            radar_service=_radar(_dauerregen(BASIS_RATE_MM_H)),
+        )
+        assert lauf1.triggered_count == 1, (
+            f"AC-6 Vorbedingung: Lauf 1 um 12:00 Ortszeit liegt VOR dem "
+            f"Ruhefenster und muss ausloesen (war {lauf1.triggered_count})."
+        )
+
+        at3 = _AT + timedelta(minutes=90)  # 13:30 Ortszeit — mitten in der Ruhezeit
+        lauf3 = strecke.lauf(
+            at=at3, zweig="radar", trip=trip,
+            radar_service=_radar(_dauerregen(VERSCHAERFT_RATE_MM_H)),
+        )
+        assert lauf3.triggered_count == 0, (
+            f"AC-6: die Ruhezeit ist unbrechbar — auch eine Verdreifachung "
+            f"darf sie nicht durchbrechen (war {lauf3.triggered_count})."
+        )
+        gruende = _gruende(uid, trip, at3)
+        assert alert_log.REASON_QUIET_HOURS in gruende, (
+            f"AC-6: der Protokollgrund muss {alert_log.REASON_QUIET_HOURS!r} "
+            f"sein. Gefunden: {gruende!r}"
+        )
+    finally:
+        _clean_user(uid)
+
+
+def test_ac7_erschoepftes_tagesbudget_stoppt_den_durchbruch():
+    """AC-7. GIVEN ein Nutzer mit endlichem Tagesbudget (Tier `standard`,
+    Limit 4), dessen Budget erschoepft ist, WHEN eine Verschaerfung vorliegt,
+    die Faktor UND Untergrenze erfuellt, THEN bleibt der Alarm aus und das
+    Protokoll weist `daily_limit` aus.
+
+    Begruendung: die Kette schliesst heute bei Sperrzeit kurz, das Tageslimit
+    wurde fuer den Ueberholungsfall also NIE geprueft. Der Durchbruch darf es
+    nicht stillschweigend mit-ueberspringen.
+
+    Kein Premium-Profil (dort gilt gar kein Limit) und deshalb ohne
+    Premium-SMS-Kanal — geprueft wird die Stille, nicht die Kanalparitaet.
+
+    RED heute: der Lauf schweigt mit Grund `cooldown` statt `daily_limit`."""
+    uid = _uid("ac7")
+    try:
+        trip = _aufbau(
+            uid, "ac7", tier="standard",
+            send_sms=False, send_premium_sms=False,
+        )
+        strecke = AlarmPruefstrecke(user_id=uid, settings=_settings_all_channels())
+        lauf1 = strecke.lauf(
+            at=_AT, zweig="radar", trip=trip,
+            radar_service=_radar(_dauerregen(BASIS_RATE_MM_H)),
+        )
+        assert lauf1.triggered_count == 1, (
+            f"AC-7 Vorbedingung: Lauf 1 muss ausloesen (war {lauf1.triggered_count})."
+        )
+
+        # Tageszaehler ueber den PRODUKTIVEN Schreibweg auf das Limit heben
+        # (Lauf 1 hat bereits einmal gezaehlt): dieselbe Zone, die auch das
+        # Gate benutzt — eine andere fuellte einen anderen Zaehler (#1726).
+        from services import alert_daily_limit
+        from services.trip_day import anchor_tz
+        from services.user_tier import daily_alert_limit
+
+        at3 = _AT + timedelta(minutes=90)
+        zone = anchor_tz(trip, at3)
+        limit = daily_alert_limit(uid)
+        assert limit == 4, f"AC-7 Vorbedingung: Tier `standard` muss Limit 4 haben ({limit})"
+        while alert_daily_limit.load(uid, at3, zone) < limit:
+            alert_daily_limit.increment(uid, at3, zone)
+        assert not alert_daily_limit.is_allowed(uid, at3, zone, reason="nowcast"), (
+            "AC-7 Vorbedingung: das Tagesbudget muss erschoepft sein."
+        )
+
+        lauf3 = strecke.lauf(
+            at=at3, zweig="radar", trip=trip,
+            radar_service=_radar(_dauerregen(VERSCHAERFT_RATE_MM_H)),
+        )
+        assert lauf3.triggered_count == 0, (
+            f"AC-7: das erschoepfte Tagesbudget bleibt hartes Stop, auch fuer "
+            f"eine Verschaerfung (war {lauf3.triggered_count})."
+        )
+        gruende = _gruende(uid, trip, at3)
+        assert alert_log.REASON_DAILY_LIMIT in gruende, (
+            f"AC-7: der Protokollgrund muss {alert_log.REASON_DAILY_LIMIT!r} "
+            f"sein — der Durchbruch der Sperrzeit muss das Tageslimit ERNEUT "
+            f"pruefen, statt es mit zu ueberspringen. Gefunden: {gruende!r}"
+        )
+    finally:
+        _clean_user(uid)
+
+
+# ──────────────────────────── AC-8 / AC-9 / AC-10 ────────────────────────────
+
+
+def test_ac8_ohne_vergleichsbasis_bleibt_die_sperre_bestehen():
+    """AC-8 (Regressionswaechter, HEUTE SCHON GRUEN — wird nach der
+    Implementierung mutations-empfindlich). GIVEN die Sperre wurde vom ZWEITEN
+    Schreiber ohne Mengenangabe gebucht (Kurzfristhinweis im Briefing,
+    `trip_report_scheduler.py:1574`), sodass keine Vergleichsbasis existiert,
+    WHEN eine beliebig starke Lage geprueft wird, THEN bricht die Sperre NICHT
+    durch und das Protokoll weist `cooldown` aus.
+
+    Konservative Fehlerrichtung: ein Durchbruch ohne Vergleichsbasis waere ein
+    Durchbruch ohne Nachweis. Liefert der Vergleichs-Helfer bei fehlender
+    Basis faelschlich `True`, wird dieser Test rot.
+
+    Positivkontrolle im selben Test: DIESELBE Lage auf einem Trip OHNE
+    gebuchte Sperre loest aus — ohne sie bewiese `triggered_count == 0` nur,
+    dass die Lage ueberhaupt nicht alarmwuerdig ist."""
+    uid, ctrl = _uid("ac8"), _uid("ac8-ctrl")
+    try:
+        trip = _aufbau(uid, "ac8")
+        # Exakt der Aufruf des zweiten Schreibers: Zeitstempel, keine Menge.
+        from services.throttle_store import ThrottleStore
+        ThrottleStore(uid).record("radar", trip.id, _AT)
+
+        at2 = _AT + timedelta(minutes=30)
+        strecke = AlarmPruefstrecke(user_id=uid, settings=_settings_all_channels())
+        lauf = strecke.lauf(
+            at=at2, zweig="radar", trip=trip,
+            radar_service=_radar(_dauerregen(VERSCHAERFT_RATE_MM_H)),
+        )
+        assert lauf.triggered_count == 0, (
+            f"AC-8: ohne gespeicherte Vergleichsbasis darf auch eine sehr starke "
+            f"Lage (~{VERSCHAERFT_MM:.2f} mm) die Sperre NICHT durchbrechen "
+            f"(war {lauf.triggered_count})."
+        )
+        gruende = _gruende(uid, trip, at2)
+        assert alert_log.REASON_COOLDOWN in gruende, (
+            f"AC-8: der Protokollgrund muss {alert_log.REASON_COOLDOWN!r} "
+            f"bleiben. Gefunden: {gruende!r}"
+        )
+
+        kontroll_trip = _aufbau(ctrl, "ac8-ctrl")
+        kontroll_strecke = AlarmPruefstrecke(
+            user_id=ctrl, settings=_settings_all_channels(),
+        )
+        kontrolle = kontroll_strecke.lauf(
+            at=at2, zweig="radar", trip=kontroll_trip,
+            radar_service=_radar(_dauerregen(VERSCHAERFT_RATE_MM_H)),
+        )
+        assert kontrolle.triggered_count == 1, (
+            f"AC-8 Positivkontrolle: dieselbe Lage OHNE gebuchte Sperre muss "
+            f"ausloesen — sonst sagt die Stille oben nichts ueber die Sperre "
+            f"aus (war {kontrolle.triggered_count})."
+        )
+    finally:
+        _clean_user(uid)
+        _clean_user(ctrl)
+
+
+def test_ac9_fortgeschriebene_vergleichsbasis_bremst_den_zweiten_durchbruch():
+    """AC-9. GIVEN ein Alarm ist im selben Sperrfenster bereits einmal
+    durchgebrochen und hat die Vergleichsbasis auf die hoehere Menge
+    fortgeschrieben, WHEN dieselbe (nicht weiter verschaerfte) Menge erneut
+    geprueft wird, THEN bricht der Alarm NICHT ein zweites Mal durch.
+
+    Selbstbremsung gegen die Wiederholungs-Kettenreaktion: nach dem
+    27,5-mm-Durchbruch braucht die naechste Verschaerfung den vollen Faktor
+    gegen 27,5 mm, nicht mehr gegen die alten 10,08 mm.
+
+    RED heute an Lauf 2: der Durchbruch findet gar nicht erst statt."""
+    uid = _uid("ac9")
+    try:
+        trip = _aufbau(uid, "ac9")
+        strecke = AlarmPruefstrecke(user_id=uid, settings=_settings_all_channels())
+        lauf1 = strecke.lauf(
+            at=_AT, zweig="radar", trip=trip,
+            radar_service=_radar(_dauerregen(BASIS_RATE_MM_H)),
+        )
+        assert lauf1.triggered_count == 1, "AC-9 Vorbedingung: Lauf 1 muss ausloesen"
+
+        at2 = _AT + timedelta(minutes=45)
+        lauf2 = strecke.lauf(
+            at=at2, zweig="radar", trip=trip,
+            radar_service=_radar(_dauerregen(VERSCHAERFT_RATE_MM_H)),
+        )
+        assert lauf2.triggered_count == 1, (
+            f"AC-9 Vorbedingung: Lauf 2 (~{VERSCHAERFT_MM:.2f} mm) muss die "
+            f"Sperre durchbrechen und die Vergleichsbasis fortschreiben "
+            f"(war {lauf2.triggered_count}, Gruende: {_gruende(uid, trip, at2)!r})."
+        )
+
+        at3 = at2 + timedelta(minutes=45)  # immer noch im Sperrfenster von Lauf 2
+        lauf3 = strecke.lauf(
+            at=at3, zweig="radar", trip=trip,
+            radar_service=_radar(_dauerregen(VERSCHAERFT_RATE_MM_H)),
+        )
+        assert lauf3.triggered_count == 0, (
+            f"AC-9: unveraenderte ~{VERSCHAERFT_MM:.2f} mm gegen eine bereits "
+            f"auf diesen Wert fortgeschriebene Vergleichsbasis duerfen NICHT "
+            f"erneut durchbrechen (war {lauf3.triggered_count})."
+        )
+        assert alert_log.REASON_COOLDOWN in _gruende(uid, trip, at3), (
+            f"AC-9: der Protokollgrund muss {alert_log.REASON_COOLDOWN!r} sein. "
+            f"Gefunden: {_gruende(uid, trip, at3)!r}"
+        )
+    finally:
+        _clean_user(uid)
+
+
+def test_ac10_gescheiterte_zustellung_schreibt_die_vergleichsbasis_nicht_fort():
+    """AC-10. GIVEN ein Durchbruchsfall, bei dem die Zustellung scheitert
+    (kein erreichbarer Kanal), WHEN der Lauf abgeschlossen ist, THEN wird die
+    Vergleichsbasis NICHT fortgeschrieben (F001-Symmetrie).
+
+    Nachgewiesen VERHALTENSSEITIG statt ueber einen Blick in die
+    Zustandsdatei: Lauf 3 faehrt dieselben ~27,5 mm noch einmal, diesmal mit
+    erreichbarem Kanal. Er darf nur dann durchbrechen, wenn die Basis noch bei
+    ~10,08 mm steht (27,5 >= 20,17). Waere sie durch den gescheiterten Lauf 2
+    auf 27,5 mm fortgeschrieben worden, laege die Schwelle bei 55 mm und
+    Lauf 3 bliebe stumm.
+
+    Der Trip fuehrt NUR E-Mail; der stumme Lauf benutzt Settings ohne
+    SMTP-Zugang (`can_send_email()` False), der Kanal bleibt also konfiguriert
+    (das effektive Kanal-Set ist nicht leer, der Lauf bricht nicht vorher ab),
+    ist aber nicht erreichbar.
+
+    RED heute: schon Lauf 3 loest nicht aus."""
+    uid = _uid("ac10")
+    try:
+        trip = _aufbau(
+            uid, "ac10", send_telegram=False, send_sms=False, send_premium_sms=False,
+        )
+        laut = _settings_all_channels()
+        stumm = laut.model_copy(update={"smtp_host": "", "smtp_user": "", "smtp_pass": ""})
+        assert laut.can_send_email() and not stumm.can_send_email(), (
+            "AC-10 Testkonstruktion: der stumme Lauf braucht einen konfigurierten, "
+            "aber NICHT erreichbaren E-Mail-Kanal."
+        )
+
+        strecke_laut = AlarmPruefstrecke(user_id=uid, settings=laut)
+        strecke_stumm = AlarmPruefstrecke(user_id=uid, settings=stumm)
+
+        lauf1 = strecke_laut.lauf(
+            at=_AT, zweig="radar", trip=trip,
+            radar_service=_radar(_dauerregen(BASIS_RATE_MM_H)),
+        )
+        assert lauf1.triggered_count == 1, "AC-10 Vorbedingung: Lauf 1 muss ausloesen"
+
+        at2 = _AT + timedelta(minutes=30)
+        lauf2 = strecke_stumm.lauf(
+            at=at2, zweig="radar", trip=trip,
+            radar_service=_radar(_dauerregen(VERSCHAERFT_RATE_MM_H)),
+        )
+        assert lauf2.triggered_count == 0, (
+            f"AC-10 Vorbedingung: ohne erreichbaren Kanal darf nichts als "
+            f"zugestellt gelten (war {lauf2.triggered_count})."
+        )
+
+        at3 = _AT + timedelta(minutes=60)
+        lauf3 = strecke_laut.lauf(
+            at=at3, zweig="radar", trip=trip,
+            radar_service=_radar(_dauerregen(VERSCHAERFT_RATE_MM_H)),
+        )
+        assert lauf3.triggered_count == 1, (
+            f"AC-10: die Vergleichsbasis darf nach der GESCHEITERTEN Zustellung "
+            f"noch bei ~{BASIS_MM:.2f} mm stehen — sonst kommt der Nutzer nach "
+            f"einem Zustellfehler an die Verschaerfung nicht mehr heran "
+            f"(war triggered_count={lauf3.triggered_count}, Gruende: "
+            f"{_gruende(uid, trip, at3)!r})."
+        )
+    finally:
+        _clean_user(uid)
+
+
+# ─────────────────────────────── AC-13 ───────────────────────────────────────
+
+
+def test_ac13_die_ueberholungsentscheidung_protokolliert_basis_und_menge(caplog):
+    """AC-13. GIVEN ein Lauf mit laufender Sperrzeit, WHEN die
+    Ueberholungsentscheidung getroffen wird (Durchbruch ODER Unterdrueckung),
+    THEN protokolliert der Lauf sowohl die gelesene Vergleichsbasis als auch
+    die aktuell gemessene Menge.
+
+    Abweichung von der Spec-Formulierung, bewusst: der Unterdrueckungsfall
+    faehrt NICHT die unveraenderte Lage aus AC-2, sondern die 15,0 mm aus
+    AC-4. Bei unveraenderter Lage waeren Basis und Menge dieselbe Zahl — der
+    Nachweis 'beide Werte stehen im Protokoll' waere dann schon mit EINER
+    Zahl erfuellt und bewachte nichts.
+
+    Geprueft wird auf die beiden ZAHLEN in einer `trip_alert`-Protokollzeile,
+    nicht auf einen Wortlaut (s. `_entscheidungszeile`).
+
+    RED heute: es gibt keine Ueberholungsentscheidung und damit auch keine
+    Protokollzeile — der gesperrte Lauf holt heute gar keine Daten."""
+    uid = _uid("ac13")
+    neue_mm = 15.0
+    try:
+        trip = _aufbau(uid, "ac13")
+        strecke = AlarmPruefstrecke(user_id=uid, settings=_settings_all_channels())
+        lauf1 = strecke.lauf(
+            at=_AT, zweig="radar", trip=trip,
+            radar_service=_radar(_dauerregen(BASIS_RATE_MM_H)),
+        )
+        assert lauf1.triggered_count == 1, "AC-13 Vorbedingung: Lauf 1 muss ausloesen"
+
+        # Unterdrueckungsfall: 15,0 mm gegen ~10,08 mm -> Faktor verfehlt.
+        at2 = _AT + timedelta(minutes=30)
+        caplog.clear()
+        with caplog.at_level(logging.DEBUG, logger="trip_alert"):
+            strecke.lauf(
+                at=at2, zweig="radar", trip=trip,
+                radar_service=_radar(_dauerregen(_rate_dauerregen(neue_mm))),
+            )
+        zeile_stille = _entscheidungszeile(caplog, BASIS_MM, neue_mm)
+        assert zeile_stille is not None, (
+            f"AC-13 (Unterdrueckung): das Protokoll muss die gelesene Basis "
+            f"(~{BASIS_MM:.2f} mm) UND die gemessene Menge ({neue_mm} mm) "
+            f"tragen. `trip_alert`-Zeilen waren: "
+            f"{[r.getMessage() for r in caplog.records if r.name == 'trip_alert']!r}"
+        )
+
+        # Durchbruchsfall: ~27,5 mm gegen ~10,08 mm.
+        at3 = _AT + timedelta(minutes=60)
+        caplog.clear()
+        with caplog.at_level(logging.DEBUG, logger="trip_alert"):
+            lauf3 = strecke.lauf(
+                at=at3, zweig="radar", trip=trip,
+                radar_service=_radar(_dauerregen(VERSCHAERFT_RATE_MM_H)),
+            )
+        assert lauf3.triggered_count == 1, (
+            f"AC-13 Vorbedingung: der Durchbruchsfall muss durchbrechen "
+            f"(war {lauf3.triggered_count})."
+        )
+        zeile_durchbruch = _entscheidungszeile(caplog, BASIS_MM, VERSCHAERFT_MM)
+        assert zeile_durchbruch is not None, (
+            f"AC-13 (Durchbruch): das Protokoll muss die gelesene Basis "
+            f"(~{BASIS_MM:.2f} mm) UND die gemessene Menge "
+            f"(~{VERSCHAERFT_MM:.2f} mm) tragen. `trip_alert`-Zeilen waren: "
+            f"{[r.getMessage() for r in caplog.records if r.name == 'trip_alert']!r}"
+        )
+    finally:
+        _clean_user(uid)

--- a/tests/tdd/test_radar_cooldown_overtake.py
+++ b/tests/tdd/test_radar_cooldown_overtake.py
@@ -680,6 +680,16 @@ def test_ac10_gescheiterte_zustellung_schreibt_die_vergleichsbasis_nicht_fort():
     (das effektive Kanal-Set ist nicht leer, der Lauf bricht nicht vorher ab),
     ist aber nicht erreichbar.
 
+    🔴 Die `test_smtp_*`-Felder MUESSEN mitgeleert werden: `AlarmPruefstrecke`
+    ruft `Settings.with_user_profile(uid)` (`config.py:355`), und weil
+    `tdd-…` eine Test-Kennung ist, laeuft das ueber `Settings.for_testing()`
+    (`config.py:318`) — das befuellt `smtp_host/-user/-pass` aus
+    `test_smtp_*` WIEDER. Ein nur auf `smtp_*` geleertes Objekt waere im Lauf
+    also erneut sendefaehig. Die Konstruktionspruefung haengt deshalb am
+    Objekt, mit dem der Lauf TATSAECHLICH faehrt (nach `with_user_profile`),
+    nicht am Rohobjekt davor — sonst bliebe ein kuenftiger Eingriff in
+    `for_testing()` hier unbemerkt.
+
     RED heute: schon Lauf 3 loest nicht aus."""
     uid = _uid("ac10")
     try:
@@ -687,10 +697,19 @@ def test_ac10_gescheiterte_zustellung_schreibt_die_vergleichsbasis_nicht_fort():
             uid, "ac10", send_telegram=False, send_sms=False, send_premium_sms=False,
         )
         laut = _settings_all_channels()
-        stumm = laut.model_copy(update={"smtp_host": "", "smtp_user": "", "smtp_pass": ""})
-        assert laut.can_send_email() and not stumm.can_send_email(), (
+        stumm = laut.model_copy(update={
+            "smtp_host": "", "smtp_user": "", "smtp_pass": "",
+            "test_smtp_user": "", "test_smtp_pass": "",
+        })
+        assert laut.with_user_profile(uid).can_send_email(), (
+            "AC-10 Testkonstruktion: der LAUTE Lauf braucht einen erreichbaren "
+            "E-Mail-Kanal — geprueft am Objekt, mit dem die Pruefstrecke faehrt."
+        )
+        assert not stumm.with_user_profile(uid).can_send_email(), (
             "AC-10 Testkonstruktion: der stumme Lauf braucht einen konfigurierten, "
-            "aber NICHT erreichbaren E-Mail-Kanal."
+            "aber NICHT erreichbaren E-Mail-Kanal — geprueft NACH "
+            "`with_user_profile()`, weil erst dort `for_testing()` die "
+            "Zugangsdaten wieder einsetzen wuerde."
         )
 
         strecke_laut = AlarmPruefstrecke(user_id=uid, settings=laut)
@@ -796,3 +815,136 @@ def test_ac13_die_ueberholungsentscheidung_protokolliert_basis_und_menge(caplog)
         )
     finally:
         _clean_user(uid)
+
+
+# ───────────────── F001 (Adversary #2065): Durchbruch ohne Ausloeser ─────────
+#
+# Nach einem erfolgreichen Durchbruch ist der Durchgang NICHT MEHR gesperrt —
+# er verhaelt sich ab da wie ein freier Lauf. Scheitert er anschliessend am
+# Ausloese-Guard (`radar_alert_due`, Onset jenseits
+# `RADAR_ONSET_THRESHOLD_MIN`), bleibt er genauso still wie ein freier Lauf in
+# derselben Lage: kein Alarm UND kein `alert_log`-Eintrag. „Nicht
+# alarmwuerdig" ist in diesem System kein Unterdrueckungs-Ereignis
+# (`trip_alert.py`, Ausloese- und Doppel-Alarm-Guard schreiben auch im freien
+# Lauf nichts). Ein `cooldown`-Eintrag waere hier FALSCH — die Sperrzeit hat
+# diesen Lauf ja gerade nicht unterdrueckt.
+
+
+def _spaeter_regen(rate_mm_h: float, minute: int = 56):
+    """EIN Frame jenseits des Ausloese-Horizonts: Onset `minute` Minuten
+    (> `RADAR_ONSET_THRESHOLD_MIN` = 55) -> `radar_alert_due` ist False. Im
+    60-Minuten-Vergleichsfenster traegt er trotzdem `60 - minute` Minuten
+    Deckung, liefert also eine echte Menge fuer die Ueberholungspruefung."""
+    def _quelle(lat: float, lon: float) -> list:
+        from providers.brightsky import RadarFrame
+        from datetime import timezone as _tz
+        jetzt = datetime.now(_tz.utc)
+        return [
+            RadarFrame(timestamp=jetzt + timedelta(minutes=minute),
+                       precip_mm_h=rate_mm_h),
+        ]
+    return _quelle
+
+
+def _gemessenes_ergebnis(trip, quelle, at: datetime):
+    """Wie `_gemessene_menge`, aber das ganze `NowcastResult` — hier wird
+    zusaetzlich der Onset gebraucht."""
+    lat, lon = trip.stages[0].waypoints[0].lat, trip.stages[0].waypoints[0].lon
+    with freeze_time(at):
+        reset_shared_radar_cache_for_tests()
+        ergebnis = _radar(quelle).get_nowcast(lat, lon)
+        reset_shared_radar_cache_for_tests()
+    return ergebnis
+
+
+def test_f001_durchbruch_ohne_ausloeser_verhaelt_sich_wie_ein_freier_lauf(caplog):
+    """F001. GIVEN eine laufende Sperrzeit und eine Lage, die die
+    Ueberholungsbedingungen erfuellt, deren Regen aber erst JENSEITS des
+    Ausloese-Horizonts beginnt, WHEN der Lauf laeuft, THEN bricht er die
+    Sperrzeit durch (Protokollzeile „Durchbruch") und bleibt danach genauso
+    still wie ein freier Lauf in derselben Lage — kein Alarm, KEIN
+    `alert_log`-Eintrag, insbesondere keiner mit Grund `cooldown`.
+
+    Positivkontrolle im selben Test (PFLICHT): derselbe Lauf auf einem Trip
+    OHNE gebuchte Sperre. Ohne sie bewiese die Stille oben nur, dass die Lage
+    nicht alarmwuerdig ist — nicht, dass sich der durchgebrochene Lauf
+    IDENTISCH zum freien verhaelt. Genau diese Gleichheit ist die Zusicherung.
+    """
+    from services import radar_service as radar_service_mod
+
+    uid, frei = _uid("f001"), _uid("f001-frei")
+    basis_mm = 1.0
+    try:
+        trip = _aufbau(uid, "f001")
+        ergebnis = _gemessenes_ergebnis(trip, _spaeter_regen(60.0), _AT)
+        assert ergebnis.onset_minutes is not None, "Testkonstruktion: Onset fehlt"
+        assert ergebnis.onset_minutes > radar_service_mod.RADAR_ONSET_THRESHOLD_MIN, (
+            f"F001 Testkonstruktion: der Regen muss JENSEITS des "
+            f"Ausloese-Horizonts ({radar_service_mod.RADAR_ONSET_THRESHOLD_MIN} "
+            f"Min) beginnen, sonst scheitert der Lauf gar nicht am "
+            f"Ausloese-Guard (Onset {ergebnis.onset_minutes})."
+        )
+        menge = ergebnis.window_precip_mm
+        assert menge >= 2.0 and menge >= basis_mm * 2.0, (
+            f"F001 Testkonstruktion: die Lage muss die Ueberholung LOCKER "
+            f"erfuellen (Menge {menge} gegen Basis {basis_mm}) — sonst kaeme "
+            f"die Stille von der Ueberholungspruefung statt vom Ausloese-Guard."
+        )
+
+        strecke = AlarmPruefstrecke(user_id=uid, settings=_settings_all_channels())
+        lauf1 = strecke.lauf(
+            at=_AT, zweig="radar", trip=trip,
+            radar_service=_radar(_kurze_spitze(_rate_spitze(basis_mm))),
+        )
+        assert lauf1.triggered_count == 1, (
+            f"F001 Vorbedingung: Lauf 1 muss ausloesen und {basis_mm} mm als "
+            f"Vergleichsbasis buchen (war {lauf1.triggered_count})."
+        )
+
+        at2 = _AT + timedelta(minutes=30)
+        caplog.clear()
+        with caplog.at_level(logging.DEBUG, logger="trip_alert"):
+            lauf2 = strecke.lauf(
+                at=at2, zweig="radar", trip=trip,
+                radar_service=_radar(_spaeter_regen(60.0)),
+            )
+        zeile = _entscheidungszeile(caplog, basis_mm, menge)
+        assert zeile is not None and "Durchbruch" in zeile, (
+            f"F001: der Lauf MUSS die Sperrzeit durchbrochen haben — sonst "
+            f"prueft dieser Test den Ausloese-Guard hinter einer Sperre, die "
+            f"gar nicht gefallen ist. Protokollzeile: {zeile!r}"
+        )
+        assert lauf2.triggered_count == 0, (
+            f"F001: jenseits des Ausloese-Horizonts darf kein Alarm rausgehen "
+            f"(war {lauf2.triggered_count})."
+        )
+        assert _gruende(uid, trip, at2) == set(), (
+            f"F001: ein durchgebrochener Lauf ist NICHT MEHR gesperrt — er darf "
+            f"am Ausloese-Guard keinen Unterdrueckungs-Eintrag hinterlassen, "
+            f"schon gar nicht mit Grund {alert_log.REASON_COOLDOWN!r}. "
+            f"Protokolliert wurde: {_gruende(uid, trip, at2)!r}"
+        )
+
+        # Positivkontrolle: derselbe Lauf ohne jede Sperre.
+        frei_trip = _aufbau(frei, "f001-frei")
+        frei_strecke = AlarmPruefstrecke(
+            user_id=frei, settings=_settings_all_channels(),
+        )
+        frei_lauf = frei_strecke.lauf(
+            at=at2, zweig="radar", trip=frei_trip,
+            radar_service=_radar(_spaeter_regen(60.0)),
+        )
+        assert frei_lauf.triggered_count == lauf2.triggered_count == 0, (
+            f"F001 Positivkontrolle: der freie Lauf muss sich genauso verhalten "
+            f"(frei={frei_lauf.triggered_count}, durchgebrochen="
+            f"{lauf2.triggered_count})."
+        )
+        assert _gruende(frei, frei_trip, at2) == _gruende(uid, trip, at2) == set(), (
+            f"F001 Positivkontrolle: auch der freie Lauf schreibt hier keinen "
+            f"Eintrag — die Gleichheit ist die Zusicherung. frei="
+            f"{_gruende(frei, frei_trip, at2)!r}, durchgebrochen="
+            f"{_gruende(uid, trip, at2)!r}"
+        )
+    finally:
+        _clean_user(uid)
+        _clean_user(frei)

--- a/tests/tdd/test_throttle_store.py
+++ b/tests/tdd/test_throttle_store.py
@@ -656,3 +656,71 @@ def test_dead_code_is_throttled_removed():
         "Toter Code _is_throttled() ist noch vorhanden — muss laut Spec "
         "(docs/specs/modules/throttle_store.md) entfernt werden"
     )
+
+
+# ═════════════ Issue #2065 AC-11: Alt-Format bleibt lesbar ═══════════════════
+# SPEC: docs/specs/modules/fix_2065_verschaerfung_ueberholt_sperre.md
+#
+# Der Eintrag wird um die zuletzt gemeldete Menge erweitert
+# (`{"at": iso, "precip_mm": float|null}`). Bestandsdateien tragen einen
+# REINEN ISO-String — der muss gueltig lesbar bleiben, und ein `record()` auf
+# EINEN Schluessel darf die uebrigen Bestandseintraege nicht anfassen
+# (Read-Modify-Write, nie Replace).
+
+
+def test_ac11_2065_alt_format_bleibt_lesbar_und_record_beruehrt_nur_einen_schluessel(tmp_path):
+    """AC-11 (Regressionswaechter, HEUTE SCHON GRUEN — kein RED-Nachweis).
+
+    GIVEN ein `throttle_state.json` im ALTEN Format (jeder Eintrag ein reiner
+    ISO-Zeitstempel ohne Mengenangabe), WHEN ein Lauf gegen diese Datei prueft
+    und anschliessend EINEN Schluessel neu schreibt, THEN bleibt die Sperrzeit
+    unveraendert wirksam, die Datei bleibt lesbar und kein Bestandsdatum geht
+    verloren.
+
+    Geprueft wird ueber die oeffentliche Store-Schnittstelle
+    (`is_throttled`/`last_sent`/`record`), nicht ueber den JSON-Rohtext: die
+    Zusicherung lautet "Bestandsdaten bleiben nutzbar", nicht "die Datei sieht
+    so und so aus". Der Rohtext wird nur EINMAL gelesen, um zu belegen, dass
+    die Alt-Eintraege im Alt-Format auf Platte lagen — sonst pruefte der Test
+    seine eigene Schreibweise."""
+    from services.throttle_store import ThrottleStore
+
+    user_dir = tmp_path / "u-2065-ac11"
+    user_dir.mkdir()
+    alt = datetime(2026, 8, 22, 9, 0, tzinfo=timezone.utc)
+    frisch = datetime(2026, 8, 22, 10, 30, tzinfo=timezone.utc)
+    _write_json(user_dir / "throttle_state.json", {
+        "radar": {"trip-alt": alt.isoformat(), "trip-unberuehrt": alt.isoformat()},
+        "trip": {"trip-alt": alt.isoformat()},
+    })
+    roh = json.loads((user_dir / "throttle_state.json").read_text())
+    assert isinstance(roh["radar"]["trip-unberuehrt"], str), (
+        "Testkonstruktion: die Bestandseintraege muessen im ALTEN Format "
+        "(reiner String) auf Platte liegen."
+    )
+
+    store = ThrottleStore("u-2065-ac11", data_dir=user_dir)
+    assert store.last_sent("radar", "trip-alt") == alt, (
+        "AC-11: ein Alt-Eintrag muss weiterhin als Zeitpunkt lesbar sein."
+    )
+    assert store.is_throttled("radar", "trip-alt", 120, alt + timedelta(minutes=30)), (
+        "AC-11: die Sperrzeit muss aus einem Alt-Eintrag heraus greifen."
+    )
+    assert not store.is_throttled("radar", "trip-alt", 120, alt + timedelta(minutes=150)), (
+        "AC-11: nach Ablauf der Sperrzeit darf ein Alt-Eintrag nicht mehr sperren."
+    )
+
+    store.record("radar", "trip-alt", frisch)
+
+    frischer_store = ThrottleStore("u-2065-ac11", data_dir=user_dir)
+    assert frischer_store.last_sent("radar", "trip-alt") == frisch, (
+        "AC-11: der neu geschriebene Eintrag muss zurueckgelesen werden koennen."
+    )
+    assert frischer_store.last_sent("radar", "trip-unberuehrt") == alt, (
+        "AC-11: der NICHT geschriebene Bestandseintrag im selben Scope muss "
+        "unangetastet bleiben (Read-Modify-Write, nie Replace)."
+    )
+    assert frischer_store.last_sent("trip", "trip-alt") == alt, (
+        "AC-11: der gleichnamige Schluessel in einem ANDEREN Scope darf vom "
+        "Schreibvorgang nicht mitgenommen werden."
+    )


### PR DESCRIPTION
Closes #2065.

## Problem

Ein Radar-Alarm über ~10 mm bucht 120 Minuten Sperrzeit. 90 Minuten später
schwieg eine auf ~27,5 mm **verdreifachte** Lage mit Protokollgrund `cooldown`.
Auf der Tour ist das die gefährliche Fehlerrichtung: die Verschärfung, die man
wissen müsste, fällt der Sperre des schwächeren Vorgängers zum Opfer.

## Lösung

Eine quantitativ deutliche Verschärfung überholt die Sperrzeit — und **nur** die
Sperrzeit.

- `alert_gate.radar_overtakes_cooldown()`: Menge ≥ 2,0 × zuletzt gemeldete Menge
  **UND** ≥ 2,0 mm (60-Minuten-Vergleichsfenster). Beide Hälften nötig: ohne die
  absolute Untergrenze verdoppelte sich auch Nieselregen „deutlich".
- `ThrottleStore` speichert die gemeldete Menge mit. Einträge sind jetzt
  `{"at": iso, "precip_mm": float|null}`; Alt-Einträge (reiner ISO-String)
  bleiben lesbar. Fortgeschrieben wird nur **nach erfolgreicher Zustellung**
  (F001-Symmetrie) — eine gescheiterte Zustellung hinterlässt keine erhöhte
  Basis.
- **Zweite Sperre, gleicher Anlass:** weil die Schwere-Skala LOW/MODERATE/HIGH
  bei 4 mm/h sättigt, ist eine Verdreifachung von 11 auf 30 mm/h zweimal `HIGH` —
  die Entdopplung hätte den Alarm weiterhin geschluckt, nur mit anderem Grund.
  Dieselbe Mengen-Feststellung reist deshalb als optionales
  `quantitative_escalation` in `check_event_identity_gate()` mit.
- **Unbrechbar bleiben Ruhezeit und Tages-Obergrenze.** Die Ruhezeit per
  PO-Entscheid (#1955); die Tages-Obergrenze wird im Durchbruchspfad
  ausdrücklich **erneut** geprüft, weil die Kette bisher schon an der Sperrzeit
  kurzschloss und der Durchbruch sie sonst stillschweigend mit-überspränge.

## Warum nicht im geteilten Baustein

`check_nowcast_gate()` bleibt in **Signatur und Verhalten** unverändert; der
Vergleich liegt allein im Trip-Zweig. Der Ortsvergleich ist PO-seitig
zurückgestellt und schreibt keine Vergleichsmenge — er bekommt die Ausnahme
nicht, und zwar ohne Signatur-Passagiere und ohne toten Default. Ein
Signatur-Wächter (AC-12) nagelt das fest. ADR-0021 trägt einen datierten
Nachtrag, `rework_1467_s3_nowcast.md` ebenfalls.

## Bekannte Grenzen

- **Fehlende Vergleichsbasis beim zweiten Schreiber:** `trip_report_scheduler.py`
  bucht dieselbe `radar`-Sperre ohne Mengenangabe (Kurzfristhinweis im
  Briefing). Dort bleibt der Durchbruch strukturell unmöglich — spezifiziert und
  festgenagelt in AC-8. Konservative Fehlerrichtung: Durchlässigkeit ohne
  Nachweis wiegt schwerer als eine ausbleibende Meldung in diesem Sonderfall.
- **Budget:** bis zu 7 zusätzliche Nowcast-Abrufe je Sperrfenster und Tour, gegen
  ein Tagesbudget von 9000. Real, aber unkritisch in der Größenordnung.
- **A-3 aus #2050 nur teilweise erfüllt** — zwei von drei Sperren; das Tageslimit
  ist eigene Scheibe (#2050 S3).

## Nachweis

- 14 ACs, 14 benannte Tests, dazu ein F001-Wächter aus der Adversary-Runde.
- Adversary-Verdict **VERIFIED** (17 Punkte, 2 Runden); 11/11 gezielte Mutationen
  gefangen.
- Feature-Tests **106 passed**; nach dem Rebase gemeinsam mit den #2050-Tests
  (laufendes Ereignis) **127 passed** — die beiden Änderungen treffen dieselbe
  Codestelle in `check_radar_alerts` und vertragen sich.
- Voller CI-äquivalenter Lauf: 14 rote Ergebnisse, alle isoliert grün und keine
  davon berührt `ThrottleStore`, `record_nowcast_sent`, `radar_overtakes_cooldown`
  oder `check_radar_alerts` — bekannte Worktree-Verschmutzung, keine Regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HKy82Wh44UyEJcuWypuneQ
