### PR TITLE
fix(#2075): Blockende nahe am Radar-Horizont nicht mehr zur Untergrenze verfaelschen

### DIFF
--- a/docs/context/fix-2075-ende-am-radar-horizont.md
+++ b/docs/context/fix-2075-ende-am-radar-horizont.md
@@ -1,0 +1,203 @@
+# Context: fix-2075-ende-am-radar-horizont
+
+Issue: [#2075](https://github.com/henemm/gregor_zwanzig/issues/2075) — `priority:high`, `bug`,
+Milestone „Tour KHW 2026-08". Basis-Stand: `1e0ee151`.
+
+## Request Summary
+
+Endet der Regen innerhalb der letzten Deckungsspanne (15 Min) vor dem Ende der Radar-Reichweite,
+meldet der Dienst `Regen mindestens bis <Horizont>` statt des echten, vom Radar belegten Endes —
+bis zu 14 Minuten Regen zu viel, und eine belegte Aussage wird als bloße Untergrenze ausgegeben.
+Gemessen auf Staging bei der Verifikation von #2051 Scheibe 1.
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `src/services/radar_service.py:325` | **Fundstelle.** `coverage_end = min(ts + _MAX_FRAME_COVERAGE, horizon)` — der direkt darunter ermittelte `next_ts` (Z. 326-327) fließt nicht ein |
+| `src/services/radar_service.py:233-276` | `_accumulate_precip_mm` — das Geschwister, das die Nachbar-Deckung **korrekt** rechnet (`min(next_ts_full, ts + _MAX_FRAME_COVERAGE, end)`, Z. 272) |
+| `src/services/radar_service.py:352-382` | `_laufendes_frame` (#2050 S2b) — drittes Geschwister, rechnet den Nachbarn ebenfalls **korrekt** ein (Z. 377-379) |
+| `src/services/radar_service.py:1011-1037` | Aufrufstellen: Onset-Zweig (#2051 S1) **und** `already_running`-Zweig (#2050 S2b, seit `ade992df` live) |
+| `src/output/renderers/alert/render.py`, `.../project.py`, `.../model.py` | Textkonsumenten von `event_end_minutes` / `event_ongoing_beyond_horizon` (Langform + Kurzform) |
+| `src/output/renderers/email/starkregen_hint.py` | Briefing-Kurzfristhinweis |
+| `src/services/validator_render_service.py`, `src/services/trip_alert.py` | Weitere Konsumenten der beiden Felder |
+
+## Existing Patterns
+
+- **Deckung je Frame** ist im Modul dreimal umgesetzt und soll überall gleich lauten:
+  `min(eigener nächster Nachbar, +_MAX_FRAME_COVERAGE, Fensterende)`. Zwei von drei Stellen tun das;
+  `_derive_wet_block_end` lässt den Nachbarn aus.
+- Keine neue Toleranzzahl einführen — beide Konstanten (`_MAX_FRAME_COVERAGE = 15 min`,
+  `_DRY_THRESHOLD_MM_H = 0.1`) sind gesetzt und durch Tests fixiert
+  (`test_nowcast_blockende_datenluecke.py::test_deckungskonstante_ist_fuenfzehn_minuten`).
+- Tests lösen ihren Prüfling relativ zur eigenen Testdatei auf
+  (`test_prueling_stammt_aus_diesem_arbeitsbaum` in allen Blockende-Tests).
+
+## Dependencies
+
+- **Upstream:** `frames` + `all_ts_sorted` aus `_derive_result`; die Konstanten oben.
+- **Downstream:** `NowcastResult.event_end_minutes` / `.event_ongoing_beyond_horizon` → alle vier
+  Kanäle (E-Mail-Langform, Telegram, SMS-Kurzform ` >@HH:MM`, Premium-SMS), Briefing-Hinweis,
+  Kommando-Antwort, Validator-Render-Service.
+- **Querschnitt:** der `already_running`-Zweig aus **#2050 S2b** ruft denselben Helfer auf und
+  nimmt `max(_end_ts, _laufend[3])`. Eine Änderung am Helfer wirkt dort mit.
+
+## Existing Specs
+
+- `docs/specs/modules/feat_2051_s1_dauer_und_ende.md` — **Implementation Details** schreiben die
+  Nachbar-Deckung ausdrücklich vor: „`min(nächster Frame, +_MAX_FRAME_COVERAGE, Horizontende)` —
+  dieselbe Nachbar-Deckungslogik wie in `_accumulate_precip_mm`". Der Code weicht davon ab.
+  ⇒ **Es ist ein Umsetzungsfehler gegen die eigene Spec, keine offene Entwurfsfrage.**
+- `docs/specs/modules/alarm_szenario_laufendes_ereignis.md` — #2050 S2b, nutzt denselben Helfer.
+
+## Bestehende Wächter (Regressionsfläche)
+
+| Test | Deckt |
+|---|---|
+| `tests/tdd/test_nowcast_blockende_ableitung.py` | AC-1 (Ende am letzten nassen Frame), AC-2 (zwei Blöcke verschmelzen nicht) |
+| `tests/tdd/test_nowcast_blockende_datenluecke.py` | AC-3 (Lücke ≤ Deckung), AC-4 (Lücke > Deckung → Deckungsgrenze) |
+| `tests/tdd/test_nowcast_blockende_horizont_waechter.py` | AC-5 (a–d): Block bis zum Horizont nass · abgeschnittene Zeitreihe · Untergrenzen-Text in E-Mail, SMS, Briefing |
+| `tests/tdd/test_nowcast_blockende_tagesfenster.py`, `..._tagesversatz.py` | Tagesfenster/Datumsversatz |
+| `tests/tdd/test_alarm_szenario_laufendes_ereignis.py` | #2050 S2b — `already_running`-Zweig über denselben Helfer |
+
+## Risks & Considerations
+
+1. **Der Ticket-Vorschlag (`coverage_end = min(coverage_end, next_ts)`) hält der Gegenprobe stand.**
+   Durchgerechnet gegen AC-5: bei einer bis zum Horizont nassen Reihe ist `next_ts` entweder
+   ≥ `horizon` oder `None` — in beiden Fällen bleibt `coverage_end == horizon`, der Wächter-Zweig
+   greift unverändert. Auch AC-3/AC-4 bleiben rechnerisch gleich. Das ist eine Herleitung, kein
+   Nachweis — die Analyse muss sie am laufenden Code messen.
+2. **#2050 S2b ist die eigentliche Regressionsfläche**, nicht #2051. Im `already_running`-Zweig kann
+   der Block künftig vor dem Horizont enden, wo er bisher immer den Horizont zurückgab.
+   Die dortige Konvention „nenne die **Deckungsgrenze** des letzten Frames, nie dessen Zeitstempel"
+   muss erhalten bleiben (sonst läge das gemeldete Ende in der Vergangenheit).
+3. **Die AC-Lücke ist der eigentliche Befund:** AC-1 prüft ein Ende *deutlich vor* dem Horizont,
+   AC-5 eine Reihe, die *bis zum* Horizont nass bleibt. Die Zone dazwischen — Ende zwischen
+   `horizon - 15 min` und `horizon` — kommt in keinem der 20 Kriterien vor. Der neue Wächter muss
+   **diese Zone** abdecken (Ende bei `horizon - 14min` … `horizon - 2min`), nicht nur den einen
+   gemeldeten Zeitpunkt.
+4. **Wortlaut ist entschieden und nicht neu vorzulegen:** `letzter Regen gegen HH:MM` /
+   `Regen mindestens bis HH:MM`, Kurzform ` >@HH:MM`; die SMS-Kurzform ist **englisch**.
+   Diese Arbeit ändert **keinen** Text — nur, welcher der beiden bestehenden Texte gewählt wird.
+5. **Keine Sicherheitsrichtung:** der Fehler übertreibt die Regendauer, verharmlost sie nie.
+   Der Fix dreht die Richtung nicht um — er darf kein Ende behaupten, das das Radar nicht belegt.
+6. **Parallel-Session-Kopplung:** #2050 S2b ist seit `ade992df` in `main`, #2073 S1 seit `1e0ee151`.
+   Beide Nachbar-Sessions haben #2075 ausdrücklich freigegeben. `render.py` ist wieder frei.
+
+---
+
+## Analysis
+
+### Type
+
+**Bug** — Umsetzungsfehler gegen die eigene Spec (`feat_2051_s1_dauer_und_ende.md`,
+Implementation Details: `min(nächster Frame, +_MAX_FRAME_COVERAGE, Horizontende)`).
+Keine Entwurfsfrage, kein neuer Text, keine neue Toleranzzahl.
+
+### Gemessen, nicht hergeleitet
+
+Alle Werte am laufenden Code im Arbeitsbaum gemessen (`now=10:35`, `horizon=13:35`,
+Beginn 10:55, 2-Min-Raster). T = Zeitstempel des letzten nassen Frames.
+
+**Die fehlerhafte Zone:**
+
+| T | IST | Fix-1 (Ticket-Vorschlag) | Fix-2 (empfohlen) |
+|---|---|---|---|
+| 13:33 | `13:35 / ongoing` | `13:35 / ongoing` ❌ | **`13:33 / Ende`** ✅ |
+| 13:31 … 13:21 | `13:35 / ongoing` ❌ | `T / Ende` ✅ | `T / Ende` ✅ |
+| 13:19 und früher | `T / Ende` ✅ | unverändert | unverändert |
+
+Die Zone beginnt exakt bei `T = 13:21`; ab dort behauptet der Dienst bis zu **14 Minuten**
+Regen zu viel und wählt die Untergrenzen-Form, obwohl das Radar ein echtes Ende belegt.
+
+### Befund: der Fix aus dem Ticket schließt die Zone nicht ganz
+
+Der im Ticket vorgeschlagene Einzeiler (`coverage_end = min(coverage_end, next_ts)`) repariert
+**13:31 bis 13:21**, lässt aber **T = 13:33 unrepariert**. Grund: der nächste Frame liegt dann
+exakt **auf** dem Horizont, `coverage_end` bleibt damit `== horizon`, und der Zweig
+`if coverage_end >= horizon: return horizon, True` greift, **bevor** der trockene Frame bei 13:35
+ausgewertet werden kann.
+
+Nötig ist deshalb ein zweiter Halbsatz: der Horizont-Zweig darf nur greifen, wenn **kein Frame
+innerhalb des Fensters mehr folgt**.
+
+```python
+if next_ts is not None:
+    coverage_end = min(coverage_end, next_ts)
+...
+if coverage_end >= horizon and (next_ts is None or next_ts > horizon):
+    return horizon, True
+```
+
+Das ist genau das, was die Begründung des Tickets fordert („danach greift der Horizont-Zweig nur
+noch, wenn wirklich kein Frame innerhalb des Horizonts mehr folgt") — der dort vorgeschlagene
+Code leistet es nur nicht vollständig.
+
+### Gegenprobe: Fix-2 verändert keinen Bestandsfall
+
+Alle sechs gemessen, IST und Fix-2 identisch:
+
+| Fall | Ergebnis (beide) |
+|---|---|
+| Durchgehend nass bis zum Horizont (AC-5 a) | `13:35 / ongoing` |
+| Abgeschnittene Zeitreihe (AC-5 b) | `13:14 / ongoing` |
+| Datenlücke 25 Min (AC-4) | Deckungsgrenze, kein ongoing |
+| Datenlücke 10 Min (AC-3) | Block läuft weiter |
+| Zwei getrennte Blöcke (AC-2) | verschmelzen nicht |
+| Nächster Frame **jenseits** des Horizonts (13:40) | `13:35 / ongoing` |
+| Nasser Frame **exakt auf** dem Horizont | `13:35 / ongoing` (kippt nicht) |
+
+**Basislinie:** die fünf Blockende-Testdateien laufen im IST-Zustand mit **25 grün, 0 rot**.
+
+### Affected Files
+
+| Datei | Änderung | Beschreibung |
+|---|---|---|
+| `src/services/radar_service.py` | MODIFY | `_derive_wet_block_end`: Nachbar in die Deckungsgrenze einrechnen, Horizont-Zweig an „kein Folge-Frame im Fenster" binden (~3 LoC) |
+| `tests/tdd/test_nowcast_blockende_zone_vor_horizont.py` | CREATE | Wächter über die **ganze** Zone `horizon−14min … horizon−2min`, inklusive des Falls „Trockenframe exakt auf dem Horizont" |
+
+### Scope Assessment
+
+- Dateien: 2 (1 MODIFY, 1 CREATE)
+- Geschätzte LoC: +~90 / −2 (davon ~85 Test)
+- Risiko: **MEDIUM** — Kernpfad des Alarm-Inhalts in allen vier Kanälen, aber eng begrenzte
+  Änderung mit gemessener Nicht-Wirkung auf alle Bestandsfälle
+
+### Technical Approach
+
+Die Deckungsrechnung an die beiden funktionierenden Geschwister (`_accumulate_precip_mm`,
+`_laufendes_frame`) angleichen — kein neuer Mechanismus, keine neue Zahl. Der Wächter-Test muss
+die **Zone** abdecken, nicht den einzelnen gemeldeten Zeitpunkt: genau daran ist #2051 S1
+gescheitert (AC-1 prüft weit vor dem Horizont, AC-5 direkt am Horizont, die Fläche dazwischen kam
+in keinem der 20 Kriterien vor).
+
+### Regressionsfläche (kartiert)
+
+- **Zwei Aufrufer:** der Onset-Zweig (#2051 S1) und der `already_running`-Zweig (#2050 S2b).
+  Letzterer maximiert das Ergebnis gegen die Deckungsgrenze des laufenden Frames
+  (`max(_end_ts, _laufend[3])`, `radar_service.py:1034`) — damit nie ein Ende in der Vergangenheit
+  genannt wird.
+- **Die Text-Weiche sitzt an genau zwei Stellen:** `alert/render.py:580` (Langform) und
+  `alert/render.py:822` (Kurzform); beide entscheiden allein an `event_ongoing_beyond_horizon`.
+  Sieben Textstellen hängen daran, alle über `event_end_display()` (`alert/project.py:37-67`).
+- **#2050 S2b ist nachgerechnet NICHT betroffen.** Erste Vermutung war, dessen AC-5 (Lage B,
+  „läuft ohne Ende") hänge am `(horizon, True)`-Rückgabepfad. Am Fixture nachgerechnet stimmt das
+  nicht: alle drei Lagen (A/B/C) haben denselben 15-Min-Raster mit dem letzten Frame 37 Minuten
+  **vor** dem Horizont, und im offenen Intervall `(Horizont−15 min, Horizont]` liegt in keiner Lage
+  ein Frame. Lage B verlässt die Funktion deshalb über den Zweig **`next_ts is None`**
+  (`return coverage_end, True`, 14:45 lokal = Deckungsgrenze), nicht über den Horizont-Zweig — und
+  läuft zudem über den **Onset**-Zweig, nicht über `already_running`. Beide Zweige lässt der Fix
+  unberührt. Lage C (der einzige echte `already_running`-Fall) endet am Trockenframe, ebenfalls
+  unberührt.
+- **Nebenbefund (kein eigenes Issue, → #1199):** Die Konvention „im Laufend-Fall die Deckungsgrenze
+  nennen, nie den Frame-Zeitstempel" steht **nur** in einem Code-Kommentar
+  (`radar_service.py:1020-1030`) und im Test-Docstring von AC-4b — die Spec
+  `alarm_szenario_laufendes_ereignis.md` beschreibt an dieser Stelle noch den verworfenen
+  Feld-Satz (`running_until_minutes`). Für #2075 genügt der Code-Anker; die Spec-Nachführung
+  gehört zu #2050.
+
+### Open Questions
+
+Keine. Wortlaut, Kanalreichweite und die Untergrenzen-Konvention sind entschieden
+(PO-Entscheid 2026-08-22); diese Arbeit ändert keinen Text, nur die Wahl zwischen zwei
+bestehenden Formen.

--- a/docs/specs/modules/fix_2075_ende_am_radar_horizont.md
+++ b/docs/specs/modules/fix_2075_ende_am_radar_horizont.md
@@ -1,0 +1,246 @@
+---
+entity_id: fix_2075_ende_am_radar_horizont
+type: module
+created: 2026-08-22
+updated: 2026-08-22
+status: draft
+version: "1.0"
+tags: [alarm, nowcast, radar, dauer, ende, bugfix]
+---
+
+# Blockende zu nah am Radar-Horizont wird zur Untergrenze verfälscht — #2075
+
+## Approval
+
+- [x] Approved (PO, 2026-08-22)
+
+## Purpose
+
+`_derive_wet_block_end` (Issue #2051 S1) leitet das Ende eines nassen Blocks
+aus der bereits abgerufenen Frame-Zeitreihe ab und rechnet dabei — anders als
+seine beiden Geschwister `_accumulate_precip_mm` und `_laufendes_frame` — den
+nächsten Frame-Nachbarn nicht in die Deckungsgrenze ein. Endet der Regen
+innerhalb der letzten `_MAX_FRAME_COVERAGE` (15 Min) vor dem Horizont, meldet
+der Dienst deshalb `Regen mindestens bis <Horizont>` statt des echten, vom
+Radar belegten Endes: bis zu 14 Minuten Regen zu viel, und eine belegte
+Aussage erscheint als bloße Untergrenze statt als das, was sie ist. Gemessen
+auf Staging bei der Verifikation von #2051 Scheibe 1. Dies ist ein
+Umsetzungsfehler gegen die eigene Spec `feat_2051_s1_dauer_und_ende.md`
+(Implementation Details schreiben die Nachbar-Deckung ausdrücklich vor), keine
+offene Entwurfsfrage.
+
+## Source
+
+- **File:** `src/services/radar_service.py`
+- **Identifier:** `_derive_wet_block_end` (Z. 278-341)
+
+> **Schicht-Hinweis:** Python-Core (`src/services/`). Kein Go-API-, kein
+> Frontend-Anteil.
+
+Begleitend, nur als Textkonsumenten betroffen (keine Änderung an ihnen
+nötig): `src/output/renderers/alert/render.py` — Langform `_onset_end_suffix`
+(ab Z. 546) und Kurzform `_sms_onset_ende` (ab Z. 796) entscheiden beide
+allein an `event_ongoing_beyond_horizon`, das `_derive_wet_block_end`
+zurückgibt.
+
+## Estimated Scope
+
+- **LoC:** ~3 Produktivcode, ~85 Test.
+- **Files:** 2 (1 MODIFY, 1 CREATE).
+- **Effort:** low.
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `_accumulate_precip_mm` | function (`radar_service.py:200-242`) | Funktionierendes Geschwister — rechnet den Nachbarn bereits korrekt in die Deckung ein (`min(next_ts_full, ts + _MAX_FRAME_COVERAGE, end)`, Z. 272). Vorbild für den Fix, nicht selbst betroffen. |
+| `_laufendes_frame` | function (`radar_service.py:352-382`) | Drittes Geschwister (#2050 S2b) — rechnet den Nachbarn ebenfalls korrekt ein. Ebenfalls nur Vorbild, nicht betroffen. |
+| `_MAX_FRAME_COVERAGE` / `_DRY_THRESHOLD_MM_H` | constants (`radar_service.py:95,122`) | Bleiben unverändert — keine neue Toleranzzahl. |
+| Onset-Zweig / `already_running`-Zweig | call sites (`radar_service.py:1014`, `1031`) | Beide Aufrufer von `_derive_wet_block_end` — der Fix wirkt in beiden. Der `already_running`-Zweig (#2050 S2b) maximiert das Ergebnis zusätzlich gegen die Deckungsgrenze des laufenden Frames (`max(_end_ts, _laufend[3])`), das bleibt unverändert. |
+| `event_end_minutes` / `event_ongoing_beyond_horizon` | fields (`NowcastResult`, #2051 S1) | Downstream-Felder, unverändert im Namen und Datentyp — nur ihr Wert in der betroffenen Zone ändert sich. |
+
+## Implementation Details
+
+`_derive_wet_block_end` bildet je nassem Frame eine `coverage_end` aus dessen
+eigener Deckung (`ts + _MAX_FRAME_COVERAGE`), gedeckelt auf den Horizont —
+ermittelt aber unmittelbar danach `next_ts` (Zeitstempel des nächsten
+Frame-Nachbarn, `bisect_right` über `all_ts_sorted`), ohne ihn einzurechnen.
+Der Fix besteht aus **zwei** Teilen — der im Ticket vorgeschlagene Einzeiler
+(Teil 1 allein) hält der Gegenprobe am Randfall `T = 13:33` **nicht** stand
+(siehe AC-2):
+
+```python
+coverage_end = min(ts + _MAX_FRAME_COVERAGE, horizon)
+next_idx = bisect.bisect_right(all_ts_sorted, ts)
+next_ts = all_ts_sorted[next_idx] if next_idx < len(all_ts_sorted) else None
+
+# Teil 1: den Nachbarn in die Deckungsgrenze einrechnen -- dieselbe
+# Nachbar-Deckungslogik wie in `_accumulate_precip_mm` und `_laufendes_frame`.
+if next_ts is not None:
+    coverage_end = min(coverage_end, next_ts)
+
+# Teil 2: der Horizont-Zweig darf nur noch greifen, wenn wirklich KEIN Frame
+# mehr innerhalb des Fensters folgt -- sonst kippt ein Trockenframe exakt AUF
+# dem Horizont den Zweig faelschlich in "ongoing", bevor er ausgewertet wird.
+if coverage_end >= horizon and (next_ts is None or next_ts > horizon):
+    return horizon, True
+if next_ts is None:
+    return coverage_end, True
+if next_ts > coverage_end:
+    return coverage_end, False
+```
+
+Teil 1 allein schließt die fehlerhafte Zone `T = 13:21 … 13:31` (Nachbar
+jenseits des reinen `coverage_end`-Deckels, aber innerhalb des Horizonts).
+Teil 2 ist zusätzlich nötig für `T = 13:33`: dort liegt der nächste
+(trockene) Frame exakt auf dem Horizont, `coverage_end` bleibt nach Teil 1
+`== horizon`, und ohne Teil 2 griffe der Horizont-Zweig weiterhin, bevor der
+trockene Frame bei 13:35 überhaupt ausgewertet wird. Beide Teile zusammen
+sind die vollständige Angleichung an die beiden funktionierenden Geschwister
+— kein neuer Mechanismus, keine neue Zahl.
+
+## Expected Behavior
+
+- **Input:** dieselbe Frame-Zeitreihe wie heute (`frames`, `all_ts_sorted`,
+  `onset_ts`, `horizon`) — kein zusätzlicher Quellenabruf, keine geänderte
+  Signatur.
+- **Output:** `_derive_wet_block_end` nennt in der Zone `horizon - 14min …
+  horizon - 2min` (gemessen: `T = 13:21 … 13:31` bei `horizon = 13:35`) das
+  echte, vom Radar belegte Ende (`last_wet_ts, False`) statt fälschlich
+  `(horizon, True)`. Alle Bestandsfälle außerhalb dieser Zone bleiben
+  unverändert.
+- **Side effects:** keine — reine Korrektur der Grenzfindung innerhalb einer
+  bestehenden, additiv eingeführten Funktion. Kein Datenmodell-Bruch, keine
+  Persistenz betroffen, keine Änderung an der Auslöseregel.
+
+## Acceptance Criteria
+
+- **AC-1:** Given eine Frame-Zeitreihe im 2-Minuten-Raster (Beginn 10:55,
+  `now = 10:35`, `horizon = 13:35`), deren letzter nasser Frame `T` einen Wert
+  aus `{13:21, 13:23, 13:25, 13:27, 13:29, 13:31}` trägt und danach nur noch
+  trockene bzw. keine weiteren Frames folgen / When `_derive_wet_block_end`
+  für jeden dieser sechs Werte einzeln ausgewertet wird / Then ist das
+  zurückgegebene Ende in JEDEM der sechs Fälle exakt `T`, und
+  `ongoing_beyond_horizon` ist `False` — nicht `(horizon, True)`. Diese Zone
+  wird bewusst als Fläche geprüft, nicht als Einzelpunkt: #2051 S1 hatte je
+  ein Kriterium an den beiden Rändern (deutlich vor dem Horizont bzw. bis zum
+  Horizont durchgehend nass) und ließ die Fläche dazwischen ungeprüft — genau
+  dort lag der Fehler.
+  - Test: parametrisierter Unit-Test gegen `_derive_wet_block_end` mit den
+    sechs `T`-Werten, je Wert `(end_ts, ongoing)` gegen `(T, False)` geprüft.
+
+- **AC-2:** Given denselben Rahmen wie AC-1, aber mit `T = 13:33` und einem
+  tatsächlich vorhandenen, trockenen Frame exakt auf dem Horizont (13:35) /
+  When `_derive_wet_block_end` ausgewertet wird / Then ist das Ende `13:33`
+  und `ongoing_beyond_horizon = False` — nicht `(horizon, True)`. Dieser Fall
+  wird von Teil 1 der Lösung allein NICHT repariert (`coverage_end` bleibt
+  nach der Nachbar-Einrechnung `== horizon`); erst Teil 2 (Horizont-Zweig nur
+  bei fehlendem Folge-Frame) schließt ihn.
+  - Test: Unit-Test mit explizitem Trockenframe auf dem Horizont-Zeitstempel,
+    `(end_ts, ongoing)` gegen `(13:33, False)` geprüft.
+
+- **AC-3:** Given eine Frame-Zeitreihe, die durchgehend nass bis zum Horizont
+  reicht (kein Trockenframe im gesamten Fenster, letzter bekannter Frame
+  liegt auf oder nach `horizon - _MAX_FRAME_COVERAGE`) / When
+  `_derive_wet_block_end` ausgewertet wird / Then bleibt das Ergebnis
+  `(horizon, True)` — unverändert gegenüber dem heutigen Verhalten. Der Fix
+  darf diesen Fall nicht berühren.
+  - Test: Regressionstest (Bestandsfixture aus
+    `test_nowcast_blockende_horizont_waechter.py`), `(end_ts, ongoing)` gegen
+    `(horizon, True)` geprüft.
+
+- **AC-4:** Given eine Frame-Zeitreihe, die vor dem Horizont abbricht (kein
+  weiterer Frame-Eintrag in `all_ts_sorted` nach dem letzten bekannten Frame),
+  während dieser letzte bekannte Frame noch nass ist / When
+  `_derive_wet_block_end` ausgewertet wird / Then bleibt das Ergebnis
+  `(coverage_end, True)` an der Deckungsgrenze des letzten Frames —
+  unverändert gegenüber dem heutigen Verhalten.
+  - Test: Regressionstest (Bestandsfixture, abgeschnittene Zeitreihe),
+    `(end_ts, ongoing)` gegen `(letzter_frame + 15min, True)` geprüft.
+
+- **AC-5:** Given eine Frame-Zeitreihe, deren letzter nasser Frame um 13:30
+  liegt und deren nächster (trockener) Frame erst bei 13:40 folgt — also
+  JENSEITS des Horizonts (13:35) / When `_derive_wet_block_end` ausgewertet
+  wird / Then bleibt das Ergebnis `(horizon, True)` — der Fix darf hier weder
+  auf 13:40 kippen (das wäre eine Aussage über unbeobachtete Zeit, die das
+  Radar zwischen 13:35 und 13:40 nicht belegt) noch auf einen früheren Wert
+  als den Horizont.
+  - Test: Unit-Test mit Nachbar-Frame jenseits des Horizonts,
+    `(end_ts, ongoing)` gegen `(horizon, True)` geprüft.
+
+- **AC-6:** Given einen nassen Block mit einer Datenlücke innerhalb der
+  `_MAX_FRAME_COVERAGE`-Deckung (Lücke ≤ 15 Min) sowie mit einer Datenlücke
+  größer als die Deckung (> 15 Min), jeweils gefolgt von einem erneut nassen
+  bzw. keinem weiteren Frame / When `_derive_wet_block_end` beide Fälle
+  auswertet / Then läuft der Block bei der kleinen Lücke unverändert weiter
+  (Ende beim späteren nassen Frame), bei der großen Lücke endet er an der
+  Deckungsgrenze des Frames vor der Lücke (`ongoing_beyond_horizon = False`)
+  — beide Fälle unverändert gegenüber dem heutigen Verhalten.
+  - Test: Regressionslauf der Bestandsfixtures aus
+    `test_nowcast_blockende_datenluecke.py`, keine inhaltliche Anpassung.
+
+- **AC-7:** Given zwei getrennte nasse Blöcke in derselben Frame-Zeitreihe
+  (Trockenframe zwischen ihnen) / When `_derive_wet_block_end` das Ende des
+  ersten Blocks ableitet / Then endet der Block beim ersten Trockenframe —
+  der zweite, spätere Block wird NICHT eingerechnet, die beiden verschmelzen
+  weiterhin nicht zu einer überlangen Dauer.
+  - Test: Regressionslauf der Bestandsfixture aus
+    `test_nowcast_blockende_ableitung.py`, keine inhaltliche Anpassung.
+
+- **AC-8:** Given den Aufbau aus AC-1 (`T` in der Zone `13:21 … 13:31`) / When
+  die Langform (`_onset_end_suffix`) und die Kurzform (`_sms_onset_ende`)
+  gerendert werden / Then enthält die Langform `letzter Regen gegen HH:MM`
+  und die Kurzform `@HH:MM` (ohne führendes ` >`) — NICHT die
+  Untergrenzen-Formen `Regen mindestens bis HH:MM` bzw. ` >@HH:MM`. Der
+  Fehler wirkt bis in den gerenderten Text durch, nicht nur in den
+  Rückgabewerten der Ableitungsfunktion.
+  - Test: Unit-Test gegen `_onset_end_suffix` und `_sms_onset_ende` mit einem
+    `OnsetEvent`, dessen `event_end_time`/`event_ongoing_beyond_horizon` aus
+    einem AC-1-Fall stammen; Substring-Prüfung auf die Normalform, Negativ-
+    Prüfung auf die Untergrenzen-Form.
+
+- **AC-9:** Given die drei Lagen (A/B/C) aus
+  `tests/tdd/test_alarm_szenario_laufendes_ereignis.py` (#2050 S2b; Lage A und
+  B laufen über den Onset-Zweig, nur Lage C über `already_running` — letzter
+  Frame jeweils 37 Minuten vor dem Horizont, außerhalb der fehlerhaften Zone) / When die volle Bestandstestdatei nach
+  dem Fix läuft / Then bleiben alle drei Lagen unverändert grün — nachgerechnet
+  betroffen ist keine von ihnen, weil im offenen Intervall
+  `(Horizont − 15 min, Horizont]` in keiner der drei Lagen ein Frame liegt.
+  Dieses AC sichert die Nicht-Betroffenheit ab, statt sie nur zu behaupten.
+  - Test: Regressionslauf von
+    `test_alarm_szenario_laufendes_ereignis.py` in voller Länge, 0 neue rote
+    Fälle.
+
+## Known Limitations
+
+- **Keine Umkehr der Sicherheitsrichtung.** Der Fehler übertreibt die
+  Regendauer, verharmlost sie nie (bis zu 14 Minuten zu viel gemeldet). Der
+  Fix dreht diese Richtung nicht um: er kann das gemeldete Ende nur nach
+  vorn (näher an die letzte tatsächliche Beobachtung) korrigieren, niemals
+  ein Ende behaupten, das das Radar nicht belegt. Unbeobachtete Zeit
+  (jenseits des Horizonts, in einer Datenlücke) bleibt unbeobachtet und wird
+  weiterhin nicht als Ende ausgegeben.
+- **R4 bleibt strukturell** (wie bereits in `feat_2051_s1_dauer_und_ende.md`
+  festgehalten): jenseits von 180 Minuten (`_NOWCAST_HORIZON_MIN`) bleibt das
+  tatsächliche Ende grundsätzlich unbekannt. Diese Arbeit ändert daran
+  nichts — sie korrigiert ausschließlich die Grenzfindung innerhalb des
+  bereits beobachteten Fensters.
+- **Abhängig vom Quellenraster** wie schon in #2051 S1: bei gröberem Raster
+  (bis 15 Min Kadenz) kann das abgeleitete Ende weiterhin um bis zu
+  `_MAX_FRAME_COVERAGE` von der Wirklichkeit abweichen — diese Toleranz wird
+  durch den Fix nicht verändert, nur korrekt angewendet.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Reine Bugfix-Korrektur einer bestehenden, additiv
+  eingeführten Funktion (#2051 S1) an die bereits etablierte
+  Nachbar-Deckungslogik ihrer beiden Geschwister an. Kein neuer Mechanismus,
+  keine neue Konstante, kein neues Feld, kein neuer Text — berührt keine der
+  vier Entscheidungsflächen (Kanäle, Provider, Datenmodell/Persistenz, Auth,
+  Editor-Paradigma, Test-/Deploy-Strategie), die ein neues ADR verlangen
+  würden.
+
+## Changelog
+
+- 2026-08-22: Initial spec created (#2075, Nachbesserung zu #2051 S1).

--- a/docs/specs/modules/fix_2075_ende_am_radar_horizont.md
+++ b/docs/specs/modules/fix_2075_ende_am_radar_horizont.md
@@ -45,7 +45,7 @@ zurückgibt.
 
 ## Estimated Scope
 
-- **LoC:** ~3 Produktivcode, ~85 Test.
+- **LoC:** ~8 Produktivcode, ~85 Test.
 - **Files:** 2 (1 MODIFY, 1 CREATE).
 - **Effort:** low.
 
@@ -64,24 +64,45 @@ zurückgibt.
 `_derive_wet_block_end` bildet je nassem Frame eine `coverage_end` aus dessen
 eigener Deckung (`ts + _MAX_FRAME_COVERAGE`), gedeckelt auf den Horizont —
 ermittelt aber unmittelbar danach `next_ts` (Zeitstempel des nächsten
-Frame-Nachbarn, `bisect_right` über `all_ts_sorted`), ohne ihn einzurechnen.
-Der Fix besteht aus **zwei** Teilen — der im Ticket vorgeschlagene Einzeiler
-(Teil 1 allein) hält der Gegenprobe am Randfall `T = 13:33` **nicht** stand
-(siehe AC-2):
+Frame-Nachbarn, `bisect_right` über `all_ts_sorted`).
+
+Der ursprünglich vorgeschlagene erste Fix-Teil rechnete diesen Nachbarn
+zusätzlich in `coverage_end` selbst ein (`coverage_end = min(coverage_end,
+next_ts)`) — analog zur Nachbar-Deckung in den beiden Geschwistern
+`_accumulate_precip_mm` und `_laufendes_frame`. Die Mutations-Gegenprobe des
+Adversary (Befund F001, 2026-08-22) hat gezeigt, dass diese Einrechnung an
+KEINER der drei Stellen wirkt, an denen `coverage_end` danach ausgelesen
+wird:
+
+- Der Horizont-Zweig (`coverage_end >= horizon and (next_ts is None or
+  next_ts > horizon)`) liefert mit und ohne die Nachbar-Einrechnung dasselbe
+  Ergebnis, weil dessen zweite Bedingung (`next_ts > horizon`) bereits genau
+  den Fall abfängt, den die Einrechnung hätte ausschließen sollen.
+- `return coverage_end, True` im `next_ts is None`-Zweig wird nur erreicht,
+  wenn `next_ts` bereits `None` ist — dort hat die Einrechnung keinen
+  Angriffspunkt mehr.
+- `if next_ts > coverage_end: return coverage_end, False` — diese Bedingung
+  ist genau dann wahr, wenn `next_ts` größer als das UNVERÄNDERTE
+  `coverage_end` ist, und dann gilt `min(coverage_end, next_ts) ==
+  coverage_end`: die Einrechnung ändert den Rückgabewert also nicht.
+
+Anders als bei `_accumulate_precip_mm` (summiert in einem BEKANNTEN Fenster)
+und `_laufendes_frame` (bestimmt die Deckung eines EINZELNEN Frames) SUCHT
+`_derive_wet_block_end` die Fenstergrenze erst (siehe Docstring) — die
+Nachbar-Deckung wirkt bei den Geschwistern, weil sie dort das Ergebnis
+unmittelbar begrenzt; hier prüfen alle drei Auslesestellen `next_ts` bereits
+direkt, sodass eine zusätzliche Einrechnung in `coverage_end` redundant ist.
+Der eigentliche Fix ist deshalb ein Einzeiler — die zusätzliche Bedingung im
+Horizont-Zweig:
 
 ```python
 coverage_end = min(ts + _MAX_FRAME_COVERAGE, horizon)
 next_idx = bisect.bisect_right(all_ts_sorted, ts)
 next_ts = all_ts_sorted[next_idx] if next_idx < len(all_ts_sorted) else None
 
-# Teil 1: den Nachbarn in die Deckungsgrenze einrechnen -- dieselbe
-# Nachbar-Deckungslogik wie in `_accumulate_precip_mm` und `_laufendes_frame`.
-if next_ts is not None:
-    coverage_end = min(coverage_end, next_ts)
-
-# Teil 2: der Horizont-Zweig darf nur noch greifen, wenn wirklich KEIN Frame
-# mehr innerhalb des Fensters folgt -- sonst kippt ein Trockenframe exakt AUF
-# dem Horizont den Zweig faelschlich in "ongoing", bevor er ausgewertet wird.
+# Der Horizont-Zweig darf nur noch greifen, wenn wirklich KEIN Frame mehr
+# innerhalb des Fensters folgt -- sonst kippt ein Trockenframe exakt AUF dem
+# Horizont den Zweig faelschlich in "ongoing", bevor er ausgewertet wird.
 if coverage_end >= horizon and (next_ts is None or next_ts > horizon):
     return horizon, True
 if next_ts is None:
@@ -90,14 +111,10 @@ if next_ts > coverage_end:
     return coverage_end, False
 ```
 
-Teil 1 allein schließt die fehlerhafte Zone `T = 13:21 … 13:31` (Nachbar
-jenseits des reinen `coverage_end`-Deckels, aber innerhalb des Horizonts).
-Teil 2 ist zusätzlich nötig für `T = 13:33`: dort liegt der nächste
-(trockene) Frame exakt auf dem Horizont, `coverage_end` bleibt nach Teil 1
-`== horizon`, und ohne Teil 2 griffe der Horizont-Zweig weiterhin, bevor der
-trockene Frame bei 13:35 überhaupt ausgewertet wird. Beide Teile zusammen
-sind die vollständige Angleichung an die beiden funktionierenden Geschwister
-— kein neuer Mechanismus, keine neue Zahl.
+Diese eine Bedingung schließt beide Randfälle: sowohl die fehlerhafte Zone
+`T = 13:21 … 13:31` (Nachbar innerhalb des Horizonts, aber jenseits des
+reinen `coverage_end`-Deckels) als auch `T = 13:33` (nächster, trockener
+Frame exakt auf dem Horizont) — siehe AC-1 und AC-2.
 
 ## Expected Behavior
 
@@ -132,10 +149,10 @@ sind die vollständige Angleichung an die beiden funktionierenden Geschwister
 - **AC-2:** Given denselben Rahmen wie AC-1, aber mit `T = 13:33` und einem
   tatsächlich vorhandenen, trockenen Frame exakt auf dem Horizont (13:35) /
   When `_derive_wet_block_end` ausgewertet wird / Then ist das Ende `13:33`
-  und `ongoing_beyond_horizon = False` — nicht `(horizon, True)`. Dieser Fall
-  wird von Teil 1 der Lösung allein NICHT repariert (`coverage_end` bleibt
-  nach der Nachbar-Einrechnung `== horizon`); erst Teil 2 (Horizont-Zweig nur
-  bei fehlendem Folge-Frame) schließt ihn.
+  und `ongoing_beyond_horizon = False` — nicht `(horizon, True)`. Eine bloße
+  Nachbar-Einrechnung in `coverage_end` allein repariert diesen Fall NICHT
+  (`coverage_end` bleibt dabei `== horizon`); erst die zusätzliche Bedingung
+  im Horizont-Zweig (nur bei fehlendem Folge-Frame) schließt ihn.
   - Test: Unit-Test mit explizitem Trockenframe auf dem Horizont-Zeitstempel,
     `(end_ts, ongoing)` gegen `(13:33, False)` geprüft.
 

--- a/src/services/radar_service.py
+++ b/src/services/radar_service.py
@@ -326,8 +326,14 @@ def _derive_wet_block_end(
         next_idx = bisect.bisect_right(all_ts_sorted, ts)
         next_ts = all_ts_sorted[next_idx] if next_idx < len(all_ts_sorted) else None
 
-        if coverage_end >= horizon:
-            # Der Block reicht bis an den Horizont der Quelle.
+        if coverage_end >= horizon and (next_ts is None or next_ts > horizon):
+            # Der Block reicht bis an den Horizont der Quelle -- und zwar nur
+            # dann, wenn wirklich KEIN Frame mehr innerhalb des Fensters
+            # folgt (#2075). Ohne die zweite Bedingung kippt ein Frame, das
+            # kurz vor dem Horizont endet (`coverage_end >= horizon` durch
+            # die Deckelung auf `horizon`, obwohl noch ein Nachbar folgt),
+            # diesen Zweig faelschlich in "ongoing" und meldet die
+            # Untergrenzen-Form statt des echten, belegten Endes.
             return horizon, True
         if next_ts is None:
             # Zeitreihe abgeschnitten, letzter bekannter Frame noch nass.

--- a/tests/tdd/test_nowcast_blockende_zone_vor_horizont.py
+++ b/tests/tdd/test_nowcast_blockende_zone_vor_horizont.py
@@ -1,0 +1,340 @@
+"""TDD RED — Issue #2075: das Blockende in der Zone kurz VOR dem Horizont.
+
+SPEC: docs/specs/modules/fix_2075_ende_am_radar_horizont.md — AC-1, AC-2,
+AC-5, AC-8.
+
+Fachlicher Kern: `_derive_wet_block_end` (#2051 S1) bildet je nassem Frame
+eine Deckungsgrenze aus dessen eigener Deckung (`ts + _MAX_FRAME_COVERAGE`),
+gedeckelt auf den Horizont — rechnet dabei aber, anders als seine beiden
+Geschwister `_accumulate_precip_mm` und `_laufendes_frame`, den naechsten
+Frame-Nachbarn NICHT ein. Endet der Regen innerhalb der letzten 15 Minuten
+vor dem Horizont, greift deshalb der Horizont-Zweig, obwohl die Quelle den
+Trockenuebergang laengst beobachtet hat: bis zu 14 Minuten Regen zu viel, und
+eine BELEGTE Aussage erscheint als blosse Untergrenze.
+
+#2051 S1 hatte je ein Kriterium an den beiden RAENDERN (Ende deutlich vor dem
+Horizont / durchgehend nass bis zum Horizont) und liess die Flaeche dazwischen
+ungeprueft — genau dort lag der Fehler. Diese Datei prueft die Zone deshalb
+als FLAECHE, nicht als Einzelpunkt.
+
+Bezugsrahmen aller Faelle (gemessen auf Staging bei der Verifikation von
+#2051 S1): `now = 10:35`, `horizon = 13:35` (180 Min), Beginn 10:55.
+
+Was hier steht:
+  * AC-1 — die fehlerhafte Zone `T = 13:21 … 13:31` als parametrisierte
+    Flaeche im 2-Minuten-Raster.
+  * AC-2 — der Randfall `T = 13:33` mit einem trockenen Frame EXAKT auf dem
+    Horizont. Bewusst ein eigener Test und nicht Teil der Parametrisierung:
+    er ist der Fall, den der naive Einzeiler (Nachbar in die Deckung
+    einrechnen) allein NICHT loest.
+  * AC-5 — Nachbar JENSEITS des Horizonts. Positivkontrolle gegen ein
+    Ueberschiessen des Fixes; heute schon gruen und nach dem Fix ebenso.
+  * AC-8 — Durchschlag bis in den gerenderten Text (Langform + Kurzform),
+    ueber die ECHTE Kette Ableitung -> `event_end_display` -> Renderer.
+
+Bestandsfaelle (AC-3, AC-4, AC-6, AC-7, AC-9) werden hier NICHT dupliziert;
+sie stehen in `test_nowcast_blockende_horizont_waechter.py`,
+`_datenluecke.py`, `_ableitung.py` und
+`test_alarm_szenario_laufendes_ereignis.py` und laufen als Regression mit.
+
+Mock-frei: echte `RadarFrame`-Objekte durch die echte Ableitung und die
+echten Renderer, die Uhr ist ueber `now=` FEST injiziert (keine Wanduhr).
+Eigener Cache je Service, damit kein prozessweit geteilter Zustand wirkt.
+"""
+from __future__ import annotations
+
+import inspect
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from output.renderers.alert.model import OnsetEvent
+from output.renderers.alert.project import event_end_display
+from output.renderers.alert.render import _onset_end_suffix, _sms_onset_ende
+from providers.brightsky import RadarFrame
+from services.radar_cache import RadarNowcastCacheService
+from services.radar_service import (
+    _NOWCAST_HORIZON_MIN, RadarNowcastService, _derive_wet_block_end,
+)
+
+# Fester Bezugszeitpunkt aller Faelle — keine Wanduhr. 10:35 UTC, damit die
+# Minutenversaetze unten unmittelbar den Uhrzeiten der Spec entsprechen:
+# Beginn 10:55 (+20), Horizont 13:35 (+180).
+_NOW = datetime(2026, 8, 21, 10, 35, tzinfo=timezone.utc)
+_HORIZON = _NOW + timedelta(minutes=_NOWCAST_HORIZON_MIN)
+_BEGINN_MIN = 20
+_BEGINN_TS = _NOW + timedelta(minutes=_BEGINN_MIN)
+
+# AC-8 rendert in Ortszeit: 2026-08-21 ist in Wien Sommerzeit (UTC+2), aus
+# 13:25 UTC wird 15:25, aus dem Horizont 13:35 UTC wird 15:35. Die beiden
+# Uhrzeiten sind BEWUSST verschieden — so faellt auf, wenn eine Fassung die
+# Zahl der anderen zeigt.
+_TZ = ZoneInfo("Europe/Vienna")
+
+# Die gemessene Zone: letzter nasser Frame innerhalb der letzten
+# `_MAX_FRAME_COVERAGE` (15 Min) vor dem Horizont, aber mit einem
+# beobachteten Trockenuebergang danach.
+_ZONE_MINUTEN = (166, 168, 170, 172, 174, 176)  # 13:21 … 13:31
+_RANDFALL_MINUTE = 178                          # 13:33
+_AC8_MINUTE = 170                               # 13:25
+
+
+def _frames(raster: dict[int, float]) -> list[RadarFrame]:
+    """`{Minutenversatz ab _NOW: Rate mm/h}` -> echte `RadarFrame`-Liste."""
+    return [
+        RadarFrame(timestamp=_NOW + timedelta(minutes=minute), precip_mm_h=rate)
+        for minute, rate in sorted(raster.items())
+    ]
+
+
+def _zwei_minuten_raster(nass_bis: int) -> dict[int, float]:
+    """Lueckenloses 2-Minuten-Raster von `_NOW` bis zum Horizont; nass
+    (1.0 mm/h) vom Beginn (Minute 20) bis einschliesslich `nass_bis`, danach
+    trocken."""
+    return {
+        m: (1.0 if _BEGINN_MIN <= m <= nass_bis else 0.0)
+        for m in range(0, _NOWCAST_HORIZON_MIN + 1, 2)
+    }
+
+
+def _blockende(raster: dict[int, float]) -> tuple[datetime, bool]:
+    """Echter Aufruf von `_derive_wet_block_end` mit derselben Bauform wie im
+    Produktivpfad: `all_ts_sorted` stammt aus der VOLLSTAENDIGEN Frame-Liste
+    (auch Frames jenseits des Horizonts), das Fenster begrenzt allein
+    `horizon`."""
+    frames = _frames(raster)
+    all_ts_sorted = sorted({f.timestamp for f in frames})
+    return _derive_wet_block_end(frames, all_ts_sorted, _BEGINN_TS, _HORIZON)
+
+
+def _ergebnis(raster: dict[int, float]):
+    """Echtes `_derive_result` mit fest injizierter Uhr — die volle Kette,
+    nicht nur der Helfer."""
+    svc = RadarNowcastService(cache=RadarNowcastCacheService())
+    return svc._derive_result(_frames(raster), "radar", now=_NOW)
+
+
+def _onset_event_aus_ableitung(raster: dict[int, float]) -> OnsetEvent:
+    """Ein `OnsetEvent`, dessen Ende-Felder aus der ECHTEN Ableitung stammen.
+
+    Der Weg ist derselbe, den beide Onset-Pfade nehmen (`project.py:555` bzw.
+    der Trip-Radar-Pfad): `_derive_result` -> `event_end_display` ->
+    `OnsetEvent`. Handgesetzte Felder wuerden hier nur den Renderer pruefen,
+    nicht die Kette — und genau die Kette ist der Gegenstand von AC-8."""
+    nc = _ergebnis(raster)
+    end_time, end_offset, end_ongoing = event_end_display(_NOW, nc, _TZ)
+    return OnsetEvent(
+        onset_minutes=nc.onset_minutes or 0,
+        onset_time="12:55",  # 10:55 UTC in Ortszeit; fuer das Ende belanglos
+        km_from=8.0, km_to=8.0, is_convective=nc.is_convective,
+        intensity_label=nc.intensity_label, source_label=nc.source,
+        event_end_time=end_time,
+        event_end_day_offset=end_offset,
+        event_ongoing_beyond_horizon=end_ongoing,
+    )
+
+
+def test_prueling_stammt_aus_diesem_arbeitsbaum():
+    """Vorbedingung (kein AC): Nowcast-Dienst, Alarm-Projektion und
+    Alarm-Renderer werden RELATIV ZU DIESER Testdatei aufgeloest — sonst
+    pruefte ein Worktree-Lauf still die Dateien des Hauptrepos und lieferte
+    falsches Gruen."""
+    from output.renderers.alert import project as project_module
+    from output.renderers.alert import render as render_module
+    from services import radar_service as radar_module
+
+    arbeitsbaum = Path(__file__).resolve().parents[2]
+    for modul in (radar_module, project_module, render_module):
+        modul_pfad = Path(inspect.getfile(modul)).resolve()
+        assert modul_pfad.is_relative_to(arbeitsbaum), (
+            f"Prueling stammt nicht aus diesem Arbeitsbaum: {modul_pfad}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-1 — die fehlerhafte Zone als FLAECHE
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("nass_bis", _ZONE_MINUTEN)
+def test_ac1_beobachtetes_ende_kurz_vor_dem_horizont_bleibt_belegtes_ende(nass_bis):
+    """AC-1 GIVEN ein lueckenloses 2-Minuten-Raster (now 10:35, Beginn 10:55,
+    Horizont 13:35), dessen letzter nasser Frame `T` in der Zone
+    `13:21 … 13:31` liegt und auf den nur noch trockene Frames folgen
+    WHEN `_derive_wet_block_end` fuer jeden dieser sechs Werte einzeln
+    ausgewertet wird
+    THEN ist das Ende in JEDEM Fall exakt `T` und der Horizont-Waechter
+    `False` — die Quelle hat den Trockenuebergang beobachtet, das Ende ist
+    bekannt und keine Untergrenze.
+
+    Als FLAECHE geprueft und nicht als Einzelpunkt: #2051 S1 hatte je ein
+    Kriterium an den beiden Raendern, und genau dazwischen lag der Fehler.
+
+    RED heute: der Horizont-Zweig greift, sobald `ts + 15 Min` den Horizont
+    erreicht, ohne den naechsten (trockenen) Frame-Nachbarn einzurechnen —
+    Rueckgabe `(13:35, True)`, also bis zu 14 Minuten Regen zu viel."""
+    erwartet_ende = _NOW + timedelta(minutes=nass_bis)
+
+    end_ts, ongoing = _blockende(_zwei_minuten_raster(nass_bis))
+
+    assert (end_ts, ongoing) == (erwartet_ende, False), (
+        f"RED: letzter nasser Frame {erwartet_ende:%H:%M}, danach trocken im "
+        f"2-Minuten-Raster bis zum Horizont {_HORIZON:%H:%M} — erwartet "
+        f"({erwartet_ende:%H:%M}, False), bekam ({end_ts:%H:%M}, {ongoing!r})"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-2 — der Randfall: Trockenframe exakt AUF dem Horizont
+# ---------------------------------------------------------------------------
+
+
+def test_ac2_trockenframe_exakt_auf_dem_horizont_beendet_den_block():
+    """AC-2 GIVEN denselben Rahmen wie AC-1, aber mit letztem nassem Frame um
+    13:33 und einem tatsaechlich vorhandenen, TROCKENEN Frame exakt auf dem
+    Horizont (13:35)
+    WHEN `_derive_wet_block_end` ausgewertet wird
+    THEN ist das Ende 13:33 und der Horizont-Waechter `False`.
+
+    Bewusst ein eigener Test statt eines siebten Parameters oben: dieser Fall
+    wird davon, den Nachbarn in die Deckungsgrenze einzurechnen, allein NICHT
+    repariert. Die Deckungsgrenze bleibt danach `== horizon` (der Nachbar IST
+    der Horizont), und der Horizont-Zweig griffe weiterhin, bevor der
+    trockene Frame ueberhaupt ausgewertet wird. Erst die zusaetzliche
+    Bedingung "Horizont-Zweig nur, wenn wirklich KEIN Frame mehr innerhalb
+    des Fensters folgt" schliesst ihn. Waere er in der Parametrisierung
+    versteckt, verschwaende dieser Unterschied im Sammelbefund.
+
+    RED heute: Rueckgabe `(13:35, True)` — zwei Minuten Regen zu viel, und
+    ein beobachtetes Ende erscheint als Untergrenze."""
+    erwartet_ende = _NOW + timedelta(minutes=_RANDFALL_MINUTE)
+    raster = _zwei_minuten_raster(_RANDFALL_MINUTE)
+
+    assert raster[_NOWCAST_HORIZON_MIN] == 0.0, (
+        "Vorbedingung: auf dem Horizont-Zeitstempel MUSS ein trockener Frame "
+        "liegen — ohne ihn pruefte dieser Fall etwas anderes."
+    )
+
+    end_ts, ongoing = _blockende(raster)
+
+    assert (end_ts, ongoing) == (erwartet_ende, False), (
+        f"RED: trockener Frame exakt auf dem Horizont {_HORIZON:%H:%M} — "
+        f"erwartet ({erwartet_ende:%H:%M}, False), bekam "
+        f"({end_ts:%H:%M}, {ongoing!r})"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-5 — Positivkontrolle: Nachbar JENSEITS des Horizonts
+# ---------------------------------------------------------------------------
+
+
+def test_ac5_nachbar_jenseits_des_horizonts_bleibt_untergrenze():
+    """AC-5 GIVEN eine Frame-Zeitreihe im 5-Minuten-Raster, deren letzter
+    nasser Frame um 13:30 liegt und deren naechster (trockener) Frame erst um
+    13:40 folgt — also JENSEITS des Horizonts 13:35
+    WHEN `_derive_wet_block_end` ausgewertet wird
+    THEN bleibt das Ergebnis `(13:35, True)`.
+
+    DIESER TEST IST HEUTE SCHON GRUEN — und muss es nach dem Fix bleiben. Er
+    ist die Positivkontrolle gegen ein Ueberschiessen und bewacht beide
+    Richtungen des moeglichen Fehlgriffs:
+
+      * nicht auf 13:40 kippen — das waere eine Aussage ueber unbeobachtete
+        Zeit; zwischen 13:35 und 13:40 belegt das Radar nichts, und der
+        Horizont ist die Reichweitengrenze der Quelle;
+      * nicht auf einen Wert VOR dem Horizont kippen — bis 13:35 ist der
+        Regen durch die Deckung des 13:30-Frames belegt.
+
+    Ohne diese Kontrolle koennte ein Fix die Zone aus AC-1 reparieren, indem
+    er den Horizont-Zweig pauschal entschaerft — und die Tests blieben gruen,
+    waehrend das Ergebnis unbeobachtete Zeit behauptet."""
+    raster = {m: (1.0 if _BEGINN_MIN <= m <= 175 else 0.0) for m in range(0, 176, 5)}
+    raster[185] = 0.0  # 13:40 — einziger Frame nach 13:30, jenseits des Horizonts
+
+    assert _NOWCAST_HORIZON_MIN not in raster, (
+        "Vorbedingung: auf dem Horizont selbst darf KEIN Frame liegen — sonst "
+        "waere dies der Randfall aus AC-2 und nicht der Nachbar dahinter."
+    )
+
+    end_ts, ongoing = _blockende(raster)
+
+    assert (end_ts, ongoing) == (_HORIZON, True), (
+        f"Der Fix ueberschiesst: letzter nasser Frame 13:30, naechster Frame "
+        f"erst 13:40 (jenseits des Horizonts {_HORIZON:%H:%M}) — erwartet "
+        f"({_HORIZON:%H:%M}, True), bekam ({end_ts:%H:%M}, {ongoing!r})"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-8 — Durchschlag bis in den gerenderten Text
+# ---------------------------------------------------------------------------
+
+
+def test_ac8_zone_erreicht_beide_textformen_als_bekanntes_ende():
+    """AC-8 GIVEN den Aufbau aus AC-1 mit `T = 13:25` (= 15:25 Ortszeit Wien)
+    WHEN das `OnsetEvent` ueber die ECHTE Kette gebaut wird
+    (`_derive_result` -> `event_end_display` -> `OnsetEvent`) und daraus die
+    Langform (`_onset_end_suffix`) sowie die Kurzform (`_sms_onset_ende`)
+    gerendert werden
+    THEN nennt die Langform `letzter Regen gegen 15:25` und die Kurzform
+    `@15:25` — NICHT die Untergrenzen-Formen `Regen mindestens bis` bzw.
+    ` >@`.
+
+    Der Fehler wirkt bis in den Text durch: heute liest der Nutzer
+    `Regen mindestens bis 15:35` und ` >@15:35`, obwohl das Radar das Ende um
+    15:25 beobachtet hat — zehn Minuten Regen zu viel, und eine belegte
+    Aussage als blosse Untergrenze. Am `>` der Kurzform haengt die ganze
+    Bedeutung: auf der Huette am Karnischen Hoehenweg kommt nur die
+    Premium-SMS an, dort stellt kein zweiter Kanal die Aussage richtig.
+
+    POSITIVKONTROLLE im selben Test: derselbe Renderer, aber mit einem
+    Ergebnis aus einer bis zum Horizont durchgehend nassen Zeitreihe, MUSS
+    sehr wohl `Regen mindestens bis 15:35` und ` >@15:35` liefern. Ohne sie
+    bestuende die Negativpruefung auch ein Renderer, der die
+    Untergrenzen-Form ueberhaupt nie schreibt."""
+    zone = _onset_event_aus_ableitung(_zwei_minuten_raster(_AC8_MINUTE))
+    # Gegenfassung: durchgehend nass bis an den Horizont -> Waechter gesetzt.
+    bis_horizont = _onset_event_aus_ableitung(
+        _zwei_minuten_raster(_NOWCAST_HORIZON_MIN)
+    )
+
+    # Vorbedingung deckt BEWUSST nur den Beginn ab, NICHT die Ende-Werte: die
+    # sind die zu pruefende Zusicherung. Stuenden sie hier, schluege der Test
+    # schon in der Vorbedingung fehl und der Nachweis, dass der Fehler bis in
+    # den TEXT durchschlaegt, bliebe ungefuehrt.
+    assert zone.onset_minutes == _BEGINN_MIN, (
+        f"Vorbedingung: Beginn bei Minute {_BEGINN_MIN}, bekam "
+        f"{zone.onset_minutes!r}"
+    )
+
+    lang_zone = _onset_end_suffix(zone)
+    sms_zone = _sms_onset_ende(zone)
+    lang_horizont = _onset_end_suffix(bis_horizont)
+    sms_horizont = _sms_onset_ende(bis_horizont)
+
+    # Positivkontrolle zuerst: die Untergrenzen-Form gibt es ueberhaupt.
+    assert "Regen mindestens bis 15:35" in lang_horizont, (
+        f"Positivkontrolle: bei durchgehend nasser Zeitreihe MUSS die "
+        f"Langform die Untergrenze nennen, bekam {lang_horizont!r}"
+    )
+    assert sms_horizont == " >@15:35", (
+        f"Positivkontrolle: bei durchgehend nasser Zeitreihe MUSS die "
+        f"Kurzform das Untergrenzen-Token tragen, bekam {sms_horizont!r}"
+    )
+
+    assert "letzter Regen gegen 15:25" in lang_zone, (
+        f"RED: ein um 15:25 beobachtetes Ende muss die Langform als bekanntes "
+        f"Ende nennen, bekam {lang_zone!r}"
+    )
+    assert "mindestens" not in lang_zone, (
+        f"Ein beobachtetes Ende darf nicht als Untergrenze erscheinen: "
+        f"{lang_zone!r}"
+    )
+    assert sms_zone == "@15:25", (
+        f"RED: die Kurzform muss das blanke Ende-Token '@15:25' tragen — ohne "
+        f"fuehrendes ' >', das eine Untergrenze behauptet — bekam "
+        f"{sms_zone!r}"
+    )


### PR DESCRIPTION
Behebt #2075.

## Problem

Endete der Regen innerhalb der letzten 15 Minuten vor dem Radar-Horizont, meldete der Dienst `Regen mindestens bis <Horizont>` statt des echten, vom Radar belegten Endes — bis zu 14 Minuten Regen zu viel, und eine belegte Aussage erschien als bloße Untergrenze. Gemessen auf Staging bei der Verifikation von #2051 Scheibe 1.

## Fix

Der Horizont-Zweig in `_derive_wet_block_end` greift nur noch, wenn wirklich kein Frame mehr innerhalb des Fensters folgt:

```python
if coverage_end >= horizon and (next_ts is None or next_ts > horizon):
    return horizon, True
```

Sonst läuft die Schleife bis zum Trockenframe weiter und liefert das echte Ende. Kein neuer Mechanismus, keine neue Toleranzzahl, keine Signaturänderung.

## Bemerkenswert: der Fix wurde durch die Mutations-Gegenprobe halbiert

Spec und Ticket sahen ursprünglich einen **zweiten** Teil vor (den Frame-Nachbarn in `coverage_end` einrechnen, analog zu `_accumulate_precip_mm` und `_laufendes_frame`). Die Adversary-Mutations-Gegenprobe zeigte: dieser Teil ist an **allen drei** Auslesestellen von `coverage_end` wirkungslos, und **kein Test** fing seine Entfernung (Befund F001).

Nachgerechnet und unabhängig bestätigt:
- Horizont-Zweig: dessen zweite Bedingung (`next_ts > horizon`) fängt bereits genau den Fall ab, den die Einrechnung ausschließen sollte
- `return coverage_end, True` im `next_ts is None`-Zweig: dort ist `next_ts` bereits `None`, die Einrechnung hat keinen Angriffspunkt
- `if next_ts > coverage_end`: die Bedingung ist genau dann wahr, wenn `next_ts` größer als das unveränderte `coverage_end` ist — und dann gilt `min(coverage_end, next_ts) == coverage_end`

Er wurde deshalb wieder entfernt; die Spec-Sektion „Implementation Details" ist entsprechend korrigiert. **Die Acceptance Criteria bleiben inhaltlich unverändert.**

Die Bewachung ist danach nachweislich **stärker**: Die Mutation „Bedingung zurückdrehen" fängt jetzt **8 Tests statt vorher 1** — der wirkungslose Teil hatte die Tests abgeschirmt.

## Nachweise

- **56 grün**: 10 neue Tests (AC-1/2/5/8) + 46 Bestand (AC-3/4/6/7/9)
- **Referenzfeger** über `tests/` nach `_derive_wet_block_end` / `event_ongoing_beyond_horizon` / `"mindestens bis"` fand sieben weitere berührte Testdateien — ebenfalls grün (39)
- **Adversary: VERIFIED**, 9/9 ACs belegt, 12 Mutationen über zwei Runden
- **AC-5 als Positivkontrolle gegen Überschießen**: liegt der nächste Frame jenseits des Horizonts, bleibt die Untergrenzen-Form. Der Fix behauptet nie eine Zeit, die das Radar nicht belegt

## Offene Nebenbefunde (nicht blockierend)

- **F002** — der Horizont-Deckel `min(ts + _MAX_FRAME_COVERAGE, horizon)` ist aus demselben Grund redundant. Bestandscode aus #2051, daher außerhalb des Scopes dieser Arbeit
- **F003** — der `next_ts is None`-Halbzweig ist verhaltensgleich zur Fallback-Zeile darunter. Als Null-Schutz sinnvoll, Entfernung würde den Code nicht kürzer machen

Beide sind bestätigte Redundanz, kein Verhaltensfehler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MytwiyEB6LSpmDm89XDa6L