### PR TITLE
fix(#2082): eine Regel fuer "ist diese Etappe vermessen"

### DIFF
--- a/docs/specs/modules/fix_2082_gehzeit_plausibilitaet.md
+++ b/docs/specs/modules/fix_2082_gehzeit_plausibilitaet.md
@@ -1,0 +1,151 @@
+---
+entity_id: fix_2082_gehzeit_plausibilitaet
+type: bugfix
+created: 2026-08-22
+updated: 2026-08-22
+status: approved
+version: "1.0"
+tags: [naismith, gehzeit, wegstrecke, ssot, khw]
+---
+
+# Gehzeit: eine Regel fuer "ist diese Etappe vermessen" (#2082)
+
+## Approval
+
+- [x] Approved — PO, 2026-08-22
+
+## Purpose
+
+Die mit #2042 eingefuehrte Distanzermittlung prueft zu schwach und auf der
+falschen Ebene. Sie benutzt eine gemessene Strecke, sobald die Differenz
+zweier Wegpunktwerte nicht negativ ist -- auch dann, wenn die Strecke
+**kuerzer als die Luftlinie** ist, was es physikalisch nicht geben kann.
+Ergebnis ist eine zu optimistische Ankunftszeit, also genau der Fehler, den
+#2042 beheben sollte.
+
+Zugleich entscheidet #2042 je Wegpunktpaar, waehrend die Ortsangabe der
+Alarme ueber `stage_measured_distances()` je Etappe entscheidet. Dieselbe
+Etappe kann deshalb in zwei Aussagen desselben Briefings verschieden
+beurteilt werden.
+
+Diese Aenderung beseitigt beides, indem sie die zweite Kopie **entfernt**:
+Beide Naismith-Implementierungen leiten kuenftig aus der kanonischen Regel
+ab, statt eine eigene mitzufuehren.
+
+## Source
+
+- **File:** `src/services/trip_segments.py` — **Identifier:** `stage_measured_distances`
+  (kanonische Regel, unveraendert; sie ist der Massstab)
+- **File:** `src/core/naismith.py` — **Identifier:** `compute_stage_arrivals`;
+  `_segment_distance_km` **entfaellt**
+- **File:** `internal/model/naismith.go` — **Identifier:** `ComputeStageArrivals`;
+  `segmentDistanceKm` wird durch ein Etappen-Pendant ersetzt
+
+Schicht: Python-Core (`src/`) UND Go-API (`internal/`) -- beide Naismith-Seiten
+sind bit-genau gespiegelt und muessen symmetrisch geaendert werden.
+
+## Estimated Scope
+
+- **LoC:** ~60 Produktivcode (Python schrumpft, Go bekommt das Pendant) + Tests
+- **Files:** 2 Produktiv-, 2 Testdateien
+- **Effort:** low
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| #2042 | Vorgaenger | fuehrte die zu behebende Regel ein |
+| `stage_measured_distances` (#2036 AC-8/AC-9/AC-14) | Regel | strikte Monotonie + Luftlinien-Plausibilitaet, je Etappe |
+
+## Implementation Details
+
+```
+Python  compute_stage_arrivals:
+        distanzen = stage_measured_distances(stage.waypoints)
+        distanzen is None  -> jede Teilstrecke = Luftlinie (Bestandsverhalten)
+        sonst              -> Teilstrecke = Differenz aufeinanderfolgender Werte
+
+Go      ComputeStageArrivals: dasselbe ueber ein neues stageMeasuredDistances(),
+        das die drei Bedingungen der Python-Regel spiegelt.
+```
+
+Entscheidung (Tech Lead, 2026-08-22): **Etappen-Ebene, alles oder nichts.**
+Eine teilweise vermessene Etappe waere eine Ankunftszeit, die an einer Stelle
+stimmt und an der naechsten still falsch ist -- und sie widerspraeche der
+Ortsangabe desselben Briefings.
+
+Nicht angefasst: Naismith-Summenformel, Tempoparameter, Startzeit, Rundung,
+die Normierung auf den Etappenstart.
+
+## Expected Behavior
+
+- **Input:** Etappe mit Wegpunkten, je optional `distance_from_start_km`.
+- **Output:** `arrival_calculated` je Wegpunkt. Vermessene, plausible Etappen
+  rechnen mit der gemessenen Strecke; alle anderen wie im Bestand.
+- **Side effects:** keine.
+
+## Acceptance Criteria
+
+- **AC-1:** Given eine Etappe, in der EIN Abschnitt kuerzer als die Luftlinie
+  zwischen seinen Wegpunkten ist / When die Ankunftszeiten berechnet werden /
+  Then rechnet die GESAMTE Etappe auf Luftlinie, nicht nur dieser Abschnitt.
+  - Test: drei Wegpunkte, mittlerer Abschnitt unplausibel kurz; alle
+    Ankunftszeiten entsprechen dem Luftlinien-Ergebnis.
+
+- **AC-2:** Given eine Etappe, deren gemessene Werte nicht strikt monoton
+  steigen (gleicher oder kleinerer Folgewert) / When gerechnet wird / Then
+  faellt die gesamte Etappe auf Luftlinie zurueck.
+  - Test: je ein Fall mit gleichem und mit kleinerem Folgewert.
+
+- **AC-3:** Given eine Etappe, in der ein einzelner Wegpunkt keinen Messwert
+  traegt / When gerechnet wird / Then gilt die GANZE Etappe als unvermessen.
+  - Test: drei Wegpunkte, mittlerer ohne Wert; alle Abschnitte Luftlinie.
+    Dies kehrt #2042 AC-3 bewusst um -- die Gegenprobe steht in Known Limitations.
+
+- **AC-4:** Given eine durchgehend vermessene, plausible Etappe / When
+  gerechnet wird / Then beruhen die Ankunftszeiten auf der gemessenen
+  Wegstrecke und liegen entsprechend spaeter als der Luftlinien-Wert.
+  - Test: Regressionswaechter fuer #2042 AC-1, unveraendert gueltig.
+
+- **AC-5:** Given die kanonische Regel `stage_measured_distances` wird zur
+  Laufzeit veraendert / When die Ankunftszeiten berechnet werden / Then
+  aendert sich das Ergebnis mit -- die Python-Seite fuehrt also keine zweite
+  Kopie der Regel mehr.
+  - Test: Mutations-Gegenprobe; die Schwelle der kanonischen Funktion
+    verstellen und nachweisen, dass die Ankunftszeiten folgen.
+
+- **AC-6:** Given dieselbe Etappe / When sie ueber die Python- und ueber die
+  Go-Implementierung berechnet wird / Then liefern beide dieselben Zeiten --
+  fuer vermessene, unvermessene UND unplausible Etappen.
+  - Test: Go-Test mit denselben Eingaben und Erwartungswerten wie der
+    Python-Test, je Fall aus AC-1 bis AC-4.
+
+- **AC-7:** Given eine Etappe ohne jeden Messwert / When gerechnet wird /
+  Then sind die Zeiten byte-identisch zum Bestand.
+  - Test: Regressionswaechter fuer #2042 AC-2, unveraendert gueltig.
+
+## Known Limitations
+
+- **#2042 AC-3 wird bewusst zurueckgenommen.** Dort war der Rueckfall je
+  Abschnitt festgelegt; diese Spec ersetzt das durch die Etappen-Regel. Der
+  zugehoerige Test aus #2042 wird entsprechend umgeschrieben, nicht geloescht.
+- Die Plausibilitaetspruefung erkennt nur Strecken, die KUERZER als die
+  Luftlinie sind. Eine zu grosse gemessene Strecke bleibt unentdeckt -- dafuer
+  gibt es keine beweisbare Obergrenze.
+- Am Produktivbestand tritt der Fall heute nicht auf (Messung 2026-08-22).
+  Die Aenderung schliesst eine Schutzluecke, sie behebt kein aktuell
+  sichtbares Fehlverhalten.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Keine Entscheidungsflaeche beruehrt. Es wird eine Kopie
+  entfernt und die bereits bestehende kanonische Regel zur einzigen Quelle
+  gemacht -- die Richtung, die #1480/#1474 fuer andere Skalen bereits
+  vorgeben.
+
+## Changelog
+
+- 2026-08-22: Initial spec created (#2082)
+- 2026-08-22: ACs vom PO freigegeben; umgesetzt — zweite Regel-Kopie entfernt,
+  beide Naismith-Seiten leiten aus `stage_measured_distances` ab

--- a/internal/model/naismith.go
+++ b/internal/model/naismith.go
@@ -105,40 +105,74 @@ func formatHHMM(totalMin int) string {
 // arrival[0] = Start; arrival[i] = arrival[i-1] + naismithHours(dist, asc, desc).
 // Pausentag (0 Wegpunkte): keine Berechnung, kein Feld.
 // sp: Tempoparameter aus ActivitySpeed(trip.Activity).
-// segmentDistanceKm liefert die Wegstrecke zwischen zwei Wegpunkten in km —
-// Issue #2042.
+// measuredSlackKm spiegelt _MEASURED_SLACK_KM der Python-Regel: 10 m Zugabe,
+// die die Rundung gespeicherter Werte abfaengt -- nicht mehr.
+const measuredSlackKm = 0.01
+
+// stageMeasuredDistances liefert die gemessene Wegstrecke je Wegpunkt, auf den
+// Etappenstart normiert -- oder nil, wenn die Etappe als UNVERMESSEN gilt
+// (Issue #2082).
 //
-// Tragen BEIDE Wegpunkte eine gemessene Strecke (DistanceFromStartKm, seit
-// #2036), ist deren Differenz die tatsächlich zu gehende Strecke. Sonst bleibt
-// es bei der Luftlinie wie im Bestand. Die Entscheidung fällt je Wegpunktpaar,
-// nicht je Etappe.
+// Spiegelt Python stage_measured_distances (services/trip_segments.py). Eine
+// Etappe ist nur vermessen, wenn
 //
-// Eine negative Differenz kann es bei korrekten Daten nicht geben; sie würde
-// die Gehzeit verkürzen und damit genau den Fehler erzeugen, den #2042 behebt.
-// Deshalb fällt auch dieser Fall auf die Luftlinie zurück.
+//  1. JEDER Wegpunkt einen Wert traegt (0 ist gueltig, fehlend nicht),
+//  2. die Werte STRIKT monoton steigen, und
+//  3. jede Teilstrecke mindestens so gross ist wie die Luftlinie zwischen den
+//     beiden Wegpunkten -- ein Track kann nie kuerzer sein als die direkte
+//     Verbindung.
 //
-// Spiegelt Python _segment_distance_km.
-func segmentDistanceKm(prev, wp Waypoint) float64 {
-	if prev.DistanceFromStartKm != nil && wp.DistanceFromStartKm != nil {
-		delta := *wp.DistanceFromStartKm - *prev.DistanceFromStartKm
-		if delta >= 0 {
-			return delta
+// Verletzt EIN Paar die Regel, gilt die GESAMTE Etappe als unvermessen: eine
+// teilweise vermessene Etappe waere eine Ankunftszeit, die an einer Stelle
+// stimmt und an der naechsten still falsch ist -- und sie widerspraeche der
+// Ortsangabe desselben Briefings, die schon je Etappe entscheidet.
+func stageMeasuredDistances(wps []Waypoint) []float64 {
+	if len(wps) == 0 {
+		return nil
+	}
+	values := make([]float64, len(wps))
+	for i, wp := range wps {
+		if wp.DistanceFromStartKm == nil {
+			return nil
+		}
+		values[i] = *wp.DistanceFromStartKm
+	}
+	for i := 0; i < len(values)-1; i++ {
+		span := values[i+1] - values[i]
+		if span <= 0 { // nicht strikt monoton
+			return nil
+		}
+		luftlinie := haversineKm(wps[i].Lat, wps[i].Lon, wps[i+1].Lat, wps[i+1].Lon)
+		if span+measuredSlackKm < luftlinie {
+			return nil
 		}
 	}
-	return haversineKm(prev.Lat, prev.Lon, wp.Lat, wp.Lon)
+	base := values[0]
+	out := make([]float64, len(values))
+	for i, v := range values {
+		out[i] = v - base
+	}
+	return out
 }
 
 func ComputeStageArrivals(stage *Stage, sp ActivitySpeeds) {
 	if stage == nil || len(stage.Waypoints) == 0 {
 		return
 	}
+	measured := stageMeasuredDistances(stage.Waypoints)
+
 	cur := float64(parseStartMinutes(stage.StartTime))
 	first := formatHHMM(int(math.Round(cur)))
 	stage.Waypoints[0].ArrivalCalculated = &first
 
 	for i := 1; i < len(stage.Waypoints); i++ {
 		prev, wp := stage.Waypoints[i-1], stage.Waypoints[i]
-		dist := segmentDistanceKm(prev, wp)
+		var dist float64
+		if measured != nil {
+			dist = measured[i] - measured[i-1]
+		} else {
+			dist = haversineKm(prev.Lat, prev.Lon, wp.Lat, wp.Lon)
+		}
 		dElev := float64(wp.ElevationM - prev.ElevationM)
 		asc := math.Max(0, dElev)
 		desc := math.Max(0, -dElev)

--- a/internal/model/naismith_gemessene_strecke_test.go
+++ b/internal/model/naismith_gemessene_strecke_test.go
@@ -1,89 +1,156 @@
 package model
 
-import (
-	"testing"
-)
+import "testing"
 
-// Spiegelbild zu tests/tdd/test_gehzeit_folgt_wegstrecke.py (#2042).
-// Dieselben Eingaben, dieselben erwarteten Ankunftszeiten — weichen die beiden
-// Seiten voneinander ab, ist die bit-genaue Spiegelung gebrochen (AC-5).
+// Spiegelbild zu tests/tdd/test_gehzeit_etappenregel.py (#2082, AC-6).
+// Dieselbe Geometrie, dieselben Faelle, dieselben Erwartungen -- weichen die
+// beiden Seiten voneinander ab, ist die bit-genaue Spiegelung gebrochen.
 
 const (
 	testLat  = 46.6500
 	testLonA = 12.4000
 	testLonB = 12.4300
+	testLonC = 12.4600
+	testElev = 1800
 )
 
 func kmPtr(v float64) *float64 { return &v }
+
+func hikerSpeeds() ActivitySpeeds { return ActivitySpeed("") }
 
 func stageWith(wps []Waypoint) *Stage {
 	start := "08:00"
 	return &Stage{ID: "T1", Name: "Pruefetappe", Date: "2026-08-25", Waypoints: wps, StartTime: &start}
 }
 
-func hikerSpeeds() ActivitySpeeds { return ActivitySpeed("") }
+func wp(id string, lon float64, km *float64) Waypoint {
+	return Waypoint{ID: id, Name: id, Lat: testLat, Lon: lon, ElevationM: testElev, DistanceFromStartKm: km}
+}
 
-// AC-1: Liegt die gemessene Strecke vor, bestimmt sie die Gehzeit.
-func TestArrivals_2042_MeasuredDistanceDrivesWalkingTime(t *testing.T) {
-	luft := haversineKm(testLat, testLonA, testLat, testLonB)
-	gemessen := luft * 2.0
+// luftlinienAnkunft liefert die erwartete Ankunft, wenn ALLE Abschnitte auf
+// Luftlinie rechnen (gleiche Hoehe => nur der Distanzanteil wirkt).
+func luftlinienAnkunft(lons ...float64) string {
+	cur := 480.0
+	for i := 0; i < len(lons)-1; i++ {
+		cur += haversineKm(testLat, lons[i], testLat, lons[i+1]) / hikerSpeeds().FlatKmh * 60.0
+	}
+	return formatHHMM(int(cur + 0.5))
+}
+
+// AC-1: Ein Abschnitt kuerzer als die Luftlinie entwertet die GANZE Etappe.
+func TestArrivals_2082_ImplausibleSegmentInvalidatesWholeStage(t *testing.T) {
+	luftAB := haversineKm(testLat, testLonA, testLat, testLonB)
+	luftBC := haversineKm(testLat, testLonB, testLat, testLonC)
 
 	stage := stageWith([]Waypoint{
-		{ID: "G1", Lat: testLat, Lon: testLonA, ElevationM: 1800, DistanceFromStartKm: kmPtr(0)},
-		{ID: "G2", Lat: testLat, Lon: testLonB, ElevationM: 1800, DistanceFromStartKm: kmPtr(gemessen)},
+		wp("G1", testLonA, kmPtr(0)),
+		wp("G2", testLonB, kmPtr(luftAB*2.0)),            // plausibel
+		wp("G3", testLonC, kmPtr(luftAB*2.0+luftBC*0.3)), // unplausibel kurz
 	})
 	ComputeStageArrivals(stage, hikerSpeeds())
 
-	got := *stage.Waypoints[1].ArrivalCalculated
-	wantMin := 480 + int(gemessen/hikerSpeeds().FlatKmh*60.0+0.5)
-	if got != formatHHMM(wantMin) {
-		t.Fatalf("gemessene Strecke muss die Gehzeit bestimmen: got %s, want %s", got, formatHHMM(wantMin))
+	if got, want := *stage.Waypoints[1].ArrivalCalculated, luftlinienAnkunft(testLonA, testLonB); got != want {
+		t.Fatalf("auch der plausible Abschnitt muss zurueckfallen: got %s, want %s", got, want)
+	}
+	if got, want := *stage.Waypoints[2].ArrivalCalculated, luftlinienAnkunft(testLonA, testLonB, testLonC); got != want {
+		t.Fatalf("Etappenende: got %s, want %s", got, want)
 	}
 }
 
-// AC-2: Ohne gemessene Strecke bleibt das Ergebnis wie im Bestand.
-func TestArrivals_2042_UnmeasuredStageUnchanged(t *testing.T) {
+// AC-2: Nicht strikt steigende Werte -> ganze Etappe Luftlinie.
+//
+// Der "gleich"-Fall braucht zwei Wegpunkte am SELBEN Ort: sonst faengt die
+// Plausibilitaetspruefung (span < Luftlinie) den Fall ab, bevor die
+// Monotonie-Regel gefragt ist, und der Test bestuende aus dem falschen Grund.
+// Die Mutation `span <= 0` -> `span < 0` blieb genau daran unentdeckt.
+func TestArrivals_2082_NonMonotonicFallsBack(t *testing.T) {
+	t.Run("kleiner", func(t *testing.T) {
+		stage := stageWith([]Waypoint{
+			wp("G1", testLonA, kmPtr(5.0)),
+			wp("G2", testLonB, kmPtr(4.0)),
+		})
+		ComputeStageArrivals(stage, hikerSpeeds())
+
+		if got, want := *stage.Waypoints[1].ArrivalCalculated, luftlinienAnkunft(testLonA, testLonB); got != want {
+			t.Fatalf("got %s, want %s", got, want)
+		}
+	})
+
+	t.Run("gleich", func(t *testing.T) {
+		// G1 und G2 am selben Ort (Luftlinie 0) mit gleichem Messwert: nur die
+		// Monotonie-Regel kann das verwerfen. G3 traegt einen grossen Wert --
+		// wird die Etappe faelschlich als vermessen gefuehrt, rechnet der
+		// zweite Abschnitt damit statt auf Luftlinie.
+		stage := stageWith([]Waypoint{
+			wp("G1", testLonA, kmPtr(5.0)),
+			wp("G2", testLonA, kmPtr(5.0)),
+			wp("G3", testLonB, kmPtr(25.0)),
+		})
+		ComputeStageArrivals(stage, hikerSpeeds())
+
+		if got, want := *stage.Waypoints[2].ArrivalCalculated, luftlinienAnkunft(testLonA, testLonA, testLonB); got != want {
+			t.Fatalf("gleiche Werte sind nicht strikt steigend: got %s, want %s", got, want)
+		}
+	})
+}
+
+// AC-3: Ein fehlender Messwert entwertet die GANZE Etappe.
+func TestArrivals_2082_MissingValueInvalidatesWholeStage(t *testing.T) {
+	luftAB := haversineKm(testLat, testLonA, testLat, testLonB)
 	stage := stageWith([]Waypoint{
-		{ID: "G1", Lat: testLat, Lon: testLonA, ElevationM: 1800},
-		{ID: "G2", Lat: testLat, Lon: testLonB, ElevationM: 1800},
+		wp("G1", testLonA, kmPtr(0)),
+		wp("G2", testLonB, nil), // Luecke
+		wp("G3", testLonC, kmPtr(luftAB*2.0+5.0)),
 	})
 	ComputeStageArrivals(stage, hikerSpeeds())
 
-	luft := haversineKm(testLat, testLonA, testLat, testLonB)
-	wantMin := 480 + int(luft/hikerSpeeds().FlatKmh*60.0+0.5)
-	if got := *stage.Waypoints[1].ArrivalCalculated; got != formatHHMM(wantMin) {
-		t.Fatalf("Bestandsetappe muss unveraendert rechnen: got %s, want %s", got, formatHHMM(wantMin))
+	if got, want := *stage.Waypoints[2].ArrivalCalculated, luftlinienAnkunft(testLonA, testLonB, testLonC); got != want {
+		t.Fatalf("eine Luecke darf keine teilweise vermessene Etappe hinterlassen: got %s, want %s", got, want)
 	}
 }
 
-// AC-4: Eine absteigende Strecke darf die Gehzeit nicht verkuerzen.
-func TestArrivals_2042_NegativeDeltaFallsBackToStraightLine(t *testing.T) {
+// AC-4: Vermessene, plausible Etappe rechnet gemessen (Waechter fuer #2042).
+func TestArrivals_2082_MeasuredPlausibleStageUsesMeasured(t *testing.T) {
+	luftAB := haversineKm(testLat, testLonA, testLat, testLonB)
+	gemessen := luftAB * 2.0
 	stage := stageWith([]Waypoint{
-		{ID: "G1", Lat: testLat, Lon: testLonA, ElevationM: 1800, DistanceFromStartKm: kmPtr(12)},
-		{ID: "G2", Lat: testLat, Lon: testLonB, ElevationM: 1800, DistanceFromStartKm: kmPtr(4)},
+		wp("G1", testLonA, kmPtr(0)),
+		wp("G2", testLonB, kmPtr(gemessen)),
 	})
 	ComputeStageArrivals(stage, hikerSpeeds())
 
-	luft := haversineKm(testLat, testLonA, testLat, testLonB)
-	wantMin := 480 + int(luft/hikerSpeeds().FlatKmh*60.0+0.5)
-	if got := *stage.Waypoints[1].ArrivalCalculated; got != formatHHMM(wantMin) {
-		t.Fatalf("negative Differenz muss auf die Luftlinie zurueckfallen: got %s, want %s", got, formatHHMM(wantMin))
+	want := formatHHMM(int(480.0 + gemessen/hikerSpeeds().FlatKmh*60.0 + 0.5))
+	if got := *stage.Waypoints[1].ArrivalCalculated; got != want {
+		t.Fatalf("gemessene Strecke muss die Gehzeit bestimmen: got %s, want %s", got, want)
 	}
 }
 
-// AC-5: feste Erwartungswerte, identisch zur Python-Seite.
-func TestArrivals_2042_ParityWithPython(t *testing.T) {
+// AC-7: Etappe ohne Messwerte bleibt beim Bestandsverhalten.
+func TestArrivals_2082_UnmeasuredStageUnchanged(t *testing.T) {
+	stage := stageWith([]Waypoint{
+		wp("G1", testLonA, nil),
+		wp("G2", testLonB, nil),
+	})
+	ComputeStageArrivals(stage, hikerSpeeds())
+
+	if got, want := *stage.Waypoints[1].ArrivalCalculated, luftlinienAnkunft(testLonA, testLonB); got != want {
+		t.Fatalf("got %s, want %s", got, want)
+	}
+}
+
+// Fester Paritaets-Anker: identische Erwartungswerte auf beiden Seiten.
+// 8,0 km / 4 km/h = 120 min; 300 Hm / 300 m/h = 60 min => 180 min ab 08:00.
+func TestArrivals_2082_ParityAnchor(t *testing.T) {
 	stage := stageWith([]Waypoint{
 		{ID: "G1", Lat: testLat, Lon: testLonA, ElevationM: 1800, DistanceFromStartKm: kmPtr(0)},
 		{ID: "G2", Lat: testLat, Lon: testLonB, ElevationM: 2100, DistanceFromStartKm: kmPtr(8)},
 	})
 	ComputeStageArrivals(stage, hikerSpeeds())
 
-	// 8,0 km / 4 km/h = 120 min; 300 Hm / 300 m/h = 60 min => 180 min ab 08:00.
 	if got := *stage.Waypoints[0].ArrivalCalculated; got != "08:00" {
 		t.Fatalf("Startzeit: got %s, want 08:00", got)
 	}
 	if got := *stage.Waypoints[1].ArrivalCalculated; got != "11:00" {
-		t.Fatalf("Paritaet zur Python-Seite gebrochen: got %s, want 11:00", got)
+		t.Fatalf("Paritaet gebrochen: got %s, want 11:00", got)
 	}
 }

--- a/src/core/naismith.py
+++ b/src/core/naismith.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Tuple
 from utils.geo import haversine_km
 
 if TYPE_CHECKING:
-    from app.trip import Stage, Waypoint
+    from app.trip import Stage
 
 _DEFAULT_START = "08:00"
 
@@ -85,31 +85,6 @@ def _naismith_hours(
     return dist_km / sp[0] + asc_m / sp[1] + desc_m / sp[2]
 
 
-def _segment_distance_km(prev: "Waypoint", wp: "Waypoint") -> float:
-    """Wegstrecke zwischen zwei Wegpunkten in km — Issue #2042.
-
-    Tragen BEIDE Wegpunkte eine gemessene Strecke (`distance_from_start_km`,
-    seit #2036), ist deren Differenz die tatsaechlich zu gehende Strecke.
-    Sonst bleibt es bei der Luftlinie wie im Bestand.
-
-    Die Entscheidung faellt je Wegpunktpaar, nicht je Etappe: eine teilweise
-    vermessene Etappe rechnet die vermessenen Abschnitte gemessen.
-
-    Eine negative Differenz kann es bei korrekten Daten nicht geben; sie wuerde
-    die Gehzeit verkuerzen und damit genau den Fehler erzeugen, den #2042
-    behebt. Deshalb faellt auch dieser Fall auf die Luftlinie zurueck.
-
-    Spiegelt Go segmentDistanceKm.
-    """
-    prev_km = getattr(prev, "distance_from_start_km", None)
-    wp_km = getattr(wp, "distance_from_start_km", None)
-    if prev_km is not None and wp_km is not None:
-        delta = float(wp_km) - float(prev_km)
-        if delta >= 0.0:
-            return delta
-    return haversine_km(prev.lat, prev.lon, wp.lat, wp.lon)
-
-
 def compute_stage_arrivals(stage: "Stage", activity: str) -> "Stage":
     """Berechnet arrival_calculated für jeden Wegpunkt — funktional, neue Stage.
 
@@ -132,6 +107,15 @@ def compute_stage_arrivals(stage: "Stage", activity: str) -> "Stage":
     else:
         start_str = None
 
+    # Issue #2082: EINE Regel fuer "ist diese Etappe vermessen" -- die
+    # kanonische aus `stage_measured_distances` (strikte Monotonie UND
+    # Plausibilitaet gegen die Luftlinie, je Etappe alles-oder-nichts).
+    # Import in der Funktion: `core` soll nicht beim Laden an `services`
+    # haengen (Muster wie in `services/track_resolution.py`).
+    from services.trip_segments import stage_measured_distances
+
+    measured = stage_measured_distances(stage.waypoints)
+
     cur = float(_parse_start_minutes(start_str))
     new_waypoints = []
 
@@ -141,7 +125,10 @@ def compute_stage_arrivals(stage: "Stage", activity: str) -> "Stage":
             new_waypoints.append(new_wp)
         else:
             prev = stage.waypoints[i - 1]
-            dist = _segment_distance_km(prev, wp)
+            if measured is not None:
+                dist = measured[i] - measured[i - 1]
+            else:
+                dist = haversine_km(prev.lat, prev.lon, wp.lat, wp.lon)
             d_elev = float((wp.elevation_m or 0) - (prev.elevation_m or 0))
             asc = max(0.0, d_elev)
             desc = max(0.0, -d_elev)

--- a/tests/tdd/test_gehzeit_etappenregel.py
+++ b/tests/tdd/test_gehzeit_etappenregel.py
@@ -1,0 +1,172 @@
+"""TDD RED — eine Regel fuer "ist diese Etappe vermessen" (#2082).
+
+Spec: docs/specs/modules/fix_2082_gehzeit_plausibilitaet.md
+
+Nutzersicht: Mit #2042 kann eine unplausibel kurze Wegstrecke (kuerzer als die
+Luftlinie -- physikalisch unmoeglich) in die Gehzeit eingehen und die Ankunft
+zu frueh ausweisen. Zugleich entscheidet die Ortsangabe der Alarme je Etappe,
+die Gehzeit aber je Abschnitt -- zwei Aussagen desselben Briefings auf
+verschiedener Grundlage.
+
+Diese Tests halten fest: Es gilt EINE Regel, die kanonische aus
+``stage_measured_distances`` -- je Etappe, alles oder nichts.
+
+KEINE MOCKS fuer den Prueflig selbst; nur AC-5 tauscht bewusst die kanonische
+Regel aus, um die Ableitung nachzuweisen.
+"""
+from __future__ import annotations
+
+from datetime import date, time
+
+import pytest
+
+from app.trip import Stage, Waypoint
+from core.naismith import activity_speeds, compute_stage_arrivals
+from utils.geo import haversine_km
+
+_LAT = 46.6500
+_LON_A = 12.4000
+_LON_B = 12.4300
+_LON_C = 12.4600
+_ELEV = 1800
+
+
+def _wp(wp_id: str, lon: float, *, km: float | None) -> Waypoint:
+    return Waypoint(
+        id=wp_id, name=wp_id, lat=_LAT, lon=lon,
+        elevation_m=_ELEV, distance_from_start_km=km,
+    )
+
+
+def _stage(waypoints: list[Waypoint]) -> Stage:
+    return Stage(
+        id="T1", name="Pruefetappe", date=date(2026, 8, 25),
+        waypoints=waypoints, start_time=time(8, 0),
+    )
+
+
+def _minutes(hhmm: str) -> int:
+    h, m = hhmm.split(":")
+    return int(h) * 60 + int(m)
+
+
+def _flat_kmh() -> float:
+    return activity_speeds("")[0]
+
+
+def _luft(lon1: float, lon2: float) -> float:
+    return haversine_km(_LAT, lon1, _LAT, lon2)
+
+
+def _verstrichen(result, i: int) -> int:
+    return _minutes(result.waypoints[i].arrival_calculated) - _minutes("08:00")
+
+
+def _luftlinien_minuten(*spannen: tuple[float, float]) -> float:
+    return sum(_luft(a, b) for a, b in spannen) / _flat_kmh() * 60.0
+
+
+def test_ac1_unplausibler_abschnitt_entwertet_die_ganze_etappe():
+    """AC-1: Ein Abschnitt kuerzer als die Luftlinie -> ganze Etappe Luftlinie."""
+    luft_ab = _luft(_LON_A, _LON_B)
+    luft_bc = _luft(_LON_B, _LON_C)
+    stage = _stage([
+        _wp("G1", _LON_A, km=0.0),
+        _wp("G2", _LON_B, km=luft_ab * 2.0),          # plausibel
+        _wp("G3", _LON_C, km=luft_ab * 2.0 + luft_bc * 0.3),  # unplausibel kurz
+    ])
+
+    result = compute_stage_arrivals(stage, "")
+
+    erwartet_1 = _luftlinien_minuten((_LON_A, _LON_B))
+    erwartet_2 = _luftlinien_minuten((_LON_A, _LON_B), (_LON_B, _LON_C))
+    assert _verstrichen(result, 1) == pytest.approx(erwartet_1, abs=1.0), (
+        "Auch der plausible Abschnitt muss auf Luftlinie fallen -- "
+        "die Regel gilt je Etappe, nicht je Abschnitt"
+    )
+    assert _verstrichen(result, 2) == pytest.approx(erwartet_2, abs=1.0)
+
+
+@pytest.mark.parametrize("zweiter_wert", [0.0, -1.0], ids=["gleich", "kleiner"])
+def test_ac2_nicht_strikt_steigend_faellt_zurueck(zweiter_wert: float):
+    """AC-2: Nicht strikt monotone Werte -> ganze Etappe Luftlinie."""
+    stage = _stage([
+        _wp("G1", _LON_A, km=5.0),
+        _wp("G2", _LON_B, km=5.0 + zweiter_wert),
+    ])
+
+    result = compute_stage_arrivals(stage, "")
+    assert _verstrichen(result, 1) == pytest.approx(
+        _luftlinien_minuten((_LON_A, _LON_B)), abs=1.0
+    )
+
+
+def test_ac3_ein_wegpunkt_ohne_messwert_entwertet_die_etappe():
+    """AC-3: Ein fehlender Wert macht die GANZE Etappe unvermessen.
+
+    Kehrt #2042 AC-3 bewusst um (dort: Rueckfall je Abschnitt).
+    """
+    luft_ab = _luft(_LON_A, _LON_B)
+    stage = _stage([
+        _wp("G1", _LON_A, km=0.0),
+        _wp("G2", _LON_B, km=None),               # Luecke
+        _wp("G3", _LON_C, km=luft_ab * 2.0 + 5.0),
+    ])
+
+    result = compute_stage_arrivals(stage, "")
+    assert _verstrichen(result, 2) == pytest.approx(
+        _luftlinien_minuten((_LON_A, _LON_B), (_LON_B, _LON_C)), abs=1.0
+    ), "Eine Luecke darf keine teilweise vermessene Etappe hinterlassen"
+
+
+def test_ac4_vermessene_plausible_etappe_rechnet_gemessen():
+    """AC-4: Regressionswaechter fuer #2042 AC-1."""
+    luft_ab = _luft(_LON_A, _LON_B)
+    gemessen = luft_ab * 2.0
+    stage = _stage([
+        _wp("G1", _LON_A, km=0.0),
+        _wp("G2", _LON_B, km=gemessen),
+    ])
+
+    result = compute_stage_arrivals(stage, "")
+    assert _verstrichen(result, 1) == pytest.approx(
+        gemessen / _flat_kmh() * 60.0, abs=1.0
+    )
+    assert _verstrichen(result, 1) > _luftlinien_minuten((_LON_A, _LON_B)) + 1.0
+
+
+def test_ac5_gehzeit_leitet_aus_der_kanonischen_regel_ab(monkeypatch):
+    """AC-5: Wird die kanonische Regel veraendert, folgen die Ankunftszeiten.
+
+    Beweist, dass ``naismith`` keine zweite Kopie der Regel mehr fuehrt.
+    """
+    import services.trip_segments as ts
+
+    gemessen = _luft(_LON_A, _LON_B) * 2.0
+    stage = _stage([
+        _wp("G1", _LON_A, km=0.0),
+        _wp("G2", _LON_B, km=gemessen),
+    ])
+
+    # Kanonische Regel liefert absichtlich das Doppelte.
+    monkeypatch.setattr(
+        ts, "stage_measured_distances", lambda wps: [0.0, gemessen * 2.0]
+    )
+
+    result = compute_stage_arrivals(stage, "")
+    assert _verstrichen(result, 1) == pytest.approx(
+        gemessen * 2.0 / _flat_kmh() * 60.0, abs=1.0
+    ), "Die Gehzeit muss der kanonischen Regel folgen, nicht einer eigenen Kopie"
+
+
+def test_ac7_etappe_ohne_messwerte_bleibt_unveraendert():
+    """AC-7: Regressionswaechter fuer #2042 AC-2."""
+    stage = _stage([
+        _wp("G1", _LON_A, km=None),
+        _wp("G2", _LON_B, km=None),
+    ])
+
+    result = compute_stage_arrivals(stage, "")
+    assert _verstrichen(result, 1) == pytest.approx(
+        _luftlinien_minuten((_LON_A, _LON_B)), abs=1.0
+    )

--- a/tests/tdd/test_gehzeit_folgt_wegstrecke.py
+++ b/tests/tdd/test_gehzeit_folgt_wegstrecke.py
@@ -105,12 +105,20 @@ def test_ac2_unvermessene_etappe_bleibt_unveraendert():
     )
 
 
-def test_ac3_rueckfall_gilt_je_abschnitt_nicht_je_etappe():
-    """AC-3: Ein unvermessener Wegpunkt entwertet nicht die ganze Etappe."""
+def test_ac3_rueckfall_gilt_je_etappe_nicht_je_abschnitt():
+    """UMGEKEHRT durch #2082 (frueher: Rueckfall je Abschnitt).
+
+    #2042 legte fest, dass ein unvermessener Abschnitt nur sich selbst auf
+    Luftlinie zurueckwirft. Das war falsch: Die Ortsangabe der Alarme
+    entscheidet je Etappe, sodass dieselbe Etappe in zwei Aussagen desselben
+    Briefings verschieden beurteilt wurde. Seit #2082 gilt die kanonische
+    Etappen-Regel -- eine Luecke entwertet die GANZE Etappe.
+
+    Ausfuehrlich bewacht in tests/tdd/test_gehzeit_etappenregel.py.
+    """
     luft = _luftlinie_km()
     gemessen = luft * 2.0
 
-    # G1->G2 vermessen, G2->G3 nicht (G3 traegt keine Strecke).
     stage = _stage([
         _wp("G1", _LON_A, km=0.0),
         _wp("G2", _LON_B, km=gemessen),
@@ -119,16 +127,10 @@ def test_ac3_rueckfall_gilt_je_abschnitt_nicht_je_etappe():
 
     result = compute_stage_arrivals(stage, "")
     ab1 = _minutes(result.waypoints[1].arrival_calculated) - _minutes("08:00")
-    ab2 = (
-        _minutes(result.waypoints[2].arrival_calculated)
-        - _minutes(result.waypoints[1].arrival_calculated)
-    )
 
-    assert ab1 == pytest.approx(gemessen / _flat_kmh() * 60.0, abs=1.0), (
-        "Der vermessene Abschnitt muss gemessen rechnen"
-    )
-    assert ab2 == pytest.approx(luft / _flat_kmh() * 60.0, abs=1.0), (
-        "Der unvermessene Abschnitt muss auf die Luftlinie zurueckfallen"
+    assert ab1 == pytest.approx(luft / _flat_kmh() * 60.0, abs=1.0), (
+        "Auch der vermessene Abschnitt muss zurueckfallen, sobald ein "
+        "Wegpunkt der Etappe keinen Messwert traegt (#2082)"
     )
 
 


### PR DESCRIPTION
Behebt #2082. Spec: `docs/specs/modules/fix_2082_gehzeit_plausibilitaet.md` (ACs vom PO freigegeben).

## Befund

Mit #2042 kam eine zweite, schwächere Kopie der Frage „ist diese Etappe vermessen" in den Code. Sie benutzte eine gemessene Strecke, sobald die Differenz zweier Wegpunktwerte nicht negativ war — auch dann, wenn die Strecke **kürzer als die Luftlinie** ist, was es physikalisch nicht geben kann. Ergebnis wäre eine zu optimistische Ankunftszeit, also genau der Fehler, den #2042 beheben sollte.

Dazu ein Granularitätsbruch: #2042 entschied je Wegpunktpaar, die Alarm-Ortsangabe über `stage_measured_distances()` je Etappe. Dieselbe Etappe konnte in zwei Aussagen desselben Briefings verschieden beurteilt werden.

## Änderung

Kein Flicken, sondern ein **Rückbau**. Die Kopie entfällt; beide Naismith-Seiten leiten aus der kanonischen Regel ab — strikte Monotonie **und** Plausibilität gegen die Luftlinie, je Etappe alles-oder-nichts.

- `src/core/naismith.py`: `_segment_distance_km` entfernt, `stage_measured_distances` wird benutzt. Import in der Funktion, damit `core` nicht beim Laden an `services` hängt (Muster wie `services/track_resolution.py`).
- `internal/model/naismith.go`: `segmentDistanceKm` ersetzt durch `stageMeasuredDistances`, das die drei Bedingungen der Python-Regel spiegelt.

**#2042 AC-3 wird bewusst zurückgenommen.** Der zugehörige Test ist umgeschrieben statt gelöscht, damit die Umkehr im Bestand sichtbar bleibt.

## Nachweise

Sieben ACs, Python- und Go-Seite mit denselben Eingaben und Erwartungen (AC-6).

Mutations-Gegenprobe — drei Verfälschungen, alle gefangen:

| Mutation | Fängt |
|---|---|
| Python umgeht die kanonische Regel (eigene Rohdifferenz) | AC-1, AC-2, AC-5 |
| Go ohne Plausibilitätsprüfung gegen die Luftlinie | AC-1 |
| Go duldet gleiche Werte (`span <= 0` → `span < 0`) | AC-2 |

Bemerkenswert: Die **erste** Fassung des Go-Testfalls „gleiche Werte" bestand aus dem falschen Grund — die Plausibilitätsprüfung fing den Fall ab, bevor die Monotonie-Regel gefragt war, und die dritte Mutation blieb unentdeckt. Der Testfall liegt jetzt an zwei Wegpunkten am selben Ort, wo nur die Monotonie greifen kann; die Mutation fällt damit mit `13:00` statt `08:34` auf.

Regression: 108 Python-Tests (Ankunfts-, Naismith-, Wegpunkt-, Track-Auflösungs- und Alarm-Ortsangabe-Pfade) und das Go-Paket `internal/model` grün; `go vet`, `ruff`, `gofmt` sauber.

## Grenzen

- Die Prüfung erkennt nur Strecken, die **kürzer** als die Luftlinie sind. Für eine zu große gibt es keine beweisbare Obergrenze.
- Am Produktivbestand tritt der Fall heute nicht auf (Messung 2026-08-22). Die Änderung schließt eine Schutzlücke, sie behebt kein aktuell sichtbares Fehlverhalten.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lq88USCyBD49bexjJ5LFvc)_