### PR TITLE
feat 2054 onset wochentagskuerzel

### DIFF
--- a/api/routers/validator.py
+++ b/api/routers/validator.py
@@ -241,11 +241,18 @@ class OnsetPayload(BaseModel):
     # Beginn), additiv und optional -- Muster `segment_id` o. Ohne sie rendert
     # der Vorschauweg die zahlenlose Alt-Form.
     onset_precip_mm: float | None = None
+    # Issue #2054: Tagesbezug des Beginns und seine Darstellung in der
+    # Kurzform, additiv und optional -- Muster `onset_precip_mm` o. Ohne die
+    # Felder verwirft pydantic sie STILL und die Vorschau zeigt einen
+    # Zeitpunkt von heute, wo der Versand einen von morgen meldet.
+    onset_day_offset: int = 0
+    onset_weekday: str | None = None
     # Issue #2051 S1: Ende des Ereignisses ("HH:MM") und sein eigener
     # Tagesbezug, additiv und optional -- Muster `onset_precip_mm` o. Ohne sie
     # rendert der Vorschauweg die Ausweichform ohne Ende.
     event_end_time: str | None = None
     event_end_day_offset: int = 0
+    event_end_weekday: str | None = None  # Issue #2054
     # Issue #2051 S1 (Spec v1.1): der R4-Waechter braucht ein EIGENES Feld --
     # seit der Umkehr auf die Untergrenzen-Form loest ihn die erzeugende Seite
     # nicht mehr in einem fehlenden Ende auf, er waehlt die Textform. Ohne das

--- a/docs/context/feat-2054-onset-wochentagskuerzel.md
+++ b/docs/context/feat-2054-onset-wochentagskuerzel.md
@@ -1,0 +1,305 @@
+# Context: feat-2054-onset-wochentagskuerzel
+
+Issue: [#2054](https://github.com/henemm/gregor_zwanzig/issues/2054) · Milestone „Tour KHW 2026-08" ·
+Label `enhancement` · Basis `origin/main` = `5c8ece93`
+
+## Request Summary
+
+Die Onset-Kurznachricht (SMS · Premium-SMS · Telegram-Kurzstil) hängt bei Mitternachts-Überlauf
+heute ein Zahlensuffix an die Uhrzeit (`R2.5@0:23+1`). Der Empfänger muss selbst rechnen, welcher
+Tag gemeint ist. Ersetzt wird es durch das **Wochentagskürzel** (`R2.5@Sa0:23`) — dieselbe
+Schreibweise, die derselbe Kanal für Abweichungs- und amtliche Warn-Alarme bereits führt.
+
+## Der eigentliche Zweck: EINE Schreibweise, nicht bloß eine bessere
+
+Der Ursprung der Entscheidung steht in `docs/specs/modules/fix_2020_alarm_blickrichtung.md`,
+Abschnitt „Zur Entscheidung mit der Freigabe" (Z. 418-434) — nicht im Ticket:
+
+> **Zieht der Radar-Onset-Kurzform-Zweig nach?** Er schreibt denselben Sachverhalt heute als
+> Zahlensuffix. Bleibt er so, trägt der Kurzkanal **zwei Schreibweisen für „Uhrzeit an einem
+> anderen Tag" nebeneinander**.
+> **Empfehlung:** Wochentagskürzel für beide Zweige — dann gibt es genau eine Schreibweise.
+
+Die zu prüfende Zusicherung ist damit nicht „das Kürzel erscheint", sondern **„der Kurzkanal kennt
+danach nur noch eine Schreibweise für Tagesbezug"**. Ein Test, der nur das neue Token prüft, ohne
+die Abwesenheit der Altform zu belegen, bewacht die Entscheidung nicht.
+
+> ⚠️ `docs/specs/modules/fix_2020_alarm_zeitangaben.md` trägt `status: superseded` — dort **nicht**
+> nachschlagen.
+
+## Der Zuschnitt ist größer als das Ticket ihn beschreibt
+
+Das Ticket nennt einen Wirkort (den Regenbeginn). Tatsächlich sind es **drei** — beide Zuwächse
+entstanden am selben Tag, nach der Ticket-Erstellung:
+
+| Aufrufer | Datei:Zeile (Stand `1e0ee151`) | Token |
+|---|---|---|
+| Beginn | `render.py:854` | `R2.5@18:00` |
+| **Ende** (#2051 S1, Merge `5c8ece93`) | `render.py:825` (`_sms_onset_ende`) | `@20:00` bzw. ` >@20:00` |
+| **Ereignis läuft bereits** (#2050 S2b, Merge `d2c7c86a`) | `render.py:862` | `R2.5 now >@20:00` — kein Beginn-Token, **aber** ein Ende-Token |
+
+> ⚠️ Der dritte Zweig kam **nach** der Spec-Freigabe hinzu. Er zeigt `now` statt einer Beginnzeit,
+> erbt das Ende-Token aber über denselben Aufruf — ein über Mitternacht laufendes Ereignis trägt
+> dort heute `+1`. Abgedeckt durch das nachgetragene AC-14.
+
+Beide Zeitpunkte tragen einen **eigenen** Tagesversatz — Beginn 23:50 (Versatz 0) und Ende 00:40
+(Versatz 1) liegen an verschiedenen Kalendertagen; #2051 hat das in seinem AC-6 festgenagelt.
+Die Umstellung wirkt über den geteilten Aufruf automatisch auf beide. **Ein Kürzel, das nur am
+Beginn geprüft wird, ginge am Ende still schief.**
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `src/output/renderers/alert/render.py:729` | `_sms_onset_time(onset_time, day_offset)` — **der Wirkort**. Modulprivat, genau zwei Aufrufer (`:796`, `:825`), kein Test importiert sie direkt |
+| `src/output/renderers/alert/render.py:1276` | `_sms_day_prefix(day_offset, weekday)` — die **Darstellungs-Vorlage** aus #2020 S2 |
+| `src/output/renderers/alert/official_alerts.py:93,802` | `_DE_WEEKDAYS` / `_de_weekday_short(dt)` — die Kürzel-Tabelle. #2020-Spec markiert sie ausdrücklich als „reuse — **nicht** nachbauen" |
+| `src/output/renderers/alert/project.py:179-193` | `_when_fields(target_utc, now_utc, tz) -> (offset, is_past, weekday)` — der **Bildungs-Baustein**. Nutzt `_de_weekday_short` (Import `project.py:23`); wird für `OnsetShiftEvent` und `_remaining_fields` verwendet, **aber nicht für `OnsetEvent`** |
+| `src/output/renderers/alert/model.py:97,~113` | `OnsetEvent.onset_day_offset` / `.event_end_day_offset` — beide **ohne** Wochentags-Pendant |
+| `src/output/renderers/alert/project.py:544` | Konstruktion Ortsvergleich-Bündel — `datetime` + `loc_tz` lokal vorhanden |
+| `src/services/trip_alert.py:1509` | Baut `RadarAlertRequest`; `_onset_dt` + `tz` liegen unmittelbar davor (`:1434`) — hier entsteht heute `onset_day_offset` |
+| `src/services/notification_service.py:168-218` | `RadarAlertRequest` — trägt `onset_day_offset`, `event_end_day_offset`, **kein** Wochentagsfeld |
+| `src/services/notification_service.py:1338` | Baut daraus das `OnsetEvent` (Trip-Versandpfad) |
+| `api/routers/validator.py:226` | `OnsetPayload` — **trägt `onset_day_offset` überhaupt nicht** (verifiziert) |
+| `src/services/validator_render_service.py:116` | Vorschau-Konstruktion; setzt `onset_day_offset` nicht ⇒ bleibt still auf `0` |
+| `tests/tdd/test_alert_onset_day_rollover.py:115-139,286-321` | **Nagelt die `+1`-Form als erwarteten String fest** — muss umgeschrieben werden, ist zugleich die Struktur-Vorlage für RED |
+
+## Existing Patterns
+
+**Das Muster existiert dreifach im Repo — es wird nichts erfunden.**
+
+1. **Modell-Konvention:** pro Zeitangabe ein Tripel `<name>_time` + `<name>_day_offset` +
+   `<name>_weekday` (`AlertEvent.occurred_*`, `.remaining_until_*`, `model.py:44-69`).
+   `OnsetEvent` hat heute zweimal nur die ersten beiden Glieder.
+2. **Bildung:** `_when_fields()` liefert alle drei Größen aus einer Hand — bewusst, „damit
+   Kalendertag und Vergangenheits-Kennzeichen nie aus verschiedenen Zonen stammen". Der Wochentag
+   entsteht aus `local_dt(target_utc, tz)`, also in **Trip-Ortszeit**, und nur bei Versatz ≠ 0.
+3. **Darstellung Kurzform:** `_sms_day_prefix()` setzt das Kürzel **vor** die Zeit (`@Do15`) und
+   entfällt am Versandtag ersatzlos.
+
+**Abweichung, die die Spec entscheiden muss:** Die Vorlage arbeitet mit **Stunden**-Granularität
+(`e.occurred_at[:2]` → `@Do15`), der Onset mit **Stunde:Minute** (`@0:23`). Die Kürzel-*Position*
+ist übertragbar, die Zeit*form* nicht — sonst verlöre die Onset-Angabe ihre Minuten.
+
+**Langform bleibt unberührt:** E-Mail/Telegram schreiben den Tagesbezug als Wort aus
+(`_time_with_day` → „morgen 17:00"). Kurzform = Kürzel, Langform = Wort ist eine bewusste
+Trennung, keine Inkonsistenz.
+
+## Dependencies
+
+- **Upstream:** `_de_weekday_short` · `_when_fields` · `day_offset()`/`local_dt()`
+  (`src/utils/timezone.py`) · `event_end_display()` (`project.py:37`, aus #2051 S1)
+- **Downstream:** `_render_sms_onset` (SMS · Premium-SMS · Telegram-Kurzstil) und über den
+  geteilten Aufruf `_sms_onset_ende`
+
+## Existing Specs
+
+| Spec | Bedeutung |
+|---|---|
+| `docs/specs/modules/fix_2020_alarm_blickrichtung.md` | **Ursprung der PO-Entscheidung** (Z. 418-434); markiert `_de_weekday_short` als reuse |
+| `docs/specs/modules/fix_2009_nowcast_vorlauf.md` | führte den abzulösenden `+1`-Suffix ein |
+| `docs/specs/modules/feat_2051_s1_dauer_und_ende.md` | der zweite Wirkort (Ende-Token), AC-6 = eigener Tagesversatz |
+| `docs/specs/modules/fix_2046_onset_menge.md` | AC-9 = 160-Zeichen-Budget der Kurznachricht |
+
+## Risks & Considerations
+
+1. **🔴 Der Vorschau-Weg ist blind für diesen Sachverhalt — verifiziert.**
+   `OnsetPayload` (`api/routers/validator.py:226`) kennt `onset_day_offset` nicht; der Vorschau-Bau
+   setzt es nicht, es bleibt auf `0`. **`alert-preview` kann einen Mitternachts-Überlauf beim
+   Beginn strukturell nicht zeigen** — weder die Alt- noch die Neuform. Ein nur dort geprüftes
+   Kriterium wäre grün, ohne etwas zu bewachen. Das ist dasselbe Muster, das bei #2020 elf von
+   vierzehn Kriterien unmessbar machte (#2069).
+   → **Empfehlung für die Spec:** `OnsetPayload` um die fehlenden Felder erweitern. Schließt
+   zugleich eine bestehende stille Lücke. Sonst: ACs auf Kern-Ebene und die Grenze ausdrücklich
+   als SKIP buchen, nicht schönreden.
+2. **Zwei Herkünfte, ein Konstruktor.** Trip-Pfad (`trip_alert.py:1509` → `RadarAlertRequest` →
+   `notification_service.py:1338`, nur Strings/Ints) und Ortsvergleich-Pfad (`project.py:544`,
+   `datetime` lokal). Der Wochentag muss in **beiden** dort gebildet werden, wo heute schon
+   `day_offset()` entsteht — ein vergessener Pfad rendert still die Altform.
+3. **Bestandstest nagelt die Altform fest — zwei Stellen.** `test_alert_onset_day_rollover.py`
+   erwartet wörtlich `"TH@0:23+1"` (`:120`, Trip-Pfad) und `"R@0:23+1"` (`:313`,
+   Ortsvergleich-Bündel) und prüft zusätzlich `"+1" not in control_sms` (`:139`, bleibt grün).
+   Umschreiben, nicht löschen — die Datei bringt 160-Zeichen-Grenze, Token-Zeichensatzprüfung und
+   Kontrollfall schon mit.
+   ⚠️ **Falle:** Der Token-Regex `r"(TH|R)@\d{1,2}:\d{2}(?:\+\d+)?"` (`:128`) matcht ein Kürzel
+   zwischen `@` und Stunde **nicht**. Er muss zuerst erweitert werden, sonst scheitert der Test an
+   `token_match is None`, bevor die eigentliche Zusicherung überhaupt greift — der Test wäre aus
+   dem falschen Grund rot.
+4. **Zeichenbudget — nachgerechnet, für #2054 unkritisch.**
+   Die Umstellung ist **zeichenneutral**: `0:23+1` und `Sa0:23` sind beide sechs Zeichen.
+   `_render_sms_onset` rendert zudem nur `msg.events[0]` — auch im Ortsvergleich-Bündel steht
+   genau **ein** Zeit-Token in der Nachricht. Der längste Token-Fall (Gewitter, beide Kürzel,
+   Untergrenzen-Form, Menge) misst rund 26 Zeichen.
+   ⚠️ **Korrektur einer früheren Annahme dieser Analyse:** Der längste Fall entstand mit #2051 S1
+   (zweites Zeit-Token), **nicht** mit #2054. #2054 vergrößert ihn nicht. Ein Absichern des
+   Schnitts gehört daher **nicht** in dieses Ticket — siehe Punkt 9.
+   Bezug bleibt AC-9 in `fix_2046_onset_menge.md` (160-Zeichen-Grenze). `140` ist im Produktivcode
+   dreifach als Default dupliziert, ohne zentrale Konstante.
+9. **🔴 Bestandsrisiko, eigenes Ticket: der Kopf wird nicht gekappt, der Schnitt ist hart.**
+   `_render_sms_onset` bildet `head = _ascii_alert_location(...)` **ohne jede Längenbegrenzung**
+   — anders als die Nachbarzweige, die auf `[:16]`/`[:24]` kürzen (`_render_sms_corridor_only`).
+   Am Ende steht `return body if len(body) <= limit else body[:limit]` (`render.py:844`), ein
+   harter Schnitt mitten durch den Text. Bei ausreichend langem Ortsnamen wird das **Zeit-Token
+   angeschnitten oder ganz abgeschnitten**: aus `@Sa0:40` wird `@Sa0:4` oder `@Sa` — keine
+   gekürzte, sondern eine **falsche** Aussage, auf dem einzigen Kanal, der auf der Hütte am
+   Karnischen Höhenweg ankommt und wo kein zweiter Kanal sie richtigstellt.
+   Latent und von #2054 **nicht verursacht**, aber durch das zweite Zeit-Token aus #2051
+   näher an die Grenze gerückt. Gehört als eigenes Issue erfasst (Nebenbefund-Triage Fall (a):
+   nutzersichtbares Fehlverhalten), nicht in die Sammelliste #1199.
+5. **GSM-7 ist geklärt** (PO-Kommentar im Ticket): Die amtliche Warn-SMS versendet die Kürzel seit
+   #1948 S5 über denselben Kanal. Reines ASCII, kein offener Punkt für #2054.
+   *Nebenbefund (kein Ticket-Ziel):* Es gibt einen geteilten Validator
+   `tests/tdd/_gsm7_charset.py::assert_gsm7_clean`, der gegen den **Onset-Pfad nicht** verwendet
+   wird — dort prüft nur `sms.isascii()`, was Extension-Zeichen (`[`, `]`, `{`, `}`, `\`, `^`,
+   `~`, `|`, `€`) durchlässt, die real zwei Septets kosten. Kandidat für #1199, nicht für diese
+   Arbeit.
+6. **`day_offset >= 2` ist strukturell ausgeschlossen** (der Nowcast schaut nur nach vorn), aber es
+   braucht ein *definiertes* Verhalten statt stiller Fehlausgabe.
+7. **Abgrenzung `build_onset_alert_message`** (`radar_alert_service.py:31`): hängt nur am
+   Debug-Endpoint (`api/routers/debug.py:110`) und kennt schon heute die `event_end_*`-Felder
+   nicht. **Nicht mitziehen.**
+8. **Getrennt bleibt #2063** (Onset-Uhrzeit oft eine Minute zu früh — Sekunden werden abgeschnitten
+   statt gerundet, `src/utils/timezone.py:133`). Berührt dieselbe Zeile, ist aber ein anderer
+   Fehlermechanismus mit anderer Beweisführung. Preis: die Zeile geht ein zweites Mal auf.
+
+## Koordination mit Parallelsitzungen
+
+`_sms_onset_time` ist dieser Session zugesagt: Session `2051` (#2051, geliefert) und
+`gregor-zwanzig-42` (#2050 S2b) halten sich dort raus. #2049, #2073 und #2065 arbeiten in anderen
+Dateien. `gregor-zwanzig-42` bearbeitet `render.py` im Bereich `_onset_time_label` (~:502) —
+Langform, von dieser Arbeit unberührt.
+
+---
+
+## Analysis
+
+### Type
+
+**Feature** (Label `enhancement`, PO-freigegebene Änderung an bestehendem Verhalten). Kein
+Bug-Intake nötig.
+
+### Technical Approach
+
+**Grundsatz: kein neues Muster.** Die Kürzel-Tabelle (`_de_weekday_short`), die Bildungsregel
+(„nur bei Versatz ≠ 0", Wochentag aus `local_dt(target, tz)`) und die Darstellungsregel (Kürzel
+**vor** die Zeit) existieren. #2054 zieht `OnsetEvent` auf die Konvention nach, die `AlertEvent`
+längst erfüllt.
+
+**Zwei neue Modellfelder** (`model.py`): `onset_weekday: str | None = None` und
+`event_end_weekday: str | None = None` — das jeweils dritte Glied der bestehenden Tripel-Konvention
+`<name>_time` + `<name>_day_offset` + `<name>_weekday`.
+
+> *Verworfen:* den Wochentag im Renderer aus `day_offset` + Versandzeit zurückrechnen (spart die
+> Felder). Verliert, weil der Renderer weder `now` noch `tz` kennt — eine zweite „jetzt"-Quelle
+> bricht genau die Invariante, die `_when_fields()` im Docstring einfordert („Kalendertag und
+> Vergangenheits-Kennzeichen nie aus verschiedenen Zonen").
+
+**Bildungsstellen — drei, nicht eine:**
+
+| Zeitpunkt | Stelle | Anmerkung |
+|---|---|---|
+| Ende | `project.py:37` `event_end_display()` | bereits **geteilt** für beide Pfade → 4. Rückgabewert ergänzen, deckt Trip und Ortsvergleich auf einen Schlag |
+| Beginn (Trip) | `trip_alert.py:1512` | braucht neuen Import `_de_weekday_short` + `local_dt` |
+| Beginn (Ortsvergleich) | `project.py:544` | |
+
+> *Verworfen:* `_when_fields()` direkt wiederverwenden. Verliert, weil sie modulprivat in
+> `project.py` liegt, ein hier unnötiges `is_past` mitliefert und `trip_alert.py` sie
+> modulübergreifend importieren müsste. Wiederverwendet wird stattdessen ihr **Baustein**
+> `_de_weekday_short` — genau wie die #2020-Spec es vorschreibt.
+
+**Der Wirkort** (`_sms_onset_time`) bekommt einen dritten Parameter. Entscheidend: **das Gate
+bleibt `day_offset`, nicht der Wahrheitswert von `weekday`.** Der Versatz ist die Quelle der
+Wahrheit, das Kürzel nur seine Darstellung.
+
+### Zielform
+
+| Fall | Token |
+|---|---|
+| Beginn, kein Überlauf | `R2.5@18:00` *(unverändert)* |
+| Beginn, Überlauf | `R2.5@Sa0:23` |
+| Ende bekannt, kein Überlauf | `R2.5@18:00@20:00` *(unverändert)* |
+| Ende bekannt, Überlauf | `R2.5@23:50@Sa0:40` |
+| Ende als Untergrenze, Überlauf | `R2.5@23:50 >@Sa0:40` |
+| Gewitter, Überlauf | `TH@Sa0:23 R2.5` |
+
+### 🔴 Der gefährlichste Fehlermodus: die Lücke ist stiller als die Altform
+
+Wird eine der beiden Beginn-Bildungsstellen vergessen, bleibt `onset_day_offset` korrekt
+(Bestandscode), aber `onset_weekday` bleibt `None`. Mit dem Gate auf `day_offset` rendert
+`_sms_onset_time` dann die **nackte Uhrzeit ohne jeden Tagesbezug** — also exakt die
+Mehrdeutigkeit, die #2009 ursprünglich beseitigen sollte, und schlimmer als ein Rückfall auf `+1`.
+
+**Folge für die Testführung:** Ein Test, der nur die *Abwesenheit* von `+N` prüft, fängt das
+**nicht**. Jeder Matrix-Fall braucht zusätzlich die **positive** Zusicherung des erwarteten
+Kürzel-Tokens. Und mindestens ein Fall muss über den **echten Versandpfad** laufen
+(`TripAlertService.check_radar_alerts()` bzw. der Ortsvergleich-Pfad), nicht nur über handgebaute
+`OnsetEvent`-Fixtures — sonst bleibt eine vergessene Bildungsstelle unsichtbar. Genau dieser
+Fehler ist bei #2009 schon einmal passiert und im Fix-Loop F001 der Bestandstestdatei dokumentiert
+(`test_alert_onset_day_rollover.py:141-165`).
+
+### „Genau EINE Schreibweise" prüfbar machen
+
+Negativ-Zusicherung als reine Ausgabeprüfung über den echten Renderer-Einstieg (`render_sms()`):
+
+```python
+assert not re.search(r"\d{1,2}:\d{2}\+\d+", sms)
+```
+
+Geht rot, sobald irgendwo wieder ein Zahlensuffix entsteht — unabhängig davon, an welcher der
+Bildungsstellen die Regression passiert.
+
+> *Verworfen:* Quelltext-Grep auf `+{day_offset}`. Verliert doppelt: Dateiinhalt-Checks sind als
+> Verhaltensnachweis untersagt, und der Test würde bei jeder Umformulierung falsch anschlagen.
+
+### Affected Files
+
+| Datei | Art | LoC | Beschreibung |
+|---|---|---|---|
+| `src/output/renderers/alert/model.py` | MODIFY | +12 | zwei Wochentagsfelder am `OnsetEvent` |
+| `src/output/renderers/alert/project.py` | MODIFY | +18 | `event_end_display()` 4. Rückgabewert; Ortsvergleich-Bündel |
+| `src/services/trip_alert.py` | MODIFY | +10 | Import + Bildung am Trip-Beginn |
+| `src/services/notification_service.py` | MODIFY | +12 | `RadarAlertRequest` + Durchreichung |
+| `src/output/renderers/alert/render.py` | MODIFY | +15 | **Wirkort**: `_sms_onset_time`, beide Aufrufer |
+| `api/routers/validator.py` | MODIFY | +10 | `OnsetPayload` (siehe unten) |
+| `src/services/validator_render_service.py` | MODIFY | +6 | Durchreichung Vorschau |
+| `tests/tdd/test_alert_onset_day_rollover.py` | MODIFY | +55 | Regex-Fix, Umstellung, Matrix, echter-Pfad-Fall |
+
+**~140 LoC** — unter dem 250er-Limit, kein `loc_limit_override` nötig.
+
+### Entscheidung: Vorschau-Felder werden mitgezogen
+
+`OnsetPayload` kennt `onset_day_offset` heute nicht; für #2054 kämen die beiden Wochentagsfelder
+hinzu. Der Vorschaudienst rechnet nichts selbst, er reicht nur durch — die Felder wären reiner
+Passthrough im bereits dreifach etablierten Muster (`onset_precip_mm`, `event_end_time`,
+`event_end_day_offset`). Aufwand: ~16 LoC.
+
+**Begründung:** Es ist derselbe Fehlermodus, der bei #2069 elf von vierzehn und bei #2036 dreizehn
+von fünfzehn Kriterien strukturell unmessbar gemacht hat — beide Male, weil `alert-preview` ein
+Feld nicht kennt, das der Versandpfad längst führt. Diese Falle für ~16 LoC ein drittes Mal zu
+bauen, wäre nicht sparsam, sondern fahrlässig.
+
+### Abgrenzungen
+
+- **`build_onset_alert_message`** (`radar_alert_service.py:31`) wird **nicht** mitgezogen — nur
+  Debug-Endpoint, kennt schon die `event_end_*`-Felder nicht.
+- **Der harte 140-Schnitt** (Risiko 9) bekommt ein eigenes Issue — #2054 verursacht ihn nicht.
+- **#2063** (Onset-Uhrzeit eine Minute zu früh) bleibt getrennt.
+- **Go-Seite** ist nicht betroffen (`grep onset internal/ cmd/` → keine Treffer).
+
+### Reihenfolge
+
+1. **Zuerst den Token-Regex** im Bestandstest (`:128`) auf die Kürzel-Form erweitern — sonst ist
+   der erste rote Lauf aus dem falschen Grund rot (`token_match is None`).
+2. Modellfelder (Fundament für alle Konstruktionen).
+3. `event_end_display()` (eine Stelle, beide Pfade).
+4. Beide Beginn-Bildungsstellen.
+5. DTO-Durchreichung.
+6. **Der Renderer zuletzt** — erst wenn 2–5 echte Werte liefern, wird der RED-Test aus dem
+   richtigen Grund grün.
+7. Vorschau-Zweig (unabhängig, vor der Staging-Verifikation).
+
+### Open Questions
+
+Keine offenen Fragen an den PO. Alle Design-Entscheidungen sind aus dokumentierten Vorgaben
+ableitbar (#2020-Spec, Tripel-Konvention, Nebenbefund-Triage) und oben mit verworfenen
+Alternativen begründet.

--- a/docs/features/architecture.md
+++ b/docs/features/architecture.md
@@ -416,8 +416,13 @@ Scheibe 3 (#1170). Scheduler: `POST /api/scheduler/compare-alert-checks`, Go-Cro
        um). Dieselbe Unterscheidung gilt in der Langform: `letzter Regen gegen HH:MM` bzw.
        `Regen mindestens bis HH:MM`, in allen sieben Textstellen (E-Mail-Betreff, E-Mail
        Trip/Mehr-Orte, Telegram rich, SMS/Premium-SMS/Telegram-Kurzstil, Briefing-
-       Kurzfristhinweis, Inbound-Kommando-Antwort).
-     - `OnsetEvent`-Datenklasse: `onset_minutes`, `onset_time`, `km_from`/`km_to`, `is_convective`, `intensity_label`, `source_label`, `onset_precip_mm` (additiv, #2046 — Menge ab Ereignisbeginn, getrennt von `NowcastResult.window_precip_mm`, das ab „jetzt" misst), `event_end_time`/`event_end_day_offset`/`event_ongoing_beyond_horizon` (additiv, #2051 S1 — Ende desselben Ereignisses mit eigenem Tagesbezug, aus `NowcastResult.event_end_minutes`/`.event_ongoing_beyond_horizon` abgeleitet)
+       Kurzfristhinweis, Inbound-Kommando-Antwort). **Seit #2054** trägt eine Uhrzeit, die an
+       einem anderen Kalendertag als der Versandzeitpunkt liegt, in der Kurzform ein
+       vorangestelltes DE-Wochentagskürzel statt des vorherigen Zahlensuffixes: `R2.5@Sa0:23`
+       statt `R2.5@0:23+1`, Beginn und Ende unabhängig bewertet (`TH@Do18:00@Fr3:00 R2.5`) —
+       dieselbe Schreibweise, die derselbe Kanal für Abweichungsalarme (#2020 S2) und amtliche
+       Warnungen (#1948 S5) bereits führt. Bei Tagesversatz 0 bleibt die Ausgabe byte-identisch.
+     - `OnsetEvent`-Datenklasse: `onset_minutes`, `onset_time`, `km_from`/`km_to`, `is_convective`, `intensity_label`, `source_label`, `onset_precip_mm` (additiv, #2046 — Menge ab Ereignisbeginn, getrennt von `NowcastResult.window_precip_mm`, das ab „jetzt" misst), `onset_day_offset`/`onset_weekday` (additiv, #2054 — Tagesbezug des Beginns und sein DE-Wochentagskürzel, `onset_day_offset` selbst existiert bereits seit #2009), `event_end_time`/`event_end_day_offset`/`event_end_weekday`/`event_ongoing_beyond_horizon` (additiv — `event_end_time`/`event_end_day_offset`/`event_ongoing_beyond_horizon` seit #2051 S1, `event_end_weekday` seit #2054 analog zu `onset_weekday`, aber eigenständig aus dem Ende-Zeitpunkt abgeleitet, da Beginn und Ende an verschiedenen Kalendertagen liegen können — Ende desselben Ereignisses aus `NowcastResult.event_end_minutes`/`.event_ongoing_beyond_horizon` abgeleitet)
      - `AlertMessage.cooldown_display` trägt den dynamischen Cooldown-Text (z.B. „2 Stunden")
      - `src/outputs/radar_alert.py` ist gelöscht — kein separater Inline-Body-Bau mehr
    - **Throttle-Semantik unverändert** (Issue #773): `radar_alert_throttle.json` + `alert_log` auch bei Best-Effort-Versandfehlern

--- a/docs/reference/api_contract.md
+++ b/docs/reference/api_contract.md
@@ -3417,7 +3417,7 @@ S1-Eingangsprotokoll (`src/services/alert_input_capture.py`, siehe
 |------|-----|------|
 | changes | `ChangePayload[]` | Zweig a (Δ-Alarm): rohe Änderungswerte je Etappe (`metric`, `old_value`, `new_value`, `delta`, `threshold`, `severity`, `direction`, `segment_id`) |
 | segment_times | `SegmentTimePayload[]` | Optional bei `changes` — fehlt es, synthetisiert der Endpoint die Etappen-Zeitfenster aus dem geladenen Trip über dieselbe Produktions-Segmentierung wie der Versandpfad (`convert_trip_to_segments`) |
-| onset | `OnsetPayload` \| null | Radar-Onset (Zweig c, Alt-Form vor S2): `onset_minutes`, `onset_time`, `km_from`, `km_to`, `is_convective`, `intensity_label`, `source_label`, `cooldown_display?`, `segment_id?` (additiv seit #1948 S5, AC-15 — ohne Segment-Kennung fiel der Zweig auf den km-Rückfall zurück), `onset_precip_mm?` (additiv seit #2046 — Menge in mm, akkumuliert über 60 Min ab Ereignisbeginn; `None`/fehlend ⇒ SMS-Onset-Token ohne Zahl), `event_end_time?: string \| null`, `event_end_day_offset?: int = 0`, `event_ongoing_beyond_horizon?: bool = false` (additiv seit #2051 S1 — Ende des zusammenhängenden nassen Blocks mit eigenem Tagesbezug, analog zu `onset_time`/`onset_day_offset`; ohne `event_end_time` rendert der Vorschauweg die Ausweichform ohne Ende; `event_ongoing_beyond_horizon=true` wählt die Untergrenzen-Form `Regen mindestens bis HH:MM` statt `letzter Regen gegen HH:MM`) |
+| onset | `OnsetPayload` \| null | Radar-Onset (Zweig c, Alt-Form vor S2): `onset_minutes`, `onset_time`, `km_from`, `km_to`, `is_convective`, `intensity_label`, `source_label`, `cooldown_display?`, `segment_id?` (additiv seit #1948 S5, AC-15 — ohne Segment-Kennung fiel der Zweig auf den km-Rückfall zurück), `onset_precip_mm?` (additiv seit #2046 — Menge in mm, akkumuliert über 60 Min ab Ereignisbeginn; `None`/fehlend ⇒ SMS-Onset-Token ohne Zahl), `onset_day_offset?: int = 0`, `onset_weekday?: string \| null` (additiv seit #2054 — Tagesbezug des Beginns und sein DE-Wochentagskürzel für die Kurzform-Darstellung; ohne die Felder zeigt die Vorschau einen Zeitpunkt von heute, wo der Versand einen von morgen meldet), `event_end_time?: string \| null`, `event_end_day_offset?: int = 0`, `event_end_weekday?: string \| null` (`event_end_weekday` additiv seit #2054, analog zu `onset_weekday`, aber eigenständig aus dem Ende-Zeitpunkt abgeleitet — Beginn und Ende können an verschiedenen Kalendertagen liegen), `event_ongoing_beyond_horizon?: bool = false` (additiv seit #2051 S1 — Ende des zusammenhängenden nassen Blocks mit eigenem Tagesbezug, analog zu `onset_time`/`onset_day_offset`/`onset_weekday`; ohne `event_end_time` rendert der Vorschauweg die Ausweichform ohne Ende; `event_ongoing_beyond_horizon=true` wählt die Untergrenzen-Form `Regen mindestens bis HH:MM` statt `letzter Regen gegen HH:MM`) |
 | official | `OfficialAlertPayload[]` \| null | **NEU (#1948 S2), Zweig b:** amtliche Warnung(en), Feldspiegel von `OfficialAlert` — `source`, `hazard`, `level: int`, `label`, `valid_from?`, `valid_to?`, `url?`, `region_label?`, `dedup_id?`, `segment_ids: string[]` |
 | nowcast_frames | `NowcastFramesPayload` \| null | **NEU (#1948 S2), Zweig c:** Replay eines S1-Nowcast-Mitschnitts — `source`, `frames: [{timestamp, precip_mm_h, is_convective}]`, `km_from`, `km_to`, `segment_id?` (additiv seit #1948 S5, AC-15, analog zu `OnsetPayload`) |
 
@@ -3702,6 +3702,18 @@ function corridorInside(value, min, max) {
 
 ## Changelog
 
+- 2026-08-22: Issue #2054 — die Alarm-Kurznachricht (SMS · Premium-SMS · Telegram-Kurzstil)
+  schreibt eine Uhrzeit an einem anderen Kalendertag jetzt mit einem vorangestellten
+  DE-Wochentagskürzel (`R2.5@Sa0:23`) statt des bisherigen Zahlensuffixes (`R2.5@0:23+1`) —
+  dieselbe Schreibweise, die derselbe Kanal für Abweichungsalarme (`@Do15`, #2020 S2) und
+  amtliche Warnungen (`Do12-22`, #1948 S5) bereits führt. Beginn und Ende werden unabhängig
+  bewertet: `TH@Do18:00@Fr3:00 R2.5`. Bei Tagesversatz 0 ist die Ausgabe byte-identisch zum
+  Bestand — der Versatz entscheidet, nicht die Präsenz des Kürzels. `OnsetPayload` (Section
+  22.5, `POST /api/trips/{trip_id}/alert-preview`) bekommt dafür additiv die Felder
+  `onset_day_offset: int = 0`, `onset_weekday: string | null` sowie `event_end_weekday: string |
+  null` (Pendant zum bereits bestehenden `event_end_day_offset`, #2051 S1). Reine additive
+  Feld-Ergänzung, kein Formatwechsel der Antwortstruktur; E-Mail- und Telegram-Langform bleiben
+  bei der Wortform („morgen 17:00"). Spec: `docs/specs/modules/feat_2054_onset_wochentagskuerzel.md`.
 - 2026-08-22: Issue #2042 — Ankunftszeiten folgen der **gemessenen Wegstrecke** statt der
   Luftlinie: `ComputeStageArrivals` (`internal/model/naismith.go`) und
   `compute_stage_arrivals` (`src/core/naismith.py`) rechnen die Gehzeit je Abschnitt aus der

--- a/docs/specs/modules/feat_2054_onset_wochentagskuerzel.md
+++ b/docs/specs/modules/feat_2054_onset_wochentagskuerzel.md
@@ -1,0 +1,224 @@
+---
+entity_id: feat_2054_onset_wochentagskuerzel
+type: module
+created: 2026-08-22
+updated: 2026-08-22
+status: draft
+version: "1.0"
+tags: [alert, sms, premium-sms, telegram, nowcast, onset, zeitangabe]
+---
+
+# Onset-Kurznachricht: Wochentagskürzel statt Zahlensuffix
+
+Issue: [#2054](https://github.com/henemm/gregor_zwanzig/issues/2054) · Milestone „Tour KHW 2026-08"
+Basis: `origin/main` = `1e0ee151`
+
+## Approval
+
+- [x] Approved — PO (Henning), 2026-08-22
+
+## Purpose
+
+Die Alarm-Kurznachricht (SMS · Premium-SMS · Telegram-Kurzstil) schreibt eine Uhrzeit, die an einem
+anderen Kalendertag liegt, heute als Zahlensuffix (`R2.5@0:23+1`). Der Empfänger muss selbst
+rechnen. Künftig steht dort das **Wochentagskürzel** (`R2.5@Sa0:23`) — dieselbe Schreibweise, die
+derselbe Kanal für Abweichungsalarme (`@Do15`, #2020 S2) und amtliche Warnungen (`Do12-22`,
+#1948 S5) bereits führt.
+
+**Der Zweck ist Vereinheitlichung, nicht Verschönerung.** Bis heute trägt der Kurzkanal zwei
+Schreibweisen für denselben Sachverhalt nebeneinander. Danach kennt er genau eine. Diese
+Zusicherung — die *Abwesenheit* der Altform — ist Teil der Akzeptanz (AC-8), nicht bloß eine
+Nebenwirkung.
+
+## Source
+
+- **File:** `src/output/renderers/alert/render.py`
+- **Identifier:** `_sms_onset_time(onset_time, day_offset)` (`:729`)
+
+Schicht: **Python-Core / Domain-Backend**. Frontend und Go-API sind nicht betroffen
+(`grep onset internal/ cmd/` → keine Treffer).
+
+## Estimated Scope
+
+- **LoC:** ~140 (unter dem 250er-Limit, kein Override nötig)
+- **Files:** 8 (7 MODIFY Produktivcode/API, 1 MODIFY Test)
+- **Effort:** medium
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|---|---|---|
+| `official_alerts.py:802` `_de_weekday_short(dt)` | **reuse** | liefert das Kürzel. Die #2020-Spec markiert es ausdrücklich als „**nicht** nachbauen" — eine zweite Tabelle wäre ein Verstoß gegen eine dokumentierte Entscheidung |
+| `utils/timezone.py` `local_dt()` / `day_offset()` | reuse | Ortszeit-Auflösung; **dieselbe** `tz`-Instanz wie der Versatz |
+| `project.py:37` `event_end_display()` | MODIFY | bereits geteilte Stelle beider Pfade — trägt den Wochentag des **Endes** als 4. Rückgabewert |
+| `project.py:179` `_when_fields()` | Muster (kein Reuse) | liefert die Bildungsregel („nur bei Versatz ≠ 0", Wochentag aus `local_dt(target, tz)`); modulprivat und mit unnötigem `is_past` — übernommen wird die Regel, nicht die Funktion |
+| `render.py:1276` `_sms_day_prefix()` | Muster (kein Reuse) | Darstellungsregel: Kürzel **vor** die Zeit; arbeitet aber mit Stunden-Granularität, der Onset braucht Stunde:Minute |
+| `feat_2051_s1_dauer_und_ende.md` | Vorgänger | brachte das **zweite** Zeit-Token (Ende) an denselben Renderer-Aufruf |
+
+## Implementation Details
+
+**Modell** (`model.py`) — zwei Felder, drittes Glied der bestehenden Tripel-Konvention
+(`<name>_time` + `<name>_day_offset` + `<name>_weekday`, wie `AlertEvent.occurred_*`):
+
+```python
+onset_weekday: str | None = None
+event_end_weekday: str | None = None
+```
+
+**Drei Bildungsstellen** — überall dort, wo heute schon der Versatz entsteht:
+
+| Zeitpunkt | Stelle | Deckt ab |
+|---|---|---|
+| Ende | `project.py:37` `event_end_display()` → 4. Rückgabewert | **beide** Pfade auf einen Schlag |
+| Beginn (Trip) | `trip_alert.py:1512` | Trip-Radar-Alarm |
+| Beginn (Ortsvergleich) | `project.py:544` | Ortsvergleich-Bündel |
+
+Jeweils: `weekday = _de_weekday_short(local_dt(dt, tz)) if offset else None`
+
+**Wirkort** (`render.py`) — dritter Parameter, Gate bleibt auf `day_offset`:
+
+```python
+def _sms_onset_time(onset_time: str, day_offset: int = 0, weekday: str | None = None) -> str:
+    hour, sep, rest = onset_time.partition(":")
+    base = onset_time if not sep else f"{hour.lstrip('0') or '0'}:{rest}"
+    return f"{weekday or ''}{base}" if day_offset else base
+```
+
+Der **Versatz** entscheidet, ob ein Tagesbezug gezeigt wird; das Kürzel ist nur seine Darstellung.
+Ein Gate auf den Wahrheitswert von `weekday` würde bei fehlendem Kürzel still den Tagesbezug
+verschlucken.
+
+**Durchreichung:** `RadarAlertRequest` (`notification_service.py:168`) und `OnsetPayload`
+(`api/routers/validator.py:226`) bekommen die Felder additiv und optional — reiner Passthrough im
+dreifach etablierten Muster (`onset_precip_mm`, `event_end_time`, `event_end_day_offset`).
+
+## Expected Behavior
+
+- **Input:** ein Onset-Alarm, dessen Regenbeginn und/oder Ereignis-Ende an einem anderen
+  Kalendertag liegt als der Versandzeitpunkt (Ortszeit des Trips bzw. des Ortes).
+- **Output:** Kurznachricht, in der jede betroffene Uhrzeit ein vorangestelltes Wochentagskürzel
+  trägt. Uhrzeiten am Versandtag bleiben **unverändert**.
+- **Side effects:** keine. Kein Versand, keine Persistenz, keine Schwellen- oder Auslöselogik wird
+  berührt. E-Mail und Telegram-Langform bleiben bei ihrer Wortform („morgen 17:00").
+
+### Zielform
+
+| Fall | Kurznachricht |
+|---|---|
+| Beginn, kein Überlauf | `R2.5@18:00` *(unverändert)* |
+| Beginn, Überlauf | `R2.5@Sa0:23` |
+| Ende bekannt, kein Überlauf | `R2.5@18:00@20:00` *(unverändert)* |
+| Ende bekannt, Überlauf | `R2.5@23:50@Sa0:40` |
+| Ende als Untergrenze, Überlauf | `R2.5@23:50 >@Sa0:40` |
+| Gewitter, Überlauf | `TH@Sa0:23 R2.5` |
+
+## Acceptance Criteria
+
+- **AC-1:** Given ein Trip-Radar-Alarm, dessen Regenbeginn hinter Mitternacht auf einen Samstag
+  fällt / When die Kurznachricht erzeugt wird / Then trägt die Uhrzeit das vorangestellte Kürzel
+  `Sa` und **kein** Zahlensuffix.
+  - Test: Alarm über den echten Versandpfad auslösen, zugestellten `sms_body` prüfen — Token
+    enthält `@Sa0:23`, nicht `@0:23+1`.
+
+- **AC-2:** Given denselben Alarm, aber mit einem Regenbeginn **am Versandtag** / When die
+  Kurznachricht erzeugt wird / Then ist sie zeichengleich zum heutigen Bestand — kein Kürzel, kein
+  Suffix, keine sonstige Abweichung.
+  - Test: Kontrollfall mit Versatz 0 gegen den festgeschriebenen Bestands-String; diese Eigenschaft
+    macht die Umstellung regressionsfrei (ausdrücklich im Ticket-Kommentar gefordert).
+
+- **AC-3:** Given einen Alarm, dessen **Ereignis-Ende** hinter Mitternacht fällt / When die
+  Kurznachricht erzeugt wird / Then trägt auch die Endzeit das Kürzel.
+  - Test: `event_end_day_offset=1` über den Renderer; Endzeit-Token zeigt `@Sa0:40`. Bewacht den
+    zweiten Wirkort, den das Ticket nicht kennt.
+
+- **AC-4:** Given einen Alarm, der um 23:50 beginnt und um 00:40 endet / When die Kurznachricht
+  erzeugt wird / Then trägt **nur die Endzeit** ein Kürzel, die Beginnzeit nicht — beide Zeitpunkte
+  werden unabhängig voneinander bewertet.
+  - Test: Beginn-Versatz 0, Ende-Versatz 1 in einer Nachricht; Ergebnis `R2.5@23:50@Sa0:40`.
+
+- **AC-5:** Given ein Ereignis, dessen Ende nur als **Untergrenze** bekannt ist („regnet mindestens
+  bis"), und das hinter Mitternacht reicht / When die Kurznachricht erzeugt wird / Then bleibt das
+  Untergrenzen-Zeichen `>` erhalten und das Kürzel steht dahinter.
+  - Test: Ergebnis ` >@Sa0:40`. Ohne das `>` kippt die Aussage von „regnet mindestens bis" zu „hört
+    auf um" (#2051 AC-20) — das Kürzel darf diese Unterscheidung nicht verdrängen.
+
+- **AC-6:** Given einen **Gewitter**-Onset mit Mitternachts-Überlauf / When die Kurznachricht
+  erzeugt wird / Then trägt die Uhrzeit das Kürzel genauso wie beim Regen.
+  - Test: `is_convective=True`; Ergebnis `TH@Sa0:23 R2.5`. Das Ticket verlangt die Umstellung
+    ausdrücklich für **beide** Zweige.
+
+- **AC-7:** Given einen **Ortsvergleich**-Onset-Alarm mit Mitternachts-Überlauf / When die
+  Kurznachricht erzeugt wird / Then trägt sie das Kürzel genauso wie der Trip-Alarm.
+  - Test: über den Ortsvergleich-Versandpfad, nicht über gebaute Testdaten — bewacht die zweite
+    Bildungsstelle, die sonst still ausbleibt.
+
+- **AC-8:** Given **irgendeinen** Onset-Alarm in irgendeiner Zusammenstellung / When die
+  Kurznachricht erzeugt wird / Then enthält sie **nirgends** ein Zahlensuffix hinter einer Uhrzeit.
+  - Test: Negativprüfung `\d{1,2}:\d{2}\+\d+` über eine Fallmatrix (Beginn-Versatz × Ende-Versatz ×
+    Ende-Form × Regen/Gewitter × läuft-bereits). Dies ist die Zusicherung „genau **eine**
+    Schreibweise" — sie geht rot, egal an welcher Bildungsstelle eine Regression entsteht.
+
+- **AC-9:** Given einen Ort, dessen Ortszeit von UTC abweicht, und einen Zeitpunkt kurz nach
+  Mitternacht Ortszeit / When das Kürzel gebildet wird / Then nennt es den Wochentag der
+  **Ortszeit**, nicht den der UTC-Zeit.
+  - Test: Zeitzone mit Versatz (z. B. Europe/Vienna) und ein Zeitpunkt, an dem UTC- und Ortstag
+    auseinanderfallen; erwartet wird der Ortstag. Verhindert einen um einen Tag falschen Wochentag
+    bei korrektem Versatz.
+
+- **AC-10:** Given ein Ereignis am Versandtag, bei dem versehentlich dennoch ein Wochentag am
+  Datensatz hinterlegt ist / When die Kurznachricht erzeugt wird / Then erscheint **kein** Kürzel.
+  - Test: `day_offset=0` zusammen mit gesetztem `weekday`; Ausgabe bleibt die nackte Uhrzeit. Sichert
+    zu, dass der Versatz entscheidet und nicht das Vorhandensein des Kürzels.
+
+- **AC-11:** Given den längsten Fall (Gewitter, Menge, Beginn **und** Ende mit Kürzel,
+  Untergrenzen-Form) / When die Kurznachricht erzeugt wird / Then bleibt sie unter 160 Zeichen und
+  besteht ausschließlich aus ASCII-Zeichen.
+  - Test: Längen- und Zeichensatzprüfung am zusammengesetzten Ergebnis.
+
+- **AC-12:** Given denselben Mitternachts-Überlauf / When die Alarm-**Vorschau** abgerufen wird
+  / Then zeigt sie dieselbe Schreibweise wie der echte Versand.
+  - Test: über `alert-preview` mit gesetztem Beginn-Versatz. Setzt voraus, dass Versatz und
+    Wochentag in der Vorschau-Schnittstelle überhaupt ankommen — heute fehlt dort bereits der
+    Versatz, weshalb die Vorschau den Sachverhalt gar nicht darstellen kann.
+
+- **AC-14:** Given ein Ereignis, das **bereits läuft** (Kurzform zeigt `now` statt einer
+  Beginnzeit) und dessen Ende hinter Mitternacht fällt / When die Kurznachricht erzeugt wird / Then
+  trägt die Endzeit das Kürzel, und das `now` bleibt unverändert stehen.
+  - Test: `already_running=True` mit Ende-Versatz 1; Ergebnis `R2.5 now >@Sa0:40`, kein `+1`.
+    Nachgetragen am 2026-08-22: dieser dritte Renderzweig entstand durch #2050 S2b erst **nach**
+    der Freigabe dieser Spec und erbt das Ende-Token über denselben Aufruf.
+
+- **AC-13:** Given denselben Alarm / When E-Mail und Telegram-**Langform** erzeugt werden / Then
+  schreiben sie den Tagesbezug unverändert als Wort („morgen 0:23"), nicht als Kürzel.
+  - Test: Langform-Ausgabe gegen den Bestand. Kurzform = Kürzel, Langform = Wort ist eine bewusste
+    Trennung und darf nicht angeglichen werden.
+
+## Known Limitations
+
+- **Ein Versatz von zwei oder mehr Tagen ist nicht darstellbar.** Der Nowcast schaut nur nach vorn,
+  ein Onset kann also nicht zwei Tage entfernt liegen; das Kürzel bliebe in einem solchen Fall
+  mehrdeutig (`Sa` ohne Angabe, welcher Samstag). Verhalten ist definiert — das Kürzel des
+  Zieltages wird gezeigt —, ein Sonderfall wird bewusst **nicht** gebaut.
+- **Der harte Zeichen-Schnitt der Kurznachricht bleibt bestehen.** Bei sehr langem Ortsnamen kann
+  das Zeit-Token angeschnitten werden und eine falsche Uhrzeit ergeben. Von dieser Arbeit **nicht
+  verursacht** (die Umstellung ist zeichenneutral) und deshalb hier nicht behoben → **#2078**.
+- **Die Onset-Uhrzeit ist gelegentlich eine Minute zu früh** (Sekunden werden abgeschnitten statt
+  gerundet). Anderer Fehlermechanismus, bleibt getrennt → **#2063**.
+- **`build_onset_alert_message`** (`radar_alert_service.py:31`) zieht nicht nach — reiner
+  Debug-Endpoint, der schon die `event_end_*`-Felder nicht kennt.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Kein neues Entscheidungsfeld. Die Grundsatzentscheidung („Wochentagskürzel für
+  beide Zweige, damit es genau eine Schreibweise gibt") ist bereits gefallen und in
+  `fix_2020_alarm_blickrichtung.md`, Abschnitt „Zur Entscheidung mit der Freigabe", festgehalten;
+  vom PO am 2026-08-21 freigegeben. Diese Spec setzt sie um, sie trifft sie nicht.
+
+## Changelog
+
+- 2026-08-22: Initial spec created
+- 2026-08-22: **AC-14 nachgetragen** — `#2050 S2b` (Merge `d2c7c86a`, nach der Freigabe) fügte den
+  dritten Renderzweig „Ereignis läuft bereits" hinzu, der das Ende-Token über denselben Aufruf
+  erbt. Additive Erweiterung der freigegebenen Richtung, keine neue Entscheidung; Fallmatrix in
+  AC-8 entsprechend erweitert. Basis auf `1e0ee151` nachgezogen.

--- a/src/output/renderers/alert/model.py
+++ b/src/output/renderers/alert/model.py
@@ -95,6 +95,13 @@ class OnsetEvent:
     # unveraenderten Normalfall (0). Beide Onset-Pfade setzen es (Trip UND
     # Ortsvergleich-Buendel, ADR-0021).
     onset_day_offset: int = 0
+    # Issue #2054: drittes Glied der Tripel-Konvention (`<name>_time` +
+    # `<name>_day_offset` + `<name>_weekday`, wie `AlertEvent.occurred_*`) --
+    # das DE-Wochentagskuerzel des Beginn-Zeitpunkts in ORTSZEIT, gebildet
+    # dort, wo auch der Versatz entsteht. Gelesen AUSSCHLIESSLICH von der
+    # Kurzform, die damit dieselbe Schreibweise fuehrt wie Abweichungsalarm
+    # (#2020 S2) und amtliche Warnung (#1948 S5). `None` bei Versatz 0.
+    onset_weekday: str | None = None
     # Issue #2046: additiv, optional (Muster `onset_day_offset` o.). Erwartete
     # Niederschlagsmenge (mm) der STUNDE AB DEM BEGINN — Quelle
     # `NowcastResult.onset_precip_mm`. Gelesen AUSSCHLIESSLICH vom
@@ -120,6 +127,10 @@ class OnsetEvent:
     # Beginn kopiert: Beginn 23:50 (Versatz 0) und Ende 00:40 (Versatz 1)
     # liegen an verschiedenen Kalendertagen.
     event_end_day_offset: int = 0
+    # Issue #2054: Wochentagskuerzel des ENDE-Zeitpunkts, analog
+    # `onset_weekday` -- und aus demselben Grund eigenstaendig: Beginn und
+    # Ende koennen an verschiedenen Kalendertagen liegen (23:50 -> 00:40).
+    event_end_weekday: str | None = None
     # Issue #2051 S1 (Spec v1.1, PO-Entscheid 2026-08-22): der R4-Waechter
     # `NowcastResult.event_ongoing_beyond_horizon` — die Frames bzw. der
     # 180-Min-Horizont sind ausgegangen, waehrend der letzte bekannte Frame

--- a/src/output/renderers/alert/project.py
+++ b/src/output/renderers/alert/project.py
@@ -36,9 +36,9 @@ COMPARE_RADAR_SOURCE = "compare-radar"
 
 def event_end_display(
     now_utc: datetime, nowcast, tz,
-) -> tuple[str | None, int, bool]:
+) -> tuple[str | None, int, bool, str | None]:
     """Anzeigefassung des Ereignis-Endes (Issue #2051 S1):
-    `("HH:MM", Versatz, Untergrenze?)`.
+    `("HH:MM", Versatz, Untergrenze?, Wochentagskuerzel)`.
 
     EINE Fassung fuer BEIDE Onset-Pfade (Trip-Radar-Alarm und
     Ortsvergleich-Buendel, ADR-0021) — zwei Kopien dieser vier Zeilen wuerden
@@ -58,13 +58,20 @@ def event_end_display(
 
     Der Tagesversatz stammt aus dem ENDE-Zeitpunkt, nicht vom Beginn: Beginn
     23:50 und Ende 00:40 liegen an verschiedenen Kalendertagen.
+
+    Issue #2054: das vierte Feld ist die DARSTELLUNG desselben Versatzes fuer
+    die Kurzform -- das Wochentagskuerzel in DERSELBEN Zone `tz`, aus der auch
+    der Versatz stammt (ein aus der UTC-Zeit gebildetes Kuerzel laege kurz
+    nach Ortsmitternacht um einen Tag daneben). `None` bei Versatz 0.
     """
     end_minutes = getattr(nowcast, "event_end_minutes", None)
     if end_minutes is None:
-        return None, 0, False
+        return None, 0, False, None
     ongoing = bool(getattr(nowcast, "event_ongoing_beyond_horizon", False))
     end_dt = now_utc + timedelta(minutes=end_minutes)
-    return local_fmt(end_dt, tz), day_offset(now_utc, end_dt, tz), ongoing
+    offset = day_offset(now_utc, end_dt, tz)
+    weekday = _de_weekday_short(local_dt(end_dt, tz)) if offset else None
+    return local_fmt(end_dt, tz), offset, ongoing, weekday
 
 
 def _resolve_metric_id(field: str, direction: str) -> str:
@@ -552,7 +559,12 @@ def to_multi_location_onset_alert_message(
         # weil jede Textform auf `already_running` verzweigt.
         _laufend = getattr(nc, "already_running", False)
         onset_dt = now + timedelta(minutes=nc.onset_minutes or 0)
-        _end_time, _end_offset, _end_ongoing = event_end_display(now, nc, loc_tz)
+        _end_time, _end_offset, _end_ongoing, _end_weekday = event_end_display(
+            now, nc, loc_tz,
+        )
+        # Issue #2054: Versatz und Kuerzel aus DEMSELBEN Zeitpunkt und
+        # DERSELBEN Ortszone -- zwei Herleitungen koennten auseinanderlaufen.
+        _onset_offset = day_offset(now, onset_dt, loc_tz)
         events.append(OnsetEvent(
             already_running=_laufend,
             onset_minutes=nc.onset_minutes or 0,
@@ -560,7 +572,11 @@ def to_multi_location_onset_alert_message(
             km_from=0.0, km_to=0.0, is_convective=nc.is_convective,
             intensity_label=nc.intensity_label, source_label=nc.source,
             location_label=location_name if multi else None,
-            onset_day_offset=day_offset(now, onset_dt, loc_tz),
+            onset_day_offset=_onset_offset,
+            onset_weekday=(
+                _de_weekday_short(local_dt(onset_dt, loc_tz))
+                if _onset_offset else None
+            ),
             # Issue #2046: die Mengenangabe der Kurznachricht kommt im
             # Ortsvergleich-Buendel aus DEMSELBEN NowcastResult wie im
             # Trip-Pfad -- sonst entstuende hier eine stille Luecke, weil
@@ -573,6 +589,7 @@ def to_multi_location_onset_alert_message(
             # dieselbe, die der Trip-Pfad benutzt (ADR-0021).
             event_end_time=_end_time,
             event_end_day_offset=_end_offset,
+            event_end_weekday=_end_weekday,  # Issue #2054
             # Issue #2051 S1 (Spec v1.1): der R4-Waechter waehlt die TEXTFORM
             # des Endes (Untergrenze vs. bekanntes Ende) und muss den Renderer
             # deshalb erreichen -- er darf nicht mehr stromaufwaerts in einem

--- a/src/output/renderers/alert/render.py
+++ b/src/output/renderers/alert/render.py
@@ -755,20 +755,29 @@ def _render_telegram_onset(msg: AlertMessage) -> str:
     return "\n".join([first, second])
 
 
-def _sms_onset_time(onset_time: str, day_offset: int = 0) -> str:
+def _sms_onset_time(
+    onset_time: str, day_offset: int = 0, weekday: str | None = None,
+) -> str:
     """Zeitpunkt-Darstellung der Kurznachricht (Issue #1948 S4, AC-11): die
     Stunde OHNE fuehrende Null (`09:05` -> `9:05`, Zeichenbudget), die Minuten
     bleiben zweistellig. Gilt AUSSCHLIESSLICH hier -- E-Mail, Telegram und
     Betreff lesen `e.onset_time` unveraendert, und das Feld selbst wird nicht
     angefasst.
 
-    Issue #2009: additiver Tages-Suffix (`+1`) bei Mitternachts-Ueberlauf --
-    zeichensparender als der Klartext-Zusatz von E-Mail/Telegram
-    (`_onset_time_label`), GSM-7-vertraeglich (nur Ziffern/`+`). Bei
-    `day_offset == 0` (Normalfall) byte-identisch zum Bestandsverhalten."""
+    Issue #2054: der Tagesbezug steht als vorangestelltes DE-Wochentagskuerzel
+    (`Sa0:23`) und nicht mehr als Zahlensuffix (`0:23+1`) -- dieselbe
+    Schreibweise, die derselbe Kanal fuer Abweichungsalarme (#2020 S2) und
+    amtliche Warnungen (#1948 S5) schon fuehrt. Zweck ist Vereinheitlichung:
+    danach kennt die Kurzform genau EINE Schreibweise fuer den Sachverhalt
+    "diese Uhrzeit liegt an einem anderen Kalendertag".
+
+    Ueber die Anzeige entscheidet der VERSATZ, nicht das Vorhandensein des
+    Kuerzels: ein Gate auf `weekday` wuerde bei fehlendem Kuerzel still den
+    Tagesbezug verschlucken (AC-10). Bei `day_offset == 0` (Normalfall)
+    byte-identisch zum Bestandsverhalten."""
     hour, sep, rest = onset_time.partition(":")
     base = onset_time if not sep else f"{hour.lstrip('0') or '0'}:{rest}"
-    return f"{base}+{day_offset}" if day_offset else base
+    return f"{weekday or ''}{base}" if day_offset else base
 
 
 # Issue #2046: Untergrenze, ab der eine Mengenangabe in der Kurznachricht
@@ -821,8 +830,13 @@ def _sms_onset_ende(e: OnsetEvent) -> str:
         return ""
     praefix = " >" if getattr(e, "event_ongoing_beyond_horizon", False) else ""
     return (
-        f"{praefix}@"
-        f"{_sms_onset_time(ende, getattr(e, 'event_end_day_offset', 0))}"
+        f"{praefix}@" + _sms_onset_time(
+            ende,
+            getattr(e, "event_end_day_offset", 0),
+            # Issue #2054: das Kuerzel des ENDE-Zeitpunkts, nicht das des
+            # Beginns -- beide Zeitpunkte werden unabhaengig bewertet.
+            getattr(e, "event_end_weekday", None),
+        )
     )
 
 
@@ -851,7 +865,10 @@ def _render_sms_onset(msg: AlertMessage, limit: int = 140) -> str:
     # drei Token-Zweige unten: so traegt AUCH der Gewitter-Zweig das Ende an
     # der Zeit (`TH@18:00@20:00 R2.5`) und nicht hinter der Menge -- sonst
     # bliebe dort eine stille Luecke.
-    zeit = _sms_onset_time(e.onset_time, e.onset_day_offset) + _sms_onset_ende(e)
+    zeit = _sms_onset_time(
+        e.onset_time, e.onset_day_offset,
+        getattr(e, "onset_weekday", None),  # Issue #2054
+    ) + _sms_onset_ende(e)
     menge = _sms_onset_menge(getattr(e, "onset_precip_mm", None))
     if getattr(e, "already_running", False):
         # Issue #2050 S2b (PO-Entscheid 2026-08-22): `now` steht dort, wo

--- a/src/services/notification_service.py
+++ b/src/services/notification_service.py
@@ -198,6 +198,12 @@ class RadarAlertRequest:
     # mehrdeutig. Berechnet wird er dort, wo `onset_time` entsteht
     # (`trip_alert.check_radar_alerts`), damit beide dieselbe Zone benutzen.
     onset_day_offset: int = 0
+    # Issue #2054: Wochentagskuerzel des Onset-Zeitpunkts -- reiner
+    # Passthrough bis in den Renderer, gebildet dort, wo auch der Versatz
+    # entsteht (`trip_alert.check_radar_alerts`), damit beide dieselbe Zone
+    # benutzen. `None` bei Versatz 0; ohne das Feld bliebe der Tagesbezug in
+    # der Kurzform ohne Darstellung.
+    onset_weekday: str | None = None
     # Issue #2018: additiv, optional (Muster `briefing_context`). Traegt die
     # ausformulierte Bezugszeile, wenn das Ereignis-Identitaets-Gate diese
     # Meldung als NACHTRAG zu einer bereits zugestellten amtlichen Warnung
@@ -217,6 +223,10 @@ class RadarAlertRequest:
     # byte-identisch.
     event_end_time: str | None = None
     event_end_day_offset: int = 0
+    # Issue #2054: Wochentagskuerzel des ENDE-Zeitpunkts (Muster
+    # `onset_weekday` o.) -- eigenstaendig, weil Beginn und Ende an
+    # verschiedenen Kalendertagen liegen koennen.
+    event_end_weekday: str | None = None
     # Issue #2051 S1 (Spec v1.1): der R4-Waechter reist MIT der Uhrzeit bis in
     # den Renderer, weil er dort ueber die Textform entscheidet (Untergrenze
     # vs. bekanntes Ende, AC-20). Ohne ihn kaeme im Waechterfall die
@@ -1364,9 +1374,11 @@ class NotificationService:
             briefing_context=request.briefing_context,
             segment_id=request.segment_id,  # Issue #1744 A1
             onset_day_offset=request.onset_day_offset,  # Issue #2009
+            onset_weekday=request.onset_weekday,  # Issue #2054
             onset_precip_mm=request.onset_precip_mm,  # Issue #2046
             event_end_time=request.event_end_time,  # Issue #2051 S1
             event_end_day_offset=request.event_end_day_offset,  # Issue #2051 S1
+            event_end_weekday=request.event_end_weekday,  # Issue #2054
             # Issue #2051 S1 (Spec v1.1): waehlt die Ende-Textform im Renderer.
             event_ongoing_beyond_horizon=request.event_ongoing_beyond_horizon,
         )

--- a/src/services/trip_alert.py
+++ b/src/services/trip_alert.py
@@ -44,7 +44,7 @@ from services.trip_day import anchor_tz, trip_local_today
 from services.user_tier import premium_sms_allowed, sms_allowed
 from services.weather_change_detection import WeatherChangeDetectionService
 from utils.timezone import (
-    day_offset, format_reference_at, local_fmt, to_utc, tz_for_coords,
+    day_offset, format_reference_at, local_dt, local_fmt, to_utc, tz_for_coords,
 )
 
 if TYPE_CHECKING:
@@ -1614,16 +1614,27 @@ class TripAlertService:
             # ausdruecklich MIT: er waehlt im Renderer die Textform
             # (Untergrenze vs. bekanntes Ende, Spec v1.1). Lazy importiert wie
             # die uebrigen Renderer-Bausteine dieses Pfads.
+            from output.renderers.alert.official_alerts import (
+                _de_weekday_short,  # Issue #2054: EIN Kuerzel-Erzeuger
+            )
             from output.renderers.alert.project import event_end_display
 
-            _end_time_str, _end_day_offset, _end_ongoing = event_end_display(
-                now_utc, result, tz,
+            _end_time_str, _end_day_offset, _end_ongoing, _end_weekday = (
+                event_end_display(now_utc, result, tz)
             )
+            # Issue #2054: Versatz und Wochentagskuerzel des BEGINNS aus
+            # DEMSELBEN Zeitpunkt und DERSELBEN Zone -- eine zweite Herleitung
+            # koennte auseinanderlaufen (Muster #2009 o.).
+            _onset_day_offset = day_offset(now_utc, _onset_dt, tz)
             _radar_request = RadarAlertRequest(
                 onset_minutes=result.onset_minutes,
                 already_running=result.already_running,  # Issue #2050 S2b
                 onset_time=_onset_time_str,
-                onset_day_offset=day_offset(now_utc, _onset_dt, tz),
+                onset_day_offset=_onset_day_offset,
+                onset_weekday=(
+                    _de_weekday_short(local_dt(_onset_dt, tz))
+                    if _onset_day_offset else None
+                ),
                 km_from=active.start_point.distance_from_start_km,
                 km_to=active.end_point.distance_from_start_km,
                 # Issue #1744 A1: dieselbe Etappe, die schon die km-Spanne
@@ -1643,6 +1654,7 @@ class TripAlertService:
                 # ohne Einfluss auf die Ausloeseregel (wie onset_precip_mm).
                 event_end_time=_end_time_str,
                 event_end_day_offset=_end_day_offset,
+                event_end_weekday=_end_weekday,  # Issue #2054
                 event_ongoing_beyond_horizon=_end_ongoing,
                 tz=tz,
             )

--- a/src/services/validator_render_service.py
+++ b/src/services/validator_render_service.py
@@ -128,11 +128,19 @@ def render_alert_preview(
             # dieser Zweig sowohl den API-Payload (`OnsetPayload`) als auch
             # den Replay-SimpleNamespace bedient -- Muster `segment_id` o.
             onset_precip_mm=getattr(body.onset, "onset_precip_mm", None),
+            # Issue #2054: Tagesbezug des Beginns UND seine Darstellung --
+            # ohne beides zeigt die Vorschau eine andere Schreibweise als der
+            # Versand. `getattr` aus demselben Grund wie oben.
+            onset_day_offset=getattr(body.onset, "onset_day_offset", 0),
+            onset_weekday=getattr(body.onset, "onset_weekday", None),
             # Issue #2051 S1: Ende-Angabe des Payloads, `getattr` aus
             # demselben Grund wie oben (API-Payload UND Replay-Namespace).
             event_end_time=getattr(body.onset, "event_end_time", None),
             event_end_day_offset=getattr(
                 body.onset, "event_end_day_offset", 0,
+            ),
+            event_end_weekday=getattr(  # Issue #2054
+                body.onset, "event_end_weekday", None,
             ),
             # Issue #2051 S1 (Spec v1.1): der R4-Waechter waehlt die
             # Ende-Textform -- er muss den Renderer auch auf dem Vorschauweg
@@ -277,7 +285,7 @@ def _render_nowcast_replay(trip_obj: Trip, body_nf: Any) -> dict:
 
     alert_tz = _alert_tz_for_trip(trip_obj)
     onset_time = now + timedelta(minutes=result.onset_minutes or 0)
-    _end_time, _end_offset, _end_ongoing = event_end_display(
+    _end_time, _end_offset, _end_ongoing, _end_weekday = event_end_display(
         now, result, alert_tz,
     )
     onset_ns = SimpleNamespace(
@@ -305,6 +313,7 @@ def _render_nowcast_replay(trip_obj: Trip, body_nf: Any) -> dict:
         # Produktivpfad.
         event_end_time=_end_time,
         event_end_day_offset=_end_offset,
+        event_end_weekday=_end_weekday,  # Issue #2054
         event_ongoing_beyond_horizon=_end_ongoing,
     )
     out = render_alert_preview(

--- a/tests/tdd/test_alert_onset_day_rollover.py
+++ b/tests/tdd/test_alert_onset_day_rollover.py
@@ -111,18 +111,26 @@ def test_ac4_email_and_telegram_show_day_on_rollover():
 def test_ac5_sms_token_carries_day_suffix():
     """AC-5: Given denselben Mitternachts-Ueberlauf-Fall / When die
     Kurznachricht (SMS und Premium-SMS teilen `_render_sms_onset`) gerendert
-    wird / Then traegt der Token ein zeichensparendes Tages-Suffix
-    ("TH@0:23+1"), bleibt GSM-7-vertraeglich und unter der 160-Zeichen-
-    Grenze; ohne Tageswechsel bleibt der Token exakt wie bisher."""
-    rollover_event = _onset_event(onset_time="00:23", onset_day_offset=1)
+    wird / Then traegt der Token einen zeichensparenden Tagesbezug, bleibt
+    GSM-7-vertraeglich und unter der 160-Zeichen-Grenze; ohne Tageswechsel
+    bleibt der Token exakt wie bisher.
+
+    Issue #2054: der Tagesbezug steht seither als vorangestelltes
+    Wochentagskuerzel ("TH@Sa0:23") statt als Zahlensuffix ("TH@0:23+1") --
+    dieselbe Schreibweise wie bei Abweichungsalarm und amtlicher Warnung. Die
+    Zusicherung dieses Tests ist unveraendert: ein Ueberlauf ist sichtbar, ein
+    Nicht-Ueberlauf nicht."""
+    rollover_event = _onset_event(
+        onset_time="00:23", onset_day_offset=1, onset_weekday="Sa",
+    )
     sms = render_sms(_onset_msg(rollover_event))
 
-    assert "TH@0:23+1" in sms, (
-        f"Erwartetes Tages-Suffix-Token 'TH@0:23+1' fehlt in der SMS: {sms!r}"
+    assert "TH@Sa0:23" in sms, (
+        f"Erwarteter Tagesbezugs-Token 'TH@Sa0:23' fehlt in der SMS: {sms!r}"
     )
     assert len(sms) <= 160, f"SMS ueberschreitet die 160-Zeichen-Grenze: {len(sms)} — {sms!r}"
 
-    token_match = re.search(r"(TH|R)@\d{1,2}:\d{2}(?:\+\d+)?", sms)
+    token_match = re.search(r"(TH|R)@(?:[A-Za-z]{2})?\d{1,2}:\d{2}", sms)
     assert token_match, f"Kein Onset-Zeitpunkt-Token in der SMS gefunden: {sms!r}"
     token = token_match.group(0)
     assert re.fullmatch(r"[A-Za-z0-9@:+\-]+", token), (
@@ -136,8 +144,9 @@ def test_ac5_sms_token_carries_day_suffix():
     assert "TH@15:40" in control_sms, (
         f"Ohne Tageswechsel muss der Token unveraendert erscheinen: {control_sms!r}"
     )
-    assert "+1" not in control_sms, (
-        f"Ohne Tageswechsel darf kein Tages-Suffix erscheinen: {control_sms!r}"
+    assert "+1" not in control_sms and "Sa15:40" not in control_sms, (
+        f"Ohne Tageswechsel darf KEIN Tagesbezug erscheinen — weder das alte "
+        f"Suffix noch das Kuerzel (#2054): {control_sms!r}"
     )
 
 
@@ -283,8 +292,11 @@ def test_f001_compare_versandpfad_traegt_den_tagesbezug_je_ort():
 
 def test_f001_compare_kurznachricht_traegt_das_tages_suffix():
     """F001, SMS-Halfte: die Kurznachricht des Ortsvergleichs-Onset-Alarms
-    traegt das `+1`-Suffix, wenn der fuehrende Ort ueber Mitternacht rutscht
-    — und NICHT, wenn er es nicht tut.
+    traegt den Tagesbezug, wenn der fuehrende Ort ueber Mitternacht rutscht
+    — und NICHT, wenn er es nicht tut. Seit #2054 ist dieser Tagesbezug das
+    vorangestellte Wochentagskuerzel (`R@Mi0:23`) statt des Zahlensuffixes;
+    die bewachte Zusicherung (Offset entsteht je Ort in DESSEN Zone) ist
+    unveraendert.
 
     Wirkort ist `to_multi_location_onset_alert_message()` selbst: dort
     entsteht der Offset des Ortsvergleichs-Pfades (`check_all_compare_
@@ -310,17 +322,23 @@ def test_f001_compare_kurznachricht_traegt_das_tages_suffix():
             tz=ZoneInfo("Europe/Vienna"), stand_at="23:30",
         ))
 
-    assert "R@0:23+1" in wien_fuehrt, (
+    # Der 2026-08-11 ist ein DIENSTAG, der Folgetag also ein Mittwoch ("Mi").
+    assert "R@Mi0:23" in wien_fuehrt, (
         f"Wien rutscht auf 00:23 des Folgetags — die Kurznachricht haette "
-        f"'R@0:23+1' tragen muessen: {wien_fuehrt!r}"
+        f"'R@Mi0:23' tragen muessen: {wien_fuehrt!r}"
     )
     assert len(wien_fuehrt) <= 160, (
         f"Kurznachricht ueberschreitet die 160-Zeichen-Grenze: "
         f"{len(wien_fuehrt)} — {wien_fuehrt!r}"
     )
-    assert "R@22:23" in rvk_fuehrt and "+1" not in rvk_fuehrt, (
-        f"Reykjavik bleibt am selben Tag (22:23) — kein Tages-Suffix "
-        f"erlaubt, und die Zone muss je Ort aufgeloest werden: {rvk_fuehrt!r}"
+    assert (
+        "R@22:23" in rvk_fuehrt
+        and "+1" not in rvk_fuehrt
+        and not re.search(r"@(Mo|Di|Mi|Do|Fr|Sa|So)", rvk_fuehrt)
+    ), (
+        f"Reykjavik bleibt am selben Tag (22:23) — kein Tagesbezug erlaubt "
+        f"(weder Suffix noch Kuerzel), und die Zone muss je Ort aufgeloest "
+        f"werden: {rvk_fuehrt!r}"
     )
 
 

--- a/tests/tdd/test_nowcast_blockende_zone_vor_horizont.py
+++ b/tests/tdd/test_nowcast_blockende_zone_vor_horizont.py
@@ -124,7 +124,7 @@ def _onset_event_aus_ableitung(raster: dict[int, float]) -> OnsetEvent:
     `OnsetEvent`. Handgesetzte Felder wuerden hier nur den Renderer pruefen,
     nicht die Kette — und genau die Kette ist der Gegenstand von AC-8."""
     nc = _ergebnis(raster)
-    end_time, end_offset, end_ongoing = event_end_display(_NOW, nc, _TZ)
+    end_time, end_offset, end_ongoing, end_weekday = event_end_display(_NOW, nc, _TZ)  # Issue #2054
     return OnsetEvent(
         onset_minutes=nc.onset_minutes or 0,
         onset_time="12:55",  # 10:55 UTC in Ortszeit; fuer das Ende belanglos
@@ -133,6 +133,7 @@ def _onset_event_aus_ableitung(raster: dict[int, float]) -> OnsetEvent:
         event_end_time=end_time,
         event_end_day_offset=end_offset,
         event_ongoing_beyond_horizon=end_ongoing,
+        event_end_weekday=end_weekday,
     )
 
 

--- a/tests/tdd/test_onset_wochentagskuerzel.py
+++ b/tests/tdd/test_onset_wochentagskuerzel.py
@@ -89,6 +89,11 @@ FREITAG_1200_UTC = "2026-08-21T12:00:00+00:00"
 # (+53 Min) faellt auf 22:33 UTC — UTC-Tag immer noch FREITAG, Ortstag bereits
 # SAMSTAG. Genau dieser Zeitpunkt trennt Ortstag von UTC-Tag (AC-9).
 FREITAG_2140_UTC = "2026-08-21T21:40:00+00:00"
+# 23:00 UTC am Freitag: der Beginn (+53 Min) faellt auf 23:53 und bleibt damit
+# am Versandtag, das ENDE des nassen Blocks (Deckungsgrenze des einzigen
+# Frames, +15 Min) auf 00:08 des Folgetags. Genau dieser Zeitpunkt trennt die
+# beiden Bildungsstellen: nur das ENDE traegt hier einen Versatz (F001).
+FREITAG_2300_UTC = "2026-08-21T23:00:00+00:00"
 
 
 def onset_event(**kw) -> OnsetEvent:
@@ -380,6 +385,56 @@ def test_ac3_endzeit_traegt_das_kuerzel():
     )
     assert not ALTFORM_RE.search(sms), (
         f"Die Altform steht noch am Ende-Token: {sms!r}"
+    )
+
+
+# ══════════ AC-3, der WIRKORT: die Ende-Bildungsstelle (F001) ════════════════
+
+
+def test_ac3_wirkort_endezeit_kuerzel_entsteht_am_echten_versandpfad(
+    telegram_stub, monkeypatch,
+):
+    """AC-3 (Wirkort) GIVEN einen Trip-Radar-Alarm, dessen Regenbeginn NOCH am
+    Versandtag liegt, dessen Ereignis-ENDE aber hinter Mitternacht faellt
+    WHEN die Kurznachricht ueber den ECHTEN Versandpfad
+    (`TripAlertService.check_radar_alerts()`) erzeugt und zugestellt wird
+    THEN traegt die Endzeit ein aus dem ZEITSTEMPEL abgeleitetes Kuerzel, die
+    Beginnzeit dagegen keines.
+
+    Adversary-Finding F001 (HIGH): der Test zu AC-3 oben konstruiert sein
+    `OnsetEvent` mit `event_end_weekday="Sa"` als LITERAL und prueft damit nur
+    den Renderer. Die Bildungszeile in `project.event_end_display()` blieb
+    unbewacht — sie komplett abzuschalten liess das gesamte Repo gruen: AC-1
+    und AC-7 fahren zwar den echten Pfad, behaupten ueber das Ende-Token aber
+    nichts, und ein fehlendes Kuerzel erzeugt keine Altform, sondern
+    verschluckt den Tagesbezug STILL (`>@0:08` statt `>@Sa0:08`).
+
+    Der Aufbau trennt die beiden Bildungsstellen bewusst: Freitag 23:00
+    Ortszeit + 53 Min = 23:53 (Beginn, Versatz 0), Ende an der Deckungsgrenze
+    des einzigen Frames (+15 Min) = 00:08 am Samstag (Versatz 1). Ein Kuerzel
+    am Ende kann hier also NICHT versehentlich aus der Beginn-Bildungsstelle
+    stammen. Da nur ein Frame vorliegt, ist das Ende eine belegte Untergrenze
+    (`event_ongoing_beyond_horizon`) und erscheint in der `>`-Form.
+
+    Reykjavik-Koordinaten (`make_trip`-Default, ganzjaehrig UTC+0): die
+    Ortszeit ist direkt aus der gestellten UTC-Zeit ablesbar.
+    """
+    text = _kurznachricht_vom_trip_pfad(
+        FREITAG_2300_UTC, telegram_stub, monkeypatch,
+        ankunft_start="22:00", ankunft_ende="02:00",
+    )
+
+    assert ">@Sa0:08" in text, (
+        f"Das Ende (00:08 des Folgetags) haette sein Kuerzel aus dem "
+        f"ENDE-Zeitstempel ableiten muessen — erwartet '>@Sa0:08'. "
+        f"Kurznachricht: {text!r}"
+    )
+    assert "@23:53" in text and "Sa23:53" not in text, (
+        f"Der Beginn bleibt am Versandtag (23:53) und darf KEIN Kuerzel "
+        f"tragen — beide Zeitpunkte werden unabhaengig bewertet: {text!r}"
+    )
+    assert not ALTFORM_RE.search(text), (
+        f"Die Altform steht noch am Ende-Token: {text!r}"
     )
 
 

--- a/tests/tdd/test_onset_wochentagskuerzel.py
+++ b/tests/tdd/test_onset_wochentagskuerzel.py
@@ -1,0 +1,872 @@
+"""TDD RED — die Onset-Kurznachricht schreibt das WOCHENTAGSKUERZEL statt des
+Zahlensuffixes.
+
+SPEC: docs/specs/modules/feat_2054_onset_wochentagskuerzel.md (Issue #2054)
+
+Was bewacht wird: Bis heute traegt der Kurzkanal (SMS · Premium-SMS ·
+Telegram-Kurzstil) ZWEI Schreibweisen fuer denselben Sachverhalt "diese
+Uhrzeit liegt an einem anderen Kalendertag" — `@0:23+1` beim Onset,
+`@Do15` beim Abweichungsalarm (#2020 S2) und `Do12-22` bei der amtlichen
+Warnung (#1948 S5). Danach kennt er genau eine: das vorangestellte Kuerzel
+(`R2.5@Sa0:23`).
+
+Warum das mehr ist als Kosmetik: die *Abwesenheit* der Altform ist Teil der
+Akzeptanz (AC-8). Auf der Huette am Karnischen Hoehenweg kommt nur die
+Premium-SMS an — es gibt dort keinen zweiten Kanal, der eine mehrdeutige
+Zeitangabe richtigstellt.
+
+Zwei Zusicherungen tragen die ganze Aenderung und werden deshalb an den
+BILDUNGSSTELLEN geprueft, nicht nur am Renderer:
+
+  * Der Trip-Radar-Alarm bildet sein `OnsetEvent` in
+    `trip_alert.check_radar_alerts()` (ueber `RadarAlertRequest`) — AC-1.
+  * Der Ortsvergleich bildet seines in
+    `project.to_multi_location_onset_alert_message()` — AC-7 / AC-9.
+
+Ein reiner Renderer-Test ginge still durch, wenn eine der beiden
+Bildungsstellen das Kuerzel nie setzt; genau diese Fehlerklasse fand der
+Adversary bei #2046 (F001) und #2051.
+
+Mock-frei: echte Services, echte `NowcastResult`/`OnsetEvent`-Objekte, echter
+Renderer, echter FastAPI-Endpunkt. Der Kurznachrichten-INHALT wird ueber den
+Telegram-Kurzstil beobachtet — `_dispatch_alert_message()` sendet dort den
+bereits gerenderten `sms_body` unveraendert (notification_service.py:1556),
+und ein echter SMS-Versand wird nie ausgeloest (#1477). Der Draht ist ein
+lokaler Aufzeichnungs-Server, kein `Mock()`/`patch()` von Verhalten.
+
+RED-Ursachen heute:
+  * `OnsetEvent` kennt weder `onset_weekday` noch `event_end_weekday`
+    (unbekanntes Schluesselwort).
+  * `_sms_onset_time()`/`_sms_onset_ende()` haengen `+1` an, statt ein
+    Kuerzel voranzustellen.
+  * `OnsetPayload` der Alarm-Vorschau fuehrt nicht einmal den VERSATZ.
+"""
+from __future__ import annotations
+
+import http.server
+import json
+import re
+import shutil
+import socket
+import threading
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import pytest
+from freezegun import freeze_time
+
+import output.channels.telegram as tg_module
+from app.config import Settings
+from app.loader import get_briefings_dir
+from output.renderers.alert.model import AlertMessage, OnsetEvent
+from output.renderers.alert.project import to_multi_location_onset_alert_message
+from output.renderers.alert.render import render_email, render_sms, render_telegram
+from services.radar_service import NowcastResult
+
+from tests.helpers.nowcast_gate_fixtures import (
+    TRIP_LAT, TRIP_LON, CountingFrameSource, clean_uid, fresh_uid, location,
+    make_trip, radar_service, reset_radar_cache, save_trip, write_user_tier,
+)
+
+# ═════════════════════════ Gemeinsame Ausdruecke ═════════════════════════════
+
+# Die ALTFORM: ein Zahlensuffix unmittelbar hinter einer Uhrzeit ("0:23+1").
+# Diese Schreibweise soll nach der Umstellung NIRGENDS mehr vorkommen (AC-8).
+ALTFORM_RE = re.compile(r"\d{1,2}:\d{2}\+\d+")
+
+# Die ZIELFORM: ein deutsches Wochentagskuerzel unmittelbar VOR einer Uhrzeit
+# ("Sa0:23"). Bewusst ohne Trennzeichen — die Kurznachricht ist zeichenknapp.
+KUERZEL_VOR_ZEIT_RE = re.compile(r"(Mo|Di|Mi|Do|Fr|Sa|So)\s?\d{1,2}:\d{2}")
+
+# Der 2026-08-21 ist ein FREITAG, der Folgetag also ein Samstag ("Sa"). Fest
+# gewaehlt statt aus der Wanduhr abgeleitet: ein aus `date.today()` gerechneter
+# Erwartungswert wuerde denselben Fehler machen wie der Pruefling.
+FREITAG_2330_UTC = "2026-08-21T23:30:00+00:00"
+FREITAG_1200_UTC = "2026-08-21T12:00:00+00:00"
+# 21:40 UTC am Freitag = 23:40 Ortszeit Wien (UTC+2 im August). Der Onset
+# (+53 Min) faellt auf 22:33 UTC — UTC-Tag immer noch FREITAG, Ortstag bereits
+# SAMSTAG. Genau dieser Zeitpunkt trennt Ortstag von UTC-Tag (AC-9).
+FREITAG_2140_UTC = "2026-08-21T21:40:00+00:00"
+
+
+def onset_event(**kw) -> OnsetEvent:
+    """Ein Onset-Ereignis mit festen Feldern (keine Wanduhr).
+
+    Die Renderer lesen ausschliesslich das uebergebene Objekt — dieselbe
+    Bauweise wie `tests/tdd/test_alert_onset_day_rollover.py::_onset_event`.
+    """
+    fields = dict(
+        onset_minutes=53, onset_time="00:23", km_from=8.0, km_to=8.0,
+        is_convective=False, intensity_label="Starker Regen",
+        source_label="INCA", onset_precip_mm=2.5,
+    )
+    fields.update(kw)
+    return OnsetEvent(**fields)
+
+
+def onset_msg(event: OnsetEvent, *, trip_short: str = "KHW 403") -> AlertMessage:
+    """`source is not None` routet die Renderer in den Onset-Zweig."""
+    return AlertMessage(
+        trip_short=trip_short, stand_at="23:30", events=(event,), source="radar",
+    )
+
+
+# ══════════════════ Echter lokaler Telegram-Bot-API-Stub ═════════════════════
+#
+# Transport-Umlenkung auf einen echten HTTP-Server — kein Verhaltens-Mock.
+# Gemessen wird die Nutzlast, die tatsaechlich am Draht ankam.
+
+
+def _free_port() -> int:
+    probe = socket.socket()
+    probe.bind(("", 0))
+    port = probe.getsockname()[1]
+    probe.close()
+    return port
+
+
+class _TelegramStub:
+    def __init__(self) -> None:
+        self.sent: list[dict] = []
+        sent = self.sent
+        counter = {"mid": 7000}
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def do_POST(self):  # noqa: N802
+                length = int(self.headers.get("Content-Length", 0))
+                try:
+                    payload = json.loads(self.rfile.read(length).decode())
+                except ValueError:
+                    payload = {}
+                sent.append(payload)
+                counter["mid"] += 1
+                body = json.dumps(
+                    {"ok": True, "result": {"message_id": counter["mid"]}}
+                ).encode()
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, *args):  # noqa: D401
+                pass
+
+        self.port = _free_port()
+        self._server = http.server.HTTPServer(("127.0.0.1", self.port), Handler)
+        threading.Thread(target=self._server.serve_forever, daemon=True).start()
+
+    @property
+    def base_url(self) -> str:
+        return f"http://127.0.0.1:{self.port}"
+
+    def stop(self) -> None:
+        self._server.shutdown()
+
+
+@pytest.fixture()
+def telegram_stub():
+    stub = _TelegramStub()
+    yield stub
+    stub.stop()
+
+
+def _telegram_only_settings(marke: str) -> Settings:
+    """Nur Telegram sendebereit — E-Mail, SMS und Premium-SMS ausdruecklich
+    AUS. Jedes weggelassene Feld faellt bei pydantic still auf die Prod-`.env`
+    des Arbeitsverzeichnisses zurueck (#1477).
+
+    `telegram_test_chat_id` ist Pflicht fuer die Herkunftssperre des
+    Telegram-Kanals aus einem Nicht-Prod-Checkout (#1476)."""
+    return Settings(
+        smtp_host=None, smtp_user=None, smtp_pass=None, mail_to=None,
+        telegram_bot_token=f"test-token-2054-{marke}",
+        telegram_chat_id="99999", telegram_test_chat_id="99999",
+        sms_gateway_url="", seven_api_key="", seven_sandbox_key="",
+        sms_to="", sms_from=None,
+        premium_sms_reply_to=None, premium_sms_reply_at=None,
+    )
+
+
+# ═══════════════ Der ECHTE Trip-Versandpfad (Bildungsstelle 1) ═══════════════
+
+
+def _kurznachricht_vom_trip_pfad(
+    zeitpunkt: str, telegram_stub, monkeypatch, *,
+    ankunft_start: str, ankunft_ende: str,
+) -> str:
+    """Faehrt `TripAlertService.check_radar_alerts()` unter gestellter Uhr und
+    gibt den Kurznachrichten-TEXT zurueck, der am Draht ankam.
+
+    Der Trip-Radar-Alarm ist der einzige Produktivpfad, der einen
+    `RadarAlertRequest` baut — dort entsteht der Tagesbezug des BEGINNS
+    (trip_alert.py:~1517). Reykjavik-Koordinaten (`make_trip`-Default,
+    ganzjaehrig UTC+0): die Ortszeit ist direkt aus der gestellten UTC-Zeit
+    ablesbar, ohne Zonenrechnung im Test.
+
+    `telegram_style="kurzform"` laesst `_dispatch_alert_message()` den bereits
+    gerenderten `sms_body` senden — der Kurznachrichten-Inhalt wird damit
+    beobachtbar, OHNE je einen SMS-Versand auszuloesen (#1477).
+    """
+    from services.trip_alert import TripAlertService
+
+    monkeypatch.setattr(tg_module, "TELEGRAM_API_BASE", telegram_stub.base_url)
+
+    uid = fresh_uid("2054-trip")
+    clean_uid(uid)
+    reset_radar_cache()
+    try:
+        with freeze_time(zeitpunkt):
+            write_user_tier(uid, "premium")
+            trip = make_trip(
+                "trip-2054-kuerzel",
+                stage_date=datetime.now(timezone.utc).date(),
+                arrival_start=ankunft_start, arrival_end=ankunft_ende,
+            )
+            save_trip(trip, uid)
+            # Der Fixture-Schreiber kennt `telegram_style` nicht; die Datei
+            # wird deshalb nachtraeglich um genau die Kanal-Felder ergaenzt,
+            # die `check_radar_alerts()` von Platte zurueckliest.
+            pfad = get_briefings_dir(uid) / f"{trip.id}.json"
+            daten = json.loads(pfad.read_text())
+            daten["report_config"].update({
+                "send_email": False, "send_telegram": True,
+                "send_sms": False, "send_premium_sms": False,
+                "telegram_style": "kurzform",
+            })
+            pfad.write_text(json.dumps(daten))
+
+            svc = TripAlertService(
+                settings=_telegram_only_settings("trip"), throttle_hours=0,
+                user_id=uid, radar_service=radar_service(
+                    CountingFrameSource(onset_minutes=53),
+                ),
+            )
+            vorher = len(telegram_stub.sent)
+            sent = svc.check_radar_alerts()
+
+        assert sent == 1, (
+            f"Testvoraussetzung bei {zeitpunkt}: genau EIN Trip-Radar-Alarm "
+            f"haette abgesetzt werden muessen, war {sent}"
+        )
+        neu = telegram_stub.sent[vorher:]
+        assert len(neu) == 1, (
+            f"Erwartet genau EINE Kurznachricht am Draht: {neu!r}"
+        )
+        return neu[0].get("text") or ""
+    finally:
+        clean_uid(uid)
+
+
+# ═══════════════════════════════ AC-1 ════════════════════════════════════════
+
+
+def test_ac1_trip_versandpfad_zeigt_wochentagskuerzel_statt_suffix(
+    telegram_stub, monkeypatch,
+):
+    """AC-1 GIVEN einen Trip-Radar-Alarm, dessen Regenbeginn hinter
+    Mitternacht auf einen Samstag faellt (Freitag 23:30 Ortszeit + 53 Min =
+    00:23 am Samstag)
+    WHEN die Kurznachricht ueber den ECHTEN Versandpfad
+    (`TripAlertService.check_radar_alerts()`) erzeugt und zugestellt wird
+    THEN traegt die Uhrzeit das vorangestellte Kuerzel `Sa` und KEIN
+    Zahlensuffix.
+
+    Die Etappe laeuft 22:00 -> 02:00, das aktive Segment endet also NACH dem
+    Onset — sonst unterdrueckte der Segment-Ende-Riegel den Alarm und der Test
+    maesse diesen statt der Schreibweise.
+
+    Bewacht die erste der beiden Beginn-Bildungsstellen: ein reiner
+    Renderer-Test bliebe gruen, wenn `RadarAlertRequest`/
+    `check_radar_alerts()` das Kuerzel nie setzten.
+
+    RED heute: die Nachricht traegt `@0:23+1`.
+    """
+    text = _kurznachricht_vom_trip_pfad(
+        FREITAG_2330_UTC, telegram_stub, monkeypatch,
+        ankunft_start="22:00", ankunft_ende="02:00",
+    )
+
+    assert "@Sa0:23" in text, (
+        f"Der Trip-Versandpfad haette den Beginn als '@Sa0:23' ausweisen "
+        f"muessen (Freitag 23:30 Ortszeit + 53 Min). Kurznachricht: {text!r}"
+    )
+    assert not ALTFORM_RE.search(text), (
+        f"Die Altform (Zahlensuffix hinter der Uhrzeit) steht noch in der "
+        f"Kurznachricht: {text!r}"
+    )
+
+
+# ═══════════════════════════════ AC-2 ════════════════════════════════════════
+
+
+def test_ac2_versandtag_bleibt_zeichengleich_zum_bestand(
+    telegram_stub, monkeypatch,
+):
+    """AC-2 GIVEN denselben Alarm, aber mit einem Regenbeginn AM VERSANDTAG
+    WHEN die Kurznachricht erzeugt wird
+    THEN ist sie zeichengleich zum heutigen Bestand — kein Kuerzel, kein
+    Suffix, keine sonstige Abweichung.
+
+    Diese Eigenschaft macht die Umstellung regressionsfrei (ausdruecklich im
+    Ticket-Kommentar gefordert) und wird an BEIDEN Enden geprueft: am Renderer
+    gegen den festgeschriebenen Bestands-String und am echten Trip-Pfad
+    (12:00 Ortszeit + 53 Min = 12:53, kein Tageswechsel).
+
+    POSITIVKONTROLLE (Pflicht bei einem Test auf ein AUSBLEIBEN): derselbe
+    Renderer-Aufruf mit Versatz 1 und hinterlegtem Kuerzel MUSS ein anderes,
+    kuerzeltragendes Ergebnis liefern. Ohne sie waere die Zusicherung
+    "unveraendert" auch dann gruen, wenn das Kuerzel NIRGENDS erschiene.
+    """
+    # Renderer: der festgeschriebene Bestands-String, Zeichen fuer Zeichen.
+    bestand = render_sms(onset_msg(onset_event(onset_time="18:00")))
+    assert bestand == "km 8-8: R2.5@18:00", (
+        f"Ohne Tageswechsel muss die Kurznachricht zeichengleich zum Bestand "
+        f"bleiben: {bestand!r}"
+    )
+
+    # Derselbe Nachweis am ECHTEN Versandpfad — bewusst VOR der
+    # Positivkontrolle, damit er schon in der RED-Phase durchlaeuft und belegt
+    # ist, dass der Pfad ueberhaupt angefahren wird.
+    text = _kurznachricht_vom_trip_pfad(
+        FREITAG_1200_UTC, telegram_stub, monkeypatch,
+        ankunft_start="11:00", ankunft_ende="14:00",
+    )
+    assert "@12:53" in text, (
+        f"Ohne Tageswechsel (12:00 + 53 Min = 12:53) muss die nackte Uhrzeit "
+        f"stehen bleiben: {text!r}"
+    )
+    assert not KUERZEL_VOR_ZEIT_RE.search(text), (
+        f"Am Versandtag darf KEIN Wochentagskuerzel erscheinen — der Versatz "
+        f"entscheidet, nicht die Bildungsstelle: {text!r}"
+    )
+    assert not ALTFORM_RE.search(text), (
+        f"Am Versandtag darf auch kein Zahlensuffix erscheinen: {text!r}"
+    )
+
+    # Positivkontrolle: mit Versatz UND Kuerzel sieht dasselbe Feld anders aus.
+    mit_kuerzel = render_sms(onset_msg(onset_event(
+        onset_time="18:00", onset_day_offset=1, onset_weekday="Sa",
+    )))
+    assert mit_kuerzel != bestand and "@Sa18:00" in mit_kuerzel, (
+        f"Positivkontrolle: mit Versatz 1 MUSS das Kuerzel erscheinen — sonst "
+        f"bewacht die Gleichheitspruefung oben nichts: {mit_kuerzel!r}"
+    )
+
+
+# ═══════════════════════════════ AC-3 ════════════════════════════════════════
+
+
+def test_ac3_endzeit_traegt_das_kuerzel():
+    """AC-3 GIVEN einen Alarm, dessen EREIGNIS-ENDE hinter Mitternacht faellt
+    WHEN die Kurznachricht erzeugt wird
+    THEN traegt auch die Endzeit das Kuerzel (`@Sa0:40`).
+
+    Bewacht den zweiten Wirkort (`_sms_onset_ende`, render.py:796), den das
+    Ticket nicht kennt: das Ende-Token entstand erst mit #2051 S1 und
+    formatiert seine Uhrzeit ueber DENSELBEN Baustein wie der Beginn.
+
+    RED heute: `OnsetEvent` kennt `event_end_weekday` nicht; nach dem
+    Anlegen des Feldes stuende dort weiter `@0:40+1`.
+    """
+    sms = render_sms(onset_msg(onset_event(
+        onset_time="23:50", event_end_time="00:40",
+        event_end_day_offset=1, event_end_weekday="Sa",
+    )))
+
+    assert "@Sa0:40" in sms, (
+        f"Die Endzeit haette das Kuerzel tragen muessen: {sms!r}"
+    )
+    assert not ALTFORM_RE.search(sms), (
+        f"Die Altform steht noch am Ende-Token: {sms!r}"
+    )
+
+
+# ═══════════════════════════════ AC-4 ════════════════════════════════════════
+
+
+def test_ac4_beginn_und_ende_werden_unabhaengig_bewertet():
+    """AC-4 GIVEN einen Alarm, der um 23:50 beginnt und um 00:40 endet
+    WHEN die Kurznachricht erzeugt wird
+    THEN traegt NUR die Endzeit ein Kuerzel, die Beginnzeit nicht — beide
+    Zeitpunkte werden unabhaengig voneinander bewertet.
+
+    Ein gemeinsamer Tagesbezug fuer beide Zeitpunkte waere fuer genau diesen,
+    haeufigsten Ueberlauf-Fall still falsch.
+    """
+    sms = render_sms(onset_msg(onset_event(
+        onset_time="23:50", onset_day_offset=0, onset_weekday=None,
+        event_end_time="00:40", event_end_day_offset=1, event_end_weekday="Sa",
+    )))
+
+    assert sms == "km 8-8: R2.5@23:50@Sa0:40", (
+        f"Erwartet 'km 8-8: R2.5@23:50@Sa0:40' — nur die Endzeit traegt das "
+        f"Kuerzel: {sms!r}"
+    )
+
+
+# ═══════════════════════════════ AC-5 ════════════════════════════════════════
+
+
+def test_ac5_untergrenzen_zeichen_bleibt_vor_dem_kuerzel():
+    """AC-5 GIVEN ein Ereignis, dessen Ende nur als UNTERGRENZE bekannt ist
+    ("regnet mindestens bis") und das hinter Mitternacht reicht
+    WHEN die Kurznachricht erzeugt wird
+    THEN bleibt das Untergrenzen-Zeichen `>` erhalten und das Kuerzel steht
+    dahinter (` >@Sa0:40`).
+
+    An diesem einen Zeichen haengt die Bedeutung: ohne `>` kippt die Aussage
+    von "regnet mindestens bis" zu "hoert auf um" (#2051 AC-20). Das Kuerzel
+    darf diese Unterscheidung nicht verdraengen.
+    """
+    sms = render_sms(onset_msg(onset_event(
+        onset_time="23:50", event_end_time="00:40",
+        event_end_day_offset=1, event_end_weekday="Sa",
+        event_ongoing_beyond_horizon=True,
+    )))
+
+    assert sms == "km 8-8: R2.5@23:50 >@Sa0:40", (
+        f"Erwartet die Untergrenzen-Form ' >@Sa0:40' mit erhaltenem '>': "
+        f"{sms!r}"
+    )
+
+
+# ═══════════════════════════════ AC-6 ════════════════════════════════════════
+
+
+def test_ac6_gewitterzweig_traegt_das_kuerzel():
+    """AC-6 GIVEN einen GEWITTER-Onset mit Mitternachts-Ueberlauf
+    WHEN die Kurznachricht erzeugt wird
+    THEN traegt die Uhrzeit das Kuerzel genauso wie beim Regen
+    (`TH@Sa0:23 R2.5`).
+
+    Das Ticket verlangt die Umstellung ausdruecklich fuer BEIDE Zweige; der
+    Gewitter-Zweig baut sein Token an einer eigenen Stelle zusammen
+    (`_render_sms_onset`, Menge NACH der Zeit) und kann deshalb getrennt
+    zurueckbleiben.
+    """
+    sms = render_sms(onset_msg(onset_event(
+        is_convective=True, onset_day_offset=1, onset_weekday="Sa",
+    )))
+
+    assert sms == "km 8-8: TH@Sa0:23 R2.5", (
+        f"Erwartet 'km 8-8: TH@Sa0:23 R2.5' — der Gewitter-Zweig traegt "
+        f"dasselbe Kuerzel wie der Regen-Zweig: {sms!r}"
+    )
+
+
+# ═══════════════════════════════ AC-7 ════════════════════════════════════════
+
+
+def test_ac7_ortsvergleich_buendel_traegt_das_kuerzel():
+    """AC-7 GIVEN einen ORTSVERGLEICH-Onset-Alarm mit Mitternachts-Ueberlauf
+    WHEN die Kurznachricht erzeugt wird
+    THEN traegt sie das Kuerzel genauso wie der Trip-Alarm.
+
+    Wirkort ist `to_multi_location_onset_alert_message()` selbst: dort baut
+    der Ortsvergleich sein `OnsetEvent` (project.py:~544) — die ZWEITE
+    Beginn-Bildungsstelle, die ohne eigenen Nachweis still ausbleibt. Genau
+    diese Fehlerklasse fand der Adversary bei #2046 (F001).
+
+    Reykjavik (ganzjaehrig UTC+0): Freitag 23:30 + 53 Min = 00:23 am Samstag.
+    Ein Ort -> `location_label is None`, der Kopf ist der Ortsname.
+    """
+    rvk = location("loc-2054", "Reykjavik", lat=TRIP_LAT, lon=TRIP_LON)
+    nc = NowcastResult(
+        onset_minutes=53, intensity_label="Starker Regen", source="INCA",
+    )
+
+    with freeze_time(FREITAG_2330_UTC):
+        sms = render_sms(to_multi_location_onset_alert_message(
+            [("Reykjavik", rvk, nc)],
+            tz=ZoneInfo("Atlantic/Reykjavik"), stand_at="23:30",
+        ))
+
+    assert "@Sa0:23" in sms, (
+        f"Der Ortsvergleich-Buendelpfad haette den Beginn als '@Sa0:23' "
+        f"ausweisen muessen: {sms!r}"
+    )
+    assert not ALTFORM_RE.search(sms), (
+        f"Die Altform steht noch in der Ortsvergleich-Kurznachricht: {sms!r}"
+    )
+
+
+# ═══════════════════════════════ AC-8 ════════════════════════════════════════
+
+
+def _fallmatrix(mit_kuerzel: bool) -> list[tuple[str, OnsetEvent]]:
+    """Beginn-Versatz × Ende-Versatz × Ende-Form × Regen/Gewitter ×
+    laeuft-bereits — die Zusammenstellungen, in denen eine Uhrzeit ueberhaupt
+    vorkommen kann.
+
+    `mit_kuerzel=False` baut dieselben Faelle OHNE die neuen Felder: so haengt
+    die Altform-Pruefung nicht am Anlegen der Felder und meldet schon heute
+    den konkreten Token statt eines Konstruktionsfehlers.
+    """
+    faelle: list[tuple[str, OnsetEvent]] = []
+    for konvektiv in (False, True):
+        for laeuft in (False, True):
+            for beginn_versatz in (0, 1):
+                for ende in (None, ("00:40", 0), ("00:40", 1)):
+                    for untergrenze in (False, True):
+                        if ende is None and untergrenze:
+                            continue  # ohne Ende gibt es keine Ende-Form
+                        felder: dict = dict(
+                            onset_time="23:50" if beginn_versatz == 0 else "00:23",
+                            onset_day_offset=beginn_versatz,
+                            is_convective=konvektiv,
+                            already_running=laeuft,
+                            event_ongoing_beyond_horizon=untergrenze,
+                        )
+                        if ende is not None:
+                            felder["event_end_time"] = ende[0]
+                            felder["event_end_day_offset"] = ende[1]
+                        if mit_kuerzel:
+                            felder["onset_weekday"] = (
+                                "Sa" if beginn_versatz else None
+                            )
+                            felder["event_end_weekday"] = (
+                                "So" if (ende and ende[1]) else None
+                            )
+                        name = (
+                            f"konvektiv={konvektiv} laeuft={laeuft} "
+                            f"beginn+{beginn_versatz} ende={ende} "
+                            f"untergrenze={untergrenze}"
+                        )
+                        faelle.append((name, onset_event(**felder)))
+    return faelle
+
+
+def test_ac8_keine_uhrzeit_traegt_irgendwo_ein_zahlensuffix():
+    """AC-8 GIVEN IRGENDEINEN Onset-Alarm in irgendeiner Zusammenstellung
+    WHEN die Kurznachricht erzeugt wird
+    THEN enthaelt sie NIRGENDS ein Zahlensuffix hinter einer Uhrzeit.
+
+    Dies ist die zentrale Zusicherung "genau EINE Schreibweise" — sie geht
+    rot, egal an welcher Bildungsstelle oder in welchem der drei Render-Zweige
+    (`already_running` / ohne Menge / mit Menge) eine Regression entsteht.
+
+    POSITIVKONTROLLE (Pflicht bei einem Test auf ein AUSBLEIBEN): der Ausdruck
+    selbst wird gegen die bekannte Altform gehalten. Ein Ausdruck, der nichts
+    faengt, waere sonst ueber die ganze Matrix hinweg still gruen.
+    """
+    assert ALTFORM_RE.search("km 8-8: R2.5@0:23+1"), (
+        "Positivkontrolle: der Altform-Ausdruck muss die bekannte Altform "
+        "'0:23+1' finden — sonst bewacht die Matrix unten nichts"
+    )
+
+    # Erster Durchgang OHNE die neuen Felder: haengt nicht am Modell und
+    # meldet schon heute den konkreten Token.
+    treffer = [
+        (name, render_sms(onset_msg(ev)))
+        for name, ev in _fallmatrix(mit_kuerzel=False)
+        if ALTFORM_RE.search(render_sms(onset_msg(ev)))
+    ]
+    assert not treffer, (
+        "Die Altform (Zahlensuffix hinter einer Uhrzeit) kommt noch vor — "
+        "es gibt damit weiter ZWEI Schreibweisen fuer denselben Sachverhalt:\n"
+        + "\n".join(f"  {name}: {text!r}" for name, text in treffer)
+    )
+
+    # Zweiter Durchgang MIT Kuerzeln: keine Altform, und jeder Versatz ist
+    # als Kuerzel sichtbar.
+    ohne_kuerzel: list[tuple[str, str]] = []
+    for name, ev in _fallmatrix(mit_kuerzel=True):
+        text = render_sms(onset_msg(ev))
+        assert not ALTFORM_RE.search(text), (
+            f"Altform trotz gesetzter Kuerzel — {name}: {text!r}"
+        )
+        erwartet_kuerzel = (
+            (ev.onset_day_offset == 1 and not ev.already_running)
+            or ev.event_end_day_offset == 1
+        )
+        if erwartet_kuerzel and not KUERZEL_VOR_ZEIT_RE.search(text):
+            ohne_kuerzel.append((name, text))
+    assert not ohne_kuerzel, (
+        "Diese Faelle tragen einen Tagesversatz, aber KEIN Kuerzel — der "
+        "Tagesbezug wird still verschluckt:\n"
+        + "\n".join(f"  {name}: {text!r}" for name, text in ohne_kuerzel)
+    )
+
+
+# ═══════════════════════════════ AC-9 ════════════════════════════════════════
+
+
+def test_ac9_kuerzel_nennt_den_ortstag_nicht_den_utc_tag():
+    """AC-9 GIVEN einen Ort, dessen Ortszeit von UTC abweicht, und einen
+    Zeitpunkt kurz nach Mitternacht ORTSZEIT
+    WHEN das Kuerzel gebildet wird
+    THEN nennt es den Wochentag der ORTSZEIT, nicht den der UTC-Zeit.
+
+    Aufbau: Freitag 21:40 UTC = 23:40 Ortszeit Wien (UTC+2 im August). Der
+    Onset (+53 Min) liegt bei 22:33 UTC — UTC-Tag ist immer noch FREITAG,
+    Ortstag bereits SAMSTAG. Wer das Kuerzel aus dem UTC-Zeitpunkt bildet,
+    schreibt `Fr` und liegt bei korrektem Versatz um einen Tag daneben; nur
+    ein aus `local_dt(dt, tz)` gebildetes Kuerzel schreibt `Sa`.
+
+    Gemessen wird am Ortsvergleich-Buendelpfad, weil der die Zone JE ORT
+    aufloest — dieselbe Stelle, an der auch der Versatz entsteht.
+    """
+    wien = location("loc-2054-wien", "Wien")
+    nc = NowcastResult(
+        onset_minutes=53, intensity_label="Starker Regen", source="INCA",
+    )
+
+    with freeze_time(FREITAG_2140_UTC):
+        sms = render_sms(to_multi_location_onset_alert_message(
+            [("Wien", wien, nc)],
+            tz=ZoneInfo("Europe/Vienna"), stand_at="23:40",
+        ))
+
+    assert "@Sa0:33" in sms, (
+        f"Erwartet den ORTSTAG 'Sa' vor 0:33 (Wien 00:33 am Samstag): {sms!r}"
+    )
+    assert "Fr0:33" not in sms, (
+        f"'Fr' waere der UTC-Tag (22:33 UTC am Freitag) — das Kuerzel muss aus "
+        f"der Ortszeit kommen: {sms!r}"
+    )
+
+
+# ══════════════════════════════ AC-10 ════════════════════════════════════════
+
+
+def test_ac10_der_versatz_entscheidet_nicht_das_vorhandene_kuerzel():
+    """AC-10 GIVEN ein Ereignis AM VERSANDTAG, bei dem versehentlich dennoch
+    ein Wochentag am Datensatz hinterlegt ist
+    WHEN die Kurznachricht erzeugt wird
+    THEN erscheint KEIN Kuerzel — die Ausgabe bleibt die nackte Uhrzeit.
+
+    Sichert die Gate-Richtung zu: der VERSATZ entscheidet, ob ein Tagesbezug
+    gezeigt wird; das Kuerzel ist nur seine Darstellung. Ein Gate auf den
+    Wahrheitswert von `weekday` wuerde bei fehlendem Kuerzel still den
+    Tagesbezug verschlucken — und hier ein falsches "Sa" an einer Uhrzeit von
+    heute zeigen.
+
+    POSITIVKONTROLLE (Pflicht bei einem Test auf ein AUSBLEIBEN): DASSELBE
+    Kuerzel am DEMSELBEN Feld erscheint sehr wohl, sobald der Versatz 1 ist —
+    fuer Beginn und Ende getrennt. Ohne sie waere der Test auch dann gruen,
+    wenn das Kuerzel ueberhaupt nie ausgegeben wuerde.
+    """
+    beginn_heute = render_sms(onset_msg(onset_event(
+        onset_time="18:00", onset_day_offset=0, onset_weekday="Sa",
+    )))
+    assert beginn_heute == "km 8-8: R2.5@18:00", (
+        f"Versatz 0 mit hinterlegtem Kuerzel muss die nackte Uhrzeit "
+        f"ausgeben: {beginn_heute!r}"
+    )
+
+    ende_heute = render_sms(onset_msg(onset_event(
+        onset_time="18:00", event_end_time="20:00",
+        event_end_day_offset=0, event_end_weekday="Sa",
+    )))
+    assert ende_heute == "km 8-8: R2.5@18:00@20:00", (
+        f"Auch am Ende-Token entscheidet der Versatz, nicht das hinterlegte "
+        f"Kuerzel: {ende_heute!r}"
+    )
+
+    # Positivkontrolle, je Feld getrennt.
+    beginn_morgen = render_sms(onset_msg(onset_event(
+        onset_time="18:00", onset_day_offset=1, onset_weekday="Sa",
+    )))
+    assert "@Sa18:00" in beginn_morgen, (
+        f"Positivkontrolle Beginn: mit Versatz 1 MUSS 'Sa' erscheinen — sonst "
+        f"bewacht die Abwesenheitspruefung oben nichts: {beginn_morgen!r}"
+    )
+    ende_morgen = render_sms(onset_msg(onset_event(
+        onset_time="18:00", event_end_time="20:00",
+        event_end_day_offset=1, event_end_weekday="Sa",
+    )))
+    assert "@Sa20:00" in ende_morgen, (
+        f"Positivkontrolle Ende: mit Versatz 1 MUSS 'Sa' erscheinen: "
+        f"{ende_morgen!r}"
+    )
+
+
+# ══════════════════════════════ AC-11 ════════════════════════════════════════
+
+
+def test_ac11_laengster_fall_bleibt_unter_160_zeichen_und_ascii():
+    """AC-11 GIVEN den laengsten Fall (Gewitter, Menge, Beginn UND Ende mit
+    Kuerzel, Untergrenzen-Form)
+    WHEN die Kurznachricht erzeugt wird
+    THEN bleibt sie unter 160 Zeichen und besteht ausschliesslich aus
+    ASCII-Zeichen.
+
+    Die Laengengrenze allein waere trivial erfuellt (der Renderer kuerzt schon
+    bei 140) — deshalb wird ZUSAETZLICH geprueft, dass der vollstaendige Token
+    unbeschnitten dasteht. Sonst waere eine abgeschnittene und damit falsche
+    Uhrzeit als "kurz genug" durchgegangen.
+
+    Beginn und Ende tragen ABSICHTLICH verschiedene Kuerzel (`Sa`/`So`): das
+    belegt in einem Zug, dass beide Zeitpunkte ihr eigenes Kuerzel fuehren.
+    """
+    sms = render_sms(onset_msg(onset_event(
+        is_convective=True, onset_time="23:50",
+        onset_day_offset=1, onset_weekday="Sa",
+        event_end_time="00:40", event_end_day_offset=1, event_end_weekday="So",
+        event_ongoing_beyond_horizon=True, onset_precip_mm=12.3,
+    )))
+
+    assert "TH@Sa23:50 >@So0:40 R12.3" in sms, (
+        f"Der laengste Fall muss unbeschnitten dastehen — sonst zeigt die "
+        f"Kurznachricht eine angeschnittene Uhrzeit: {sms!r}"
+    )
+    assert len(sms) <= 160, (
+        f"Kurznachricht ueberschreitet die 160-Zeichen-Grenze: {len(sms)} — "
+        f"{sms!r}"
+    )
+    assert sms.isascii(), (
+        f"Kurznachricht enthaelt Nicht-ASCII-Zeichen (GSM-7): {sms!r}"
+    )
+
+
+# ══════════════════════════════ AC-12 ════════════════════════════════════════
+
+
+@pytest.fixture
+def preview_client():
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from api.routers import validator
+    app = FastAPI()
+    app.include_router(validator.router)
+    return TestClient(app)
+
+
+@pytest.fixture
+def preview_trip():
+    user_id = f"test_2054_onset_{uuid.uuid4().hex[:8]}"
+    trip_id = "trip-2054-vorschau"
+    trip_dir = Path("data/users") / user_id / "briefings"
+    trip_dir.mkdir(parents=True, exist_ok=True)
+    (trip_dir / f"{trip_id}.json").write_text(json.dumps({
+        "id": trip_id, "name": "Vorschau-Trip", "stages": [],
+    }))
+    yield user_id, trip_id
+    shutil.rmtree(Path("data/users") / user_id, ignore_errors=True)
+
+
+@pytest.mark.real_data_root
+def test_ac12_alarmvorschau_zeigt_dieselbe_schreibweise(
+    preview_client, preview_trip,
+):
+    """AC-12 GIVEN denselben Mitternachts-Ueberlauf
+    WHEN die Alarm-VORSCHAU (`POST /api/trips/{id}/alert-preview`) abgerufen
+    wird
+    THEN zeigt sie dieselbe Schreibweise wie der echte Versand (`@Sa0:23`).
+
+    WAS DIESER TEST HEUTE MISST: die fehlende DURCHREICHUNG. `OnsetPayload`
+    (api/routers/validator.py:~226) fuehrt weder `onset_day_offset` noch
+    `onset_weekday` — pydantic verwirft unbekannte Schluessel STILL, und
+    `validator_render_service.render_alert_preview()` (Zeile ~116) baut sein
+    `OnsetEvent` ohne beide Felder. Die Vorschau kann den Sachverhalt damit
+    heute gar nicht darstellen; sie zeigt `R@0:23` und behauptet einen
+    Zeitpunkt von heute, wo der Versand einen von morgen meldet.
+
+    Der Test bleibt deshalb bewusst auf der ANTWORT des Endpunkts (nicht auf
+    dem Modell): rot ist er, solange die Ergaenzung an `OnsetPayload` und am
+    Vorschau-Renderer fehlt — genau die von der Spec geforderte Arbeit.
+
+    Muster: `tests/tdd/test_alert_preview_onset_payload.py` (#2046 F002,
+    dieselbe Fehlerklasse: ein still verworfenes Payload-Feld).
+    """
+    user_id, trip_id = preview_trip
+    resp = preview_client.post(
+        f"/api/trips/{trip_id}/alert-preview",
+        params={"user_id": user_id},
+        json={"onset": {
+            "onset_minutes": 53,
+            "onset_time": "00:23",
+            "onset_day_offset": 1,
+            "onset_weekday": "Sa",
+            "km_from": 0.0,
+            "km_to": 6.0,
+            "is_convective": False,
+            "intensity_label": "starker Regen",
+            "source_label": "Radar (DWD)",
+        }},
+    )
+
+    assert resp.status_code == 200, f"Body: {resp.text[:300]}"
+    sms = resp.json().get("sms") or ""
+    assert "@Sa0:23" in sms, (
+        "Die Alarm-Vorschau reicht Tagesversatz und Wochentagskuerzel nicht "
+        f"bis zum Renderer durch und zeigt eine andere Schreibweise als der "
+        f"echte Versand: {sms!r}"
+    )
+    assert not ALTFORM_RE.search(sms), (
+        f"Die Vorschau zeigt die Altform: {sms!r}"
+    )
+
+
+# ══════════════════════════════ AC-14 ════════════════════════════════════════
+
+
+def test_ac14_laufendes_ereignis_behaelt_now_und_endzeit_traegt_kuerzel():
+    """AC-14 GIVEN ein Ereignis, das BEREITS LAEUFT (die Kurzform zeigt `now`
+    statt einer Beginnzeit) und dessen Ende hinter Mitternacht faellt
+    WHEN die Kurznachricht erzeugt wird
+    THEN traegt die Endzeit das Kuerzel, und das `now` bleibt unveraendert
+    stehen (`R2.5 now >@Sa0:40`).
+
+    Dieser dritte Render-Zweig entstand durch #2050 S2b erst NACH der Freigabe
+    der Spec und erbt das Ende-Token ueber denselben Aufruf. `now` ist
+    ENGLISCH wie die ganze Kurzform und darf durch die Umstellung nicht
+    beruehrt werden.
+    """
+    sms = render_sms(onset_msg(onset_event(
+        already_running=True,
+        event_end_time="00:40", event_end_day_offset=1, event_end_weekday="Sa",
+        event_ongoing_beyond_horizon=True,
+    )))
+
+    assert sms == "km 8-8: R2.5 now >@Sa0:40", (
+        f"Erwartet 'km 8-8: R2.5 now >@Sa0:40' — `now` unveraendert, Endzeit "
+        f"mit Kuerzel: {sms!r}"
+    )
+
+
+# ══════════════════════════════ AC-13 ════════════════════════════════════════
+
+
+def test_ac13_langform_bleibt_beim_tageswort():
+    """AC-13 GIVEN denselben Alarm
+    WHEN E-Mail und Telegram-LANGFORM erzeugt werden
+    THEN schreiben sie den Tagesbezug unveraendert als WORT ("morgen 00:23"),
+    nicht als Kuerzel.
+
+    Kurzform = Kuerzel, Langform = Wort ist eine bewusste Trennung (die
+    Langform hat kein Zeichenbudget-Problem) und darf nicht angeglichen
+    werden.
+
+    POSITIVKONTROLLE (Pflicht bei einem Test auf ein AUSBLEIBEN): DIESELBE
+    `AlertMessage` traegt in der KURZform sehr wohl das Kuerzel. Ohne sie
+    waere der Test auch dann gruen, wenn das Kuerzel nirgends entstuende —
+    und bewiese dann nur, dass sich nichts geaendert hat.
+    """
+    msg = onset_msg(onset_event(onset_day_offset=1, onset_weekday="Sa"))
+
+    _, plain = render_email(msg)
+    telegram = render_telegram(msg)
+
+    assert "morgen 00:23" in plain, (
+        f"Die E-Mail-Langform muss beim Tageswort bleiben: {plain!r}"
+    )
+    assert "morgen 00:23" in telegram, (
+        f"Die Telegram-Langform muss beim Tageswort bleiben: {telegram!r}"
+    )
+    for name, text in (("E-Mail", plain), ("Telegram-Langform", telegram)):
+        assert not KUERZEL_VOR_ZEIT_RE.search(text), (
+            f"{name} schreibt ein Wochentagskuerzel vor einer Uhrzeit — die "
+            f"Langform bleibt beim Wort: {text!r}"
+        )
+
+    # Positivkontrolle: dieselbe Meldung, Kurzform.
+    kurz = render_sms(msg)
+    assert "@Sa0:23" in kurz, (
+        f"Positivkontrolle: die KURZform derselben Meldung MUSS das Kuerzel "
+        f"tragen — sonst bewacht die Abwesenheitspruefung oben nichts: "
+        f"{kurz!r}"
+    )


### PR DESCRIPTION
- **docs(#2054): Kontext und freigegebene Spec fuer Onset-Wochentagskuerzel**
- **test(#2054): RED — Wochentagskuerzel statt Zahlensuffix in der Onset-Kurzform**
- **feat(#2054): Wochentagskuerzel statt Zahlensuffix in der Onset-Kurzform**
