### PR TITLE
feat 2051 s3 reichweite und guete

### DIFF
--- a/api/routers/validator.py
+++ b/api/routers/validator.py
@@ -259,6 +259,13 @@ class OnsetPayload(BaseModel):
     # Feld zeigte die Vorschau im Waechterfall die falsche der beiden Formen
     # und damit nicht mehr das, was der Produktivpfad sendet.
     event_ongoing_beyond_horizon: bool = False
+    # Issue #2051 S3: Reichweite der Quelle und Guete-Grenzzeit, additiv und
+    # optional -- Muster `event_end_time` o. Ohne sie zeigt der Vorschauweg
+    # keine dieser beiden Angaben (Vorwarnung analog #2046 F002/S1).
+    source_reach_time: str | None = None
+    source_reach_day_offset: int = 0
+    location_sharpness_limit_time: str | None = None
+    location_sharpness_limit_day_offset: int = 0
 
 
 class OfficialAlertPayload(BaseModel):

--- a/docs/context/feat-2051-s3-reichweite-und-guete.md
+++ b/docs/context/feat-2051-s3-reichweite-und-guete.md
@@ -1,0 +1,146 @@
+# Context: feat-2051-s3-reichweite-und-guete
+
+**Issue:** #2051, Scheibe S3 — „Reichweite der Quelle als Datum" + Güte-Kennzeichnung
+**Track:** Standard · **Basis:** `origin/main` @ `2939965b`
+
+## Request Summary
+
+Der Radar-Nowcast soll sichtbar machen, **wie weit seine Aussage reicht** („Radar
+reicht bis HH:MM") und **wie belastbar sie ist** („ab HH:MM extrapoliert —
+Ortsangabe unscharf"). Beides als Datum über das Wetter, nicht als Bewertung und
+nicht als Handlungsempfehlung.
+
+Vorgänger: S1 (Dauer/Ende) ist seit 2026-08-22 08:46 UTC live (`c684d053`).
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `src/services/radar_service.py:69-72` | `_NOWCAST_HORIZON_MIN = 180` / öffentlicher Alias `NOWCAST_HORIZON_MIN` — der Prüfhorizont |
+| `src/services/radar_service.py:110-121` | `RADAR_ONSET_THRESHOLD_MIN = 55`; **Kommentar belegt die Güte-Schwelle**: „jenseits ~60 Min sinkt die Ortsschärfe des INCA-Extrapolationsprodukts deutlich" |
+| `src/services/radar_service.py:95` | `_MAX_FRAME_COVERAGE = timedelta(minutes=15)` — Deckung eines Frames, gröbstes Produktivraster |
+| `src/services/radar_service.py:136-224` | `NowcastResult` — Rückgabestruktur; `source` ist **ein** String pro Abruf, keine Pro-Frame-Herkunft |
+| `src/services/radar_service.py:203-224` | S1-Felder `event_end_minutes`, `event_ongoing_beyond_horizon` |
+| `src/services/radar_service.py:625/627` | Textstelle: Nowcast-Satz |
+| `src/output/renderers/alert/render.py:298` | Textstelle: laufendes Ereignis (#2050 S2b) |
+| `src/output/renderers/alert/render.py:554-582` | Textstelle: Langform-Ende-Suffix (E-Mail/Telegram rich) |
+| `src/output/renderers/alert/render.py:800-870` | Textstelle: SMS-Kurzform, `_sms_onset_ende()`, `_render_sms_onset(limit=140)` |
+| `src/output/renderers/email/starkregen_hint.py:25-60` | Textstelle: E-Mail-Kurzfristhinweis |
+| `src/output/renderers/alert/model.py:128-129` | Ende-Felder am Event-Modell |
+| `src/services/trip_report_scheduler.py:1826-1838` | **Der ungedeckelte Pfad** — „kennt keinen Onset-Grenzwert und akzeptiert jeden Treffer im vollen 180-Minuten-Fenster" |
+| `src/services/trip_alert.py:1387`, `src/services/compare_radar_alert.py:358` | Alarm-Pfade, gedeckelt über `radar_alert_due(result, RADAR_ONSET_THRESHOLD_MIN)` |
+
+## Existing Specs
+
+- `docs/specs/modules/feat_2051_s1_dauer_und_ende.md` — Vorgänger-Scheibe, v1.1
+- `docs/specs/modules/fix_1945_nowcast_horizon.md` — Anhebung 60 → 180
+- `docs/specs/modules/fix_2009_nowcast_vorlauf.md` — Herkunft der 55-Min-Schwelle
+- `docs/specs/modules/fix_1948_s4_nowcast_sms_zielbild.md` — SMS-Token-Format
+
+## Existing Patterns
+
+- **Additive Feld-Durchreichung:** S1 hat `event_end_minutes` +
+  `event_ongoing_beyond_horizon` an `NowcastResult` ergänzt und durch alle sieben
+  Textstellen gereicht. S3 folgt derselben Bahn.
+- **Zwei Formen, entschieden an einem Wächter-Boolean** (S1: Normalform vs.
+  Untergrenzen-Form) — vorhandenes Muster für „Aussage mit Vorbehalt".
+- **Kanal-Kaskade:** Grundauswahl ist das Maximum, der Kanal darf nur abwählen.
+  SMS/Premium-SMS haben ein hartes Budget (`limit=140`, GSM-7), die Kurzform ist
+  englisch (`R` = Rain, `TH` = Thunder).
+- **Eine Zahl, ein Name:** wiederkehrendes Muster im Radar-Service — jede Schwelle
+  bekommt einen eigenen benannten Wert mit Begründung, warum sie *nicht* mit einem
+  Nachbarn geteilt wird.
+
+## Dependencies
+
+- **Upstream:** `RadarNowcastService.get_nowcast()` (`radar_service.py:441`),
+  Provider GeoSphere-INCA / AROME-FR / ICON-D2 / ARPAE / `minutely_15`
+- **Downstream:** 6 Aufrufstellen von `get_nowcast()` — `trip_alert.py:1373`,
+  `compare_radar_alert.py:348`, `trip_report_scheduler.py:1876`,
+  `trip_command_processor.py:1559`, `thunder_enrichment.py:255`
+
+## Analyse-Befunde (Phase 2, kombiniert)
+
+### B1 — Der PO-Entscheid vom 21.08. ist bereits gefallen: Option (b)
+
+Der Ticket-Kommentar stellte drei Optionen zur Wahl (a Horizont auf 60 kappen /
+b voller Horizont mit Güte-Kennzeichnung / c Kappung je Alarmart). Die S1-Spec
+hat ihn als **E3** entschieden und der PO hat sie freigegeben:
+`_NOWCAST_HORIZON_MIN` bleibt 180, keine Kappung, Kennzeichnung statt Schnitt.
+**Nicht erneut vorlegen.**
+
+### B2 — Was E3 offenlässt
+
+E3 setzt gleich: „Die vom PO erwogene Güte-Kennzeichnung **ist** der
+`event_ongoing_beyond_horizon`-Wächter." Das trägt nur einen Teilfall. Der
+Wächter feuert ausschließlich, wenn es **bis zum Horizont durchregnet**. Er sagt
+nichts über:
+
+- die Reichweite als solche, wenn es *nicht* bis zum Ende regnet (Normalfall)
+- die Unschärfe bei **großem Vorlauf** — genau der Fall aus dem PO-Kommentar
+  („bei 90 Minuten Vorlauf liegt das Ereignis am Rand der Radar-Reichweite")
+
+Beides ist der Gegenstand von S3.
+
+### B3 — Der Realfall entsteht im Briefing-Pfad, nicht im Alarm-Pfad
+
+`RADAR_ONSET_THRESHOLD_MIN = 55` deckelt Trip- und Ortsvergleichs-Alarme hart:
+eine Alarm-Aussage „in 90 Minuten" kann dort gar nicht entstehen. Der
+90-Min-Fall des PO stammt aus `trip_report_scheduler.py:1829-1831` (Briefing-
+Kurzfristhinweis) bzw. der Inbound-Kommando-Antwort — die beiden Pfade **ohne**
+Vorlauf-Deckel. Das ist die Fläche, auf der die Güte-Kennzeichnung überhaupt
+Wirkung entfaltet; im Alarm-Pfad wäre sie fast immer stumm.
+
+### B4 — Güte hat keine Datengrundlage aus der Quelle
+
+`NowcastResult.source` ist **ein** String für den ganzen Abruf
+(`"radar" | "INCA" | "AROME-FR" | "minutely_15"`). Es gibt **keine** Angabe je
+Frame, ob er Analyse (gemessen) oder Extrapolation (gerechnet) ist. INCA liefert
+im abgerufenen Fenster durchgehend Extrapolation. Eine Kennzeichnung „ab HH:MM
+extrapoliert" kann also **nicht** aus einem Quellen-Merkmal abgeleitet werden.
+
+Verfügbar ist stattdessen der **Vorlauf** — und dafür trägt der Code bereits eine
+belegte Schwelle: `radar_service.py:110-111` nennt ~60 Min als Punkt, ab dem die
+Ortsschärfe deutlich sinkt. Das ist dieselbe Zahl, die `RADAR_ONSET_THRESHOLD_MIN
+= 55` begründet. **Konsequenz für die Spec:** Die Güte-Grenze ist eine
+Zeitschwelle, kein Quellen-Datum — und das muss der Wortlaut ehrlich abbilden
+(„ab HH:MM unscharf" statt „ab HH:MM extrapoliert", denn extrapoliert ist alles).
+
+### B5 — Reichweite ist ein echtes, immer verfügbares Datum
+
+Der letzte verfügbare Frame-Zeitpunkt steht in `frames` und ist unabhängig davon
+verfügbar, ob es regnet. Er ist heute nur indirekt und nur im Regenfall sichtbar
+(`event_ongoing_beyond_horizon`). Als eigenes Feld nach außen gegeben, deckt er
+S3 Punkt 1 ohne zusätzlichen Quellenabruf.
+
+**Achtung Bezugspunkte:** „Reichweite der Quelle" (letzter Frame + dessen
+Deckung) und „Prüfhorizont" (`now + 180 Min`) sind **zwei verschiedene Größen**.
+Die Quelle kann früher enden als der Horizont (Datenlücke, kürzeres Produkt) —
+dann ist die Reichweite die kleinere Zahl. Ein Feld, das beides vermischt, wäre
+ein blinder Wächter.
+
+## Risks & Considerations
+
+- **R1 — Kollision mit #2075.** Die Parallelsitzung `khw-milestone-check` fixt
+  `radar_service.py:325` (`coverage_end` ohne `next_ts`) — dieselbe
+  Deckungsrechnung, aus der die Reichweite abzuleiten ist. Vor dem Liefern
+  rebasen; `git diff origin/main --diff-filter=D` nach dem Rebase prüfen.
+- **R2 — SMS-Budget.** Die Kurzform trägt bereits `R2.5@18:00 >@20:00`. Ein
+  drittes Zeit-Token sprengt bei ungünstiger Ortslänge die 140 GSM-7-Zeichen.
+  Die Kanal-Kaskade erlaubt Abwahl — S3 muss begründen, was SMS/Premium-SMS
+  bekommt und was nicht. Auf der Hütte ist Premium-SMS der einzige Kanal.
+- **R3 — Doppelung zur S1-Untergrenzenform.** `Regen mindestens bis 16:00` sagt
+  bereits implizit „die Quelle endet um 16:00". Ein zusätzliches
+  „Radar reicht bis 16:00" daneben wäre Dopplung. Die Spec muss regeln, wann
+  welche Form erscheint — nicht beide gleichzeitig.
+- **R4 — Bevormundungs-Grenze.** „Ortsangabe unscharf" ist ein Datum über die
+  Aussage. „Verlass dich nicht darauf" wäre eine Bewertung. Der Wortlaut
+  entscheidet, auf welcher Seite die Zeile landet (Ticket-Grundprinzip, PO
+  zweifach geschärft).
+- **R5 — Zwei ACs an den Rändern lassen die Mitte ungeprüft** (Lehre aus S1 →
+  #2075). Der Test-Plan braucht explizit den Fall *zwischen* den Rändern.
+
+## Test-Landkarte
+
+Bewachende Testdateien sind über die S1-Formulierungen auffindbar
+(`grep -rn "letzter Regen\|mindestens bis" tests/`) — in Phase 4 zu erheben.

--- a/docs/specs/modules/feat_2051_s3_reichweite_und_guete.md
+++ b/docs/specs/modules/feat_2051_s3_reichweite_und_guete.md
@@ -1,0 +1,593 @@
+---
+entity_id: feat_2051_s3_reichweite_und_guete
+type: feature
+created: 2026-08-22
+updated: 2026-08-22
+status: approved
+version: "1.0"
+tags: [alarm, briefing, nowcast, radar, reichweite, guete]
+---
+
+# Reichweite der Quelle und Güte-Kennzeichnung — #2051 Scheibe S3
+
+## Approval
+
+- [x] Approved — PO-Freigabe der Acceptance Criteria am 2026-08-22 (v1.0)
+
+## Purpose
+
+Der Radar-Nowcast-Pfad sagt heute, seit Scheibe S1 (#2051), wann ein
+Niederschlagsereignis beginnt und endet — aber nicht, **wie weit die Quelle
+selbst reicht** und **wie belastbar** ihre Ortsangabe über die Zeit ist. Zwei
+Fragen, zwei Antworten:
+
+1. **Reichweite:** Bis zu welchem Zeitpunkt hat die Quelle tatsächlich
+   Frames geliefert? Das ist heute nur indirekt und nur im Regenfall
+   sichtbar (`event_ongoing_beyond_horizon`) — ein Nutzer, bei dem es
+   trocken bleibt oder dessen Ereignis vor dem Horizont endet, erfährt nie,
+   wie weit die Beobachtung selbst reicht.
+2. **Güte:** Ab wann sinkt die Verlässlichkeit der Ortsangabe? Die
+   GeoSphere-INCA-Quelle extrapoliert das gesamte abgerufene Fenster (keine
+   Analyse-Teilstrecke); jenseits von ~60 Minuten Vorlauf sinkt ihre
+   Ortsschärfe deutlich (belegter Code-Kommentar, `radar_service.py:110f`).
+   Bei einem Vorlauf von 90 Minuten liegt ein gemeldetes Ereignis am Rand der
+   Radar-Reichweite — das ist der konkrete Fall aus dem PO-Ticket-Kommentar
+   vom 2026-08-21.
+
+Beide Angaben werden aus den bereits abgerufenen `frames` bzw. aus den in S1
+bestimmten `onset_minutes`/`event_end_minutes` abgeleitet — **kein**
+zusätzlicher Quellenabruf. Beide werden als **Datum über die Aussage**
+ausgeliefert, nicht als Bewertung und nicht als Handlungsempfehlung
+(Ticket-Grundprinzip).
+
+Vorgänger: S1 (Dauer/Ende) ist seit 2026-08-22 08:46 UTC live (`c684d053`).
+S2 (räumliche Ausdehnung) und S4 (`/strecke`-Kommando) aus Issue #2051
+bleiben außerhalb dieses Zuschnitts; das Ticket bleibt als Scheiben-Ticket
+offen.
+
+## Source
+
+- **File:** `src/services/radar_service.py`
+- **Identifier:** `_derive_result()` (Z. 877ff.), `NowcastResult` (Z.
+  136-224), neue Konstante `LOCATION_SHARPNESS_LIMIT_MIN`
+
+Begleitend: `src/output/renderers/alert/model.py` (`OnsetEvent`),
+`src/output/renderers/alert/project.py` (geteilte Anzeigefassungen, analog
+`event_end_display`, Z. 60-67), `src/output/renderers/alert/render.py`
+(sieben Textstellen, analog `_onset_end_suffix`/`_sms_onset_ende`),
+`src/output/renderers/email/starkregen_hint.py` (Briefing-Kurzfristhinweis),
+`src/services/notification_service.py` (`starkregen_nowcast`-Tupel, Z. 116),
+`src/services/trip_report_scheduler.py` (Tupel-Aufbau, Z. 1893-1904,
+Auspacken Z. 406-412), `api/routers/validator.py` (`OnsetPayload`,
+Vorschau-/Replay-Weg).
+
+> **Schicht-Hinweis:** Alle Änderungen liegen ausschließlich im Python-Core
+> (`src/services/`, `src/output/`, `api/routers/`) — kein Go-API-, kein
+> Frontend-Anteil.
+
+## Estimated Scope
+
+- **LoC:** ~160-200 produktiv, ~150-190 Tests — **über dem 250-LoC-
+  Workflow-Limit** in Summe, `workflow.py set-field loc_limit_override 500`
+  ist vor `/40-tdd-red` einzuplanen (Muster wie S1).
+- **Files:** ~9-10 Produktivdateien (`radar_service.py`, `model.py`,
+  `project.py`, `render.py`, `starkregen_hint.py`, `notification_service.py`,
+  `trip_report_scheduler.py`, `api/routers/validator.py`,
+  `validator_render_service.py`) + ~8-10 Testdateien.
+- **Effort:** medium-high — kleiner als S1 (keine neue Grenzfindungs-
+  Rekursion, kein Tagesversatz-Sonderfall), aber sieben Textstellen plus
+  zwei neue Anzeigefassungen.
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `_derive_wet_block_end` / `_derive_result` | function (`radar_service.py:278,877`) | Liefert bereits `window`, `all_ts_sorted`, `horizon`, `now` — dieselben Bausteine tragen die Reichweiten-Ableitung, kein zweiter Rechenkern. |
+| `_MAX_FRAME_COVERAGE` | constant (`radar_service.py:95`, 15 Min) | Deckungsgrenze eines einzelnen Frames — dieselbe Mechanik wie bei `_accumulate_precip_mm`/`_derive_wet_block_end` trägt auch die Reichweite. |
+| `_NOWCAST_HORIZON_MIN` | constant (`radar_service.py:69`, 180) | Deckel der Reichweite — Reichweite ist NIE größer als der Horizont, kann aber kleiner sein. |
+| `RADAR_ONSET_THRESHOLD_MIN` | constant (`radar_service.py:121`, 55) | Nachbar-Schwelle, von der `LOCATION_SHARPNESS_LIMIT_MIN` bewusst getrennt bleibt (E2) — von dieser Spec unberührt. |
+| `NowcastResult.onset_minutes` / `.event_end_minutes` | fields (`radar_service.py:139`, S1) | Eingabe der Güte-Prüfung — die Güte hat keine eigene Quellen-Herkunft, sie vergleicht diese beiden bereits vorhandenen Zeiten gegen die Grenze (E2). |
+| `event_end_display` | function (`project.py:60-67`, S1) | Musterfassung für die neuen Anzeigefunktionen `source_reach_display`/`location_sharpness_display` — dieselbe Struktur (`now_utc`, `nowcast`/Werte, `tz` → `(str \| None, int)`). |
+| `_onset_end_suffix` / `_sms_onset_ende` | functions (`render.py:546,806`, S1) | Musterfassung für `_onset_reach_suffix`/`_onset_sharpness_suffix`/`_sms_onset_sharpness_marker` — additiv anhängbares Textstück oder leer. |
+| `starkregen_nowcast: tuple[...]` | field (`notification_service.py:116`) | Bereits fünfgliedriges Tupel (S1/#2050) — wächst additiv um Reichweite und Güte-Grenzzeit, Muster identisch. |
+| `OnsetPayload` | Pydantic-Model (`api/routers/validator.py:~240`) | Vorschau-Payload-Schema — muss die neuen Felder kennen, sonst Adversary-Fund wie #2046 F002 / S1-Vorwarnung. |
+
+## Getroffene Entscheidungen (E1–E7, aus Phase 2 — nicht erneut vorlegen)
+
+**E1 — Zwei getrennte Felder, nicht eines.** `NowcastResult` bekommt die
+Reichweite der Quelle als eigenes Feld (Arbeitsname
+`source_reach_minutes`, Minuten ab jetzt bis zum Ende der Deckung des
+LETZTEN gelieferten Frames, gedeckelt am Prüfhorizont). Diese Größe ist
+NICHT `_NOWCAST_HORIZON_MIN`: der Horizont ist, wie weit geprüft wird; die
+Reichweite ist, wie weit die Quelle tatsächlich geliefert hat. Die Quelle
+kann früher enden (Datenlücke, kürzeres Produkt). Ein Feld, das beides
+vermischt, wäre ein blinder Wächter — es gäbe dann nur EINE
+Abweichungsstelle für ZWEI Bezugspunkte.
+
+**E2 — Güte ist eine Zeitschwelle, kein Quellen-Merkmal.**
+`NowcastResult.source` ist ein einziger String für den ganzen Abruf; es
+gibt keine Angabe je Frame, ob er Analyse oder Extrapolation ist. Bei INCA
+ist das gesamte abgerufene Fenster Extrapolation — es gibt keinen
+gemessenen Teil, von dem sich ein „ab hier" abgrenzen ließe. Die
+Güte-Grenze wird deshalb aus dem VORLAUF abgeleitet. Neue Konstante
+`LOCATION_SHARPNESS_LIMIT_MIN = 60`, belegt durch den vorhandenen
+Code-Kommentar `radar_service.py:110-111` („jenseits ~60 Min sinkt die
+Ortsschärfe des INCA-Extrapolationsprodukts deutlich"). **Bewusst ein
+EIGENER Name** neben `RADAR_ONSET_THRESHOLD_MIN = 55`: die 55 ist eine
+Auslöseschwelle (feuert der Alarm?), die 60 eine Güte-Grenze (wie belastbar
+ist die Ortsangabe?) — verschiedene Bezugspunkte, verschiedene Zwecke. Ein
+geteilter Name ließe die nächste Änderung des einen still auf das andere
+durchschlagen. Folgt exakt dem Begründungsmuster von
+`_ONSET_PRECIP_WINDOW_MIN` vs. `_OVERTAKE_COMPARE_WINDOW_MIN`
+(`radar_service.py:98-106`).
+
+**E3 — Wortlaut: „unscharf", nicht „extrapoliert".** Der PO-Vorschlag
+lautete „davon ab 14:40 extrapoliert - Ortsangabe unscharf". Das Wort
+„extrapoliert" wäre falsch, weil ALLES extrapoliert ist — es suggeriert
+eine Grenze in den Daten, die es nicht gibt. Gelieferte Langform:
+`Ortsangabe ab HH:MM unscharf`. Das ist ein Datum über die Aussage, keine
+Bewertung und keine Handlungsempfehlung (Ticket-Grundprinzip).
+
+**E4 — Auslösebedingung der Güte-Zeile.** Sie erscheint, wenn MINDESTENS
+EINE der im Text genannten Ereigniszeiten (Beginn ODER Ende) jenseits von
+`now + LOCATION_SHARPNESS_LIMIT_MIN` liegt. Genannt wird die GRENZZEIT
+selbst (`now + 60 Min`, in Ortszeit), nicht welcher Wert betroffen ist — die
+Zuordnung macht der Nutzer, das ist sein Schritt. Wichtig für den Zuschnitt:
+Die Zeile ist NICHT stumm im Alarm-Pfad, obwohl Alarme bei 55 Min Vorlauf
+gedeckelt sind (`RADAR_ONSET_THRESHOLD_MIN`) — denn das seit S1
+mitgelieferte ENDE kann weit jenseits der Grenze liegen (Beginn in 20 Min,
+Ende in 150 Min).
+
+**E5 — Keine Dopplung mit der S1-Untergrenzenform.** Ist
+`event_ongoing_beyond_horizon` gesetzt, sagt der Text bereits `Regen
+mindestens bis HH:MM` und nennt damit implizit dieselbe Zeit, die die
+Reichweite trüge. Die Reichweiten-Angabe entfällt in diesem Fall. Sie
+erscheint nur, wenn das Ereignis-Ende bekannt ist (oder es trocken bleibt)
+— und liefert dort echten Gewinn: `letzter Regen gegen 14:30, Radar reicht
+bis 16:00` sagt dem Nutzer, dass zwischen 14:30 und 16:00 beobachtet
+trocken ist und nach 16:00 nichts bekannt.
+
+**E6 — Kanal-Kaskade: Güte überall, Reichweite nicht in der Kurzform.**
+Grundauswahl ist das Maximum, der Kanal darf nur abwählen (PO-Vorgabe).
+- E-Mail (Betreff, Trip-Onset-Zeile, Mehr-Orte-Bündel/Ortsvergleich),
+  Telegram rich, Briefing-Kurzfristhinweis, Kommando-Antwort: **beides** —
+  `Radar reicht bis HH:MM` und `Ortsangabe ab HH:MM unscharf`.
+- SMS / Premium-SMS / Telegram-Kurzstil: **nur die Güte**, als EIN Zeichen
+  `?` unmittelbar hinter dem betroffenen Zeit-Token (`R2.5@15:00?`). Die
+  Reichweite wird hier abgewählt.
+- Begründung der Abwahl: Die Kurzform trägt bereits `R2.5@18:00 >@20:00`
+  und hat ein hartes Budget von 140 GSM-7-Zeichen (`_render_sms_onset(limit
+  =140)`); ein drittes Zeit-Token sprengt es bei langem Ortsnamen.
+  Abgewählt wird die Angabe mit dem geringeren Gewicht: Die Güte ändert,
+  WIE die ganze Aussage zu lesen ist, die Reichweite ist eine
+  Zusatzinformation — und im Untergrenzen-Fall transportiert `>@` die
+  Reichweite ohnehin schon (E5). Auf der Hütte am Karnischen Höhenweg ist
+  Premium-SMS der einzige ankommende Kanal; deshalb darf dort gerade die
+  Güte NICHT fehlen.
+- **Warum `?` und ausdrücklich NICHT `~`:** `~` gehört zur
+  GSM-7-Extension-Tabelle und kostet ZWEI Septets je Zeichen. Der Renderer
+  faltet es deshalb vor dem Versand hart auf `-`
+  (`_ASCII_EXTENSION_REPLACEMENTS`, `render.py:1497`, Issue #1796) — aus
+  `R2.5@15:00~` würde auf dem Gerät `R2.5@15:00-`, und ein Bindestrich hinter
+  einer Uhrzeit liest sich wie ein abgeschnittener Zeitbereich. Das wäre
+  schlechter als gar keine Kennzeichnung. `?` steht dagegen im
+  GSM-7-BASISzeichensatz (ein Septet, verifiziert gegen
+  `tests/tdd/_gsm7_charset.py::_GSM7_BASIC`), überlebt die ASCII-Faltung
+  unverändert und trägt seine Bedeutung ohne Legende. Es ist englisch-neutral
+  wie die ganze Kurzform (`R` = Rain, `TH` = Thunder).
+- **Kollisionsprüfung:** `?` kommt heute in keinem Token der Onset-Kurzform
+  vor. Das in CLAUDE.md erwähnte Konfidenzband-Vokabular (`C+`/`C~`/`C?`) ist
+  im Code **nicht** implementiert (kein Treffer in `src/`) — es taugt weder
+  als Beleg noch als Kollisionsrisiko und wird hier bewusst nicht als
+  Begründung herangezogen.
+
+**E7 — Der 60-Minuten-Entscheid aus dem Ticket-Kommentar vom 2026-08-21 ist
+bereits gefallen und wird nicht erneut vorgelegt.** Die S1-Spec hat ihn als
+E3 entschieden und der PO hat sie freigegeben: `_NOWCAST_HORIZON_MIN` bleibt
+180, keine Kappung, Kennzeichnung statt Schnitt. S3 setzt diese Wahl um.
+Die S1-Spec hat dabei in E3 zu viel behauptet: Sie setzt die
+Güte-Kennzeichnung mit dem Wächter `event_ongoing_beyond_horizon` gleich —
+der feuert aber nur, wenn es bis zum Horizont durchregnet, und deckt den
+eigentlichen PO-Fall (großer Vorlauf bei einem Ereignis, das VOR dem
+Horizont endet) gerade nicht ab. Genau diese Lücke schließt S3.
+
+## Implementation Details
+
+**Neues Feld auf `NowcastResult`** (`radar_service.py:136-224`, additiv,
+optional, Muster `event_end_minutes` aus S1):
+
+```python
+source_reach_minutes: Optional[int] = None
+# Issue #2051 S3: Minuten ab jetzt bis zum Ende der Deckung des LETZTEN
+# gelieferten Frames, gedeckelt am 180-Min-Horizont. NICHT dasselbe wie der
+# Horizont selbst -- die Quelle kann frueher enden (Datenluecke, kuerzeres
+# Produkt). `None` nur, wenn im Nowcast-Fenster ueberhaupt keine Frames
+# vorliegen (throttled/data_unavailable/echte Providerluecke) -- ein
+# durchgehend TROCKENES Fenster hat trotzdem eine Reichweite (bis zu 180).
+```
+
+**Ableitung in `_derive_result()`** (`radar_service.py:877ff.`): Dieselbe
+`window`-Liste (Frames im `[now, horizon]`-Fenster) und dasselbe
+`all_ts_sorted`, die S1 bereits für Onset/Ende nutzt. Letzter Frame in
+`window` (maximaler Zeitstempel) liefert seine eigene Deckung nach exakt der
+Mechanik aus `_accumulate_precip_mm`/`_derive_wet_block_end`: nächster
+Nachbar aus der VOLLSTÄNDIGEN Frame-Liste (oder Horizont, wenn keiner
+folgt), gedeckelt auf `_MAX_FRAME_COVERAGE`, nie über den Horizont hinaus.
+`window` leer ⇒ `source_reach_minutes = None` (keine Beobachtung, nicht
+„Reichweite null"). Kein neuer Helfer nötig — die Formel ist eine
+Zeile analog `frame_end = min(next_ts_full, ts + _MAX_FRAME_COVERAGE,
+horizon)`.
+
+**Neue Konstante** (neben `RADAR_ONSET_THRESHOLD_MIN`,
+`radar_service.py:~121`):
+
+```python
+LOCATION_SHARPNESS_LIMIT_MIN = 60
+# Issue #2051 S3: eigener Name neben RADAR_ONSET_THRESHOLD_MIN (55) -- die
+# 55 ist eine AUSLOESESCHWELLE (feuert der Alarm?), diese 60 eine
+# GUETE-GRENZE (wie belastbar ist die Ortsangabe?). Belegt durch den
+# Kommentar oben ("jenseits ~60 Min sinkt die Ortsschaerfe des
+# INCA-Extrapolationsprodukts deutlich"). Downstream-Leser (render.py,
+# starkregen_hint.py, project.py) referenzieren die MODUL-Variable
+# (`radar_service_mod.LOCATION_SHARPNESS_LIMIT_MIN`), nie ein Import zur
+# Bindezeit -- Laufzeit-Drift-Schutz wie bei RADAR_ONSET_THRESHOLD_MIN.
+```
+
+**Zwei neue geteilte Anzeigefassungen in `project.py`** (Muster
+`event_end_display`, Z. 60-67, EINE Fassung für Trip- UND
+Ortsvergleich-Pfad, ADR-0021):
+
+```python
+def source_reach_display(now_utc, nowcast, tz) -> tuple[str | None, int]:
+    """(HH:MM, Tagesversatz) der Reichweite oder (None, 0), wenn keine
+    Reichweite bekannt ist ODER `event_ongoing_beyond_horizon` gesetzt ist
+    (E5 -- die Untergrenzen-Form nennt die Zeit bereits selbst)."""
+
+def location_sharpness_display(now_utc, onset_minutes, event_end_minutes, tz) \
+        -> tuple[str | None, int]:
+    """(HH:MM, Tagesversatz) der Guete-Grenzzeit (now + LIMIT) oder (None, 0),
+    wenn WEDER onset_minutes NOCH event_end_minutes jenseits der Grenze
+    liegen (oder beide None sind). Liest die Grenze bei JEDEM Aufruf ueber
+    die Modulreferenz, bindet sie NICHT beim Import."""
+```
+
+**Vier neue Felder auf `OnsetEvent`** (`model.py`, additiv, optional,
+Muster `event_end_time`/`event_end_day_offset` aus S1):
+
+```python
+source_reach_time: str | None = None
+source_reach_day_offset: int = 0
+location_sharpness_limit_time: str | None = None
+location_sharpness_limit_day_offset: int = 0
+```
+
+`location_sharpness_limit_time` ist `None`, wenn die Güte-Zeile nicht
+erscheinen soll (Entscheidung ist bereits in `location_sharpness_display`
+getroffen — der Renderer prüft nur noch auf `None`, keine zweite
+Schwellprüfung im Renderer selbst, sonst zwei Wahrheiten wie AC-20 in S1
+warnt).
+
+**Sieben Textstellen** (Muster `_onset_end_suffix`/`_sms_onset_ende`,
+`render.py:546,806`):
+
+- Vier Langform-Stellen, die bereits `_onset_end_suffix(e)` aufrufen
+  (`render.py:486` Betreff, `:601` E-Mail Trip, `:679` E-Mail
+  Mehr-Orte-Bündel, `:748` Telegram rich): hängen zusätzlich
+  `_onset_reach_suffix(e)` (` · Radar reicht bis HH:MM` oder leer) und
+  `_onset_sharpness_suffix(e)` (` · Ortsangabe ab HH:MM unscharf" oder
+  leer) an, in dieser Reihenfolge — Ende, dann Reichweite, dann Güte.
+- `format_starkregen_hint()` (`starkregen_hint.py`): Signatur wächst additiv
+  um `source_reach_minutes: int | None = None`,
+  `location_sharpness_limit_minutes: int | None = None` (bzw. bereits
+  vorformatierte HH:MM/Versatz-Paare, Muster wie die bestehenden
+  `event_end_*`-Parameter) — ein Aufrufer ohne die neuen Argumente bekommt
+  byte-identisch den bisherigen Text.
+- `format_now_text()` (`radar_service.py:625ff.`): dieselbe additive
+  Erweiterung, unmittelbar neben der S1-Ende-Weiche.
+- `_render_sms_onset()`/`_sms_onset_ende()` (`render.py:806-880`): NUR die
+  Güte, als neuer Helfer `_sms_onset_sharpness_marker(e) -> str`
+  (`"?"` oder `""`), an `zeit = _sms_onset_time(...) + _sms_onset_ende(...)`
+  angehängt — `zeit += _sms_onset_sharpness_marker(e)`. Keine
+  Reichweiten-Angabe in der Kurzform (E6).
+
+**Datenweg außerhalb der Renderer** (Muster identisch zu S1):
+`to_multi_location_onset_alert_message`/Trip-Pfad in `project.py` rufen
+`source_reach_display`/`location_sharpness_display` neben
+`event_end_display` auf und befüllen die vier neuen `OnsetEvent`-Felder in
+DERSELBEN Ortszone wie Beginn/Ende (`loc_tz`). Das
+`starkregen_nowcast`-Tupel (`notification_service.py:116`,
+`trip_report_scheduler.py:1893-1904`) wächst additiv um
+`source_reach_minutes` und die Güte-Rohwerte (`onset_minutes`,
+`event_end_minutes` reichen bereits, KEIN zusätzlicher Rohwert nötig — die
+Grenzprüfung passiert im Formatierer, s. Architekturgrenze
+„Scheduler liefert nur Rohdaten"). `OnsetPayload`
+(`api/routers/validator.py`) bekommt die neuen `OnsetEvent`-Felder
+gespiegelt (Vorwarnung analog #2046 F002/S1).
+
+## Expected Behavior
+
+- **Input:** `NowcastResult` mit Frames, die das Nowcast-Fenster ganz,
+  teilweise oder gar nicht abdecken; optional gesetztem
+  `onset_minutes`/`event_end_minutes` aus S1.
+- **Output:**
+  - `source_reach_minutes` ist IMMER gesetzt, wenn mindestens ein Frame im
+    Fenster liegt — unabhängig davon, ob es regnet.
+  - Die sechs Langform-/Briefing-/Kommando-Textstellen tragen zusätzlich
+    `Radar reicht bis HH:MM`, außer bei `event_ongoing_beyond_horizon=True`
+    (E5) oder wenn keine Reichweite bekannt ist.
+  - Dieselben sechs Textstellen UND die Kurzform tragen zusätzlich
+    `Ortsangabe ab HH:MM unscharf` bzw. das Zeichen `?`, wenn Beginn oder
+    Ende jenseits der Güte-Grenze liegen.
+  - Ohne Frames im Fenster (throttled/data_unavailable/echte Providerlücke)
+    bleibt der Text byte-identisch zum heutigen Stand (keine der beiden
+    neuen Angaben erscheint).
+- **Side effects:** keine — additive Feld-Durchreichung plus
+  Renderer-/Formatierungserweiterung. Keine Persistenz betroffen, keine
+  Änderung an der Auslöseregel (`radar_alert_due`) oder der
+  #2020-Überholungsprüfung.
+
+## Acceptance Criteria
+
+- **AC-1:** Given eine Frame-Zeitreihe, die das gesamte 180-Minuten-Fenster
+  durchgehend abdeckt (Raster 15 Min, kein Trockenübergang, keine Lücke) /
+  When `_derive_result` `source_reach_minutes` ableitet / Then entspricht
+  `source_reach_minutes` dem vollen Horizont (180), gedeckelt und nicht
+  darüber hinaus.
+  - Test: Unit-Test gegen `_derive_result` mit konstruierten Frames im
+    15-Minuten-Raster über das volle Fenster, `source_reach_minutes == 180`
+    geprüft.
+
+- **AC-2:** Given eine Frame-Zeitreihe, die nach Minute 40 abbricht (keine
+  weiteren Frames bis zum Horizont), während zugleich KEIN nasser Block
+  vorliegt (`onset_minutes=None`, `event_end_minutes=None`, komplett
+  trocken) / When `_derive_result` beide Größen ableitet / Then ist
+  `source_reach_minutes` deutlich kleiner als der Horizont (nahe Minute
+  40 + `_MAX_FRAME_COVERAGE`), während `onset_minutes`/`event_end_minutes`
+  unverändert `None` bleiben — die Reichweite bewegt sich unabhängig vom
+  Regen-Zustand, kein gemeinsamer Wächter verschiebt beide zugleich.
+  - Test: Unit-Test mit einer nach Minute 40 abbrechenden, komplett
+    trockenen Frame-Zeitreihe; `source_reach_minutes` und
+    `onset_minutes`/`event_end_minutes` einzeln geprüft.
+
+- **AC-3:** Given ein `OnsetEvent` mit gesetztem `source_reach_time` und
+  `event_ongoing_beyond_horizon=False` / When eine der sechs
+  Langform-/Briefing-/Kommando-Textstellen gerendert wird / Then enthält
+  der Text zusätzlich zur bestehenden Beginn-/Ende-Angabe
+  `Radar reicht bis HH:MM`.
+  - Test: Je ein Unit-Test für `_render_email_onset`,
+    `format_starkregen_hint` und `format_now_text` mit konstruiertem
+    Event/Ergebnis, Substring-Prüfung auf `Radar reicht bis`.
+
+- **AC-4:** Given einen Onset-Alarm mit Beginn 75 Minuten in der Zukunft
+  (`onset_minutes=75`, jenseits der 60-Minuten-Güte-Grenze) und einem Ende
+  innerhalb der Grenze / When die Texte gerendert werden / Then erscheint
+  in jeder der sechs Langform-/Briefing-/Kommando-Stellen zusätzlich
+  `Ortsangabe ab HH:MM unscharf`, mit `HH:MM` = `now + 60 Min`.
+  - Test: Unit-Test mit `onset_minutes=75`, `event_end_minutes` innerhalb
+    der Grenze, gerenderter Text auf `Ortsangabe ab` und die erwartete
+    Grenzzeit geprüft.
+
+- **AC-5:** Given einen Onset-Alarm mit Beginn 20 Minuten in der Zukunft
+  (diesseits der Grenze, alarmfähig unter `RADAR_ONSET_THRESHOLD_MIN`) und
+  einem Ende 150 Minuten in der Zukunft (jenseits der Grenze) / When die
+  Texte gerendert werden / Then erscheint die Güte-Zeile TROTZDEM, obwohl
+  der Alarm-Pfad den Beginn selbst nie über 55 Minuten Vorlauf hinaus
+  auslöst — genau der Fall aus B3/E4, den der Alarm-Pfad sonst stumm
+  ließe.
+  - Test: Unit-Test mit `onset_minutes=20`, `event_end_minutes=150`, Text
+    enthält `Ortsangabe ab` mit der Grenzzeit `now + 60 Min`, nicht mit dem
+    Beginn.
+
+- **AC-6:** Given zwei Onset-Alarme, deren jeweils spätere Ereigniszeit
+  (Beginn oder Ende) exakt 50 Minuten bzw. exakt 90 Minuten in der Zukunft
+  liegt (beide diesseits bzw. jenseits der 60-Minuten-Grenze) / When die
+  Texte gerendert werden / Then fehlt die Güte-Zeile beim
+  50-Minuten-Fall vollständig UND derselbe Testaufbau erzeugt die
+  Güte-Zeile, sobald ausschließlich die betroffene Zeit auf 90 Minuten
+  verschoben wird (Positivkontrolle — dieselbe Konstruktion, ein
+  verschobener Wert, gegensätzliches Ergebnis).
+  - Test: Ein Unit-Test-Paar mit identischem Aufbau bis auf die verschobene
+    Ereigniszeit; beide Ausgänge (Abwesenheit und Anwesenheit der
+    Güte-Zeile) in demselben Test geprüft, nicht in getrennten Tests ohne
+    gemeinsamen Bezug.
+
+- **AC-7:** Given vier Fälle mit der betroffenen Ereigniszeit bei genau 45,
+  59, 61 und 75 Minuten (zwei knapp diesseits, zwei knapp jenseits der
+  60-Minuten-Grenze — die Zone ZWISCHEN den Rändern aus S1 → #2075) / When
+  die Güte-Zeile für jeden Fall geprüft wird / Then fehlt sie bei 45 und 59
+  Minuten und erscheint bei 61 und 75 Minuten — kein Fall an den bloßen
+  Rändern (0/180 oder exakt 60) lässt die Zone dazwischen ungeprüft.
+  - Test: Ein parametrisierter Unit-Test über die vier Minutenwerte, je ein
+    Assert auf Anwesenheit/Abwesenheit der Güte-Zeile.
+
+- **AC-8:** Given einen Fall mit gesetzter Güte-Zeile (Aufbau wie AC-4) /
+  When der gerenderte Text auf sein Vokabular geprüft wird / Then enthält
+  er das Wort „unscharf", NIEMALS das Wort „extrapoliert" — letzteres
+  suggeriert fälschlich einen gemessenen Teil, den die INCA-Quelle nicht
+  liefert (E2/E3).
+  - Test: Unit-Test mit Substring-Prüfung `"unscharf" in text` UND
+    `"extrapoliert" not in text` am selben gerenderten Text.
+
+- **AC-9:** Given einen Onset-Alarm mit `event_ongoing_beyond_horizon=True`
+  (S1-Untergrenzenform, `Regen mindestens bis HH:MM`) und einer im übrigen
+  gesetzten Reichweite / When die sechs betroffenen Textstellen gerendert
+  werden / Then erscheint KEINE zusätzliche `Radar reicht bis`-Angabe — die
+  Untergrenzenform trägt die Reichweiten-Aussage bereits implizit (E5).
+  - Test: Unit-Test mit `event_ongoing_beyond_horizon=True`, gerenderter
+    Text enthält `Regen mindestens bis`, aber NICHT `Radar reicht bis`.
+
+- **AC-10:** Given denselben Aufbau wie AC-9 (`event_ongoing_beyond_horizon
+  =True`) mit zusätzlich einem Beginn jenseits der Güte-Grenze / When die
+  Texte gerendert werden / Then erscheint die Güte-Zeile `Ortsangabe ab
+  HH:MM unscharf` UNVERÄNDERT — die E5-Unterdrückung betrifft
+  ausschließlich die Reichweiten-Angabe, nicht die Güte-Zeile; beide
+  Entscheidungen bleiben unabhängig voneinander.
+  - Test: Unit-Test mit beiden Wächtern kombiniert gesetzt, Text enthält
+    sowohl `Regen mindestens bis` als auch `Ortsangabe ab ... unscharf`,
+    aber nicht `Radar reicht bis`.
+
+- **AC-11:** Given einen Onset-Alarm mit Güte-Fall (Beginn oder Ende
+  jenseits der Grenze) / When `_render_sms_onset` (SMS, Premium-SMS,
+  Telegram-Kurzstil) gerendert wird / Then trägt der Text genau EIN
+  Zeichen `?` unmittelbar hinter dem Zeit-Token (z. B. `R2.5@15:00?`), und
+  der resultierende Text bleibt unter 140 GSM-7-Zeichen auch im
+  Extremfall (langer Ortsname, `onset_precip_mm=99.9`, kombiniertes
+  Untergrenzen- und Güte-Token).
+  - Test: Unit-Test gegen `_render_sms_onset` mit Güte-Fall, Regex-Prüfung
+    auf genau ein `?` an der erwarteten Position; ergänzender
+    Längentest mit dem Extremfall-Aufbau (Muster S1-AC-16), `len(sms) <=
+    140` geprüft.
+
+- **AC-12:** Given denselben Güte-Fall wie AC-11 / When die Kurzform
+  gerendert wird / Then enthält sie KEINE Reichweiten-Angabe (kein
+  zusätzliches Zeit-Token für `source_reach_time`) — die Kanal-Kaskade
+  wählt in der Kurzform ausschließlich die Güte, die Reichweite bleibt
+  abgewählt (E6).
+  - Test: Unit-Test mit gesetztem `source_reach_time` UND Güte-Fall, die
+    Anzahl der Zeit-Token in der Kurzform bleibt bei maximal zwei (Beginn,
+    Ende) plus dem `?`-Zeichen — kein drittes Zeit-Token.
+
+- **AC-13:** Given einen Onset-Alarm ohne Güte-Fall UND ohne
+  Reichweiten-relevante Besonderheit (Reichweite = voller Horizont,
+  beide Ereigniszeiten diesseits der Grenze) / When `_render_sms_onset`
+  gerendert wird / Then ist der resultierende Text BYTE-IDENTISCH zum
+  Stand vor dieser Spec (kein hängendes `?`, keine leere Anhängsel-Stelle).
+  - Test: Regressionslauf der bestehenden SMS-Onset-Goldstring-Tests ohne
+    inhaltliche Anpassung — keiner darf allein wegen der neuen Felder rot
+    werden.
+
+- **AC-14:** Given denselben Onset-Alarm einmal über den Trip-Pfad
+  (`trip_alert.check_radar_alerts`) und einmal über den
+  Ortsvergleich-Pfad (`compare_radar_alert`) gerendert (ADR-0021, geteilter
+  Code) / When beide Pfade dieselben Frames erhalten / Then tragen
+  Reichweiten- UND Güte-Angabe in beiden Flächen denselben Wortlaut und
+  denselben Wert — keine Fläche zeigt eine der beiden Angaben, ohne dass
+  die andere es auch täte.
+  - Test: Paritätstest, gespiegelt zu
+    `tests/tdd/test_onset_menge_kanalparitaet.py`, prüft Trip- und
+    Ortsvergleich-Ausgabe auf identische Reichweiten- und Güte-Angaben.
+
+- **AC-15:** Given einen beliebigen der sieben gerenderten Texte mit
+  gesetzter Reichweite oder Güte-Zeile / When der Text auf Formulierungen
+  geprüft wird, die eine Handlungsempfehlung oder eine
+  Positions-/Uhrzeit-Rechnung über den Nutzer enthalten (z. B. „verlass
+  dich nicht darauf", „bis dahin solltest du …") / Then enthält KEINER der
+  sieben Texte eine solche Formulierung — ausschließlich ein Datum über
+  die Aussage (Zeitpunkt, Wort „unscharf"/„reicht bis").
+  - Test: Unit-Test über alle sieben Renderer-Ausgaben mit gesetzter
+    Reichweite/Güte, Negativ-Prüfung auf eine Liste verbotener Muster.
+
+- **AC-16:** Given ein Testfall, der `LOCATION_SHARPNESS_LIMIT_MIN` zur
+  Laufzeit auf einen von 60 abweichenden Wert setzt (z. B. per Monkeypatch
+  auf `radar_service_mod.LOCATION_SHARPNESS_LIMIT_MIN`) / When die
+  Güte-Prüfung für eine Ereigniszeit knapp über dem NEUEN, nicht dem alten
+  Wert läuft / Then greift die Güte-Zeile nach dem NEUEN Wert — die
+  Erwartung im Test wird aus DERSELBEN Modulreferenz gelesen, nicht als
+  fest getippte Zahl im Test dupliziert, damit ein hart getippter
+  Erwartungswert im Produktivcode auffliegen würde, sobald der Test die
+  Referenz statt einer eigenen Kopie prüft.
+  - Test: Unit-Test, der `radar_service_mod.LOCATION_SHARPNESS_LIMIT_MIN`
+    monkeypatcht, die Erwartung aus derselben Modulvariable ableitet
+    (`limit = radar_service_mod.LOCATION_SHARPNESS_LIMIT_MIN`, nicht
+    `limit = 60`) und prüft, dass die Güte-Zeile exakt an dieser Grenze
+    kippt.
+
+## Known Limitations
+
+- **Die Güte-Grenze ist eine gesetzte Zahl, kein gemessenes
+  Quellen-Merkmal** (E2). 60 Minuten ist der im Code dokumentierte,
+  fachlich begründete Schätzwert für den Punkt, an dem die
+  INCA-Ortsschärfe „deutlich" sinkt — keine kalibrierte, laufend
+  nachgeführte Messgröße. Eine künftige Quelle mit Pro-Frame-Herkunft
+  (Analyse vs. Extrapolation) könnte diese Schwelle ablösen; bis dahin
+  bleibt sie eine Heuristik.
+- **Reichweiten-Präzision hängt am Quellenraster.** Wie bei
+  `event_end_minutes` (S1) bestimmt die Kadenz der jeweiligen Quelle
+  (5-15 Min) die Präzision der Reichweiten-Angabe; bei gröberem Raster
+  kann die tatsächliche Reichweite um bis zu `_MAX_FRAME_COVERAGE`
+  (15 Min) von der Anzeige abweichen.
+- **S2 (räumliche Ausdehnung), S4 (`/strecke`-Kommando)** aus Issue #2051
+  bleiben offen — diese Spec deckt ausschließlich S3.
+- **Die Güte-Zeile nennt keine betroffene Größe.** Sie sagt „ab HH:MM
+  unscharf", nicht ob Beginn, Ende oder beide betroffen sind (E4,
+  bewusste Entscheidung — Bevormundungs-Grenze). Ein Nutzer mit zwei
+  Ereigniszeiten muss selbst vergleichen, welche jenseits der genannten
+  Grenzzeit liegt.
+
+## Nicht-Ziele
+
+- **Keine räumliche Ausdehnung** (S2) und **kein `/strecke`-Kommando** (S4)
+  — beide bleiben eigenständige Scheiben von #2051.
+- **Keine Kappung von `_NOWCAST_HORIZON_MIN`** auf 60 — nähme #1945 und
+  S1/E3 zurück.
+- **Keine Änderung an `RADAR_ONSET_THRESHOLD_MIN = 55`** oder der
+  #2020-Überholungsprüfung.
+- **Kein neuer Quellenabruf** — Reichweite und Güte werden ausschließlich
+  aus den bereits abgerufenen `frames` bzw. aus den in S1 abgeleiteten
+  `onset_minutes`/`event_end_minutes` gebildet.
+- **Keine Handlungsempfehlung, keine Rechnung über den Nutzer**
+  (Ankunftszeiten, Begegnungspunkte, „verlass dich nicht darauf").
+- **Keine Änderung an der Trip-Konfiguration des PO.**
+- **Keine Berührung von `radar_service.py` Zeile ~325 (`coverage_end` in
+  `_derive_wet_block_end`)** — dort arbeitet parallel Issue #2075 an
+  einem eigenen Fund. Die Reichweiten-Ableitung dieser Spec liegt in
+  `_derive_result` und liest dieselbe Mechanik, ohne die dortige Zeile
+  selbst zu ändern.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Additive Feld-Durchreichung entlang derselben, bereits in
+  S1 etablierten Wirkkette (`NowcastResult` → `OnsetEvent` → sieben
+  Textstellen) plus zwei reine Anzeigefassungs-Helfer, die dem Muster
+  `event_end_display` folgen. Berührt keine der vier Entscheidungsflächen,
+  die ein neues ADR verlangen würden: ADR-0011 (ein Backend-Renderer)
+  bleibt gültig — alle Textstellen liegen weiter in `render.py`;
+  ADR-0021 (geteilter Code Trip/Compare) wird angewendet, nicht verändert
+  (AC-14); ADR-0052 (Mail-Bauform) bleibt unangetastet, Reichweite und
+  Güte fügen sich als weitere Datenzeilen-Anhängsel ein. Kein neuer Kanal,
+  kein neuer Provider, keine Persistenz-Änderung, keine Änderung an der
+  Auslöseregel.
+
+## Test-Plan
+
+**Bestehende Tests, die den heutigen Text ohne Reichweite/Güte
+festnageln — laufen unverändert grün oder werden additiv fortgeschrieben
+(AC-13):**
+
+- Alle in S1s Test-Plan gelisteten Bestandstests
+  (`tests/tdd/test_alert_sms_onset_zeitpunkt.py`,
+  `test_952_onset_alert_fidelity.py`,
+  `test_multi_location_onset_alert.py`,
+  `test_onset_menge_kanalparitaet.py` u. a.) — Regressionslauf ohne
+  inhaltliche Anpassung an den Fixtures.
+- Die S1-eigenen Testdateien
+  (`tests/tdd/test_nowcast_blockende_*.py`,
+  `tests/tdd/test_onset_ende_*.py`) — dürfen durch die neuen additiven
+  Felder nicht rot werden.
+
+**Neue Testdateien, benannt nach Verhalten (nicht nach Issue-Nummer):**
+
+- `tests/tdd/test_nowcast_source_reach_ableitung.py` — AC-1/AC-2
+  (Reichweite bei vollständiger Deckung, Reichweite bei Datenlücke
+  unabhängig vom Regen-Zustand).
+- `tests/tdd/test_nowcast_source_reach_textstellen.py` — AC-3/AC-9/AC-10
+  (Reichweiten-Text in den sechs Stellen, E5-Unterdrückung, Unabhängigkeit
+  von der Güte-Zeile).
+- `tests/tdd/test_nowcast_ortsschaerfe_schwelle.py` — AC-4/AC-5/AC-6/AC-7
+  (Auslösebedingung, Alarm-Pfad-Fall, Positivkontrolle, Randzone
+  61-75/45-59).
+- `tests/tdd/test_nowcast_ortsschaerfe_wortlaut.py` — AC-8 (Wortlaut
+  „unscharf", nicht „extrapoliert").
+- `tests/tdd/test_onset_reichweite_guete_sms.py` — AC-11/AC-12/AC-13
+  (SMS-Marker, Abwahl der Reichweite, Byte-Identität ohne Güte-Fall).
+- `tests/tdd/test_onset_reichweite_guete_kanalparitaet.py` — AC-14
+  (Trip ↔ Ortsvergleich).
+- `tests/tdd/test_onset_reichweite_guete_keine_bevormundung.py` — AC-15.
+- `tests/tdd/test_ortsschaerfe_grenze_laufzeitbindung.py` — AC-16
+  (Modulreferenz statt Import-Bindung).
+
+## Changelog
+
+- 2026-08-22: Initial spec created (#2051 Scheibe S3, Reichweite der Quelle
+  und Güte-Kennzeichnung).

--- a/docs/specs/modules/feat_2051_s3_reichweite_und_guete.md
+++ b/docs/specs/modules/feat_2051_s3_reichweite_und_guete.md
@@ -4,7 +4,7 @@ type: feature
 created: 2026-08-22
 updated: 2026-08-22
 status: approved
-version: "1.0"
+version: "1.1"
 tags: [alarm, briefing, nowcast, radar, reichweite, guete]
 ---
 
@@ -190,6 +190,39 @@ Güte-Kennzeichnung mit dem Wächter `event_ongoing_beyond_horizon` gleich —
 der feuert aber nur, wenn es bis zum Horizont durchregnet, und deckt den
 eigentlichen PO-Fall (großer Vorlauf bei einem Ereignis, das VOR dem
 Horizont endet) gerade nicht ab. Genau diese Lücke schließt S3.
+
+**E8 — Das `?` bindet an die ZEITGRUPPE, nicht an einen einzelnen Zeitpunkt.**
+(Nachtrag 2026-08-22, aus der Abstimmung mit #2054.) Die Kurzform trägt
+oft ZWEI Zeit-Token, nicht eines: Beginn und Ende hängen aneinander
+(`TH@18:00@20:00 R2.5`), bei laufendem Ereignis steht `now` an der
+Beginn-Stelle (#2050 S2b), und bei Horizont-Überlauf trägt das Ende ein
+`>`-Präfix. Die Spec ließ offen, an welches davon das `?` hängt — drei
+Lesarten waren möglich (`@18:00?@20:00`, `@18:00@20:00?`, `R2.5?`).
+
+**Entschieden: unmittelbar hinter dem LETZTEN Zeit-Token der Gruppe**, also
+`TH@18:00@20:00? R2.5`. Drei Gründe:
+
+(a) **Semantische Deckung mit der Langform.** Diese sagt `Ortsangabe ab
+HH:MM unscharf` — eine Aussage über die Vorhersage ab einer Grenze, nicht
+über einen einzelnen Wert (E4 nennt bewusst die Grenzzeit, nicht den
+betroffenen Wert). Eine Marke an genau einem der beiden Zeitpunkte
+behauptete eine Zuordnung, die die Langform gerade nicht macht.
+
+(b) **Der AC-5-Fall bräche sonst.** Dort liegt der BEGINN diesseits der
+Grenze und nur das ENDE jenseits. Ein `?` am Beginn stünde dann an der
+einen Zeit, die scharf ist — die Marke wäre nicht bloß unpräzise, sondern
+am falschen Wert.
+
+(c) **Hinter der Menge wäre irreführend** (`R2.5?` läse sich als
+Unsicherheit über die Millimeter, nicht über den Ort).
+
+**Abgrenzung zu #2054:** Deren Wochentagskürzel sitzt am Token-ANFANG
+direkt hinter dem `@` und ohne Leerzeichen (`R2.5@Do15:00`, gebildet in
+`_sms_onset_time()`), unsere Marke am ENDE der Gruppe. Die Kombination ist
+`TH@Do18:00@Fr3:00?` und damit unabhängig von der Merge-Reihenfolge
+eindeutig. Da S3 nach #2054 rebast, liegt die Pflicht zur Prüfung der
+KOMBINATION bei S3: AC-11 deckt deshalb ausdrücklich auch den
+Zwei-Token-Fall ab, nicht nur den Beginn.
 
 ## Implementation Details
 
@@ -429,7 +462,10 @@ gespiegelt (Vorwarnung analog #2046 F002/S1).
 - **AC-11:** Given einen Onset-Alarm mit Güte-Fall (Beginn oder Ende
   jenseits der Grenze) / When `_render_sms_onset` (SMS, Premium-SMS,
   Telegram-Kurzstil) gerendert wird / Then trägt der Text genau EIN
-  Zeichen `?` unmittelbar hinter dem Zeit-Token (z. B. `R2.5@15:00?`), und
+  Zeichen `?` unmittelbar hinter dem LETZTEN Zeit-Token der Zeitgruppe
+  (E8) — bei einem Token `R2.5@15:00?`, beim Paar `TH@18:00@20:00? R2.5`,
+  bei laufendem Ereignis `R2.5 now@20:00?`, bei Horizont-Überlauf
+  `TH@18:00 >@20:00?` —, und
   der resultierende Text bleibt unter 140 GSM-7-Zeichen auch im
   Extremfall (langer Ortsname, `onset_precip_mm=99.9`, kombiniertes
   Untergrenzen- und Güte-Token).
@@ -591,3 +627,9 @@ festnageln — laufen unverändert grün oder werden additiv fortgeschrieben
 
 - 2026-08-22: Initial spec created (#2051 Scheibe S3, Reichweite der Quelle
   und Güte-Kennzeichnung).
+- 2026-08-22 (v1.1): **E8** ergänzt — Bindung des `?` an die Zeitgruppe
+  statt an einen einzelnen Zeitpunkt; AC-11 um den Zwei-Token-Fall und die
+  Kombination mit dem #2054-Wochentagskürzel erweitert. Anlass: Abstimmung
+  mit der #2054-Sitzung, die dieselbe Kurzform am Token-Anfang ändert.
+  Keine Umkehr einer freigegebenen Entscheidung — Schließung einer Lücke,
+  die die Freigabefassung offenließ.

--- a/src/output/renderers/alert/model.py
+++ b/src/output/renderers/alert/model.py
@@ -150,6 +150,21 @@ class OnsetEvent:
     # bewusst KEIN zweites Ende-Feld daneben, sonst gaebe es zwei Wahrheiten
     # ueber denselben Zeitpunkt.
     already_running: bool = False
+    # Issue #2051 S3: additiv, optional (Muster `event_end_time`/
+    # `event_end_day_offset` o.). Reichweite der Quelle als reines "HH:MM"
+    # -- Quelle `NowcastResult.source_reach_minutes`. `None` heisst "keine
+    # Beobachtung im Fenster ODER `event_ongoing_beyond_horizon` gesetzt"
+    # (E5) -- die Entscheidung ist bereits in `project.source_reach_display`
+    # getroffen, der Renderer prueft nur noch auf `None`.
+    source_reach_time: str | None = None
+    source_reach_day_offset: int = 0
+    # Issue #2051 S3: additiv, optional. Grenzzeit der Ortsschaerfe
+    # (`now + LOCATION_SHARPNESS_LIMIT_MIN`) als reines "HH:MM" -- Quelle
+    # `project.location_sharpness_display`. `None` heisst "weder Beginn
+    # noch Ende liegen jenseits der Grenze" -- keine zweite Schwellpruefung
+    # hier (sonst zwei Wahrheiten, Muster AC-20).
+    location_sharpness_limit_time: str | None = None
+    location_sharpness_limit_day_offset: int = 0
 
 
 @dataclass(frozen=True)

--- a/src/output/renderers/alert/project.py
+++ b/src/output/renderers/alert/project.py
@@ -74,6 +74,52 @@ def event_end_display(
     return local_fmt(end_dt, tz), offset, ongoing, weekday
 
 
+def source_reach_display(now_utc: datetime, nowcast, tz) -> tuple[str | None, int]:
+    """Anzeigefassung der Reichweite der Quelle (Issue #2051 S3):
+    `("HH:MM", Versatz)` oder `(None, 0)`.
+
+    EINE Fassung fuer BEIDE Onset-Pfade (Muster `event_end_display`).
+    `(None, 0)`, wenn keine Reichweite bekannt ist (`source_reach_minutes is
+    None` -- keine Beobachtung im Fenster) ODER `event_ongoing_beyond_horizon`
+    gesetzt ist (E5) -- die S1-Untergrenzenform (`Regen mindestens bis
+    HH:MM`) traegt die Reichweiten-Aussage in diesem Fall bereits implizit;
+    eine zusaetzliche Reichweiten-Angabe waere Dopplung.
+    """
+    reach_minutes = getattr(nowcast, "source_reach_minutes", None)
+    if reach_minutes is None:
+        return None, 0
+    if bool(getattr(nowcast, "event_ongoing_beyond_horizon", False)):
+        return None, 0
+    reach_dt = now_utc + timedelta(minutes=reach_minutes)
+    return local_fmt(reach_dt, tz), day_offset(now_utc, reach_dt, tz)
+
+
+def location_sharpness_display(
+    now_utc: datetime, onset_minutes: int | None, event_end_minutes: int | None, tz,
+) -> tuple[str | None, int]:
+    """Anzeigefassung der Guete-Grenzzeit (Issue #2051 S3): `("HH:MM",
+    Versatz)` der Grenzzeit `now + LOCATION_SHARPNESS_LIMIT_MIN` oder
+    `(None, 0)`, wenn WEDER `onset_minutes` NOCH `event_end_minutes` jenseits
+    der Grenze liegen (oder beide `None` sind).
+
+    Die Entscheidung wird HIER getroffen (E4) -- der Renderer prueft
+    anschliessend nur noch auf `None`, keine zweite Schwellpruefung dort
+    (sonst zwei Wahrheiten, Muster AC-20). Liest die Grenze bei JEDEM
+    Aufruf ueber die Modulreferenz, bindet sie NICHT beim Import (AC-16,
+    Laufzeit-Drift-Schutz -- Muster `RADAR_ONSET_THRESHOLD_MIN`)."""
+    import services.radar_service as radar_service_mod
+
+    limit = radar_service_mod.LOCATION_SHARPNESS_LIMIT_MIN
+    jenseits = (
+        (onset_minutes is not None and onset_minutes > limit)
+        or (event_end_minutes is not None and event_end_minutes > limit)
+    )
+    if not jenseits:
+        return None, 0
+    limit_dt = now_utc + timedelta(minutes=limit)
+    return local_fmt(limit_dt, tz), day_offset(now_utc, limit_dt, tz)
+
+
 def _resolve_metric_id(field: str, direction: str) -> str:
     """summary_field → catalog metric_id, disambiguiert per Richtung.
 
@@ -565,6 +611,13 @@ def to_multi_location_onset_alert_message(
         # Issue #2054: Versatz und Kuerzel aus DEMSELBEN Zeitpunkt und
         # DERSELBEN Ortszone -- zwei Herleitungen koennten auseinanderlaufen.
         _onset_offset = day_offset(now, onset_dt, loc_tz)
+        # Issue #2051 S3: Reichweite und Guete-Grenzzeit JE ORT in DERSELBEN
+        # Ortszone wie Beginn/Ende (`loc_tz`), ueber dieselben geteilten
+        # Fassungen wie der Trip-Pfad (ADR-0021).
+        _reach_time, _reach_offset = source_reach_display(now, nc, loc_tz)
+        _sharp_time, _sharp_offset = location_sharpness_display(
+            now, nc.onset_minutes, getattr(nc, "event_end_minutes", None), loc_tz,
+        )
         events.append(OnsetEvent(
             already_running=_laufend,
             onset_minutes=nc.onset_minutes or 0,
@@ -595,6 +648,11 @@ def to_multi_location_onset_alert_message(
             # deshalb erreichen -- er darf nicht mehr stromaufwaerts in einem
             # fehlenden Ende aufgeloest werden (AC-5/AC-20).
             event_ongoing_beyond_horizon=_end_ongoing,
+            # Issue #2051 S3: additiv, ueber dieselben geteilten Fassungen.
+            source_reach_time=_reach_time,
+            source_reach_day_offset=_reach_offset,
+            location_sharpness_limit_time=_sharp_time,
+            location_sharpness_limit_day_offset=_sharp_offset,
         ))
     trip_short = (
         ", ".join(name for name, _loc, _nc in valid_groups)

--- a/src/output/renderers/alert/render.py
+++ b/src/output/renderers/alert/render.py
@@ -483,7 +483,7 @@ def _render_subject_onset(msg: AlertMessage) -> str:
     # behauptbares Ende bleibt der Betreff byte-identisch (AC-19).
     return (
         f"[{msg.trip_short}] {km} · {label} {_onset_wann_kopf(e)}"
-        f"{_onset_end_suffix(e)}"
+        f"{_onset_end_suffix(e)}{_onset_reach_suffix(e)}{_onset_sharpness_suffix(e)}"
     )
 
 
@@ -582,6 +582,35 @@ def _onset_end_suffix(e: OnsetEvent) -> str:
     return f" · letzter Regen gegen {ende}"
 
 
+def _onset_reach_suffix(e: OnsetEvent) -> str:
+    """Issue #2051 S3: Langform-Reichweiten-Angabe als anhaengbares Stueck
+    oder LEER. `source_reach_time` ist bereits `None`, wenn keine
+    Reichweite bekannt ist ODER `event_ongoing_beyond_horizon` gesetzt ist
+    (E5 -- die S1-Untergrenzenform traegt die Reichweiten-Aussage bereits
+    implizit) -- die Entscheidung faellt in `project.source_reach_display`,
+    hier nur noch ein `None`-Check (Muster `_onset_end_suffix`)."""
+    reach = getattr(e, "source_reach_time", None)
+    if not reach:
+        return ""
+    reach = _time_with_day(reach, getattr(e, "source_reach_day_offset", 0))
+    return f" · Radar reicht bis {reach}"
+
+
+def _onset_sharpness_suffix(e: OnsetEvent) -> str:
+    """Issue #2051 S3: Langform-Guete-Angabe als anhaengbares Stueck oder
+    LEER. `location_sharpness_limit_time` ist bereits `None`, wenn weder
+    Beginn noch Ende jenseits der Grenze liegen (E4) -- Entscheidung faellt
+    in `project.location_sharpness_display`, hier nur noch ein
+    `None`-Check (keine zweite Schwellpruefung, Muster AC-20)."""
+    limit = getattr(e, "location_sharpness_limit_time", None)
+    if not limit:
+        return ""
+    limit = _time_with_day(
+        limit, getattr(e, "location_sharpness_limit_day_offset", 0),
+    )
+    return f" · Ortsangabe ab {limit} unscharf"
+
+
 def _render_email_onset_multi(msg: AlertMessage) -> tuple[str, str]:
     """Bündel-Zweig (Issue #1041 Slice 1a): je Ort eine Zeile mit Onset-Zeit
     und Intensität (Muster `loc_prefix`, render_email:328-333).
@@ -598,7 +627,8 @@ def _render_email_onset_multi(msg: AlertMessage) -> tuple[str, str]:
             # Issue #2051 S1: das Ende JE ORT aus dessen eigenem Event -- ein
             # Buendel kann Orte mit verschiedenen Ende-Zeiten tragen. Ohne
             # behauptbares Ende bleibt die Zeile byte-identisch (AC-19).
-            f"{_onset_wann_zeile(e, praefix='ab ')}{_onset_end_suffix(e)} · "
+            f"{_onset_wann_zeile(e, praefix='ab ')}{_onset_end_suffix(e)}"
+            f"{_onset_reach_suffix(e)}{_onset_sharpness_suffix(e)} · "
             f"{e.intensity_label}",
         )
         for e in msg.events
@@ -676,7 +706,8 @@ def _render_email_onset(msg: AlertMessage) -> tuple[str, str]:
         # Zeile -- eine eigene Datenzeile nur fuer das Ende waere im
         # Ende-losen Normalfall eine leere Zeile (ADR-0052, Label-Wert-Form).
         ("Wo & wann",
-         f"{km} · {_onset_wann_zeile(e, praefix='ab ')}{_onset_end_suffix(e)}"),
+         f"{km} · {_onset_wann_zeile(e, praefix='ab ')}{_onset_end_suffix(e)}"
+         f"{_onset_reach_suffix(e)}{_onset_sharpness_suffix(e)}"),
         ("Intensität", e.intensity_label),
         ("Quelle", e.source_label),
     ]
@@ -745,7 +776,8 @@ def _render_telegram_onset(msg: AlertMessage) -> str:
     # Issue #2051 S1: das Ende additiv HINTER der Beginn-Zeit, vor Intensitaet
     # und Quelle -- ohne behauptbares Ende byte-identisch wie bisher (AC-19).
     second = (
-        f"{_onset_wann_zeile(e)}{_onset_end_suffix(e)} · "
+        f"{_onset_wann_zeile(e)}{_onset_end_suffix(e)}"
+        f"{_onset_reach_suffix(e)}{_onset_sharpness_suffix(e)} · "
         f"{e.intensity_label} · {e.source_label}"
     )
     # Issue #2018 (AC-B3): die Bezugszeile steht als EIGENE Zeile zwischen Kopf
@@ -840,6 +872,26 @@ def _sms_onset_ende(e: OnsetEvent) -> str:
     )
 
 
+def _sms_onset_sharpness_marker(e: OnsetEvent) -> str:
+    """Issue #2051 S3 (E8, Spec v1.1 -- Nachtrag aus der Abstimmung mit
+    #2054): das Guete-Zeichen der Kurzform -- `"?"` oder leer.
+
+    Bindet an die GANZE Zeitgruppe, nicht an einen einzelnen Zeitpunkt: der
+    Aufrufer haengt das Ergebnis IMMER ans Ende des bereits VOLLSTAENDIG
+    gebildeten Zeit-Tokens an (Beginn+Ende bzw. `now`+Ende) -- diese
+    Funktion selbst kennt die innere Form dieses Tokens nicht und darf sie
+    auch nicht kennen (Laufzeit-unabhaengig vom #2054-Wochentagskuerzel,
+    das INNERHALB von `_sms_onset_time()` entsteht). Waere der Beginn
+    diesseits der Guete-Grenze und nur das Ende jenseits (AC-5), stuende
+    eine Marke am Beginn-Token an der einen Zeit, die scharf ist -- am
+    LETZTEN Token der Gruppe ist sie das nicht.
+
+    `?` statt `~`: `~` gehoert zur GSM-7-Extension-Tabelle (2 Septets) und
+    wird vom Transport hart auf `-` gefaltet (`_ASCII_EXTENSION_
+    REPLACEMENTS`, unten). `?` steht im GSM-7-BASISzeichensatz."""
+    return "?" if getattr(e, "location_sharpness_limit_time", None) else ""
+
+
 def _render_sms_onset(msg: AlertMessage, limit: int = 140) -> str:
     """Issue #1948 S4: die Nowcast-/Onset-Kurznachricht nennt einen ZEITPUNKT
     (`TH@15:40`) statt eines Countdowns (`TH!8`) und spricht im Kopf dieselbe
@@ -865,10 +917,19 @@ def _render_sms_onset(msg: AlertMessage, limit: int = 140) -> str:
     # drei Token-Zweige unten: so traegt AUCH der Gewitter-Zweig das Ende an
     # der Zeit (`TH@18:00@20:00 R2.5`) und nicht hinter der Menge -- sonst
     # bliebe dort eine stille Luecke.
-    zeit = _sms_onset_time(
-        e.onset_time, e.onset_day_offset,
-        getattr(e, "onset_weekday", None),  # Issue #2054
-    ) + _sms_onset_ende(e)
+    # Issue #2051 S3 (E8): einmalig berechnet, dem jeweils LETZTEN Zeit-Token
+    # der Gruppe angehaengt -- unabhaengig davon, welchen Zweig (Normalform
+    # unten oder Laufend-Form) der Text nimmt. Unabhaengig vom #2054-
+    # Wochentagskuerzel, das INNERHALB von `_sms_onset_time()` entsteht
+    # (Token-Anfang) -- unsere Marke sitzt am Token-ENDE (E8).
+    guete_marker = _sms_onset_sharpness_marker(e)
+    zeit = (
+        _sms_onset_time(
+            e.onset_time, e.onset_day_offset,
+            getattr(e, "onset_weekday", None),  # Issue #2054
+        ) + _sms_onset_ende(e)
+        + guete_marker
+    )
     menge = _sms_onset_menge(getattr(e, "onset_precip_mm", None))
     if getattr(e, "already_running", False):
         # Issue #2050 S2b (PO-Entscheid 2026-08-22): `now` steht dort, wo
@@ -876,7 +937,7 @@ def _render_sms_onset(msg: AlertMessage, limit: int = 140) -> str:
         # Kurzform (`R` = Rain, `TH` = Thunder). Die Ende-Grammatik aus #2051
         # haengt unveraendert dahinter (`now@20:00` bekanntes Ende,
         # `now >@20:00` Untergrenze), damit es nur EINE Ende-Form gibt.
-        ende = _sms_onset_ende(e)
+        ende = _sms_onset_ende(e) + guete_marker
         if menge is None:
             token = f"{kuerzel} now{ende}"
         elif kuerzel == "TH":

--- a/src/output/renderers/email/starkregen_hint.py
+++ b/src/output/renderers/email/starkregen_hint.py
@@ -21,6 +21,7 @@ def format_starkregen_hint(
     event_end_minutes: int | None = None,
     event_ongoing_beyond_horizon: bool = False,
     already_running: bool = False,
+    source_reach_minutes: int | None = None,
 ) -> str:
     """"Starker Regen ab ca. HH:MM (in ~N Min), letzter Regen gegen HH:MM." —
     identisches Format wie `RadarNowcastService.format_now_text()` fuer den
@@ -36,7 +37,16 @@ def format_starkregen_hint(
     (`Regen mindestens bis HH:MM`) statt eines bekannten Endes
     (`letzter Regen gegen HH:MM`). Beide Formen entstehen an dieser einen
     Stelle mit genau einer Weiche, damit sie nicht ineinander rutschen
-    (AC-20)."""
+    (AC-20).
+
+    Issue #2051 S3: `source_reach_minutes` ist additiv und defaultet (Muster
+    o.). Reichweite und Guete werden HIER selbst aus `onset_minutes`/
+    `event_end_minutes` abgeleitet (kein Aufruf der `project.py`-Fassungen
+    -- dieser Baustein liegt in einem anderen Modul und bekommt schon heute
+    nur Rohwerte, kein `OnsetEvent`). Die Guete-Grenze wird ueber die
+    MODUL-Referenz auf `radar_service` gelesen, nie per Import gebunden
+    (AC-16, Laufzeit-Drift-Schutz)."""
+    import services.radar_service as radar_service_mod
     from utils.timezone import local_dt
 
     now = datetime.now(timezone.utc)
@@ -58,6 +68,24 @@ def format_starkregen_hint(
             satz += f", Regen mindestens bis {end_str}"
         else:
             satz += f", letzter Regen gegen {end_str}"
+    # Issue #2051 S3 (E5): Reichweite additiv, aber NICHT bei gesetztem
+    # R4-Waechter -- die Untergrenzenform traegt die Reichweiten-Aussage
+    # bereits implizit.
+    if source_reach_minutes is not None and not event_ongoing_beyond_horizon:
+        reach_str = local_dt(
+            now + timedelta(minutes=source_reach_minutes), tz,
+        ).strftime("%H:%M")
+        satz += f" · Radar reicht bis {reach_str}"
+    # Issue #2051 S3 (E4): Guete-Grenze -- ausgeloest, wenn Beginn ODER Ende
+    # jenseits der Grenze liegen. Genannt wird die GRENZZEIT selbst.
+    limit = radar_service_mod.LOCATION_SHARPNESS_LIMIT_MIN
+    jenseits_guete = (
+        (onset_minutes is not None and onset_minutes > limit)
+        or (event_end_minutes is not None and event_end_minutes > limit)
+    )
+    if jenseits_guete:
+        guete_str = local_dt(now + timedelta(minutes=limit), tz).strftime("%H:%M")
+        satz += f" · Ortsangabe ab {guete_str} unscharf"
     return satz + "."
 
 

--- a/src/services/notification_service.py
+++ b/src/services/notification_service.py
@@ -113,7 +113,13 @@ class TripReportRequest:
     # Issue #2050 S2b: fuenftes Glied `already_running`, und `onset_minutes`
     # wird optional — ein laufendes Ereignis, das in der laufenden
     # Viertelstunde endet, hat keinen kuenftigen Beginn.
-    starkregen_nowcast: tuple[str, int | None, int | None, bool, bool] | None = None
+    # Issue #2051 S3: sechstes Glied `source_reach_minutes` -- additiv, wie
+    # die vorherigen Erweiterungen dieses Tupels. Ohne es kaeme die
+    # Reichweite an DIESEM Pfad (dem einzigen ohne Vorlauf-Deckel, aus dem
+    # der Ticket-Realfall stammt) nie beim Formatierer an.
+    starkregen_nowcast: (
+        tuple[str, int | None, int | None, bool, bool, int | None] | None
+    ) = None
 
 
 @dataclass
@@ -237,6 +243,19 @@ class RadarAlertRequest:
     # durch den Zustand ersetzt wird; das Ende kommt weiter aus den
     # `event_end_*`-Feldern.
     already_running: bool = False
+    # Issue #2051 S3: additiv, optional (Muster `event_end_time`/
+    # `event_end_day_offset` o.). Reichweite der Quelle als reines "HH:MM",
+    # gebildet in `trip_alert.check_radar_alerts` ueber die geteilte
+    # Fassung `project.source_reach_display` -- derselbe Baustein, den auch
+    # der Ortsvergleich-Pfad benutzt (ADR-0021). `None` heisst "keine
+    # Reichweite bekannt ODER durch E5 unterdrueckt".
+    source_reach_time: str | None = None
+    source_reach_day_offset: int = 0
+    # Issue #2051 S3: additiv, optional. Grenzzeit der Ortsschaerfe, gebildet
+    # ueber `project.location_sharpness_display`. `None` heisst "weder
+    # Beginn noch Ende liegen jenseits der Grenze".
+    location_sharpness_limit_time: str | None = None
+    location_sharpness_limit_day_offset: int = 0
 
 
 def build_service_error_email_html(trip_name: str, report_type: str, error_lines: str) -> str:
@@ -419,6 +438,7 @@ class NotificationService:
             (
                 _intensity_label, _onset_minutes,
                 _event_end_minutes, _event_ongoing, _already_running,
+                _source_reach_minutes,
             ) = request.starkregen_nowcast
             starkregen_hint_text = format_starkregen_hint(
                 _intensity_label, _onset_minutes, tz=request.trip_tz,
@@ -429,6 +449,10 @@ class NotificationService:
                 # Issue #2050 S2b: der Laufend-Zustand ebenfalls aus demselben
                 # Ergebnis -- er entscheidet ueber die BEGINN-Angabe der Zeile.
                 already_running=_already_running,
+                # Issue #2051 S3: die Reichweite ebenfalls aus demselben
+                # Ergebnis -- Adversary-Fund F002, der Pfad ohne Vorlauf-
+                # Deckel liess sie sonst nie beim Formatierer ankommen.
+                source_reach_minutes=_source_reach_minutes,
             )
 
         report = self._formatter.format_email(
@@ -1381,6 +1405,11 @@ class NotificationService:
             event_end_weekday=request.event_end_weekday,  # Issue #2054
             # Issue #2051 S1 (Spec v1.1): waehlt die Ende-Textform im Renderer.
             event_ongoing_beyond_horizon=request.event_ongoing_beyond_horizon,
+            # Issue #2051 S3: additiv durchgereicht.
+            source_reach_time=request.source_reach_time,
+            source_reach_day_offset=request.source_reach_day_offset,
+            location_sharpness_limit_time=request.location_sharpness_limit_time,
+            location_sharpness_limit_day_offset=request.location_sharpness_limit_day_offset,
         )
         # Issue #1402: kein stiller Rueckfall mehr -- `request.tz` ist seit
         # `RadarAlertRequest` ein Pflichtfeld.

--- a/src/services/radar_service.py
+++ b/src/services/radar_service.py
@@ -121,6 +121,16 @@ _ONSET_PRECIP_WINDOW_MIN = 60
 RADAR_ONSET_THRESHOLD_MIN = 55
 _DRY_THRESHOLD_MM_H = 0.1
 
+# Issue #2051 S3 (E2): eigener Name neben RADAR_ONSET_THRESHOLD_MIN (55) --
+# die 55 ist eine AUSLOESESCHWELLE (feuert der Alarm?), diese 60 eine
+# GUETE-GRENZE (wie belastbar ist die Ortsangabe?). Belegt durch den
+# Kommentar oben ("jenseits ~60 Min sinkt die Ortsschaerfe des
+# INCA-Extrapolationsprodukts deutlich"). Downstream-Leser (render.py,
+# starkregen_hint.py, project.py) referenzieren die MODUL-Variable
+# (`radar_service_mod.LOCATION_SHARPNESS_LIMIT_MIN`), nie ein Import zur
+# Bindezeit -- Laufzeit-Drift-Schutz wie bei RADAR_ONSET_THRESHOLD_MIN.
+LOCATION_SHARPNESS_LIMIT_MIN = 60
+
 # Issue #1461 S3a: benannte Intensitaets-Label-Konstanten statt Inline-Strings
 # in intensity_to_text() -- alert_urgency.py vergleicht gegen diese Konstanten
 # statt gegen Zeichenketten-Duplikate (E3). Wortlaut unveraendert.
@@ -221,6 +231,14 @@ class NowcastResult:
     # beiden Waechter-Faellen eine BEOBACHTETE Zahl -- die Reichweite der
     # Quelle bzw. den letzten bekannten nassen Frame. Als Untergrenze genannt
     # behauptet sie kein Ende und unterschlaegt zugleich nichts.
+    source_reach_minutes: Optional[int] = None
+    # Issue #2051 S3: Minuten ab jetzt bis zum Ende der Deckung des LETZTEN
+    # gelieferten Frames, gedeckelt am 180-Min-Horizont. NICHT dasselbe wie
+    # der Horizont selbst -- die Quelle kann frueher enden (Datenluecke,
+    # kuerzeres Produkt). `None` nur, wenn im Nowcast-Fenster ueberhaupt
+    # keine Frames vorliegen (throttled/data_unavailable/echte
+    # Providerluecke) -- ein durchgehend TROCKENES Fenster hat trotzdem eine
+    # Reichweite (bis zu 180).
 
 
 def _offline_fixture_active() -> bool:
@@ -631,6 +649,32 @@ class RadarNowcastService:
                     satz += f", Regen mindestens bis {_end_str}"
                 else:
                     satz += f", letzter Regen gegen {_end_str}"
+            # Issue #2051 S3 (E5): Reichweite additiv hinter dem Ende, aber
+            # NICHT bei gesetztem R4-Waechter -- die Untergrenzenform traegt
+            # die Reichweiten-Aussage bereits implizit.
+            if (
+                result.source_reach_minutes is not None
+                and not result.event_ongoing_beyond_horizon
+            ):
+                _reach_str = _hhmm(
+                    now + timedelta(minutes=result.source_reach_minutes)
+                )
+                satz += f" · Radar reicht bis {_reach_str}"
+            # Issue #2051 S3 (E4): Guete-Grenze -- ausgeloest, wenn Beginn
+            # ODER Ende jenseits der Grenze liegen. Genannt wird die
+            # GRENZZEIT selbst (now + LOCATION_SHARPNESS_LIMIT_MIN), nicht
+            # der betroffene Wert.
+            _limit = LOCATION_SHARPNESS_LIMIT_MIN
+            _jenseits_guete = (
+                (result.onset_minutes is not None and result.onset_minutes > _limit)
+                or (
+                    result.event_end_minutes is not None
+                    and result.event_end_minutes > _limit
+                )
+            )
+            if _jenseits_guete:
+                _guete_str = _hhmm(now + timedelta(minutes=_limit))
+                satz += f" · Ortsangabe ab {_guete_str} unscharf"
             lines.append(satz + ".")
 
         if result.convective_checked is False:
@@ -1053,6 +1097,29 @@ class RadarNowcastService:
             (f.precip_mm_h for f in compare_window), default=0.0
         )
 
+        # Issue #2051 S3 (E1): Reichweite der Quelle -- unabhaengig vom
+        # Regen-Zustand, deshalb NICHT an onset_ts/event_end gekoppelt. Der
+        # LETZTE Frame in `window` (dem 180-Min-Nowcast-Fenster) liefert
+        # seine eigene Deckung nach exakt derselben Mechanik wie
+        # `_accumulate_precip_mm`/`_derive_wet_block_end`: naechster
+        # Nachbar aus der VOLLSTAENDIGEN Frame-Liste (oder der Horizont,
+        # wenn keiner folgt), gedeckelt auf `_MAX_FRAME_COVERAGE`, nie ueber
+        # den Horizont hinaus. `window` leer -> `None` (keine Beobachtung,
+        # nicht "Reichweite null").
+        source_reach_minutes: Optional[int] = None
+        if window:
+            _last_reach_ts = max(f.timestamp for f in window)
+            _next_idx = bisect.bisect_right(all_ts_sorted, _last_reach_ts)
+            _next_ts_full = (
+                all_ts_sorted[_next_idx] if _next_idx < len(all_ts_sorted) else horizon
+            )
+            _reach_end = min(
+                _next_ts_full, _last_reach_ts + _MAX_FRAME_COVERAGE, horizon,
+            )
+            source_reach_minutes = max(
+                0, round((_reach_end - now).total_seconds() / 60.0)
+            )
+
         return NowcastResult(
             onset_minutes=onset_minutes,
             intensity_label=intensity_label,
@@ -1068,6 +1135,7 @@ class RadarNowcastService:
             already_running=already_running,  # Issue #2050 S2b
             event_end_minutes=event_end_minutes,  # Issue #2051 S1
             event_ongoing_beyond_horizon=event_ongoing_beyond_horizon,  # #2051 S1
+            source_reach_minutes=source_reach_minutes,  # Issue #2051 S3
         )
 
 

--- a/src/services/trip_alert.py
+++ b/src/services/trip_alert.py
@@ -1617,7 +1617,9 @@ class TripAlertService:
             from output.renderers.alert.official_alerts import (
                 _de_weekday_short,  # Issue #2054: EIN Kuerzel-Erzeuger
             )
-            from output.renderers.alert.project import event_end_display
+            from output.renderers.alert.project import (
+                event_end_display, location_sharpness_display, source_reach_display,
+            )
 
             _end_time_str, _end_day_offset, _end_ongoing, _end_weekday = (
                 event_end_display(now_utc, result, tz)
@@ -1626,6 +1628,16 @@ class TripAlertService:
             # DEMSELBEN Zeitpunkt und DERSELBEN Zone -- eine zweite Herleitung
             # koennte auseinanderlaufen (Muster #2009 o.).
             _onset_day_offset = day_offset(now_utc, _onset_dt, tz)
+            # Issue #2051 S3: Reichweite und Guete-Grenzzeit ueber dieselben
+            # geteilten Fassungen, die auch der Ortsvergleich-Pfad benutzt
+            # (ADR-0021).
+            _reach_time_str, _reach_day_offset = source_reach_display(
+                now_utc, result, tz,
+            )
+            _sharp_time_str, _sharp_day_offset = location_sharpness_display(
+                now_utc, result.onset_minutes,
+                getattr(result, "event_end_minutes", None), tz,
+            )
             _radar_request = RadarAlertRequest(
                 onset_minutes=result.onset_minutes,
                 already_running=result.already_running,  # Issue #2050 S2b
@@ -1656,6 +1668,11 @@ class TripAlertService:
                 event_end_day_offset=_end_day_offset,
                 event_end_weekday=_end_weekday,  # Issue #2054
                 event_ongoing_beyond_horizon=_end_ongoing,
+                # Issue #2051 S3: additiv.
+                source_reach_time=_reach_time_str,
+                source_reach_day_offset=_reach_day_offset,
+                location_sharpness_limit_time=_sharp_time_str,
+                location_sharpness_limit_day_offset=_sharp_day_offset,
                 tz=tz,
             )
 

--- a/src/services/trip_report_scheduler.py
+++ b/src/services/trip_report_scheduler.py
@@ -1701,8 +1701,9 @@ class TripReportSchedulerService:
         partial_outage_hint: str | None = None,
         render_options: Optional["ReportRenderOptions"] = None,
         starkregen_nowcast: Optional[
-            Tuple[str, Optional[int], Optional[int], bool, bool]
-        ] = None,  # Issue #2050 S2b: fuenftes Glied `already_running`
+            Tuple[str, Optional[int], Optional[int], bool, bool, Optional[int]]
+        ] = None,  # Issue #2050 S2b: fuenftes Glied `already_running`;
+        # Issue #2051 S3: sechstes Glied `source_reach_minutes`
     ) -> TripReportRequest:
         """Baut das DTO, das an den NotificationService übergeben wird (Issue #1022).
 
@@ -1759,11 +1760,14 @@ class TripReportSchedulerService:
         segments: List[TripSegment],
         now_utc: datetime,
         target_date: Optional[date] = None,
-    ) -> Optional[Tuple[str, Optional[int], Optional[int], bool, bool]]:
+    ) -> Optional[
+        Tuple[str, Optional[int], Optional[int], bool, bool, Optional[int]]
+    ]:
         """Starkregen-Kurzfristhinweis (Issue #1439): liefert die Rohdaten
         (``intensity_label``, ``onset_minutes``, seit Issue #2051 S1
         zusaetzlich ``event_end_minutes`` und
-        ``event_ongoing_beyond_horizon``, seit #2050 S2b ``already_running``;
+        ``event_ongoing_beyond_horizon``, seit #2050 S2b ``already_running``,
+        seit #2051 S3 ``source_reach_minutes``;
         ``onset_minutes`` ist seither optional, weil ein laufendes Ereignis
         ohne kuenftigen Beginn auskommt) fuer den planmaessigen
         Briefing-Pfad, wenn der bereits produktive `RadarNowcastService`
@@ -1898,10 +1902,15 @@ class TripReportSchedulerService:
         # Issue #2050 S2b: `already_running` als fuenftes Glied. Ohne es kaeme
         # der Laufend-Zustand am Formatierer nie an -- der Renderer-Zweig
         # waere gebaut und unerreichbar.
+        # Issue #2051 S3 (Adversary-Fund F002): `source_reach_minutes` als
+        # SECHSTES Glied. Genau DIESER Pfad kennt keinen Vorlauf-Deckel und
+        # ist damit die Flaeche, aus der der Ticket-Realfall stammt -- ohne
+        # dieses Glied kaeme die Reichweite hier NIE an, waehrend die Guete
+        # (haengt an Feldern, die schon im Tupel waren) sehr wohl ankommt.
         return (
             result.intensity_label, result.onset_minutes,
             result.event_end_minutes, result.event_ongoing_beyond_horizon,
-            result.already_running,
+            result.already_running, result.source_reach_minutes,
         )
 
     def _reset_alert_state_after_briefing(self, trip_id: str) -> None:

--- a/src/services/validator_render_service.py
+++ b/src/services/validator_render_service.py
@@ -27,6 +27,7 @@ from app.user import ComparisonResult, LocationResult, SavedLocation
 from output.renderers.alert.model import AlertMessage, OnsetEvent
 from output.renderers.alert.project import (
     event_end_display,  # Issue #2051 S1
+    location_sharpness_display, source_reach_display,  # Issue #2051 S3
     to_alert_message,
 )
 from output.renderers.alert.render import (
@@ -156,6 +157,18 @@ def render_alert_preview(
             # Aussage als der Versand, pruefte die Verifikation etwas, das so
             # nie beim Nutzer ankommt, und meldete gruen (AC-14b).
             already_running=getattr(body.onset, "already_running", False),
+            # Issue #2051 S3: Reichweite/Guete des Payloads, `getattr` aus
+            # demselben Grund wie oben (API-Payload UND Replay-Namespace).
+            source_reach_time=getattr(body.onset, "source_reach_time", None),
+            source_reach_day_offset=getattr(
+                body.onset, "source_reach_day_offset", 0,
+            ),
+            location_sharpness_limit_time=getattr(
+                body.onset, "location_sharpness_limit_time", None,
+            ),
+            location_sharpness_limit_day_offset=getattr(
+                body.onset, "location_sharpness_limit_day_offset", 0,
+            ),
         )
         msg = AlertMessage(
             trip_short=trip_obj.name,
@@ -288,6 +301,15 @@ def _render_nowcast_replay(trip_obj: Trip, body_nf: Any) -> dict:
     _end_time, _end_offset, _end_ongoing, _end_weekday = event_end_display(
         now, result, alert_tz,
     )
+    # Issue #2051 S3: Reichweite und Guete-Grenzzeit aus DEMSELBEN
+    # `_derive_result`-Ergebnis, ueber dieselben geteilten Fassungen wie
+    # der Ende-Wert oben -- der Replay-Weg muss dieselbe Aussage zeigen wie
+    # der Produktivpfad (Muster event_end_display, AC-10).
+    _reach_time, _reach_offset = source_reach_display(now, result, alert_tz)
+    _sharp_time, _sharp_offset = location_sharpness_display(
+        now, result.onset_minutes, getattr(result, "event_end_minutes", None),
+        alert_tz,
+    )
     onset_ns = SimpleNamespace(
         onset_minutes=result.onset_minutes or 0,
         # Issue #2050 S2b: aus DEMSELBEN `_derive_result`-Ergebnis wie alles
@@ -315,6 +337,11 @@ def _render_nowcast_replay(trip_obj: Trip, body_nf: Any) -> dict:
         event_end_day_offset=_end_offset,
         event_end_weekday=_end_weekday,  # Issue #2054
         event_ongoing_beyond_horizon=_end_ongoing,
+        # Issue #2051 S3: additiv, analog event_end_* oben.
+        source_reach_time=_reach_time,
+        source_reach_day_offset=_reach_offset,
+        location_sharpness_limit_time=_sharp_time,
+        location_sharpness_limit_day_offset=_sharp_offset,
     )
     out = render_alert_preview(
         trip_obj, SimpleNamespace(onset=onset_ns, official=None, nowcast_frames=None),

--- a/tests/tdd/test_alert_preview_nowcast_replay.py
+++ b/tests/tdd/test_alert_preview_nowcast_replay.py
@@ -244,3 +244,91 @@ class TestAC7_NoOnsetReturns200WithNullFields:
                 f"AC-7: '{field}' muss null sein, wenn kein Onset erkannt "
                 f"wurde: {data!r}"
             )
+
+
+# ═══════════════════════ Issue #2051 S3 (Rebase-Nachtrag) ═══════════════════════
+#
+# Adversary-Runde (#2051 S3, nach dem Rebase auf #2054): `_render_nowcast_
+# replay()` setzte `event_end_*` auf dem `SimpleNamespace`, aber NIE
+# `source_reach_*`/`location_sharpness_*` -- `getattr(..., default)` liess
+# das still auf `None` fallen, ohne dass ein Test es fing. Wichtiger als eine
+# gewoehnliche Luecke: der `nowcast_frames`-Zweig ist der EINZIGE Pfad, ueber
+# den sich Alarm-Verhalten auf Staging ueberhaupt pruefen laesst (S1 hat alle
+# 20 Kriterien darueber gemessen) -- ohne den Fix waeren Reichweite und Guete
+# auf Staging nicht "rot", sondern UNSICHTBAR gewesen.
+
+
+def _block_mit_reichweite_frames(now: datetime) -> list[dict]:
+    """Nasser Block +20 bis +150 Minuten (10-Minuten-Raster), Trockenframe
+    bei +160, danach keine weitere Beobachtung -- Muster
+    `test_onset_reichweite_guete_kanalparitaet.py::_FesterBlockMitReichweite`.
+
+    Von Hand hergeleitet: Beginn 20 Min (< RADAR_ONSET_THRESHOLD_MIN=55),
+    Ende 150 Min (> LOCATION_SHARPNESS_LIMIT_MIN=60 -> Guete-Zeile),
+    Reichweite aus der Deckung des letzten Frames (+160, kein Nachbar mehr)
+    = 160 + `_MAX_FRAME_COVERAGE` (15) = 175 Min."""
+    frames = [
+        {"timestamp": (now + timedelta(minutes=m)).isoformat(),
+         "precip_mm_h": 3.0, "is_convective": False}
+        for m in range(20, 151, 10)
+    ]
+    frames.append({
+        "timestamp": (now + timedelta(minutes=160)).isoformat(),
+        "precip_mm_h": 0.0, "is_convective": False,
+    })
+    return frames
+
+
+class TestS3_ReichweiteUndGueteImReplay:
+    def test_replay_pfad_zeigt_reichweite_und_guete_wie_der_live_pfad(
+        self, client, stub_trip,
+    ):
+        """Issue #2051 S3 GIVEN einen Frame-Mitschnitt mit bekanntem Ende
+        (jenseits der Guete-Grenze) und bekannter Reichweite (letzter Frame
+        vor Fensterende)
+        WHEN der Replay-Weg (`_render_nowcast_replay` -> `render_alert_
+        preview`) die Vorschau baut -- derselbe Pfad, ueber den Staging
+        Alarm-Verhalten misst
+        THEN traegt der Klartext-Teil zusaetzlich zur Beginn-Angabe sowohl
+        `Radar reicht bis HH:MM` als auch `Ortsangabe ab HH:MM unscharf`,
+        mit Werten, die aus den Frames HERGELEITET sind (Toleranz 1 Minute
+        Wanduhr-Versatz), nicht nur irgendein Format.
+
+        RED vor dem Fix: `_render_nowcast_replay` reichte `source_reach_*`/
+        `location_sharpness_*` nicht durch -- `getattr(..., default)` liess
+        beide Angaben ersatzlos entfallen."""
+        user_id, trip_id = stub_trip
+        request_now = datetime.now(timezone.utc)
+        body = {"nowcast_frames": {
+            "source": "radar", "frames": _block_mit_reichweite_frames(request_now),
+            "km_from": 2.0, "km_to": 6.0,
+        }}
+        resp = client.post(
+            f"/api/trips/{trip_id}/alert-preview",
+            params={"user_id": user_id}, json=body,
+        )
+        assert resp.status_code == 200, f"Body: {resp.text[:300]}"
+        data = resp.json()
+        assert data.get("onset_detected") is True, (
+            f"Voraussetzung: der Beginn bei +20 Min muss erkannt werden: {data!r}"
+        )
+        plain = data["email_plain"]
+
+        reach_treffer = re.search(r"Radar reicht bis (\d{2}:\d{2})", plain)
+        assert reach_treffer is not None, (
+            f"RED: der Replay-Weg nennt keine Reichweite: {plain!r}"
+        )
+        guete_treffer = re.search(r"Ortsangabe ab (\d{2}:\d{2}) unscharf", plain)
+        assert guete_treffer is not None, (
+            f"RED: der Replay-Weg nennt keine Guete-Zeile: {plain!r}"
+        )
+        # Wertkontrolle relativ statt absolut (Muster AC-6-Test oben, das die
+        # Trip-Zone dieses Fixture-Trips ebenfalls nicht kennt): die Guete-
+        # Grenzzeit muss NACH der Reichweite-unabhaengigen Beginn-Zeit liegen
+        # und darf nicht mit ihr identisch sein -- sonst waere hier nur ein
+        # zufaelliges HH:MM durchgereicht worden, keine echte Ableitung.
+        assert guete_treffer.group(1) != reach_treffer.group(1), (
+            f"Guete-Grenzzeit und Reichweite sind identisch -- vermutlich "
+            f"beide auf denselben (falschen) Platzhalter zurueckgefallen: "
+            f"{plain!r}"
+        )

--- a/tests/tdd/test_alert_preview_nowcast_replay.py
+++ b/tests/tdd/test_alert_preview_nowcast_replay.py
@@ -279,6 +279,16 @@ def _block_mit_reichweite_frames(now: datetime) -> list[dict]:
     return frames
 
 
+def _minuten(hhmm: str) -> int:
+    stunde, _, minute = hhmm.partition(":")
+    return int(stunde) * 60 + int(minute)
+
+
+def _abstand_minuten(a: str, b: str) -> int:
+    roh = abs(_minuten(a) - _minuten(b))
+    return min(roh, 24 * 60 - roh)
+
+
 class TestS3_ReichweiteUndGueteImReplay:
     def test_replay_pfad_zeigt_reichweite_und_guete_wie_der_live_pfad(
         self, client, stub_trip,
@@ -291,12 +301,20 @@ class TestS3_ReichweiteUndGueteImReplay:
         Alarm-Verhalten misst
         THEN traegt der Klartext-Teil zusaetzlich zur Beginn-Angabe sowohl
         `Radar reicht bis HH:MM` als auch `Ortsangabe ab HH:MM unscharf`,
-        mit Werten, die aus den Frames HERGELEITET sind (Toleranz 1 Minute
-        Wanduhr-Versatz), nicht nur irgendein Format.
+        JE MIT dem aus den Frames HERGELEITETEN Wert (Toleranz 1 Minute
+        Wanduhr-Versatz) -- nicht nur irgendeine HH:MM-Zeichenkette.
 
-        RED vor dem Fix: `_render_nowcast_replay` reichte `source_reach_*`/
-        `location_sharpness_*` nicht durch -- `getattr(..., default)` liess
-        beide Angaben ersatzlos entfallen."""
+        Adversary-Fund F004 (Adversary-Runde 3): eine reine Format- und
+        Verschiedenheits-Pruefung liess `"23:59"`/`"00:01"` unbemerkt durch.
+        Der Fixture-Trip hat keine Wegpunkte -- `_alert_tz_for_trip` faellt
+        deshalb auf UTC zurueck (kein Zonenumrechnungs-Risiko), die
+        erwarteten Werte werden direkt aus `request_now` + den bekannten
+        Minutenzahlen gebildet (Muster `test_2051s3_briefing_hinweis_
+        traegt_die_reichweite_ueber_den_echten_scheduler_pfad`, F003).
+
+        RED vor dem urspruenglichen Fix: `_render_nowcast_replay` reichte
+        `source_reach_*`/`location_sharpness_*` nicht durch -- `getattr(...,
+        default)` liess beide Angaben ersatzlos entfallen."""
         user_id, trip_id = stub_trip
         request_now = datetime.now(timezone.utc)
         body = {"nowcast_frames": {
@@ -322,13 +340,26 @@ class TestS3_ReichweiteUndGueteImReplay:
         assert guete_treffer is not None, (
             f"RED: der Replay-Weg nennt keine Guete-Zeile: {plain!r}"
         )
-        # Wertkontrolle relativ statt absolut (Muster AC-6-Test oben, das die
-        # Trip-Zone dieses Fixture-Trips ebenfalls nicht kennt): die Guete-
-        # Grenzzeit muss NACH der Reichweite-unabhaengigen Beginn-Zeit liegen
-        # und darf nicht mit ihr identisch sein -- sonst waere hier nur ein
-        # zufaelliges HH:MM durchgereicht worden, keine echte Ableitung.
-        assert guete_treffer.group(1) != reach_treffer.group(1), (
-            f"Guete-Grenzzeit und Reichweite sind identisch -- vermutlich "
-            f"beide auf denselben (falschen) Platzhalter zurueckgefallen: "
-            f"{plain!r}"
+
+        # F004: beide Werte einzeln gegen die aus den Frames hergeleitete
+        # Erwartung pruefen -- Reichweite = letzter Frame (+160) + 15 Min
+        # (_MAX_FRAME_COVERAGE) = 175 Min; Guete-Grenze = now + 60 Min
+        # (LOCATION_SHARPNESS_LIMIT_MIN). `_alert_tz_for_trip` liefert UTC
+        # fuer diesen wegpunktlosen Fixture-Trip, `request_now` ist bereits
+        # UTC -- keine Zonenumrechnung noetig.
+        erwartete_reichweite = (
+            (request_now + timedelta(minutes=175)).strftime("%H:%M")
+        )
+        erwartete_guete_grenze = (
+            (request_now + timedelta(minutes=60)).strftime("%H:%M")
+        )
+        assert _abstand_minuten(reach_treffer.group(1), erwartete_reichweite) <= 1, (
+            f"F004: die Reichweite {reach_treffer.group(1)!r} stammt nicht "
+            f"aus den injizierten Frames (erwartet nahe "
+            f"{erwartete_reichweite!r}): {plain!r}"
+        )
+        assert _abstand_minuten(guete_treffer.group(1), erwartete_guete_grenze) <= 1, (
+            f"F004: die Guete-Grenzzeit {guete_treffer.group(1)!r} stammt "
+            f"nicht aus der 60-Minuten-Grenze (erwartet nahe "
+            f"{erwartete_guete_grenze!r}): {plain!r}"
         )

--- a/tests/tdd/test_nowcast_ortsschaerfe_schwelle.py
+++ b/tests/tdd/test_nowcast_ortsschaerfe_schwelle.py
@@ -1,0 +1,236 @@
+"""TDD RED — Issue #2051 S3: die Guete-Kennzeichnung ("Ortsangabe ab HH:MM
+unscharf") und ihre Ausloesebedingung.
+
+SPEC: docs/specs/modules/feat_2051_s3_reichweite_und_guete.md — AC-4, AC-5,
+AC-6, AC-7.
+
+Fachlicher Kern (E2/E4): die Guete ist eine Zeitschwelle, kein
+Quellen-Merkmal. `LOCATION_SHARPNESS_LIMIT_MIN = 60` -- die Guete-Zeile
+erscheint, wenn MINDESTENS EINE der im Text genannten Ereigniszeiten (Beginn
+ODER Ende) jenseits von `now + LOCATION_SHARPNESS_LIMIT_MIN` liegt. Genannt
+wird die GRENZZEIT selbst (`now + 60 Min`), nicht welcher Wert betroffen ist.
+
+Vier Zusicherungen:
+  * AC-4 -- Beginn 75 Min (jenseits): die Guete-Zeile erscheint in allen
+    sechs Textstellen, mit der Grenzzeit `now + 60 Min`.
+  * AC-5 -- Beginn 20 Min (diesseits, alarmfaehig), Ende 150 Min (jenseits):
+    die Guete-Zeile erscheint TROTZDEM, obwohl der Alarm-Pfad den Beginn
+    selbst nie ueber 55 Min Vorlauf hinaus ausloest (B3/E4).
+  * AC-6 -- Positivkontrolle: derselbe Aufbau erzeugt bei 50 Min KEINE und
+    bei 90 Min EINE Guete-Zeile, in EINEM Test.
+  * AC-7 -- die Zone zwischen den Raendern: 45/59 Min (diesseits) vs. 61/75
+    Min (jenseits), parametrisiert.
+
+RED heute: `NowcastResult` kennt `event_end_minutes` bereits (S1), aber
+`OnsetEvent`/die Renderer kennen die Guete-Suffixe nicht -- die erwarteten
+Substrings fehlen ersatzlos im gerenderten Text.
+
+Mock-frei: echte `NowcastResult`/`OnsetEvent`-Objekte durch die echten
+Projektions- und Renderfunktionen. Die Uhr steht per `freeze_time`.
+"""
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import pytest
+from freezegun import freeze_time
+
+from output.renderers.alert.project import to_multi_location_onset_alert_message
+from output.renderers.alert.render import render_email, render_subject, render_telegram
+from output.renderers.email.starkregen_hint import format_starkregen_hint
+from services.radar_cache import RadarNowcastCacheService
+from services.radar_service import NowcastResult, RadarNowcastService
+
+# 18:00 Ortszeit Wien (= 16:00 UTC im Sommer). Guete-Grenzzeit now + 60 Min
+# = 19:00 lokal -- UNABHAENGIG vom konkret betroffenen Ereigniswert.
+_TZ = ZoneInfo("Europe/Vienna")
+_FROZEN_UTC = "2026-08-21 16:00:00+00:00"
+_GUETE_HHMM = "19:00"
+
+
+def _nowcast(**kw) -> NowcastResult:
+    fields = dict(
+        onset_minutes=30, intensity_label="Mäßiger Regen", source="radar",
+        is_convective=False,
+    )
+    fields.update(kw)
+    return NowcastResult(**fields)
+
+
+def _texte(nc: NowcastResult) -> dict[str, str]:
+    """Die sechs Textstellen fuer EIN NowcastResult (Einzel-Ort-Pfad),
+    Muster `test_nowcast_source_reach_textstellen.py`."""
+    einzel = to_multi_location_onset_alert_message(
+        [("Sillian", nc)], tz=_TZ, stand_at="17:55",
+    )
+    buendel = to_multi_location_onset_alert_message(
+        [("Sillian", nc), ("Obertilliach", nc)], tz=_TZ, stand_at="17:55",
+    )
+    _html, plain_einzel = render_email(einzel)
+    _html_buendel, plain_buendel = render_email(buendel)
+    svc = RadarNowcastService(cache=RadarNowcastCacheService())
+    return {
+        "email_betreff": render_subject(einzel),
+        "email_trip_plain": plain_einzel,
+        "email_mehr_orte": plain_buendel,
+        "telegram_rich": render_telegram(einzel),
+        "briefing_hinweis": format_starkregen_hint(
+            nc.intensity_label, nc.onset_minutes, tz=_TZ,
+            event_end_minutes=nc.event_end_minutes,
+            event_ongoing_beyond_horizon=nc.event_ongoing_beyond_horizon,
+            source_reach_minutes=nc.source_reach_minutes,
+        ),
+        "kommando_antwort": svc.format_now_text(nc, tz=_TZ, include_source=False),
+    }
+
+
+def _befund(treffer: dict[str, str]) -> str:
+    return "; ".join(f"{name}={text[:160]!r}" for name, text in sorted(treffer.items()))
+
+
+def test_prueling_stammt_aus_diesem_arbeitsbaum():
+    """Vorbedingung (kein AC): Projektion, Renderer, Briefing-Hinweis und
+    Nowcast-Dienst werden RELATIV ZU DIESER Testdatei aufgeloest."""
+    from output.renderers.alert import project as project_module
+    from output.renderers.alert import render as render_module
+    from output.renderers.email import starkregen_hint as hint_module
+    from services import radar_service as radar_module
+
+    arbeitsbaum = Path(__file__).resolve().parents[2]
+    for modul in (project_module, render_module, hint_module, radar_module):
+        modul_pfad = Path(inspect.getfile(modul)).resolve()
+        assert modul_pfad.is_relative_to(arbeitsbaum), (
+            f"Prueling stammt nicht aus diesem Arbeitsbaum: {modul_pfad}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-4 -- Beginn jenseits der Grenze: alle sechs Stellen tragen die Zeile
+# ---------------------------------------------------------------------------
+
+
+@freeze_time(_FROZEN_UTC)
+def test_ac4_beginn_jenseits_der_grenze_erzeugt_die_guete_zeile_ueberall():
+    """AC-4 GIVEN einen Onset-Alarm mit Beginn 75 Minuten in der Zukunft
+    (jenseits der 60-Minuten-Guete-Grenze) und einem Ende innerhalb der
+    Grenze
+    WHEN die Texte gerendert werden
+    THEN erscheint in JEDER der sechs Textstellen zusaetzlich
+    `Ortsangabe ab 19:00 unscharf`, mit `19:00` = `now + 60 Min`.
+
+    RED heute: keine der sechs Stellen kennt die Guete-Suffixe."""
+    nc = _nowcast(onset_minutes=75, event_end_minutes=30)
+    texte = _texte(nc)
+
+    ohne_guete = {
+        name: text for name, text in texte.items()
+        if f"Ortsangabe ab {_GUETE_HHMM} unscharf" not in text
+    }
+    assert not ohne_guete, (
+        f"RED: diese Stellen tragen die Guete-Zeile nicht: {_befund(ohne_guete)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-5 -- der Alarm-Pfad-Fall: Ende jenseits der Grenze, Beginn diesseits
+# ---------------------------------------------------------------------------
+
+
+@freeze_time(_FROZEN_UTC)
+def test_ac5_guete_zeile_erscheint_auch_wenn_nur_das_ende_jenseits_liegt():
+    """AC-5 GIVEN einen Onset-Alarm mit Beginn 20 Minuten in der Zukunft
+    (diesseits der Grenze, alarmfaehig unter `RADAR_ONSET_THRESHOLD_MIN`)
+    und einem Ende 150 Minuten in der Zukunft (jenseits der Grenze)
+    WHEN die Texte gerendert werden
+    THEN erscheint die Guete-Zeile TROTZDEM, mit der Grenzzeit `19:00`
+    (`now + 60 Min`) -- NICHT mit dem Beginn (20 Min) oder dem Ende (150
+    Min) selbst.
+
+    Genau der Fall aus B3/E4: der Alarm-Pfad selbst loest den Beginn nie
+    ueber 55 Minuten Vorlauf hinaus aus und wuerde diese Guete-Zeile sonst
+    stumm lassen.
+
+    RED heute: keine Stelle kennt die Guete-Suffixe."""
+    nc = _nowcast(onset_minutes=20, event_end_minutes=150)
+    text = _texte(nc)["email_trip_plain"]
+
+    assert f"Ortsangabe ab {_GUETE_HHMM} unscharf" in text, (
+        f"RED: die Guete-Zeile fehlt, obwohl nur das ENDE jenseits der "
+        f"Grenze liegt: {text!r}"
+    )
+    assert "Ortsangabe ab 18:20" not in text, (
+        f"Die Guete-Zeile darf nicht den Beginn (20 Min) nennen: {text!r}"
+    )
+    assert "Ortsangabe ab 20:30" not in text, (
+        f"Die Guete-Zeile darf nicht das Ende (150 Min) nennen, sondern "
+        f"ausschliesslich die Grenzzeit: {text!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-6 -- Positivkontrolle: derselbe Aufbau, ein verschobener Wert
+# ---------------------------------------------------------------------------
+
+
+@freeze_time(_FROZEN_UTC)
+def test_ac6_positivkontrolle_50_minuten_ohne_90_minuten_mit_guete_zeile():
+    """AC-6 GIVEN zwei Onset-Alarme mit identischem Aufbau bis auf die
+    betroffene Ereigniszeit -- einmal 50 Minuten (diesseits), einmal 90
+    Minuten (jenseits der 60-Minuten-Grenze)
+    WHEN die Texte gerendert werden
+    THEN fehlt die Guete-Zeile beim 50-Minuten-Fall VOLLSTAENDIG UND
+    derselbe Testaufbau erzeugt die Guete-Zeile, sobald ausschliesslich die
+    betroffene Zeit auf 90 Minuten verschoben wird -- dieselbe Konstruktion,
+    ein verschobener Wert, gegensaetzliches Ergebnis, in EINEM Test.
+
+    RED heute: keine Stelle kennt die Guete-Suffixe -- der 90-Minuten-Fall
+    bleibt ohne Zeile."""
+    diesseits = _texte(_nowcast(onset_minutes=50))["email_trip_plain"]
+    jenseits = _texte(_nowcast(onset_minutes=90))["email_trip_plain"]
+
+    assert "Ortsangabe ab" not in diesseits, (
+        f"Bei 50 Minuten (diesseits der Grenze) darf keine Guete-Zeile "
+        f"entstehen: {diesseits!r}"
+    )
+    assert f"Ortsangabe ab {_GUETE_HHMM} unscharf" in jenseits, (
+        f"RED: bei 90 Minuten (jenseits der Grenze) muss dieselbe "
+        f"Konstruktion die Guete-Zeile erzeugen: {jenseits!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-7 -- die Zone ZWISCHEN den Raendern (Lehre aus S1 -> #2075)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "minuten,erwartet_guete",
+    [
+        (45, False),  # deutlich diesseits
+        (59, False),  # knapp diesseits
+        (61, True),   # knapp jenseits
+        (75, True),   # deutlich jenseits
+    ],
+)
+@freeze_time(_FROZEN_UTC)
+def test_ac7_guete_zeile_kippt_zwischen_59_und_61_minuten(minuten, erwartet_guete):
+    """AC-7 GIVEN vier Faelle mit der betroffenen Ereigniszeit bei genau 45,
+    59, 61 und 75 Minuten -- zwei knapp diesseits, zwei knapp jenseits der
+    60-Minuten-Grenze (die Zone ZWISCHEN den Raendern aus S1, Lehre aus
+    #2075: zwei ACs pruefen dort nur die blossen Raender 0/180 bzw. exakt
+    60 und lassen die Zone dazwischen ungeprueft)
+    WHEN die Guete-Zeile fuer jeden Fall geprueft wird
+    THEN fehlt sie bei 45 und 59 Minuten und erscheint bei 61 und 75
+    Minuten.
+
+    RED heute: keine Stelle kennt die Guete-Suffixe -- 61 und 75 bleiben
+    ohne Zeile."""
+    text = _texte(_nowcast(onset_minutes=minuten))["email_trip_plain"]
+
+    guete_vorhanden = "Ortsangabe ab" in text
+    assert guete_vorhanden == erwartet_guete, (
+        f"RED/Zone: bei {minuten} Minuten erwartet Guete-Zeile="
+        f"{erwartet_guete}, tatsaechlich {guete_vorhanden}: {text!r}"
+    )

--- a/tests/tdd/test_nowcast_ortsschaerfe_wortlaut.py
+++ b/tests/tdd/test_nowcast_ortsschaerfe_wortlaut.py
@@ -1,0 +1,79 @@
+"""TDD RED — Issue #2051 S3: Wortlaut der Guete-Zeile — "unscharf", niemals
+"extrapoliert".
+
+SPEC: docs/specs/modules/feat_2051_s3_reichweite_und_guete.md — AC-8.
+
+Fachlicher Kern (E2/E3): die GeoSphere-INCA-Quelle extrapoliert das GESAMTE
+abgerufene Fenster -- es gibt keinen gemessenen Teil, von dem sich ein
+"ab hier extrapoliert" sinnvoll abgrenzen liesse. Das Wort "extrapoliert"
+waere deshalb sachlich falsch: es suggeriert eine Grenze in den Daten, die
+es nicht gibt. Der PO-Vorschlag "davon ab 14:40 extrapoliert" wurde deshalb
+zu "Ortsangabe ab HH:MM unscharf" praezisiert.
+
+RED heute: keine Renderer-Stelle kennt die Guete-Suffixe -- das Wort
+"unscharf" fehlt ersatzlos.
+
+Mock-frei: echte `NowcastResult`/`OnsetEvent`-Objekte durch die echten
+Projektions- und Renderfunktionen. Die Uhr steht per `freeze_time`.
+"""
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+from freezegun import freeze_time
+
+from output.renderers.alert.project import to_multi_location_onset_alert_message
+from output.renderers.alert.render import render_email, render_subject, render_telegram
+from services.radar_service import NowcastResult
+
+_TZ = ZoneInfo("Europe/Vienna")
+_FROZEN_UTC = "2026-08-21 16:00:00+00:00"
+
+
+def test_prueling_stammt_aus_diesem_arbeitsbaum():
+    """Vorbedingung (kein AC): Projektion und Renderer werden RELATIV ZU
+    DIESER Testdatei aufgeloest."""
+    from output.renderers.alert import project as project_module
+    from output.renderers.alert import render as render_module
+
+    arbeitsbaum = Path(__file__).resolve().parents[2]
+    for modul in (project_module, render_module):
+        modul_pfad = Path(inspect.getfile(modul)).resolve()
+        assert modul_pfad.is_relative_to(arbeitsbaum), (
+            f"Prueling stammt nicht aus diesem Arbeitsbaum: {modul_pfad}"
+        )
+
+
+@freeze_time(_FROZEN_UTC)
+def test_ac8_guete_zeile_sagt_unscharf_niemals_extrapoliert():
+    """AC-8 GIVEN einen Fall mit gesetzter Guete-Zeile (Beginn 75 Minuten in
+    der Zukunft, jenseits der 60-Minuten-Grenze -- Aufbau wie AC-4)
+    WHEN der gerenderte Text auf sein Vokabular geprueft wird
+    THEN enthaelt er das Wort "unscharf", NIEMALS das Wort "extrapoliert" --
+    letzteres suggeriert faelschlich einen gemessenen Teil, den die
+    INCA-Quelle nicht liefert (E2/E3).
+
+    RED heute: die Guete-Zeile fehlt komplett -- weder "unscharf" noch
+    "extrapoliert" stehen im Text, die Positivkontrolle ("unscharf" IST da)
+    schlaegt fehl."""
+    nc = NowcastResult(
+        onset_minutes=75, intensity_label="Mäßiger Regen", source="radar",
+        is_convective=False, event_end_minutes=30,
+    )
+    msg = to_multi_location_onset_alert_message(
+        [("Sillian", nc)], tz=_TZ, stand_at="17:55",
+    )
+    _html, plain = render_email(msg)
+    betreff = render_subject(msg)
+    telegram = render_telegram(msg)
+
+    for name, text in (("email", plain), ("betreff", betreff), ("telegram", telegram)):
+        assert "unscharf" in text, (
+            f"RED: das Wort 'unscharf' fehlt in {name}: {text!r}"
+        )
+        assert "extrapoliert" not in text, (
+            f"Das Wort 'extrapoliert' darf NIEMALS im Text stehen (E2/E3), "
+            f"gefunden in {name}: {text!r}"
+        )

--- a/tests/tdd/test_nowcast_source_reach_ableitung.py
+++ b/tests/tdd/test_nowcast_source_reach_ableitung.py
@@ -1,0 +1,182 @@
+"""TDD RED — Issue #2051 S3: Reichweite der Quelle (`source_reach_minutes`).
+
+SPEC: docs/specs/modules/feat_2051_s3_reichweite_und_guete.md — AC-1, AC-2.
+
+Fachlicher Kern: `_derive_result` kennt seit S1 Beginn und Ende eines nassen
+Blocks, aber nicht, WIE WEIT die Quelle selbst geliefert hat. Das neue Feld
+`source_reach_minutes` beantwortet das unabhaengig vom Regen-Zustand -- ein
+durchgehend TROCKENES Fenster hat trotzdem eine Reichweite.
+
+Zwei Zusicherungen dieser Datei:
+  * AC-1 -- eine luecklose Deckung ueber das gesamte 180-Minuten-Fenster
+    liefert `source_reach_minutes == 180`, gedeckelt am Horizont.
+  * AC-2 -- eine nach Minute 40 abbrechende, komplett TROCKENE Zeitreihe
+    liefert eine deutlich kleinere Reichweite (nahe 40 + `_MAX_FRAME_COVERAGE`
+    = 55), waehrend `onset_minutes`/`event_end_minutes` unveraendert `None`
+    bleiben -- die Reichweite bewegt sich unabhaengig vom Regen-Zustand, kein
+    gemeinsamer Waechter verschiebt beide zugleich.
+
+RED heute: `NowcastResult` kennt das additive Feld `source_reach_minutes`
+noch nicht -> `AttributeError` beim Zugriff auf das Ergebnis (Dataclass ohne
+dieses Feld).
+
+Mock-frei: echte `RadarFrame`-Objekte durch das echte `_derive_result`, die
+Uhr ist ueber `now=` FEST injiziert (keine Wanduhr). Eigener Cache je Service
+(`cache=RadarNowcastCacheService()`), damit kein prozessweit geteilter
+Zustand zwischen den Faellen wirkt.
+"""
+from __future__ import annotations
+
+import inspect
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from providers.brightsky import RadarFrame
+from services.radar_cache import RadarNowcastCacheService
+from services.radar_service import RadarNowcastService
+
+# Fester Bezugszeitpunkt aller Faelle -- keine Wanduhr.
+_NOW = datetime(2026, 8, 21, 12, 0, tzinfo=timezone.utc)
+
+
+def _frames(raster: dict[int, float]) -> list[RadarFrame]:
+    """`{Minutenversatz ab _NOW: Rate mm/h}` -> echte `RadarFrame`-Liste."""
+    return [
+        RadarFrame(timestamp=_NOW + timedelta(minutes=minute), precip_mm_h=rate)
+        for minute, rate in sorted(raster.items())
+    ]
+
+
+def _result(raster: dict[int, float]):
+    """Echtes `_derive_result` mit fest injizierter Uhr."""
+    svc = RadarNowcastService(cache=RadarNowcastCacheService())
+    return svc._derive_result(_frames(raster), "radar", now=_NOW)
+
+
+def test_prueling_stammt_aus_diesem_arbeitsbaum():
+    """Vorbedingung (kein AC): der gepruefte Nowcast-Dienst wird RELATIV ZU
+    DIESER Testdatei aufgeloest -- sonst pruefte ein Worktree-Lauf still die
+    Datei des Hauptrepos und lieferte falsches Gruen."""
+    from services import radar_service as radar_module
+
+    modul_pfad = Path(inspect.getfile(radar_module)).resolve()
+    arbeitsbaum = Path(__file__).resolve().parents[2]
+    assert modul_pfad.is_relative_to(arbeitsbaum), (
+        f"Prueling stammt nicht aus diesem Arbeitsbaum: {modul_pfad}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-1 -- luecklose Deckung ueber das gesamte Fenster -> voller Horizont
+# ---------------------------------------------------------------------------
+
+
+def _volle_deckung_nass() -> dict[int, float]:
+    """15-Minuten-Raster, durchgehend nass (1.0 mm/h), von Minute 15 bis
+    Minute 180 -- keine Luecke, kein Trockenuebergang."""
+    return {m: 1.0 for m in range(15, 181, 15)}
+
+
+def test_ac1_luecklose_deckung_liefert_den_vollen_horizont():
+    """AC-1 GIVEN eine Frame-Zeitreihe, die das gesamte 180-Minuten-Fenster
+    durchgehend abdeckt (Raster 15 Min, kein Trockenuebergang, keine Luecke)
+    WHEN `_derive_result` `source_reach_minutes` ableitet
+    THEN entspricht `source_reach_minutes` dem vollen Horizont (180),
+    gedeckelt und nicht darueber hinaus.
+
+    RED heute: `NowcastResult` kennt `source_reach_minutes` nicht
+    (`AttributeError`)."""
+    result = _result(_volle_deckung_nass())
+
+    assert result.source_reach_minutes == 180, (
+        f"RED: bei lueckloser Deckung ueber das gesamte Fenster muss die "
+        f"Reichweite dem vollen Horizont (180) entsprechen, bekam "
+        f"{result.source_reach_minutes!r}"
+    )
+
+
+def test_ac1_reichweite_uebersteigt_niemals_den_horizont():
+    """AC-1 (Deckelung) GIVEN dieselbe luecklose Zeitreihe, deren letzter
+    Frame GENAU auf dem Horizont liegt (Minute 180)
+    WHEN die Reichweite abgeleitet wird
+    THEN bleibt sie exakt auf 180 gedeckelt -- ein Frame am Horizont darf die
+    Reichweite nicht ueber den Pruefhorizont hinaustragen (die Formel
+    `min(next_ts_full, ts + _MAX_FRAME_COVERAGE, horizon)` deckelt hart auf
+    `horizon`).
+
+    RED heute: `NowcastResult` kennt `source_reach_minutes` nicht."""
+    result = _result(_volle_deckung_nass())
+
+    assert result.source_reach_minutes <= 180, (
+        f"Die Reichweite darf den 180-Minuten-Horizont nicht ueberschreiten: "
+        f"{result.source_reach_minutes!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-2 -- abbrechende, komplett trockene Zeitreihe: Reichweite unabhaengig
+# vom Regen-Zustand
+# ---------------------------------------------------------------------------
+
+
+def _abbrechende_trockene_reihe() -> dict[int, float]:
+    """10-Minuten-Raster, komplett TROCKEN (0.0 mm/h), bricht nach Minute 40
+    ab -- keine weiteren Frames bis zum Horizont."""
+    return {m: 0.0 for m in range(0, 41, 10)}
+
+
+def test_ac2_abbruch_nach_minute_40_liefert_reichweite_nahe_55():
+    """AC-2 GIVEN eine Frame-Zeitreihe, die nach Minute 40 abbricht (keine
+    weiteren Frames bis zum Horizont), waehrend zugleich KEIN nasser Block
+    vorliegt (komplett trocken)
+    WHEN `_derive_result` `source_reach_minutes` ableitet
+    THEN ist `source_reach_minutes` deutlich kleiner als der Horizont (nahe
+    Minute 40 + `_MAX_FRAME_COVERAGE` = 55) -- der letzte Frame (Minute 40)
+    hat keinen Nachbarn mehr, seine Deckung reicht bis 40 + 15 = 55, gedeckelt
+    am Horizont (hier irrelevant, 55 < 180).
+
+    RED heute: `NowcastResult` kennt `source_reach_minutes` nicht."""
+    result = _result(_abbrechende_trockene_reihe())
+
+    assert result.source_reach_minutes == 55, (
+        f"RED: nach Abbruch bei Minute 40 muss die Reichweite bei "
+        f"40 + _MAX_FRAME_COVERAGE (15) = 55 liegen, bekam "
+        f"{result.source_reach_minutes!r}"
+    )
+    assert result.source_reach_minutes < 180, (
+        "Die abgebrochene Reichweite darf nicht auf den vollen Horizont "
+        f"zurueckfallen: {result.source_reach_minutes!r}"
+    )
+
+
+def test_ac2_reichweite_bewegt_sich_unabhaengig_vom_regen_zustand():
+    """AC-2 (Kernaussage) GIVEN dieselbe abbrechende, komplett trockene
+    Zeitreihe
+    WHEN `_derive_result` gleichzeitig `source_reach_minutes` UND
+    `onset_minutes`/`event_end_minutes` ableitet
+    THEN bleiben `onset_minutes` und `event_end_minutes` unveraendert `None`
+    (kein nasser Frame im Fenster), waehrend `source_reach_minutes` einen
+    konkreten, von 180 verschiedenen Wert traegt -- ein durchgehend
+    trockenes Fenster hat trotzdem eine Reichweite, kein gemeinsamer
+    Waechter verschiebt beide Groessen zugleich.
+
+    RED heute: `NowcastResult` kennt `source_reach_minutes` nicht."""
+    result = _result(_abbrechende_trockene_reihe())
+
+    assert result.onset_minutes is None, (
+        f"Vorbedingung verletzt: kein Beginn erwartet, bekam "
+        f"{result.onset_minutes!r}"
+    )
+    assert result.event_end_minutes is None, (
+        f"Vorbedingung verletzt: kein Ende erwartet, bekam "
+        f"{result.event_end_minutes!r}"
+    )
+    assert result.source_reach_minutes is not None, (
+        "RED: ein durchgehend trockenes Fenster muss trotzdem eine "
+        "Reichweite tragen -- 'kein Regen' darf nicht mit 'keine "
+        "Beobachtung' verwechselt werden."
+    )
+    assert result.source_reach_minutes == 55, (
+        f"Die Reichweite muss unabhaengig vom fehlenden Regen bei 55 liegen: "
+        f"{result.source_reach_minutes!r}"
+    )

--- a/tests/tdd/test_nowcast_source_reach_textstellen.py
+++ b/tests/tdd/test_nowcast_source_reach_textstellen.py
@@ -157,29 +157,33 @@ def test_ac3_reichweite_erscheint_in_allen_sechs_textstellen():
 
 @freeze_time(_FROZEN_UTC)
 def test_ac9_untergrenzenform_unterdrueckt_die_reichweite_vollstaendig():
-    """AC-9 GIVEN einen Onset-Alarm mit `event_ongoing_beyond_horizon=True`
-    (S1-Untergrenzenform, `Regen mindestens bis HH:MM`) und einer im
-    uebrigen gesetzten Reichweite
-    WHEN die sechs betroffenen Textstellen gerendert werden
-    THEN enthaelt JEDE die S1-Untergrenzenform `Regen mindestens bis 19:30`,
-    aber KEINE zusaetzlich `Radar reicht bis` -- die Untergrenzenform traegt
-    die Reichweiten-Aussage bereits implizit (E5).
-
-    Die Positivkontrolle (Untergrenzenform IST da) steht im selben Test wie
-    die Negativpruefung (Reichweite fehlt) -- sonst waere Letzteres trivial
-    wahr, weil der heutige Code auch die Reichweite selbst noch gar nicht
-    kennt.
+    """AC-9 GIVEN denselben Aufbau EINMAL mit `event_ongoing_beyond_horizon
+    =True` (S1-Untergrenzenform, `Regen mindestens bis HH:MM`) und EINMAL mit
+    `False` -- sonst identisch (gleiches `event_end_minutes`, gleiche
+    `source_reach_minutes`), nur der EINE Waechter verschoben
+    WHEN die sechs betroffenen Textstellen fuer BEIDE Faelle gerendert
+    werden
+    THEN fehlt `Radar reicht bis` bei `True` VOLLSTAENDIG (die
+    Untergrenzenform traegt die Reichweiten-Aussage bereits implizit, E5)
+    UND derselbe Aufbau erzeugt `Radar reicht bis 20:00` bei `False` in
+    JEDER der sechs Stellen -- Positivkontrolle: erst das Paar beweist, dass
+    die Unterdrueckung aus E5 tatsaechlich WIRKT und nicht bloss nichts
+    verdrahtet ist (Muster AC-6, Lehre aus #2075-Fehlklassifikation ohne
+    Gegenprobe).
 
     RED heute: `NowcastResult` kennt `source_reach_minutes` nicht
     (`TypeError`)."""
-    nc = _nowcast(
+    waechter_gesetzt = _texte(_nowcast(
         event_end_minutes=_ENDE_MIN, event_ongoing_beyond_horizon=True,
         source_reach_minutes=_REACH_MIN,
-    )
-    texte = _texte(nc)
+    ))
+    waechter_nicht_gesetzt = _texte(_nowcast(
+        event_end_minutes=_ENDE_MIN, event_ongoing_beyond_horizon=False,
+        source_reach_minutes=_REACH_MIN,
+    ))
 
     ohne_untergrenze = {
-        name: text for name, text in texte.items()
+        name: text for name, text in waechter_gesetzt.items()
         if f"Regen mindestens bis {_ENDE_HHMM}" not in text
     }
     assert not ohne_untergrenze, (
@@ -187,13 +191,26 @@ def test_ac9_untergrenzenform_unterdrueckt_die_reichweite_vollstaendig():
         f"{_befund(ohne_untergrenze)}"
     )
 
-    mit_reichweite = {
-        name: text for name, text in texte.items() if "Radar reicht bis" in text
+    mit_reichweite_trotz_waechter = {
+        name: text for name, text in waechter_gesetzt.items()
+        if "Radar reicht bis" in text
     }
-    assert not mit_reichweite, (
+    assert not mit_reichweite_trotz_waechter, (
         f"RED/E5: diese Stellen zeigen die Reichweite trotz gesetztem "
         f"R4-Waechter -- Dopplung mit der Untergrenzenform: "
-        f"{_befund(mit_reichweite)}"
+        f"{_befund(mit_reichweite_trotz_waechter)}"
+    )
+
+    ohne_reichweite_ohne_waechter = {
+        name: text for name, text in waechter_nicht_gesetzt.items()
+        if f"Radar reicht bis {_REACH_HHMM}" not in text
+    }
+    assert not ohne_reichweite_ohne_waechter, (
+        f"Positivkontrolle: derselbe Aufbau MUSS die Reichweite zeigen, "
+        f"sobald ausschliesslich der R4-Waechter auf False steht -- sonst "
+        f"beweist die Negativpruefung oben nur eine ueberhaupt nicht "
+        f"existierende Angabe, keine echte Unterdrueckung: "
+        f"{_befund(ohne_reichweite_ohne_waechter)}"
     )
 
 
@@ -204,37 +221,61 @@ def test_ac9_untergrenzenform_unterdrueckt_die_reichweite_vollstaendig():
 
 @freeze_time(_FROZEN_UTC)
 def test_ac10_guete_zeile_bleibt_trotz_e5_unterdrueckung_unveraendert():
-    """AC-10 GIVEN denselben Aufbau wie AC-9 (`event_ongoing_beyond_horizon
-    =True`) mit zusaetzlich einem Beginn jenseits der Guete-Grenze
-    (`onset_minutes=75`)
-    WHEN die Texte gerendert werden
-    THEN erscheint die Guete-Zeile `Ortsangabe ab 19:00 unscharf`
-    UNVERAENDERT in allen sechs Stellen, WAEHREND `Radar reicht bis`
-    weiterhin VOLLSTAENDIG fehlt -- die E5-Unterdrueckung betrifft
-    ausschliesslich die Reichweiten-Angabe, beide Entscheidungen bleiben
-    unabhaengig voneinander.
+    """AC-10 GIVEN denselben Aufbau wie AC-9 (Beginn jenseits der
+    Guete-Grenze, `onset_minutes=75`), EINMAL mit `event_ongoing_beyond_
+    horizon=True` und EINMAL mit `False` -- sonst identisch
+    WHEN die Texte fuer BEIDE Faelle gerendert werden
+    THEN erscheint die Guete-Zeile `Ortsangabe ab 19:00 unscharf` in BEIDEN
+    Faellen UNVERAENDERT (der Beginn ist in beiden Faellen derselbe, die
+    Guete-Entscheidung haengt nicht am R4-Waechter), WAEHREND `Radar reicht
+    bis` NUR bei `True` fehlt und bei `False` (Positivkontrolle) erscheint
+    -- die E5-Unterdrueckung betrifft ausschliesslich die
+    Reichweiten-Angabe, beide Entscheidungen bleiben unabhaengig
+    voneinander.
 
     RED heute: `NowcastResult` kennt `source_reach_minutes` nicht
     (`TypeError`)."""
-    nc = _nowcast(
+    waechter_gesetzt = _texte(_nowcast(
         onset_minutes=_ONSET_JENSEITS_GUETE,
         event_end_minutes=_ENDE_MIN, event_ongoing_beyond_horizon=True,
         source_reach_minutes=_REACH_MIN,
-    )
-    texte = _texte(nc)
+    ))
+    waechter_nicht_gesetzt = _texte(_nowcast(
+        onset_minutes=_ONSET_JENSEITS_GUETE,
+        event_end_minutes=_ENDE_MIN, event_ongoing_beyond_horizon=False,
+        source_reach_minutes=_REACH_MIN,
+    ))
 
-    ohne_guete = {
-        name: text for name, text in texte.items()
-        if f"Ortsangabe ab {_GUETE_HHMM} unscharf" not in text
-    }
-    assert not ohne_guete, (
-        f"RED: diese Stellen tragen die Guete-Zeile nicht: {_befund(ohne_guete)}"
-    )
+    for label, texte in (
+        ("Waechter=True", waechter_gesetzt), ("Waechter=False", waechter_nicht_gesetzt),
+    ):
+        ohne_guete = {
+            name: text for name, text in texte.items()
+            if f"Ortsangabe ab {_GUETE_HHMM} unscharf" not in text
+        }
+        assert not ohne_guete, (
+            f"RED ({label}): diese Stellen tragen die Guete-Zeile nicht -- "
+            f"sie muss unabhaengig vom R4-Waechter stehen: {_befund(ohne_guete)}"
+        )
 
-    mit_reichweite = {
-        name: text for name, text in texte.items() if "Radar reicht bis" in text
+    mit_reichweite_trotz_waechter = {
+        name: text for name, text in waechter_gesetzt.items()
+        if "Radar reicht bis" in text
     }
-    assert not mit_reichweite, (
+    assert not mit_reichweite_trotz_waechter, (
         f"Die Reichweite darf trotz Guete-Fall weiter unterdrueckt bleiben "
-        f"(E5, unabhaengig von der Guete-Entscheidung): {_befund(mit_reichweite)}"
+        f"(E5, unabhaengig von der Guete-Entscheidung): "
+        f"{_befund(mit_reichweite_trotz_waechter)}"
+    )
+
+    ohne_reichweite_ohne_waechter = {
+        name: text for name, text in waechter_nicht_gesetzt.items()
+        if f"Radar reicht bis {_REACH_HHMM}" not in text
+    }
+    assert not ohne_reichweite_ohne_waechter, (
+        f"Positivkontrolle: derselbe Aufbau (inkl. Guete-Fall) MUSS die "
+        f"Reichweite zeigen, sobald ausschliesslich der R4-Waechter auf "
+        f"False steht -- sonst beweist die Negativpruefung oben nur eine "
+        f"ueberhaupt nicht existierende Angabe: "
+        f"{_befund(ohne_reichweite_ohne_waechter)}"
     )

--- a/tests/tdd/test_nowcast_source_reach_textstellen.py
+++ b/tests/tdd/test_nowcast_source_reach_textstellen.py
@@ -1,0 +1,240 @@
+"""TDD RED — Issue #2051 S3: die Reichweiten-Angabe ("Radar reicht bis
+HH:MM") in den sechs Langform-/Briefing-/Kommando-Textstellen.
+
+SPEC: docs/specs/modules/feat_2051_s3_reichweite_und_guete.md — AC-3, AC-9,
+AC-10.
+
+Fachlicher Kern: `NowcastResult.source_reach_minutes` (S3) traegt, wie weit
+die Quelle tatsaechlich geliefert hat. Additiv durchgereicht ueber die
+geteilte Anzeigefassung `source_reach_display` (Muster `event_end_display`,
+S1) bis in die sechs Textstellen:
+
+  1. E-Mail-Betreff (`_render_subject_onset`)
+  2. E-Mail Trip, Klartext (`_render_email_onset`)
+  3. E-Mail Mehr-Orte-Buendel (`_render_email_onset_multi`)
+  4. Telegram rich (`_render_telegram_onset`)
+  5. Briefing-Kurzfristhinweis (`format_starkregen_hint`)
+  6. Kommando-Antwort (`RadarNowcastService.format_now_text`)
+
+Drei Zusicherungen:
+  * AC-3 -- mit gesetzter Reichweite und OHNE den R4-Waechter
+    (`event_ongoing_beyond_horizon=False`) tragen alle sechs Stellen
+    zusaetzlich `Radar reicht bis HH:MM`.
+  * AC-9 -- mit gesetztem R4-Waechter (S1-Untergrenzenform, `Regen
+    mindestens bis HH:MM`) entfaellt die Reichweiten-Angabe VOLLSTAENDIG
+    (E5): die Untergrenzenform traegt die Reichweiten-Aussage bereits
+    implizit.
+  * AC-10 -- derselbe Waechterfall wie AC-9, zusaetzlich mit einem Beginn
+    jenseits der Guete-Grenze: die Guete-Zeile erscheint UNVERAENDERT, die
+    E5-Unterdrueckung betrifft ausschliesslich die Reichweiten-Angabe.
+
+RED heute: `NowcastResult` kennt `source_reach_minutes` nicht ->
+`TypeError` bereits bei der Konstruktion.
+
+Mock-frei: echte `NowcastResult`/`OnsetEvent`-Objekte durch die echten
+Projektions- und Renderfunktionen. Die Uhr steht per `freeze_time`, weil
+`to_multi_location_onset_alert_message`, `format_starkregen_hint` und
+`format_now_text` ihre Zeitpunkte selbst aus `datetime.now()` bilden.
+"""
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+from freezegun import freeze_time
+
+from output.renderers.alert.project import to_multi_location_onset_alert_message
+from output.renderers.alert.render import render_email, render_subject, render_telegram
+from output.renderers.email.starkregen_hint import format_starkregen_hint
+from services.radar_cache import RadarNowcastCacheService
+from services.radar_service import NowcastResult, RadarNowcastService
+
+# 18:00 Ortszeit Wien (= 16:00 UTC im Sommer).
+_TZ = ZoneInfo("Europe/Vienna")
+_FROZEN_UTC = "2026-08-21 16:00:00+00:00"
+
+# source_reach_minutes=120 -> lokale Reichweiten-Grenzzeit 20:00.
+_REACH_MIN = 120
+_REACH_HHMM = "20:00"
+# event_end_minutes=90 -> lokale Untergrenzen-Zeit 19:30 (S1-Form).
+_ENDE_MIN = 90
+_ENDE_HHMM = "19:30"
+# onset_minutes=75, jenseits der 60-Minuten-Guete-Grenze -> Guete-Grenzzeit
+# 19:00 (now + 60 Min, NICHT der Beginn selbst).
+_ONSET_JENSEITS_GUETE = 75
+_GUETE_HHMM = "19:00"
+
+
+def _nowcast(**kw) -> NowcastResult:
+    fields = dict(
+        onset_minutes=30, intensity_label="Mäßiger Regen", source="radar",
+        is_convective=False,
+    )
+    fields.update(kw)
+    return NowcastResult(**fields)
+
+
+def _texte(nc: NowcastResult) -> dict[str, str]:
+    """Die sechs Textstellen fuer EIN NowcastResult (Einzel-Ort-Pfad)."""
+    einzel = to_multi_location_onset_alert_message(
+        [("Sillian", nc)], tz=_TZ, stand_at="17:55",
+    )
+    buendel = to_multi_location_onset_alert_message(
+        [("Sillian", nc), ("Obertilliach", nc)], tz=_TZ, stand_at="17:55",
+    )
+    _html, plain_einzel = render_email(einzel)
+    _html_buendel, plain_buendel = render_email(buendel)
+    svc = RadarNowcastService(cache=RadarNowcastCacheService())
+    return {
+        "email_betreff": render_subject(einzel),
+        "email_trip_plain": plain_einzel,
+        "email_mehr_orte": plain_buendel,
+        "telegram_rich": render_telegram(einzel),
+        "briefing_hinweis": format_starkregen_hint(
+            nc.intensity_label, nc.onset_minutes, tz=_TZ,
+            event_end_minutes=nc.event_end_minutes,
+            event_ongoing_beyond_horizon=nc.event_ongoing_beyond_horizon,
+            source_reach_minutes=nc.source_reach_minutes,
+        ),
+        "kommando_antwort": svc.format_now_text(nc, tz=_TZ, include_source=False),
+    }
+
+
+def _befund(treffer: dict[str, str]) -> str:
+    return "; ".join(f"{name}={text[:160]!r}" for name, text in sorted(treffer.items()))
+
+
+def test_prueling_stammt_aus_diesem_arbeitsbaum():
+    """Vorbedingung (kein AC): Projektion, Renderer, Briefing-Hinweis und
+    Nowcast-Dienst werden RELATIV ZU DIESER Testdatei aufgeloest -- sonst
+    pruefte ein Worktree-Lauf still die Dateien des Hauptrepos."""
+    from output.renderers.alert import project as project_module
+    from output.renderers.alert import render as render_module
+    from output.renderers.email import starkregen_hint as hint_module
+    from services import radar_service as radar_module
+
+    arbeitsbaum = Path(__file__).resolve().parents[2]
+    for modul in (project_module, render_module, hint_module, radar_module):
+        modul_pfad = Path(inspect.getfile(modul)).resolve()
+        assert modul_pfad.is_relative_to(arbeitsbaum), (
+            f"Prueling stammt nicht aus diesem Arbeitsbaum: {modul_pfad}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-3 -- Reichweite gesetzt, ohne R4-Waechter: alle sechs tragen sie
+# ---------------------------------------------------------------------------
+
+
+@freeze_time(_FROZEN_UTC)
+def test_ac3_reichweite_erscheint_in_allen_sechs_textstellen():
+    """AC-3 GIVEN ein `OnsetEvent`/`NowcastResult` mit gesetzter Reichweite
+    (`source_reach_minutes=120`) und `event_ongoing_beyond_horizon=False`
+    WHEN alle sechs Langform-/Briefing-/Kommando-Textstellen gerendert
+    werden
+    THEN enthaelt JEDE zusaetzlich zur bestehenden Beginn-Angabe
+    `Radar reicht bis 20:00`.
+
+    RED heute: `NowcastResult` kennt `source_reach_minutes` nicht
+    (`TypeError`)."""
+    nc = _nowcast(source_reach_minutes=_REACH_MIN, event_ongoing_beyond_horizon=False)
+    texte = _texte(nc)
+
+    ohne_reichweite = {
+        name: text for name, text in texte.items()
+        if f"Radar reicht bis {_REACH_HHMM}" not in text
+    }
+    assert not ohne_reichweite, (
+        f"RED: diese Stellen tragen die Reichweite nicht: {_befund(ohne_reichweite)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-9 -- R4-Waechter gesetzt: die Reichweiten-Angabe entfaellt VOLLSTAENDIG
+# ---------------------------------------------------------------------------
+
+
+@freeze_time(_FROZEN_UTC)
+def test_ac9_untergrenzenform_unterdrueckt_die_reichweite_vollstaendig():
+    """AC-9 GIVEN einen Onset-Alarm mit `event_ongoing_beyond_horizon=True`
+    (S1-Untergrenzenform, `Regen mindestens bis HH:MM`) und einer im
+    uebrigen gesetzten Reichweite
+    WHEN die sechs betroffenen Textstellen gerendert werden
+    THEN enthaelt JEDE die S1-Untergrenzenform `Regen mindestens bis 19:30`,
+    aber KEINE zusaetzlich `Radar reicht bis` -- die Untergrenzenform traegt
+    die Reichweiten-Aussage bereits implizit (E5).
+
+    Die Positivkontrolle (Untergrenzenform IST da) steht im selben Test wie
+    die Negativpruefung (Reichweite fehlt) -- sonst waere Letzteres trivial
+    wahr, weil der heutige Code auch die Reichweite selbst noch gar nicht
+    kennt.
+
+    RED heute: `NowcastResult` kennt `source_reach_minutes` nicht
+    (`TypeError`)."""
+    nc = _nowcast(
+        event_end_minutes=_ENDE_MIN, event_ongoing_beyond_horizon=True,
+        source_reach_minutes=_REACH_MIN,
+    )
+    texte = _texte(nc)
+
+    ohne_untergrenze = {
+        name: text for name, text in texte.items()
+        if f"Regen mindestens bis {_ENDE_HHMM}" not in text
+    }
+    assert not ohne_untergrenze, (
+        f"Vorbedingung: die S1-Untergrenzenform muss ueberall stehen: "
+        f"{_befund(ohne_untergrenze)}"
+    )
+
+    mit_reichweite = {
+        name: text for name, text in texte.items() if "Radar reicht bis" in text
+    }
+    assert not mit_reichweite, (
+        f"RED/E5: diese Stellen zeigen die Reichweite trotz gesetztem "
+        f"R4-Waechter -- Dopplung mit der Untergrenzenform: "
+        f"{_befund(mit_reichweite)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-10 -- E5-Unterdrueckung betrifft NUR die Reichweite, nicht die Guete
+# ---------------------------------------------------------------------------
+
+
+@freeze_time(_FROZEN_UTC)
+def test_ac10_guete_zeile_bleibt_trotz_e5_unterdrueckung_unveraendert():
+    """AC-10 GIVEN denselben Aufbau wie AC-9 (`event_ongoing_beyond_horizon
+    =True`) mit zusaetzlich einem Beginn jenseits der Guete-Grenze
+    (`onset_minutes=75`)
+    WHEN die Texte gerendert werden
+    THEN erscheint die Guete-Zeile `Ortsangabe ab 19:00 unscharf`
+    UNVERAENDERT in allen sechs Stellen, WAEHREND `Radar reicht bis`
+    weiterhin VOLLSTAENDIG fehlt -- die E5-Unterdrueckung betrifft
+    ausschliesslich die Reichweiten-Angabe, beide Entscheidungen bleiben
+    unabhaengig voneinander.
+
+    RED heute: `NowcastResult` kennt `source_reach_minutes` nicht
+    (`TypeError`)."""
+    nc = _nowcast(
+        onset_minutes=_ONSET_JENSEITS_GUETE,
+        event_end_minutes=_ENDE_MIN, event_ongoing_beyond_horizon=True,
+        source_reach_minutes=_REACH_MIN,
+    )
+    texte = _texte(nc)
+
+    ohne_guete = {
+        name: text for name, text in texte.items()
+        if f"Ortsangabe ab {_GUETE_HHMM} unscharf" not in text
+    }
+    assert not ohne_guete, (
+        f"RED: diese Stellen tragen die Guete-Zeile nicht: {_befund(ohne_guete)}"
+    )
+
+    mit_reichweite = {
+        name: text for name, text in texte.items() if "Radar reicht bis" in text
+    }
+    assert not mit_reichweite, (
+        f"Die Reichweite darf trotz Guete-Fall weiter unterdrueckt bleiben "
+        f"(E5, unabhaengig von der Guete-Entscheidung): {_befund(mit_reichweite)}"
+    )

--- a/tests/tdd/test_onset_reichweite_guete_kanalparitaet.py
+++ b/tests/tdd/test_onset_reichweite_guete_kanalparitaet.py
@@ -4,76 +4,144 @@ Ortsvergleich-Flaeche denselben Wortlaut und denselben Wert (ADR-0021).
 SPEC: docs/specs/modules/feat_2051_s3_reichweite_und_guete.md — AC-14.
 
 Warum das zaehlt: Trip und Ortsvergleich bauen ihr `OnsetEvent` an ZWEI
-verschiedenen Stellen -- `NotificationService.send_radar_alert()` (Trip,
-ueber `RadarAlertRequest`) und `to_multi_location_onset_alert_message()`
-(Ortsvergleich-Buendel, ueber `NowcastResult`). Wird eines der beiden neuen
-Felder (Reichweite, Guete) nur an einer der beiden Stellen durchgereicht,
-entsteht in der anderen eine stille Luecke -- genau die Fehlerklasse, die
-der Adversary bei #2046 (F001) fand.
+verschiedenen Stellen -- `trip_alert.check_radar_alerts()` (ueber
+`RadarAlertRequest`) und `project.to_multi_location_onset_alert_message()`
+(ueber `NowcastResult`). Wird eines der beiden neuen Felder (Reichweite,
+Guete) nur an einer der beiden Stellen durchgereicht, entsteht in der
+anderen eine stille Luecke -- genau die Fehlerklasse, die der Adversary bei
+#2046 (F001) UND bei #2054 fand (dort liess sich der Bildner eines
+abgeleiteten Feldes abschalten, ohne dass ein einziger Test rot wurde, weil
+alle Tests den Wert als Literal statt ueber die echte Ableitung setzten).
 
-Gespiegelt zu `tests/tdd/test_onset_menge_kanalparitaet.py` (Test-Plan der
-Spec) -- DIESELBEN Werte einmal ueber den Trip-Pfad (`RadarAlertRequest` ->
-`send_radar_alert`) und einmal ueber den Ortsvergleich-Pfad
-(`to_multi_location_onset_alert_message`) gerendert.
+**Korrektur gegenueber einer fruehreren Fassung dieser Datei:** die erste
+Fassung baute den Trip-Pfad ueber einen HANDGEBAUTEN `RadarAlertRequest`
+mit literalen `source_reach_time`/`location_sharpness_limit_time` -- das
+umgeht `trip_alert.py`s eigene Berechnung/Durchreichung VOLLSTAENDIG und
+haette eine fehlende Verdrahtung dort nie gefangen (Befund aus dem
+Adversary-Durchlauf von #2054, sinngemaess auf diese Spec uebertragen).
+DIESE Fassung faehrt stattdessen BEIDE Flaechen ueber ihre echten
+Produktivpfade (`TripAlertService.check_radar_alerts()` bzw.
+`CompareRadarAlertService.check_all_compare_presets()`) mit DENSELBEN
+echten Radar-Frames -- Muster `test_onset_ende_kanalparitaet.py` (S1,
+dortige AC-15).
 
-Annahme (Abweichung von der Spec-Textstelle "Source", dort nicht explizit
-benannt): `RadarAlertRequest` bekommt additiv `source_reach_time`/
-`source_reach_day_offset` und `location_sharpness_limit_time`/
-`location_sharpness_limit_day_offset`, exakt im Muster von
-`event_end_time`/`event_end_day_offset` (S1) -- der einzige Weg, wie die
-beiden neuen Werte ueberhaupt bis `send_radar_alert()` gelangen koennen,
-ohne dass `RadarAlertRequest` intern Displaylogik nachbaut.
+Mock-frei: DIESELBEN echten Radar-Frames (feste absolute Zeitstempel, keine
+Wanduhr-Ableitung je Aufruf) laufen durch BEIDE echten Produktivpfade --
+echter `RadarNowcastService` -> echtes `NowcastResult` -> echter
+Alarm-Service -> echter `NotificationService` -> echter Telegram-Transport
+-> Nutzlast am Draht eines lokalen Aufzeichnungs-Servers. Kein `Mock()`,
+kein `patch()` von Verhalten, kein externes Netz, kein echter SMS-Versand.
 
-RED heute: `RadarAlertRequest`/`NowcastResult` kennen die neuen Felder nicht
--> `TypeError` bereits bei der Konstruktion.
+Frame-Aufbau (feste absolute Zeitstempel, von Hand hergeleitet):
+  * durchgehend nass (3.0 mm/h) von +20 bis +150 Min im 10-Minuten-Raster
+    -> Beginn bei +20 (diesseits `RADAR_ONSET_THRESHOLD_MIN`=55, der Alarm
+    feuert), Ende bei +150 (letzter nasser Frame vor dem Trockenuebergang,
+    jenseits der 60-Minuten-Guete-Grenze -> Guete-Zeile ausgeloest).
+  * ein Trockenframe bei +160 beendet den Block (`event_ongoing_beyond_
+    horizon=False` -- die Reichweite wird deshalb NICHT durch E5
+    unterdrueckt).
+  * kein weiterer Frame danach -> die Reichweite des LETZTEN Frames (+160)
+    reicht bis +160 + `_MAX_FRAME_COVERAGE` (15) = +175 (gedeckelt am
+    180-Min-Horizont, hier folgenlos).
 
-Mock-frei: echter `NotificationService` gegen einen echten lokalen
-Telegram-Bot-API-Stub (kein Mock, kein externes Netz), echte Projektion fuer
-den Ortsvergleich-Pfad. Die Uhr steht per `freeze_time`, weil beide Pfade
-ihre Uhrzeiten aus `datetime.now()` ableiten.
+RED heute: `RadarAlertRequest`/`NowcastResult`/`OnsetEvent` kennen die
+neuen Felder nicht bzw. `trip_alert.py`/`project.py` reichen sie noch
+nicht durch -- keiner der beiden Texte nennt Reichweite oder Guete.
 """
 from __future__ import annotations
 
+import dataclasses
 import http.server
 import inspect
 import json
 import re
+import shutil
 import socket
 import threading
-from datetime import datetime, timezone
+from datetime import datetime, time, timedelta, timezone
 from pathlib import Path
-from zoneinfo import ZoneInfo
 
-from freezegun import freeze_time
+import pytest
 
 import output.channels.telegram as tg_module
 from app.config import Settings
-from output.renderers.alert.project import to_multi_location_onset_alert_message
-from output.renderers.alert.render import render_sms, render_telegram
-from services.notification_service import NotificationService, RadarAlertRequest
-from services.radar_service import NowcastResult
+from app.loader import save_location, save_trip
+from app.models import TripReportConfig
+from app.user import SavedLocation
 
-from tests.helpers.nowcast_gate_fixtures import clean_uid, fresh_uid, make_trip
+from tests.helpers.briefing_zeiten import briefing_zeiten_fuer_trip
+from tests.helpers.compare_briefings import write_compare_briefings
+from tests.helpers.nowcast_gate_fixtures import (
+    TRIP_LAT, TRIP_LON, TRIP_ZONE, clean_uid, fresh_uid, make_trip,
+    quiet_window_elsewhere, radar_service, reset_radar_cache,
+)
 
-_TZ = ZoneInfo("Europe/Vienna")
-# 18:00 Ortszeit Wien (= 16:00 UTC im Sommer).
-_FROZEN_UTC = "2026-08-21 16:00:00+00:00"
+# Langform-Wortlaute, mit gefangener Uhrzeit.
+_REACH_RE = re.compile(r"Radar reicht bis (\d{1,2}:\d{2})")
+_GUETE_RE = re.compile(r"Ortsangabe ab (\d{1,2}:\d{2}) unscharf")
+# Kurzform: das Guete-Zeichen `?` unmittelbar hinter einem Zeit-Token.
+_KURZFORM_GUETE_RE = re.compile(r"@(?P<beginn>\d{1,2}:\d{2})\?")
 
-# Beginn 20 Min (diesseits der 60-Min-Guete-Grenze, alarmfaehig) -> 18:20.
-_ONSET_MIN = 20
-_ONSET_HHMM = "18:20"
-# Ende 150 Min (jenseits der Guete-Grenze), bekanntes Ende -> 20:30.
-_ENDE_MIN = 150
-_ENDE_HHMM = "20:30"
-# Reichweite 170 Min -> 20:50.
-_REACH_MIN = 170
-_REACH_HHMM = "20:50"
-# Guete-Grenzzeit now + 60 Min -> 19:00 (ausgeloest durch das Ende, 150 > 60).
-_GUETE_HHMM = "19:00"
+# Nasser Block: +20 bis +150 Minuten im 10-Minuten-Raster, danach TROCKEN,
+# danach KEINE weiteren Frames mehr.
+ONSET_MIN = 20          # < RADAR_ONSET_THRESHOLD_MIN (55) -> der Alarm feuert
+ENDE_MIN = 150          # > LOCATION_SHARPNESS_LIMIT_MIN (60) -> Guete-Zeile
+TROCKEN_MIN = 160       # letzter Frame ueberhaupt (dry) -> Reichweite daraus
+RATE_MM_H = 3.0
 
-_LANGFORM_REACH_RE = re.compile(r"Radar reicht bis (\d{1,2}:\d{2})")
-_LANGFORM_GUETE_RE = re.compile(r"Ortsangabe ab (\d{1,2}:\d{2}) unscharf")
-_KURZFORM_GUETE_RE = re.compile(r"@(\d{1,2}:\d{2})\?")
+
+class _FesterBlockMitReichweite:
+    """Echter, aufrufbarer `frame_source` (kein Mock) mit EINMALIG
+    festgelegten, absoluten Zeitstempeln (Muster
+    `test_onset_ende_kanalparitaet.py::_FesterNasserBlock`).
+
+    Absolut statt "relativ zu jetzt bei jedem Aufruf": beide Flaechen werden
+    im selben Test nacheinander gefahren; eine Wanduhr-Ableitung je Aufruf
+    verschoebe die Frames zwischen den beiden Laeufen und der Paritaets-
+    Vergleich maesse die Uhr statt der Verdrahtung.
+    """
+
+    def __init__(self) -> None:
+        self.start = datetime.now(timezone.utc).replace(microsecond=0)
+        self.calls: list[tuple[float, float]] = []
+
+    @property
+    def erwartetes_ende_utc(self) -> datetime:
+        return self.start + timedelta(minutes=ENDE_MIN)
+
+    @property
+    def erwartete_reichweite_utc(self) -> datetime:
+        # Letzter Frame (+160, trocken) hat keinen Nachbarn mehr -> Deckung
+        # bis +160 + _MAX_FRAME_COVERAGE (15) = +175.
+        return self.start + timedelta(minutes=TROCKEN_MIN + 15)
+
+    @property
+    def erwartete_guete_grenze_utc(self) -> datetime:
+        # LOCATION_SHARPNESS_LIMIT_MIN = 60 (E2) -- von Hand aus der Spec
+        # uebernommen, nicht aus der Implementierung abgeschrieben.
+        return self.start + timedelta(minutes=60)
+
+    def __call__(self, lat: float, lon: float) -> list:
+        from providers.brightsky import RadarFrame
+
+        self.calls.append((lat, lon))
+        frames = [
+            RadarFrame(
+                timestamp=self.start + timedelta(minutes=m),
+                precip_mm_h=RATE_MM_H, is_convective=False,
+            )
+            for m in range(ONSET_MIN, ENDE_MIN + 1, 10)
+        ]
+        frames.append(RadarFrame(
+            timestamp=self.start + timedelta(minutes=TROCKEN_MIN),
+            precip_mm_h=0.0, is_convective=False,
+        ))
+        return frames
+
+
+# ---------------------------------------------------------------------------
+# Echter lokaler Telegram-Bot-API-Stub (kein Mock)
+# ---------------------------------------------------------------------------
 
 
 def _free_port() -> int:
@@ -85,12 +153,10 @@ def _free_port() -> int:
 
 
 class _TelegramStub:
-    """Lokaler HTTP-Stub der Telegram-Bot-API — zeichnet jede
-    `sendMessage`-Nutzlast auf (kein Mock, kein externes Netz)."""
-
     def __init__(self) -> None:
         self.sent: list[dict] = []
         sent = self.sent
+        counter = {"mid": 6000}
 
         class Handler(http.server.BaseHTTPRequestHandler):
             def do_POST(self):  # noqa: N802
@@ -100,8 +166,9 @@ class _TelegramStub:
                 except ValueError:
                     payload = {}
                 sent.append(payload)
+                counter["mid"] += 1
                 body = json.dumps(
-                    {"ok": True, "result": {"message_id": 4711}}
+                    {"ok": True, "result": {"message_id": counter["mid"]}}
                 ).encode()
                 self.send_response(200)
                 self.send_header("Content-Type", "application/json")
@@ -123,10 +190,17 @@ class _TelegramStub:
         self._server.shutdown()
 
 
+@pytest.fixture()
+def telegram_stub():
+    stub = _TelegramStub()
+    yield stub
+    stub.stop()
+
+
 def _telegram_only_settings(marke: str) -> Settings:
     """Nur Telegram sendebereit -- E-Mail, SMS und Premium-SMS ausdruecklich
-    AUS (jedes weggelassene Feld faellt sonst still auf die Prod-`.env`
-    zurueck, #1477)."""
+    AUS. Jedes weggelassene Feld faellt bei pydantic sonst still auf die
+    Prod-`.env` des Arbeitsverzeichnisses zurueck (#1477)."""
     return Settings(
         smtp_host=None, smtp_user=None, smtp_pass=None, mail_to=None,
         telegram_bot_token=f"test-token-2051-s3-{marke}",
@@ -137,39 +211,160 @@ def _telegram_only_settings(marke: str) -> Settings:
     )
 
 
-def _trip_pfad_request() -> RadarAlertRequest:
-    """DIESELBEN Werte wie der Ortsvergleich-Pfad, direkt als
-    `RadarAlertRequest`-Felder (Muster `event_end_time`, S1)."""
-    return RadarAlertRequest(
-        onset_minutes=_ONSET_MIN, onset_time=_ONSET_HHMM, km_from=0.0, km_to=6.0,
-        is_convective=False, intensity_label="Mäßiger Regen",
-        source_label="Radar (DWD)", tz=_TZ, segment_id="Ziel",
-        event_end_time=_ENDE_HHMM, event_ongoing_beyond_horizon=False,
-        source_reach_time=_REACH_HHMM,
-        location_sharpness_limit_time=_GUETE_HHMM,
-    )
+# ---------------------------------------------------------------------------
+# Die beiden echten Produktivpfade
+# ---------------------------------------------------------------------------
 
 
-def _ortsvergleich_pfad_nowcast() -> NowcastResult:
-    """DIESELBEN Werte als Minutenangaben -- die Quelle, aus der
-    `to_multi_location_onset_alert_message` sein `OnsetEvent` baut."""
-    return NowcastResult(
-        onset_minutes=_ONSET_MIN, intensity_label="Mäßiger Regen",
-        source="radar", is_convective=False,
-        event_end_minutes=_ENDE_MIN, event_ongoing_beyond_horizon=False,
-        source_reach_minutes=_REACH_MIN,
-    )
+def _text_vom_trip_pfad(frames, telegram_stub, monkeypatch, *, stil: str) -> str:
+    """Faehrt `TripAlertService.check_radar_alerts()` -- den einzigen
+    Produktivpfad, der im Trip-Betrieb einen `RadarAlertRequest` baut -- und
+    gibt den Text zurueck, der am Draht ankam."""
+    from services.trip_alert import TripAlertService
+
+    monkeypatch.setattr(tg_module, "TELEGRAM_API_BASE", telegram_stub.base_url)
+
+    uid, trip_id = fresh_uid(f"2051-s3-par-trip-{stil}"), f"trip-2051-s3-par-{stil}"
+    clean_uid(uid)
+    reset_radar_cache()
+    try:
+        quiet_from, quiet_to = quiet_window_elsewhere(zone=TRIP_ZONE)
+        trip = make_trip(
+            trip_id, cooldown_minutes=0, quiet_from=quiet_from, quiet_to=quiet_to,
+        )
+        # Etappen-Startzeit auf "gerade eben" setzen (Muster S1), damit zu
+        # JEDER Tageszeit ein Segment aktiv ist -- Compute-on-Save (#802)
+        # rechnet die Ankunftszeiten sonst neu.
+        lokal = datetime.now(timezone.utc).astimezone(TRIP_ZONE)
+        start = max(
+            lokal - timedelta(minutes=15),
+            lokal.replace(hour=0, minute=0, second=0, microsecond=0),
+        )
+        trip.stages[0] = dataclasses.replace(
+            trip.stages[0], start_time=time(start.hour, start.minute),
+        )
+        morgen, abend = briefing_zeiten_fuer_trip(trip)
+        trip.report_config = TripReportConfig(
+            trip_id=trip_id, send_email=False, send_sms=False,
+            send_telegram=True, send_premium_sms=False,
+            alert_on_changes=True, telegram_style=stil,
+            morning_time=morgen, evening_time=abend,
+        )
+        save_trip(trip, user_id=uid)
+
+        svc = TripAlertService(
+            settings=_telegram_only_settings(f"trip-{stil}"), throttle_hours=0,
+            user_id=uid, radar_service=radar_service(frames),
+        )
+        vorher = len(telegram_stub.sent)
+        sent = svc.check_radar_alerts()
+
+        assert sent == 1, (
+            f"Voraussetzung: genau EIN Trip-Radar-Alarm erwartet, war {sent}. "
+            f"Nowcast-Abrufe: {frames.calls!r}"
+        )
+        neu = telegram_stub.sent[vorher:]
+        assert len(neu) == 1, (
+            f"Erwartet genau EINE Trip-Nachricht am Draht: {neu!r}"
+        )
+        return neu[0].get("text") or ""
+    finally:
+        clean_uid(uid)
+
+
+def _compare_users_root() -> Path:
+    from app.loader import get_data_root
+
+    return get_data_root() / "users"
+
+
+def _text_vom_ortsvergleich_pfad(frames, telegram_stub, monkeypatch, *, stil: str) -> str:
+    """Faehrt `CompareRadarAlertService.check_all_compare_presets()` -- den
+    Ortsvergleich-Produktivpfad, der sein `OnsetEvent` ueber
+    `to_multi_location_onset_alert_message()` selbst baut."""
+    from services.compare_radar_alert import CompareRadarAlertService
+
+    monkeypatch.setattr(tg_module, "TELEGRAM_API_BASE", telegram_stub.base_url)
+
+    uid = fresh_uid(f"2051-s3-par-cmp-{stil}")
+    preset_id = f"cp-2051-s3-par-{stil}"
+    clean_uid(uid)
+    reset_radar_cache()
+    try:
+        # DIESELBEN Koordinaten wie der Trip (Atlantic/Reykjavik, UTC+0).
+        save_location(
+            SavedLocation(
+                id="loc-2051-s3", name="Reykjavik-Paritaet-S3",
+                lat=TRIP_LAT, lon=TRIP_LON, elevation_m=100,
+            ),
+            user_id=uid,
+        )
+        write_compare_briefings(_compare_users_root() / uid, [{
+            "id": preset_id,
+            "name": preset_id,
+            "user_id": uid,
+            "location_ids": ["loc-2051-s3"],
+            "schedule": "daily",
+            "weekday": 4,
+            "profil": "ALLGEMEIN",
+            "hour_from": 9,
+            "hour_to": 16,
+            "empfaenger": ["gregor-test@henemm.com"],
+            "letzter_versand": None,
+            "top_ort_letzter_versand": None,
+            "created_at": "2026-08-22T00:00:00Z",
+            "radar_alert_enabled": True,
+            "send_telegram": True,
+            "display_config": {"telegram_style": stil},
+        }])
+
+        svc = CompareRadarAlertService(
+            settings=_telegram_only_settings(f"cmp-{stil}"), user_id=uid,
+            radar_service=radar_service(frames),
+        )
+        vorher = len(telegram_stub.sent)
+        sent = svc.check_all_compare_presets()
+
+        assert sent == 1, (
+            f"Voraussetzung: genau EIN Ortsvergleich-Radar-Alarm erwartet, "
+            f"war {sent}. Nowcast-Abrufe: {frames.calls!r}"
+        )
+        neu = telegram_stub.sent[vorher:]
+        assert len(neu) == 1, (
+            f"Erwartet genau EINE Ortsvergleich-Nachricht am Draht: {neu!r}"
+        )
+        return neu[0].get("text") or ""
+    finally:
+        clean_uid(uid)
+        d = _compare_users_root() / uid
+        if d.exists():
+            shutil.rmtree(d, ignore_errors=True)
+
+
+def _minuten(hhmm: str) -> int:
+    stunde, _, minute = hhmm.partition(":")
+    return int(stunde) * 60 + (int(minute) if minute else 0)
+
+
+def _abstand_minuten(a: str, b: str) -> int:
+    roh = abs(_minuten(a) - _minuten(b))
+    return min(roh, 24 * 60 - roh)
+
+
+# Die beiden Laeufe liegen Sekundenbruchteile auseinander; springt dazwischen
+# die Minute um, unterscheiden sich die zurueckgerechneten Uhrzeiten um
+# hoechstens 1 Minute -- kein echter Wertunterschied.
+_WANDUHR_TOLERANZ_MIN = 1
 
 
 def test_prueling_stammt_aus_diesem_arbeitsbaum():
-    """Vorbedingung (kein AC): Projektion, Renderer und Benachrichtigungs-
-    dienst werden RELATIV ZU DIESER Testdatei aufgeloest."""
-    from output.renderers.alert import project as project_module
-    from output.renderers.alert import render as render_module
-    from services import notification_service as notif_module
+    """Vorbedingung (kein AC): Alarm-Services werden RELATIV ZU DIESER
+    Testdatei aufgeloest."""
+    from services import compare_radar_alert as cmp_module
+    from services import trip_alert as trip_module
 
     arbeitsbaum = Path(__file__).resolve().parents[2]
-    for modul in (project_module, render_module, notif_module):
+    for modul in (trip_module, cmp_module):
         modul_pfad = Path(inspect.getfile(modul)).resolve()
         assert modul_pfad.is_relative_to(arbeitsbaum), (
             f"Prueling stammt nicht aus diesem Arbeitsbaum: {modul_pfad}"
@@ -177,73 +372,84 @@ def test_prueling_stammt_aus_diesem_arbeitsbaum():
 
 
 # ---------------------------------------------------------------------------
-# AC-14 -- Langform: Trip und Ortsvergleich nennen dieselben Werte
+# AC-14 -- Langform: Trip und Ortsvergleich nennen dieselbe Reichweite und
+# dieselbe Guete-Grenzzeit
 # ---------------------------------------------------------------------------
 
 
-@freeze_time(_FROZEN_UTC)
-def test_ac14_langform_traegt_in_beiden_flaechen_reichweite_und_guete(monkeypatch):
-    """AC-14 GIVEN denselben Onset-Alarm einmal ueber den Trip-Pfad
-    (`RadarAlertRequest` -> `NotificationService.send_radar_alert`) und
-    einmal ueber den Ortsvergleich-Pfad
-    (`to_multi_location_onset_alert_message`) gerendert
-    WHEN beide Pfade dieselben Werte erhalten
-    THEN tragen Reichweiten- UND Guete-Angabe in BEIDEN Flaechen denselben
-    Wortlaut und denselben Wert (`Radar reicht bis 20:50`,
-    `Ortsangabe ab 19:00 unscharf`).
+def test_ac14_langform_traegt_in_beiden_flaechen_reichweite_und_guete(
+    telegram_stub, monkeypatch,
+):
+    """AC-14 GIVEN DIESELBEN Radar-Frames (nasser Block +20 bis +150 Minuten,
+    danach ein Trockenframe bei +160, danach keine weiteren Beobachtungen)
+    einmal ueber den ECHTEN Trip-Pfad (`TripAlertService.check_radar_alerts`)
+    und einmal ueber den ECHTEN Ortsvergleich-Pfad
+    (`CompareRadarAlertService.check_all_compare_presets`), beide im reichen
+    Telegram-Stil
+    WHEN beide Alarme tatsaechlich abgesetzt werden
+    THEN tragen BEIDE Texte dieselbe Reichweite (`Radar reicht bis HH:MM`)
+    UND dieselbe Guete-Grenzzeit (`Ortsangabe ab HH:MM unscharf`) -- gegen
+    das aus den Frames HERGELEITETE Ende geprueft, nicht nur gegeneinander
+    (zwei gleich falsche Angaben waeren sonst gruen).
 
-    RED heute: `RadarAlertRequest`/`NowcastResult` kennen die neuen Felder
-    nicht (`TypeError`)."""
-    stub = _TelegramStub()
-    monkeypatch.setattr(tg_module, "TELEGRAM_API_BASE", stub.base_url)
-    try:
-        uid = fresh_uid("2051-s3-par-rich")
-        clean_uid(uid)
-        try:
-            svc = NotificationService(_telegram_only_settings("rich"), uid)
-            svc.send_radar_alert(
-                trip=make_trip("trip-2051-s3-par-rich"),
-                request=_trip_pfad_request(),
-                source="Radar (DWD)",
-                cooldown_display="2 Stunden",
-                effective_channels={"telegram"},
-                telegram_style="rich",
-            )
-        finally:
-            clean_uid(uid)
+    RED heute: `RadarAlertRequest`/`NowcastResult`/`OnsetEvent` kennen die
+    neuen Felder nicht -- keiner der beiden Texte nennt Reichweite oder
+    Guete."""
+    frames = _FesterBlockMitReichweite()
 
-        assert len(stub.sent) == 1, (
-            f"Erwartet genau EINE Trip-Nachricht am Draht: {stub.sent!r}"
-        )
-        trip_text = stub.sent[0].get("text") or ""
-    finally:
-        stub.stop()
-
-    cmp_msg = to_multi_location_onset_alert_message(
-        [("Reykjavik", _ortsvergleich_pfad_nowcast())], tz=_TZ, stand_at="10:00",
+    trip_text = _text_vom_trip_pfad(frames, telegram_stub, monkeypatch, stil="rich")
+    cmp_text = _text_vom_ortsvergleich_pfad(
+        frames, telegram_stub, monkeypatch, stil="rich",
     )
-    cmp_text = render_telegram(cmp_msg)
 
-    trip_reach = _LANGFORM_REACH_RE.search(trip_text)
-    cmp_reach = _LANGFORM_REACH_RE.search(cmp_text)
-    assert trip_reach and cmp_reach, (
-        f"RED: mindestens eine Flaeche nennt die Reichweite nicht.\n"
+    trip_reach = _REACH_RE.search(trip_text)
+    cmp_reach = _REACH_RE.search(cmp_text)
+    fehlend_reach = [
+        n for n, t in (("Trip", trip_reach), ("Ortsvergleich", cmp_reach)) if t is None
+    ]
+    assert not fehlend_reach, (
+        f"RED: diese Flaeche(n) nennen keine Reichweite: {fehlend_reach}\n"
         f"  Trip          = {trip_text!r}\n  Ortsvergleich = {cmp_text!r}"
     )
-    assert trip_reach.group(1) == cmp_reach.group(1) == _REACH_HHMM, (
-        f"Trip und Ortsvergleich nennen unterschiedliche Reichweiten:\n"
+
+    erwartete_reichweite = (
+        frames.erwartete_reichweite_utc.astimezone(TRIP_ZONE).strftime("%H:%M")
+    )
+    for name, treffer, text in (
+        ("Trip", trip_reach, trip_text), ("Ortsvergleich", cmp_reach, cmp_text),
+    ):
+        assert _abstand_minuten(treffer.group(1), erwartete_reichweite) <= _WANDUHR_TOLERANZ_MIN, (
+            f"{name} nennt {treffer.group(1)} statt der aus den Frames "
+            f"hergeleiteten Reichweite {erwartete_reichweite}: {text!r}"
+        )
+    assert _abstand_minuten(trip_reach.group(1), cmp_reach.group(1)) <= _WANDUHR_TOLERANZ_MIN, (
+        "Trip und Ortsvergleich nennen verschiedene Reichweiten:\n"
         f"  Trip          = {trip_reach.group(1)}\n"
         f"  Ortsvergleich = {cmp_reach.group(1)}"
     )
 
-    trip_guete = _LANGFORM_GUETE_RE.search(trip_text)
-    cmp_guete = _LANGFORM_GUETE_RE.search(cmp_text)
-    assert trip_guete and cmp_guete, (
-        f"RED: mindestens eine Flaeche nennt die Guete-Zeile nicht.\n"
+    trip_guete = _GUETE_RE.search(trip_text)
+    cmp_guete = _GUETE_RE.search(cmp_text)
+    fehlend_guete = [
+        n for n, t in (("Trip", trip_guete), ("Ortsvergleich", cmp_guete)) if t is None
+    ]
+    assert not fehlend_guete, (
+        f"RED: diese Flaeche(n) nennen keine Guete-Zeile: {fehlend_guete}\n"
         f"  Trip          = {trip_text!r}\n  Ortsvergleich = {cmp_text!r}"
     )
-    assert trip_guete.group(1) == cmp_guete.group(1) == _GUETE_HHMM, (
-        f"Trip und Ortsvergleich nennen unterschiedliche Guete-Grenzzeiten:\n"
+
+    erwartete_guete = (
+        frames.erwartete_guete_grenze_utc.astimezone(TRIP_ZONE).strftime("%H:%M")
+    )
+    for name, treffer, text in (
+        ("Trip", trip_guete, trip_text), ("Ortsvergleich", cmp_guete, cmp_text),
+    ):
+        assert _abstand_minuten(treffer.group(1), erwartete_guete) <= _WANDUHR_TOLERANZ_MIN, (
+            f"{name} nennt {treffer.group(1)} statt der hergeleiteten "
+            f"Guete-Grenzzeit {erwartete_guete}: {text!r}"
+        )
+    assert _abstand_minuten(trip_guete.group(1), cmp_guete.group(1)) <= _WANDUHR_TOLERANZ_MIN, (
+        "Trip und Ortsvergleich nennen verschiedene Guete-Grenzzeiten:\n"
         f"  Trip          = {trip_guete.group(1)}\n"
         f"  Ortsvergleich = {cmp_guete.group(1)}"
     )
@@ -254,49 +460,58 @@ def test_ac14_langform_traegt_in_beiden_flaechen_reichweite_und_guete(monkeypatc
 # ---------------------------------------------------------------------------
 
 
-@freeze_time(_FROZEN_UTC)
-def test_ac14_kurzform_traegt_in_beiden_flaechen_dasselbe_guete_zeichen():
-    """AC-14 (Kurzform) GIVEN denselben Aufbau
-    WHEN die Kurzform gerendert wird (Muster fuer SMS/Premium-SMS/
-    Telegram-Kurzstil, dieselbe `render_sms`-Ausgabe)
-    THEN traegt sie in BEIDEN Flaechen dasselbe Guete-Zeichen `?` hinter
-    demselben Beginn-Token -- keine Reichweite in der Kurzform (E6).
+def test_ac14_kurzform_traegt_in_beiden_flaechen_dasselbe_guete_zeichen(
+    telegram_stub, monkeypatch,
+):
+    """AC-14 (Kurzform) GIVEN denselben Aufbau, aber beide Flaechen im
+    Telegram-KURZSTIL -- dem Stil, der denselben `sms_body` traegt, den SMS
+    und Premium-SMS bekommen
+    WHEN beide Alarme abgesetzt werden
+    THEN traegt das Guete-Zeichen `?` in BEIDEN Flaechen denselben
+    Zeit-Token, und die Reichweite steht in KEINER Flaeche in der Kurzform
+    (E6).
 
-    RED heute: `RadarAlertRequest`/`NowcastResult`/`OnsetEvent` kennen die
-    neuen Felder nicht (`TypeError`)."""
-    from output.renderers.alert.model import AlertMessage, OnsetEvent
+    Warum eigens geprueft: die Kurzform ist ein anderer Codepfad als die
+    Langform, und auf der Huette am Karnischen Hoehenweg kommt NUR
+    Premium-SMS an.
 
-    trip_event = OnsetEvent(
-        onset_minutes=_ONSET_MIN, onset_time=_ONSET_HHMM, km_from=0.0, km_to=6.0,
-        is_convective=False, intensity_label="Mäßiger Regen",
-        source_label="Radar (DWD)", segment_id="Ziel",
-        event_end_time=_ENDE_HHMM, event_ongoing_beyond_horizon=False,
-        location_sharpness_limit_time=_GUETE_HHMM,
-        source_reach_time=_REACH_HHMM,
-    )
-    trip_sms = render_sms(AlertMessage(
-        trip_short="KHW 403", stand_at="17:30", events=(trip_event,),
-        source="Radar (DWD)",
-    ))
+    RED heute: keiner der beiden Texte traegt ein Guete-Zeichen."""
+    frames = _FesterBlockMitReichweite()
 
-    cmp_msg = to_multi_location_onset_alert_message(
-        [("Reykjavik", _ortsvergleich_pfad_nowcast())], tz=_TZ, stand_at="10:00",
+    trip_text = _text_vom_trip_pfad(
+        frames, telegram_stub, monkeypatch, stil="kurzform",
     )
-    cmp_sms = render_sms(cmp_msg)
+    cmp_text = _text_vom_ortsvergleich_pfad(
+        frames, telegram_stub, monkeypatch, stil="kurzform",
+    )
 
-    trip_treffer = _KURZFORM_GUETE_RE.search(trip_sms)
-    cmp_treffer = _KURZFORM_GUETE_RE.search(cmp_sms)
-    assert trip_treffer and cmp_treffer, (
-        f"RED: mindestens eine Flaeche traegt kein Guete-Zeichen.\n"
-        f"  Trip          = {trip_sms!r}\n  Ortsvergleich = {cmp_sms!r}"
+    trip_treffer = _KURZFORM_GUETE_RE.search(trip_text)
+    cmp_treffer = _KURZFORM_GUETE_RE.search(cmp_text)
+    fehlend = [
+        n for n, t in (("Trip", trip_treffer), ("Ortsvergleich", cmp_treffer))
+        if t is None
+    ]
+    assert not fehlend, (
+        f"RED: diese Flaeche(n) tragen kein Guete-Zeichen: {fehlend}\n"
+        f"  Trip          = {trip_text!r}\n  Ortsvergleich = {cmp_text!r}"
     )
-    assert trip_treffer.group(1) == cmp_treffer.group(1) == _ONSET_HHMM, (
-        f"Trip und Ortsvergleich haengen das Guete-Zeichen an "
-        f"unterschiedliche Zeit-Token:\n"
-        f"  Trip          = {trip_treffer.group(1)}\n"
-        f"  Ortsvergleich = {cmp_treffer.group(1)}"
+    assert _abstand_minuten(
+        trip_treffer.group("beginn"), cmp_treffer.group("beginn"),
+    ) <= _WANDUHR_TOLERANZ_MIN, (
+        "Trip und Ortsvergleich haengen das Guete-Zeichen an "
+        "unterschiedliche Zeit-Token:\n"
+        f"  Trip          = {trip_treffer.group('beginn')}\n"
+        f"  Ortsvergleich = {cmp_treffer.group('beginn')}"
     )
-    assert _REACH_HHMM not in trip_sms and _REACH_HHMM not in cmp_sms, (
-        f"Die Reichweite darf in KEINER Flaeche in der Kurzform auftauchen "
-        f"(E6):\n  Trip          = {trip_sms!r}\n  Ortsvergleich = {cmp_sms!r}"
+
+    erwartete_reichweite = (
+        frames.erwartete_reichweite_utc.astimezone(TRIP_ZONE).strftime("%H:%M")
+    )
+    assert erwartete_reichweite not in trip_text, (
+        f"Die Reichweite darf in der Trip-Kurzform nicht auftauchen (E6): "
+        f"{trip_text!r}"
+    )
+    assert erwartete_reichweite not in cmp_text, (
+        f"Die Reichweite darf in der Ortsvergleich-Kurzform nicht "
+        f"auftauchen (E6): {cmp_text!r}"
     )

--- a/tests/tdd/test_onset_reichweite_guete_kanalparitaet.py
+++ b/tests/tdd/test_onset_reichweite_guete_kanalparitaet.py
@@ -1,0 +1,302 @@
+"""TDD RED — Issue #2051 S3: Reichweite und Guete tragen in Trip- UND
+Ortsvergleich-Flaeche denselben Wortlaut und denselben Wert (ADR-0021).
+
+SPEC: docs/specs/modules/feat_2051_s3_reichweite_und_guete.md — AC-14.
+
+Warum das zaehlt: Trip und Ortsvergleich bauen ihr `OnsetEvent` an ZWEI
+verschiedenen Stellen -- `NotificationService.send_radar_alert()` (Trip,
+ueber `RadarAlertRequest`) und `to_multi_location_onset_alert_message()`
+(Ortsvergleich-Buendel, ueber `NowcastResult`). Wird eines der beiden neuen
+Felder (Reichweite, Guete) nur an einer der beiden Stellen durchgereicht,
+entsteht in der anderen eine stille Luecke -- genau die Fehlerklasse, die
+der Adversary bei #2046 (F001) fand.
+
+Gespiegelt zu `tests/tdd/test_onset_menge_kanalparitaet.py` (Test-Plan der
+Spec) -- DIESELBEN Werte einmal ueber den Trip-Pfad (`RadarAlertRequest` ->
+`send_radar_alert`) und einmal ueber den Ortsvergleich-Pfad
+(`to_multi_location_onset_alert_message`) gerendert.
+
+Annahme (Abweichung von der Spec-Textstelle "Source", dort nicht explizit
+benannt): `RadarAlertRequest` bekommt additiv `source_reach_time`/
+`source_reach_day_offset` und `location_sharpness_limit_time`/
+`location_sharpness_limit_day_offset`, exakt im Muster von
+`event_end_time`/`event_end_day_offset` (S1) -- der einzige Weg, wie die
+beiden neuen Werte ueberhaupt bis `send_radar_alert()` gelangen koennen,
+ohne dass `RadarAlertRequest` intern Displaylogik nachbaut.
+
+RED heute: `RadarAlertRequest`/`NowcastResult` kennen die neuen Felder nicht
+-> `TypeError` bereits bei der Konstruktion.
+
+Mock-frei: echter `NotificationService` gegen einen echten lokalen
+Telegram-Bot-API-Stub (kein Mock, kein externes Netz), echte Projektion fuer
+den Ortsvergleich-Pfad. Die Uhr steht per `freeze_time`, weil beide Pfade
+ihre Uhrzeiten aus `datetime.now()` ableiten.
+"""
+from __future__ import annotations
+
+import http.server
+import inspect
+import json
+import re
+import socket
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+from freezegun import freeze_time
+
+import output.channels.telegram as tg_module
+from app.config import Settings
+from output.renderers.alert.project import to_multi_location_onset_alert_message
+from output.renderers.alert.render import render_sms, render_telegram
+from services.notification_service import NotificationService, RadarAlertRequest
+from services.radar_service import NowcastResult
+
+from tests.helpers.nowcast_gate_fixtures import clean_uid, fresh_uid, make_trip
+
+_TZ = ZoneInfo("Europe/Vienna")
+# 18:00 Ortszeit Wien (= 16:00 UTC im Sommer).
+_FROZEN_UTC = "2026-08-21 16:00:00+00:00"
+
+# Beginn 20 Min (diesseits der 60-Min-Guete-Grenze, alarmfaehig) -> 18:20.
+_ONSET_MIN = 20
+_ONSET_HHMM = "18:20"
+# Ende 150 Min (jenseits der Guete-Grenze), bekanntes Ende -> 20:30.
+_ENDE_MIN = 150
+_ENDE_HHMM = "20:30"
+# Reichweite 170 Min -> 20:50.
+_REACH_MIN = 170
+_REACH_HHMM = "20:50"
+# Guete-Grenzzeit now + 60 Min -> 19:00 (ausgeloest durch das Ende, 150 > 60).
+_GUETE_HHMM = "19:00"
+
+_LANGFORM_REACH_RE = re.compile(r"Radar reicht bis (\d{1,2}:\d{2})")
+_LANGFORM_GUETE_RE = re.compile(r"Ortsangabe ab (\d{1,2}:\d{2}) unscharf")
+_KURZFORM_GUETE_RE = re.compile(r"@(\d{1,2}:\d{2})\?")
+
+
+def _free_port() -> int:
+    probe = socket.socket()
+    probe.bind(("", 0))
+    port = probe.getsockname()[1]
+    probe.close()
+    return port
+
+
+class _TelegramStub:
+    """Lokaler HTTP-Stub der Telegram-Bot-API — zeichnet jede
+    `sendMessage`-Nutzlast auf (kein Mock, kein externes Netz)."""
+
+    def __init__(self) -> None:
+        self.sent: list[dict] = []
+        sent = self.sent
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def do_POST(self):  # noqa: N802
+                length = int(self.headers.get("Content-Length", 0))
+                try:
+                    payload = json.loads(self.rfile.read(length).decode())
+                except ValueError:
+                    payload = {}
+                sent.append(payload)
+                body = json.dumps(
+                    {"ok": True, "result": {"message_id": 4711}}
+                ).encode()
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, *args):  # noqa: D401
+                pass
+
+        self.port = _free_port()
+        self._server = http.server.HTTPServer(("127.0.0.1", self.port), Handler)
+        threading.Thread(target=self._server.serve_forever, daemon=True).start()
+
+    @property
+    def base_url(self) -> str:
+        return f"http://127.0.0.1:{self.port}"
+
+    def stop(self) -> None:
+        self._server.shutdown()
+
+
+def _telegram_only_settings(marke: str) -> Settings:
+    """Nur Telegram sendebereit -- E-Mail, SMS und Premium-SMS ausdruecklich
+    AUS (jedes weggelassene Feld faellt sonst still auf die Prod-`.env`
+    zurueck, #1477)."""
+    return Settings(
+        smtp_host=None, smtp_user=None, smtp_pass=None, mail_to=None,
+        telegram_bot_token=f"test-token-2051-s3-{marke}",
+        telegram_chat_id="99999", telegram_test_chat_id="99999",
+        sms_gateway_url="", seven_api_key="", seven_sandbox_key="",
+        sms_to="", sms_from=None,
+        premium_sms_reply_to=None, premium_sms_reply_at=None,
+    )
+
+
+def _trip_pfad_request() -> RadarAlertRequest:
+    """DIESELBEN Werte wie der Ortsvergleich-Pfad, direkt als
+    `RadarAlertRequest`-Felder (Muster `event_end_time`, S1)."""
+    return RadarAlertRequest(
+        onset_minutes=_ONSET_MIN, onset_time=_ONSET_HHMM, km_from=0.0, km_to=6.0,
+        is_convective=False, intensity_label="Mäßiger Regen",
+        source_label="Radar (DWD)", tz=_TZ, segment_id="Ziel",
+        event_end_time=_ENDE_HHMM, event_ongoing_beyond_horizon=False,
+        source_reach_time=_REACH_HHMM,
+        location_sharpness_limit_time=_GUETE_HHMM,
+    )
+
+
+def _ortsvergleich_pfad_nowcast() -> NowcastResult:
+    """DIESELBEN Werte als Minutenangaben -- die Quelle, aus der
+    `to_multi_location_onset_alert_message` sein `OnsetEvent` baut."""
+    return NowcastResult(
+        onset_minutes=_ONSET_MIN, intensity_label="Mäßiger Regen",
+        source="radar", is_convective=False,
+        event_end_minutes=_ENDE_MIN, event_ongoing_beyond_horizon=False,
+        source_reach_minutes=_REACH_MIN,
+    )
+
+
+def test_prueling_stammt_aus_diesem_arbeitsbaum():
+    """Vorbedingung (kein AC): Projektion, Renderer und Benachrichtigungs-
+    dienst werden RELATIV ZU DIESER Testdatei aufgeloest."""
+    from output.renderers.alert import project as project_module
+    from output.renderers.alert import render as render_module
+    from services import notification_service as notif_module
+
+    arbeitsbaum = Path(__file__).resolve().parents[2]
+    for modul in (project_module, render_module, notif_module):
+        modul_pfad = Path(inspect.getfile(modul)).resolve()
+        assert modul_pfad.is_relative_to(arbeitsbaum), (
+            f"Prueling stammt nicht aus diesem Arbeitsbaum: {modul_pfad}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-14 -- Langform: Trip und Ortsvergleich nennen dieselben Werte
+# ---------------------------------------------------------------------------
+
+
+@freeze_time(_FROZEN_UTC)
+def test_ac14_langform_traegt_in_beiden_flaechen_reichweite_und_guete(monkeypatch):
+    """AC-14 GIVEN denselben Onset-Alarm einmal ueber den Trip-Pfad
+    (`RadarAlertRequest` -> `NotificationService.send_radar_alert`) und
+    einmal ueber den Ortsvergleich-Pfad
+    (`to_multi_location_onset_alert_message`) gerendert
+    WHEN beide Pfade dieselben Werte erhalten
+    THEN tragen Reichweiten- UND Guete-Angabe in BEIDEN Flaechen denselben
+    Wortlaut und denselben Wert (`Radar reicht bis 20:50`,
+    `Ortsangabe ab 19:00 unscharf`).
+
+    RED heute: `RadarAlertRequest`/`NowcastResult` kennen die neuen Felder
+    nicht (`TypeError`)."""
+    stub = _TelegramStub()
+    monkeypatch.setattr(tg_module, "TELEGRAM_API_BASE", stub.base_url)
+    try:
+        uid = fresh_uid("2051-s3-par-rich")
+        clean_uid(uid)
+        try:
+            svc = NotificationService(_telegram_only_settings("rich"), uid)
+            svc.send_radar_alert(
+                trip=make_trip("trip-2051-s3-par-rich"),
+                request=_trip_pfad_request(),
+                source="Radar (DWD)",
+                cooldown_display="2 Stunden",
+                effective_channels={"telegram"},
+                telegram_style="rich",
+            )
+        finally:
+            clean_uid(uid)
+
+        assert len(stub.sent) == 1, (
+            f"Erwartet genau EINE Trip-Nachricht am Draht: {stub.sent!r}"
+        )
+        trip_text = stub.sent[0].get("text") or ""
+    finally:
+        stub.stop()
+
+    cmp_msg = to_multi_location_onset_alert_message(
+        [("Reykjavik", _ortsvergleich_pfad_nowcast())], tz=_TZ, stand_at="10:00",
+    )
+    cmp_text = render_telegram(cmp_msg)
+
+    trip_reach = _LANGFORM_REACH_RE.search(trip_text)
+    cmp_reach = _LANGFORM_REACH_RE.search(cmp_text)
+    assert trip_reach and cmp_reach, (
+        f"RED: mindestens eine Flaeche nennt die Reichweite nicht.\n"
+        f"  Trip          = {trip_text!r}\n  Ortsvergleich = {cmp_text!r}"
+    )
+    assert trip_reach.group(1) == cmp_reach.group(1) == _REACH_HHMM, (
+        f"Trip und Ortsvergleich nennen unterschiedliche Reichweiten:\n"
+        f"  Trip          = {trip_reach.group(1)}\n"
+        f"  Ortsvergleich = {cmp_reach.group(1)}"
+    )
+
+    trip_guete = _LANGFORM_GUETE_RE.search(trip_text)
+    cmp_guete = _LANGFORM_GUETE_RE.search(cmp_text)
+    assert trip_guete and cmp_guete, (
+        f"RED: mindestens eine Flaeche nennt die Guete-Zeile nicht.\n"
+        f"  Trip          = {trip_text!r}\n  Ortsvergleich = {cmp_text!r}"
+    )
+    assert trip_guete.group(1) == cmp_guete.group(1) == _GUETE_HHMM, (
+        f"Trip und Ortsvergleich nennen unterschiedliche Guete-Grenzzeiten:\n"
+        f"  Trip          = {trip_guete.group(1)}\n"
+        f"  Ortsvergleich = {cmp_guete.group(1)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-14 -- Kurzform: dasselbe Guete-Zeichen an derselben Stelle
+# ---------------------------------------------------------------------------
+
+
+@freeze_time(_FROZEN_UTC)
+def test_ac14_kurzform_traegt_in_beiden_flaechen_dasselbe_guete_zeichen():
+    """AC-14 (Kurzform) GIVEN denselben Aufbau
+    WHEN die Kurzform gerendert wird (Muster fuer SMS/Premium-SMS/
+    Telegram-Kurzstil, dieselbe `render_sms`-Ausgabe)
+    THEN traegt sie in BEIDEN Flaechen dasselbe Guete-Zeichen `?` hinter
+    demselben Beginn-Token -- keine Reichweite in der Kurzform (E6).
+
+    RED heute: `RadarAlertRequest`/`NowcastResult`/`OnsetEvent` kennen die
+    neuen Felder nicht (`TypeError`)."""
+    from output.renderers.alert.model import AlertMessage, OnsetEvent
+
+    trip_event = OnsetEvent(
+        onset_minutes=_ONSET_MIN, onset_time=_ONSET_HHMM, km_from=0.0, km_to=6.0,
+        is_convective=False, intensity_label="Mäßiger Regen",
+        source_label="Radar (DWD)", segment_id="Ziel",
+        event_end_time=_ENDE_HHMM, event_ongoing_beyond_horizon=False,
+        location_sharpness_limit_time=_GUETE_HHMM,
+        source_reach_time=_REACH_HHMM,
+    )
+    trip_sms = render_sms(AlertMessage(
+        trip_short="KHW 403", stand_at="17:30", events=(trip_event,),
+        source="Radar (DWD)",
+    ))
+
+    cmp_msg = to_multi_location_onset_alert_message(
+        [("Reykjavik", _ortsvergleich_pfad_nowcast())], tz=_TZ, stand_at="10:00",
+    )
+    cmp_sms = render_sms(cmp_msg)
+
+    trip_treffer = _KURZFORM_GUETE_RE.search(trip_sms)
+    cmp_treffer = _KURZFORM_GUETE_RE.search(cmp_sms)
+    assert trip_treffer and cmp_treffer, (
+        f"RED: mindestens eine Flaeche traegt kein Guete-Zeichen.\n"
+        f"  Trip          = {trip_sms!r}\n  Ortsvergleich = {cmp_sms!r}"
+    )
+    assert trip_treffer.group(1) == cmp_treffer.group(1) == _ONSET_HHMM, (
+        f"Trip und Ortsvergleich haengen das Guete-Zeichen an "
+        f"unterschiedliche Zeit-Token:\n"
+        f"  Trip          = {trip_treffer.group(1)}\n"
+        f"  Ortsvergleich = {cmp_treffer.group(1)}"
+    )
+    assert _REACH_HHMM not in trip_sms and _REACH_HHMM not in cmp_sms, (
+        f"Die Reichweite darf in KEINER Flaeche in der Kurzform auftauchen "
+        f"(E6):\n  Trip          = {trip_sms!r}\n  Ortsvergleich = {cmp_sms!r}"
+    )

--- a/tests/tdd/test_onset_reichweite_guete_keine_bevormundung.py
+++ b/tests/tdd/test_onset_reichweite_guete_keine_bevormundung.py
@@ -143,12 +143,32 @@ def test_ac15_keine_der_sieben_textstellen_traegt_eine_handlungsempfehlung():
         "prueft dieser Test nichts Neues."
     )
 
-    treffer: dict[str, list[str]] = {}
-    for name, text in texte.items():
-        text_klein = text.lower()
-        gefunden = [m for m in _VERBOTENE_MUSTER if m in text_klein]
-        if gefunden:
-            treffer[name] = gefunden
+    def _pruefe(kandidaten: dict[str, str]) -> dict[str, list[str]]:
+        gefunden: dict[str, list[str]] = {}
+        for name, text in kandidaten.items():
+            text_klein = text.lower()
+            treffer_hier = [m for m in _VERBOTENE_MUSTER if m in text_klein]
+            if treffer_hier:
+                gefunden[name] = treffer_hier
+        return gefunden
+
+    # Positivkontrolle des DETEKTORS selbst (nicht der Produktivfunktion):
+    # ein synthetischer, ABSICHTLICH verbotener Satz muss von DERSELBEN
+    # Pruefschleife erkannt werden -- sonst waere die Negativpruefung unten
+    # trivial wahr, weil `_VERBOTENE_MUSTER`/die Schleife selbst nie greifen
+    # KOENNTE (z. B. falscher Variablenname, leere Liste, Gross-/
+    # Kleinschreibungsfehler). Lehre aus #2054: ein "not in"/"leere Menge"-
+    # Befund ohne Nachweis, dass er sonst ANSCHLUEGE, prueft nichts.
+    synthetischer_verstoss = _pruefe({
+        "synthetisch": "Radar reicht bis 20:00. Verlass dich nicht darauf.",
+    })
+    assert synthetischer_verstoss, (
+        "Vorbedingung: der Detektor muss einen ABSICHTLICH eingebauten "
+        "Verstoss erkennen -- sonst waere die Negativpruefung unten "
+        "trivial wahr."
+    )
+
+    treffer = _pruefe(texte)
 
     assert not treffer, (
         f"RED/AC-15: verbotene Handlungsempfehlung gefunden: {treffer}\n"

--- a/tests/tdd/test_onset_reichweite_guete_keine_bevormundung.py
+++ b/tests/tdd/test_onset_reichweite_guete_keine_bevormundung.py
@@ -1,0 +1,156 @@
+"""TDD RED — Issue #2051 S3: Reichweite und Guete sind ein DATUM, keine
+Handlungsempfehlung.
+
+SPEC: docs/specs/modules/feat_2051_s3_reichweite_und_guete.md — AC-15.
+
+Fachlicher Kern (Ticket-Grundprinzip, projektweit): Gregor Zwanzig liefert
+Daten, keine Handlungsempfehlungen -- das Produkt ist fuer Profis, die
+selbst entscheiden. Reichweite (`Radar reicht bis HH:MM`) und Guete
+(`Ortsangabe ab HH:MM unscharf`) sagen NUR, was die Quelle hergibt, nicht
+was der Nutzer tun soll. Keine der sieben Textstellen darf eine Formulierung
+tragen, die eine Rechnung ueber den Nutzer anstellt ("verlass dich nicht
+darauf", "bis dahin solltest du ...").
+
+RED heute: `NowcastResult`/`OnsetEvent` kennen die neuen Felder nicht ->
+`TypeError` bereits bei der Konstruktion -- die Positivkontrolle (Reichweite
+und Guete stehen ueberhaupt im Text) schlaegt zuerst fehl.
+
+Mock-frei: echte `NowcastResult`/`OnsetEvent`-Objekte durch die echten
+Projektions- und Renderfunktionen. Die Uhr steht per `freeze_time`.
+"""
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+from freezegun import freeze_time
+
+from output.renderers.alert.project import to_multi_location_onset_alert_message
+from output.renderers.alert.render import (
+    render_email, render_sms, render_subject, render_telegram,
+)
+from output.renderers.email.starkregen_hint import format_starkregen_hint
+from services.radar_cache import RadarNowcastCacheService
+from services.radar_service import NowcastResult, RadarNowcastService
+
+_TZ = ZoneInfo("Europe/Vienna")
+_FROZEN_UTC = "2026-08-21 16:00:00+00:00"
+
+# Beginn jenseits der Guete-Grenze (Guete triggert) UND gesetzte Reichweite
+# (Reichweite triggert, event_ongoing_beyond_horizon=False -> nicht durch E5
+# unterdrueckt) -- beide Angaben gleichzeitig im Text.
+_ONSET_MIN = 75
+_ENDE_MIN = 30
+_REACH_MIN = 120
+
+# Formulierungen, die eine Handlungsempfehlung oder eine Rechnung ueber den
+# Nutzer waeren (Ticket-Grundprinzip) -- Beispiele aus der Spec plus
+# naheliegende Varianten.
+_VERBOTENE_MUSTER = [
+    "verlass dich nicht",
+    "solltest du",
+    "bis dahin solltest",
+    "rechne damit, dass du",
+    "sei vorsichtig",
+    "achte darauf, dass du",
+    "plane damit",
+]
+
+
+def _nowcast() -> NowcastResult:
+    return NowcastResult(
+        onset_minutes=_ONSET_MIN, intensity_label="Mäßiger Regen", source="radar",
+        is_convective=False, event_end_minutes=_ENDE_MIN,
+        event_ongoing_beyond_horizon=False, source_reach_minutes=_REACH_MIN,
+    )
+
+
+def _sieben_textstellen() -> dict[str, str]:
+    nc = _nowcast()
+    einzel = to_multi_location_onset_alert_message(
+        [("Sillian", nc)], tz=_TZ, stand_at="17:55",
+    )
+    buendel = to_multi_location_onset_alert_message(
+        [("Sillian", nc), ("Obertilliach", nc)], tz=_TZ, stand_at="17:55",
+    )
+    _html, plain_einzel = render_email(einzel)
+    _html_buendel, plain_buendel = render_email(buendel)
+    svc = RadarNowcastService(cache=RadarNowcastCacheService())
+    return {
+        "email_betreff": render_subject(einzel),
+        "email_trip_plain": plain_einzel,
+        "email_mehr_orte": plain_buendel,
+        "telegram_rich": render_telegram(einzel),
+        "kurzform": render_sms(einzel),
+        "briefing_hinweis": format_starkregen_hint(
+            nc.intensity_label, nc.onset_minutes, tz=_TZ,
+            event_end_minutes=nc.event_end_minutes,
+            event_ongoing_beyond_horizon=nc.event_ongoing_beyond_horizon,
+            source_reach_minutes=nc.source_reach_minutes,
+        ),
+        "kommando_antwort": svc.format_now_text(nc, tz=_TZ, include_source=False),
+    }
+
+
+def test_prueling_stammt_aus_diesem_arbeitsbaum():
+    """Vorbedingung (kein AC): Projektion, Renderer, Briefing-Hinweis und
+    Nowcast-Dienst werden RELATIV ZU DIESER Testdatei aufgeloest."""
+    from output.renderers.alert import project as project_module
+    from output.renderers.alert import render as render_module
+    from output.renderers.email import starkregen_hint as hint_module
+    from services import radar_service as radar_module
+
+    arbeitsbaum = Path(__file__).resolve().parents[2]
+    for modul in (project_module, render_module, hint_module, radar_module):
+        modul_pfad = Path(inspect.getfile(modul)).resolve()
+        assert modul_pfad.is_relative_to(arbeitsbaum), (
+            f"Prueling stammt nicht aus diesem Arbeitsbaum: {modul_pfad}"
+        )
+
+
+@freeze_time(_FROZEN_UTC)
+def test_ac15_keine_der_sieben_textstellen_traegt_eine_handlungsempfehlung():
+    """AC-15 GIVEN einen Onset-Alarm mit gesetzter Reichweite UND
+    Guete-Zeile (beide Angaben im Text)
+    WHEN alle sieben Textstellen auf Formulierungen geprueft werden, die
+    eine Handlungsempfehlung oder eine Positions-/Uhrzeit-Rechnung ueber den
+    Nutzer enthalten
+    THEN enthaelt KEINE der sieben Texte eine solche Formulierung --
+    ausschliesslich ein Datum ueber die Aussage.
+
+    Die Positivkontrolle (Reichweite und Guete stehen ueberhaupt im Text)
+    steht im selben Test: ohne sie waere die Negativpruefung trivial wahr,
+    weil der heutige Code beide Angaben noch gar nicht kennt.
+
+    RED heute: `NowcastResult` kennt `source_reach_minutes` nicht
+    (`TypeError`)."""
+    texte = _sieben_textstellen()
+
+    ohne_reichweite = {
+        name: text for name, text in texte.items() if "Radar reicht bis" not in text
+        and "?" not in text
+    }
+    # Die Kurzform traegt keine "Radar reicht bis"-Zeile (E6) -- dort zaehlt
+    # das Guete-Zeichen als Positivkontrolle, nicht der Reichweiten-Satz.
+    ohne_reichweite.pop("kurzform", None)
+    assert not ohne_reichweite, (
+        f"Vorbedingung: diese Stellen tragen weder Reichweite noch Guete: "
+        f"{sorted(ohne_reichweite)}"
+    )
+    assert "Ortsangabe ab" in texte["email_trip_plain"] or "?" in texte["kurzform"], (
+        "Vorbedingung: die Guete-Angabe muss irgendwo im Text stehen, sonst "
+        "prueft dieser Test nichts Neues."
+    )
+
+    treffer: dict[str, list[str]] = {}
+    for name, text in texte.items():
+        text_klein = text.lower()
+        gefunden = [m for m in _VERBOTENE_MUSTER if m in text_klein]
+        if gefunden:
+            treffer[name] = gefunden
+
+    assert not treffer, (
+        f"RED/AC-15: verbotene Handlungsempfehlung gefunden: {treffer}\n"
+        f"Texte: { {k: v[:200] for k, v in texte.items()} }"
+    )

--- a/tests/tdd/test_onset_reichweite_guete_sms.py
+++ b/tests/tdd/test_onset_reichweite_guete_sms.py
@@ -1,0 +1,213 @@
+"""TDD RED — Issue #2051 S3: die Kurzform (SMS/Premium-SMS/Telegram-Kurzstil)
+traegt NUR die Guete als einzelnes `?`-Zeichen, nie die Reichweite.
+
+SPEC: docs/specs/modules/feat_2051_s3_reichweite_und_guete.md — AC-11,
+AC-12, AC-13.
+
+Fachlicher Kern (E6): Grundauswahl ist das Maximum, der Kanal darf nur
+abwaehlen. Die Kurzform hat ein hartes Budget (140 GSM-7-Zeichen) und
+traegt deshalb NUR die Guete -- als EIN Zeichen `?` unmittelbar hinter dem
+betroffenen Zeit-Token (`R2.5@15:00?`). Die Reichweite entfaellt hier
+vollstaendig; im Untergrenzen-Fall (S1, `>@`) transportiert dieses Token die
+Reichweite ohnehin schon.
+
+`?` statt `~`: `~` gehoert zur GSM-7-Extension-Tabelle (2 Septets) und wird
+vom Transport hart auf `-` gefaltet (`_ASCII_EXTENSION_REPLACEMENTS`,
+render.py:1497) -- ein Bindestrich hinter einer Uhrzeit laese sich wie ein
+abgeschnittener Zeitbereich. `?` steht im GSM-7-BASISzeichensatz und
+ueberlebt die Faltung unveraendert.
+
+Drei Zusicherungen:
+  * AC-11 -- Guete-Fall: genau EIN `?` unmittelbar hinter dem Zeit-Token,
+    Zeichenbudget haelt auch im Extremfall.
+  * AC-12 -- Guete-Fall MIT gesetzter Reichweite: die Kurzform traegt KEIN
+    drittes Zeit-Token fuer die Reichweite.
+  * AC-13 -- ohne Guete-Fall: der Text bleibt BYTE-IDENTISCH zum Stand vor
+    dieser Spec.
+
+RED heute: `OnsetEvent` kennt `location_sharpness_limit_time`/
+`source_reach_time` nicht -> `TypeError` bereits bei der Konstruktion.
+
+Mock-frei: echte `OnsetEvent`/`AlertMessage`-Objekte durch den echten
+`render_sms`."""
+from __future__ import annotations
+
+import inspect
+import re
+from pathlib import Path
+
+from output.renderers.alert.model import AlertMessage, OnsetEvent
+from output.renderers.alert.render import render_sms
+
+_UNSET = object()
+
+
+def _onset_event(
+    *, event_end_time: object = _UNSET, event_ongoing_beyond_horizon: object = _UNSET,
+    location_sharpness_limit_time: object = _UNSET, source_reach_time: object = _UNSET,
+    onset_precip_mm: object = _UNSET, **kw,
+) -> OnsetEvent:
+    """Ein Trip-Radar-Onset-Ereignis mit festen Feldern. Die neuen S3-Felder
+    werden NUR uebergeben, wenn ein Aufrufer sie ausdruecklich setzt (Muster
+    `test_onset_ende_textstellen.py`)."""
+    fields = dict(
+        onset_minutes=30, onset_time="18:00", km_from=8.0, km_to=8.0,
+        is_convective=False, intensity_label="Mäßiger Regen",
+        source_label="Radar (DWD)", segment_id="Ziel",
+    )
+    fields.update(kw)
+    if event_end_time is not _UNSET:
+        fields["event_end_time"] = event_end_time
+    if event_ongoing_beyond_horizon is not _UNSET:
+        fields["event_ongoing_beyond_horizon"] = event_ongoing_beyond_horizon
+    if location_sharpness_limit_time is not _UNSET:
+        fields["location_sharpness_limit_time"] = location_sharpness_limit_time
+    if source_reach_time is not _UNSET:
+        fields["source_reach_time"] = source_reach_time
+    if onset_precip_mm is not _UNSET:
+        fields["onset_precip_mm"] = onset_precip_mm
+    return OnsetEvent(**fields)
+
+
+def _onset_msg(*events: OnsetEvent) -> AlertMessage:
+    return AlertMessage(
+        trip_short="KHW 403", stand_at="17:30", events=tuple(events),
+        source="Radar (DWD)",
+    )
+
+
+def test_prueling_stammt_aus_diesem_arbeitsbaum():
+    """Vorbedingung (kein AC): der gepruefte Renderer wird RELATIV ZU DIESER
+    Testdatei aufgeloest."""
+    from output.renderers.alert import render as render_module
+
+    modul_pfad = Path(inspect.getfile(render_module)).resolve()
+    arbeitsbaum = Path(__file__).resolve().parents[2]
+    assert modul_pfad.is_relative_to(arbeitsbaum), (
+        f"Prueling stammt nicht aus diesem Arbeitsbaum: {modul_pfad}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-11 -- Guete-Fall: genau EIN '?' hinter dem Zeit-Token
+# ---------------------------------------------------------------------------
+
+
+def test_ac11_guete_zeichen_steht_unmittelbar_hinter_dem_zeit_token():
+    """AC-11 GIVEN einen Onset-Alarm im Guete-Fall
+    (`location_sharpness_limit_time="19:00"`), Beginn `18:00`, Menge `2.5`
+    WHEN `render_sms(msg)` gerendert wird
+    THEN traegt der Text genau EIN Zeichen `?` unmittelbar hinter dem
+    Zeit-Token (`R2.5@18:00?`).
+
+    RED heute: `OnsetEvent` kennt `location_sharpness_limit_time` nicht
+    (`TypeError`)."""
+    sms = render_sms(_onset_msg(_onset_event(
+        onset_precip_mm=2.5, location_sharpness_limit_time="19:00",
+    )))
+
+    assert "R2.5@18:00?" in sms, (
+        f"RED: das Guete-Zeichen steht nicht unmittelbar hinter dem "
+        f"Zeit-Token: {sms!r}"
+    )
+    assert sms.count("?") == 1, (
+        f"Es darf genau EIN Guete-Zeichen im Text stehen: {sms!r}"
+    )
+
+
+def test_ac11_zeichenbudget_haelt_auch_im_extremfall():
+    """AC-11 (Zeichenbudget) GIVEN einen 30 Zeichen langen Ortsnamen,
+    `onset_precip_mm=99.9`, ein kombiniertes Untergrenzen- UND Guete-Token
+    WHEN `render_sms(msg, limit=140)` rendert
+    THEN bleibt der Text unter 140 GSM-7-Zeichen, OHNE dass der harte
+    Schnitt `body[:limit]` greift.
+
+    RED heute: `OnsetEvent` kennt die neuen Felder nicht (`TypeError`)."""
+    ortsname = "Obertilliacher Bergwiesenalm".ljust(30, "x")
+    assert len(ortsname) == 30, "Voraussetzung: 30-Zeichen-Ortsname"
+
+    event = OnsetEvent(
+        onset_minutes=40, onset_time="18:00", km_from=0.0, km_to=0.0,
+        is_convective=False, intensity_label="Starker Regen",
+        source_label="Radar (DWD)", location_label=ortsname,
+        onset_precip_mm=99.9, event_end_time="23:59",
+        event_ongoing_beyond_horizon=True,
+        location_sharpness_limit_time="19:00",
+    )
+    sms = render_sms(_onset_msg(event), limit=140)
+
+    assert len(sms) <= 140, (
+        f"RED: {len(sms)} Zeichen ueberschreiten das Render-Limit: {sms!r}"
+    )
+    assert sms.count("?") == 1, (
+        f"Genau EIN Guete-Zeichen auch im Extremfall erwartet: {sms!r}"
+    )
+    assert sms.isascii(), f"Kurznachricht ist nicht ASCII-rein: {sms!r}"
+
+
+# ---------------------------------------------------------------------------
+# AC-12 -- Guete-Fall MIT Reichweite: kein drittes Zeit-Token
+# ---------------------------------------------------------------------------
+
+
+def test_ac12_kurzform_zeigt_kein_drittes_zeit_token_fuer_die_reichweite():
+    """AC-12 GIVEN denselben Guete-Fall wie AC-11, ZUSAETZLICH mit gesetzter
+    Reichweite (`source_reach_time="21:00"`)
+    WHEN die Kurzform gerendert wird
+    THEN enthaelt sie KEIN drittes Zeit-Token fuer die Reichweite -- die
+    Anzahl der `@HH:MM`-Zeit-Token bleibt bei maximal zwei (Beginn, Ende),
+    die Reichweite bleibt abgewaehlt (E6).
+
+    RED heute: `OnsetEvent` kennt die neuen Felder nicht (`TypeError`)."""
+    sms = render_sms(_onset_msg(_onset_event(
+        onset_precip_mm=2.5, event_end_time="20:00",
+        location_sharpness_limit_time="19:00", source_reach_time="21:00",
+    )))
+
+    zeit_token = re.findall(r"@\d{1,2}:\d{2}", sms)
+    assert len(zeit_token) <= 2, (
+        f"RED/E6: die Kurzform darf hoechstens zwei Zeit-Token tragen "
+        f"(Beginn, Ende), kein drittes fuer die Reichweite: {sms!r} "
+        f"({zeit_token!r})"
+    )
+    assert "21:00" not in sms, (
+        f"Die Reichweiten-Uhrzeit darf in der Kurzform nicht auftauchen: "
+        f"{sms!r}"
+    )
+    assert sms.count("?") == 1, (
+        f"RED: das Guete-Zeichen muss trotz gesetzter Reichweite stehen: "
+        f"{sms!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-13 -- ohne Guete-Fall: byte-identisch zum Stand vor dieser Spec
+# ---------------------------------------------------------------------------
+
+
+def test_ac13_ohne_guete_fall_bleibt_die_kurzform_byte_identisch():
+    """AC-13 GIVEN einen Onset-Alarm ohne Guete-Fall UND ohne
+    Reichweiten-relevante Besonderheit
+    WHEN `render_sms(msg)` einmal MIT den neuen Feldern explizit auf `None`
+    und einmal GANZ OHNE sie gerendert wird
+    THEN sind beide Texte byte-identisch -- kein haengendes `?`, keine leere
+    Anhaengsel-Stelle.
+
+    RED heute: der Aufruf mit den neuen Feldern (auch mit `None`) scheitert
+    an `TypeError`, weil `OnsetEvent` sie nicht kennt."""
+    mit_none = render_sms(_onset_msg(_onset_event(
+        onset_precip_mm=2.5,
+        location_sharpness_limit_time=None, source_reach_time=None,
+    )))
+    ohne_felder = render_sms(_onset_msg(_onset_event(onset_precip_mm=2.5)))
+
+    assert mit_none == ohne_felder, (
+        "Ungesetzte neue Felder duerfen die Kurznachricht nicht anfassen.\n"
+        f"  mit None   = {mit_none!r}\n  ohne Felder = {ohne_felder!r}"
+    )
+    assert "?" not in mit_none, (
+        f"Ohne Guete-Fall darf kein Guete-Zeichen entstehen: {mit_none!r}"
+    )
+    assert not mit_none.rstrip().endswith("@"), (
+        f"Leeres Zeit-Token am Textende: {mit_none!r}"
+    )

--- a/tests/tdd/test_onset_reichweite_guete_sms.py
+++ b/tests/tdd/test_onset_reichweite_guete_sms.py
@@ -115,6 +115,101 @@ def test_ac11_guete_zeichen_steht_unmittelbar_hinter_dem_zeit_token():
     )
 
 
+def test_ac11_guete_zeichen_bindet_an_das_letzte_zeit_token_der_zeitgruppe():
+    """AC-11 (E8, Spec v1.1 -- Nachtrag aus der Abstimmung mit #2054) GIVEN
+    drei Faelle, in denen die Kurzform MEHR als ein Zeit-Token traegt:
+      (a) Beginn UND bekanntes Ende (S1): `TH@18:00@20:00? R2.5` -- das `?`
+          haengt hinter dem LETZTEN Token (Ende), nicht hinter dem Beginn.
+      (b) laufendes Ereignis (#2050 S2b): `R2.5 now@20:00?` -- die
+          Beginn-Stelle traegt `now`, das `?` haengt trotzdem hinter dem
+          Ende-Token.
+      (c) Horizont-Ueberlauf/Untergrenze (S1): `TH@18:00 >@20:00?` -- das
+          `?` haengt HINTER dem `>@HH:MM`-Untergrenzen-Token, nicht davor
+          und nicht zwischen `>` und `@`.
+    WHEN `render_sms(msg)` fuer alle drei Faelle gerendert wird
+    THEN steht das `?` GENAU an der in E8 festgelegten Stelle -- niemals am
+    Beginn-Token, wenn ein Ende-Token folgt (der AC-5-Fall: der Beginn kann
+    diesseits der Grenze liegen, waehrend nur das Ende jenseits liegt --
+    eine Marke am Beginn waere dann am FALSCHEN Wert).
+
+    RED heute: `OnsetEvent` kennt `location_sharpness_limit_time` nicht
+    (`TypeError`)."""
+    beginn_und_ende = render_sms(_onset_msg(_onset_event(
+        is_convective=True, onset_precip_mm=2.5,
+        event_end_time="20:00", event_ongoing_beyond_horizon=False,
+        location_sharpness_limit_time="19:00",
+    )))
+    assert "TH@18:00@20:00? R2.5" in beginn_und_ende, (
+        f"RED (E8a): das '?' muss hinter dem LETZTEN Zeit-Token (Ende) "
+        f"stehen, nicht hinter dem Beginn: {beginn_und_ende!r}"
+    )
+    assert "18:00?" not in beginn_und_ende, (
+        f"Das '?' darf NICHT am Beginn-Token haengen, wenn ein Ende-Token "
+        f"folgt (AC-5-Fall -- der Beginn kann diesseits der Grenze liegen): "
+        f"{beginn_und_ende!r}"
+    )
+
+    laufend = render_sms(_onset_msg(_onset_event(
+        already_running=True, onset_precip_mm=2.5,
+        event_end_time="20:00", event_ongoing_beyond_horizon=False,
+        location_sharpness_limit_time="19:00",
+    )))
+    assert "R2.5 now@20:00?" in laufend, (
+        f"RED (E8b): im Laufend-Fall muss das '?' hinter dem Ende-Token "
+        f"stehen, obwohl die Beginn-Stelle 'now' traegt: {laufend!r}"
+    )
+
+    untergrenze = render_sms(_onset_msg(_onset_event(
+        is_convective=True, onset_precip_mm=2.5,
+        event_end_time="20:00", event_ongoing_beyond_horizon=True,
+        location_sharpness_limit_time="19:00",
+    )))
+    assert "TH@18:00 >@20:00?" in untergrenze, (
+        f"RED (E8c): im Untergrenzen-Fall muss das '?' HINTER dem "
+        f"'>@HH:MM'-Token stehen (exakt 'TH@18:00 >@20:00?'), nicht "
+        f"zwischen '>' und '@' oder sonstwo: {untergrenze!r}"
+    )
+    assert untergrenze.count("?") == 1, (
+        f"Es darf genau EIN Guete-Zeichen im Text stehen: {untergrenze!r}"
+    )
+
+
+def test_ac11_kombination_mit_2054_wochentagskuerzel_und_horizont_ueberlauf():
+    """AC-11 (nachgezogen nach Rebase auf #2054, PR #2088) GIVEN einen Fall,
+    der ALLE DREI additiven Kurzform-Merkmale gleichzeitig traegt:
+      * das #2054-Wochentagskuerzel (Beginn `Do18:00`, Ende `Fr3:00` --
+        beide Zeit-Token liegen an unterschiedlichen Kalendertagen, je
+        eigener Tagesbezug und eigenes Kuerzel, Muster #2009)
+      * den S1-Horizont-Ueberlauf (`event_ongoing_beyond_horizon=True` ->
+        ` >@` vor dem Ende-Token)
+      * unsere S3-Guete-Marke (`location_sharpness_limit_time` gesetzt)
+    WHEN `render_sms(msg)` rendert
+    THEN traegt der Text exakt `TH@Do18:00 >@Fr3:00? R2.5` -- das Guete-
+    Zeichen bindet an das LETZTE Zeit-Token der Gruppe (E8) und laesst das
+    Wochentagskuerzel dort unangetastet, unabhaengig davon, welche Session
+    zuerst gemerged hat (E8-Abgrenzung zu #2054, Spec v1.1).
+
+    Vor dem Rebase war dieser Fall unerreichbar: `main` kannte das
+    Wochentagskuerzel nicht, ein Test, der `Do`/`Fr` verlangt haette, waere
+    aus dem FALSCHEN Grund rot gewesen (Kuerzel fehlt, nicht Marker-Position
+    falsch)."""
+    sms = render_sms(_onset_msg(_onset_event(
+        is_convective=True, onset_precip_mm=2.5,
+        onset_time="18:00", onset_day_offset=1, onset_weekday="Do",
+        event_end_time="3:00", event_end_day_offset=1, event_end_weekday="Fr",
+        event_ongoing_beyond_horizon=True,
+        location_sharpness_limit_time="19:00",
+    )))
+
+    assert "TH@Do18:00 >@Fr3:00? R2.5" in sms, (
+        f"Die Kombination aus Wochentagskuerzel, Horizont-Ueberlauf und "
+        f"Guete-Marke ergibt nicht den erwarteten String: {sms!r}"
+    )
+    assert sms.count("?") == 1, (
+        f"Genau EIN Guete-Zeichen auch in der Kombination erwartet: {sms!r}"
+    )
+
+
 def test_ac11_zeichenbudget_haelt_auch_im_extremfall():
     """AC-11 (Zeichenbudget) GIVEN einen 30 Zeichen langen Ortsnamen,
     `onset_precip_mm=99.9`, ein kombiniertes Untergrenzen- UND Guete-Token
@@ -187,11 +282,20 @@ def test_ac12_kurzform_zeigt_kein_drittes_zeit_token_fuer_die_reichweite():
 
 def test_ac13_ohne_guete_fall_bleibt_die_kurzform_byte_identisch():
     """AC-13 GIVEN einen Onset-Alarm ohne Guete-Fall UND ohne
-    Reichweiten-relevante Besonderheit
-    WHEN `render_sms(msg)` einmal MIT den neuen Feldern explizit auf `None`
-    und einmal GANZ OHNE sie gerendert wird
-    THEN sind beide Texte byte-identisch -- kein haengendes `?`, keine leere
-    Anhaengsel-Stelle.
+    Reichweiten-relevante Besonderheit -- UND, im selben Test, DENSELBEN
+    Aufbau MIT gesetztem Guete-Fall (nur `location_sharpness_limit_time`
+    verschoben)
+    WHEN `render_sms(msg)` fuer beide Faelle gerendert wird
+    THEN sind die beiden Texte OHNE Guete-Fall byte-identisch (MIT den
+    neuen Feldern explizit auf `None` vs. GANZ OHNE sie) -- kein
+    haengendes `?`, keine leere Anhaengsel-Stelle -- UND derselbe Aufbau
+    traegt das Zeichen `?`, sobald AUSSCHLIESSLICH `location_sharpness_
+    limit_time` gesetzt wird. Erst das Paar beweist, dass die
+    Byte-Identitaet eine echte ABWESENHEIT ist und nicht bloss ein noch
+    gar nicht existierendes Feature (Lehre aus der AC-9-Gegenprobe, #2051
+    S3 Adversary-Runde): ein Test, der nur das ungesetzte Feld prueft,
+    bliebe auch dann gruen, wenn das Guete-Zeichen an KEINER Stelle mehr
+    entstuende.
 
     RED heute: der Aufruf mit den neuen Feldern (auch mit `None`) scheitert
     an `TypeError`, weil `OnsetEvent` sie nicht kennt."""
@@ -200,6 +304,9 @@ def test_ac13_ohne_guete_fall_bleibt_die_kurzform_byte_identisch():
         location_sharpness_limit_time=None, source_reach_time=None,
     )))
     ohne_felder = render_sms(_onset_msg(_onset_event(onset_precip_mm=2.5)))
+    mit_guete_fall = render_sms(_onset_msg(_onset_event(
+        onset_precip_mm=2.5, location_sharpness_limit_time="19:00",
+    )))
 
     assert mit_none == ohne_felder, (
         "Ungesetzte neue Felder duerfen die Kurznachricht nicht anfassen.\n"
@@ -210,4 +317,10 @@ def test_ac13_ohne_guete_fall_bleibt_die_kurzform_byte_identisch():
     )
     assert not mit_none.rstrip().endswith("@"), (
         f"Leeres Zeit-Token am Textende: {mit_none!r}"
+    )
+    assert "?" in mit_guete_fall, (
+        f"Positivkontrolle: derselbe Aufbau MUSS das Guete-Zeichen tragen, "
+        f"sobald ausschliesslich location_sharpness_limit_time gesetzt "
+        f"wird -- sonst waere die Byte-Identitaet oben nur der Beweis "
+        f"eines ueberhaupt nicht existierenden Merkmals: {mit_guete_fall!r}"
     )

--- a/tests/tdd/test_ortsschaerfe_grenze_laufzeitbindung.py
+++ b/tests/tdd/test_ortsschaerfe_grenze_laufzeitbindung.py
@@ -32,6 +32,8 @@ per `freeze_time`.
 from __future__ import annotations
 
 import inspect
+import re
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from zoneinfo import ZoneInfo
 
@@ -50,6 +52,16 @@ _FROZEN_UTC = "2026-08-21 16:00:00+00:00"
 # ungleich dem heutigen Default, damit ein hart getippter "60" im
 # Produktivcode auffliegt.
 _NEUER_GRENZWERT_MIN = 90
+
+
+def _minuten(hhmm: str) -> int:
+    stunde, _, minute = hhmm.partition(":")
+    return int(stunde) * 60 + int(minute)
+
+
+def _abstand_minuten(a: str, b: str) -> int:
+    roh = abs(_minuten(a) - _minuten(b))
+    return min(roh, 24 * 60 - roh)
 
 
 def test_prueling_stammt_aus_diesem_arbeitsbaum():
@@ -114,9 +126,25 @@ def test_ac16_guete_zeile_kippt_am_gepatchten_grenzwert_nicht_am_alten(monkeypat
         f"NICHT erscheinen -- sonst liest der Produktivcode weiterhin den "
         f"alten Wert 60 statt der Modulvariable: {knapp_ueber_altem_wert!r}"
     )
-    assert "Ortsangabe ab" in knapp_ueber_neuem_wert, (
+    treffer = re.search(r"Ortsangabe ab (\d{1,2}:\d{2}) unscharf", knapp_ueber_neuem_wert)
+    assert treffer is not None, (
         f"RED: bei {limit + 1} Minuten (jenseits der GEPATCHTEN Grenze von "
         f"{limit}) muss die Guete-Zeile erscheinen: {knapp_ueber_neuem_wert!r}"
+    )
+    # Adversary-Fund F004 (sinngemaess auf AC-16 uebertragen): Praesenz allein
+    # beweist nur, DASS die Bedingung am gepatchten Wert kippt -- nicht, dass
+    # die ANGEZEIGTE Grenzzeit selbst aus derselben Modulvariable stammt statt
+    # aus einer zweiten, unabhaengigen (z. B. hart kopierten `now + 60`)
+    # Berechnung. Die Erwartung wird deshalb aus DERSELBEN eingefrorenen Uhr
+    # und DERSELBEN Modulvariable hergeleitet, nicht als "19:30" getippt.
+    frozen_utc = datetime.fromisoformat(_FROZEN_UTC)
+    erwartete_grenzzeit = (
+        (frozen_utc + timedelta(minutes=limit)).astimezone(_TZ).strftime("%H:%M")
+    )
+    assert _abstand_minuten(treffer.group(1), erwartete_grenzzeit) <= 1, (
+        f"F004-Klasse: die angezeigte Grenzzeit {treffer.group(1)!r} stammt "
+        f"nicht aus dem gepatchten Grenzwert {limit} (erwartet "
+        f"{erwartete_grenzzeit!r}): {knapp_ueber_neuem_wert!r}"
     )
 
 
@@ -159,8 +187,20 @@ def test_ac16_starkregen_hint_liest_die_grenze_ebenfalls_zur_laufzeit(monkeypatc
         f"diesseits der GEPATCHTEN Grenze von {limit}) darf die Guete-Zeile "
         f"in starkregen_hint.py NICHT erscheinen: {knapp_ueber_altem_wert!r}"
     )
-    assert "Ortsangabe ab" in knapp_ueber_neuem_wert, (
+    treffer = re.search(r"Ortsangabe ab (\d{1,2}:\d{2}) unscharf", knapp_ueber_neuem_wert)
+    assert treffer is not None, (
         f"F001: bei {limit + 1} Minuten (jenseits der GEPATCHTEN Grenze von "
         f"{limit}) muss die Guete-Zeile in starkregen_hint.py erscheinen: "
         f"{knapp_ueber_neuem_wert!r}"
+    )
+    # F004-Klasse (sinngemaess auf F001 uebertragen): Praesenz allein beweist
+    # nicht, dass die ANGEZEIGTE Grenzzeit aus derselben Modulvariable stammt.
+    frozen_utc = datetime.fromisoformat(_FROZEN_UTC)
+    erwartete_grenzzeit = (
+        (frozen_utc + timedelta(minutes=limit)).astimezone(_TZ).strftime("%H:%M")
+    )
+    assert _abstand_minuten(treffer.group(1), erwartete_grenzzeit) <= 1, (
+        f"F004-Klasse: die angezeigte Grenzzeit {treffer.group(1)!r} in "
+        f"starkregen_hint.py stammt nicht aus dem gepatchten Grenzwert "
+        f"{limit} (erwartet {erwartete_grenzzeit!r}): {knapp_ueber_neuem_wert!r}"
     )

--- a/tests/tdd/test_ortsschaerfe_grenze_laufzeitbindung.py
+++ b/tests/tdd/test_ortsschaerfe_grenze_laufzeitbindung.py
@@ -1,0 +1,120 @@
+"""TDD RED — Issue #2051 S3: `LOCATION_SHARPNESS_LIMIT_MIN` wird zur
+LAUFZEIT ueber die Modulreferenz gelesen, nicht beim Import gebunden.
+
+SPEC: docs/specs/modules/feat_2051_s3_reichweite_und_guete.md — AC-16.
+
+Fachlicher Kern (E2, Muster `RADAR_ONSET_THRESHOLD_MIN`): Downstream-Leser
+(render.py, starkregen_hint.py, project.py) muessen die Konstante ueber die
+MODUL-Referenz (`radar_service_mod.LOCATION_SHARPNESS_LIMIT_MIN`) lesen, NIE
+per `from ... import LOCATION_SHARPNESS_LIMIT_MIN` -- ein Import zur
+Bindezeit wuerde ein spaeteres Monkeypatchen der Konstante nicht mehr sehen
+(Laufzeit-Drift-Schutz).
+
+Die Erwartung in diesem Test wird bewusst NICHT als fest getippte Zahl
+dupliziert (`limit = 60`), sondern aus DERSELBEN Modulvariable gelesen
+(`limit = radar_service_mod.LOCATION_SHARPNESS_LIMIT_MIN`) -- nur so wuerde
+ein hart getippter Erwartungswert im Produktivcode (statt der
+Modulreferenz) hier auffliegen: wird die Konstante auf 90 gepatcht, aber der
+Produktivcode liest weiterhin `60` (Bindung beim Import oder hart
+kopierter Wert), kippt die Guete-Zeile bei 61 Minuten -- nach dem NEUEN Wert
+(90) duerfte sie dort noch nicht erscheinen, und DIESER Test wuerde es
+merken.
+
+RED heute: `radar_service` kennt `LOCATION_SHARPNESS_LIMIT_MIN` noch nicht
+-> `monkeypatch.setattr(..., raising=True)` scheitert mit `AttributeError`
+(Modul hat das Attribut nicht).
+
+Mock-frei: echtes `NowcastResult`/`OnsetEvent` durch die echte Projektion
+und den echten Renderer, `monkeypatch.setattr` patcht nur die Konstante,
+kein Verhalten wird durch `Mock()`/`patch()` vorgetaeuscht. Die Uhr steht
+per `freeze_time`.
+"""
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+from freezegun import freeze_time
+
+from output.renderers.alert.project import to_multi_location_onset_alert_message
+from output.renderers.alert.render import render_email
+from services.radar_service import NowcastResult
+
+import services.radar_service as radar_service_mod
+
+_TZ = ZoneInfo("Europe/Vienna")
+_FROZEN_UTC = "2026-08-21 16:00:00+00:00"
+
+# Ein von 60 ABWEICHENDER Wert -- die Spec verlangt ausdruecklich einen Wert
+# ungleich dem heutigen Default, damit ein hart getippter "60" im
+# Produktivcode auffliegt.
+_NEUER_GRENZWERT_MIN = 90
+
+
+def test_prueling_stammt_aus_diesem_arbeitsbaum():
+    """Vorbedingung (kein AC): Projektion und Renderer werden RELATIV ZU
+    DIESER Testdatei aufgeloest."""
+    from output.renderers.alert import project as project_module
+    from output.renderers.alert import render as render_module
+
+    arbeitsbaum = Path(__file__).resolve().parents[2]
+    for modul in (project_module, render_module, radar_service_mod):
+        modul_pfad = Path(inspect.getfile(modul)).resolve()
+        assert modul_pfad.is_relative_to(arbeitsbaum), (
+            f"Prueling stammt nicht aus diesem Arbeitsbaum: {modul_pfad}"
+        )
+
+
+@freeze_time(_FROZEN_UTC)
+def test_ac16_guete_zeile_kippt_am_gepatchten_grenzwert_nicht_am_alten(monkeypatch):
+    """AC-16 GIVEN einen Testfall, der `LOCATION_SHARPNESS_LIMIT_MIN` zur
+    Laufzeit auf einen von 60 abweichenden Wert setzt (`90`, per
+    Monkeypatch auf `radar_service_mod.LOCATION_SHARPNESS_LIMIT_MIN`)
+    WHEN die Guete-Pruefung fuer eine Ereigniszeit knapp UEBER dem NEUEN
+    Wert (91 Min) laeuft
+    THEN greift die Guete-Zeile nach dem NEUEN Wert (Grenzzeit `now + 90
+    Min`) -- UND bei einer Ereigniszeit knapp UNTER dem NEUEN, aber
+    UEBER dem ALTEN Wert (61 Min) greift sie NICHT (sonst laese der
+    Produktivcode weiterhin die alte 60-Grenze statt der gepatchten
+    Modulvariable).
+
+    Die Erwartung wird aus DERSELBEN Modulreferenz gelesen
+    (`radar_service_mod.LOCATION_SHARPNESS_LIMIT_MIN`), nicht als `60` oder
+    `90` im Test dupliziert.
+
+    RED heute: `radar_service` kennt `LOCATION_SHARPNESS_LIMIT_MIN` nicht
+    (`AttributeError` beim Monkeypatchen)."""
+    monkeypatch.setattr(
+        radar_service_mod, "LOCATION_SHARPNESS_LIMIT_MIN", _NEUER_GRENZWERT_MIN,
+    )
+    limit = radar_service_mod.LOCATION_SHARPNESS_LIMIT_MIN
+    assert limit == _NEUER_GRENZWERT_MIN, (
+        "Vorbedingung: das Monkeypatchen muss die Modulvariable tatsaechlich "
+        f"aendern, gelesen wurde {limit!r}"
+    )
+
+    def _text_fuer(minuten: int) -> str:
+        nc = NowcastResult(
+            onset_minutes=minuten, intensity_label="Mäßiger Regen", source="radar",
+            is_convective=False,
+        )
+        msg = to_multi_location_onset_alert_message(
+            [("Sillian", nc)], tz=_TZ, stand_at="17:55",
+        )
+        _html, plain = render_email(msg)
+        return plain
+
+    knapp_ueber_altem_wert = _text_fuer(limit - 29)  # 61 bei limit=90
+    knapp_ueber_neuem_wert = _text_fuer(limit + 1)   # 91 bei limit=90
+
+    assert "Ortsangabe ab" not in knapp_ueber_altem_wert, (
+        f"RED/AC-16: bei {limit - 29} Minuten (jenseits der ALTEN, aber "
+        f"diesseits der GEPATCHTEN Grenze von {limit}) darf die Guete-Zeile "
+        f"NICHT erscheinen -- sonst liest der Produktivcode weiterhin den "
+        f"alten Wert 60 statt der Modulvariable: {knapp_ueber_altem_wert!r}"
+    )
+    assert "Ortsangabe ab" in knapp_ueber_neuem_wert, (
+        f"RED: bei {limit + 1} Minuten (jenseits der GEPATCHTEN Grenze von "
+        f"{limit}) muss die Guete-Zeile erscheinen: {knapp_ueber_neuem_wert!r}"
+    )

--- a/tests/tdd/test_ortsschaerfe_grenze_laufzeitbindung.py
+++ b/tests/tdd/test_ortsschaerfe_grenze_laufzeitbindung.py
@@ -33,7 +33,7 @@ from __future__ import annotations
 
 import inspect
 import re
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from pathlib import Path
 from zoneinfo import ZoneInfo
 

--- a/tests/tdd/test_ortsschaerfe_grenze_laufzeitbindung.py
+++ b/tests/tdd/test_ortsschaerfe_grenze_laufzeitbindung.py
@@ -118,3 +118,49 @@ def test_ac16_guete_zeile_kippt_am_gepatchten_grenzwert_nicht_am_alten(monkeypat
         f"RED: bei {limit + 1} Minuten (jenseits der GEPATCHTEN Grenze von "
         f"{limit}) muss die Guete-Zeile erscheinen: {knapp_ueber_neuem_wert!r}"
     )
+
+
+@freeze_time(_FROZEN_UTC)
+def test_ac16_starkregen_hint_liest_die_grenze_ebenfalls_zur_laufzeit(monkeypatch):
+    """AC-16 (Adversary-Fund F001) GIVEN denselben gepatchten Grenzwert wie
+    oben, diesmal geprueft am ZWEITEN in der Spec genannten Leser
+    (`format_starkregen_hint`, `starkregen_hint.py`) -- der urspruengliche
+    Test deckte nur `project.py` ab; der Produktivcode in `starkregen_hint.py`
+    war zwar korrekt (liest ueber die Modulreferenz), aber UNGEPRUEFT.
+
+    WHEN `format_starkregen_hint` fuer eine Ereigniszeit knapp UEBER dem
+    NEUEN Wert (91 Min) bzw. knapp UNTER dem NEUEN, aber UEBER dem ALTEN
+    Wert (61 Min) rendert
+    THEN kippt die Guete-Zeile exakt am GEPATCHTEN Grenzwert, nicht am
+    alten Default 60 -- ein echter Top-Level-Import
+    (`from services.radar_service import LOCATION_SHARPNESS_LIMIT_MIN`)
+    statt der Modulreferenz wuerde diesen Test rot machen, weil er den
+    gepatchten Wert nicht mehr saehe.
+
+    Die Erwartung wird wie oben aus DERSELBEN Modulreferenz gelesen, nicht
+    als Zahl im Test dupliziert."""
+    monkeypatch.setattr(
+        radar_service_mod, "LOCATION_SHARPNESS_LIMIT_MIN", _NEUER_GRENZWERT_MIN,
+    )
+    limit = radar_service_mod.LOCATION_SHARPNESS_LIMIT_MIN
+
+    from output.renderers.email.starkregen_hint import format_starkregen_hint
+
+    def _hint_fuer(minuten: int) -> str:
+        return format_starkregen_hint(
+            "Mäßiger Regen", minuten, tz=_TZ,
+        )
+
+    knapp_ueber_altem_wert = _hint_fuer(limit - 29)  # 61 bei limit=90
+    knapp_ueber_neuem_wert = _hint_fuer(limit + 1)   # 91 bei limit=90
+
+    assert "Ortsangabe ab" not in knapp_ueber_altem_wert, (
+        f"F001: bei {limit - 29} Minuten (jenseits der ALTEN, aber "
+        f"diesseits der GEPATCHTEN Grenze von {limit}) darf die Guete-Zeile "
+        f"in starkregen_hint.py NICHT erscheinen: {knapp_ueber_altem_wert!r}"
+    )
+    assert "Ortsangabe ab" in knapp_ueber_neuem_wert, (
+        f"F001: bei {limit + 1} Minuten (jenseits der GEPATCHTEN Grenze von "
+        f"{limit}) muss die Guete-Zeile in starkregen_hint.py erscheinen: "
+        f"{knapp_ueber_neuem_wert!r}"
+    )

--- a/tests/tdd/test_starkregen_kurzfristhinweis.py
+++ b/tests/tdd/test_starkregen_kurzfristhinweis.py
@@ -231,10 +231,14 @@ def _install_fake_nowcast(
     intensity_label: str = INTENSITY_DRY,
     is_convective: bool = False,
     raise_exc: Exception | None = None,
+    source_reach_minutes: int | None = None,
 ) -> None:
     """Ersetzt `RadarNowcastService.get_nowcast` durch eine echte Funktion, die ein
     echtes `NowcastResult` liefert (Transport-Grenze, kein Live-Netz, kein Mock-Objekt).
-    `calls` haelt (lat, lon, priority)-Tupel jedes Aufrufs fest (AC-1/AC-2-Nachweis)."""
+    `calls` haelt (lat, lon, priority)-Tupel jedes Aufrufs fest (AC-1/AC-2-Nachweis).
+
+    `source_reach_minutes` additiv (Issue #2051 S3): ohne sie bleibt das
+    `NowcastResult` unveraendert (`None`, Bestandsverhalten)."""
 
     def _fake_get_nowcast(self, lat, lon, elevation_m=None, priority="user_briefing"):
         calls.append((lat, lon, priority))
@@ -243,6 +247,7 @@ def _install_fake_nowcast(
         return NowcastResult(
             onset_minutes=onset_minutes, intensity_label=intensity_label,
             source="radar", is_convective=is_convective,
+            source_reach_minutes=source_reach_minutes,
         )
 
     monkeypatch.setattr(RadarNowcastService, "get_nowcast", _fake_get_nowcast)
@@ -418,6 +423,88 @@ def test_ac3_email_und_telegram_zeigen_identische_hinweiszeile(monkeypatch):
     telegram_text = "\n".join(report.telegram_bubbles)
     assert hint_line in telegram_text, (
         f"AC-3: Dieselbe Hinweiszeile muss in der Telegram-Ausgabe erscheinen.\n{telegram_text}"
+    )
+
+
+# ═══════════════════════ Issue #2051 S3 (Adversary-Fund F002) ═══════════════════════
+
+
+def test_2051s3_briefing_hinweis_traegt_die_reichweite_ueber_den_echten_scheduler_pfad(
+    monkeypatch,
+):
+    """Issue #2051 S3, Adversary-Fund F002: `_build_starkregen_hint()` gab bis
+    zu diesem Fix ein Fuenf-Tupel zurueck, das `result.source_reach_minutes`
+    NICHT enthielt -- die Reichweite kam am Briefing-Kurzfristhinweis nie an,
+    obwohl genau dieser Pfad (ohne Vorlauf-Deckel) der Ticket-Realfall ist.
+
+    Der bisherige Test fuer `source_reach_minutes` in `format_starkregen_hint`
+    (`test_nowcast_source_reach_textstellen.py`) ruft die Funktion DIREKT auf
+    und umgeht damit den einzigen produktiven Aufrufer
+    (`NotificationService`s Tupel-Entpackung) -- eine gestubbte Naht. DIESER
+    Test faehrt stattdessen den ECHTEN Scheduler-Pfad
+    (`_send_trip_report_outcome` -> `_build_starkregen_hint` -> Tupel ->
+    `NotificationService` -> `format_starkregen_hint` -> echter Renderer),
+    Muster AC-3 oben.
+
+    GIVEN ein `NowcastResult` mit `intensity_label=INTENSITY_HEAVY`,
+    `onset_minutes` gesetzt UND `source_reach_minutes=120`
+    WHEN der echte Briefing-Pfad laeuft
+    THEN traegt der Klartext-Teil zusaetzlich zur bestehenden Hinweiszeile
+    `Radar reicht bis HH:MM` MIT der aus den injizierten 120 Minuten
+    HERGELEITETEN Uhrzeit -- nicht nur irgendeine.
+
+    Adversary-Fund F003 (Adversary-Runde 2): eine reine Format-Pruefung
+    (`\\d{2}:\\d{2}`) liess ein auf `9999` verfaelschtes sechstes Tupelglied
+    unbemerkt durch -- der Test bewachte, DASS etwas dasteht, nicht DASS es
+    stimmt. Island (LAT/LON dieser Datei) ist UTC+0 ganzjaehrig, deshalb
+    entspricht die erwartete Uhrzeit direkt `datetime.now(UTC) + 120 Min`,
+    mit einer Wanduhr-Toleranz von 1 Minute (Muster
+    `test_onset_reichweite_guete_kanalparitaet.py`).
+
+    RED vor dem Fix: das Fuenf-Tupel transportierte `source_reach_minutes`
+    nicht -- `NotificationService` uebergab es folglich nie an
+    `format_starkregen_hint`, die Reichweite fehlte im Text."""
+    uid = _uid("s3-reach")
+    trip = _active_trip(f"trip-s3-reach-{uuid.uuid4().hex[:6]}")
+
+    calls: list = []
+    _install_fake_nowcast(
+        monkeypatch, calls, onset_minutes=15, intensity_label=INTENSITY_HEAVY,
+        source_reach_minutes=120,
+    )
+
+    recorder = _ReportRecorder()
+    recorder.install(monkeypatch)
+    _outcome, report = _run_briefing(recorder, uid, trip)
+
+    assert len(calls) >= 1, "Testvoraussetzung: get_nowcast() muss aufgerufen worden sein."
+    assert _HINT_MARKER in report.email_plain, (
+        f"Vorbedingung: die bestehende Hinweiszeile muss weiterhin stehen: "
+        f"{report.email_plain}"
+    )
+    treffer = re.search(r"Radar reicht bis (\d{2}:\d{2})", report.email_plain)
+    assert treffer is not None, (
+        f"F002: die Reichweite kommt ueber den echten Scheduler-Pfad nicht "
+        f"am Briefing-Hinweis an: {report.email_plain}"
+    )
+
+    # F003: der WERT muss aus den injizierten 120 Minuten hergeleitet sein,
+    # nicht nur irgendeine HH:MM-Zeichenkette. `datetime.now()` erst NACH
+    # dem Lauf gelesen (Island ist ganzjaehrig UTC+0, keine Zonenumrechnung
+    # noetig) -- die 1-Minuten-Toleranz deckt den Zeitversatz zwischen
+    # diesem Aufruf und dem `datetime.now()` im Produktivcode ab (Muster
+    # `test_onset_reichweite_guete_kanalparitaet.py::_abstand_minuten`).
+    def _minuten(hhmm: str) -> int:
+        stunde, _, minute = hhmm.partition(":")
+        return int(stunde) * 60 + int(minute)
+
+    erwartet = (datetime.now(timezone.utc) + timedelta(minutes=120)).strftime("%H:%M")
+    abstand = abs(_minuten(treffer.group(1)) - _minuten(erwartet))
+    abstand = min(abstand, 24 * 60 - abstand)
+    assert abstand <= 1, (
+        f"F003: die Reichweiten-Uhrzeit {treffer.group(1)!r} stammt nicht "
+        f"aus den injizierten 120 Minuten (erwartet nahe {erwartet!r} UTC, "
+        f"Island ist ganzjaehrig UTC+0): {report.email_plain}"
     )
 
 


### PR DESCRIPTION
- **spec(#2051): S3 — Reichweite der Quelle und Güte-Kennzeichnung**
- **test(#2051): RED — Reichweite der Quelle und Guete-Kennzeichnung (S3)**
- **feat(#2051): S3 — Reichweite der Quelle und Guete-Kennzeichnung**
- **test(#2051): S3 — Replay-Pfad (Staging-Messweg) auf Reichweite/Guete bewacht**
