### PR TITLE
feat(#2050 S6): Alarm-Protokoll haelt Vorwarnzeit, Ereigniszeit, Messpunkt, Vergleichsbasis und Quelle fest

### DIFF
--- a/docs/context/feat-2050-s6-protokoll-vorwarnzeit.md
+++ b/docs/context/feat-2050-s6-protokoll-vorwarnzeit.md
@@ -1,0 +1,138 @@
+# Context: feat-2050-s6-protokoll-vorwarnzeit
+
+Issue #2050, Scheibe **S6** — Anforderung **E-1** (Nachvollziehbarkeit).
+Erstellt 2026-08-22. Vorgaenger: S1 (Pruefstrecke), S2a (Waechter Szenarien 2+3),
+S2b (laufendes Ereignis) — alle drei geliefert. Stand: `origin/main` = `5fd9008f`.
+
+Alle Aussagen dieses Dokuments sind am Code nachgeprueft (Kartierung per Explore auf
+`5fd9008f`); jede Zeilenangabe ist ein Beleg, keine Schaetzung.
+
+## Request Summary
+
+Das Alarm-Protokoll soll die Groessen festhalten, mit denen sich nachtraeglich belegen
+laesst, **warum ein Alarm kam oder ausblieb**: gemeldete Vorwarnzeit, Ereigniszeit,
+Messpunkt, Vergleichsbasis und Quelle. Heute fehlt die Vorwarnzeit vollstaendig — ein
+Vorfall "kam zu spaet" ist im Nachhinein nicht belegbar.
+
+## Ist-Stand: was das Protokoll heute haelt
+
+Ein Schreibmodul, `src/services/alert_log.py` (613 Zeilen), Ablage pro Nutzer unter
+`get_data_dir(user_id) / "alert_log.json"` (`alert_log.py:388`), zwei Top-Level-Listen:
+
+| Liste | Bedeutung | Beleg |
+|---|---|---|
+| `entries` | mindestens ein Kanal war erreichbar | `alert_log.py:384` |
+| `not_delivered` | kein Kanal erreichbar **oder** vor dem Versand abgewiesen | `alert_log.py:479` |
+
+Der Eintrag ist ein rohes dict (keine dataclass), `alert_log.py:358-382`:
+
+```
+entity_id, entity_type, sent_at, changes_count, severity,
+metrics[{metric_id, aggregation, value?, previous_value?}],
+hazards[], reason, channels_sent[], channels_not_sent[{channel, reason}]
+```
+
+Additiv-optional: `capture_id` (`:377`), `capture_ids` (`:379`),
+`is_addendum` + `addendum_reported_at` (`:381-382`).
+
+## Abgleich mit E-1 — vier von fuenf Groessen fehlen
+
+| E-1-Groesse | Heute | Wo der Wert am Aufrufort bereits vorliegt |
+|---|---|---|
+| **Vorwarnzeit** | **fehlt vollstaendig** — kein `onset`/`lead`/`minutes`-Schluessel im Modul | `result.onset_minutes` (`trip_alert.py:1523`), `nowcast.onset_minutes` (`compare_radar_alert.py`) |
+| **Ereigniszeit** | fehlt. `sent_at` ist der Zeitpunkt des Protokollschreibens (`:364`, `:462`), nicht des Ereignisses. Einzige Ausnahme `addendum_reported_at` (`:382`) — das ist der Meldezeitpunkt der Vorwarnung, nicht die Ereigniszeit | `_onset_dt` (`trip_alert.py:1395`); amtlich `_alert.valid_from`/`valid_to` (`trip_alert.py:2001`) |
+| **Messpunkt** | fehlt. `MetricValue.segment_id` existiert (`:93`), dient aber nur der Gleichstands-Aufloesung in `_ist_extremer()` (`:104`) und wird in `_metric_dict()` (`:142-156`) **nicht** serialisiert | `active.segment_id` / `km_from` / `km_to` (`trip_alert.py:1524-1531`); `loc.id` im Ortsvergleich; `change.segment_id` im Abweichungszweig |
+| **Vergleichsbasis** | fehlt. `reference_at` wird berechnet, geht aber nur in die Mail-Fusszeile (`output/renderers/alert/render.py:1093`). Der Briefing-Schnappschuss `_briefing_precip` (`trip_alert.py:1428`) landet nur als Freitext im `gate_reason` bei Unterdrueckung (`:1435`) | `reference_at` (`trip_alert.py:388-403`, `compare_alert.py:286-308`) |
+| **Quelle** | **teilweise.** `reason` nennt den Zweig (`forecast_change` / `nowcast` / `official_alert`, `alert_log.py:66-68`); der **Datenlieferant** (DWD/RADOLAN, GeoSphere INCA, Open-Meteo) fehlt und ist ueber `capture_id` nur indirekt aufloesbar | `radar_svc.source_label(result.source)` (`trip_alert.py:1536`) |
+
+**Nichts muss neu berechnet werden.** Alle fuenf Groessen liegen an der jeweiligen
+Aufrufstelle bereits als Variable vor. Die Scheibe reicht durch, sie leitet nicht ab.
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `src/services/alert_log.py` | Das Schreibmodul. `append_entry()` `:275`, `_append()` `:387`, `append_suppressed_entry()` `:402`. Hier entstehen die neuen kwargs und ihre additive Serialisierung |
+| `src/services/trip_alert.py` | Drei `append_entry` (`:408` deviation, `:1632` radar, `:2050` official) und vier `append_suppressed_entry` (`:1299`, `:1433`, `:1583`, `:2010`) |
+| `src/services/compare_alert.py` | `append_entry` `:327` (deviation, Ortsvergleich); `reference_at` `:286-308` |
+| `src/services/compare_radar_alert.py` | `append_entry` `:287`, `append_suppressed_entry` `:199`/`:243` |
+| `src/services/compare_official_alert.py` | `append_entry` `:265`, `append_suppressed_entry` `:226` |
+| `internal/store/log.go` | Go-Leseseite. `AlertLogEntry` `:48-56` liest **nur sechs Felder** und verwirft alles andere still — deshalb ist eine additive Erweiterung fuer Go unsichtbar |
+| `src/services/alert_input_capture.py` | Der Roh-Mitschnitt (E-2, #1948). **Anderes Ablagesystem**, ueber `capture_id` mit dem Protokoll verbunden |
+
+## Existing Patterns
+
+**Additive Feld-Erweiterung ist der etablierte Weg — zweimal erfolgreich gefahren:**
+
+- `capture_id` (#1948): `if capture_id is not None: entry["capture_id"] = capture_id` (`alert_log.py:377`)
+- `is_addendum` / `addendum_reported_at` (#2018): `if is_addendum:` (`:381-382`)
+
+Beide folgen derselben Regel: **Absenz statt `null`** (`_metric_dict()` `:142-156`). Alt-Eintraege
+bleiben dadurch bit-identisch, es braucht keinen Migrationsschritt. `_append()` faehrt
+Read-Modify-Write ueber die volle Datei (`:387-401`) — die Projektregel fuer Persistenz-Aenderungen.
+
+**Fail-soft ist bereits im Schreibpfad verankert:** `_append()` faengt `OSError`/`ValueError`
+und legt die Datei notfalls neu an (`:391-394`) — "eine kaputte Datei darf keinen Alarm killen".
+
+## Dependencies
+
+- **Upstream** (was das Protokoll nutzt): `get_data_dir(user_id)`, `metric_catalog`
+  (Register-Kennungen, O1 aus #1459), `NotificationResult` (Kanal-Aufschluesselung).
+- **Downstream** (was das Protokoll nutzt):
+  - Go: `LoadAlertLog()` (`log.go:63`, liest **nur** `entries`) → `AlertCountByEntity()` (`:116`)
+    → Archiv-Statistik (`internal/handler/archive_stats.go:22`) und Cockpit-Kachel
+    (`internal/handler/cockpit.go:22-41`, Route `GET /api/cockpit/status`, `router.go:197`)
+  - Python: `read_undelivered()` (`alert_log.py:536`) → `alert_briefing_anchor.py:247` →
+    Briefing-Abschnitt "FEHLGESCHLAGEN / ZURUECKGEHALTEN"
+    (`src/output/renderers/email/undelivered_hint.py`)
+  - Frontend: liest **nur** die aggregierte Cockpit-Antwort, nie die Datei — kein Feldzugriff
+    auf Protokoll-Details
+
+## Existing Specs
+
+- `docs/specs/modules/feat_1459_alert_protokoll.md` — die Grundspec des Protokolls. Enthaelt
+  die **harte Nebenbedingung D4** (PO-Entscheidung 2026-08-02): Cockpit-Kachel und
+  Archiv-Statistik duerfen sich fuer Bestandstouren **um keine einzige Zahl** aendern.
+  Das Protokoll ist ein internes Protokoll, kein Anzeige-Feature. Dort auch die
+  offene Luecke **O3** (`:921-931`).
+- `docs/specs/modules/alarm_eingangsprotokoll.md` — der Roh-Mitschnitt (E-2, #1948 S1)
+- `docs/specs/modules/alarm_pruefstrecke.md` — der Harness aus S1
+- `docs/specs/modules/alarm_szenarien_waechter_2_3.md` — S2a
+- `docs/specs/modules/alarm_szenario_laufendes_ereignis.md` — S2b
+
+## Risks & Considerations
+
+1. **Die drei `append_entry()`-Aufrufe in `trip_alert.py` sind ungeschuetzt.**
+   `:408`, `:1632`, `:2050` — kein `try/except`. Ein neuer Feldbau, der wirft (etwa
+   `.isoformat()` auf `None` oder eine Zeitdifferenz gegen `None`), **verhindert den Alarm**.
+   Die Unterdrueckungs-Aufrufe sind dagegen alle gewrappt (`:1298`, `:1432`, `:1582`, `:2009`).
+   Das ist das einzige echte Schadenspotenzial dieser Scheibe.
+
+2. **D4 aus #1459 muss halten.** Go verwirft unbekannte JSON-Felder still
+   (`log.go:48-56`), Cockpit und Archiv-Statistik aendern sich also von selbst um keine Zahl —
+   vorausgesetzt, die Erweiterung bleibt rein additiv und fasst die sechs gelesenen Felder
+   nicht an.
+
+3. **Der Bestand sichert Schema-Identitaet ausdruecklich zu.**
+   `tests/tdd/test_alert_log.py:259` prueft, dass der Normalfall schema-identisch bleibt.
+   Rund 2.500 Zeilen Protokoll-Tests in zehn Dateien (`test_alert_log*.py`,
+   `test_nowcast_suppression_logging.py` mit 783 Zeilen) muessen mitgezogen werden.
+
+4. **Nicht jede Groesse existiert in jedem Zweig.** Der Abweichungsalarm kennt keine
+   Vorwarnzeit im Nowcast-Sinn, die amtliche Warnung hat `valid_from`/`valid_to` statt eines
+   Onsets. Das Schema muss "diese Groesse gibt es hier nicht" von "sie fehlt" unterscheiden —
+   die Absenz-Regel des Bestands leistet genau das.
+
+5. **Der Mitschnitt (E-2) hilft fuer E-1 nur begrenzt.** Der Nowcast-Mitschnitt haelt rohe
+   Frames (`radar_service.py:1146`), **kein** abgeleitetes `onset_minutes`. Die *gemeldete*
+   Vorwarnzeit — die Zahl, die beim Nutzer ankam — steht dort nicht und muss ins Protokoll.
+
+## Abgrenzung (bewusst NICHT in dieser Scheibe)
+
+- **Luecke O3** — der Vorhersage-Aenderungsalarm protokolliert seine Unterdrueckungen
+  **gar nicht** (`alert_log.py:432-434`, `feat_1459_alert_protokoll.md:921-931`). Das ist
+  Anforderung **D-2**, nicht E-1, und gehoert in eine eigene Scheibe.
+- **Sichtbarmachung** — keine Go-, keine Frontend-Aenderung. D4 stellt das Protokoll
+  ausdruecklich als internes Werkzeug fest.
+- **E-2 (Roh-Mitschnitt)** — existiert und funktioniert (#1948 S1); dass er teils unter
+  `debug/` liegt, ist ein eigener Befund.

--- a/docs/reference/api_contract.md
+++ b/docs/reference/api_contract.md
@@ -1,7 +1,12 @@
 
 # API Contract — Gregor Zwanzig
 
-**Updated:** 2026-08-22 (Issue #2049, `fix-2049-vorschau-einfach` — neues Sibling-Feld
+**Updated:** 2026-08-22 (Issue #2050 Scheibe S6, `feat-2050-s6-protokoll-vorwarnzeit` —
+`WeatherSnapshotService.load_dated()` bekommt additiven keyword-only Parameter
+`segment_fetched_at: bool = False`; datierte Snapshot-Segmente tragen additiv ihren eigenen
+`fetched_at`-Wert. Rein Python-intern, keine Go-/Frontend-Änderung, keine neue Route. Details
+Abschnitt „WeatherSnapshotService — Dated Snapshot Storage (Issue #747)", Spec:
+`docs/specs/modules/alarm_protokoll_vorwarnzeit.md`); 2026-08-22 (Issue #2049, `fix-2049-vorschau-einfach` — neues Sibling-Feld
 `display_config.outlook_metric_formats: Record<string, boolean>` neben `outlook_metrics`
 macht den bis dahin wirkungslosen Roh/Einfach-Umschalter im 3-Tages-Ausblick wirksam:
 `true` = Wortstufe/Symbol, fehlend/`false` = Rohzahl (harter Default, unabhängig von
@@ -4267,7 +4272,7 @@ Diese Sektion dokumentiert interne Service-Klassen, die nicht über REST-Endpoin
 | Methode | Signatur | Verhalten |
 |---------|----------|----------|
 | `save_dated()` | `(trip_id: str, target_date: date, segments: List[SegmentWeatherData]) → None` | Schreibt datierte Kopie zu `{trip_id}_{YYYY-MM-DD}.json`. Ruft intern `_prune_dated_snapshots()` auf. Fehler werden geloggt, nicht geworfen. |
-| `load_dated()` | `(trip_id: str, target_date: date) → Optional[List[SegmentWeatherData]]` | Lädt datierte Snapshot-Datei für den angegebenen Tag. Gibt `None` zurück wenn Datei nicht vorhanden (kein Absturz). Deserialisialisiert `SegmentWeatherData` mit Enum-Rekonstruktion. |
+| `load_dated()` | `(trip_id: str, target_date: date, *, segment_fetched_at: bool = False) → Optional[List[SegmentWeatherData]]` | Lädt datierte Snapshot-Datei für den angegebenen Tag. Gibt `None` zurück wenn Datei nicht vorhanden (kein Absturz). Deserialisialisiert `SegmentWeatherData` mit Enum-Rekonstruktion. Issue #2050 S6: additiver keyword-only Parameter `segment_fetched_at` (Default `False`, bestehende Aufrufer unverändert). `True` liefert je Segment dessen EIGENEN Erhebungszeitpunkt (aus dem gleichnamigen, additiven `fetched_at`-Feld je Segment im JSON) statt des Schreibzeitpunkts der Datei (`snapshot_at`); fehlt das Feld (Bestandsdateien) oder ist es unlesbar, fällt es fail-soft auf `snapshot_at` zurück. Bewusst opt-in — nur die Alarm-Protokoll-Ableitung (`alert_log.py`, `reference_at`) fragt den genaueren Wert an, alle anderen Leser (Alarm-Footer #1916, rollierender Alarm-Anker) bemessen sich weiter am Schreibzeitpunkt, da `format_reference_at()` am Kalendertag verzweigt. |
 | `_prune_dated_snapshots()` | `(trip_id: str) → None` | Löscht älteste datierte Snapshots für diesen Trip, behält maximal 7 (mtime-sortiert). Fehler beim Löschen werden geloggt. |
 | `save()` | `(trip_id: str, segments: List[SegmentWeatherData], target_date: date, *, briefing_backed: bool = True) → None` | Speichert auf `{trip_id}.json` für Alert-Pfad, ansonsten unverändert. Issue #1699: zusätzliches keyword-only Feld `briefing_backed` im JSON hält die Herkunft fest — nur ein Snapshot aus einem regulären Briefing taugt als Abweichungs-Alarm-Vergleichsbasis (ADR-0009). Default `True` (bestehende Aufrufer: Briefing-Lauf, Compare-Presets, unverändert); `False` setzt ausschließlich der reine Abfrage-Pfad (`trip_command_processor._fetch_and_save_snapshot`, z. B. `glance`/`gewitter`/`timeline`). |
 | `load()` | _(bestehend, unverändert)_ | Lädt von `{trip_id}.json` für Alert-Pfad. Byte-identisch vor/nach Issue #747. |
@@ -4300,6 +4305,7 @@ _snapshot_svc.save_dated(trip_id, target_date, segment_weather)  # neu, Issue #7
 - Bestehende `save()`-/`load()`-Methoden sind byte-identisch
 - Alert-Pfad (`trip_alert.py`) nutzt nur `save()`/`load()` — keine Verhaltensänderung
 - Bestandsdaten in `{trip_id}.json` bleiben unverändert
+- 2026-08-22: Issue #2050 S6 — `WeatherSnapshotService.load_dated()` bekommt additiven keyword-only Parameter `segment_fetched_at: bool = False`. Segmente im datierten JSON tragen zusätzlich ihren eigenen `fetched_at`-Wert (additiv, `_serialize_segment`). Nur die Alarm-Protokoll-Ableitung setzt `segment_fetched_at=True`; alle anderen Aufrufer unverändert. Details: `docs/specs/modules/alarm_protokoll_vorwarnzeit.md`.
 - 2026-08-17: Issue #1699 — `WeatherSnapshotService.save()` bekommt additiven keyword-only Parameter `briefing_backed: bool = True` (Herkunftsmerkmal des undatierten Snapshots) und neue Lesemethode `load_briefing_backed()` (fail-soft auf `True`). `TripAlertService._get_cached_weather` lehnt in Stufe 3 der #1916-Prioritätskette (undatierter Rückfall) einen nicht briefing-gestützten Anker für den Abweichungs-Alarm mit dem vierten Ablehnungsgrund `not_briefing_backed` ab (`diagnostics/alert_anchor_rejected.jsonl`, neben `wrong_day`/`too_old`/`missing` aus #1661); amtliche Warnungen (Geometrie-Lesart) bleiben unberührt. Siehe Zeile 3921 ff. oben und `docs/specs/modules/fix_1699_anker_ohne_briefing.md`.
 - 2026-05-30: Issue #461 — Compare-Presets Daily Dispatch (Cronjob): New `POST /api/scheduler/compare-presets-daily` endpoint (section 17) triggered daily by Go scheduler at 06:00 UTC. Filters presets by `schedule='daily'`, runs Compare Engine, renders/sends emails via Resend, updates `letzter_versand` and `top_ort_letzter_versand` fields. Per-preset error isolation; BetterStack Heartbeat pinged only on `error_count==0` (Readiness Principle). Config field `HeartbeatComparePresets` added to Go config; Go scheduler job count increased from 5 to 6. Tests: 11 new comprehensive tests in `test_issue_461_compare_preset_dispatch.py`.
 - 2026-05-30: Added section 18 — Authentication Endpoints (Issue #450 Passkey/WebAuthn V1): 5 passkey endpoints (register/begin|finish, login/begin|finish, delete), password auth methods (register, login), profile endpoint with `has_passkey`+`passkeys[]`. User model extended with `PasskeyCredentials[]` and `PasswordHash` now optional. Rate-limit 30/h per IP (alle 5 Endpoints), challenge TTL 5 min, RP-ID isolation (prod vs staging), 64 KB body cap.

--- a/docs/specs/modules/alarm_protokoll_vorwarnzeit.md
+++ b/docs/specs/modules/alarm_protokoll_vorwarnzeit.md
@@ -1,0 +1,322 @@
+---
+entity_id: alarm_protokoll_vorwarnzeit
+type: feature
+created: 2026-08-22
+updated: 2026-08-22
+status: approved
+workflow: feat-2050-s6-protokoll-vorwarnzeit
+version: "1.0"
+tags: [alarm, protokoll, nachvollziehbarkeit]
+---
+
+# Alarm-Protokoll haelt Vorwarnzeit, Ereigniszeit, Messpunkt, Vergleichsbasis und Quelle fest (Scheibe S6, Issue #2050)
+
+## Approval
+
+- [x] Approved — PO-Freigabe ("go") am 2026-08-22
+
+## Purpose
+
+Anforderung **E-1** (Nachvollziehbarkeit) verlangt, dass sich nachtraeglich belegen laesst,
+**warum ein Alarm kam oder ausblieb**. Das Alarm-Protokoll (`src/services/alert_log.py`) haelt
+heute WAS gemeldet wurde (Register-Groesse, Schweregrad, Kanaele), aber NICHT WANN und WOMIT
+begruendet: die gemeldete Vorwarnzeit fehlt vollstaendig — ein Vorfall "kam zu spaet" ist
+nachtraeglich nicht belegbar. Diese Scheibe ergaenzt fuenf Groessen rein additiv: gemeldete
+Vorwarnzeit, Ereigniszeit (Beginn/Ende), Messpunkt, Vergleichsbasis, Quelle.
+
+## Source
+
+- **File:** `src/services/alert_log.py` (`append_entry()`, `append_suppressed_entry()`)
+- **Identifier:** neue optionale Schluesselwort-Argumente auf beiden Funktionen, plus eine neue
+  Hilfsfunktion `unique_or_none()`
+
+> Schicht: Python-Core (`src/services/`) — kein Go-, kein Frontend-Anteil (Nebenbedingung **D4**
+> aus `feat_1459_alert_protokoll.md`: Go liest nur sechs Felder und verwirft den Rest still,
+> `internal/store/log.go:48-56`).
+
+## Estimated Scope
+
+- **LoC:** produktiv ~100-150 (Standardlimit 250 reicht rechnerisch, der Workflow hebt es laut
+  Auftrag vorsorglich auf 500 an — 5 Aufrufstellen-Dateien verteilen die Aenderung breit statt
+  tief), Tests deutlich mehr (13 Aufrufstellen x mehrere Szenarien)
+- **Files:** 5 (`alert_log.py` + 4 Aufrufer-Dateien), plus diese Spec
+- **Effort:** medium
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `src/services/alert_log.py::append_entry()` (`:275`) | function | Bekommt die sechs neuen additiven kwargs (fuenf E-1-Groessen + Absenz-Logik) |
+| `src/services/alert_log.py::append_suppressed_entry()` (`:402`) | function | Dieselben sechs kwargs, **nur soweit am jeweiligen Gate bereits bekannt** (Punkt 4 unten) |
+| `src/services/alert_log.py` (neu) `unique_or_none()` | function | Geteilter Baustein: aus mehreren Werten (Segmenten/Orten/Zeitpunkten EINES Eintrags) den einen gemeinsamen liefern, sonst `None` — reine Mehrdeutigkeitspruefung, keine Neuberechnung |
+| `src/services/trip_alert.py` (`:408`, `:1299`, `:1433`, `:1583`, `:1632`, `:2010`, `:2050`) | code | Drei `append_entry`- und vier `append_suppressed_entry`-Aufrufe, alle drei Zweige (Abweichung/Nowcast/amtlich) |
+| `src/services/compare_alert.py` (`:327`) | code | `append_entry` Abweichungszweig, Ortsvergleich |
+| `src/services/compare_radar_alert.py` (`:199`, `:243`, `:287`) | code | Ein `append_entry`, zwei `append_suppressed_entry`, Nowcast-Zweig Ortsvergleich |
+| `src/services/compare_official_alert.py` (`:226`, `:265`) | code | Ein `append_entry`, ein `append_suppressed_entry`, amtlicher Zweig Ortsvergleich |
+| `internal/store/log.go` (`:48-56`) | code | Liest **unveraendert** nur sechs Felder — Abnahme-Nachweis fuer D4, keine Aenderung noetig |
+
+## Implementation Details
+
+### Sechs neue additive Schluessel
+
+Beide Schreibfunktionen bekommen dieselben sechs optionalen kwargs, alle default `None`, alle nach
+dem etablierten Muster serialisiert (`if wert is not None: entry[schluessel] = wert`) — Absenz statt
+`null`, Alt-Eintraege und Eintraege ohne bestimmbaren Wert bleiben schema-identisch zum Bestand:
+
+| kwarg | Typ | Bedeutung |
+|---|---|---|
+| `lead_time_minutes` | `int \| None` | die **gemeldete** Vorwarnzeit — die Minutenzahl, die tatsaechlich beim Nutzer ankam. **Nur der Nowcast-Zweig** kennt dieses Konzept |
+| `event_at` | `str (ISO) \| None` | Ereignisbeginn: Onset-Zeitpunkt (Nowcast) bzw. `valid_from` (amtlich) bzw. Zeitpunkt des ausloesenden Spitzenwerts (Abweichung, nur wenn eindeutig — s. u.) |
+| `event_end_at` | `str (ISO) \| None` | voraussichtliches Ende: aus `event_end_minutes` (Nowcast) bzw. `valid_to` (amtlich). **Der Abweichungszweig kennt kein Ende** — strukturell immer `None` |
+| `measurement_point` | `dict \| None` | `{"segment_id":, "km_from":, "km_to":}` (Trip) oder `{"location_id":}` (Ortsvergleich) — **nur gesetzt, wenn der Eintrag GENAU EINEN Ort/EIN Segment betrifft** |
+| `reference_at` | `str (ISO) \| None` | Vergleichsbasis: Anker-Fetchzeitpunkt (Abweichung) bzw. Briefing-Schnappschusszeitpunkt (Nowcast/Trip). **Die amtliche Warnung hat keine Vergleichsbasis** — strukturell immer `None` |
+| `source` | `str \| None` | roher Datenlieferant-Schluessel (`result.source` bzw. `OfficialAlert.source` bzw. `SegmentWeatherData.provider` — jeweils bereits vorhandene Rohwerte, keine neue Formatierung) |
+
+**Der `reason`-Wert des Eintrags (bereits vorhanden: `forecast_change`/`nowcast`/`official_alert`)
+ist der Diskriminator, der "diese Groesse gibt es hier strukturell nicht" von "sie war in diesem
+Einzelfall nicht bestimmbar" unterscheidbar macht** — bei `reason=official_alert` sind
+`lead_time_minutes`/`reference_at` IMMER `None` (kein Aufrufer uebergibt sie je), waehrend bei
+`reason=nowcast` ihre Absenz einzelfallbedingt ist (z. B. `onset_minutes is None` im laufenden
+Ereignis, S2b). Kein neues Feld noetig — die Unterscheidung steht bereits im Bestand.
+
+### `unique_or_none()` — der einzige neue Verarbeitungsschritt
+
+```python
+def unique_or_none(values: Iterable) -> "Any | None":
+    """Liefert den einen Wert, wenn alle NICHT-None-Werte uebereinstimmen und
+    mindestens einer vorhanden ist; sonst None. Reine Mehrdeutigkeitspruefung
+    -- es wird nichts abgeleitet, nur entschieden, ob ein bereits bekannter
+    Wert EINDEUTIG genug ist, um ihn zu berichten."""
+```
+
+Wird an den Aufrufstellen gebraucht, deren Eintrag MEHRERE Segmente/Orte/Zeitpunkte buendeln kann
+(Abweichungszweig: `to_report` mehrere `WeatherChange`; amtlicher Zweig: mehrere Warnungen bzw.
+mehrere `_segment_ids`/`loc_ids` je Warnung; Nowcast-Ortsvergleich: mehrere getriggerte Orte in
+`triggered`). Ohne diese Pruefung waere ein Eintrag mit zwei Segmenten gezwungen, WILLKUERLICH
+eines davon als "den" Messpunkt zu behaupten — genau die Verfaelschung, die E-1 verhindern soll.
+
+### Je Aufrufstelle: was ist WIRKLICH bekannt (geprueft am Code, `5fd9008f`)
+
+**`append_entry()` — immer NACH dem Versandversuch, alles unten Genannte liegt vor:**
+
+| Aufrufstelle | `lead_time_minutes` | `event_at`/`event_end_at` | `measurement_point` | `reference_at` | `source` |
+|---|---|---|---|---|---|
+| `trip_alert.py:408` (Abweichung) | strukturell `None` | `unique_or_none([c.occurred_at for c in to_report])` | `unique_or_none([c.segment_id for c in to_report])` als `{"segment_id":}` | `anchor_fetched.isoformat()` (`:389`, bereits vorhanden), `None` falls `cached_weather` leer (Erstlauf) | `cached_weather[0].provider` (`SegmentWeatherData.provider`), `None` im Erstlauf |
+| `trip_alert.py:1632` (Nowcast) | `result.onset_minutes` | `_onset_dt.isoformat()` (`:1395`, immer gesetzt) / `event_end_minutes`-Ableitung, `None` falls kein Ende bestimmbar | `{"segment_id": active.segment_id, "km_from":, "km_to":}` (immer EIN Segment je Trip-Lauf) | `_snapshot[0].fetched_at.isoformat()` (`weather_snapshot.py:173`, der ECHTE Erzeugungszeitpunkt der Briefing-Momentaufnahme, nicht nur das Datum), `None` falls kein Snapshot fuer den Tag existiert | `result.source` — der ROHE Schluessel, NICHT `radar_svc.source_label(...)` (Korrektur 2026-08-22, s. u. "Korrektur: `source` ist immer der rohe Schluessel") |
+| `trip_alert.py:2050` (amtlich) | strukturell `None` | `_alert.valid_from.isoformat()` / `_alert.valid_to.isoformat()`, je Warnung | `unique_or_none(alle _segment_ids ueber die Warnungen dieses Eintrags)` | strukturell `None` | `unique_or_none([a.source for a, _ in official_notices])` |
+| `compare_alert.py:327` (Abweichung, Compare) | strukturell `None` | analog Trip, ueber `alle_changes` | analog Trip ueber `t["loc"].id` je Gruppe | `first_anchor_fetched_at.isoformat()` (`:287`, bereits vorhanden) | `cached[0].provider` (`PointWeatherData.provider`) an der Stelle, wo `anchor_fetched_at` heute schon gebaut wird (`:464`) — additiv mitgefuehrt |
+| `compare_radar_alert.py:287` (Nowcast, Compare) | `unique_or_none([nc.onset_minutes for _,_,nc in triggered])` | analog, `unique_or_none` ueber alle `triggered`-Nowcasts | `unique_or_none([loc.id for _,loc,_ in triggered])` als `{"location_id":}` | strukturell `None` — es gibt in diesem Pfad KEINE "bereits im Briefing angekuendigt"-Pruefung (anders als Trip) | `unique_or_none([nc.source for _,_,nc in triggered])` |
+| `compare_official_alert.py:265` (amtlich, Compare) | strukturell `None` | analog Trip, je Warnung ueber `tagged_alerts` | `unique_or_none(alle loc_ids ueber die Warnungen)` | strukturell `None` | `unique_or_none([a.source for a, _ in tagged_alerts])` |
+
+**`append_suppressed_entry()` — Bekanntheitsgrad haengt vom GATE ab, nicht generell "noch nichts
+bekannt" (der bestehende Docstring, `alert_log.py:415-420`, behauptet das pauschal falsch fuer
+6 von 7 Aufrufstellen):**
+
+| Aufrufstelle | Gate | Was ist bekannt |
+|---|---|---|
+| `trip_alert.py:1299` | Cooldown/Ruhezeit, VOR dem Nowcast-Abruf | **Wirklich nichts** — kein `result` existiert noch. Alle sechs Felder `None`. Einzige Stelle, an der der heutige Docstring stimmt |
+| `compare_radar_alert.py:199` | Cooldown/Ruhezeit, VOR `_detect_triggered_locations()` | **Wirklich nichts** — analog zu oben |
+| `trip_alert.py:1433` | Briefing-Ueberholung | `result` liegt bereits vor (`get_nowcast` lief bei `:1373`) — `lead_time_minutes`, `event_at`/`event_end_at`, `measurement_point`, `source` bekannt; `reference_at` = GENAU der Briefing-Schnappschuss, dessen Ankuendigung hier die Unterdrueckung begruendet — hier am wertvollsten |
+| `trip_alert.py:1583` | Ereignis-Identitaet (Entdopplung) | Alles bekannt; `source` aus dem ROHEN `result.source` (nicht aus `_radar_request.source_label`) |
+| `trip_alert.py:2010` | Ereignis-Identitaet, amtlich | `_alert.valid_from`/`valid_to`/`.source` bekannt; `measurement_point` bekannt, wenn `_segment_ids` dieser EINEN Warnung genau ein Segment traegt; `lead_time_minutes`/`reference_at` strukturell `None` |
+| `compare_radar_alert.py:243` | Ereignis-Identitaet, Nowcast Compare | `nowcast`/`loc` liegen bereits vor (innerhalb der `for name, loc, nowcast in triggered:`-Schleife) — alles bekannt bis auf `reference_at` (strukturell `None`, wie bei `append_entry` dieses Zweigs) |
+| `compare_official_alert.py:226` | Ereignis-Identitaet, amtlich Compare | `alert`/`loc_id` liegen einzeln vor (innere Schleife) — `measurement_point={"location_id": loc_id}` immer eindeutig; `event_at`/`event_end_at`/`source` bekannt; `lead_time_minutes`/`reference_at` strukturell `None` |
+
+## Expected Behavior
+
+- **Input:** dieselben lokalen Variablen, die an jeder Aufrufstelle bereits existieren (Beleg-Tabelle
+  oben) — keine neue Datenbeschaffung.
+- **Output:** `entries`- bzw. `not_delivered`-Eintraege tragen zusaetzlich bis zu sechs neue
+  Schluessel, nur wenn bestimmbar. Alt-Eintraege und Eintraege ohne bestimmbaren Wert bleiben
+  schema-identisch zum Bestand (byte-identisch fuer Alt-Eintraege).
+- **Side effects:** keine neuen. Versand, Kanal-Auswertung, Cooldown, Entdopplung — alles
+  unveraendert. Ein Fehler beim Feldbau darf laut Auftrag NIE den Alarm verhindern (Punkt 5,
+  Risiko 1 aus dem Kontext-Dokument) — durchgesetzt durch defensive Feldableitung INNERHALB
+  `alert_log.py` (jede `None`-Eingabe -> Absenz, nie eine Ausnahme), nicht durch `try/except` an
+  den ungeschuetzten `append_entry()`-Aufrufstellen in `trip_alert.py` (`:408`, `:1632`, `:2050`).
+
+## Acceptance Criteria
+
+- **AC-1:** Given ein Trip-Nowcast-Alarm mit bestimmbarem Beginn (`onset_minutes` gesetzt), When
+  der Alarm zugestellt und protokolliert wird, Then traegt der `entries`-Eintrag
+  `lead_time_minutes` (= `onset_minutes`), `event_at`, `measurement_point` (mit `segment_id`,
+  `km_from`, `km_to`) und `source`.
+  - Test: `AlarmPruefstrecke.lauf(zweig="radar", ...)` mit einem Segment und bestimmbarem
+    Beginn; das geschriebene JSON traegt alle vier Schluessel mit den erwarteten Werten.
+
+- **AC-2:** Given derselbe Trip-Nowcast-Alarm, aber das Ereignis endet nachweislich (bekanntes
+  `event_end_minutes`), When protokolliert wird, Then traegt der Eintrag zusaetzlich
+  `event_end_at`.
+  - Test: Frames mit trockenem Folge-Frame vor Sichtfensterende (Muster aus S2b AC-4); der
+    Eintrag traegt `event_end_at` als ISO-Zeitpunkt.
+
+- **AC-3:** Given eine Vorhersage-Aenderung ueber GENAU EIN Segment (ein einzelner `WeatherChange`
+  in `to_report`), When der Aenderungsalarm protokolliert wird, Then traegt der Eintrag
+  `measurement_point={"segment_id": <das eine Segment>}` und `reference_at` (Anker-Fetchzeitpunkt).
+  - Test: `AlarmPruefstrecke.lauf(zweig="deviation", ...)` mit einer Aenderung an einem Segment;
+    der Eintrag traegt beide Schluessel.
+
+- **AC-4 (Positivkontrolle zu AC-3):** Given dieselbe Vorhersage-Aenderung, aber ueber ZWEI
+  VERSCHIEDENE Segmente in EINEM Protokoll-Eintrag, When protokolliert wird, Then FEHLT
+  `measurement_point` in diesem Eintrag vollstaendig (kein willkuerlich gewaehltes Segment).
+  - Test: zwei `WeatherChange` mit unterschiedlichem `segment_id` im selben Lauf; der Eintrag
+    enthaelt den Schluessel `measurement_point` NICHT. Gegenprobe: mit nur EINEM der beiden
+    Segmente (AC-3-Fixture) ist der Schluessel vorhanden — der Unterschied beweist, dass die
+    Mehrdeutigkeit tatsaechlich der Grund fuer die Absenz ist, nicht ein durchgehend leerer Pfad.
+
+- **AC-5 (Zweig-Abdeckung amtlich):** Given eine zugestellte amtliche Warnung mit `valid_from`/
+  `valid_to`, When protokolliert wird, Then traegt der Eintrag `event_at`/`event_end_at` und
+  `source` (= `OfficialAlert.source`), aber NIEMALS `lead_time_minutes` oder `reference_at` —
+  auch nicht als `null`, der Schluessel fehlt.
+  - Test: `AlarmPruefstrecke.lauf(zweig="official", ...)` mit einer Warnung; `event_at`/
+    `event_end_at`/`source` vorhanden, `"lead_time_minutes" not in entry` und
+    `"reference_at" not in entry`.
+
+- **AC-6 (Zweig-Abdeckung Abweichung, Positivkontrolle zu AC-5):** Given eine Vorhersage-
+  Aenderung wird protokolliert, When derselbe Eintrag gepruft wird, Then fehlt
+  `lead_time_minutes` UND `event_end_at` ebenfalls vollstaendig (strukturell, nicht nur in diesem
+  Einzelfall) — waehrend derselbe Eintrag `event_at` sehr wohl tragen KANN (AC-3). Der
+  Unterschied zwischen "kommt hier nie vor" (`lead_time_minutes`) und "kommt vor, wenn eindeutig"
+  (`event_at`) ist am Schema selbst ablesbar.
+  - Test: Fixture aus AC-3; `"lead_time_minutes" not in entry` und `"event_end_at" not in entry`,
+    waehrend `"event_at" in entry`.
+
+- **AC-7 (Ortsvergleich, Nowcast, Positivkontrolle Ambiguitaet):** Given ein Ortsvergleichs-
+  Nowcast-Alarm, der GENAU EINEN Ort ausloest, When protokolliert wird, Then traegt der Eintrag
+  `measurement_point={"location_id": <der eine Ort>}`; ausloesend an ZWEI Orten GLEICHZEITIG,
+  wenn protokolliert wird, dann fehlt `measurement_point` in diesem zweiten Fall vollstaendig.
+  - Test: zwei Compare-Radar-Laeufe ueber die Pruefstrecke, einer mit einem, einer mit zwei
+    getriggerten Orten; nur der Ein-Ort-Fall traegt `measurement_point`.
+
+- **AC-8 (Fail-soft, PFLICHT):** Given ein Alarm, bei dem ALLE sechs neuen Groessen nicht
+  bestimmbar sind (z. B. eine Vorhersage-Aenderung ohne Vergleichs-Anker — Erstlauf-Situation —
+  ueber mehr als ein Segment gleichzeitig), When der Alarm ausgeloest wird, Then wird er TROTZDEM
+  zugestellt (mindestens ein Kanal in `channels_sent`) UND vollstaendig protokolliert — der
+  Eintrag entsteht ohne Ausnahme, nur ohne die sechs neuen Schluessel.
+  - Test: echter Lauf ueber `AlarmPruefstrecke` mit leerem Anker-Snapshot und zwei Segmenten;
+    `triggered_count == 1`, der Eintrag existiert und enthaelt keinen der sechs neuen Schluessel.
+
+- **AC-9 (Unterdrueckung, fruehes Gate — nichts bekannt):** Given ein Nowcast-Alarm wird durch
+  das Cooldown-/Ruhezeit-Gate VOR dem eigentlichen Radar-Abruf unterdrueckt, When der
+  Unterdrueckungs-Eintrag geschrieben wird, Then enthaelt er KEINEN der sechs neuen Schluessel
+  (strukturell nichts bekannt an dieser Stelle).
+  - Test: Trip mit aktivem Cooldown, Radar-Zweig ausgeloest; der `not_delivered`-Eintrag hat
+    `gate_reason` wie bisher, aber keinen der sechs neuen Schluessel.
+
+- **AC-10 (Unterdrueckung, spaetes Gate — Vergleichsbasis ist die Begruendung):** Given ein
+  Nowcast-Alarm wird unterdrueckt, WEIL das Briefing die Menge bereits angekuendigt hatte (Gate
+  NACH dem Radar-Abruf), When der Unterdrueckungs-Eintrag geschrieben wird, Then traegt er
+  `reference_at` (der Briefing-Schnappschusszeitpunkt, der die Unterdrueckung begruendet) sowie
+  `lead_time_minutes`/`event_at`/`measurement_point`/`source`.
+  - Test: Trip mit vorhandenem, ausreichend angekuendigtem Briefing-Schnappschuss, Nowcast lost
+    aus, wird aber wegen Ankuendigung unterdrueckt; der Eintrag traegt alle fuenf genannten
+    Schluessel (`event_end_at` ggf. zusaetzlich, wenn ein Ende bestimmbar ist).
+
+- **AC-11 (Mandantentrennung, PFLICHT):** Given zwei verschiedene Nutzer A und B loesen im
+  selben Testlauf je einen Nowcast-Alarm fuer ihren jeweils eigenen Trip aus, When beide
+  protokolliert werden, Then traegt Nutzer As Eintrag in `data/users/<A>/alert_log.json` As
+  eigenen Messpunkt/Vorwarnzeit, Nutzer Bs Eintrag in `data/users/<B>/alert_log.json` Bs eigenen
+  — keine Vermischung, keiner der Werte des anderen Nutzers erscheint in der falschen Datei.
+  - Test: `AlarmPruefstrecke.lauf(...)` zweimal mit unterschiedlicher `user_id` und
+    unterschiedlichen Segment-/Ort-Daten; beide Protokolldateien getrennt gelesen und auf die
+    JEWEILS EIGENEN Werte geprueft.
+
+- **AC-12 (Alt-Eintraege unangetastet, PFLICHT mit Gegenprobe):** Given eine bestehende
+  `alert_log.json` mit einem Eintrag aus VOR dieser Scheibe (ohne die sechs neuen Schluessel),
+  When ein neuer Alarm fuer denselben Nutzer protokolliert wird, Then bleibt der ALTE Eintrag
+  byte-identisch (keiner der sechs Schluessel wird nachtraeglich ergaenzt), WAEHREND der NEUE
+  Eintrag in DERSELBEN Datei die neuen Schluessel traegt, wo bestimmbar.
+  - Test: Fixture-Datei mit einem Alt-Eintrag laden, `append_entry()` fuer denselben `user_id`
+    aufrufen, Datei neu einlesen; alter Eintrag `==` Fixture-Alt-Eintrag (dict-Vergleich), neuer
+    Eintrag hat mindestens einen der sechs Schluessel. Der Kontrast zwischen den beiden
+    Eintraegen in derselben Datei ist die Positivkontrolle: er zeigt, dass die neuen Schluessel
+    technisch geschrieben WERDEN, nur eben nicht rueckwirkend.
+
+- **AC-13 (D4-Invarianz, PFLICHT mit Gegenprobe):** Given zwei sonst identische
+  `alert_log.json`-Dateien fuer denselben Nutzer, eine MIT den sechs neuen Schluesseln in ihren
+  Eintraegen befuellt, eine OHNE, When `internal/store/log.go LoadAlertLog()` bzw.
+  `AlertCountByEntity()` auf beide angewendet wird, Then liefern beide Dateien EXAKT dieselbe
+  Zahl fuer dieselbe `entity_id`.
+  - Test: **Go-Test** in `internal/store/` (Geschwister von `archive_stats_test.go`) — eine
+    Python-seitige Nachbildung des Lesevertrags ist AUSDRUECKLICH NICHT zulaessig: sie pruefte
+    die Zusicherung dort, wo unser Code steht, nicht dort, wo sie WIRKT. Genau die Schicht,
+    die unbekannte Felder verwerfen soll, ist die zu pruefende.
+    Zwei Fixture-Dateien, identisch bis auf die sechs neuen Schluessel; beide durch den
+    Zaehl-Pfad gejagt; Ergebnis-Zahl identisch. Gegenprobe: eine dritte Fixture mit einem
+    ECHT geaenderten der sechs BESTEHENDEN Felder (z. B. `changes_count` erhoeht) MUSS eine
+    andere Zahl liefern — das zeigt, dass der Zaehl-Pfad ueberhaupt etwas misst und nicht
+    zufaellig immer gleich zaehlt.
+
+- **AC-14 (`unique_or_none()` selbst, PFLICHT mit Gegenprobe):** Given eine Werteliste mit genau
+  einem wiederkehrenden Nicht-`None`-Wert (z. B. `["seg-1", "seg-1"]` oder `["seg-1", None]`),
+  When `unique_or_none()` aufgerufen wird, Then liefert es diesen einen Wert. Given eine Liste
+  mit ZWEI VERSCHIEDENEN Nicht-`None`-Werten (z. B. `["seg-1", "seg-2"]`) ODER einer leeren
+  Liste, When aufgerufen wird, Then liefert es `None`.
+  - Test: reiner Funktionstest mit den drei Fallgruppen (eindeutig direkt, eindeutig mit
+    `None`-Rauschen, mehrdeutig) plus Leerfall; alle vier Erwartungen in einem Test.
+
+- **AC-15 (Protokollfehler darf Alarm nie verhindern, PFLICHT):** Given eine der sechs neuen
+  Eingaben an einer ungeschuetzten `append_entry()`-Aufrufstelle (`trip_alert.py:408`, `:1632`
+  oder `:2050`) ist unerwartet fehlerhaft geformt (z. B. ein nicht-serialisierbares Objekt statt
+  `None`/`str`/`dict`), When der Alarm ausgeloest wird, Then wirft `append_entry()` KEINE
+  Ausnahme, die den Alarm verhindert — die defensive Feldableitung in `alert_log.py` faengt den
+  Fall ab, der Eintrag entsteht ohne den betroffenen Schluessel statt den Lauf abzubrechen.
+  Das Abfangen ist jedoch **nicht still**: es schreibt eine `logger.warning`-Zeile, die den
+  betroffenen Schluessel und die `entity_id` nennt. Ein stilles Verschlucken wuerde genau den
+  Zweck von E-1 aufheben — das Protokoll behauptete dann "diese Groesse gab es hier nicht",
+  wo in Wahrheit ein Defekt vorlag.
+  - Test: `append_entry()` direkt mit einem absichtlich falsch geformten Wert fuer eines der
+    sechs kwargs aufrufen (z. B. `measurement_point` als String statt `dict`); der Aufruf
+    schliesst ohne Ausnahme ab, der geschriebene Eintrag hat den Schluessel entweder korrekt
+    oder gar nicht, die Funktion terminiert normal — UND die Warnung ist im Log nachweisbar
+    (`caplog`). Gegenprobe: derselbe Aufruf mit einem korrekt geformten Wert erzeugt KEINE
+    Warnung; der Unterschied beweist, dass die Warnung den Fehlerfall anzeigt und nicht immer
+    erscheint.
+
+## Korrektur: `source` ist immer der rohe Schluessel (2026-08-22)
+
+Die Feldtabelle oben ("roher Datenlieferant-Schluessel ... keine neue Formatierung") und die
+Aufrufstellen-Tabelle widersprachen sich: letztere nannte fuer den Trip-Radar-Zweig
+`radar_svc.source_label(result.source)`. **Es gilt die Feldtabelle** — `source` traegt in ALLEN
+Zweigen und auf BEIDEN Flaechen den rohen Schluessel.
+
+`radar_service.py:531-537` zeigt, was `source_label()` ist: `self._SOURCE_LABELS.get(source, source)`
+— eine menschenlesbare **Beschriftung** fuer `format_now_text` und die Anzeige. Zwei Gruende, warum
+sie im Protokoll nichts zu suchen hat:
+
+1. **Zwei Vokabulare in einem Feld.** Der Trip-Radar-Zweig schriebe die Beschriftung, der
+   Ortsvergleich-Radar-Zweig den rohen Schluessel — dieselbe Quelle staende je nach Flaeche
+   unterschiedlich im Protokoll und waere nicht auswertbar. Genau die Regel **O1** aus
+   `feat_1459_alert_protokoll.md`: "keine Liste darf ein eigenes Vokabular erfinden".
+2. **Beschriftungen aendern sich.** Eine Anpassung an `_SOURCE_LABELS` verschoebe rueckwirkend die
+   Bedeutung alter Protokolleintraege, ohne dass sich der Sachverhalt geaendert haette. Ein
+   Protokoll haelt fest, was war — nicht, wie es heute heissen wuerde.
+
+Die Aufloesung zur Beschriftung ist beim LESEN billig; die Rueckrichtung ist es nicht.
+
+## Known Limitations
+
+- **Luecke O3** bleibt unberuehrt: der Vorhersage-Aenderungsalarm protokolliert seine
+  Unterdrueckungen weiterhin GAR NICHT (eigene Scheibe, D-2, nicht E-1).
+- **`compare_radar_alert.py` hat keine "bereits im Briefing angekuendigt"-Pruefung** — anders als
+  der Trip-Pfad. `reference_at` bleibt dort deshalb STRUKTURELL immer `None`, nicht einzelfall-
+  bedingt. Sollte diese Pruefung je fuer den Ortsvergleich nachgezogen werden, muesste
+  `reference_at` dort neu bewertet werden.
+- **Keine Migration bestehender Dateien** — Bestandseintraege bleiben unveraendert (Muster
+  `capture_id`/#1948, `is_addendum`/#2018).
+- **Keine Sichtbarmachung** — weder Go noch Frontend lesen die neuen Felder; das Protokoll bleibt
+  internes Werkzeug (D4).
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Rein additive Feld-Erweiterung nach dem bereits zweimal etablierten Muster
+  (`capture_id` #1948, `is_addendum`/`addendum_reported_at` #2018) — keine neue Route, kein neues
+  Datenmodell, keine Rueknahme einer bestehenden Architekturentscheidung. Die einzige neue
+  Verarbeitungslogik (`unique_or_none()`) ist eine reine Mehrdeutigkeitspruefung ueber bereits
+  vorhandene Werte, keine neue Berechnung.
+
+## Changelog
+
+- 2026-08-22: Initial spec created (Scheibe S6 aus #2050, Anforderung E-1, verdichtet aus
+  `docs/context/feat-2050-s6-protokoll-vorwarnzeit.md`).

--- a/internal/store/log_new_fields_invariance_test.go
+++ b/internal/store/log_new_fields_invariance_test.go
@@ -1,0 +1,118 @@
+package store
+
+// Issue #2050 Scheibe S6 -- AC-13 (D4-Invarianz, PFLICHT mit Gegenprobe).
+// SPEC: docs/specs/modules/alarm_protokoll_vorwarnzeit.md (AC-13)
+//
+// Die Spec verlangt ausdruecklich einen Go-Test statt einer Python-Nachbildung
+// des Lesevertrags: geprueft wird die Schicht, die unbekannte Felder verwerfen
+// soll (log.go:48-56), nicht der Python-Schreibpfad. Vorbild:
+// archive_stats_test.go (writeLogFile-Helper, echtes store.New(t.TempDir())).
+//
+// Diese Zusicherung ist BEWUSST von Anfang an GRUEN: log.go braucht laut Spec
+// KEINE Aenderung ("keine Aenderung noetig") -- Go's encoding/json verwirft
+// unbekannte Felder strukturell bereits heute. Der Test ist trotzdem PFLICHT
+// als dauerhafter Regressions-Waechter fuer D4 (Cockpit-Kachel/Archiv-
+// Statistik duerfen sich fuer Bestandstouren um keine Zahl aendern), samt
+// Gegenprobe, dass die Pruefung ueberhaupt etwas MISST.
+
+import (
+	"testing"
+)
+
+// AC-13: zwei sonst identische alert_log.json-Dateien fuer denselben Nutzer,
+// eine MIT den sechs neuen S6-Schluesseln je Eintrag befuellt, eine OHNE --
+// AlertCountByEntity() muss fuer dieselbe entity_id EXAKT dieselbe Zahl liefern.
+func TestAlertCountByEntity_IgnoresNewS6FieldsInvariantly(t *testing.T) {
+	entityID := "trip-2050-s6-ac13"
+
+	mitNeuenFeldern := []map[string]interface{}{
+		{
+			"entity_id": entityID, "entity_type": "trip",
+			"sent_at": "2026-06-10T09:00:00Z", "changes_count": 2, "severity": "MODERATE",
+			"lead_time_minutes": 12, "event_at": "2026-06-10T09:12:00Z",
+			"event_end_at":      "2026-06-10T09:45:00Z",
+			"measurement_point": map[string]interface{}{"segment_id": "1", "km_from": 0.0, "km_to": 3.0},
+			"reference_at":      "2026-06-10T08:00:00Z", "source": "Radar (DWD)",
+		},
+		{
+			"entity_id": entityID, "entity_type": "trip",
+			"sent_at": "2026-06-11T10:00:00Z", "changes_count": 1, "severity": "LOW",
+			"lead_time_minutes": 5, "source": "INCA (GeoSphere AT)",
+		},
+		{
+			"entity_id": entityID, "entity_type": "trip",
+			"sent_at": "2026-06-12T11:00:00Z", "changes_count": 3, "severity": "HIGH",
+		},
+	}
+	ohneNeueFelder := []map[string]interface{}{
+		{
+			"entity_id": entityID, "entity_type": "trip",
+			"sent_at": "2026-06-10T09:00:00Z", "changes_count": 2, "severity": "MODERATE",
+		},
+		{
+			"entity_id": entityID, "entity_type": "trip",
+			"sent_at": "2026-06-11T10:00:00Z", "changes_count": 1, "severity": "LOW",
+		},
+		{
+			"entity_id": entityID, "entity_type": "trip",
+			"sent_at": "2026-06-12T11:00:00Z", "changes_count": 3, "severity": "HIGH",
+		},
+	}
+
+	dataDirMit := t.TempDir()
+	writeLogFile(t, dataDirMit, "s6-mit", "alert_log.json", mitNeuenFeldern)
+	dataDirOhne := t.TempDir()
+	writeLogFile(t, dataDirOhne, "s6-ohne", "alert_log.json", ohneNeueFelder)
+
+	countsMit, err := New(dataDirMit, "s6-mit").AlertCountByEntity()
+	if err != nil {
+		t.Fatalf("unexpected error (mit neuen Feldern): %v", err)
+	}
+	countsOhne, err := New(dataDirOhne, "s6-ohne").AlertCountByEntity()
+	if err != nil {
+		t.Fatalf("unexpected error (ohne neue Felder): %v", err)
+	}
+
+	key := "trip:" + entityID
+	if countsMit[key] != countsOhne[key] {
+		t.Fatalf(
+			"AC-13: die sechs neuen Schluessel duerfen die Zaehlung NICHT veraendern -- mit=%d ohne=%d (erwarte gleiche Zahl)",
+			countsMit[key], countsOhne[key],
+		)
+	}
+	if countsMit[key] != 3 {
+		t.Fatalf("Vorbedingung: erwarte 3 Eintraege fuer %s, bekam %d", key, countsMit[key])
+	}
+
+	// Gegenprobe: eine dritte Fixture mit einem ECHT geaenderten bestehenden
+	// Feld (changes_count des ersten Eintrags 2 -> 9) MUSS beim Lesen der
+	// EINZELNEN Eintraege eine ANDERE Zahl liefern -- das zeigt, dass der
+	// Lesepfad ueberhaupt etwas misst und nicht zufaellig immer gleich zaehlt
+	// bzw. blind einen festen Wert zurueckgibt.
+	echtGeaendert := []map[string]interface{}{
+		{
+			"entity_id": entityID, "entity_type": "trip",
+			"sent_at": "2026-06-10T09:00:00Z", "changes_count": 9, "severity": "MODERATE",
+			"lead_time_minutes": 12,
+		},
+	}
+	dataDirGeaendert := t.TempDir()
+	writeLogFile(t, dataDirGeaendert, "s6-geaendert", "alert_log.json", echtGeaendert)
+
+	entriesGeaendert, err := New(dataDirGeaendert, "s6-geaendert").LoadAlertLog()
+	if err != nil {
+		t.Fatalf("unexpected error (Gegenprobe): %v", err)
+	}
+	if len(entriesGeaendert) != 1 {
+		t.Fatalf("Gegenprobe-Vorbedingung: erwarte genau 1 Eintrag, bekam %d", len(entriesGeaendert))
+	}
+	if entriesGeaendert[0].ChangesCount != 9 {
+		t.Fatalf(
+			"Gegenprobe: ein ECHT geaendertes bestehendes Feld (changes_count=9) muss beim Lesen ANKOMMEN (bekam %d) -- sonst waere die Invarianz oben nur ein blind immer-gleiches Ergebnis, kein echter Vergleich",
+			entriesGeaendert[0].ChangesCount,
+		)
+	}
+	if entriesGeaendert[0].ChangesCount == 2 {
+		t.Fatalf("Gegenprobe-Konstruktion: die Gegenprobe-Fixture muss sich vom changes_count der ersten Fixture (2) UNTERSCHEIDEN, sonst beweist sie nichts")
+	}
+}

--- a/src/services/alert_log.py
+++ b/src/services/alert_log.py
@@ -272,6 +272,100 @@ def capture_kwargs_from_alerts(alerts: Iterable) -> dict:
     return {}
 
 
+def unique_or_none(values: Iterable):
+    """Liefert den einen Wert, wenn alle NICHT-``None``-Werte uebereinstimmen
+    und mindestens einer vorhanden ist; sonst ``None`` (Issue #2050 S6).
+
+    Reine Mehrdeutigkeitspruefung -- es wird nichts abgeleitet, nur
+    entschieden, ob ein bereits bekannter Wert EINDEUTIG genug ist, um ihn
+    im Protokoll (E-1) zu berichten. Ohne diese Pruefung waere ein Eintrag
+    mit mehreren Segmenten/Orten/Zeitpunkten gezwungen, WILLKUERLICH eines
+    davon als "den" Messpunkt zu behaupten."""
+    gefunden = False
+    ergebnis = None
+    for wert in values:
+        if wert is None:
+            continue
+        if not gefunden:
+            ergebnis = wert
+            gefunden = True
+        elif wert != ergebnis:
+            return None
+    return ergebnis if gefunden else None
+
+
+def nowcast_onset_at(nowcast, now_utc: datetime) -> datetime:
+    """Ereignisbeginn eines Nowcast-Ergebnisses (Issue #2050 S6, E-1).
+
+    EINE Ableitung fuer BEIDE Flaechen (Trip-Radar und Ortsvergleich-Radar,
+    ADR-0021). Ohne kuenftigen Beginn (laufendes Ereignis, `onset_minutes is
+    None`, S2b) ist der Bezugszeitpunkt JETZT -- der Beginn ist an diesem
+    Zweig damit IMMER bestimmbar."""
+    return now_utc + timedelta(minutes=getattr(nowcast, "onset_minutes", None) or 0)
+
+
+def nowcast_event_end_at(nowcast, now_utc: datetime) -> "datetime | None":
+    """Voraussichtliches Ereignisende desselben Nowcast-Ergebnisses, oder
+    ``None``, wenn keines bestimmbar ist (Issue #2050 S6, E-1)."""
+    ende_min = getattr(nowcast, "event_end_minutes", None)
+    return now_utc + timedelta(minutes=ende_min) if ende_min is not None else None
+
+
+# Issue #2050 S6 (E-1): die sechs additiven Groessen und ihr erwarteter Typ.
+# Reihenfolge ist die Serialisierungsreihenfolge im Eintrag.
+_E1_FIELD_TYPES = {
+    "lead_time_minutes": int,
+    "event_at": str,
+    "event_end_at": str,
+    "measurement_point": dict,
+    "reference_at": str,
+    "source": str,
+}
+
+
+def _apply_e1_fields(
+    entry: dict, *, entity_id: str,
+    lead_time_minutes=None, event_at=None, event_end_at=None,
+    measurement_point=None, reference_at=None, source=None,
+) -> None:
+    """Additive E-1-Groessen additiv-defensiv in ``entry`` schreiben
+    (Issue #2050 S6). ``None`` -> Absenz (kein Schluessel, kein ``null``).
+
+    Fail-soft, aber NICHT still (AC-15): ein Wert, der nicht zum erwarteten
+    Typ passt oder sich nicht JSON-serialisieren laesst, entsteht NICHT im
+    Eintrag, aber die Funktion wirft nie eine Ausnahme -- ein Fehler in der
+    Beweisaufnahme darf den Alarm nie verhindern (die drei ``append_entry()``-
+    Aufrufstellen in ``trip_alert.py`` sind ungeschuetzt). Die Absenz wird
+    laut protokolliert (`logger.warning` mit Schluessel + `entity_id`), sonst
+    behauptete das Protokoll faelschlich "diese Groesse gab es hier nicht",
+    wo in Wahrheit ein Defekt vorlag."""
+    for schluessel, wert in (
+        ("lead_time_minutes", lead_time_minutes),
+        ("event_at", event_at),
+        ("event_end_at", event_end_at),
+        ("measurement_point", measurement_point),
+        ("reference_at", reference_at),
+        ("source", source),
+    ):
+        if wert is None:
+            continue
+        erwarteter_typ = _E1_FIELD_TYPES[schluessel]
+        try:
+            if not isinstance(wert, erwarteter_typ):
+                raise TypeError(
+                    f"{schluessel} muss {erwarteter_typ.__name__} sein, "
+                    f"war {type(wert).__name__}"
+                )
+            json.dumps(wert)  # Serialisierbarkeits-Probe
+        except Exception as e:
+            logger.warning(
+                "alert_log: %s fuer entity_id=%s fehlerhaft geformt (%s) -- "
+                "der Eintrag entsteht ohne dieses Feld.", schluessel, entity_id, e,
+            )
+            continue
+        entry[schluessel] = wert
+
+
 def append_entry(
     user_id: str,
     *,
@@ -291,6 +385,12 @@ def append_entry(
     capture_ids: Optional[Iterable[str]] = None,
     is_addendum: bool = False,
     addendum_reported_at: Optional[str] = None,
+    lead_time_minutes: Optional[int] = None,
+    event_at: Optional[str] = None,
+    event_end_at: Optional[str] = None,
+    measurement_point: Optional[dict] = None,
+    reference_at: Optional[str] = None,
+    source: Optional[str] = None,
 ) -> None:
     """Haengt GENAU EINEN Eintrag an das Alarm-Protokoll des Nutzers an.
 
@@ -380,6 +480,14 @@ def append_entry(
     if is_addendum:  # additiv (#2018): Nachtrag statt zweitem Voll-Alarm
         entry["is_addendum"] = True
         entry["addendum_reported_at"] = addendum_reported_at
+    # Issue #2050 S6 (E-1): gemeldete Vorwarnzeit, Ereigniszeit, Messpunkt,
+    # Vergleichsbasis, Quelle -- additiv, defensiv, nie werfend (AC-15).
+    _apply_e1_fields(
+        entry, entity_id=entity_id,
+        lead_time_minutes=lead_time_minutes, event_at=event_at,
+        event_end_at=event_end_at, measurement_point=measurement_point,
+        reference_at=reference_at, source=source,
+    )
 
     _append(user_id, "entries" if reachable else "not_delivered", entry)
 
@@ -408,6 +516,12 @@ def append_suppressed_entry(
     gate_reason: str,
     effective_channels: Iterable[str],
     capture_id: Optional[str] = None,
+    lead_time_minutes: Optional[int] = None,
+    event_at: Optional[str] = None,
+    event_end_at: Optional[str] = None,
+    measurement_point: Optional[dict] = None,
+    reference_at: Optional[str] = None,
+    source: Optional[str] = None,
 ) -> None:
     """Haengt GENAU EINEN Eintrag fuer eine VOR dem Versand abgewiesene
     Meldung an (#1467 S3, Aenderung (d)).
@@ -476,6 +590,15 @@ def append_suppressed_entry(
     }
     if capture_id is not None:  # additiv (#1948), siehe append_entry()
         entry["capture_id"] = capture_id
+    # Issue #2050 S6 (E-1): dieselben sechs Groessen, nur soweit am jeweiligen
+    # Gate bereits bekannt -- der Aufrufer uebergibt an fruehen Gates schlicht
+    # nichts (Absenz durch Nicht-Uebergabe).
+    _apply_e1_fields(
+        entry, entity_id=entity_id,
+        lead_time_minutes=lead_time_minutes, event_at=event_at,
+        event_end_at=event_end_at, measurement_point=measurement_point,
+        reference_at=reference_at, source=source,
+    )
     _append(user_id, "not_delivered", entry)
 
 

--- a/src/services/compare_alert.py
+++ b/src/services/compare_alert.py
@@ -324,6 +324,29 @@ class CompareAlertService:
             # (`config.channels`), nur der tatsaechliche Versand wurde gefiltert
             # (rote Linie #638).
             alle_changes = [c for t in triggered for c in t["changes"]]
+            # Issue #2050 S6 (E-1): Ereigniszeit/Messpunkt nur, wenn ALLE
+            # gebuendelten Aenderungen bzw. Orte uebereinstimmen
+            # (`unique_or_none`) -- Abweichungszweig kennt strukturell keine
+            # Vorwarnzeit und kein Ereignisende (analog Trip).
+            _e1_event_at_dt = alert_log.unique_or_none(
+                c.occurred_at for c in alle_changes
+            )
+            _e1_event_at = (
+                _e1_event_at_dt.isoformat() if _e1_event_at_dt is not None else None
+            )
+            _e1_loc_id = alert_log.unique_or_none(t["loc"].id for t in triggered)
+            _e1_measurement_point = (
+                {"location_id": _e1_loc_id} if _e1_loc_id is not None else None
+            )
+            _e1_reference_at_dt = alert_log.unique_or_none(
+                t["anchor_fetched_at"] for t in triggered
+            )
+            _e1_reference_at = (
+                _e1_reference_at_dt.isoformat() if _e1_reference_at_dt is not None else None
+            )
+            _e1_source = alert_log.unique_or_none(
+                t["anchor_provider"] for t in triggered
+            )
             alert_log.append_entry(
                 self._user_id, entity_id=preset_id, entity_type="compare",
                 changes_count=len(alle_changes),
@@ -335,6 +358,10 @@ class CompareAlertService:
                 reachable_channels=sorted(reachable_all),
                 below_threshold_channels=below_threshold_all,
                 blocked_reason_codes=blocked_reason_codes_all,
+                event_at=_e1_event_at,
+                measurement_point=_e1_measurement_point,
+                reference_at=_e1_reference_at,
+                source=_e1_source,
             )
             if not any_sent:
                 continue
@@ -462,6 +489,9 @@ class CompareAlertService:
             # Alarm-Footer -- `None`, wenn kein Anker geladen wurde
             # (Bootstrap-Fall, `cached=[]`).
             "anchor_fetched_at": cached[0].fetched_at if cached else None,
+            # Issue #2050 S6 (E-1): Rohwert-Quelle desselben Ankers, additiv
+            # mitgefuehrt -- fuer `alert_log.append_entry(source=...)`.
+            "anchor_provider": cached[0].provider if cached else None,
         }
 
     @staticmethod

--- a/src/services/compare_official_alert.py
+++ b/src/services/compare_official_alert.py
@@ -223,11 +223,19 @@ class CompareOfficialAlertService:
                 if alert in for_loc:
                     for_loc.remove(alert)
                 try:
+                    # Issue #2050 S6 (E-1): dieser Zweig steht INNERHALB der
+                    # `for loc_id in loc_ids`-Schleife -- Warnung und Ort sind
+                    # hier je EIN Wert, `measurement_point` ist deshalb IMMER
+                    # eindeutig (kein `unique_or_none` noetig).
                     alert_log.append_suppressed_entry(
                         self._user_id, entity_id=preset_id, entity_type="compare",
                         reason=alert_log.REASON_OFFICIAL_ALERT,
                         gate_reason=identity_gate.reason,
                         effective_channels=effective_channels,
+                        event_at=alert.valid_from.isoformat() if alert.valid_from else None,
+                        event_end_at=alert.valid_to.isoformat() if alert.valid_to else None,
+                        measurement_point={"location_id": loc_id},
+                        source=alert.source,
                     )
                 except Exception as e:
                     logger.error(
@@ -261,6 +269,27 @@ class CompareOfficialAlertService:
             mail_sink=self._mail_sink, sms_sink=self._sms_sink,
             telegram_sink=self._telegram_sink,
         )
+        # Issue #2050 S6 (E-1): Ereigniszeit/Messpunkt/Quelle nur, wenn ALLE
+        # Warnungen dieses Eintrags uebereinstimmen (`unique_or_none`) --
+        # amtliche Warnungen kennen strukturell keine Vorwarnzeit und keine
+        # Vergleichsbasis (analog Trip).
+        _e1_event_at_dt = alert_log.unique_or_none(
+            a.valid_from for a, _loc_ids in tagged_alerts
+        )
+        _e1_event_at = _e1_event_at_dt.isoformat() if _e1_event_at_dt is not None else None
+        _e1_event_end_at_dt = alert_log.unique_or_none(
+            a.valid_to for a, _loc_ids in tagged_alerts
+        )
+        _e1_event_end_at = (
+            _e1_event_end_at_dt.isoformat() if _e1_event_end_at_dt is not None else None
+        )
+        _e1_loc_id = alert_log.unique_or_none(
+            loc_id for _a, loc_ids in tagged_alerts for loc_id in loc_ids
+        )
+        _e1_measurement_point = (
+            {"location_id": _e1_loc_id} if _e1_loc_id is not None else None
+        )
+        _e1_source = alert_log.unique_or_none(a.source for a, _loc_ids in tagged_alerts)
         # Issue #1459: die Gefahrenart steht in `hazards`, nicht in `metrics` (O1).
         alert_log.append_entry(
             self._user_id, entity_id=preset_id, entity_type="compare",
@@ -275,6 +304,8 @@ class CompareOfficialAlertService:
             reachable_channels=result.sent_channels,
             below_threshold_channels=suppressed,
             blocked_reason_codes=result.blocked_reason_codes,
+            event_at=_e1_event_at, event_end_at=_e1_event_end_at,
+            measurement_point=_e1_measurement_point, source=_e1_source,
             # Issue #1944: derselbe geteilte Baustein wie im Trip-Pfad.
             **alert_log.capture_kwargs_from_alerts(
                 [a for a, _loc_ids in tagged_alerts]

--- a/src/services/compare_radar_alert.py
+++ b/src/services/compare_radar_alert.py
@@ -97,6 +97,13 @@ def _format_cooldown_display(cooldown_minutes: int) -> str:
     return f"{cooldown_minutes} Minuten"
 
 
+# Issue #2050 S6 (E-1): Ereigniszeit-Ableitung aus dem GETEILTEN Baustein --
+# dieselbe Fassung benutzt der Trip-Radar-Zweig (`trip_alert.py`), damit
+# Protokoll-Beginn und -Ende auf beiden Flaechen nicht auseinanderlaufen.
+_onset_at = alert_log.nowcast_onset_at
+_event_end_at = alert_log.nowcast_event_end_at
+
+
 class CompareRadarAlertService:
     """Prüft je Compare-Preset/Ort den Radar-Nowcast und versendet gebündelte
     Onset-Alarm-Mails an die Preset-Empfänger (Parallelpfad zu
@@ -240,11 +247,21 @@ class CompareRadarAlertService:
                 f"fuer {preset_id}:{loc.id}"
             )
             try:
+                # Issue #2050 S6 (E-1): `nowcast`/`loc` liegen hier EINZELN vor
+                # (innere Schleife) -- alles bekannt bis auf `reference_at`
+                # (strukturell `None`, wie beim Radar-Compare-Zweig generell --
+                # es gibt hier keine "bereits im Briefing angekuendigt"-Pruefung).
+                _event_end_dt = _event_end_at(nowcast, now_utc)
                 alert_log.append_suppressed_entry(
                     self._user_id, entity_id=preset_id, entity_type="compare",
                     reason=alert_log.REASON_NOWCAST,
                     gate_reason=identity_gate.reason,
                     effective_channels=effective_channels,
+                    lead_time_minutes=nowcast.onset_minutes,
+                    event_at=_onset_at(nowcast, now_utc).isoformat(),
+                    event_end_at=_event_end_dt.isoformat() if _event_end_dt else None,
+                    measurement_point={"location_id": loc.id},
+                    source=nowcast.source,
                 )
             except Exception as e:
                 logger.error(
@@ -282,6 +299,30 @@ class CompareRadarAlertService:
             cooldown_display=_format_cooldown_display(cooldown_minutes),
             telegram_style=effective_compare_telegram_style(preset),
         )
+        # Issue #2050 S6 (E-1): nur, wenn ALLE getriggerten Orte uebereinstimmen
+        # (`unique_or_none`) -- `reference_at` bleibt strukturell `None`
+        # (dieser Zweig kennt keine "bereits im Briefing angekuendigt"-Pruefung,
+        # anders als der Trip-Pfad).
+        _e1_lead_time = alert_log.unique_or_none(
+            nowcast.onset_minutes for _name, _loc, nowcast in triggered
+        )
+        _e1_event_at_dt = alert_log.unique_or_none(
+            _onset_at(nowcast, now_utc) for _name, _loc, nowcast in triggered
+        )
+        _e1_event_at = _e1_event_at_dt.isoformat() if _e1_event_at_dt is not None else None
+        _e1_event_end_dt = alert_log.unique_or_none(
+            _event_end_at(nowcast, now_utc) for _name, _loc, nowcast in triggered
+        )
+        _e1_event_end_at = (
+            _e1_event_end_dt.isoformat() if _e1_event_end_dt is not None else None
+        )
+        _e1_loc_id = alert_log.unique_or_none(loc.id for _name, loc, _nowcast in triggered)
+        _e1_measurement_point = (
+            {"location_id": _e1_loc_id} if _e1_loc_id is not None else None
+        )
+        _e1_source = alert_log.unique_or_none(
+            nowcast.source for _name, _loc, nowcast in triggered
+        )
         # Issue #1459: gemischt konvektive/nicht-konvektive Orte ergeben BEIDE
         # Register-Paare in EINEM Eintrag.
         alert_log.append_entry(
@@ -297,6 +338,9 @@ class CompareRadarAlertService:
             reachable_channels=notif_result.sent_channels,
             below_threshold_channels=suppressed,
             blocked_reason_codes=notif_result.blocked_reason_codes,
+            lead_time_minutes=_e1_lead_time,
+            event_at=_e1_event_at, event_end_at=_e1_event_end_at,
+            measurement_point=_e1_measurement_point, source=_e1_source,
         )
         if not notif_result.sent:
             return False

--- a/src/services/trip_alert.py
+++ b/src/services/trip_alert.py
@@ -158,6 +158,58 @@ def radar_alert_due(result: object, threshold_min: int) -> bool:
     return bool(getattr(result, "already_running", False))
 
 
+def _radar_e1_fields(
+    *, entity_id: str, result, now_utc: datetime, onset_dt: datetime,
+    active, snapshot,
+) -> dict:
+    """Die fuenf E-1-Groessen des Radar-Nowcast-Zweigs (Issue #2050 S6).
+
+    EINE Ableitung fuer alle drei Protokollstellen dieses Zweigs
+    (Briefing-Gate, Ereignis-Identitaet, Versand) — sonst stuende derselbe
+    Vorfall je nach Ausgang mit verschiedenen Zeitangaben im Protokoll.
+
+    `snapshot` ist zugleich die Vergleichsbasis, deren Ankuendigung das
+    Briefing-Gate ueberhaupt erst begruendet; fehlt sie, bleibt `reference_at`
+    weg statt erfunden zu werden. `source` ist der ROHE Quellen-Schluessel,
+    NICHT `radar_svc.source_label(...)`: die Beschriftung ist ein zweites
+    Vokabular fuer dieselbe Sache (Regel O1) und aendert sich ausserdem, was
+    rueckwirkend die Bedeutung alter Eintraege verschoebe (Spec-Abschnitt
+    "Korrektur: `source` ist immer der rohe Schluessel").
+
+    Absicherung wie die Nachbarschritte derselben Schleife (Nowcast-Abruf,
+    Unterdrueckungs-Protokoll): die Ableitung steht VOR dem Versand, ein
+    Fehler hier duerfte deshalb nie den Alarm verhindern — und erst recht
+    nicht die uebrigen Trips desselben Nutzers mitreissen (Muster
+    `fix_1479`). Sie scheitert fail-soft zu "gar keine Zusatzfelder", aber
+    NICHT still (AC-15): ohne die Meldung behauptete das Protokoll
+    faelschlich "diese Groessen gab es hier nicht", wo in Wahrheit ein Defekt
+    vorlag.
+    """
+    try:
+        ende_dt = alert_log.nowcast_event_end_at(result, now_utc)
+        return {
+            "lead_time_minutes": result.onset_minutes,
+            "event_at": onset_dt.isoformat(),
+            "event_end_at": ende_dt.isoformat() if ende_dt else None,
+            "measurement_point": {
+                "segment_id": normalize_segment_id(active.segment_id),
+                "km_from": active.start_point.distance_from_start_km,
+                "km_to": active.end_point.distance_from_start_km,
+            },
+            "reference_at": (
+                snapshot[0].fetched_at.isoformat() if snapshot else None
+            ),
+            "source": result.source,
+        }
+    except Exception as e:
+        logger.warning(
+            "alert_log: E-1-Groessen fuer entity_id=%s nicht ableitbar (%s) — "
+            "der Alarm laeuft weiter, der Eintrag entsteht ohne diese Felder.",
+            entity_id, e,
+        )
+        return {}
+
+
 def _trip_telegram_style(trip: "Trip") -> str:
     """Issue #1260 S3: aufgelöster Telegram-Stil des Trips ("rich" Default).
 
@@ -407,6 +459,14 @@ class TripAlertService:
         # Issue #1459: Alarm-Protokoll VOR dem Zustellbarkeits-Guard — die
         # Funktion entscheidet selbst, ob der Eintrag nach `entries` (mindestens
         # ein Kanal kam an, Ist-Verhalten) oder nach `not_delivered` geht (D4).
+        # Issue #2050 S6 (E-1): Ereigniszeit und Messpunkt nur, wenn ALLE
+        # gebuendelten Aenderungen dieses EINEN Eintrags denselben Wert tragen
+        # (`unique_or_none`) -- sonst behauptete der Eintrag willkuerlich eines
+        # von mehreren Segmenten. Vorwarnzeit und Ereignisende kennt dieser
+        # Zweig strukturell nicht; Vergleichsbasis und Quelle stammen aus dem
+        # ANKER, der im Erstlauf fehlen darf (dann Absenz statt Erfindung).
+        _e1_occurred_at = alert_log.unique_or_none(c.occurred_at for c in to_report)
+        _e1_segment_id = alert_log.unique_or_none(c.segment_id for c in to_report)
         alert_log.append_entry(
             self._user_id,
             entity_id=trip.id,
@@ -427,6 +487,16 @@ class TripAlertService:
             below_threshold_channels=self._last_below_threshold_channels,
             blocked_reason_codes=notif_result.blocked_reason_codes,
             capture_id=capture_id,
+            event_at=(
+                _e1_occurred_at.isoformat() if _e1_occurred_at is not None else None
+            ),
+            measurement_point=(
+                {"segment_id": _e1_segment_id} if _e1_segment_id is not None else None
+            ),
+            reference_at=(
+                anchor_fetched.isoformat() if anchor_fetched is not None else None
+            ),
+            source=cached_weather[0].provider if cached_weather else None,
         )
         delivered = notif_result.sent
         if not delivered:
@@ -1503,9 +1573,23 @@ class TripAlertService:
             # gerade gewonnener Alarm bliebe unbegruendet unterdrueckt bzw.
             # der angekuendigte Regen unerkannt.
             from services.weather_snapshot import WeatherSnapshotService
-            _snapshot = WeatherSnapshotService(self._user_id).load_dated(trip.id, segment_date)
+            # Issue #2050 S6 (E-1): `segment_fetched_at=True` -- die
+            # Vergleichsbasis im Protokoll soll den Abruf benennen, auf den
+            # sich der Briefing-Vergleich wirklich beruft. Nur HIER opt-in
+            # (s. `load_dated()`): der Alarm-Footer #1916 laeuft ueber
+            # `_get_cached_weather()` und bleibt beim Schreibzeitpunkt.
+            _snapshot = WeatherSnapshotService(self._user_id).load_dated(
+                trip.id, segment_date, segment_fetched_at=True,
+            )
             _briefing_precip = self._briefing_precip_for_onset(_snapshot, active.segment_id, _onset_dt)
             _briefing_announced = (_briefing_precip is not None and _briefing_precip >= 0.5)
+            # Issue #2050 S6 (E-1): die an DIESEM Zweig bekannten Groessen --
+            # EINMAL abgeleitet und an allen drei Protokollstellen dieses
+            # Zweigs identisch (Briefing-Gate, Ereignis-Identitaet, Versand).
+            _e1 = _radar_e1_fields(
+                entity_id=trip.id, result=result, now_utc=now_utc,
+                onset_dt=_onset_dt, active=active, snapshot=_snapshot,
+            )
             # Sicherheits-Override (Slice 4, #883): konvektive Gefahr (Gewitter/Hagel)
             # durchbricht die Briefing-Unterdrückung. Normaler (nicht-konvektiver)
             # angekündigter Regen bleibt unterdrückt (reines Δ-Modell).
@@ -1535,6 +1619,7 @@ class TripAlertService:
                         reason=alert_log.REASON_NOWCAST,
                         gate_reason=f"briefing_announced:{_briefing_precip}mm",
                         effective_channels=effective_channels,
+                        **_e1,
                     )
                 except Exception as e:
                     logger.error(
@@ -1701,6 +1786,7 @@ class TripAlertService:
                         self._user_id, entity_id=trip.id, entity_type="trip",
                         reason=alert_log.REASON_NOWCAST, gate_reason=_identity_gate.reason,
                         effective_channels=effective_channels,
+                        **_e1,
                     )
                 except Exception as e:
                     logger.error(
@@ -1767,6 +1853,7 @@ class TripAlertService:
                     _identity_gate.addendum_reported_at.isoformat()
                     if _identity_gate.addendum_reported_at is not None else None
                 ),
+                **_e1,
             )
             delivered = result.sent
             if not delivered:
@@ -2128,11 +2215,27 @@ class TripAlertService:
                 f"Official alert suppressed ({_identity_gate.reason}) for trip {trip.id}"
             )
             try:
+                # Issue #2050 S6 (E-1): hier liegt GENAU EINE Warnung vor --
+                # Ereigniszeit und Quelle sind bekannt, der Messpunkt nur,
+                # wenn ihre Segmentliste eindeutig ist. Vorwarnzeit und
+                # Vergleichsbasis kennt der amtliche Zweig strukturell nicht.
+                _e1_segment_id = alert_log.unique_or_none(_segment_ids)
                 alert_log.append_suppressed_entry(
                     self._user_id, entity_id=trip.id, entity_type="trip",
                     reason=alert_log.REASON_OFFICIAL_ALERT,
                     gate_reason=_identity_gate.reason,
                     effective_channels=effective_channels,
+                    event_at=(
+                        _alert.valid_from.isoformat() if _alert.valid_from else None
+                    ),
+                    event_end_at=(
+                        _alert.valid_to.isoformat() if _alert.valid_to else None
+                    ),
+                    measurement_point=(
+                        {"segment_id": _e1_segment_id}
+                        if _e1_segment_id is not None else None
+                    ),
+                    source=_alert.source,
                 )
             except Exception as e:
                 logger.error(
@@ -2166,6 +2269,20 @@ class TripAlertService:
             # leer und die Warnung bei der Segment-Sprache (AC-10).
             segment_km=measured_segment_km(segments),
         )
+        # Issue #2050 S6 (E-1): Ereigniszeit, Messpunkt und Quelle nur, wenn
+        # ALLE Warnungen dieses EINEN Eintrags darin uebereinstimmen
+        # (`unique_or_none`) -- sonst behauptete der Eintrag willkuerlich eine
+        # von mehreren. Vorwarnzeit und Vergleichsbasis kennt dieser Zweig
+        # strukturell nicht.
+        _e1_valid_from = alert_log.unique_or_none(
+            a.valid_from for a, _segment_ids in official_notices
+        )
+        _e1_valid_to = alert_log.unique_or_none(
+            a.valid_to for a, _segment_ids in official_notices
+        )
+        _e1_segment_id = alert_log.unique_or_none(
+            sid for _a, _segment_ids in official_notices for sid in (_segment_ids or [])
+        )
         # Issue #1459: amtliche Warnungen tragen ihre Gefahrenart in `hazards`,
         # NICHT als Register-Kennung in `metrics` (eigenes Vokabular, O1).
         alert_log.append_entry(
@@ -2181,6 +2298,14 @@ class TripAlertService:
             reachable_channels=result.sent_channels,
             below_threshold_channels=_official_suppressed,
             blocked_reason_codes=result.blocked_reason_codes,
+            event_at=_e1_valid_from.isoformat() if _e1_valid_from else None,
+            event_end_at=_e1_valid_to.isoformat() if _e1_valid_to else None,
+            measurement_point=(
+                {"segment_id": _e1_segment_id} if _e1_segment_id is not None else None
+            ),
+            source=alert_log.unique_or_none(
+                a.source for a, _segment_ids in official_notices
+            ),
             # Issue #1944: Herkunft der versendeten Warnungen (ein Mitschnitt
             # -> `capture_id`, mehrere -> `capture_ids`).
             **alert_log.capture_kwargs_from_alerts(

--- a/src/services/weather_snapshot.py
+++ b/src/services/weather_snapshot.py
@@ -147,8 +147,20 @@ class WeatherSnapshotService:
         self,
         trip_id: str,
         target_date: date,
+        *,
+        segment_fetched_at: bool = False,
     ) -> Optional[List[SegmentWeatherData]]:
-        """Load dated forecast snapshot from {trip_id}_{YYYY-MM-DD}.json."""
+        """Load dated forecast snapshot from {trip_id}_{YYYY-MM-DD}.json.
+
+        `segment_fetched_at=True` liefert je Segment seinen EIGENEN
+        Erhebungszeitpunkt statt des Schreibzeitpunkts der Datei (Issue #2050
+        S6, E-1). Bewusst opt-in und per Vorgabe AUS: derselbe Wert speist
+        ueber `trip_alert._check_deviation_alerts()` den nutzersichtbaren
+        Referenz-Zeitpunkt im Alarm-Footer (#1916), und `format_reference_at()`
+        verzweigt am KALENDERTAG — eine Verschiebung um Minuten ueber
+        Mitternacht machte aus "07:00" ein "gestern 23:55 Uhr". Diese Scheibe
+        ist rein additiv und darf keine Anzeige verschieben; die
+        Protokoll-Ableitung fragt den genaueren Wert deshalb ausdruecklich an."""
         filepath = self._snapshots_dir / f"{trip_id}_{target_date.isoformat()}.json"
 
         if not filepath.exists():
@@ -170,7 +182,10 @@ class WeatherSnapshotService:
                         segment=segment,
                         timeseries=timeseries,
                         aggregated=aggregated,
-                        fetched_at=snapshot_at,
+                        fetched_at=(
+                            _segment_fetched_at(seg_data, snapshot_at)
+                            if segment_fetched_at else snapshot_at
+                        ),
                         provider=provider,
                     )
                 )
@@ -445,6 +460,27 @@ def _deserialize_summary(data: dict) -> SegmentWeatherSummary:
     return SegmentWeatherSummary(**kwargs)
 
 
+def _segment_fetched_at(seg_data: dict, snapshot_at: datetime) -> datetime:
+    """Erhebungszeitpunkt DIESES Segments (Issue #2050 S6, E-1): der
+    mitgeschriebene eigene Wert, sonst der Schreibzeitpunkt der Datei --
+    Bestandsdateien ohne das additive Feld verhalten sich unveraendert.
+
+    Bewusst NUR ueber `load_dated(segment_fetched_at=True)` erreichbar, also
+    allein fuer die Protokoll-Ableitung: dort fragt E-1, auf welchen Abruf
+    sich der Briefing-Vergleich beruft. Ueberall sonst -- rollierender
+    Alarm-Anker, undatierter Rueckfall, Alarm-Footer (#1916) -- bemisst sich
+    der Zeitpunkt weiter am SCHREIBzeitpunkt der Datei (Tagesgrenze #823,
+    Ceiling-Fallback #1987)."""
+    roh = seg_data.get("fetched_at")
+    if not roh:
+        return snapshot_at
+    try:
+        wert = datetime.fromisoformat(roh)
+    except (TypeError, ValueError):
+        return snapshot_at
+    return wert if wert.tzinfo else wert.replace(tzinfo=timezone.utc)
+
+
 def _serialize_segment(seg: SegmentWeatherData) -> dict:
     """Serialize a single SegmentWeatherData to dict, with optional hourly."""
     entry: dict = {
@@ -480,6 +516,16 @@ def _serialize_segment(seg: SegmentWeatherData) -> dict:
             ) if v is not None
         },
         "aggregated": _serialize_summary(seg.aggregated),
+        # Issue #2050 S6 (E-1): der EIGENE Erhebungszeitpunkt dieses Segments.
+        # Bis hierher ging er beim Laden verloren (alle Segmente erbten den
+        # Schreibzeitpunkt der Datei) -- damit war der Zeitpunkt, auf den sich
+        # ein Briefing-Vergleich beruft, nachtraeglich nicht mehr belegbar.
+        # Additiv: fehlt der Schluessel (Bestandsdateien), gilt weiter der
+        # Schreibzeitpunkt.
+        **(
+            {"fetched_at": seg.fetched_at.isoformat()}
+            if seg.fetched_at is not None else {}
+        ),
     }
     if seg.timeseries is not None:
         hourly = []

--- a/tests/tdd/test_alert_log_ereignisgroessen.py
+++ b/tests/tdd/test_alert_log_ereignisgroessen.py
@@ -1,0 +1,592 @@
+"""Issue #2050 Scheibe S6 — Alarm-Protokoll haelt Vorwarnzeit, Ereigniszeit,
+Messpunkt, Vergleichsbasis und Quelle fest (Anforderung E-1).
+
+SPEC: docs/specs/modules/alarm_protokoll_vorwarnzeit.md (AC-1..AC-8)
+
+Alle Laeufe gehen ueber die ECHTE Ausloeseentscheidung: `AlarmPruefstrecke`
+(S1, Radar-/Abweichungs-/amtlicher Zweig) fuer den Trip-Pfad,
+`CompareRadarAlertService.check_all_compare_presets()` direkt fuer den
+Ortsvergleich-Nowcast (kein Trip-Pendant in der Pruefstrecke). Kein
+Mock()/patch()/MagicMock — echte DI-Naehte (`frame_source`, `radar_service`,
+`mail_sink`), echte `alert_log.json`-Dateien unter `get_data_dir(user_id)`.
+
+RED-Grund: keine der fuenf E-1-Groessen existiert heute im Protokoll-Eintrag
+(`services/alert_log.py`) — jede Praesenz-Zusicherung schlaegt fehl, weil der
+Schluessel schlicht fehlt.
+"""
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from freezegun import freeze_time
+
+from app.loader import get_data_dir, load_all_trips, save_location
+from app.models import (
+    ForecastDataPoint, ForecastMeta, NormalizedTimeseries, Provider,
+    SegmentWeatherData, SegmentWeatherSummary,
+)
+from output.renderers.alert.segments import normalize_segment_id
+from services.official_alerts.models import OfficialAlert
+from services.radar_service import NowcastResult, RadarNowcastService
+from services.trip_alert import TripAlertService
+from services.trip_day import trip_local_today
+
+from tests.helpers.alarm_pruefstrecke import AlarmPruefstrecke
+from tests.tdd.test_952_onset_alert_fidelity import _clean_user
+from tests.tdd.test_alarm_pruefstrecke_selbstschutz import (
+    _AT, _radar_trip, _settings_all_channels, _write_premium_profile,
+)
+from tests.tdd.test_issue_1070_daily_alert_limit import (
+    _deviation_trip, _segment,
+)
+from tests.tdd.test_compare_radar_alert import (
+    _CoordFrameSource, _clean_user as _clean_user_compare, _location,
+    _radar_preset, _settings_email_capable_dummy, _write_preset_file,
+)
+
+_ANGELEGT: list[str] = []
+
+
+def _uid(tag: str) -> str:
+    uid = f"tdd-2050-s6-{tag}-{uuid.uuid4().hex[:6]}"
+    _ANGELEGT.append(uid)
+    return uid
+
+
+def _entry_for(uid: str, entity_id: str) -> dict:
+    """Liest den JUENGSTEN `entries`-Eintrag fuer `entity_id` zurueck."""
+    path = get_data_dir(uid) / "alert_log.json"
+    data = json.loads(path.read_text())
+    treffer = [e for e in data.get("entries", []) if e.get("entity_id") == entity_id]
+    assert treffer, f"kein entries-Eintrag fuer {entity_id!r} in {path}: {data!r}"
+    return treffer[-1]
+
+
+class _FixedRadar(RadarNowcastService):
+    """Echte `RadarNowcastService`-Unterklasse (DI-Seam, Vorbild
+    `_GuaranteedWetRadar`) mit frei waehlbarem `NowcastResult` — im
+    Unterschied zum Vorbild auch mit `event_end_minutes` steuerbar (AC-2)."""
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__()
+        kwargs.setdefault("intensity_label", "leichter Regen")
+        kwargs.setdefault("source", "radar")
+        self._fixed = NowcastResult(**kwargs)
+
+    def get_nowcast(self, lat, lon, elevation_m=None, priority="user_briefing"):
+        return self._fixed
+
+
+def _weather_data_mit_peak(segment_id, precip_sum_mm: float, peak_at: datetime) -> SegmentWeatherData:
+    """`SegmentWeatherData` mit EINEM Zeitreihenpunkt -- macht den
+    Spitzenwert-Zeitpunkt (`occurred_at`) fuer den Abweichungszweig
+    bestimmbar (Vorbild `_weather_data()`, aber mit befuellter Zeitreihe
+    statt `data=[]`)."""
+    return SegmentWeatherData(
+        segment=_segment(segment_id),
+        timeseries=NormalizedTimeseries(
+            meta=ForecastMeta(provider=Provider.OPENMETEO, model="test", grid_res_km=1.0),
+            data=[ForecastDataPoint(ts=peak_at, precip_1h_mm=5.0)],
+        ),
+        aggregated=SegmentWeatherSummary(precip_sum_mm=precip_sum_mm),
+        fetched_at=_AT - timedelta(hours=1),
+        provider="openmeteo",
+    )
+
+
+def _active_segment_snapshot(uid: str, trip_id: str, at: datetime):
+    """Ermittelt das aktive Segment GENAU wie `check_radar_alerts()` es waehlt
+    -- ueber dieselbe Ableitung (`TripAlertService._resolve_alert_segment`),
+    NICHT ueber geratene Literale. Aufruf NACH dem echten Pruefstrecken-Lauf
+    und ueber `load_all_trips()` (statt des lokalen `trip`-Objekts), damit
+    dieselbe -- ggf. von `_resolve_alert_segment` nachgeruestete -- Trip-Datei
+    gelesen wird wie im echten Lauf (Vorbild: km-Nachruestung Issue #2036
+    AC-7)."""
+    with freeze_time(at):
+        now = datetime.now(timezone.utc)
+        svc = TripAlertService(user_id=uid)
+        trip = next(t for t in load_all_trips(user_id=uid) if t.id == trip_id)
+        today = trip_local_today(trip, now)
+        resolved = svc._resolve_alert_segment(trip, now, today)
+    assert resolved is not None, f"kein aktives Segment fuer {trip_id!r} ableitbar"
+    active, _segment_date = resolved
+    return active
+
+
+def _aufraeumen() -> None:
+    for uid in _ANGELEGT:
+        _clean_user(uid)
+        _clean_user_compare(uid)
+    _ANGELEGT.clear()
+
+
+# ---------------------------------------------------------------------------
+# AC-1/AC-2: Radar-Zweig (Trip)
+# ---------------------------------------------------------------------------
+
+def test_ac1_radar_alarm_traegt_vorwarnzeit_ereigniszeit_messpunkt_und_quelle():
+    uid = _uid("ac1")
+    try:
+        _write_premium_profile(uid, _AT)
+        trip = _radar_trip(uid, "trip-2050-s6-ac1", send_email=True)
+        # EINE Variable fuer die Vorwarnzeit -- speist sowohl den Nowcast-Stub
+        # als auch die Erwartung unten, damit die Bildungsstelle (`_onset_dt =
+        # now_utc + timedelta(minutes=result.onset_minutes)`) tatsaechlich
+        # bewacht ist statt nur die ISO-Parsebarkeit der Ausgabe.
+        vorwarnzeit_min = 12
+        strecke = AlarmPruefstrecke(user_id=uid, settings=_settings_all_channels())
+        lauf = strecke.lauf(
+            at=_AT, zweig="radar", trip=trip,
+            radar_service=_FixedRadar(onset_minutes=vorwarnzeit_min),
+        )
+        assert lauf.triggered_count == 1, (
+            f"AC-1 Vorbedingung: der Radar-Alarm muss ausloesen (war {lauf.triggered_count})."
+        )
+        entry = _entry_for(uid, trip.id)
+
+        assert entry.get("lead_time_minutes") == vorwarnzeit_min, (
+            f"AC-1: lead_time_minutes fehlt oder stimmt nicht mit onset_minutes ueberein: {entry!r}"
+        )
+        assert "event_at" in entry, f"AC-1: event_at fehlt: {entry!r}"
+        tatsaechlicher_event_at = datetime.fromisoformat(entry["event_at"])
+        if tatsaechlicher_event_at.tzinfo is None:
+            tatsaechlicher_event_at = tatsaechlicher_event_at.replace(tzinfo=timezone.utc)
+        erwarteter_event_at = _AT + timedelta(minutes=vorwarnzeit_min)
+        assert tatsaechlicher_event_at == erwarteter_event_at, (
+            f"AC-1: event_at muss der Ereignisbeginn sein (Laufzeitpunkt {_AT.isoformat()} "
+            f"+ Vorwarnzeit {vorwarnzeit_min} min = {erwarteter_event_at.isoformat()}), "
+            f"nicht bloss irgendein ISO-parsebarer Zeitstempel: war {tatsaechlicher_event_at.isoformat()}"
+        )
+
+        mp = entry.get("measurement_point")
+        assert mp is not None, f"AC-1: measurement_point fehlt: {entry!r}"
+        assert {"segment_id", "km_from", "km_to"} <= set(mp), (
+            f"AC-1: measurement_point unvollstaendig (erwarte segment_id/km_from/km_to): {mp!r}"
+        )
+        aktives_segment = _active_segment_snapshot(uid, trip.id, _AT)
+        assert mp["segment_id"] == normalize_segment_id(aktives_segment.segment_id), (
+            f"AC-1: measurement_point.segment_id muss die Segment-Kennung des "
+            f"aktiven Segments sein: {mp!r} vs. Segment {aktives_segment.segment_id!r}"
+        )
+        assert mp["km_from"] == aktives_segment.start_point.distance_from_start_km, (
+            f"AC-1: measurement_point.km_from muss die Start-km des aktiven "
+            f"Segments sein (nicht vertauscht mit km_to): {mp!r} vs. Segment "
+            f"start={aktives_segment.start_point.distance_from_start_km!r}/"
+            f"end={aktives_segment.end_point.distance_from_start_km!r}"
+        )
+        assert mp["km_to"] == aktives_segment.end_point.distance_from_start_km, (
+            f"AC-1: measurement_point.km_to muss die End-km des aktiven "
+            f"Segments sein (nicht vertauscht mit km_from): {mp!r} vs. Segment "
+            f"start={aktives_segment.start_point.distance_from_start_km!r}/"
+            f"end={aktives_segment.end_point.distance_from_start_km!r}"
+        )
+
+        assert entry.get("source") == "radar", (
+            f"AC-1: source muss der ROHE Quellen-Schluessel sein (`result.source`), "
+            f"nicht die Beschriftung aus `source_label()` -- sonst stuenden zwei "
+            f"Vokabulare in EINEM Feld (Spec-Abschnitt \"Korrektur: `source` ist "
+            f"immer der rohe Schluessel\", Regel O1): {entry!r}"
+        )
+    finally:
+        _aufraeumen()
+
+
+def test_ac2_laufendes_ereignis_mit_bestimmbarem_ende_traegt_event_end_at():
+    uid = _uid("ac2")
+    try:
+        _write_premium_profile(uid, _AT)
+        trip = _radar_trip(uid, "trip-2050-s6-ac2", send_email=True)
+        # Dieselben Variablen speisen den Nowcast-Stub UND die Erwartung --
+        # sonst prueft `ende > beginn` nur die Reihenfolge, nie den WERT.
+        vorwarnzeit_min = 12
+        ereignisende_min = 45
+        strecke = AlarmPruefstrecke(user_id=uid, settings=_settings_all_channels())
+        lauf = strecke.lauf(
+            at=_AT, zweig="radar", trip=trip,
+            radar_service=_FixedRadar(
+                onset_minutes=vorwarnzeit_min, event_end_minutes=ereignisende_min,
+            ),
+        )
+        assert lauf.triggered_count == 1, (
+            f"AC-2 Vorbedingung: der Radar-Alarm muss ausloesen (war {lauf.triggered_count})."
+        )
+        entry = _entry_for(uid, trip.id)
+
+        assert "event_at" in entry, f"AC-2 Vorbedingung: event_at fehlt: {entry!r}"
+        assert "event_end_at" in entry, f"AC-2: event_end_at fehlt: {entry!r}"
+        beginn = datetime.fromisoformat(entry["event_at"])
+        ende = datetime.fromisoformat(entry["event_end_at"])
+        if beginn.tzinfo is None:
+            beginn = beginn.replace(tzinfo=timezone.utc)
+        if ende.tzinfo is None:
+            ende = ende.replace(tzinfo=timezone.utc)
+        assert ende > beginn, (
+            f"AC-2: event_end_at ({ende}) muss NACH event_at ({beginn}) liegen -- "
+            f"sonst ist es kein Ende des GEMELDETEN Ereignisses."
+        )
+
+        erwarteter_beginn = _AT + timedelta(minutes=vorwarnzeit_min)
+        erwartetes_ende = _AT + timedelta(minutes=ereignisende_min)
+        assert beginn == erwarteter_beginn, (
+            f"AC-2: event_at muss der Laufzeitpunkt {_AT.isoformat()} + Vorwarnzeit "
+            f"{vorwarnzeit_min} min sein: erwartet {erwarteter_beginn.isoformat()}, war {beginn.isoformat()}"
+        )
+        assert ende == erwartetes_ende, (
+            f"AC-2: event_end_at muss der Laufzeitpunkt {_AT.isoformat()} + Ereignisende "
+            f"{ereignisende_min} min sein: erwartet {erwartetes_ende.isoformat()}, war {ende.isoformat()}"
+        )
+    finally:
+        _aufraeumen()
+
+
+# ---------------------------------------------------------------------------
+# AC-3/AC-4/AC-6: Abweichungszweig (Trip)
+# ---------------------------------------------------------------------------
+
+def test_ac3_vorhersageaenderung_ueber_ein_segment_traegt_messpunkt_und_vergleichsbasis():
+    uid = _uid("ac3")
+    try:
+        trip = _deviation_trip("trip-2050-s6-ac3")
+        anker_zeit = _AT - timedelta(hours=1)
+        cached = [_weather_data_mit_peak(1, 2.0, _AT - timedelta(hours=2))]
+        fresh = [_weather_data_mit_peak(1, 18.0, _AT - timedelta(minutes=30))]
+        strecke = AlarmPruefstrecke(user_id=uid, settings=_settings_all_channels())
+        lauf = strecke.lauf(
+            at=_AT, zweig="deviation", trip=trip, cached_weather=cached, fresh_weather=fresh,
+        )
+        assert lauf.triggered_count == 1, (
+            f"AC-3 Vorbedingung: die Aenderung muss ausloesen (war {lauf.triggered_count})."
+        )
+        entry = _entry_for(uid, trip.id)
+
+        mp = entry.get("measurement_point")
+        assert mp == {"segment_id": "1"}, (
+            f"AC-3: measurement_point muss GENAU das eine betroffene Segment tragen: {mp!r}"
+        )
+        assert "reference_at" in entry, f"AC-3: reference_at fehlt: {entry!r}"
+        assert datetime.fromisoformat(entry["reference_at"]) == anker_zeit, (
+            f"AC-3: reference_at muss der Anker-Fetchzeitpunkt sein: {entry.get('reference_at')!r}"
+        )
+    finally:
+        _aufraeumen()
+
+
+def test_ac4_vorhersageaenderung_ueber_zwei_segmente_hat_keinen_messpunkt():
+    """AC-4, Positivkontrolle zu AC-3: zwei VERSCHIEDENE Segmente in einem
+    Eintrag -> `measurement_point` fehlt komplett. Gegenprobe im selben Test:
+    derselbe Aufbau mit nur EINEM der beiden Segmente traegt den Schluessel
+    sehr wohl -- der Unterschied beweist, dass die Mehrdeutigkeit selbst der
+    Grund fuer die Absenz ist, nicht ein durchgehend leerer Pfad."""
+    uid_zwei, uid_eins = _uid("ac4-zwei"), _uid("ac4-eins")
+    try:
+        trip_zwei = _deviation_trip("trip-2050-s6-ac4-zwei")
+        cached_zwei = [
+            _weather_data_mit_peak(1, 2.0, _AT - timedelta(hours=2)),
+            _weather_data_mit_peak(2, 2.0, _AT - timedelta(hours=2)),
+        ]
+        fresh_zwei = [
+            _weather_data_mit_peak(1, 18.0, _AT - timedelta(minutes=30)),
+            _weather_data_mit_peak(2, 18.0, _AT - timedelta(minutes=45)),
+        ]
+        strecke_zwei = AlarmPruefstrecke(user_id=uid_zwei, settings=_settings_all_channels())
+        lauf_zwei = strecke_zwei.lauf(
+            at=_AT, zweig="deviation", trip=trip_zwei,
+            cached_weather=cached_zwei, fresh_weather=fresh_zwei,
+        )
+        assert lauf_zwei.triggered_count == 1, (
+            f"AC-4 Vorbedingung: BEIDE Segmente muessen ausloesen (war {lauf_zwei.triggered_count})."
+        )
+        entry_zwei = _entry_for(uid_zwei, trip_zwei.id)
+        assert entry_zwei.get("changes_count") == 2, (
+            f"AC-4 Vorbedingung: der Eintrag muss ZWEI Aenderungen buendeln, "
+            f"sonst prueft der Test keine Mehrdeutigkeit: {entry_zwei!r}"
+        )
+        assert "measurement_point" not in entry_zwei, (
+            f"AC-4: bei zwei verschiedenen Segmenten darf KEIN willkuerlich "
+            f"gewaehltes Segment als Messpunkt erscheinen: {entry_zwei!r}"
+        )
+
+        # Gegenprobe: dieselbe Konstruktion mit nur EINEM Segment.
+        trip_eins = _deviation_trip("trip-2050-s6-ac4-eins")
+        cached_eins = [_weather_data_mit_peak(1, 2.0, _AT - timedelta(hours=2))]
+        fresh_eins = [_weather_data_mit_peak(1, 18.0, _AT - timedelta(minutes=30))]
+        strecke_eins = AlarmPruefstrecke(user_id=uid_eins, settings=_settings_all_channels())
+        lauf_eins = strecke_eins.lauf(
+            at=_AT, zweig="deviation", trip=trip_eins,
+            cached_weather=cached_eins, fresh_weather=fresh_eins,
+        )
+        assert lauf_eins.triggered_count == 1
+        entry_eins = _entry_for(uid_eins, trip_eins.id)
+        assert entry_eins.get("measurement_point") == {"segment_id": "1"}, (
+            f"AC-4 Gegenprobe: mit nur EINEM Segment muss measurement_point "
+            f"vorhanden sein -- sonst ist die Absenz oben nicht durch die "
+            f"Mehrdeutigkeit erklaert, sondern ein durchgehend leerer Pfad: {entry_eins!r}"
+        )
+    finally:
+        _aufraeumen()
+
+
+def test_ac6_vorhersageaenderung_kennt_weder_vorwarnzeit_noch_ereignisende():
+    """AC-6, Positivkontrolle zu AC-5: derselbe Abweichungs-Eintrag traegt
+    NIE `lead_time_minutes`/`event_end_at` (strukturell), waehrend `event_at`
+    sehr wohl vorkommen KANN (AC-3) -- der Unterschied ist am Schema selbst
+    ablesbar."""
+    uid = _uid("ac6")
+    try:
+        trip = _deviation_trip("trip-2050-s6-ac6")
+        cached = [_weather_data_mit_peak(1, 2.0, _AT - timedelta(hours=2))]
+        fresh = [_weather_data_mit_peak(1, 18.0, _AT - timedelta(minutes=30))]
+        strecke = AlarmPruefstrecke(user_id=uid, settings=_settings_all_channels())
+        lauf = strecke.lauf(
+            at=_AT, zweig="deviation", trip=trip, cached_weather=cached, fresh_weather=fresh,
+        )
+        assert lauf.triggered_count == 1
+        entry = _entry_for(uid, trip.id)
+
+        assert "lead_time_minutes" not in entry, (
+            f"AC-6: der Abweichungszweig kennt keine Vorwarnzeit im Nowcast-Sinn: {entry!r}"
+        )
+        assert "event_end_at" not in entry, (
+            f"AC-6: der Abweichungszweig kennt kein Ereignisende: {entry!r}"
+        )
+        assert "event_at" in entry, (
+            f"AC-6: event_at MUSS bei eindeutigem Segment vorkommen (AC-3) -- "
+            f"sonst waere die Absenz oben nur ein durchgehend leerer Pfad: {entry!r}"
+        )
+    finally:
+        _aufraeumen()
+
+
+# ---------------------------------------------------------------------------
+# AC-5: amtlicher Zweig (Trip)
+# ---------------------------------------------------------------------------
+
+def test_ac5_amtliche_warnung_traegt_ereigniszeit_und_quelle_ohne_vorwarnzeit_und_vergleichsbasis():
+    uid = _uid("ac5")
+    try:
+        trip = _deviation_trip("trip-2050-s6-ac5")
+        alert = OfficialAlert(
+            source="tdd-2050-s6-ac5-quelle", hazard="thunderstorm", level=3,
+            label="Gewitterwarnung",
+            valid_from=_AT + timedelta(hours=1), valid_to=_AT + timedelta(hours=6),
+        )
+        strecke = AlarmPruefstrecke(user_id=uid, settings=_settings_all_channels())
+        lauf = strecke.lauf(at=_AT, zweig="official", trip=trip, official_notices=[(alert, ["1"])])
+        assert lauf.triggered_count == 1, (
+            f"AC-5 Vorbedingung: die amtliche Warnung muss ausloesen (war {lauf.triggered_count})."
+        )
+        entry = _entry_for(uid, trip.id)
+
+        assert entry.get("source") == "tdd-2050-s6-ac5-quelle", (
+            f"AC-5: source muss OfficialAlert.source sein: {entry!r}"
+        )
+        assert "event_at" in entry and "event_end_at" in entry, (
+            f"AC-5: event_at/event_end_at fehlen: {entry!r}"
+        )
+        assert datetime.fromisoformat(entry["event_at"]) == alert.valid_from, (
+            f"AC-5: event_at muss valid_from sein: {entry.get('event_at')!r}"
+        )
+        assert datetime.fromisoformat(entry["event_end_at"]) == alert.valid_to, (
+            f"AC-5: event_end_at muss valid_to sein: {entry.get('event_end_at')!r}"
+        )
+        assert "lead_time_minutes" not in entry, (
+            f"AC-5: amtliche Warnungen haben KEINE Vorwarnzeit -- auch nicht als null: {entry!r}"
+        )
+        assert "reference_at" not in entry, (
+            f"AC-5: amtliche Warnungen haben KEINE Vergleichsbasis -- auch nicht als null: {entry!r}"
+        )
+    finally:
+        _aufraeumen()
+
+
+# ---------------------------------------------------------------------------
+# AC-7: Ortsvergleich, Nowcast
+# ---------------------------------------------------------------------------
+
+def _compare_entry_for(uid: str, preset_id: str) -> dict:
+    path = get_data_dir(uid) / "alert_log.json"
+    data = json.loads(path.read_text())
+    treffer = [e for e in data.get("entries", []) if e.get("entity_id") == preset_id]
+    assert treffer, f"kein entries-Eintrag fuer {preset_id!r} in {path}: {data!r}"
+    return treffer[-1]
+
+
+def _wet_frame(onset_minutes: int) -> list:
+    from providers.brightsky import RadarFrame
+    ts = datetime.now(timezone.utc) + timedelta(minutes=onset_minutes)
+    return [RadarFrame(timestamp=ts, precip_mm_h=2.0)]
+
+
+def test_ac7_ortsvergleich_nowcast_ein_ort_traegt_messpunkt_zwei_orte_nicht():
+    from services.compare_radar_alert import CompareRadarAlertService
+
+    uid_eins, uid_zwei = _uid("ac7-eins"), _uid("ac7-zwei")
+    try:
+        loc = _location("loc-ac7", "Zermatt-2050-S6", 46.0207, 7.7491)
+        save_location(loc, user_id=uid_eins)
+        preset_id_eins = "cp-2050-s6-ac7-eins"
+        _write_preset_file(
+            uid_eins, [_radar_preset(preset_id_eins, ["loc-ac7"], ["gregor-test@henemm.com"])],
+        )
+        frame_source_eins = _CoordFrameSource({(46.0207, 7.7491): _wet_frame(8)})
+        service_eins = CompareRadarAlertService(
+            settings=_settings_email_capable_dummy(), user_id=uid_eins,
+            radar_service=RadarNowcastService(frame_source=frame_source_eins),
+            mail_sink=lambda subject, body: None,
+        )
+        sent_eins = service_eins.check_all_compare_presets()
+        assert sent_eins == 1, (
+            f"AC-7 Vorbedingung: EIN ausloesender Ort muss senden (war {sent_eins})."
+        )
+        entry_eins = _compare_entry_for(uid_eins, preset_id_eins)
+        assert entry_eins.get("measurement_point") == {"location_id": "loc-ac7"}, (
+            f"AC-7: EIN getriggerter Ort MUSS als measurement_point erscheinen: {entry_eins!r}"
+        )
+
+        loc_a = _location("loc-a", "Zermatt-2050-S6-a", 46.0207, 7.7491)
+        loc_b = _location("loc-b", "Chamonix-2050-S6-b", 45.9237, 6.8694)
+        save_location(loc_a, user_id=uid_zwei)
+        save_location(loc_b, user_id=uid_zwei)
+        preset_id_zwei = "cp-2050-s6-ac7-zwei"
+        _write_preset_file(
+            uid_zwei,
+            [_radar_preset(preset_id_zwei, ["loc-a", "loc-b"], ["gregor-test@henemm.com"])],
+        )
+        frame_source_zwei = _CoordFrameSource({
+            (46.0207, 7.7491): _wet_frame(5),
+            (45.9237, 6.8694): _wet_frame(18),
+        })
+        service_zwei = CompareRadarAlertService(
+            settings=_settings_email_capable_dummy(), user_id=uid_zwei,
+            radar_service=RadarNowcastService(frame_source=frame_source_zwei),
+            mail_sink=lambda subject, body: None,
+        )
+        sent_zwei = service_zwei.check_all_compare_presets()
+        assert sent_zwei == 1, (
+            f"AC-7 Vorbedingung: ZWEI gleichzeitig ausloesende Orte muessen "
+            f"EINE gebuendelte Mail ergeben (war {sent_zwei})."
+        )
+        entry_zwei = _compare_entry_for(uid_zwei, preset_id_zwei)
+        assert "measurement_point" not in entry_zwei, (
+            f"AC-7: bei ZWEI gleichzeitig ausloesenden Orten darf KEIN "
+            f"willkuerlich gewaehlter Ort als Messpunkt erscheinen: {entry_zwei!r}"
+        )
+    finally:
+        _aufraeumen()
+
+
+# ---------------------------------------------------------------------------
+# AC-8: Fail-soft
+# ---------------------------------------------------------------------------
+
+def test_ac8_direktaufruf_ohne_bestimmbare_werte_erzeugt_absenz_statt_null():
+    """Absenz-Regel (Baustein von AC-8, aber NICHT dessen Fail-soft-
+    Zusicherung): ruft man `append_entry()` direkt mit allen sechs kwargs
+    auf `None`, entsteht KEINER der sechs Schluessel im Eintrag -- Absenz
+    statt eines erfundenen `null`. Das ist ein reiner Verhaltenstest der
+    Schreibfunktion selbst (Team-Lead-Review 2026-08-22: der urspruengliche
+    Test hier bewies NUR seine eigene Eingabe zurueck -- `sent_channels`/
+    `changes_count` wurden selbst uebergeben und identisch wieder ausgelesen,
+    das ist keine Zusicherung ueber Zustellung. Die eigentliche Fail-soft-
+    Zusicherung "der Alarm geht trotzdem raus" wirkt im Versandpfad, nicht
+    in `append_entry()`, und wird deshalb unten als echter Pruefstrecken-Lauf
+    gefuehrt, s. `test_ac8_radar_alarm_mit_unbestimmbaren_groessen_...`)."""
+    from services import alert_log
+
+    uid = _uid("ac8-absenz")
+    try:
+        alert_log.append_entry(
+            uid, entity_id="trip-2050-s6-ac8-absenz", entity_type="trip",
+            changes_count=2, severity="MODERATE",
+            reason=alert_log.REASON_FORECAST_CHANGE,
+            effective_channels={"email"}, sent_channels=["email"],
+            # Die sechs neuen Groessen: alle explizit unbelegt.
+            lead_time_minutes=None, event_at=None, event_end_at=None,
+            measurement_point=None, reference_at=None, source=None,
+        )
+        entry = _entry_for(uid, "trip-2050-s6-ac8-absenz")
+        for schluessel in (
+            "lead_time_minutes", "event_at", "event_end_at",
+            "measurement_point", "reference_at", "source",
+        ):
+            assert schluessel not in entry, (
+                f"Absenz-Regel: {schluessel!r} darf bei `None`-Eingabe NICHT im "
+                f"Eintrag stehen (Absenz statt null): {entry!r}"
+            )
+    finally:
+        _aufraeumen()
+
+
+def test_ac8_radar_alarm_mit_unbestimmbaren_groessen_wird_trotzdem_zugestellt_und_protokolliert():
+    """AC-8 (Fail-soft, PFLICHT): echter Lauf ueber `AlarmPruefstrecke`
+    (`zweig="radar"`), NICHT nur ein Direktaufruf -- die Zusicherung "der
+    Alarm geht trotzdem raus" wirkt im Versandpfad, nicht in
+    `append_entry()`, und muss deshalb dort geprueft werden, wo sie WIRKT
+    (Team-Lead-Review 2026-08-22).
+
+    Konstruktion, ehrlich auf das begrenzt, was am Radar-Nowcast-Zweig
+    tatsaechlich unbestimmbar herstellbar ist:
+
+    - **laufendes Ereignis ohne kuenftigen Beginn** (S2b-Fall,
+      `onset_minutes=None`, `already_running=True`) -> `lead_time_minutes`
+      bleibt `None` (= `result.onset_minutes`, direkt uebernommen).
+    - **kein Ende bestimmbar** (`event_end_minutes=None`) -> `event_end_at`
+      bleibt `None`.
+    - **kein Briefing-Snapshot fuer den Tag** (keiner geschrieben) ->
+      `_briefing_precip_for_onset()` liefert sofort `None` -> `reference_at`
+      bleibt `None` ("None falls kein Snapshot fuer den Tag existiert",
+      Spec-Tabelle Radar-Zeile).
+
+    Das sind damit DREI der sechs Groessen -- NICHT alle sechs: `event_at`
+    ist am Radar-Zweig laut Spec-Tabelle "immer gesetzt"
+    (`_onset_dt = now_utc + timedelta(minutes=result.onset_minutes or 0)`,
+    `trip_alert.py`, Kommentar "Bezugszeitpunkt ist dann JETZT" -- S2b-
+    Bruchstelle 3), `measurement_point` (`active.segment_id`/`km_from`/
+    `km_to`) und `source` (der rohe `result.source`) sind am
+    Radar-Zweig strukturell IMMER aus dem laufenden Trip/Request ableitbar.
+    Diese drei koennen an dieser Aufrufstelle nicht auf unbestimmbar gebracht
+    werden -- das ist keine Testschwaeche, sondern folgt aus der
+    Aufrufstellen-Tabelle der Spec selbst.
+
+    BEWUSST von Anfang an GRUEN (gemessen 2026-08-22): `triggered_count==1`
+    und `channels_sent` sind bereits VOR dieser Scheibe unveraendertes
+    Verhalten (Zustellung haengt nicht von den sechs neuen Feldern ab), und
+    die drei Absenz-Zusicherungen sind vor GREEN trivial erfuellt, weil noch
+    KEIN Aufrufer irgendeinen der sechs kwargs uebergibt -- nicht nur fuer
+    diese drei. Die Positivkontrolle, dass die Absenz-Pruefung ueberhaupt
+    etwas MISST (statt eines durchgehend leeren Pfads), liefern die drei
+    Nachbar-Tests in DERSELBEN Datei: `test_ac1_...` zeigt `lead_time_minutes`
+    PRAESENT bei bestimmbarem Onset, `test_ac2_...` zeigt `event_end_at`
+    PRAESENT bei bestimmbarem Ende, `test_ac3_...` zeigt `reference_at`
+    PRAESENT bei vorhandenem Anker -- exakt dieselbe Codefamilie
+    (Radar-/Abweichungszweig), nur mit den jeweils bestimmbaren statt
+    unbestimmbaren Eingaben."""
+    uid = _uid("ac8-radar")
+    try:
+        trip = _radar_trip(uid, "trip-2050-s6-ac8-radar", send_email=True)
+        # Kein Briefing-Snapshot fuer den Tag geschrieben (bewusst) ->
+        # reference_at bleibt unbestimmbar.
+        strecke = AlarmPruefstrecke(user_id=uid, settings=_settings_all_channels())
+        lauf = strecke.lauf(
+            at=_AT, zweig="radar", trip=trip,
+            radar_service=_FixedRadar(onset_minutes=None, already_running=True, event_end_minutes=None),
+        )
+        assert lauf.triggered_count == 1, (
+            f"AC-8 Vorbedingung: das laufende Ereignis (already_running=True) "
+            f"muss trotz unbestimmbarem Beginn ausloesen (war {lauf.triggered_count})."
+        )
+        entry = _entry_for(uid, trip.id)
+
+        assert entry.get("changes_count") == 1 and entry.get("channels_sent"), (
+            f"AC-8: der Alarm muss trotzdem VOLLSTAENDIG protokolliert und "
+            f"zugestellt werden (mind. ein Kanal in channels_sent): {entry!r}"
+        )
+        for schluessel in ("lead_time_minutes", "event_end_at", "reference_at"):
+            assert schluessel not in entry, (
+                f"AC-8: {schluessel!r} ist an dieser Aufrufstelle unbestimmbar "
+                f"und darf NICHT im Eintrag stehen: {entry!r}"
+            )
+    finally:
+        _aufraeumen()

--- a/tests/tdd/test_alert_log_mandanten_und_altbestand.py
+++ b/tests/tdd/test_alert_log_mandanten_und_altbestand.py
@@ -1,0 +1,157 @@
+"""Issue #2050 Scheibe S6 — Mandantentrennung (AC-11) und Alt-Bestand bleibt
+unangetastet (AC-12) fuer die sechs neuen E-1-Groessen.
+
+SPEC: docs/specs/modules/alarm_protokoll_vorwarnzeit.md (AC-11, AC-12)
+"""
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime, timezone
+
+from app.loader import get_data_dir
+from services.radar_service import NowcastResult, RadarNowcastService
+
+from tests.helpers.alarm_pruefstrecke import AlarmPruefstrecke
+from tests.tdd.test_952_onset_alert_fidelity import _clean_user
+from tests.tdd.test_alarm_pruefstrecke_selbstschutz import (
+    _AT, _radar_trip, _settings_all_channels,
+)
+
+_ANGELEGT: list[str] = []
+
+
+def _uid(tag: str) -> str:
+    uid = f"tdd-2050-s6-{tag}-{uuid.uuid4().hex[:6]}"
+    _ANGELEGT.append(uid)
+    return uid
+
+
+def _aufraeumen() -> None:
+    for uid in _ANGELEGT:
+        _clean_user(uid)
+    _ANGELEGT.clear()
+
+
+class _FixedRadar(RadarNowcastService):
+    def __init__(self, **kwargs) -> None:
+        super().__init__()
+        kwargs.setdefault("intensity_label", "leichter Regen")
+        kwargs.setdefault("source", "radar")
+        self._fixed = NowcastResult(**kwargs)
+
+    def get_nowcast(self, lat, lon, elevation_m=None, priority="user_briefing"):
+        return self._fixed
+
+
+def _entry_for(uid: str, entity_id: str) -> dict:
+    path = get_data_dir(uid) / "alert_log.json"
+    data = json.loads(path.read_text())
+    treffer = [e for e in data.get("entries", []) if e.get("entity_id") == entity_id]
+    assert treffer, f"kein entries-Eintrag fuer {entity_id!r} in {path}: {data!r}"
+    return treffer[-1]
+
+
+def test_ac11_zwei_nutzer_mit_eigenen_alarmen_vermischen_ihre_werte_nicht():
+    """AC-11 (Mandantentrennung, PFLICHT): zwei Nutzer, je ein Nowcast-Alarm
+    mit UNTERSCHIEDLICHER Vorwarnzeit im selben Testlauf -- Nutzer As Wert
+    darf in Nutzer Bs Datei nicht auftauchen und umgekehrt."""
+    uid_a, uid_b = _uid("ac11-a"), _uid("ac11-b")
+    try:
+        trip_a = _radar_trip(uid_a, "trip-2050-s6-ac11-a", send_email=True)
+        trip_b = _radar_trip(uid_b, "trip-2050-s6-ac11-b", send_email=True)
+
+        strecke_a = AlarmPruefstrecke(user_id=uid_a, settings=_settings_all_channels())
+        strecke_b = AlarmPruefstrecke(user_id=uid_b, settings=_settings_all_channels())
+        lauf_a = strecke_a.lauf(at=_AT, zweig="radar", trip=trip_a, radar_service=_FixedRadar(onset_minutes=7))
+        lauf_b = strecke_b.lauf(at=_AT, zweig="radar", trip=trip_b, radar_service=_FixedRadar(onset_minutes=33))
+        assert lauf_a.triggered_count == 1 and lauf_b.triggered_count == 1, (
+            f"AC-11 Vorbedingung: beide Nutzer muessen ausloesen "
+            f"(a={lauf_a.triggered_count}, b={lauf_b.triggered_count})."
+        )
+
+        entry_a = _entry_for(uid_a, trip_a.id)
+        entry_b = _entry_for(uid_b, trip_b.id)
+
+        assert entry_a.get("lead_time_minutes") == 7, (
+            f"AC-11: Nutzer As eigener Wert (7) fehlt in seiner Datei: {entry_a!r}"
+        )
+        assert entry_b.get("lead_time_minutes") == 33, (
+            f"AC-11: Nutzer Bs eigener Wert (33) fehlt in seiner Datei: {entry_b!r}"
+        )
+
+        data_a = json.loads((get_data_dir(uid_a) / "alert_log.json").read_text())
+        data_b = json.loads((get_data_dir(uid_b) / "alert_log.json").read_text())
+        assert not any(e.get("lead_time_minutes") == 33 for e in data_a.get("entries", [])), (
+            f"AC-11: Nutzer Bs Wert (33) ist in Nutzer As Datei aufgetaucht: {data_a!r}"
+        )
+        assert not any(e.get("lead_time_minutes") == 7 for e in data_b.get("entries", [])), (
+            f"AC-11: Nutzer As Wert (7) ist in Nutzer Bs Datei aufgetaucht: {data_b!r}"
+        )
+    finally:
+        _aufraeumen()
+
+
+def test_ac12_alter_eintrag_bleibt_byte_identisch_waehrend_neuer_eintrag_die_sechs_groessen_traegt():
+    """AC-12 (Alt-Eintraege unangetastet, PFLICHT mit Gegenprobe): eine
+    bestehende `alert_log.json` mit einem Eintrag aus VOR dieser Scheibe --
+    ein neuer Alarm fuer denselben Nutzer darf den alten NICHT nachtraeglich
+    um die sechs neuen Schluessel ergaenzen, waehrend der NEUE Eintrag in
+    DERSELBEN Datei sie traegt, wo bestimmbar. Der Kontrast zwischen den
+    beiden Eintraegen IST die Positivkontrolle."""
+    from services import alert_log
+
+    uid = _uid("ac12")
+    try:
+        data_dir = get_data_dir(uid)
+        data_dir.mkdir(parents=True, exist_ok=True)
+        alt_eintrag = {
+            "entity_id": "trip-2050-s6-ac12-alt", "entity_type": "trip",
+            "sent_at": "2026-01-01T09:00:00+00:00",
+            "changes_count": 1, "severity": "MODERATE",
+            "metrics": [{"metric_id": "precipitation", "aggregation": "sum"}],
+            "hazards": [], "reason": "forecast_change",
+            "channels_sent": ["email"], "channels_not_sent": [],
+        }
+        (data_dir / "alert_log.json").write_text(
+            json.dumps({"entries": [alt_eintrag], "not_delivered": []}, indent=2)
+        )
+
+        alert_log.append_entry(
+            uid, entity_id="trip-2050-s6-ac12-neu", entity_type="trip",
+            changes_count=1, severity="MODERATE",
+            reason=alert_log.REASON_NOWCAST,
+            effective_channels={"email"}, sent_channels=["email"],
+            lead_time_minutes=9, event_at=datetime(2026, 4, 5, 10, 12, tzinfo=timezone.utc).isoformat(),
+            measurement_point={"segment_id": "1", "km_from": 0.0, "km_to": 3.0},
+            source="radar",  # roher Schluessel, nicht die Beschriftung (O1)
+        )
+
+        data = json.loads((data_dir / "alert_log.json").read_text())
+        entries = data.get("entries", [])
+        assert len(entries) == 2, (
+            f"AC-12 Vorbedingung: Read-Modify-Write muss den alten Eintrag "
+            f"BEHALTEN und den neuen ANHAENGEN: {entries!r}"
+        )
+        alter_wiedergelesen = next(
+            e for e in entries if e.get("entity_id") == "trip-2050-s6-ac12-alt"
+        )
+        assert alter_wiedergelesen == alt_eintrag, (
+            f"AC-12: der ALTE Eintrag muss byte-identisch (dict-gleich) bleiben "
+            f"-- keiner der sechs neuen Schluessel darf nachtraeglich ergaenzt "
+            f"werden: {alter_wiedergelesen!r}"
+        )
+        neuer_eintrag = next(
+            e for e in entries if e.get("entity_id") == "trip-2050-s6-ac12-neu"
+        )
+        assert any(
+            k in neuer_eintrag for k in (
+                "lead_time_minutes", "event_at", "measurement_point", "source",
+            )
+        ), (
+            f"AC-12 Gegenprobe: der NEUE Eintrag muss mindestens einen der "
+            f"sechs Schluessel tragen -- sonst zeigt der Kontrast oben nichts, "
+            f"weil schlicht NIE geschrieben wird: {neuer_eintrag!r}"
+        )
+    finally:
+        _aufraeumen()

--- a/tests/tdd/test_alert_log_unique_or_none_und_fail_soft.py
+++ b/tests/tdd/test_alert_log_unique_or_none_und_fail_soft.py
@@ -1,0 +1,210 @@
+"""Issue #2050 Scheibe S6 — `unique_or_none()` selbst (AC-14) und
+Fail-soft bei fehlerhaft geformten Eingaben an `append_entry()` (AC-15).
+
+SPEC: docs/specs/modules/alarm_protokoll_vorwarnzeit.md (AC-14, AC-15)
+
+RED-Grund: `services.alert_log.unique_or_none` existiert noch nicht
+(ImportError); `append_entry()` kennt die sechs neuen kwargs noch nicht
+(TypeError) -- beides der korrekte, ehrliche Rot-Grund fuer diese Scheibe.
+"""
+from __future__ import annotations
+
+import logging
+import uuid
+
+from app.loader import get_data_dir
+
+
+_ANGELEGT: list[str] = []
+
+
+def _uid(tag: str) -> str:
+    uid = f"tdd-2050-s6-{tag}-{uuid.uuid4().hex[:6]}"
+    _ANGELEGT.append(uid)
+    return uid
+
+
+def _aufraeumen() -> None:
+    import shutil
+    for uid in _ANGELEGT:
+        d = get_data_dir(uid)
+        if d.exists():
+            shutil.rmtree(d)
+    _ANGELEGT.clear()
+
+
+def test_ac14_unique_or_none_liefert_den_einen_wert_oder_none_bei_mehrdeutigkeit():
+    """AC-14 (PFLICHT mit Gegenprobe): vier Fallgruppen in einem Test --
+    eindeutig direkt, eindeutig mit `None`-Rauschen, mehrdeutig (zwei
+    verschiedene Werte), leere Liste."""
+    from services.alert_log import unique_or_none
+
+    assert unique_or_none(["seg-1", "seg-1"]) == "seg-1", (
+        "AC-14: zwei gleiche Nicht-None-Werte muessen den einen Wert liefern"
+    )
+    assert unique_or_none(["seg-1", None]) == "seg-1", (
+        "AC-14: ein Wert plus None-Rauschen muss den einen Wert liefern"
+    )
+    assert unique_or_none(["seg-1", "seg-2"]) is None, (
+        "AC-14: ZWEI VERSCHIEDENE Nicht-None-Werte muessen None liefern "
+        "(Mehrdeutigkeit) -- sonst waere das eine willkuerliche Wahl"
+    )
+    assert unique_or_none([]) is None, (
+        "AC-14: eine leere Liste muss None liefern"
+    )
+
+
+def test_ac15_fehlerhaft_geformter_wert_verhindert_den_alarm_nicht_und_wird_laut_verworfen(caplog):
+    """AC-15 (PFLICHT): `measurement_point` als String statt dict --
+    `append_entry()` darf KEINE Ausnahme werfen (der Alarm darf nie
+    verhindert werden), der fehlerhafte Schluessel entsteht nicht (mit oder
+    ohne korrekten Wert je nach Absicherung), aber es erscheint eine
+    `logger.warning`-Zeile mit dem betroffenen Schluessel und der
+    `entity_id`. Gegenprobe: derselbe Aufruf mit korrekt geformtem Wert
+    erzeugt KEINE Warnung -- der Unterschied beweist, dass die Warnung den
+    Fehlerfall anzeigt, nicht immer erscheint."""
+    from services import alert_log
+
+    uid = _uid("ac15")
+    try:
+        with caplog.at_level(logging.WARNING, logger="services.alert_log"):
+            caplog.clear()
+            alert_log.append_entry(
+                uid, entity_id="trip-2050-s6-ac15-defekt", entity_type="trip",
+                changes_count=1, severity="MODERATE",
+                reason=alert_log.REASON_NOWCAST,
+                effective_channels={"email"}, sent_channels=["email"],
+                measurement_point="das-ist-KEIN-dict",  # absichtlich falsch geformt
+            )
+        assert any(
+            "trip-2050-s6-ac15-defekt" in r.message and "measurement_point" in r.message
+            for r in caplog.records
+        ), (
+            f"AC-15: erwarte eine Warnung mit Schluessel UND entity_id, "
+            f"nicht stilles Verschlucken. Log: {[r.message for r in caplog.records]!r}"
+        )
+
+        # Gegenprobe: derselbe Aufruf mit korrekt geformtem Wert -- KEINE Warnung.
+        with caplog.at_level(logging.WARNING, logger="services.alert_log"):
+            caplog.clear()
+            alert_log.append_entry(
+                uid, entity_id="trip-2050-s6-ac15-korrekt", entity_type="trip",
+                changes_count=1, severity="MODERATE",
+                reason=alert_log.REASON_NOWCAST,
+                effective_channels={"email"}, sent_channels=["email"],
+                measurement_point={"segment_id": "1", "km_from": 0.0, "km_to": 3.0},
+            )
+        assert not caplog.records, (
+            f"AC-15 Gegenprobe: ein KORREKT geformter Wert darf KEINE Warnung "
+            f"ausloesen -- sonst zeigt die Warnung oben nicht den Fehlerfall, "
+            f"sondern erscheint immer. Log: {[r.message for r in caplog.records]!r}"
+        )
+    finally:
+        _aufraeumen()
+
+
+def test_ac15_defekte_e1_ableitung_stoppt_weder_den_alarm_noch_die_folgenden_trips(
+    monkeypatch, caplog,
+):
+    """AC-15 an der Stelle, an der die Zusicherung WIRKT: die E-1-Ableitung
+    des Radar-Zweigs (`trip_alert._radar_e1_fields()`) steht VOR dem Versand
+    und laeuft INNERHALB der Schleife ueber alle Trips des Nutzers. Ein
+    Fehler dort duerfte deshalb weder den Alarm dieses Trips verhindern noch
+    die uebrigen Trips mitreissen (Muster `fix_1479`).
+
+    Fehler-Injektion ueber die ECHTE geteilte Naht
+    `alert_log.nowcast_event_end_at()`, die die Ableitung benutzt -- kein
+    Mock(): gemessen wird nicht die Injektion selbst, sondern das Verhalten
+    dahinter (Zustellung, Protokoll-Eintrag, Warnung). Ohne diese Injektion
+    ist der Zweig heute nicht auf Fehler zu bringen; genau deshalb ist die
+    Absicherung strukturell und braucht einen eigenen Waechter.
+
+    Positivkontrolle im selben Test: derselbe Aufbau OHNE Defekt traegt die
+    Groessen sehr wohl -- sonst waere die Absenz oben nur ein durchgehend
+    leerer Pfad statt der Wirkung des Defekts."""
+    import logging as _logging
+
+    from services import alert_log as alert_log_mod
+
+    from tests.helpers.alarm_pruefstrecke import AlarmPruefstrecke
+    from tests.tdd.test_952_onset_alert_fidelity import _clean_user
+    from tests.tdd.test_alarm_pruefstrecke_selbstschutz import (
+        _AT, _radar_trip, _settings_all_channels,
+    )
+    from tests.tdd.test_alert_log_mandanten_und_altbestand import (
+        _FixedRadar, _entry_for,
+    )
+
+    _SECHS = (
+        "lead_time_minutes", "event_at", "event_end_at",
+        "measurement_point", "reference_at", "source",
+    )
+    uid_defekt, uid_ok = _uid("ac15-defekt"), _uid("ac15-ok")
+    try:
+        # --- Lauf MIT Defekt: zwei Trips desselben Nutzers ---------------
+        trip_a = _radar_trip(uid_defekt, "trip-2050-s6-ac15-a", send_email=True)
+        trip_b = _radar_trip(uid_defekt, "trip-2050-s6-ac15-b", send_email=True)
+
+        def _wirft(*_args, **_kwargs):
+            raise RuntimeError("defekte E-1-Ableitung (Fehler-Injektion AC-15)")
+
+        monkeypatch.setattr(alert_log_mod, "nowcast_event_end_at", _wirft)
+        strecke = AlarmPruefstrecke(user_id=uid_defekt, settings=_settings_all_channels())
+        with caplog.at_level(_logging.WARNING, logger="services.trip_alert"):
+            caplog.clear()
+            lauf = strecke.lauf(
+                at=_AT, zweig="radar", trip=trip_a,
+                radar_service=_FixedRadar(onset_minutes=12, event_end_minutes=45),
+            )
+        assert lauf.triggered_count == 2, (
+            f"AC-15: BEIDE Trips muessen trotz der defekten Ableitung alarmieren "
+            f"-- ein Protokollfehler darf weder den eigenen Alarm verhindern noch "
+            f"die restlichen Trips des Nutzers mitreissen (war {lauf.triggered_count})."
+        )
+        for trip in (trip_a, trip_b):
+            entry = _entry_for(uid_defekt, trip.id)
+            assert entry.get("channels_sent"), (
+                f"AC-15: der Alarm fuer {trip.id} muss zugestellt und vollstaendig "
+                f"protokolliert werden: {entry!r}"
+            )
+            for schluessel in _SECHS:
+                assert schluessel not in entry, (
+                    f"AC-15: nach dem Defekt darf {schluessel!r} nicht im Eintrag "
+                    f"stehen (fail-soft zu Absenz, nicht zu einem Ratewert): {entry!r}"
+                )
+        gemeldet = " ".join(r.getMessage() for r in caplog.records)
+        for trip in (trip_a, trip_b):
+            assert trip.id in gemeldet, (
+                f"AC-15: der Defekt muss LAUT verworfen werden -- eine Warnung mit "
+                f"{trip.id!r} fehlt. Sonst behauptete das Protokoll 'diese Groessen "
+                f"gab es hier nicht', wo ein Defekt vorlag. Log: {gemeldet!r}"
+            )
+
+        # --- Positivkontrolle: derselbe Aufbau OHNE Defekt ---------------
+        monkeypatch.undo()
+        trip_c = _radar_trip(uid_ok, "trip-2050-s6-ac15-c", send_email=True)
+        strecke_ok = AlarmPruefstrecke(user_id=uid_ok, settings=_settings_all_channels())
+        with caplog.at_level(_logging.WARNING, logger="services.trip_alert"):
+            caplog.clear()
+            lauf_ok = strecke_ok.lauf(
+                at=_AT, zweig="radar", trip=trip_c,
+                radar_service=_FixedRadar(onset_minutes=12, event_end_minutes=45),
+            )
+        assert lauf_ok.triggered_count == 1
+        ohne_defekt = [r.getMessage() for r in caplog.records
+                       if "nicht ableitbar" in r.getMessage()]
+        assert not ohne_defekt, (
+            f"AC-15 Gegenprobe: ein fehlerfreier Lauf darf KEINE "
+            f"'nicht ableitbar'-Warnung erzeugen -- sonst zeigt die Warnung oben "
+            f"nicht den Fehlerfall an, sondern erscheint immer und ginge im "
+            f"Betrieb im Rauschen unter. Log: {ohne_defekt!r}"
+        )
+        entry_ok = _entry_for(uid_ok, trip_c.id)
+        assert entry_ok.get("lead_time_minutes") == 12 and "event_end_at" in entry_ok, (
+            f"AC-15 Positivkontrolle: ohne Defekt MUESSEN die Groessen entstehen -- "
+            f"sonst zeigt ihre Absenz oben nur einen leeren Pfad: {entry_ok!r}"
+        )
+    finally:
+        for uid in (uid_defekt, uid_ok):
+            _clean_user(uid)
+        _aufraeumen()

--- a/tests/tdd/test_alert_log_unterdrueckung_groessen.py
+++ b/tests/tdd/test_alert_log_unterdrueckung_groessen.py
@@ -1,0 +1,228 @@
+"""Issue #2050 Scheibe S6 — Unterdrueckungs-Eintraege (`not_delivered`) und
+die E-1-Groessen: AC-9 (frueh, VOR dem Nowcast-Abruf -- strukturell nichts
+bekannt) und AC-10 (spaet, NACH dem Abruf -- die Vergleichsbasis ist die
+Begruendung der Unterdrueckung selbst).
+
+SPEC: docs/specs/modules/alarm_protokoll_vorwarnzeit.md (AC-9, AC-10)
+
+Beide Laeufe ueber `AlarmPruefstrecke` (S1, `zweig="radar"`) gegen die echte
+Auslöseentscheidung. Kein Mock()/patch()/MagicMock.
+"""
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from app.loader import get_data_dir
+from app.models import (
+    ForecastDataPoint, ForecastMeta, NormalizedTimeseries, Provider,
+    SegmentWeatherData, SegmentWeatherSummary,
+)
+from services.radar_service import NowcastResult, RadarNowcastService
+from services.throttle_store import ThrottleStore
+from services.weather_snapshot import WeatherSnapshotService
+
+from tests.helpers.alarm_pruefstrecke import AlarmPruefstrecke
+from tests.tdd.test_952_onset_alert_fidelity import _clean_user
+from tests.tdd.test_alarm_pruefstrecke_selbstschutz import (
+    _AT, _radar_trip, _settings_all_channels,
+)
+from tests.tdd.test_issue_1070_daily_alert_limit import _segment
+
+_ANGELEGT: list[str] = []
+_SECHS_SCHLUESSEL = (
+    "lead_time_minutes", "event_at", "event_end_at",
+    "measurement_point", "reference_at", "source",
+)
+
+
+def _uid(tag: str) -> str:
+    uid = f"tdd-2050-s6-{tag}-{uuid.uuid4().hex[:6]}"
+    _ANGELEGT.append(uid)
+    return uid
+
+
+def _aufraeumen() -> None:
+    for uid in _ANGELEGT:
+        _clean_user(uid)
+    _ANGELEGT.clear()
+
+
+class _FixedRadar(RadarNowcastService):
+    def __init__(self, **kwargs) -> None:
+        super().__init__()
+        kwargs.setdefault("intensity_label", "leichter Regen")
+        kwargs.setdefault("source", "radar")
+        self._fixed = NowcastResult(**kwargs)
+
+    def get_nowcast(self, lat, lon, elevation_m=None, priority="user_briefing"):
+        return self._fixed
+
+
+def _not_delivered_entry_for(uid: str, entity_id: str) -> dict:
+    path = get_data_dir(uid) / "alert_log.json"
+    data = json.loads(path.read_text())
+    treffer = [e for e in data.get("not_delivered", []) if e.get("entity_id") == entity_id]
+    assert treffer, f"kein not_delivered-Eintrag fuer {entity_id!r} in {path}: {data!r}"
+    return treffer[-1]
+
+
+def test_ac9_fruehe_sperrzeit_unterdrueckt_nowcast_ohne_jede_der_sechs_groessen():
+    """AC-9: Cooldown/Ruhezeit-Gate VOR dem Nowcast-Abruf -- an dieser
+    Stelle existiert noch kein `result`, strukturell nichts bekannt.
+
+    BEWUSST von Anfang an GRUEN (Vorbild: `test_alarm_szenario_
+    laufendes_ereignis.py::test_ac2_...`, dort ausdruecklich als
+    Regressions-Invariante markiert): die sechs neuen Schluessel fehlen
+    HEUTE (vor GREEN) UND NACH GREEN an dieser Aufrufstelle gleichermassen,
+    weil trip_alert.py:1299 laut Spec-Tabelle keinen der sechs kwargs je
+    uebergibt. Die Positivkontrolle, dass die Pruefung ueberhaupt etwas
+    MISST (und nicht bloss einen durchgehend leeren Pfad bestaetigt), liefert
+    der direkte Nachbar-Test `test_ac10_...` in dieser Datei: SELBE
+    Codefamilie (`append_suppressed_entry`, Radar-Nowcast-Zweig), aber am
+    SPAETEREN Gate traegt der Eintrag dieselben Schluessel sehr wohl.
+    """
+    uid = _uid("ac9")
+    try:
+        trip = _radar_trip(uid, "trip-2050-s6-ac9", send_email=True)
+        # Cooldown-Fenster (Default 120 Min, `AlarmPruefstrecke(throttle_hours=2)`)
+        # aus einem vorherigen Lauf VOR dem eigentlichen Prueflauf gebucht.
+        ThrottleStore(uid).record("radar", trip.id, _AT - timedelta(minutes=10))
+
+        strecke = AlarmPruefstrecke(user_id=uid, settings=_settings_all_channels())
+        lauf = strecke.lauf(
+            at=_AT, zweig="radar", trip=trip, radar_service=_FixedRadar(onset_minutes=12),
+        )
+        assert lauf.triggered_count == 0, (
+            f"AC-9 Vorbedingung: der gebuchte Cooldown muss den Alarm unterdruecken "
+            f"(war triggered_count={lauf.triggered_count})."
+        )
+        entry = _not_delivered_entry_for(uid, trip.id)
+        gruende = {c.get("reason") for c in entry.get("channels_not_sent") or []}
+        assert gruende, (
+            f"AC-9 Vorbedingung: kein Unterdrueckungs-Grund im Eintrag: {entry!r}"
+        )
+        for schluessel in _SECHS_SCHLUESSEL:
+            assert schluessel not in entry, (
+                f"AC-9: {schluessel!r} darf am fruehen Gate NICHT im Eintrag "
+                f"stehen -- an dieser Stelle ist strukturell nichts bekannt: {entry!r}"
+            )
+    finally:
+        _aufraeumen()
+
+
+def test_ac10_briefing_ankuendigung_unterdrueckt_nowcast_aber_traegt_die_vergleichsbasis():
+    """AC-10: das Gate NACH dem Abruf (Briefing hatte die Menge bereits
+    angekuendigt) -- hier ist der Briefing-Schnappschuss die Begruendung der
+    Unterdrueckung und muss als `reference_at` im Eintrag stehen, zusammen mit
+    den vier weiteren an dieser Stelle bereits bekannten Groessen."""
+    uid = _uid("ac10")
+    try:
+        trip = _radar_trip(uid, "trip-2050-s6-ac10", send_email=True)
+        trip.alert_cooldown_minutes = 0  # nur das Briefing-Gate soll greifen
+
+        onset_minutes = 12
+        onset_hour_utc = (_AT + timedelta(minutes=onset_minutes)).replace(
+            minute=0, second=0, microsecond=0,
+        )
+        schnappschuss_zeit = _AT - timedelta(hours=3)
+        snapshot_segment = SegmentWeatherData(
+            segment=_segment(1),
+            timeseries=NormalizedTimeseries(
+                meta=ForecastMeta(provider=Provider.OPENMETEO, model="test", grid_res_km=1.0),
+                data=[ForecastDataPoint(ts=onset_hour_utc, precip_1h_mm=2.0)],
+            ),
+            aggregated=SegmentWeatherSummary(),
+            fetched_at=schnappschuss_zeit,
+            provider="openmeteo",
+        )
+        WeatherSnapshotService(uid).save_dated(trip.id, _AT.date(), [snapshot_segment])
+
+        strecke = AlarmPruefstrecke(user_id=uid, settings=_settings_all_channels())
+        lauf = strecke.lauf(
+            at=_AT, zweig="radar", trip=trip,
+            radar_service=_FixedRadar(onset_minutes=onset_minutes),
+        )
+        assert lauf.triggered_count == 0, (
+            f"AC-10 Vorbedingung: die Briefing-Ankuendigung (2.0mm >= 0.5mm) "
+            f"muss den Alarm unterdruecken (war triggered_count={lauf.triggered_count})."
+        )
+        entry = _not_delivered_entry_for(uid, trip.id)
+        gruende = {c.get("reason") for c in entry.get("channels_not_sent") or []}
+        assert any((g or "").startswith("briefing_announced:") for g in gruende), (
+            f"AC-10 Vorbedingung: falscher Unterdrueckungs-Grund: {entry!r}"
+        )
+
+        assert entry.get("lead_time_minutes") == onset_minutes, (
+            f"AC-10: lead_time_minutes fehlt/falsch: {entry!r}"
+        )
+        assert "event_at" in entry, f"AC-10: event_at fehlt: {entry!r}"
+        mp = entry.get("measurement_point")
+        assert mp is not None and {"segment_id", "km_from", "km_to"} <= set(mp), (
+            f"AC-10: measurement_point fehlt/unvollstaendig: {entry!r}"
+        )
+        assert entry.get("source") == "radar", (
+            f"AC-10: source muss der ROHE Quellen-Schluessel sein, nicht die "
+            f"Beschriftung aus `source_label()` (Spec-Abschnitt \"Korrektur: "
+            f"`source` ist immer der rohe Schluessel\"): {entry!r}"
+        )
+        assert "reference_at" in entry, (
+            f"AC-10: reference_at (der Briefing-Schnappschusszeitpunkt, der die "
+            f"Unterdrueckung begruendet) fehlt: {entry!r}"
+        )
+        assert datetime.fromisoformat(entry["reference_at"]) == schnappschuss_zeit, (
+            f"AC-10: reference_at muss GENAU der Schnappschuss-Zeitpunkt sein, "
+            f"der die Unterdrueckung begruendet: {entry.get('reference_at')!r}"
+        )
+    finally:
+        _aufraeumen()
+
+
+def test_vergleichsbasis_ist_opt_in_und_verschiebt_den_alarm_footer_nicht():
+    """F003 (Adversary 2026-08-22): der segment-eigene Erhebungszeitpunkt ist
+    NUR ueber `load_dated(segment_fetched_at=True)` zu haben.
+
+    Ohne den Schalter liefert `load_dated()` weiter den Schreibzeitpunkt der
+    Datei -- und nur dieser Weg speist ueber `_get_cached_weather()` den
+    nutzersichtbaren Referenz-Zeitpunkt im Alarm-Footer (#1916), dessen
+    Formatierung am KALENDERTAG verzweigt ("gestern HH:MM Uhr"). Eine rein
+    additive Protokoll-Scheibe darf diese Anzeige nicht verschieben; kippte
+    der Vorgabewert, faende es sonst niemand.
+
+    Beide Richtungen in EINEM Test: der Kontrast IST die Positivkontrolle."""
+    uid = _uid("f003")
+    try:
+        schnappschuss_zeit = _AT - timedelta(hours=3)
+        segment = SegmentWeatherData(
+            segment=_segment(1),
+            timeseries=NormalizedTimeseries(
+                meta=ForecastMeta(provider=Provider.OPENMETEO, model="test", grid_res_km=1.0),
+                data=[ForecastDataPoint(ts=_AT, precip_1h_mm=2.0)],
+            ),
+            aggregated=SegmentWeatherSummary(),
+            fetched_at=schnappschuss_zeit,
+            provider="openmeteo",
+        )
+        svc = WeatherSnapshotService(uid)
+        vorher = datetime.now(timezone.utc)
+        svc.save_dated("trip-2050-s6-f003", _AT.date(), [segment])
+        nachher = datetime.now(timezone.utc)
+
+        ohne_schalter = svc.load_dated("trip-2050-s6-f003", _AT.date())
+        assert vorher <= ohne_schalter[0].fetched_at <= nachher, (
+            f"F003: ohne `segment_fetched_at=True` MUSS der Schreibzeitpunkt der "
+            f"Datei gelten (Bestandsverhalten, Alarm-Footer #1916) -- war "
+            f"{ohne_schalter[0].fetched_at}"
+        )
+
+        mit_schalter = svc.load_dated(
+            "trip-2050-s6-f003", _AT.date(), segment_fetched_at=True,
+        )
+        assert mit_schalter[0].fetched_at == schnappschuss_zeit, (
+            f"F003: MIT dem Schalter muss der segment-eigene Erhebungszeitpunkt "
+            f"herauskommen -- sonst haette die Protokoll-Vergleichsbasis (AC-10) "
+            f"keine Quelle: {mit_schalter[0].fetched_at}"
+        )
+    finally:
+        _aufraeumen()


### PR DESCRIPTION
Scheibe 6 zu #2050.

Das Alarm-Protokoll haelt jetzt pro Eintrag fest: Vorwarnzeit (lead_time_minutes), Ereigniszeit, Messpunkt, Vergleichsbasis (reference_at) und Quelle. Gilt fuer Trip- und Ortsvergleichs-Alarme inklusive Radar- und amtlicher Alarme.

- 15 AC-Tests + F002-/F003-Waechter + Go-Invarianztest (AC-13) gruen
- Adversary Runde 2: VERIFIED (7 Mutationen, alle gefangen)

Closes-part-of: #2050

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xp5kQd6dPVWif32ivzEJRF