### PR TITLE
fix(#2010,#2011): Gewitter-Stufenwoerter und Ampelfarben aus kanonischer Quelle ableiten

### DIFF
--- a/docs/context/fix-2010-2011-gewitter-stufenwoerter.md
+++ b/docs/context/fix-2010-2011-gewitter-stufenwoerter.md
@@ -1,0 +1,185 @@
+# Context: Gewitter-Stufenwörter und -Ampelfarbe aus der kanonischen Quelle speisen (#2010 + #2011)
+
+## Request Summary
+Zwei Kanäle bauen die Gewitter-Stufenskala (`ThunderLevel`: NONE/LOW/MED/HIGH) lokal
+statt aus der kanonischen Quelle `src/output/metric_format.py` zu lesen: Telegram
+(`trip_command_processor.py`, #2010, Wortdrift „mäßig"/„keins" statt „mittel"/„kein")
+und die Briefing-Mail-Ampelfarbe (`email/html.py`, #2011, `_thunder_risk_level` weicht
+vom eigenen Docstring ab und verschmilzt LOW/MED im Zahlen-Fallback). Diese sechs
+Fundstellen sind bereits **namentlich als Altlasten des #1480-Wächters erfasst** — das
+ist die verbindliche Liste dessen, was zu sanieren ist.
+
+## Kanonische Quelle (Ziel jeder Sanierung)
+`src/output/metric_format.py`:
+- `THUNDER_LABEL_DE: dict[ThunderLevel, str]` (Zeile 283) — NONE→"kein", LOW→"leicht",
+  MED→"mittel", HIGH→"hoch". NONE fehlt bewusst nicht; Konsumenten mit abweichender
+  NONE-Darstellung (z.B. "—") überschreiben nur diesen einen Eintrag lokal.
+- `thunder_ampel_band(level: Optional[ThunderLevel]) -> Optional[str]` (Zeile 302) —
+  NONE→"green", LOW→"yellow", MED→"orange", HIGH→"red". `None` (keine Aussage) liefert
+  `None` — Aufrufer zeigen dafür einen Strich, NIEMALS ein Ampelband (Issue #1491 AC-1).
+
+Vorbild für korrekte Nutzung: `src/output/renderers/narrow.py` und
+`src/output/renderers/email/helpers.py` importieren `THUNDER_LABEL_DE` direkt statt
+eine eigene Zuordnung zu pflegen.
+
+## Verbindliche Fundstellen-Liste (aus `tests/tdd/test_thunder_scale_local_copy_guard.py::ALTLASTEN`)
+
+Diese Liste ist Teil des #1480-Wächters und **muss beim Fix um exakt diese Einträge
+schrumpfen** (`test_altlasten_basislinie_hat_keinen_leerlauf_eintrag` schlägt sonst an —
+„Sanierte Stelle => Zeile in ALTLASTEN streichen"):
+
+| Datei | Symbol | Regel | Grund | Issue |
+|---|---|---|---|---|
+| `src/output/renderers/email/html.py` | `_thunder_risk_level` | B | eigene Stufen-Wort-Kette statt `thunder_ampel_band()`, obwohl Docstring die Angleichung behauptet | #2011 |
+| `src/output/renderers/email/html.py` | `_thunder_risk_level` | C | Zahlen-Fallback verschmilzt LOW und MED zu 'watch' | #2011 |
+| `src/services/trip_command_processor.py` | `_THUNDER_LABEL` | A | Telegram-Label mit Wortdrift ('mäßig' statt 'mittel') | #2010 |
+| `src/services/trip_command_processor.py` | `_MAP_EMOJI` | A | Emoji-Karte mit Wortdrift ('keins'/'mäßig') | #2010 |
+| `src/services/trip_command_processor.py` | `_MAP_PLAIN` | A | Klartext-Karte, unabhängig gepflegtes Duplikat von `_MAP_EMOJI` | #2010 |
+| `src/services/trip_command_processor.py` | `_handle_hours_drilldown` | B | Stundentabelle verzweigt auf rohe Stufen-Strings mit eigenen Wörtern | #2010 |
+
+**Wichtig:** Die tatsächliche Codelage hat eine vierte #2010-Fundstelle, die das Issue
+selbst noch nicht nennt (Zeilennummern haben sich seit Issue-Erfassung verschoben), aber
+in `ALTLASTEN` bereits korrekt als `_handle_hours_drilldown` registriert ist — dort
+verzweigt die Stundentabelle (Zeile ~806-816, `t_sym = "mäßig"` im MED-Zweig) direkt auf
+rohe Strings statt `THUNDER_LABEL_DE` zu lesen.
+
+Zwei weitere Altlasten-Einträge (`day_window.py::_NIGHT_ADDENDUM_WORD`,
+`trip_report_scheduler.py::_thunder_entry_from_trend_row` /
+`_build_thunder_forecast`) gehören **nicht** zu #2010/#2011 und bleiben unangetastet.
+
+## Related Files
+
+| File | Relevance |
+|------|-----------|
+| `src/services/trip_command_processor.py:139-146` | `_THUNDER_LABEL` — Dict NONE/LOW/MED/HIGH → deutsche Wörter, „mäßig" statt „mittel" |
+| `src/services/trip_command_processor.py:223-230` | `_MAP_EMOJI`/`_MAP_PLAIN` — „keins"/„mäßig" statt „kein"/„mittel" |
+| `src/services/trip_command_processor.py:806-816` | `_handle_hours_drilldown` — if/elif-Kette mit eigenem `"mäßig"`-Literal für MED |
+| `src/services/trip_command_processor.py:1028,1095,1155` | Drei Aufrufstellen von `_THUNDER_LABEL.get(...)` — bleiben unverändert, solange `_THUNDER_LABEL` selbst aus `THUNDER_LABEL_DE` gespeist wird |
+| `src/output/renderers/email/html.py:168-204` | `_thunder_risk_level` — eigene if/elif-Kette (String-Zweig) + Zahlen-Fallback, der LOW/MED verschmilzt |
+| `src/output/renderers/email/html.py:207-224` | `_row_risk` — einziger Aufrufer von `_thunder_risk_level`, kombiniert Gewitter-Risikostufe mit Wind/Böen/Regen/Sicht zur „schärfsten Stufe" der Zeile (Vokabular `ok/yellow/watch/risk`) |
+| `src/output/renderers/email/html.py:843-862` | Zweiter Aufrufer: `elif key == "thunder"` — String-Rohwert nutzt bereits korrekt `thunder_ampel_band()`; nur der `else`-Zweig (numerischer Legacy-Rohwert, `#1491`-Regression AC-10) fällt auf `_thunder_risk_level()` zurück, gemappt über `{"risk": "red", "watch": "orange"}` (kein "yellow"!) |
+| `src/output/metric_format.py:279-320` | Kanonische Quelle: `THUNDER_LABEL_DE`, `_THUNDER_AMPEL_BAND`, `thunder_ampel_band()` |
+| `tests/tdd/test_thunder_scale_local_copy_guard.py` | #1480-Wächter — `ALTLASTEN` (Zeile 285-347) ist die verbindliche Fundstellen-Liste; `test_altlasten_basislinie_hat_keinen_leerlauf_eintrag` (Zeile 1109) verlangt, sanierte Einträge zu streichen |
+| `tests/tdd/test_thunder_risk_dot_and_tint.py`, `test_row_risk_thunder_pair_escalation.py` | Bestehende Tests auf `_thunder_risk_level`/`_row_risk` — Verhalten dieser Funktionen ist bereits getestet, Fix darf diese Erwartungen nicht brechen (Vokabular `risk/watch/yellow` muss erhalten bleiben, nur die INTERNE Berechnung ändert sich) |
+| `tests/tdd/test_telegram_thunder_low_level.py`, `test_thunder_low_output_channels.py` | Bestehende Tests auf Telegram-Ausgabe der Gewitterstufen — prüfen vermutlich bereits die (noch falschen) Wörter; ggf. Anpassung nötig |
+
+## Existing Patterns
+- **Geteilte Quelle statt Kopie** (Issue #1474/#1491-Muster): `narrow.py` und
+  `email/helpers.py` importieren `THUNDER_LABEL_DE`/`thunder_ampel_band` direkt, statt
+  eigene Zuordnungen zu pflegen — das ist die Bauform, an die #2010/#2011 angeglichen
+  werden.
+- **Symbolscharfe Whitelist statt Dateiweite**: der #1480-Wächter duldet nur benannte
+  Symbole in `metric_format.py`, keine ganze Datei — verhindert, dass eine neue Kopie
+  dort unsichtbar entsteht.
+
+## Dependencies
+- Upstream: `src/output/metric_format.py::THUNDER_LABEL_DE`, `thunder_ampel_band()`
+  (kanonische Quelle, ADR-0025, Issue #1491).
+- Downstream:
+  - `_THUNDER_LABEL`/`_MAP_EMOJI`/`_MAP_PLAIN` werden an mehreren Telegram-Drilldown-
+    und Zusammenfassungsstellen in `trip_command_processor.py` gelesen (Zeilen 1028,
+    1095, 1155 u.a.) — deren Aufrufer bleiben unverändert, solange die Dicts selbst
+    korrekt aus `THUNDER_LABEL_DE` gespeist werden.
+  - `_thunder_risk_level()` wird von `_row_risk()` (Zeilen-Gesamtrisiko der
+    Stundentabelle) und von einem zweiten Aufrufer (Zell-Tönung bei numerischem
+    Legacy-Rohwert, Zeile 861) genutzt. Beide erwarten weiterhin das Vokabular
+    `"risk"/"watch"/"yellow"/None` — die interne Berechnung darf sich ändern, die
+    Rückgabewerte-Menge nicht, sonst brechen `_row_risk` und die `{"risk":...,
+    "watch":...}`-Zuordnung bei Zeile 861.
+  - `tests/tdd/test_thunder_scale_local_copy_guard.py::ALTLASTEN` — muss um die
+    sanierten Einträge schrumpfen.
+
+## Existing Specs
+- `docs/specs/modules/thunder_scale_guard.md` — Spec des #1480-Wächters, definiert
+  Regeln A-D und Duldungsmechanik.
+- `docs/specs/modules/thunder_threshold_katalog.md` — evtl. relevante Schwellenwerte-
+  Doku (noch nicht gelesen, bei Bedarf in Analyse-Phase).
+
+## Risks & Considerations
+- **Vokabular-Bruch bei `_thunder_risk_level`**: `THUNDER_LABEL_DE`/`thunder_ampel_band`
+  sprechen `kein/leicht/mittel/hoch` bzw. `green/yellow/orange/red` —
+  `_thunder_risk_level` spricht `risk/watch/yellow/None`. Ein einfaches „ruft
+  `thunder_ampel_band()` auf" reicht nicht; es braucht eine explizite Zuordnung
+  `{green:None (oder "ok"?), yellow:"yellow", orange:"watch", red:"risk"}` — das ist
+  Analyse-/Spec-Arbeit, keine mechanische Umbenennung.
+- **Toter-Code-Verdacht beim Zahlen-Fallback** (#2011 Abgrenzung): Vor dem Fix klären,
+  ob der `isinstance(thunder, str)`-Zweig in der Praxis IMMER greift (weil
+  `ThunderLevel` von `str` erbt) und der numerische Fallback (`_safe_float`) nie
+  erreicht wird außer im expliziten Legacy-Pfad bei Zeile 861. Ein Test, der den
+  Fallback nachweislich erreicht, ist laut Issue der Nachweis — sonst ist „entfernen"
+  die richtige Behebung statt „reparieren".
+- **NONE-Sonderfall**: `thunder_ampel_band(NONE)` liefert `"green"`, aber
+  `_thunder_risk_level` liefert für `"NONE"` `None` (keine Fußzeile-Farbe). Eine direkte
+  1:1-Übernahme von `thunder_ampel_band` würde `_row_risk` grün statt "ok" einfärben —
+  muss in der Spec explizit entschieden werden.
+- **#1480-Wächter als Testorakel**: Nach dem Fix muss `ALTLASTEN` um die sechs Einträge
+  schrumpfen, sonst schlägt `test_altlasten_basislinie_hat_keinen_leerlauf_eintrag` an.
+  Das ist ein zusätzlicher, expliziter Implementierungsschritt (keine Testdatei einfach
+  löschen — nur die betroffenen `Altlast(...)`-Zeilen entfernen).
+- **Bestehende Tests könnten falsches Verhalten fixieren**: `test_telegram_thunder_low_level.py`
+  und `test_thunder_low_output_channels.py` prüfen vermutlich die heutigen (falschen)
+  Wörter „mäßig"/„keins" — die Analyse-Phase muss prüfen, ob diese Tests aktualisiert
+  werden müssen (Bug-Nachweis-Pflicht: mindestens ein Test muss den Bug aus
+  Nutzersicht rot zeigen vor dem Fix).
+
+## Analysis
+
+### Type
+Bug (zwei getrennte, aber thematisch verbundene Bugs — beide sanieren Altlasten des
+#1480-Wächters).
+
+### Affected Files (with changes)
+
+| File | Change Type | Description |
+|------|-------------|--------------|
+| `src/services/trip_command_processor.py` | MODIFY | `_THUNDER_LABEL`/`_MAP_PLAIN` aus `THUNDER_LABEL_DE` ableiten statt Wert-Kopie; `_MAP_EMOJI` kombiniert weiterhin hartcodierten Emoji-Präfix mit abgeleitetem Label; `_handle_hours_drilldown` (~806-816) auf Lookup gegen dieselbe abgeleitete Karte umstellen (NONE-Sonderfall "—" bleibt) |
+| `src/output/renderers/email/html.py` | MODIFY | `_thunder_risk_level()` ruft `thunder_ampel_band()` auf + explizite Übersetzung `{"green":"ok","yellow":"yellow","orange":"watch","red":"risk"}`; Zahlen-Fallback-Zweig bleibt erhalten (aktiv genutzt bei Zeile ~861) |
+| `tests/tdd/test_command_reply_channel_emoji.py` | MODIFY | Zeilen 157, 190: `"mäßig"` → `"mittel"` |
+| `tests/tdd/test_issue_654_telegram_thunder_drilldown.py` | MODIFY | Zeile 185: `label_keywords` `"keins"`/`"mäßig"` → `"kein"`/`"mittel"` |
+| `tests/tdd/test_thunder_scale_local_copy_guard.py` | MODIFY | 6 sanierte `Altlast(...)`-Einträge aus `ALTLASTEN` streichen (sonst `test_altlasten_basislinie_hat_keinen_leerlauf_eintrag` rot) |
+
+### Scope Assessment
+- Files: ~5 (2 Produktivdateien, 2 Testdateien mit Wortkorrektur, 1 Wächter-Bereinigung)
+- Estimated LoC: ~+25/-20 (deutlich unter 250-LoC-Limit)
+- Risk Level: LOW — beide Fixes sind lokal begrenzt, kanonische Quelle bereits etabliert
+  und anderswo (`narrow.py`, `email/helpers.py`) korrekt genutzt
+
+### Technical Approach
+
+**#2010:** `_THUNDER_LABEL` und `_MAP_PLAIN` werden aus `THUNDER_LABEL_DE`
+(`metric_format.py`) abgeleitet statt einzelne Werte von Hand zu kopieren (z.B.
+`{level.name: label for level, label in THUNDER_LABEL_DE.items()}`) — jede
+Wert-für-Wert-Ersetzung von Hand wäre derselbe Kopier-Fehler, den #2010 gerade behebt.
+`_MAP_EMOJI` kombiniert einen weiterhin hartcodierten Emoji-Präfix (⚪/🟢/🟡/🔴 — kein
+Teil von `THUNDER_LABEL_DE`) mit dem abgeleiteten Wort-Suffix. `_handle_hours_drilldown`
+verzweigt nicht mehr per if/elif mit eigenem `"mäßig"`-Literal, sondern liest dieselbe
+abgeleitete Karte; die NONE-Sonderdarstellung ("—" statt Wort) bleibt als eigener Zweig
+bestehen. Die drei reinen Lesestellen (`_THUNDER_LABEL.get(...)`, ~Zeilen 1028/1095/1155)
+bleiben unverändert.
+
+**#2011:** `_thunder_risk_level()` ruft `thunder_ampel_band()` tatsächlich auf (löst die
+Docstring-Diskrepanz) und übersetzt dessen vierwertiges Ampel-Vokabular
+(`green/yellow/orange/red`) explizit auf das von `_row_risk()` erwartete Vokabular
+(`ok/yellow/watch/risk`/`None`): `{"green":"ok","yellow":"yellow","orange":"watch",
+"red":"risk"}`. **NONE/green → `"ok"`** (nicht `None` wie bisher) — geprüft
+verhaltensneutral: weder `_row_risk` noch die zweite Aufrufstelle (Zeile ~861,
+`{"risk":...,"watch":...}.get(...)`) unterscheiden `None` von `"ok"`, beide fallen an
+jeder Prüfstelle gleich wirkungslos durch. `ThunderLevel(str, Enum)` verhält sich beim
+Vergleich wie sein String-Wert — die bestehende `.upper()`-Normalisierung vor dem
+`thunder_ampel_band()`-Aufruf bleibt erhalten, damit sowohl Enum-Instanzen als auch rohe
+Strings funktionieren.
+
+**Korrektur gegenüber der Kontext-Phase:** Der Zahlen-Fallback-Zweig in
+`_thunder_risk_level` (`num > 20`/`num > 0`) ist **NICHT tot**. Er wird beim zweiten
+Aufrufer (Zeile ~855-862, `else`-Zweig für nicht-string `raw_val`) für ältere Test-/
+Datenpfade mit rohem numerischem `thunder`-Wert aktiv gebraucht (Kommentar Zeile
+849-854 bestätigt das explizit als einzigen Zweck). Bleibt erhalten — Entfernen wäre
+eine stille Regression auf `None`-Zellfärbung für diese seltene Datenform.
+
+### Dependencies
+Bestätigt aus Context-Phase, keine neuen Funde. `_row_risk`-Vokabular bleibt stabil
+(`_RISK_LEVEL_TO_AMPEL` kennt weiterhin genau `ok/yellow/watch/risk`).
+
+### Open Questions
+Keine offenen — beide Ansätze sind vollständig bestimmt. Reihenfolge: #2010 zuerst
+(einfachere reine Label-Ableitung), #2011 danach (Vokabular-Übersetzung).

--- a/docs/reference/renderer_email_spec.md
+++ b/docs/reference/renderer_email_spec.md
@@ -2,11 +2,15 @@
 
 This document defines how E-Mail reports are generated in Gregor Zwanzig.
 
-**Last Updated:** 2026-08-22 (Issue #2049 — Abgrenzung „Metric Display Contract" (Sektion 4/5)
-gegen die eigene, unabhängige Roh/Einfach-Entscheidung des 3-Tages-Ausblicks (Sektion 6,
-`display_config.outlook_metric_formats`) ergänzt, s.u.)
+**Last Updated:** 2026-08-22 (Issue #2011 — `_thunder_risk_level()` ruft für String-/Enum-Rohwerte
+jetzt tatsächlich `thunder_ampel_band()` auf statt einer eigenen Stufen-Wort-Kette; nur der
+numerische Legacy-Fallback bleibt hartcodiert, s.u.)
 
-**Vorherige Aktualisierung:** 2026-08-14 (Bug #1801 S2 — neue Ampel-Palette (Punkt/Fläche/Text) für
+**Vorherige Aktualisierung:** 2026-08-22 (Issue #2049 — Abgrenzung „Metric Display Contract" (Sektion 4/5)
+gegen die eigene, unabhängige Roh/Einfach-Entscheidung des 3-Tages-Ausblicks (Sektion 6,
+`display_config.outlook_metric_formats`) ergänzt)
+
+**Davor:** 2026-08-14 (Bug #1801 S2 — neue Ampel-Palette (Punkt/Fläche/Text) für
 gelb/orange/rot, WCAG-Fix grüner Zelltext (`G_AMPEL_TEXT_GREEN`); `html.py`/`outlook.py`
 beziehen die Zellfarben seither aus `design_tokens.tone_css()` statt eigener Kopien)
 
@@ -67,8 +71,11 @@ Detaillierte Sektionsspezifikationen: siehe `docs/specs/_archive/modules/issue_8
     Wind/Böen/Regen/Regenwahrscheinlichkeit/Sicht
     einheitlich aus `severity_for`/`ampel_level` und den Katalog-Schwellen der
     „Best-Practice-Schwellen"-Tabelle unten (Wind z.B. 30/50/70 km/h, nicht mehr die alte
-    fixe 20-km/h-Grenze). Gewitter bleibt ausdrücklich hartcodiert (kein `display_thresholds`
-    im Katalog): rot ab >30, orange >20-30, gelb >0-20 (`html.py:658-659`).
+    fixe 20-km/h-Grenze). Gewitter läuft für String-/Enum-Rohwerte seit #2011 über die
+    kanonische `thunder_ampel_band()` (`green/yellow/orange/red` → `ok/yellow/watch/risk`,
+    `metric_format.py`); nur der numerische Legacy-Fallback (seltener Rohdatenpfad #1425)
+    bleibt ausdrücklich hartcodiert, zweistufig, ohne `display_thresholds` im Katalog:
+    rot ab >20, orange >0-20 (`_thunder_risk_level()`, `html.py:171-203`).
 - **Mobile-Tabelle:** `EmailHourList` zwei-Zeilen-Format (neu ab Issue #884; ersetzt `_render_mobile_compact_rows`)
   - Hauptzeile: Zeit (mono bold, 26px breit) · Wetter-Glyph · Temp · gefühlte Temp · Risk-Dot
   - Detailzeile: Wind/Regen/Sicht/UV/Höhe komprimiert

--- a/docs/specs/modules/fix_2010_2011_gewitter_stufenwoerter.md
+++ b/docs/specs/modules/fix_2010_2011_gewitter_stufenwoerter.md
@@ -1,0 +1,250 @@
+---
+entity_id: fix_2010_2011_gewitter_stufenwoerter
+type: bugfix
+created: 2026-08-22
+updated: 2026-08-22
+status: draft
+version: "1.0"
+tags: [gewitter, telegram, mail, ampel, renderer, issue-2010, issue-2011, issue-1480]
+---
+
+# Gewitter-Stufenwörter und -Ampelfarbe aus der kanonischen Quelle speisen (#2010 + #2011)
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Zwei Kanäle bauen die Gewitter-Stufenskala (`ThunderLevel`: NONE/LOW/MED/HIGH) lokal statt
+aus der kanonischen Quelle `src/output/metric_format.py::THUNDER_LABEL_DE` /
+`thunder_ampel_band()` zu lesen: Telegram zeigt „mäßig"/„keins" statt „mittel"/„kein"
+(#2010), und die Briefing-Mail-Ampelfarbe berechnet ihre eigene Stufen-Wort-Kette, obwohl
+ihr eigener Docstring behauptet, sie nutze die kanonische Zuordnung (#2011). Beide Stellen
+sind bereits **namentlich als Altlasten des #1480-Wächters erfasst** — diese Arbeit saniert
+genau die sechs dort verzeichneten Fundstellen.
+
+## Source
+
+- **File:** `src/services/trip_command_processor.py`, `src/output/renderers/email/html.py`
+- **Identifier:** `_THUNDER_LABEL`, `_thunder_fmt()` (Karten `_MAP_EMOJI`/`_MAP_PLAIN`),
+  `_handle_hours_drilldown()`, `_thunder_risk_level()`
+
+**Schicht:** ausschließlich Python-Core (`src/services/`, `src/output/renderers/`). Kein
+Go, kein Frontend.
+
+## Estimated Scope
+
+- **LoC:** ~+25/−20
+- **Files:** 2 Produktivdateien geändert, 3 Testdateien (2 mit Wortkorrektur, 1
+  Wächter-Bereinigung)
+- **Effort:** low
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|---|---|---|
+| `THUNDER_LABEL_DE` (`metric_format.py:283-288`) | kanonische Quelle | liefert die vier deutschen Wörter kein/leicht/mittel/hoch — Ziel der Ableitung für `_THUNDER_LABEL`/`_MAP_PLAIN` |
+| `thunder_ampel_band()` (`metric_format.py:302-312`) | kanonische Quelle | liefert green/yellow/orange/red je Stufe — Ziel des tatsächlichen Aufrufs in `_thunder_risk_level()` |
+| `docs/specs/modules/thunder_scale_guard.md` | bindender Mechanismus | definiert Regel A/B/C und die **dreistufige Duldung** (Whitelist / benannte Altlasten-Basislinie / Marker-Kommentar) — diese Arbeit bewegt zwei ALTLASTEN-Fundstellen von Stufe 2 auf „saniert" bzw. Stufe 3 |
+| `tests/tdd/test_thunder_scale_local_copy_guard.py::ALTLASTEN` | Wächter-Basislinie | muss um exakt die sechs hier sanierten Einträge schrumpfen, sonst schlägt `test_altlasten_basislinie_hat_keinen_leerlauf_eintrag` an |
+| `src/output/renderers/narrow.py`, `src/output/renderers/email/helpers.py` | Vorbild | importieren `THUNDER_LABEL_DE` bereits direkt statt eine eigene Zuordnung zu pflegen — Bauform, an die #2010/#2011 angeglichen werden |
+| `_row_risk()` (`email/html.py:207-224`) | Downstream-Aufrufer | erwartet von `_thunder_risk_level()` weiterhin exakt das Vokabular `risk`/`watch`/`yellow`/`ok` — Rückgabewerte-Menge darf sich nicht ändern |
+| zweiter Aufrufer bei `elif key == "thunder"` (`email/html.py:855-862`) | Downstream-Aufrufer | nutzt `_thunder_risk_level()` nur noch für den numerischen Legacy-Rohwert; String-/Enum-Rohwerte laufen bereits über `thunder_ampel_band()` direkt |
+| `tests/tdd/test_command_reply_channel_emoji.py:157,190`, `tests/tdd/test_issue_654_telegram_thunder_drilldown.py:185` | Bestandsschutz | prüfen heute die (falschen) Wörter „mäßig"/„keins" — werden im selben Commit auf „mittel"/„kein" korrigiert |
+| `tests/tdd/test_thunder_risk_dot_and_tint.py`, `test_row_risk_thunder_pair_escalation.py` | Bestandsschutz | prüfen `_thunder_risk_level`/`_row_risk`-Verhalten (Vokabular `risk/watch/yellow`) — darf durch #2011 nicht brechen |
+
+## Implementation Details
+
+```
+#2010 — trip_command_processor.py:
+
+_THUNDER_LABEL = {level.name: label for level, label in THUNDER_LABEL_DE.items()}
+  -- ersetzt die bisherige Wert-Kopie (Zeile 139-146). Jede Wert-fuer-Wert-
+     Handkorrektur waere derselbe Kopierfehler, den #2010 gerade behebt.
+
+_thunder_fmt(): _MAP_PLAIN wird aus THUNDER_LABEL_DE abgeleitet (wie oben).
+  _MAP_EMOJI kombiniert weiterhin einen hartcodierten Emoji-Praefix
+  (⚪/🟢/🟡/🔴 -- kein Teil von THUNDER_LABEL_DE) mit dem abgeleiteten
+  Wort-Suffix, z.B. {level.name: f"{emoji} {label}" fuer level,label in
+  THUNDER_LABEL_DE.items(), emoji aus einer separaten festen Emoji-Zuordnung}.
+
+_handle_hours_drilldown() (~Zeile 790-817): das if/elif mit eigenem
+  "mäßig"-Literal verschwindet; die Stundenzeile liest dieselbe abgeleitete
+  Karte (Wort ueber _MAP_PLAIN-Aequivalent, Symbol ueber die separate
+  Emoji-Zuordnung aus _thunder_fmt). Der NONE-Sonderfall "—" bei fehlendem
+  Wert bleibt ein eigener Zweig (kein Wort fuer "keine Daten").
+
+Die drei reinen Lesestellen _THUNDER_LABEL.get(...) (~Zeilen 1028/1095/1155)
+bleiben unveraendert, solange das Dict selbst korrekt gespeist wird.
+
+#2011 — email/html.py:
+
+_thunder_risk_level(): der String-Zweig (isinstance(thunder, str)) ruft
+  thunder_ampel_band() tatsaechlich auf (loest den Docstring-Widerspruch)
+  und uebersetzt dessen Vokabular explizit:
+    {"green": "ok", "yellow": "yellow", "orange": "watch", "red": "risk"}
+  NONE/green -> "ok" (bisher None) -- siehe Known Limitations.
+
+  Der Zahlen-Fallback-Zweig (num > 20 -> "risk", num > 0 -> "watch") bleibt
+  UNVERAENDERT bestehen -- er verarbeitet einen rohen Zahlenwert, keine
+  diskrete Stufe, und ist deshalb kein Fall fuer thunder_ampel_band().
+  Er bekommt einen Marker-Kommentar `# gz-thunder-scale: <Begruendung>`
+  (Duldungsstufe 3 des #1480-Waechters, s. thunder_scale_guard.md) und
+  wechselt damit von "benannte Altlast" auf "begruendete Duldung" --
+  das ist der Mechanismus, ueber den Regel C an dieser Stelle sanktionsfrei
+  bleibt, OHNE die Zahlen-Schwellen selbst zu aendern.
+
+ALTLASTEN-Bereinigung (test_thunder_scale_local_copy_guard.py):
+  Die sechs Eintraege zu html.py::_thunder_risk_level (Regel B, Regel C)
+  und trip_command_processor.py::_THUNDER_LABEL / _MAP_EMOJI / _MAP_PLAIN /
+  _handle_hours_drilldown werden aus ALTLASTEN gestrichen. Die drei
+  uebrigen Eintraege (day_window.py, zwei trip_report_scheduler.py-Symbole)
+  bleiben unangetastet.
+```
+
+## Expected Behavior
+
+- **Input:** eine Telegram-Kommando-Antwort (Zusammenfassung, Emoji- und Klartext-Kanal,
+  Stundendrilldown) bzw. eine gerenderte Trip-Briefing-HTML-Mail, jeweils mit
+  Gewitterstufen aus der vollen Menge NONE/LOW/MED/HIGH.
+- **Output:** Telegram zeigt in jedem Pfad die Wörter „kein"/„leicht"/„mittel"/„hoch" (nie
+  „keins"/„mäßig"); die Mail-Ampelfarbe für Gewitter stimmt mit `thunder_ampel_band()`
+  überein (übersetzt auf das bestehende Zeilen-Risiko-Vokabular). Der #1480-Wächter bleibt
+  grün und ist um sechs Einträge geschrumpft.
+- **Side effects:** keine — reine Formatierungs-/Ableitungsänderung, `ThunderLevel`-Werte
+  selbst werden nicht verändert.
+
+## Acceptance Criteria
+
+- **AC-1 (#2010, Klartext-Pfad zeigt die vier korrekten Wörter):** Given die vier
+  Gewitterstufen NONE/LOW/MED/HIGH / When der Telegram-Klartext-Konsument (kein
+  Emoji-Modus, z.B. E-Mail-Kanal-Antwort auf `dd_thunder_today`) für jede Stufe gerendert
+  wird / Then zeigt er genau „kein"/„leicht"/„mittel"/„hoch" — nirgends „keins" oder
+  „mäßig".
+  - Test: bestehenden bzw. erweiterten Testfall für alle vier Stufen durchlaufen lassen,
+    Wortgleichheit prüfen und explizit die Abwesenheit von „keins"/„mäßig" im Antworttext
+    nachweisen.
+
+- **AC-2 (#2010, Emoji-Pfad behält Symbol UND korrigiert das Wort):** Given dieselben vier
+  Stufen / When derselbe Konsument im Emoji-Modus (Telegram-Kanal) rendert / Then enthält
+  die Antwort weiterhin das passende Kreis-Emoji (⚪/🟢/🟡/🔴) UND das korrigierte Wort
+  („mittel" statt „mäßig" bei MED), beides gemeinsam in derselben Zeile.
+  - Test: Emoji-Regex weiterhin erfüllt UND Wortsuche auf „mittel" (nicht „mäßig") in
+    derselben Antwort.
+
+- **AC-3 (#2010, Stundendrilldown ist ein unabhängiger zweiter Pfad):** Given eine
+  Stundenübersicht-Anfrage (`dd_hours_today`/`dd_hours_tomorrow`) mit mindestens einer
+  Stunde der Stufe MED / When `_handle_hours_drilldown` die Stundenzeilen baut / Then
+  enthält die Zeile dieser Stunde „mittel" (Klartext) bzw. das gelb/orange Kreis-Emoji
+  (Emoji-Modus) — nicht „mäßig". Dieser Nachweis ist unabhängig von AC-1/AC-2, weil
+  `_handle_hours_drilldown` bislang eine eigene if/elif-Verzweigung mit eigenem
+  „mäßig"-Literal besaß statt die Karte aus AC-1/AC-2 zu lesen.
+  - Test: Stundendrilldown mit einer MED-Stunde rendern, Zeilentext auf „mittel"/korrektes
+    Emoji prüfen, Abwesenheit von „mäßig" nachweisen.
+
+- **AC-4 (#2010, Ableitung statt Wert-Kopie — Regressionsschutz):** Given ein temporär
+  veränderter Wert für `THUNDER_LABEL_DE[ThunderLevel.MED]` (Test-lokal gesetzt, nicht die
+  Produktionsquelle dauerhaft verändert) / When eine Telegram-Ausgabe für MED gerendert
+  wird / Then folgt das angezeigte Wort dem veränderten Quellwert. Das beweist, dass
+  `_THUNDER_LABEL`/`_MAP_PLAIN` tatsächlich aus `THUNDER_LABEL_DE` **abgeleitet** sind,
+  nicht bloß einmalig wortgleich kopiert wurden.
+  - Test: `THUNDER_LABEL_DE[ThunderLevel.MED]` im Testkontext überschreiben (z.B. via
+    `monkeypatch`), Telegram-Rendering für MED erneut aufrufen, geänderten Wert im
+    Ergebnis nachweisen.
+
+- **AC-5 (#2011, Ampelübersetzung für alle vier Stufen abgeleitet statt kopiert):** Given
+  die vier Gewitterstufen als String-/Enum-Rohwert in einer Stundentabellen-Zeile
+  (`r["thunder"]`) / When `_thunder_risk_level()` bzw. `_row_risk()` für jede Stufe
+  berechnet wird / Then liefert es „yellow" für LOW, „watch" für MED, „risk" für HIGH
+  (unverändert sichtbares Vokabular) — UND ein temporär veränderter Eintrag in
+  `_THUNDER_AMPEL_BAND[ThunderLevel.MED]` (Test-lokal) ändert das Ergebnis für MED
+  entsprechend, als Beleg dafür, dass die Übersetzung jetzt tatsächlich über
+  `thunder_ampel_band()` läuft statt über eine eigene Wort-Kette.
+  - Test: alle vier Stufen durch `_thunder_risk_level()` schicken, Vokabular-Gleichheit
+    zum bisherigen Verhalten prüfen; zusätzlich `_THUNDER_AMPEL_BAND`-Eintrag für MED
+    testlokal überschreiben und geänderte Ausgabe nachweisen.
+
+- **AC-6 (#2011, NONE liefert jetzt „ok" statt `None` — verhaltensneutral abgesichert):**
+  Given die Gewitterstufe NONE (als String „NONE" und als `ThunderLevel.NONE`) / When
+  `_thunder_risk_level()` direkt aufgerufen wird / Then liefert die Funktion `"ok"` (nicht
+  mehr `None`) — UND ein zweiter Test belegt, dass sowohl `_row_risk()` als auch die
+  Zell-Tönungs-Zuordnung bei `elif key == "thunder"` (html.py ~855-862) für `"ok"` exakt
+  dasselbe sichtbare Ergebnis liefern wie zuvor für `None` (keine Zeile eskaliert
+  fälschlich, keine Zelle bekommt einen Hintergrund). Die Änderung ist an der Wirkung
+  nicht beobachtbar, nur intern.
+  - Test: `_thunder_risk_level("NONE")` und `_thunder_risk_level(ThunderLevel.NONE)` auf
+    `"ok"` prüfen; zusätzlich eine vollständig gerenderte Zeile mit NONE-Gewitter vor und
+    nach dem Fix auf identische Zell-Tönung/Zeilen-Risiko vergleichen.
+
+- **AC-7 (#2011, Zahlen-Fallback bleibt funktionsfähig — Regressionsschutz gegen
+  versehentliches Entfernen):** Given eine Tabellenzeile, deren `thunder`-Rohwert ein
+  reiner Zahlenwert ist (kein String/Enum, älterer Legacy-Datenpfad, #1425) / When die
+  HTML-Mail-Zell-Tönung bei der `elif key == "thunder"`-Verzweigung (html.py ~855-862)
+  für diesen numerischen Rohwert berechnet wird / Then bekommt die Zelle weiterhin einen
+  Warnhintergrund (rot bei Werten > 20, orange bei Werten > 0) statt gar keinen
+  Hintergrund — der Fallback-Zweig wurde nicht entfernt.
+  - Test: numerische `thunder`-Rohwerte (z.B. 25.0 und 5.0) durch die Zell-Tönungslogik
+    schicken, roten bzw. orangen Hintergrund nachweisen; Gegenprobe mit 0 liefert keinen
+    Hintergrund.
+
+- **AC-8 (ALTLASTEN-Wächter schrumpft um genau die sechs sanierten Einträge):** Given die
+  sechs benannten Altlasten-Einträge zu `html.py::_thunder_risk_level` (Regel B, Regel C)
+  und `trip_command_processor.py::_THUNDER_LABEL`/`_MAP_EMOJI`/`_MAP_PLAIN`/
+  `_handle_hours_drilldown` in `ALTLASTEN` / When der #1480-Wächter
+  (`tests/tdd/test_thunder_scale_local_copy_guard.py`) nach dem Fix läuft / Then sind
+  diese sechs Einträge aus `ALTLASTEN` entfernt, `test_altlasten_basislinie_hat_keinen_leerlauf_eintrag`
+  bleibt grün, und die drei ursprünglich nicht betroffenen Einträge (`day_window.py`,
+  zwei `trip_report_scheduler.py`-Symbole) bleiben unverändert in der Liste.
+  - Test: struktureller Nachweis über den bestehenden Wächter-Test selbst (legitimer
+    Nachweis für diese eine Bereinigung, keine neu erfundene String-Prüfung) — Länge und
+    Inhalt von `ALTLASTEN` vor/nach dem Fix vergleichen (sechs `(Datei, Symbol, Regel)`-
+    Tripel fehlen, drei bleiben), plus vollständiger, grüner Testlauf des gesamten
+    Wächter-Moduls.
+
+- **AC-9 (Regel-C-Fundstelle wechselt von Altlast auf begründete Marker-Duldung):** Given
+  der `# gz-thunder-scale: <Begründung>`-Marker-Mechanismus (Duldungsstufe 3 des
+  #1480-Wächters, `docs/specs/modules/thunder_scale_guard.md`) / When der numerische
+  Fallback-Zweig in `_thunder_risk_level()` nach dem Fix weiterhin sein eigenes
+  `num > 20`/`num > 0`-Schwellenpaar mit eigenen Rückgabe-Literalen führt (bewusst NICHT
+  auf `thunder_ampel_band()` umgestellt, da er einen rohen Zahlenwert statt einer
+  diskreten Stufe erhält) / Then trägt die Fundstelle einen Marker-Kommentar mit
+  mindestens 15 sinnvollen Zeichen Begründung, und der Backend-Wächter meldet dort keinen
+  neuen, ungedeckten Regel-C-Fund mehr.
+  - Test: voller Wächter-Testlauf bleibt grün mit dem numerischen Fallback-Zweig
+    unverändert im Code vorhanden (Positivkontrolle: ohne Marker-Kommentar meldet der
+    Wächter an dieser Stelle einen Fund — Nachweis, dass der Marker tatsächlich wirkt und
+    nicht nur zufällig grün ist).
+
+## Known Limitations
+
+- **NONE/green → „ok" ist eine bewusste, verhaltensneutrale Vokabular-Erweiterung.** Vor
+  dieser Arbeit lieferte `_thunder_risk_level(NONE)` `None`; danach `"ok"`. Beide Werte
+  wirken an jeder heute existierenden Prüfstelle (`_row_risk`, Zell-Tönungs-`.get(...)`)
+  identisch wirkungslos — geprüft in AC-6. Ein künftiger Refactor, der `None` und `"ok"`
+  irgendwo unterschiedlich behandelt, würde diesen Unterschied sonst versehentlich
+  sichtbar machen; AC-6 ist die Absicherung dagegen.
+- **`ThunderLevel` erbt von `str`.** Tests decken sowohl Enum-Instanzen
+  (`ThunderLevel.MED`) als auch reine String-Werte (`"MED"`) ab, wo beide Formen in der
+  Praxis vorkommen (Roundtrip über Persistenz/API liefert teils reine Strings).
+- **Der Zahlen-Fallback-Zweig in `_thunder_risk_level()` wird NICHT auf
+  `thunder_ampel_band()` umgestellt.** Er verarbeitet einen rohen Zahlenwert (kein
+  `ThunderLevel`), für den es keine sinnvolle Stufen-Ableitung gibt, ohne selbst eine
+  Schwellen-Klassifikation vorzunehmen. Er bleibt bestehen und wird stattdessen über den
+  Marker-Kommentar-Mechanismus (AC-9) als begründete Duldung eingestuft statt als
+  benannte Altlast getrackt. Eine Vereinheitlichung dieser dual gearteten Funktion (Stufe
+  vs. Zahl) ist explizit außerhalb des Scopes dieser Arbeit.
+- **Ortsvergleich, `narrow.py`, `day_window.py`, `trip_report_scheduler.py` sind nicht
+  Teil dieser Arbeit** — weder betroffen noch verändert (siehe Context-Dokument).
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine neue.
+- **Rationale:** Diese Arbeit bewegt sich innerhalb ADR-0025 (Gewitter-Skala lebt zentral
+  in `metric_format.py`, gilt für alle Briefing-Kanäle) und saniert zwei bereits durch den
+  #1480-Wächter (`thunder_scale_guard.md`) benannte, bekannte Kopien. Kein neuer
+  Architektur-Entscheidungsraum.
+
+## Changelog
+
+- 2026-08-22: Initial spec created (Issues #2010, #2011).

--- a/docs/specs/modules/thunder_scale_guard.md
+++ b/docs/specs/modules/thunder_scale_guard.md
@@ -187,8 +187,9 @@ nutzersichtbare Defekte sind (#2010, #2011).
    **Nicht-Leerlauf-Test** wie für die Basislinie, dazu ein **Granularitäts-Nachweis**: eine
    konstruierte Kopie in einer kanonischen Datei unter anderem Symbolnamen **muss** gemeldet
    werden.
-2. **Benannte Altlasten-Basislinie** (`ALTLASTEN` im Backend-Wächter, 9 Einträge): die bekannten
-   Kopien aus #1474. **Symbolgeschlüsselt** über `(Datei, Symbol-/Funktionsname, Regel)` —
+2. **Benannte Altlasten-Basislinie** (`ALTLASTEN` im Backend-Wächter, ursprünglich 9 Einträge,
+   seit #2010/#2011 noch 3): die bekannten Kopien aus #1474. **Symbolgeschlüsselt** über
+   `(Datei, Symbol-/Funktionsname, Regel)` —
    **niemals** über Zeilennummern (#1466); jeder Eintrag trägt Grund und Tracking-Issue. Die Liste
    darf nur schrumpfen. Gegen Verrotten schützt ein **Nicht-Leerlauf-Test**: erzeugt ein Eintrag
    heute keinen echten Fund mehr (Symbol saniert, umbenannt, verschoben), wird der Wächter **rot**
@@ -545,10 +546,14 @@ unfangbar bleibt" — bewusst nicht Teil dieser Lieferung:
    Mitgliedsnamen, Scan-Wurzeln als Argumente), wird aber vorerst nur auf `ThunderLevel`
    angewandt — ein späterer `RiskLevel`-Wächter kostet dadurch ~20–30 LoC statt Neubau.
 5. **Die 10 bestehenden Kopien im Produktivcode werden nicht saniert.** Das ist ausdrücklich
-   nicht Teil dieses Workflows (#2010, #2011 decken zwei davon in eigenen PRs ab). Der Wächter
-   startet als Ratsche mit benannter, nur schrumpfender Duldungsliste — heute **neun**
-   Basislinien-Einträge (davon 7 in `src/services/`, 2 in `email/html.py`) plus der eine
-   Marker-Fall in `narrow.py`. Die beiden Go-Kopien liegen außerhalb der Python-Scanfläche.
+   nicht Teil dieses Workflows. Der Wächter startet als Ratsche mit benannter, nur schrumpfender
+   Duldungsliste — bei Einführung **neun** Basislinien-Einträge (davon 7 in `src/services/`,
+   2 in `email/html.py`) plus der eine Marker-Fall in `narrow.py`. **#2010/#2011 (2026-08-22)**
+   haben sechs davon saniert (4× `src/services/trip_command_processor.py`: `_THUNDER_LABEL`,
+   `_MAP_EMOJI`, `_MAP_PLAIN`, `_handle_hours_drilldown`; 2× `src/output/renderers/email/html.py`:
+   `_thunder_risk_level` Regel B und C) — verbleibend **drei** Einträge (`day_window.py` und
+   zwei `trip_report_scheduler.py`-Symbole). Die beiden Go-Kopien liegen außerhalb der
+   Python-Scanfläche.
 6. **Regel A/P laufen nicht auf Testdateien** — eine korrekte Fixture führt zwangsläufig alle
    vier Stufen-Wörter und würde 16 Dauerfeuer-Treffer erzeugen. Nur Regel D läuft dort.
 7. **Ein falsch schlagender Wächter blockiert jeden PR jeder Session** — beide CI-Jobs (`test`,
@@ -617,3 +622,10 @@ unfangbar bleibt" — bewusst nicht Teil dieser Lieferung:
   Marker in `src/output/renderers/narrow.py` besteht die verschärfte Prüfung unverändert
   (47 sinnvolle Zeichen, 16 verschiedene). Neue Fixtures und Grenzproben von beiden Seiten
   (14 → rot, 15 → grün): 50 → 56 Backend-, 30 → 36 Frontend-Tests.
+- 2026-08-22: `ALTLASTEN` um sechs sanierte Einträge geschrumpft (#2010, #2011) — 9 → 3.
+  `trip_command_processor.py::_THUNDER_LABEL`/`_MAP_EMOJI`/`_MAP_PLAIN`/`_handle_hours_drilldown`
+  leiten ihre Wörter jetzt aus `THUNDER_LABEL_DE` ab statt sie lokal zu kopieren;
+  `email/html.py::_thunder_risk_level` ruft für den String-/Enum-Pfad tatsächlich
+  `thunder_ampel_band()` auf (Regel B und C). Verbleibende drei Einträge (`day_window.py`,
+  zwei `trip_report_scheduler.py`-Symbole) unverändert. Details:
+  `docs/specs/modules/fix_2010_2011_gewitter_stufenwoerter.md`.

--- a/src/output/renderers/email/html.py
+++ b/src/output/renderers/email/html.py
@@ -165,6 +165,9 @@ def _safe_float(v, default: float = 0.0) -> float:
         return default
 
 
+_AMPEL_BAND_RISK = {"green": "ok", "yellow": "yellow", "orange": "watch", "red": "risk"}
+
+
 def _thunder_risk_level(thunder) -> Optional[str]:
     """Bestimmt den Risiko-Beitrag von Gewitter fuer `_row_risk` (Issue #1418
     Fehler 1; Issue #1927 v1.1: eigenstaendige Gelb-Stufe fuer LOW). `r["thunder"]`
@@ -178,25 +181,21 @@ def _thunder_risk_level(thunder) -> Optional[str]:
     historische Zahlenwert (Regressionsschutz AC-7, #1377 — Gewitter war
     dort ausdruecklich ausgenommen) bleibt als Fallback erhalten.
 
-    LOW liefert seit v1.1 eine eigenstaendige 'yellow'-Stufe statt wie zuvor
-    zusammen mit MED auf 'watch' verschmolzen zu werden — Angleichung an die
-    bereits bestehende `_THUNDER_AMPEL_BAND`-Zuordnung
-    (`metric_format.py`: NONE→green, LOW→yellow, MED→orange, HIGH→red).
-    Liefert 'risk'/'watch'/'yellow'/None (kein Beitrag) — nie einen Absturz.
+    Die Stufen-Uebersetzung liest seit Issue #2011 tatsaechlich
+    `thunder_ampel_band()` (`metric_format.py`: NONE→green, LOW→yellow,
+    MED→orange, HIGH→red) statt einer eigenen Wort-Kette; NONE liefert damit
+    'ok' statt None (an jeder Pruefstelle gleich wirkungslos, s. Spec
+    fix_2010_2011_gewitter_stufenwoerter „Known Limitations").
+    Liefert 'risk'/'watch'/'yellow'/'ok'/None (kein Beitrag) — nie einen Absturz.
     """
     if isinstance(thunder, str):
-        level = thunder.upper()
-        if level == "HIGH":
-            return "risk"
-        if level == "MED":
-            return "watch"
-        if level == "LOW":
-            return "yellow"
-        if level == "NONE":
-            return None
+        band = thunder_ampel_band(ThunderLevel.__members__.get(thunder.upper()))
+        if band is not None:
+            return _AMPEL_BAND_RISK[band]
 
     num = _safe_float(thunder, None)
     if num is not None:
+        # gz-thunder-scale: roher Zahlenwert (Legacy-Datenpfad #1425), keine diskrete Stufe -- bewusst kein thunder_ampel_band()
         if num > 20:
             return "risk"
         if num > 0:

--- a/src/services/trip_command_processor.py
+++ b/src/services/trip_command_processor.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, Optional
 
 from app.loader import get_data_dir, get_snapshots_dir, load_all_trips, save_trip
 from app.trip import Stage, Trip
+from output.metric_format import THUNDER_LABEL_DE, thunder_ampel_band
 from services.trip_day import anchor_tz, display_tz, trip_local_now, trip_local_today
 from utils.timezone import UTC, local_dt, local_fmt, local_hour
 
@@ -136,14 +137,25 @@ _MORGEN_BUTTONS = {
     ]
 }
 
-_THUNDER_LABEL = {
-    "NONE": "kein",
-    # Issue #1474 Adversary-Folgeaudit: LOW fehlte -- fiel auf den
-    # Unbekannt-Fallback "?" zurueck, obwohl LOW ein bekannter Wert ist.
-    "LOW": "leicht",
-    "MED": "mäßig",
-    "HIGH": "hoch",
-}
+# Kreis-Emoji je Ampelband der Stufe (`thunder_ampel_band`, metric_format.py) --
+# das Symbol stellt das Band dar, es ist keine zweite Stufen-Zuordnung.
+_BAND_EMOJI = {"green": "⚪", "yellow": "🟢", "orange": "🟡", "red": "🔴"}
+
+
+def _thunder_words() -> dict:
+    """Stufenname -> deutsches Wort, bei JEDEM Aufruf frisch aus
+    ``THUNDER_LABEL_DE`` abgeleitet (Issue #2010: die fruehere Wert-Kopie war
+    auf "mäßig"/"keins" abgedriftet)."""
+    return {level.name: label for level, label in THUNDER_LABEL_DE.items()}
+
+
+def _thunder_symbols() -> dict:
+    """Stufenname -> Kreis-Emoji, ueber das Ampelband der Stufe abgeleitet."""
+    return {
+        level.name: _BAND_EMOJI[thunder_ampel_band(level)]
+        for level in THUNDER_LABEL_DE
+    }
+
 
 # Issue #1818: der Hinweis, der die ehrliche Fehlanzeige begleitet — je Tag
 # das Kommando, das FUER DIESEN TAG ein Briefing ausloest. `/heute`/`/morgen`
@@ -218,12 +230,9 @@ def _thunder_fmt(value, *, with_emoji: bool = True) -> str:
     Issue #1222 AC-6: E-Mail/SMS bekommen KEIN Kreis-Emoji (nur das Wort),
     Telegram bleibt byte-identisch mit Emoji.
     """
-    # Issue #1474 Adversary-Folgeaudit: LOW fehlte in beiden Karten -- fiel
-    # auf "· keine Daten" zurueck, obwohl LOW ein bekannter Wert ist.
-    _MAP_EMOJI = {
-        "NONE": "⚪ keins", "LOW": "🟢 leicht", "MED": "🟡 mäßig", "HIGH": "🔴 hoch",
-    }
-    _MAP_PLAIN = {"NONE": "keins", "LOW": "leicht", "MED": "mäßig", "HIGH": "hoch"}
+    _MAP_PLAIN = _thunder_words()
+    _symbole = _thunder_symbols()
+    _MAP_EMOJI = {k: f"{_symbole[k]} {wort}" for k, wort in _MAP_PLAIN.items()}
     if value is None:
         return "· keine Daten"
     key = value.value if hasattr(value, "value") else str(value)
@@ -794,6 +803,10 @@ class TripCommandProcessor:
         rain_map  = {p.ts: p.value for p in r_rain.points}  if r_rain.available  else {}
         thund_map = {p.ts: p.value for p in r_thund.points} if r_thund.available else {}
 
+        # Issue #2010: dieselbe abgeleitete Quelle wie `_thunder_fmt` statt
+        # einer eigenen Verzweigung mit eigenen Woertern.
+        thunder_karte = _thunder_symbols() if with_emoji else _thunder_words()
+
         lines = [f"📅 Stunden · {label} ({today_date:%d.%m})", ""]
         for pt in r_temp.points:
             h = f"{local_hour(pt.ts, tz):02d}"
@@ -803,17 +816,12 @@ class TripCommandProcessor:
             rain_val = rain_map.get(pt.ts)
             rain = f"{rain_val:.1f}mm" if rain_val is not None else "?"
             thund_val = thund_map.get(pt.ts)
-            if thund_val is None or str(thund_val) in ("NONE", "ThunderLevel.NONE"):
-                t_sym = "—"
-            # Issue #1474 Adversary-Folgeaudit: LOW fiel bisher mangels
-            # eigenem Zweig in den ELSE-Fall und wurde faelschlich als
-            # starkes Gewitter (🔴/hoch) angezeigt.
-            elif str(thund_val) in ("LOW", "ThunderLevel.LOW"):
-                t_sym = "🟢" if with_emoji else "leicht"
-            elif str(thund_val) in ("MED", "ThunderLevel.MED"):
-                t_sym = "🟡" if with_emoji else "mäßig"
-            else:
-                t_sym = "🔴" if with_emoji else "hoch"
+            # `str(ThunderLevel.MED)` liefert je nach Python-Version "MED" oder
+            # "ThunderLevel.MED" -- beide Schreibweisen enden auf dem Stufennamen.
+            stufe = None if thund_val is None else str(thund_val).rsplit(".", 1)[-1]
+            # NONE bleibt eigener Zweig: die Stundenzeile zeigt einen Strich
+            # statt eines Wortes.
+            t_sym = "—" if stufe in (None, "NONE") else thunder_karte.get(stufe, "—")
             lines.append(f"{h}  {temp:<7} {wind:<8} {rain:<6} {t_sym}")
 
         markup = {"inline_keyboard": [[{"text": back_btn, "callback_data": back_cb}]]}
@@ -1025,7 +1033,7 @@ class TripCommandProcessor:
         t_max = f"{agg['temp_max']:.0f}" if agg['temp_max'] is not None else "?"
         t_min = f"{agg['temp_min']:.0f}" if agg['temp_min'] is not None else "?"
         wind = f"{agg['wind_max']:.0f}" if agg['wind_max'] is not None else "?"
-        thunder_label = _THUNDER_LABEL.get(agg['thunder'].value if agg['thunder'] else "NONE", "?")
+        thunder_label = _thunder_words().get(agg['thunder'].value if agg['thunder'] else "NONE", "?")
         # Issue #1680 S3 (Spec D3, abgeloeste Entscheidung): die tragende(n)
         # Zutat(en) der oben gezeigten Tagesstufe -- aus DEMSELBEN Aggregat,
         # das auch `agg['thunder']` traegt (`_aggregate_day()`, EINE Rechnung
@@ -1092,7 +1100,7 @@ class TripCommandProcessor:
             return f"Heute ({today:%d.%m}): " + self._tagesaussage_ohne_daten(
                 trip, today, "today", zusatz=" — kein Gewitter-Status.")
         thunder = agg["thunder"]
-        label = _THUNDER_LABEL.get(thunder.value if thunder else "NONE", "?")
+        label = _thunder_words().get(thunder.value if thunder else "NONE", "?")
         # Issue #1475 S5a: derselbe geteilte Textbaustein wie in den Mail-
         # Renderern (#1481 DRY, call-time Import) -- rein deskriptiv NEBEN der
         # Gewitterstufe, ohne Handlungsempfehlung (ADR-0007, Spec AC-8). Bei
@@ -1152,7 +1160,7 @@ class TripCommandProcessor:
             wind = f"{m.wind_max_kmh:.0f}" if m.wind_max_kmh is not None else "?"
             precip = f"{m.precip_sum_mm:.1f}" if m.precip_sum_mm is not None else "0.0"
             thunder = m.thunder_level_max
-            t_label = _THUNDER_LABEL.get(thunder.value if thunder else "NONE", "?")
+            t_label = _thunder_words().get(thunder.value if thunder else "NONE", "?")
             # Issue #1680 S3 (Spec D2): die tragende(n) Zutat(en) DIESES
             # Wegpunkts -- `thunder_level_max` UND `thunder_level_max_signals`
             # stammen aus DEMSELBEN `m` (`SegmentWeatherSummary`, von

--- a/tests/tdd/test_command_reply_channel_emoji.py
+++ b/tests/tdd/test_command_reply_channel_emoji.py
@@ -154,9 +154,11 @@ def test_dd_hours_today_email_has_no_circle_emoji_but_word(env):
     assert not _CIRCLE_EMOJI_RE.search(body), (
         f"Kreis-Emoji im E-Mail-Kanal gefunden:\n{body}"
     )
-    assert ("mäßig" in body) or ("hoch" in body), (
-        f"Erwartet Gewitter-Wort 'mäßig' oder 'hoch' im E-Mail-Body:\n{body}"
+    # Issue #2010: kanonisches Wort ist "mittel", nicht "mäßig".
+    assert ("mittel" in body) or ("hoch" in body), (
+        f"Erwartet Gewitter-Wort 'mittel' oder 'hoch' im E-Mail-Body:\n{body}"
     )
+    assert "mäßig" not in body, f"'mäßig' (Wortdrift #2010) noch im Body:\n{body}"
 
 
 # ---------------------------------------------------------------------------
@@ -187,9 +189,11 @@ def test_dd_thunder_today_email_has_no_circle_emoji_but_word(env):
     assert not _CIRCLE_EMOJI_RE.search(body), (
         f"Kreis-Emoji im E-Mail-Kanal gefunden:\n{body}"
     )
-    assert ("mäßig" in body) or ("hoch" in body), (
-        f"Erwartet Gewitter-Wort 'mäßig' oder 'hoch' im E-Mail-Body:\n{body}"
+    # Issue #2010: kanonisches Wort ist "mittel", nicht "mäßig".
+    assert ("mittel" in body) or ("hoch" in body), (
+        f"Erwartet Gewitter-Wort 'mittel' oder 'hoch' im E-Mail-Body:\n{body}"
     )
+    assert "mäßig" not in body, f"'mäßig' (Wortdrift #2010) noch im Body:\n{body}"
 
 
 def test_dd_thunder_today_telegram_keeps_circle_emoji(env):

--- a/tests/tdd/test_issue_654_telegram_thunder_drilldown.py
+++ b/tests/tdd/test_issue_654_telegram_thunder_drilldown.py
@@ -181,11 +181,14 @@ def test_ac1_dd_thunder_today_returns_hourly_list(env):
         f"Erwartet ≥6 HH:MM-Zeilen, gefunden {len(time_lines)}:\n{body}"
     )
 
-    # Mindestens eines der Stufen-Labels muss vorkommen
-    label_keywords = ["keins", "mäßig", "hoch", "⚪", "🟡", "🔴"]
+    # Mindestens eines der Stufen-Labels muss vorkommen (Issue #2010: kanonische
+    # Woerter "kein"/"mittel", nicht "keins"/"mäßig").
+    label_keywords = ["kein", "mittel", "hoch", "⚪", "🟡", "🔴"]
     assert any(kw in body for kw in label_keywords), (
         f"Keine Stufen-Labels in:\n{body}"
     )
+    assert "mäßig" not in body, f"'mäßig' (Wortdrift #2010) noch im Body:\n{body}"
+    assert "keins" not in body, f"'keins' (Wortdrift #2010) noch im Body:\n{body}"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tdd/test_thunder_scale_local_copy_guard.py
+++ b/tests/tdd/test_thunder_scale_local_copy_guard.py
@@ -290,49 +290,6 @@ ALTLASTEN = (
         "Nacht-Zusatz fuehrt LOW/MED/HIGH lokal, NONE absichtlich ausgelassen",
     ),
     Altlast(
-        "src/output/renderers/email/html.py",
-        "_thunder_risk_level",
-        "B",
-        "eigene Stufen-Wort-Kette statt thunder_ampel_band(), obwohl der "
-        "Docstring die Angleichung behauptet",
-        "#2011",
-    ),
-    Altlast(
-        "src/output/renderers/email/html.py",
-        "_thunder_risk_level",
-        "C",
-        "Zahlen-Fallback verschmilzt LOW und MED zu 'watch'",
-        "#2011",
-    ),
-    Altlast(
-        "src/services/trip_command_processor.py",
-        "_THUNDER_LABEL",
-        "A",
-        "Telegram-Label mit Wortdrift ('maessig' statt 'mittel')",
-        "#2010",
-    ),
-    Altlast(
-        "src/services/trip_command_processor.py",
-        "_MAP_EMOJI",
-        "A",
-        "Emoji-Karte mit Wortdrift ('keins'/'maessig')",
-        "#2010",
-    ),
-    Altlast(
-        "src/services/trip_command_processor.py",
-        "_MAP_PLAIN",
-        "A",
-        "Klartext-Karte, unabhaengig gepflegtes Duplikat von _MAP_EMOJI",
-        "#2010",
-    ),
-    Altlast(
-        "src/services/trip_command_processor.py",
-        "_handle_hours_drilldown",
-        "B",
-        "Stundentabelle verzweigt auf rohe Stufen-Strings mit eigenen Woertern",
-        "#2010",
-    ),
-    Altlast(
         "src/services/trip_report_scheduler.py",
         "_thunder_entry_from_trend_row",
         "B",
@@ -1133,6 +1090,86 @@ def test_altlasten_basislinie_deckt_nichts_zu_das_nicht_in_ihr_steht(bestand_ohn
         "ALTLASTEN aufnehmen, sondern beheben:\n"
         + "\n".join(f"  Code reference: {d} ({s}, Regel {r})" for d, s, r in unbekannt)
     )
+
+
+# ---------------------------------------------------------------------------
+# #2010/#2011: ALTLASTEN schrumpft um die sechs sanierten Eintraege (AC-8),
+# Marker-Positivkontrolle fuer den Regel-C-Fallback (AC-9).
+# Spec: docs/specs/modules/fix_2010_2011_gewitter_stufenwoerter.md
+# ---------------------------------------------------------------------------
+
+
+def test_ac8_2010_2011_sechs_eintraege_sind_aus_altlasten_gestrichen():
+    """AC-8: Nach dem Fix sind exakt die drei NICHT von #2010/#2011
+    betroffenen Eintraege in ALTLASTEN uebrig -- die sechs sanierten
+    Eintraege (html.py::_thunder_risk_level Regel B/C,
+    trip_command_processor.py::_THUNDER_LABEL/_MAP_EMOJI/_MAP_PLAIN/
+    _handle_hours_drilldown) sind gestrichen. Struktureller Nachweis ueber
+    ALTLASTEN selbst (Laenge/Inhalt vor/nach dem Fix), keine neu erfundene
+    String-Pruefung."""
+    verbleibende = {e.key for e in ALTLASTEN}
+    sanierte = {
+        ("src/output/renderers/email/html.py", "_thunder_risk_level", "B"),
+        ("src/output/renderers/email/html.py", "_thunder_risk_level", "C"),
+        ("src/services/trip_command_processor.py", "_THUNDER_LABEL", "A"),
+        ("src/services/trip_command_processor.py", "_MAP_EMOJI", "A"),
+        ("src/services/trip_command_processor.py", "_MAP_PLAIN", "A"),
+        ("src/services/trip_command_processor.py", "_handle_hours_drilldown", "B"),
+    }
+    noch_vorhanden = verbleibende & sanierte
+    assert not noch_vorhanden, (
+        "Sanierte #2010/#2011-Eintraege noch in ALTLASTEN vorhanden -- Zeile "
+        f"streichen: {sorted(noch_vorhanden)}"
+    )
+    erwartete_rest = {
+        ("src/app/day_window.py", "_NIGHT_ADDENDUM_WORD", "A"),
+        ("src/services/trip_report_scheduler.py", "_thunder_entry_from_trend_row", "B"),
+        ("src/services/trip_report_scheduler.py", "_build_thunder_forecast", "B"),
+    }
+    assert verbleibende == erwartete_rest, (
+        f"ALTLASTEN nach dem Fix: erwartet genau {sorted(erwartete_rest)}, "
+        f"gefunden {sorted(verbleibende)}"
+    )
+
+
+def test_ac9_regelc_fundstelle_ohne_marker_meldet_einen_fund_positivkontrolle():
+    """AC-9 Positivkontrolle: Beweis, dass der Marker-Mechanismus tatsaechlich
+    wirkt und nicht nur zufaellig gruen ist -- derselbe Zahlen-Fallback-Zweig
+    (Struktur wie html.py::_thunder_risk_level) OHNE Marker-Kommentar erzeugt
+    einen echten Regel-C-Fund."""
+    quelle = (
+        "def _thunder_risk_level(thunder):\n"
+        "    num = _safe_float(thunder, None)\n"
+        "    if num is not None:\n"
+        "        if num > 20:\n"
+        "            return 'risk'\n"
+        "        if num > 0:\n"
+        "            return 'watch'\n"
+        "    return None\n"
+    )
+    findings = scan_source(quelle, "<ac9-ohne-marker>", _thunder_spec(), rules=("C",))  # noqa: F821
+    assert len(findings) == 1, f"erwartet 1 Regel-C-Fund ohne Marker: {_refs(findings)}"
+
+
+def test_ac9_regelc_fundstelle_mit_marker_bleibt_gruen():
+    """AC-9 Gegenprobe: derselbe Zweig MIT begruendetem Marker-Kommentar
+    (Duldungsstufe 3, direkt ueber der Fundstelle 'if num > 20:') bleibt
+    gruen -- das ist der Mechanismus, ueber den die Fundstelle nach dem Fix
+    von 'benannte Altlast' auf 'begruendete Duldung' wechselt, OHNE die
+    Zahlen-Schwellen selbst zu aendern."""
+    quelle = (
+        "def _thunder_risk_level(thunder):\n"
+        "    num = _safe_float(thunder, None)\n"
+        "    if num is not None:\n"
+        "        # gz-thunder-scale: verarbeitet rohen Zahlenwert, keine diskrete Stufe\n"
+        "        if num > 20:\n"
+        "            return 'risk'\n"
+        "        if num > 0:\n"
+        "            return 'watch'\n"
+        "    return None\n"
+    )
+    findings = scan_source(quelle, "<ac9-mit-marker>", _thunder_spec(), rules=("C",))  # noqa: F821
+    assert findings == [], f"Marker sollte den Fund durchlassen: {_refs(findings)}"
 
 
 @pytest.fixture(scope="module")

--- a/tests/tdd/test_thunder_stage_words_from_canonical_source.py
+++ b/tests/tdd/test_thunder_stage_words_from_canonical_source.py
@@ -1,0 +1,402 @@
+"""TDD RED — Issue #2010 (Telegram) / #2011 (Briefing-Mail-Ampelfarbe):
+Gewitter-Stufenwörter/-Ampelfarbe folgen der kanonischen Quelle
+(``src/output/metric_format.py::THUNDER_LABEL_DE`` / ``thunder_ampel_band()``)
+statt lokal kopierter Wort-/Zahlenketten.
+
+AC-1 bis AC-3 (#2010, Telegram-Klartext/-Emoji/-Stundendrilldown) und AC-4
+(Ableitungsnachweis) messen ``_thunder_fmt``/``_handle_hours_drilldown`` in
+``src/services/trip_command_processor.py``. AC-5 bis AC-7 (#2011) messen
+``_thunder_risk_level``/``_row_risk`` in
+``src/output/renderers/email/html.py``. AC-8/AC-9 (Wächter-Basislinie/
+Marker-Positivkontrolle) liegen in
+``tests/tdd/test_thunder_scale_local_copy_guard.py``.
+
+Spec: docs/specs/modules/fix_2010_2011_gewitter_stufenwoerter.md
+Kontext: docs/context/fix-2010-2011-gewitter-stufenwoerter.md
+
+Kern-Schicht, deterministisch: keine Mocks/patch()/MagicMock, kein Netz.
+"""
+from __future__ import annotations
+
+import re
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from bs4 import BeautifulSoup
+
+from app.loader import save_trip
+from app.models import (
+    ForecastDataPoint,
+    ForecastMeta,
+    GPXPoint,
+    NormalizedTimeseries,
+    Provider,
+    SegmentWeatherData,
+    SegmentWeatherSummary,
+    ThunderLevel,
+    TripSegment,
+)
+from app.trip import Stage, Trip, Waypoint
+from output.metric_format import THUNDER_LABEL_DE, _THUNDER_AMPEL_BAND
+from services.trip_command_processor import (
+    CommandResult,
+    InboundMessage,
+    TripCommandProcessor,
+    _thunder_fmt,
+    _thunder_symbols,
+    _thunder_words,
+)
+from src.output.renderers.email.html import _render_html_table, _row_risk, _thunder_risk_level
+
+# ---------------------------------------------------------------------------
+# AC-1 / AC-2: _thunder_fmt() -- Klartext- und Emoji-Pfad, alle vier Stufen
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "level,expected_word",
+    [
+        (ThunderLevel.NONE, "kein"),
+        (ThunderLevel.LOW, "leicht"),
+        (ThunderLevel.MED, "mittel"),
+        (ThunderLevel.HIGH, "hoch"),
+    ],
+)
+def test_ac1_thunder_fmt_plain_zeigt_die_vier_korrekten_woerter(level, expected_word):
+    """AC-1: Klartext-Pfad (``with_emoji=False``) zeigt fuer jede Stufe genau
+    das kanonische Wort -- insbesondere 'mittel' statt 'mäßig' und 'kein'
+    statt 'keins'."""
+    text = _thunder_fmt(level, with_emoji=False)
+    assert text == expected_word, f"{level}: erwartet {expected_word!r}, erhalten {text!r}"
+    assert "mäßig" not in text and "keins" not in text
+
+
+@pytest.mark.parametrize(
+    "level,expected_word,expected_emoji",
+    [
+        (ThunderLevel.NONE, "kein", "⚪"),
+        (ThunderLevel.LOW, "leicht", "🟢"),
+        (ThunderLevel.MED, "mittel", "🟡"),
+        (ThunderLevel.HIGH, "hoch", "🔴"),
+    ],
+)
+def test_ac2_thunder_fmt_emoji_behaelt_symbol_und_korrigiert_wort(level, expected_word, expected_emoji):
+    """AC-2: Emoji-Pfad (``with_emoji=True``) behaelt das Kreis-Emoji UND
+    zeigt das korrigierte Wort, beide gemeinsam in derselben Zeile.
+
+    Exakter Split statt Teilstring-Suche: 'kein' ist Teilstring von 'keins'
+    -- eine reine ``in``-Pruefung wuerde den Bug nicht fangen.
+    """
+    text = _thunder_fmt(level, with_emoji=True)
+    parts = text.split(" ", 1)
+    assert len(parts) == 2, f"{level}: erwartet 'EMOJI WORT', erhalten {text!r}"
+    assert parts[0] == expected_emoji, f"{level}: Emoji {parts[0]!r}, erwartet {expected_emoji!r}"
+    assert parts[1] == expected_word, f"{level}: Wort {parts[1]!r}, erwartet {expected_word!r}"
+
+
+# ---------------------------------------------------------------------------
+# AC-3: Stundendrilldown ist ein unabhaengiger zweiter Pfad
+# ---------------------------------------------------------------------------
+
+TODAY = date(2026, 9, 10)
+RECEIVED_AT = datetime(2026, 9, 10, 8, 0, tzinfo=timezone.utc)
+_TRIP_ID = "test-2010-2011-hours-drilldown"
+_TRIP_NAME = "Stufenwoerter-Test-Tour"
+_USER_ID = "default"
+
+
+def _make_trip() -> Trip:
+    return Trip(
+        id=_TRIP_ID,
+        name=_TRIP_NAME,
+        stages=[
+            Stage(
+                id="S1",
+                name="Heute-Etappe",
+                date=TODAY,
+                waypoints=[Waypoint(id="W1", name="Start", lat=42.1, lon=9.0, elevation_m=800)],
+            ),
+        ],
+    )
+
+
+def _make_snapshot_segments() -> list[SegmentWeatherData]:
+    """6 Stundenpunkte mit einer MED-Stunde -- unabhaengiger Nachweis von
+    AC-1/AC-2, da ``_handle_hours_drilldown`` bislang eine eigene
+    if/elif-Verzweigung mit eigenem 'mäßig'-Literal besass."""
+    provider = Provider.OPENMETEO
+    meta = ForecastMeta(provider=provider, model="test", grid_res_km=0.0)
+    thunder_seq = [ThunderLevel.NONE, ThunderLevel.MED, ThunderLevel.HIGH]
+    hourly_points = [
+        ForecastDataPoint(
+            ts=RECEIVED_AT + timedelta(hours=i),
+            thunder_level=thunder_seq[i % len(thunder_seq)],
+            wind10m_kmh=20.0,
+            precip_1h_mm=0.0,
+        )
+        for i in range(6)
+    ]
+    timeseries = NormalizedTimeseries(meta=meta, data=hourly_points)
+    segment = TripSegment(
+        segment_id="seg-2010",
+        start_point=GPXPoint(lat=42.1, lon=9.0, elevation_m=800),
+        end_point=GPXPoint(lat=42.2, lon=9.1, elevation_m=600),
+        start_time=RECEIVED_AT,
+        end_time=RECEIVED_AT + timedelta(hours=5),
+        duration_hours=5.0,
+        distance_km=8.0,
+        ascent_m=100.0,
+        descent_m=100.0,
+    )
+    summary = SegmentWeatherSummary(
+        thunder_level_max=ThunderLevel.HIGH, wind_max_kmh=20.0, precip_sum_mm=0.0
+    )
+    return [
+        SegmentWeatherData(
+            segment=segment,
+            timeseries=timeseries,
+            aggregated=summary,
+            fetched_at=RECEIVED_AT,
+            provider=provider.value,
+        )
+    ]
+
+
+@pytest.fixture
+def env(tmp_path: Path, monkeypatch) -> Path:
+    redirect = lambda user_id="default": tmp_path / user_id
+    monkeypatch.setattr("app.loader.get_data_dir", redirect)
+    monkeypatch.setattr("services.trip_command_processor.get_data_dir", redirect)
+    save_trip(_make_trip(), _USER_ID)
+    from services.weather_snapshot import WeatherSnapshotService
+
+    WeatherSnapshotService(_USER_ID).save(_TRIP_ID, _make_snapshot_segments(), TODAY)
+    return tmp_path
+
+
+def _process(body: str, channel: str) -> CommandResult:
+    msg = InboundMessage(
+        channel=channel,
+        trip_name=_TRIP_NAME,
+        body=body,
+        sender="test",
+        received_at=RECEIVED_AT,
+        user_id=_USER_ID,
+    )
+    return TripCommandProcessor().process(msg)
+
+
+def test_ac3_hours_drilldown_med_stunde_zeigt_mittel_nicht_maessig(env):
+    """AC-3, Klartext (E-Mail-Kanal): die MED-Stunde zeigt 'mittel' am
+    Zeilenende, 'mäßig' erscheint nirgends im Body."""
+    result = _process("### query: dd_hours_today", channel="email")
+    assert result.success is True, f"Erwartet success=True: {result.confirmation_body!r}"
+    body = result.confirmation_body
+
+    zeilen_mit_mittel = [ln for ln in body.splitlines() if ln.rstrip().endswith("mittel")]
+    assert zeilen_mit_mittel, f"Keine Zeile mit 'mittel' (Klartext, MED) gefunden:\n{body}"
+    assert "mäßig" not in body, f"'mäßig' noch im Stundendrilldown-Body:\n{body}"
+
+
+def test_ac3_hours_drilldown_med_stunde_zeigt_gelbes_emoji_telegram(env):
+    """AC-3, Emoji (Telegram-Kanal): die MED-Stunde zeigt das gelbe
+    Kreis-Emoji 🟡 am Zeilenende, 'mäßig' erscheint nirgends im Body."""
+    result = _process("### query: dd_hours_today", channel="telegram")
+    assert result.success is True, f"Erwartet success=True: {result.confirmation_body!r}"
+    body = result.confirmation_body
+
+    zeilen_mit_gelb = [ln for ln in body.splitlines() if ln.rstrip().endswith("🟡")]
+    assert zeilen_mit_gelb, f"Keine Zeile mit 🟡 (Emoji, MED) gefunden:\n{body}"
+    assert "mäßig" not in body, f"'mäßig' noch im Stundendrilldown-Body:\n{body}"
+
+
+_STUNDENZEILE = re.compile(r"^(\d{2})\s")
+# NONE-Stunden der Fixture in Ortszeit: `thunder_seq[i % 3] == NONE` fuer i=0/3,
+# Startpunkt 08:00 UTC, Korsika im September UTC+2.
+_NONE_STUNDEN = ("10", "13")
+
+
+@pytest.mark.parametrize(
+    "channel,karte",
+    [("email", _thunder_words), ("telegram", _thunder_symbols)],
+)
+def test_ac3_hours_drilldown_none_stunde_zeigt_strich_statt_stufenwort(env, channel, karte):
+    """AC-3 / Implementation Details #2010: der NONE-Sonderfall bleibt ein
+    eigener Zweig -- eine Stunde ohne Gewitter zeigt '—', NICHT den Eintrag,
+    den ``thunder_karte`` fuer NONE traegt ('kein' bzw. ⚪). Ohne den
+    Sonderfall stuende dort dieser Eintrag."""
+    none_eintrag = karte()["NONE"]
+    assert none_eintrag and none_eintrag != "—", (
+        "Positivkontrolle: die Stufenkarte muss fuer NONE einen eigenen, vom "
+        f"Strich verschiedenen Eintrag tragen, gefunden {none_eintrag!r}"
+    )
+
+    result = _process("### query: dd_hours_today", channel=channel)
+    assert result.success is True, f"Erwartet success=True: {result.confirmation_body!r}"
+    body = result.confirmation_body
+    stunden = {
+        m.group(1): ln.rstrip()
+        for ln in body.splitlines()
+        if (m := _STUNDENZEILE.match(ln))
+    }
+
+    for h in _NONE_STUNDEN:
+        assert h in stunden, f"Stunde {h} fehlt im Drilldown:\n{body}"
+        assert stunden[h].endswith("—"), (
+            f"NONE-Stunde {h} endet nicht auf '—': {stunden[h]!r}"
+        )
+    fehlgriffe = [ln for ln in stunden.values() if ln.endswith(none_eintrag)]
+    assert not fehlgriffe, (
+        f"Stundenzeile zeigt den NONE-Eintrag {none_eintrag!r} statt '—': {fehlgriffe}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-4: Ableitung statt Wert-Kopie (Regressionsschutz)
+# ---------------------------------------------------------------------------
+
+
+def test_ac4_thunder_fmt_plain_folgt_veraendertem_quellwort(monkeypatch):
+    """AC-4: ein testlokal veraendertes ``THUNDER_LABEL_DE[MED]`` muss im
+    ueber ``_thunder_fmt()`` gerenderten Wort erscheinen -- Beleg fuer
+    Ableitung statt einmaliger Wert-Kopie."""
+    monkeypatch.setitem(THUNDER_LABEL_DE, ThunderLevel.MED, "XTESTWORT")
+    text = _thunder_fmt(ThunderLevel.MED, with_emoji=False)
+    assert text == "XTESTWORT", (
+        f"Erwartet den veraenderten Quellwert 'XTESTWORT', erhalten {text!r} -- "
+        "_thunder_fmt() liest THUNDER_LABEL_DE offenbar nicht bei jedem Aufruf."
+    )
+
+
+@pytest.mark.parametrize(
+    "body,konsument",
+    [
+        ("gewitter", "_fmt_gewitter"),
+        ("glance", "_fmt_day_agg"),
+        ("### query: timeline_heute", "_fmt_timeline"),
+    ],
+)
+def test_ac4_zusammenfassung_glance_timeline_folgen_veraendertem_quellwort(
+    env, monkeypatch, body, konsument
+):
+    """AC-4 fuer die drei uebrigen Stufenwort-Konsumenten: auch
+    ``_fmt_gewitter``/``_fmt_day_agg``/``_fmt_timeline`` muessen bei JEDEM
+    Aufruf aus ``THUNDER_LABEL_DE`` ableiten. Ein einmaliger Modul-Snapshot
+    (frueher ``_THUNDER_LABEL``) bliebe hier auf dem alten Wort stehen.
+
+    Veraendert wird HIGH, weil der Fixture-Schnappschuss als Tages-/Wegpunkt-
+    Stufe HIGH traegt -- MED erreicht diese drei Ausgaben nicht."""
+    monkeypatch.setitem(THUNDER_LABEL_DE, ThunderLevel.HIGH, "XTESTWORT")
+    result = _process(body, channel="email")
+    assert result.success is True, f"Erwartet success=True: {result.confirmation_body!r}"
+    text = result.confirmation_body
+    assert "XTESTWORT" in text, (
+        f"{konsument} zeigt den veraenderten Quellwert nicht:\n{text}"
+    )
+    assert "hoch" not in text, (
+        f"{konsument} zeigt weiterhin das eingefrorene Wort 'hoch':\n{text}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-5: Ampeluebersetzung aller vier Stufen -- abgeleitet statt kopiert
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "level,expected",
+    [
+        (ThunderLevel.NONE, "ok"),
+        (ThunderLevel.LOW, "yellow"),
+        (ThunderLevel.MED, "watch"),
+        (ThunderLevel.HIGH, "risk"),
+    ],
+)
+def test_ac5_thunder_risk_level_uebersetzt_alle_vier_stufen_enum(level, expected):
+    assert _thunder_risk_level(level) == expected
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [("NONE", "ok"), ("LOW", "yellow"), ("MED", "watch"), ("HIGH", "risk")],
+)
+def test_ac5_thunder_risk_level_uebersetzt_alle_vier_stufen_string(raw, expected):
+    assert _thunder_risk_level(raw) == expected
+
+
+def test_ac5_thunder_risk_level_folgt_veraendertem_ampel_band_fuer_med(monkeypatch):
+    """AC-5: Ableitungsnachweis -- ein testlokal veraenderter Eintrag in
+    ``_THUNDER_AMPEL_BAND[MED]`` aendert das Ergebnis fuer MED entsprechend,
+    weil die Uebersetzung jetzt tatsaechlich ueber ``thunder_ampel_band()``
+    laeuft statt ueber eine eigene Wort-Kette."""
+    monkeypatch.setitem(_THUNDER_AMPEL_BAND, ThunderLevel.MED, "red")
+    ergebnis = _thunder_risk_level(ThunderLevel.MED)
+    assert ergebnis == "risk", (
+        f"Veraendertes Ampelband fuer MED ('red') liefert {ergebnis!r}, erwartet "
+        "'risk' -- _thunder_risk_level() scheint eine eigene Wort-Kette statt "
+        "thunder_ampel_band() zu nutzen."
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-6: NONE liefert jetzt "ok" statt None
+# ---------------------------------------------------------------------------
+
+
+def test_ac6_thunder_risk_level_none_liefert_ok_statt_none():
+    """AC-6: NONE liefert jetzt 'ok' (nicht mehr None) -- Vokabular-
+    Erweiterung, verhaltensneutral abgesichert (Regressionsschutz-Nachweis
+    fuer die Downstream-Wirkung: siehe
+    test_thunder_risk_dot_and_tint.py::test_ac4_..., unveraendert gruen)."""
+    assert _thunder_risk_level(ThunderLevel.NONE) == "ok"
+    assert _thunder_risk_level("NONE") == "ok"
+
+
+def test_ac6_row_risk_bleibt_fuer_none_gewitter_unveraendert_ok():
+    """AC-6 zweiter Teil: ``_row_risk()`` liefert fuer eine ansonsten
+    unauffaellige Zeile mit NONE-Gewitter unveraendert 'ok' -- der Wechsel
+    von None auf 'ok' bei ``_thunder_risk_level()`` bleibt an dieser
+    Pruefstelle wirkungslos."""
+    row = {
+        "time": "14:00", "temp": 18.0, "wind": 10.0, "gust": 15.0,
+        "precip": 0.0, "pop": 5.0, "thunder": ThunderLevel.NONE,
+    }
+    assert _row_risk(row) == "ok"
+
+
+# ---------------------------------------------------------------------------
+# AC-7: Zahlen-Fallback bleibt funktionsfaehig (Regressionsschutz)
+# ---------------------------------------------------------------------------
+
+_BG_HEX = re.compile(r"background:\s*(#[0-9a-fA-F]{6})")
+_THUNDER_COL_LABEL = "Thdr"
+CELL_RED = "#f7d3e2"
+CELL_ORANGE = "#fbe3cc"
+
+
+def _render_one(row: dict) -> str:
+    return _render_html_table([row], friendly_keys=set(), indicator_keys=set())
+
+
+def _thunder_cell_bg(html: str):
+    soup = BeautifulSoup(html, "html.parser")
+    tr = soup.find("tbody").find_all("tr")[0]
+    td = tr.find("td", attrs={"data-label": _THUNDER_COL_LABEL})
+    if td is None:
+        return None
+    match = _BG_HEX.search(td.get("style", ""))
+    return match.group(1).lower() if match else None
+
+
+def test_ac7_zahlen_fallback_bleibt_funktionsfaehig_fuer_numerische_rohwerte():
+    """AC-7 (Regressionsschutz gegen versehentliches Entfernen): eine
+    Tabellenzeile mit rohem numerischem 'thunder'-Wert (aelterer Legacy-
+    Datenpfad, #1425) bekommt weiterhin einen Warnhintergrund ueber den
+    Zahlen-Fallback-Zweig in ``_thunder_risk_level()``."""
+    row_base = {"time": "14:00", "temp": 18.0, "wind": 10.0, "gust": 15.0,
+                "precip": 0.0, "pop": 5.0}
+
+    assert _thunder_cell_bg(_render_one({**row_base, "thunder": 25.0})) == CELL_RED
+    assert _thunder_cell_bg(_render_one({**row_base, "thunder": 5.0})) == CELL_ORANGE
+    assert _thunder_cell_bg(_render_one({**row_base, "thunder": 0.0})) is None


### PR DESCRIPTION
Die vier Gewitter-Stufenwoerter (kein/leicht/mittel/hoch) wurden in
trip_command_processor.py als Modul-Import-Snapshot (_THUNDER_LABEL) statt
live aus THUNDER_LABEL_DE abgeleitet -- Zusammenfassung, Glance und Timeline
konnten dadurch veraltete Woerter zeigen. In html.py wird die E-Mail-Ampelfarbe
jetzt durchgaengig ueber thunder_ampel_band() bestimmt statt lokal kopiert.

Adversary-Fix-Loop (F001 NONE-Sonderfall im Stundendrilldown ungetestet,
F002 Snapshot-Konsumenten ohne Regressionsschutz) per Mutations-Gegenprobe
geschlossen, Verdict VERIFIED, 123 Tests gruen.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PCqABf8AgBRTc1EUFV2bTX
