### PR TITLE
fix(#2078): Onset-SMS-Kopf vor dem Zeit-Token kappen statt fertigen Text hart zu schneiden

### DIFF
--- a/docs/context/fix-2078-onset-sms-zeit-token-schnitt.md
+++ b/docs/context/fix-2078-onset-sms-zeit-token-schnitt.md
@@ -1,0 +1,73 @@
+# Context: Onset-Kurznachricht — harter Zeichen-Schnitt zerschneidet das Zeit-Token (#2078)
+
+## Request Summary
+`_render_sms_onset` baut den Kopf (Ortsname) ohne Längenbegrenzung und schneidet danach
+den fertigen Text stur bei `limit` (Default 140) ab. Bei ausreichend langem Ortsnamen trifft
+der Schnitt mitten ins Zeit-Token am Ende — die Kurznachricht (SMS/Premium-SMS/
+Telegram-Kurzstil) trägt dann eine **inhaltlich falsche** statt einer fehlenden Uhrzeit
+(`Sa0:40` → `Sa0:4`). Fix: Kopf vor dem Zusammensetzen kappen, analog zu den Nachbarzweigen.
+
+## Related Files
+| File | Relevance |
+|------|-----------|
+| `src/output/renderers/alert/render.py:895-964` | `_render_sms_onset` — Fundstelle des Bugs. Kopf (`head`, Zeilen 957-962) wird ungekappt gebaut, `body[:limit]` (Zeile 964) schneidet hart am Ende. |
+| `src/output/renderers/alert/render.py:466-471` | `_render_sms_onset_shift_only` — **identisches Muster** (ungekappter Kopf + harter Endschnitt), gleicher Bug, nicht Teil der Issue-Meldung. |
+| `src/output/renderers/alert/render.py:1420-1438` | `_render_sms_corridor_only` — Referenzmuster: `trip[:16]`, `location_label[:24]`/`where[:24]` werden VOR dem Zusammensetzen gekappt. |
+| `src/output/renderers/alert/render.py:1472-1533` | `_render_sms_body` — Dispatcher zu allen SMS-Zweigen; eigener Fallback-Kopf-Zweig (Zeile 1530, `_km_str(msg)`) ist ebenfalls ungekappt, aber `_km_str` liefert typischerweise kurze km-Spannen/Segmentnamen, kein frei langer Ortsname. |
+| `src/output/renderers/alert/render.py:1611-1621` | `_ascii_alert_location` — Piktogramm-Entfernung + ASCII/GSM-7-Faltung + `"Segment " → "Seg "`; erzeugt den `head`-Text in `_render_sms_onset`. |
+| `src/services/notification_service.py:1487-1492` | Einziger Produktivaufruf für den Alarm-Pfad: `render_alert_sms(alert_msg, location_positions=...)` — kein `limit`-Override, also Default 140. |
+| `src/services/notification_service.py:1598,1666,1680` | Dieselbe `sms_body`-Variable geht unverändert an SMS, Premium-SMS **und** Telegram-Kurzstil (Zeile 1598) — ein Fix am Renderer wirkt automatisch auf alle drei Kanäle. |
+| `tests/tdd/test_alert_sms_segment_head.py` | Bestehende Kopf-Tests (AC-5 bis AC-8, AC-12 aus #1935/#1779) — Referenzmuster für Testaufbau (echte `AlertEvent`/`OnsetEvent`/`AlertMessage`, kein Mock). |
+| `tests/tdd/test_alert_sms_onset_zeitpunkt.py` | Bestehende Tests zu `_render_sms_onset` (#1948 S4) — hier laufen die neuen Regressionstests am wahrscheinlichsten mit. |
+
+## Existing Patterns
+- **Kopf-Kappung vor dem Zusammensetzen ist der etablierte Standard**, nicht die Ausnahme:
+  `_render_sms_corridor_only` kappt `trip[:16]` und `location_label[:24]`, `_render_sms_body`
+  kappt `trip[:16]` und `location_label[:24]` in fast allen Zweigen. `_render_sms_onset` und
+  `_render_sms_onset_shift_only` sind die beiden Ausreißer ohne Kappung.
+- **Harter Endschnitt (`body[:limit]`) bleibt als Sicherheitsnetz überall bestehen** — auch
+  nach Kopf-Kappung ist er nicht überflüssig (z.B. wenn `_ascii_alert_location` durch
+  GSM-7-Ersatzsequenzen wieder wächst), aber er soll im Normalfall nicht mehr greifen.
+- **`_ascii_alert_location`** ist bereits der gemeinsame Ort für Piktogramm-Entfernung +
+  ASCII-Faltung + Segment-Kürzung — eine Längenkappung gehört der bestehenden Konvention nach
+  an die Aufrufstelle (wie bei `corridor_only`), nicht in die Funktion selbst, da sie an
+  verschiedenen Stellen mit verschiedenen Limits (16/24) verwendet wird.
+
+## Dependencies
+- **Upstream:** `OnsetEvent.location_label` / `msg.trip_short` / `_location_of(...)` liefern den
+  Rohtext für den Kopf — deren Länge ist nutzergesteuert (Ortsname im Trip/Ortsvergleich) und
+  nicht durch das System begrenzt.
+- **Downstream:** `render_sms()` → `_render_sms_body()` → `_render_sms_onset()` wird von
+  `notification_service.py` für SMS, Premium-SMS und Telegram-Kurzstil konsumiert (gleicher
+  Text, drei Kanäle). Kein weiterer Aufrufer im Baum.
+
+## Existing Specs
+- `docs/specs/modules/fix_1948_s4_nowcast_sms_zielbild.md` — Ursprungs-Spec von
+  `_render_sms_onset`. **Known Limitations (Zeile 272-278)** benennt das Risiko bereits
+  ausdrücklich als "geerbtes Risiko" und stuft das Längenbudget zum damaligen Zeitpunkt als
+  „insgesamt unkritisch" ein (nur EIN Zeit-Token, Endschnitt hätte selten getroffen).
+- `docs/specs/modules/fix_2051_s1_ende_und_dauer.md` (referenziert in Issue #2078) — führte das
+  **zweite** Zeit-Token (Ende-Suffix) ein, wodurch der Kopf-Endschnitt-Konflikt real wurde.
+- `docs/specs/modules/fix_1935_1779_alarm_nachricht_klarheit.md` — legt die Kopf-Kappung
+  `[:24]` als Konvention für den Nachbarzweig fest (Referenzmuster für diesen Fix).
+
+## Risks & Considerations
+- **Scope-Frage aus der Issue:** ob auch `_render_sms_onset_shift_only` (identisches Muster,
+  nicht in der Issue erwähnt) und der `_render_sms_body`-Fallback-Kopf (Zeile 1530, geringeres
+  Risiko) in dieser Scheibe mitgehen. Empfehlung: **`_render_sms_onset` UND
+  `_render_sms_onset_shift_only`** in dieser Scheibe (identischer Bug, identischer Fix,
+  ein Testaufwand), `_render_sms_body`-Fallback als Sammel-Eintrag (#1199) — dort ist die
+  Kopfquelle (`_km_str`) strukturell kurz, kein konkreter Fehlerfall belegt.
+- **Verlustärmere Richtung laut Issue:** Kopf vorher kappen (analog `[:24]`) statt am
+  Token-Ende zu schneiden — bei Kopf-Kappung bleibt die Zeit-Aussage vollständig, nur der
+  Ortsname wird ggf. kürzer. Das ist die im Ticket bereits vorgezeichnete Richtung, keine
+  offene Designfrage mehr.
+- **Messgrundlage statt Schätzung** (PO-Vorgabe im Ticket): längster real vorkommender
+  `location_label`/Segmentname aus Prod-Daten (`/var/lib/gregor`, nur mit sudo) erheben, um
+  ein sauberes Golden-Beispiel für den Testfall zu haben — nicht raten.
+- **140 ist dreifach als Default dupliziert** (`_render_sms_onset`, `render_sms`,
+  `_render_sms_body`) ohne zentrale Konstante — nicht Teil dieser Scheibe (kosmetisch,
+  Sammel-Eintrag #1199 falls überhaupt).
+- **KHW-Tour startet heute (2026-08-23)** — Milestone „Tour KHW 2026-08" ist bereits fällig
+  (2026-08-22). Dieser Fix hat direkte Auswirkung auf die Hütten-Situation (nur Premium-SMS
+  erreicht dort, siehe Produktkontext in `CLAUDE.md`).

--- a/docs/specs/modules/fix_1948_s4_nowcast_sms_zielbild.md
+++ b/docs/specs/modules/fix_1948_s4_nowcast_sms_zielbild.md
@@ -276,6 +276,12 @@ Preview-Abhängigkeit vom Onset-Pfad.
   - **Längen-Budget insgesamt unkritisch** (Limit 140, harter Endschnitt `body[:limit]`):
     Trip mit Segmentnamen +3 Zeichen, Trip-km-Rückfall +4 Zeichen, Compare mit kurzem
     Ortsnamen −4 Zeichen (kürzer als vorher), nur der lange Ortsname wächst nennenswert.
+  - **2026-08-23 geschlossen (#2078):** Der harte Endschnitt `body[:limit]` konnte bei
+    ausreichend langem Ortsnamen mitten ins Zeit-Token schneiden (`Sa0:40` → `Sa0:4`,
+    liest sich wie eine andere echte Uhrzeit). Fix in
+    `docs/specs/modules/fix_2078_onset_sms_zeit_token_schnitt.md`: Kopf-Anteil wird jetzt
+    VOR dem Zusammenbau auf 24 Zeichen gekappt (analog `_render_sms_corridor_only`), der
+    harte Endschnitt bleibt als Sicherheitsnetz bestehen.
 - **Kurznachricht wertet weiterhin nur das führende Event aus** — kein `+N`-Zähler, PO-Entscheid
   3b. Bei mehreren gleichzeitig auslösenden Orten verschweigt die Nachricht die übrigen; das
   ist gewollt (ein Zähler würde Vollständigkeit versprechen, die er nicht einlöst), gehört aber

--- a/docs/specs/modules/fix_2078_onset_sms_zeit_token_schnitt.md
+++ b/docs/specs/modules/fix_2078_onset_sms_zeit_token_schnitt.md
@@ -1,0 +1,242 @@
+---
+entity_id: fix_2078_onset_sms_zeit_token_schnitt
+type: bugfix
+created: 2026-08-23
+updated: 2026-08-23
+status: draft
+workflow: fix-2078-onset-sms-zeit-token-schnitt
+---
+
+# Onset-Kurznachricht: Kopf vor dem Zeit-Token kappen statt den fertigen Text hart zu schneiden (#2078)
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+`_render_sms_onset` und `_render_sms_onset_shift_only` bauen den Kopf (Ortsname) ohne
+Längenbegrenzung und schneiden danach den fertigen Text stur bei `limit` (Default 140)
+ab. Bei ausreichend langem Ortsnamen trifft dieser Endschnitt mitten ins Zeit-Token —
+die Kurznachricht (SMS/Premium-SMS/Telegram-Kurzstil) trägt dann eine **inhaltlich
+falsche** statt einer fehlenden Uhrzeit (`Sa0:40` → `Sa0:4`, liest sich wie eine andere
+echte Uhrzeit). Fix: den Kopf VOR dem Zusammensetzen kappen (analog zum etablierten
+Muster in `_render_sms_corridor_only`) — die Zeit-Aussage bleibt dadurch bei jeder
+Kopflänge vollständig, nur der Ortsname wird im Extremfall kürzer.
+
+## Source
+
+- **File:** `src/output/renderers/alert/render.py`
+- **Identifier:** `_render_sms_onset` (Zeilen 895-964), `_render_sms_onset_shift_only`
+  (Zeilen 466-471)
+
+Schicht: **Python-Core** (Renderer). Keine Go-Änderung, keine Frontend-Änderung.
+
+## Estimated Scope
+
+- **LoC:** ca. +6/-2 in `render.py` (zwei Kopf-Zeilen je einen `[:24]`-Zuschnitt);
+  Test-LoC deutlich höher (neue Verhaltens-Testdatei mit ~7 ACs)
+- **Files:** 1 Produktivdatei, 1 neue Testdatei
+- **Effort:** low — lokal begrenzte Änderung an zwei strukturell identischen
+  Zweigen, kein Datenmodell-, kein API-Vertrag berührt
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `_ascii_alert_location` (`render.py:1611-1621`) | Funktion | erzeugt den Kopf-Rohtext (Piktogramm-Entfernung + ASCII/GSM-7-Faltung); MUSS weiterhin VOR der neuen Kappung laufen, sonst zählt die Kappung Unicode-Codepoints statt gefalteter Zeichen |
+| `_render_sms_corridor_only` (`render.py:1420-1438`) | Funktion | Referenzmuster für die Kopf-Kappung (`trip[:16]`, `location_label[:24]`/`where[:24]`) — wird nicht verändert, nur als Vorbild übernommen |
+| `_sms_onset_time` / `_sms_onset_ende` / `_sms_onset_menge` / `_sms_onset_sharpness_marker` (`render.py`) | Funktionen | bauen das Zeit-/Mengen-Token; bleiben unverändert — die Spec ändert ausschließlich den Kopf-Anteil `head` |
+| `_sms_onset_shift_token` (`render.py:430-437`) | Funktion | baut das Verschiebungs-Token in `_render_sms_onset_shift_only`; bleibt unverändert |
+| `notification_service.py:1598,1666,1680` | Aufrufer | konsumiert `sms_body` unverändert für SMS, Premium-SMS und Telegram-Kurzstil — kein Aufrufer-Code ändert sich |
+| `docs/specs/modules/fix_1935_1779_alarm_nachricht_klarheit.md` | Spec | legt die `[:24]`-Kopf-Kappung als Konvention für den Nachbarzweig fest — diese Spec überträgt sie auf die beiden verbliebenen Ausreißer |
+| `docs/specs/modules/fix_1948_s4_nowcast_sms_zielbild.md` | Spec | Ursprungs-Spec von `_render_sms_onset`; „Known Limitations" dort benannte das Risiko bereits als „geerbtes Risiko" — diese Spec schließt es |
+| `docs/specs/modules/fix_2051_s1_ende_und_dauer.md` | Spec | führte das zweite Zeit-Token (Ende-Suffix) ein, wodurch der Kopf-Endschnitt-Konflikt real wurde |
+
+## Scope
+
+### Affected Files
+
+| File | Change Type | Description |
+|------|-------------|--------------|
+| `src/output/renderers/alert/render.py` | MODIFY | `_render_sms_onset`: `head` mit `[:24]` kappen, bevor `body = f"{head}: {token}"` gebaut wird. `_render_sms_onset_shift_only`: identische Kappung auf `_onset_shift_location(msg)` |
+| `tests/tdd/test_alert_sms_onset_zeit_token_kappung.py` | CREATE | neue Verhaltens-Testdatei für diese Spec (Name nach Verhalten, nicht nach Issue-Nummer) |
+
+### Estimated Changes
+
+- Files: 2
+- LoC: +6/-2 (Produktivcode), Testdatei separat
+
+## Implementation Details
+
+In `_render_sms_onset` (`render.py:957-963`) wird jeder der drei Kopf-Zweige VOR dem
+Zusammensetzen mit `body = f"{head}: {token}"` auf 24 Zeichen gekappt — analog zu
+`location_label[:24]` in `_render_sms_corridor_only`:
+
+```
+if getattr(e, "location_label", None):
+    head = _ascii_alert_location(e.location_label)[:24]
+elif msg.source == COMPARE_RADAR_SOURCE:
+    head = _ascii_alert_location(msg.trip_short)[:24]
+else:
+    head = _ascii_alert_location(_location_of((e,), None))[:24]
+body = f"{head}: {token}"
+return body if len(body) <= limit else body[:limit]
+```
+
+Die Reihenfolge bleibt bewusst: `_ascii_alert_location` (Piktogramm-Entfernung +
+ASCII/GSM-7-Faltung) läuft ZUERST, `[:24]` schneidet danach den bereits gefalteten
+Text — sonst zählt die Kappung Unicode-Codepoints eines Piktogramms statt sichtbarer
+ASCII-Zeichen, und die Grenze verschiebt sich unvorhersehbar.
+
+In `_render_sms_onset_shift_only` (`render.py:466-471`) analog:
+
+```
+head = f"{_ascii_alert_location(_onset_shift_location(msg))[:24]}: "
+body = head + " ".join(
+    _sms_onset_shift_token(oe) for oe in msg.onset_shift_events
+)
+return body if len(body) <= limit else body[:limit]
+```
+
+Der harte Endschnitt (`body[:limit]`, Default 140) bleibt in beiden Funktionen
+UNVERÄNDERT als Sicherheitsnetz bestehen — er greift im Normalfall nach der Kopf-Kappung
+nicht mehr, ist aber weiterhin die letzte Instanz gegen ein Überlaufen des Limits (z. B.
+bei mehreren Tokens in `onset_shift_events` oder einem sehr kleinen, vom Aufrufer
+übergebenen `limit`).
+
+## Expected Behavior
+
+- **Input:** `AlertMessage`/`OnsetEvent`/`OnsetShiftEvent` mit einem Ortsnamen
+  (`location_label`, `trip_short` oder aufgelöster Segmentname), der nach ASCII-Faltung
+  länger als 24 Zeichen ist.
+- **Output:** Der Kopf-Anteil der Kurznachricht (vor dem `": "`) ist auf maximal 24
+  Zeichen gekappt; das/die nachfolgenden Zeit-Token(s) stehen vollständig und
+  unverändert im Text — unabhängig davon, wie lang der ungekappte Ortsname gewesen wäre.
+- **Side effects:** keine. Reines Text-Rendering, keine Persistenz-, keine API-Änderung.
+  Wirkt automatisch auf alle drei Kanäle, die denselben `sms_body` konsumieren (SMS,
+  Premium-SMS, Telegram-Kurzstil).
+
+## Acceptance Criteria
+
+- **AC-1:** Given ein Trip-Onset-Alarm über `_render_sms_onset`, dessen aufgelöster
+  Ortsname (`_location_of`-Fallback, dritter Kopf-Zweig) nach ASCII-Faltung länger als
+  24 Zeichen ist / When `render_sms` rendert / Then ist der Kopf-Anteil vor dem `": "`
+  auf maximal 24 Zeichen gekappt UND das vollständige Zeit-Token (`TH@HH:MM` bzw.
+  `R@HH:MM`) steht unverändert und ungekürzt im Text.
+  - Test: `OnsetEvent` ohne `location_label`, dessen Segment-/km-Auflösung einen langen
+    Text erzeugt (oder ein präpariertes langes `trip_short` im COMPARE_RADAR_SOURCE-Zweig,
+    s. AC-2), `render_sms()` aufrufen, Kopf-Teil vor `": "` extrahieren und auf Länge
+    ≤24 prüfen, Zeit-Token per Regex (`\b(TH|R)@\d{1,2}:\d{2}\b`) vollständig nachweisen.
+
+- **AC-2:** Given ein Ortsvergleich-Alarm mit genau einem Ort (`msg.source ==
+  COMPARE_RADAR_SOURCE`, `location_label is None`, `msg.trip_short` länger als 24
+  Zeichen) / When `render_sms` rendert / Then ist der Kopf auf 24 Zeichen gekappt und
+  das Zeit-Token bleibt vollständig lesbar, unabhängig von der Kopflänge.
+  - Test: `AlertMessage` mit `source=COMPARE_RADAR_SOURCE` und einem langen
+    `trip_short` (z. B. einem konkatenierten, real langen Ortsnamen aus dem
+    Testbestand) bauen, `render_sms()` aufrufen, Kopf-Länge und Token-Vollständigkeit
+    wie AC-1 prüfen.
+
+- **AC-3:** Given ein gebündelter Ortsvergleich-Alarm (`OnsetEvent.location_label`
+  gesetzt, länger als 24 Zeichen) / When `render_sms` rendert / Then ist der Kopf
+  gekappt und das Zeit-Token vollständig — derselbe Nachweis wie AC-1/AC-2, aber für den
+  ersten der drei Kopf-Zweige (`location_label` gesetzt).
+  - Test: `OnsetEvent(location_label=<langer Ortsname>)` bauen, `render_sms()` aufrufen,
+    Kopf-Länge ≤24 und Zeit-Token vollständig per Regex prüfen.
+
+- **AC-4:** Given einen kurzen, alltagstypischen Ortsnamen (≤24 Zeichen nach
+  ASCII-Faltung, Normalfall) / When `render_sms` über `_render_sms_onset` rendert /
+  Then ist die Ausgabe byte-identisch zum Verhalten vor diesem Fix — die Kappungsgrenze
+  darf im Alltag nicht sichtbar werden (Regressionsschutz).
+  - Test: bestehende Fixture aus `tests/tdd/test_alert_sms_onset_zeitpunkt.py`
+    (`_onset_event()`, kurzer Ort) erneut durch `render_sms()` schicken und auf den
+    bereits bekannten Goldstring (`"km 8-8: TH@15:40"`) prüfen — muss unverändert
+    grün bleiben.
+
+- **AC-5:** Given einen `_render_sms_onset_shift_only`-Alarm mit einem Ortsnamen länger
+  als 24 Zeichen / When `render_sms` über den Onset-Shift-Zweig rendert / Then ist der
+  Kopf auf 24 Zeichen gekappt UND das Verschiebungs-Token (`_sms_onset_shift_token`,
+  Uhrzeit + Richtungswort) steht vollständig und unverändert im Text.
+  - Test: `AlertMessage` mit `onset_shift_events` und langem, auflösbarem
+    Ortsbezug bauen (Route ohne `events`/`corridor_events`, damit `_render_sms_body` in
+    den Shift-Zweig verzweigt), `render_sms()` aufrufen, Kopf-Länge ≤24 und
+    vollständiges Token (`to_time` + `shift_text`) per String-Suche nachweisen.
+
+- **AC-6:** Given einen laufenden Nowcast-Alarm (`already_running=True`, Issue #2050
+  S2b, `now`-Token statt Beginn-Zeit) mit einem Ortsnamen länger als 24 Zeichen / When
+  `render_sms` rendert / Then ist der Kopf gekappt und das `now`-Token samt
+  Ende-Grammatik (`now@HH:MM` bzw. `now >@HH:MM`) bleibt vollständig erhalten — der
+  `already_running`-Zweig baut denselben `head` wie der Normalfall und ist von der
+  Kappung ebenso betroffen.
+  - Test: `OnsetEvent(already_running=True, ...)` mit langem Ortsnamen bauen,
+    `render_sms()` aufrufen, Kopf-Länge ≤24 prüfen und `"now"` samt anschließendem
+    Zeit-/Grenz-Token vollständig im Text nachweisen (kein abgeschnittenes `no`/`now@1`).
+
+- **AC-7:** Given ein Onset-Ereignis mit ZWEI Zeit-Token (Beginn UND Ende-Suffix,
+  Issue #2051 S1, `event_end_time` gesetzt) und einem Ortsnamen länger als 24 Zeichen /
+  When `render_sms` rendert / Then bleiben BEIDE Zeit-Token (Beginn-Zeitpunkt und
+  Ende-Suffix `@HH:MM` bzw. `>@HH:MM`) vollständig erhalten — genau der Fall, der den
+  Bug laut Issue #2078 erst real gemacht hat, weil zwei Token statt einem am
+  Zeilenende stehen.
+  - Test: `OnsetEvent` mit gesetztem `event_end_time` (bzw. dem für den
+    Ende-Suffix nötigen Feld-Kombination aus `fix_2051_s1_ende_und_dauer.md`) und
+    langem Ortsnamen bauen, `render_sms()` aufrufen, beide Zeit-Token per Regex
+    vollständig nachweisen (kein abgeschnittenes Suffix am Textende).
+
+- **AC-8:** Given einen absurd langen Kopf-Rohtext, der auch nach der 24-Zeichen-Kappung
+  plus Token-Anteil das Gesamtlimit (`limit`-Parameter) überschreiten würde (z. B.
+  `limit` bewusst klein gewählt, etwa `limit=10`) / When `render_sms`/`_render_sms_onset`
+  mit diesem `limit` rendert / Then greift weiterhin der harte Endschnitt
+  `body[:limit]` — die Ausgabe ist nie länger als `limit` Zeichen, kein Crash, kein
+  Overflow (Regressionsschutz für das bestehende Sicherheitsnetz).
+  - Test: `_render_sms_onset`/`_render_sms_onset_shift_only` direkt mit kleinem
+    `limit`-Wert aufrufen (bestehendes Muster aus den Signatur-Tests dieser Funktionen),
+    `len(ergebnis) <= limit` prüfen.
+
+- **AC-9:** Given einen Ortsnamen, der ein Piktogramm ODER GSM-7-Extension-Zeichen
+  enthält (z. B. `~`, das auf `-` gefaltet wird) UND lang genug ist, um die
+  24-Zeichen-Grenze zu berühren / When `render_sms` rendert / Then laufen
+  Piktogramm-Entfernung und ASCII/GSM-7-Faltung (`_ascii_alert_location`) VOR der
+  neuen 24-Zeichen-Kappung — die Kappung zählt sichtbare ASCII-Zeichen des bereits
+  gefalteten Texts, nicht Unicode-Codepoints des Rohtexts.
+  - Test: `OnsetEvent`/`AlertMessage` mit einem Ortsnamen bauen, der ein Piktogramm
+    (z. B. 🏁) und danach ausreichend viele Zeichen enthält, sodass ein Zählen VOR der
+    Faltung eine andere Kapp-Stelle träfe als ein Zählen NACH der Faltung;
+    `render_sms()` aufrufen und den Kopf-Text gegen den erwarteten, bereits gefalteten
+    und auf 24 Zeichen gekappten Text vergleichen (kein Piktogramm-Rest, keine
+    GSM-7-Extension-Zeichen im Kopf).
+
+## Out of Scope
+
+- **`_render_sms_body`-Fallback-Kopf** (`render.py:1530`, Trip-Δ-Pfad ohne
+  `location_positions`/`multi_location`/`location_label`, nutzt `_km_str(msg)`): trägt
+  denselben ungekappten Kopf + harten Endschnitt, ist aber laut Kontext-Analyse
+  strukturell geringeres Risiko — `_km_str` liefert typischerweise kurze km-Spannen/
+  Segmentnamen, kein frei langer, nutzergesteuerter Ortsname. Kein konkreter
+  Fehlerfall belegt. Bei Bedarf als Eintrag in Sammel-Issue #1199 nachtragen, nicht
+  Teil dieser Scheibe.
+- **Zentrale `limit`-Konstante** (aktuell dreifach als Default `140` dupliziert): rein
+  kosmetisch, nicht Teil dieser Scheibe.
+
+## Known Limitations
+
+- Die 24-Zeichen-Grenze ist aus dem bestehenden Nachbarzweig (`_render_sms_corridor_only`)
+  übernommen, nicht neu hergeleitet — sie ist die im Projekt bereits etablierte Konvention
+  für SMS-Kopf-Ortstexte und wird hier bewusst NICHT neu bemessen.
+- Der harte Endschnitt `body[:limit]` kann in seltenen Extremfällen (sehr viele
+  Tokens/`onset_shift_events`, sehr kleines `limit`) weiterhin mitten in ein Token
+  schneiden — dieses Restrisiko ist mit AC-8 als bestehendes, bewusst beibehaltenes
+  Sicherheitsnetz dokumentiert, nicht Ziel dieser Spec, das restlos auszuschließen.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** lokale Rendering-Korrektur innerhalb eines bestehenden, bereits per
+  ADR-0011 (ein Backend-Renderer für alle vier Kanäle) etablierten Musters — keine neue
+  Entscheidungsfläche (kein Kanal, kein Provider, kein Datenmodell, kein Auth-Aspekt
+  betroffen).
+
+## Changelog
+
+- 2026-08-23: Initial spec created

--- a/src/output/renderers/alert/render.py
+++ b/src/output/renderers/alert/render.py
@@ -464,7 +464,7 @@ def _render_email_onset_shift_only(msg: AlertMessage) -> tuple[str, str]:
 
 
 def _render_sms_onset_shift_only(msg: AlertMessage, limit: int) -> str:
-    head = f"{_ascii_alert_location(_onset_shift_location(msg))}: "
+    head = f"{_ascii_alert_location(_onset_shift_location(msg))[:24]}: "
     body = head + " ".join(
         _sms_onset_shift_token(oe) for oe in msg.onset_shift_events
     )
@@ -955,11 +955,11 @@ def _render_sms_onset(msg: AlertMessage, limit: int = 140) -> str:
     else:
         token = f"R{menge}@{zeit}"
     if getattr(e, "location_label", None):
-        head = _ascii_alert_location(e.location_label)
+        head = _ascii_alert_location(e.location_label)[:24]
     elif msg.source == COMPARE_RADAR_SOURCE:
-        head = _ascii_alert_location(msg.trip_short)
+        head = _ascii_alert_location(msg.trip_short)[:24]
     else:
-        head = _ascii_alert_location(_location_of((e,), None))
+        head = _ascii_alert_location(_location_of((e,), None))[:24]
     body = f"{head}: {token}"
     return body if len(body) <= limit else body[:limit]
 

--- a/tests/tdd/test_alert_sms_onset_zeit_token_kappung.py
+++ b/tests/tdd/test_alert_sms_onset_zeit_token_kappung.py
@@ -1,0 +1,339 @@
+"""TDD RED — Issue #2078: Kopf vor dem Zeit-Token kappen statt den fertigen
+Text hart zu schneiden.
+
+SPEC: docs/specs/modules/fix_2078_onset_sms_zeit_token_schnitt.md (AC-1..AC-9)
+
+`_render_sms_onset` und `_render_sms_onset_shift_only` bauen den Kopf
+(Ortsname) heute OHNE Laengenbegrenzung und schneiden danach den fertigen
+Text stur bei `limit` ab. Bei einem ausreichend langen Ortsnamen trifft
+dieser Endschnitt mitten ins Zeit-Token (`Sa0:40` -> `Sa0:4`) -- eine
+inhaltlich FALSCHE statt einer fehlenden Uhrzeit. Der Fix kappt den Kopf VOR
+dem Zusammensetzen auf 24 Zeichen (Muster `_render_sms_corridor_only`).
+
+RED-Ursache: `head` traegt heute keinen `[:24]`-Zuschnitt. Bei den Faellen
+mit langem Ortsnamen (AC-1/2/3/5/6/7/9) ist der Kopf im Ist-Zustand LAENGER
+als 24 Zeichen -- die Laengen- und Gleichheits-Assertions schlagen rot.
+AC-4 (kurzer Ortsname) und AC-8 (harter Endschnitt bei kleinem `limit`)
+pruefen bestehendes, vom Fix UNBERUEHRTES Verhalten und sind bewusst als
+Regressionsschutz bereits heute gruen (Muster `test_alert_sms_onset_
+zeitpunkt.py::test_ac10_...`, "Nicht-Beruehrungs-Nachweis").
+
+Mock-frei: echte `OnsetEvent`/`OnsetShiftEvent`/`AlertMessage`-Objekte durch
+den echten Renderer. Alle Zeiten sind FEST gesetzt (keine Wanduhr).
+"""
+from __future__ import annotations
+
+import re
+
+from output.renderers.alert.model import AlertMessage, OnsetEvent, OnsetShiftEvent
+from output.renderers.alert.render import render_sms
+
+_ZEITPUNKT_TOKEN_RE = re.compile(r"\b(TH|R)@(\d{1,2}):(\d{2})\b")
+_ZEITPUNKT_MIT_ENDE_RE = re.compile(
+    r"\b(TH|R)@(\d{1,2}):(\d{2})@(\d{1,2}):(\d{2})\b"
+)
+_NOW_MIT_ENDE_RE = re.compile(r"\bnow@(\d{1,2}):(\d{2})\b")
+
+
+def _onset_event(**kw) -> OnsetEvent:
+    """Ein Trip-Radar-Onset-Ereignis mit festen Feldern (keine Wanduhr) --
+    dieselben Default-Werte wie `test_alert_sms_onset_zeitpunkt.py::
+    _onset_event`, damit der Goldstring 'km 8-8: TH@15:40' aus AC-4 der dort
+    bereits bewiesene ist."""
+    fields = dict(
+        onset_minutes=8, onset_time="15:40", km_from=8.0, km_to=8.0,
+        is_convective=True, intensity_label="Gewitter mit Hagel",
+        source_label="Radar (ICON-D2)",
+    )
+    fields.update(kw)
+    return OnsetEvent(**fields)
+
+
+def _onset_msg(event: OnsetEvent, *, trip_short: str = "KHW 403",
+               source: str = "radar") -> AlertMessage:
+    """`source is not None` routet `render_sms` in den Onset-Zweig."""
+    return AlertMessage(
+        trip_short=trip_short, stand_at="10:00", events=(event,), source=source,
+    )
+
+
+def _kopf(sms: str) -> str:
+    """Der Kopf-Anteil vor dem ': ' -- die Ortsangabe der Kurznachricht."""
+    assert ": " in sms, f"Kurznachricht hat keinen '<Ort>: <Token>'-Aufbau: {sms!r}"
+    return sms.split(": ", 1)[0]
+
+
+def _langer_name(n: int = 30) -> str:
+    """ASCII-Ortsname, garantiert laenger als die 24-Zeichen-Kappgrenze."""
+    name = "Obertilliacher Bergwiesenalm".ljust(n, "x")
+    assert len(name) == n and n > 24, "Vorbedingung: Name muss die Grenze ueberschreiten"
+    return name
+
+
+# ---------------------------------------------------------------------------
+# AC-1 -- dritter Kopf-Zweig (km-Rueckfall ohne Segment/location_label)
+# ---------------------------------------------------------------------------
+
+
+def test_ac1_dritter_kopf_zweig_km_rueckfall_wird_auf_24_zeichen_gekappt():
+    """AC-1: Given ein Trip-Onset-Alarm, dessen aufgeloester Ortsname (dritter
+    Kopf-Zweig, `_location_of`-km-Rueckfall) nach ASCII-Faltung laenger als
+    24 Zeichen ist / When `render_sms` rendert / Then ist der Kopf auf 24
+    Zeichen gekappt UND das Zeit-Token `TH@15:40` steht vollstaendig."""
+    km_from, km_to = 11234567890.0, 98765432109.0
+    voller_kopf = f"km {int(round(km_from))}-{int(round(km_to))}"
+    assert len(voller_kopf) > 24, "Vorbedingung: ungekappter Kopf muss die Grenze beruehren"
+
+    event = _onset_event(km_from=km_from, km_to=km_to, segment_id=None)
+    sms = render_sms(_onset_msg(event))
+    kopf = _kopf(sms)
+
+    assert len(kopf) <= 24, f"Kopf ist laenger als 24 Zeichen: {kopf!r}"
+    assert kopf == voller_kopf[:24], (
+        f"Kopf muss der auf 24 Zeichen gekappte km-Rueckfall sein, "
+        f"erwartet {voller_kopf[:24]!r}, bekam {kopf!r}"
+    )
+    treffer = _ZEITPUNKT_TOKEN_RE.search(sms)
+    assert treffer and treffer.group(0) == "TH@15:40", (
+        f"Vollstaendiges Zeit-Token 'TH@15:40' fehlt oder ist beschaedigt: {sms!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-2 -- Ortsvergleich mit genau einem Ort (Kopf aus trip_short)
+# ---------------------------------------------------------------------------
+
+
+def test_ac2_compare_radar_kopf_aus_trip_short_wird_auf_24_zeichen_gekappt():
+    """AC-2: Given einen Ortsvergleich-Alarm mit genau einem Ort
+    (`source=COMPARE_RADAR_SOURCE`, `location_label is None`, langer
+    `trip_short`) / When `render_sms` rendert / Then ist der Kopf auf 24
+    Zeichen gekappt und das Zeit-Token bleibt vollstaendig."""
+    from output.renderers.alert.project import COMPARE_RADAR_SOURCE
+
+    langer_name = _langer_name()
+    msg = AlertMessage(
+        trip_short=langer_name, stand_at="10:00", events=(_onset_event(),),
+        source=COMPARE_RADAR_SOURCE,
+    )
+    sms = render_sms(msg)
+    kopf = _kopf(sms)
+
+    assert len(kopf) <= 24, f"Kopf ist laenger als 24 Zeichen: {kopf!r}"
+    assert kopf == langer_name[:24], (
+        f"Kopf muss der auf 24 Zeichen gekappte trip_short sein, "
+        f"erwartet {langer_name[:24]!r}, bekam {kopf!r}"
+    )
+    treffer = _ZEITPUNKT_TOKEN_RE.search(sms)
+    assert treffer and treffer.group(0) == "TH@15:40", (
+        f"Vollstaendiges Zeit-Token 'TH@15:40' fehlt oder ist beschaedigt: {sms!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-3 -- gebuendelter Ortsvergleich (location_label gesetzt)
+# ---------------------------------------------------------------------------
+
+
+def test_ac3_location_label_kopf_wird_auf_24_zeichen_gekappt():
+    """AC-3: Given einen gebuendelten Ortsvergleich-Alarm
+    (`OnsetEvent.location_label` gesetzt, laenger als 24 Zeichen) / When
+    `render_sms` rendert / Then ist der Kopf gekappt und das Zeit-Token
+    vollstaendig."""
+    langer_name = _langer_name()
+    sms = render_sms(_onset_msg(_onset_event(location_label=langer_name)))
+    kopf = _kopf(sms)
+
+    assert len(kopf) <= 24, f"Kopf ist laenger als 24 Zeichen: {kopf!r}"
+    assert kopf == langer_name[:24], (
+        f"Kopf muss der auf 24 Zeichen gekappte location_label sein, "
+        f"erwartet {langer_name[:24]!r}, bekam {kopf!r}"
+    )
+    treffer = _ZEITPUNKT_TOKEN_RE.search(sms)
+    assert treffer and treffer.group(0) == "TH@15:40", (
+        f"Vollstaendiges Zeit-Token 'TH@15:40' fehlt oder ist beschaedigt: {sms!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-4 -- Regressionsschutz: kurzer Ortsname bleibt byte-identisch
+# ---------------------------------------------------------------------------
+
+
+def test_ac4_kurzer_ortsname_bleibt_byte_identisch_zum_bisherigen_verhalten():
+    """AC-4 (Regressionsschutz): Given einen kurzen, alltagstypischen
+    Ortsnamen (<=24 Zeichen) / When `render_sms` rendert / Then bleibt die
+    Ausgabe byte-identisch zum bekannten Goldstring aus `test_alert_sms_
+    onset_zeitpunkt.py::test_ac1_...` -- die neue Kappgrenze darf im Alltag
+    nicht sichtbar werden. Bewusst bereits heute gruen (Nicht-Beruehrungs-
+    Nachweis, unbetroffen vom Fix)."""
+    sms = render_sms(_onset_msg(_onset_event()))
+
+    assert sms == "km 8-8: TH@15:40", (
+        f"Erwartet unveraendert 'km 8-8: TH@15:40', bekam {sms!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-5 -- Onset-Shift-Zweig
+# ---------------------------------------------------------------------------
+
+
+def test_ac5_onset_shift_kopf_wird_auf_24_zeichen_gekappt():
+    """AC-5: Given einen `_render_sms_onset_shift_only`-Alarm mit einem
+    Ortsnamen laenger als 24 Zeichen / When `render_sms` ueber den
+    Onset-Shift-Zweig rendert / Then ist der Kopf gekappt UND das
+    Verschiebungs-Token (`to_time` + `shift_text`) steht vollstaendig."""
+    langer_name = _langer_name()
+    shift = OnsetShiftEvent(
+        metric_id="precipitation", from_time="17:00", to_time="15:00",
+        shift_text="2 h früher", km_from=8.0, km_to=8.0,
+    )
+    msg = AlertMessage(
+        trip_short="KHW 403", stand_at="10:00", events=(),
+        location_label=langer_name, onset_shift_events=(shift,),
+    )
+    sms = render_sms(msg)
+    kopf = _kopf(sms)
+
+    assert len(kopf) <= 24, f"Kopf ist laenger als 24 Zeichen: {kopf!r}"
+    assert kopf == langer_name[:24], (
+        f"Kopf muss der auf 24 Zeichen gekappte location_label sein, "
+        f"erwartet {langer_name[:24]!r}, bekam {kopf!r}"
+    )
+    assert f"{shift.to_time} {shift.shift_text}" in sms, (
+        f"Verschiebungs-Token (to_time + shift_text) muss vollstaendig "
+        f"erhalten bleiben: {sms!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-6 -- laufender Nowcast-Alarm (already_running)
+# ---------------------------------------------------------------------------
+
+
+def test_ac6_already_running_kopf_wird_auf_24_zeichen_gekappt_now_token_bleibt_ganz():
+    """AC-6: Given einen laufenden Nowcast-Alarm (`already_running=True`) mit
+    einem Ortsnamen laenger als 24 Zeichen / When `render_sms` rendert / Then
+    ist der Kopf gekappt und das `now`-Token samt Ende-Grammatik bleibt
+    vollstaendig erhalten."""
+    langer_name = _langer_name()
+    event = _onset_event(
+        location_label=langer_name, already_running=True, event_end_time="20:00",
+    )
+    sms = render_sms(_onset_msg(event))
+    kopf = _kopf(sms)
+
+    assert len(kopf) <= 24, f"Kopf ist laenger als 24 Zeichen: {kopf!r}"
+    assert kopf == langer_name[:24], (
+        f"Kopf muss der auf 24 Zeichen gekappte location_label sein, "
+        f"erwartet {langer_name[:24]!r}, bekam {kopf!r}"
+    )
+    treffer = _NOW_MIT_ENDE_RE.search(sms)
+    assert treffer and treffer.group(0) == "now@20:00", (
+        f"'now'-Token samt Ende-Grammatik muss vollstaendig erhalten bleiben "
+        f"(kein abgeschnittenes 'no'/'now@2'): {sms!r}"
+    )
+    assert sms.endswith("TH now@20:00"), (
+        f"Erwartet Endung 'TH now@20:00', bekam {sms!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-7 -- zwei Zeit-Token (Beginn UND Ende-Suffix)
+# ---------------------------------------------------------------------------
+
+
+def test_ac7_beide_zeit_token_bleiben_vollstaendig_bei_langem_kopf():
+    """AC-7: Given ein Onset-Ereignis mit ZWEI Zeit-Token (Beginn UND
+    Ende-Suffix, `event_end_time` gesetzt) und einem Ortsnamen laenger als 24
+    Zeichen / When `render_sms` rendert / Then bleiben BEIDE Zeit-Token
+    vollstaendig erhalten -- genau der Fall, der den Bug laut Issue #2078
+    erst real gemacht hat."""
+    langer_name = _langer_name()
+    event = _onset_event(location_label=langer_name, event_end_time="20:00")
+    sms = render_sms(_onset_msg(event))
+    kopf = _kopf(sms)
+
+    assert len(kopf) <= 24, f"Kopf ist laenger als 24 Zeichen: {kopf!r}"
+    assert kopf == langer_name[:24], (
+        f"Kopf muss der auf 24 Zeichen gekappte location_label sein, "
+        f"erwartet {langer_name[:24]!r}, bekam {kopf!r}"
+    )
+    treffer = _ZEITPUNKT_MIT_ENDE_RE.search(sms)
+    assert treffer and treffer.group(0) == "TH@15:40@20:00", (
+        f"Beide Zeit-Token (Beginn UND Ende-Suffix) muessen vollstaendig "
+        f"erhalten bleiben, kein abgeschnittenes Suffix am Textende: {sms!r}"
+    )
+    assert sms.endswith("TH@15:40@20:00"), (
+        f"Erwartet Endung 'TH@15:40@20:00', bekam {sms!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-8 -- Regressionsschutz: harter Endschnitt bleibt Sicherheitsnetz
+# ---------------------------------------------------------------------------
+
+
+def test_ac8_harter_endschnitt_bleibt_sicherheitsnetz_fuer_render_sms_onset():
+    """AC-8 (Regressionsschutz): Given einen absurd kleinen `limit`-Wert /
+    When `_render_sms_onset` direkt rendert / Then greift weiterhin der
+    harte Endschnitt `body[:limit]` -- die Ausgabe ist nie laenger als
+    `limit`. Bewusst bereits heute gruen: der harte Endschnitt selbst ist
+    vom Fix unveraendert."""
+    from output.renderers.alert.render import _render_sms_onset
+
+    msg = _onset_msg(_onset_event(location_label=_langer_name()))
+    ergebnis = _render_sms_onset(msg, limit=10)
+
+    assert len(ergebnis) <= 10, (
+        f"Harter Endschnitt (Sicherheitsnetz) muss weiterhin greifen, "
+        f"bekam {len(ergebnis)} Zeichen: {ergebnis!r}"
+    )
+
+
+def test_ac8_harter_endschnitt_bleibt_sicherheitsnetz_fuer_render_sms_onset_shift_only():
+    """AC-8 (Regressionsschutz), zweite Aufrufstelle: dasselbe fuer
+    `_render_sms_onset_shift_only`."""
+    from output.renderers.alert.render import _render_sms_onset_shift_only
+
+    shift = OnsetShiftEvent(
+        metric_id="precipitation", from_time="17:00", to_time="15:00",
+        shift_text="2 h früher", km_from=8.0, km_to=8.0,
+    )
+    msg = AlertMessage(
+        trip_short="KHW 403", stand_at="10:00", events=(),
+        location_label=_langer_name(), onset_shift_events=(shift,),
+    )
+    ergebnis = _render_sms_onset_shift_only(msg, limit=10)
+
+    assert len(ergebnis) <= 10, (
+        f"Harter Endschnitt (Sicherheitsnetz) muss weiterhin greifen, "
+        f"bekam {len(ergebnis)} Zeichen: {ergebnis!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-9 -- Reihenfolge: Piktogramm/GSM-7-Faltung VOR der 24-Zeichen-Kappung
+# ---------------------------------------------------------------------------
+
+
+def test_ac9_piktogramm_entfernung_und_ascii_faltung_laufen_vor_der_kappung():
+    """AC-9: Given einen Ortsnamen mit Piktogramm gefolgt von ausreichend
+    vielen Zeichen, sodass ein Zaehlen VOR der Faltung eine andere
+    Kapp-Stelle traefe als ein Zaehlen NACH der Faltung / When `render_sms`
+    rendert / Then zaehlt die Kappung die sichtbaren ASCII-Zeichen des
+    bereits gefalteten Texts -- kein Piktogramm-Rest im Kopf."""
+    roh = "\U0001F3C1 " + "A" * 30  # Piktogramm + Leerzeichen + 30x 'A'
+    gefaltet = "A" * 30
+    assert len(gefaltet) > 24, "Vorbedingung: gefalteter Text muss die Grenze beruehren"
+
+    sms = render_sms(_onset_msg(_onset_event(location_label=roh)))
+    kopf = _kopf(sms)
+
+    assert kopf == gefaltet[:24], (
+        f"Kappung muss NACH Piktogramm-Entfernung/ASCII-Faltung zaehlen, "
+        f"erwartet {gefaltet[:24]!r} (24x 'A'), bekam {kopf!r}"
+    )
+    assert "\U0001F3C1" not in sms, f"Piktogramm-Rest in der Kurznachricht: {sms!r}"
+    assert sms.isascii(), f"Kurznachricht ist nicht ASCII-rein: {sms!r}"


### PR DESCRIPTION
_render_sms_onset und _render_sms_onset_shift_only kappten bislang den
fertigen Text erst am Ende hart bei limit, wodurch ein langer Ortsname
das Zeit-Token mittendurch schneiden konnte (Sa0:40 -> Sa0:4, liest sich
wie eine andere echte Uhrzeit). Jetzt wird der Kopf-Anteil analog zu
_render_sms_corridor_only vor dem Zusammensetzen auf 24 Zeichen gekappt,
das Zeit-Token bleibt dadurch bei jeder Kopflaenge vollstaendig.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RJmAfTDnRDzAp32Ckm9kEZ
