### PR TITLE
fix(#2096): Tagesbezug-Testwaechter statt nackter HH:MM-Anker

### DIFF
--- a/docs/context/fix-2096-paritaets-regex-tagesbezug.md
+++ b/docs/context/fix-2096-paritaets-regex-tagesbezug.md
@@ -1,0 +1,189 @@
+# Kontext — fix-2096-paritaets-regex-tagesbezug
+
+**Issue:** [#2096](https://github.com/henemm/gregor_zwanzig/issues/2096) — CI-Ampel wird abends rot
+**Typ:** Bug (Testfehler, kein Produktivdefekt)
+**Branch:** `fix-2096-paritaets-regex-tagesbezug` (von `origin/main` @ `f56e01fd`)
+
+## Symptom
+
+Ab ~21:05 UTC scheitert der CI-Check `test` auf **jedem** PR im Repo, unabhängig vom Inhalt.
+Belegt an PR #2095 (ändert ausschließlich zwei Markdown-Dateien).
+
+## Gemessener Blast Radius
+
+Nachgemessen am 2026-08-22 zwischen 23:05 und 23:15 UTC auf `origin/main`, Testlauf mit den
+echten CI-Flags (`--disable-socket --allow-unix-socket --allow-hosts=127.0.0.1,::1,localhost`).
+**Sieben** Tests rot — das Ticket nannte nur vier davon.
+
+| # | Datei | Tests | Mechanismus |
+|---|---|---|---|
+| 1 | `tests/tdd/test_onset_reichweite_guete_kanalparitaet.py` | 2 | A |
+| 2 | `tests/tdd/test_onset_ende_kanalparitaet.py` | 2 | A |
+| 3 | `tests/tdd/test_alert_preview_nowcast_replay.py` | 1 | A |
+| 4 | `tests/tdd/test_onset_ende_textstellen.py` | 1 | A |
+| 5 | `tests/tdd/test_952_onset_alert_fidelity.py` | 2 | B |
+
+**Acht** rote Tests in **fünf** Dateien. Das Ticket nannte vier davon.
+
+### Mechanismus A — Uhrzeit-Regex trifft den Tagesbezug nicht
+
+Die Tests ankern per Regex unmittelbar auf `\d{1,2}:\d{2}`:
+
+| Ort | Regex |
+|---|---|
+| `test_onset_reichweite_guete_kanalparitaet.py:80` | `r"Radar reicht bis (\d{1,2}:\d{2})"` |
+| `test_onset_reichweite_guete_kanalparitaet.py:81` | `r"Ortsangabe ab (\d{1,2}:\d{2}) unscharf"` |
+| `test_onset_reichweite_guete_kanalparitaet.py:83` | `r"@(?P<beginn>\d{1,2}:\d{2})\?"` |
+| `test_onset_ende_kanalparitaet.py:60` | `r"letzter Regen gegen (\d{1,2}:\d{2})"` |
+| `test_alert_preview_nowcast_replay.py:335` | `r"Radar reicht bis (\d{2}:\d{2})"` |
+| `test_onset_ende_textstellen.py:61` (`_LANGFORM_RE`, wirksam ab `:382`) | `letzter Regen gegen (\d{1,2}:\d{2})` |
+
+Fällt die Zeitangabe auf den Folgetag, stellt der Renderer korrekt einen Qualifier voran und der
+Anker trifft nicht mehr:
+
+| Fläche | Erzeuger | Ist-Text |
+|---|---|---|
+| Langform | `src/output/renderers/alert/render.py:214-240` (`_time_with_day`) | `Radar reicht bis morgen 00:12` |
+| Kurzform | `src/output/renderers/alert/render.py:1387` (Wochentagskürzel) | `Seg 1: R3.0@23:25@So1:35?` |
+
+Gemessene Ist-Texte:
+
+```
+Wo & wann: km 2–6 · ab 23:28 · letzter Regen gegen morgen 01:38
+           · Radar reicht bis morgen 02:03 · Ortsangabe ab morgen 00:08 unscharf
+Trip          = 'Seg 1: R3.0@23:25@So1:35?'
+Ortsvergleich = 'Reykjavik-Paritaet-S3: R3.0@23:25@So1:35?'
+```
+
+**Kipp-Zeitpunkt je Anker** (Fixture-Offsets ab `jetzt`, Trip-Zone UTC+0):
+
+| Anker | Offset | kippt ab |
+|---|---|---|
+| Quellen-Reichweite | +175 Min | 21:05 UTC |
+| Ereignis-Ende (Reichweiten-Datei) | +150 Min | 21:30 UTC |
+| Ereignis-Ende (Ende-Datei) | +80 Min | 22:40 UTC |
+| Onset | +20 Min | 23:40 UTC |
+
+### Mechanismus B — Ortszeit-Fenster mit Systemdatum gestempelt
+
+`tests/tdd/test_952_onset_alert_fidelity.py:125-148` (`_active_window`) rechnet das Etappenfenster
+in **Ortszeit** (`tz_for_coords(42.20, 9.10)` → `Europe/Paris`, UTC+2), aber
+`:172` (`_trip_with_active_segment`) stempelt es mit `date_type.today()` — dem **Systemdatum** (UTC).
+
+Ab 22:00 UTC weichen lokales Datum und Systemdatum um einen Tag ab. Das Segment landet damit rund
+24 Stunden in der Vergangenheit, die Aktivitätsprüfung `seg.start_time <= now_utc <= seg.end_time`
+schlägt fehl und `check_radar_alerts()` liefert `0` statt `1`.
+
+## Kein Produktivdefekt
+
+Der Tagesbezug **entfernt** nichts, er macht die Angabe eindeutig (`morgen 00:12` statt eines
+mehrdeutigen `00:12`) — genau das, wofür die Spec das Feld `source_reach_day_offset` vorsieht
+(`docs/specs/modules/feat_2051_s3_reichweite_und_guete.md:291-294`). Der einzige Pfad, auf dem die
+Reichweite tatsächlich entfällt, ist E5 (`event_ongoing_beyond_horizon`,
+`src/output/renderers/alert/project.py:91-92`) — bewusst, dokumentiert, tageszeitunabhängig.
+
+Mechanismus B trifft nur die Fixture: echte Trips tragen echte `stage.date`-Werte, die nicht aus
+dem Systemdatum abgeleitet werden.
+
+**Gegengeprüft durch `analysis-challenger`** (Auftrag: Behauptung aktiv widerlegen) — Urteil
+BESTÄTIGT für alle drei Mechanismen. Der entscheidende Nachweis für den Produktivpfad:
+`src/services/trip_alert.py:1246-1249` löst „heute" **nicht** über `date.today()` auf, sondern über
+`trip_local_today(trip, now_utc)` (`src/services/trip_day.py:90-96`, Ortszeit der Tour, ADR-0044),
+und `resolve_current_segment` (`src/services/trip_segments.py:449-499`) fällt am Tagesrand
+zusätzlich auf „gestern" zurück (#1667 S3). Echte Trips tragen ein fest zugewiesenes
+Kalenderdatum — die Inkonsistenz der Fixture kann dort strukturell nicht entstehen.
+
+Zwei Punkte des Berichts waren falsch und sind nachgemessen korrigiert: `test_starkregen_kurzfristhinweis.py`
+ist nicht rot (Mechanismus C), `test_onset_ende_textstellen.py` ist rot (er hatte den falschen Test
+in der Datei geprüft).
+
+## Wächterlücke
+
+`grep -rn "source_reach_day_offset" tests/` liefert **null** Treffer. Ausgerechnet der Zweig, der
+die Ampel rot färbt, ist von keinem Test bewacht. Eine bloße Regex-Aufweichung (`(?:morgen )?`)
+ließe ihn weiterhin ungeprüft — das Muster „Test prüft die Form statt des Werts", das in dieser
+Scheibe bereits viermal zugeschlagen hat.
+
+## Mechanismus C — Test überspringt sich still statt rot zu werden
+
+`tests/tdd/test_starkregen_kurzfristhinweis.py:125` trägt denselben verwundbaren Anker
+(`:485,501`, Offset `datetime.now(timezone.utc) + timedelta(minutes=120)`), hat aber einen eigenen
+Wächter, der bei Nähe zur Mitternachtsgrenze `pytest.skip` auslöst:
+
+```
+SKIPPED [1] tests/tdd/test_starkregen_kurzfristhinweis.py:125:
+  Testzeitpunkt zu nah an einer Mitternachtsgrenze (UTC) fuer Offset-Segment
+```
+
+Keine rote Ampel — aber auch **keine Prüfung**. Der Zweig, der abends interessant wäre, ist genau
+der, den der Test dann nicht mehr durchläuft. Blindheit statt Rot; gehört in denselben Zuschnitt.
+
+## Latente Zwillinge (noch grün)
+
+Ankern onset-nah (+20 Min), kippen erst in den letzten 20 Minuten vor Mitternacht:
+
+- `tests/tdd/test_onset_kurzform_menge.py:51,239`
+- `tests/tdd/test_onset_reichweite_guete_sms.py:262`
+
+Bereits abgesichert (stellt die Uhr per `@freeze_time`, Offsets überqueren nie Mitternacht) und
+damit das Vorbild für die richtige Bauart:
+
+- `tests/tdd/test_onset_ende_untergrenze_abgrenzung.py:201ff`
+- `tests/tdd/test_ortsschaerfe_grenze_laufzeitbindung.py:49,81,151`
+
+## Ausgeschlossen: produktive Verbraucher des Tagesbezugs
+
+`grep` über `src/`, `api/`, `internal/` nach Uhrzeit-Regexen liefert genau **einen** Treffer:
+`internal/handler/compare_preset.go:39` — `^\d{2}:\d{2}(:\d{2})?$`, validiert ein Eingabefeld für
+Vergleichs-Presets, nicht den Alarmtext. Kein Produktivpfad zerlegt gerenderten Alarmtext per
+Uhrzeit-Regex; der vorangestellte Tagesbezug kann dort also nichts brechen.
+
+## Vorhandene Bausteine
+
+| Baustein | Ort | Was |
+|---|---|---|
+| `frozen_active_window(hour_utc=12)` | `tests/helpers/nowcast_gate_fixtures.py:438-473` | Contextmanager, stellt die Uhr per `freezegun` |
+| — | — | **Kein** Helfer, der `(Tageswort, "HH:MM")` aus einem Text zieht |
+
+## Technischer Ansatz
+
+Die Klammer über allen drei Mechanismen: **der Test hängt an der Wanduhr**. Vier Bausteine, die
+nur zusammen wirken — einzeln tauscht man eine Lücke gegen eine andere.
+
+1. **Geteilter Test-Helfer statt nackter HH:MM-Regexe.** Neu in `tests/helpers/`: eine Funktion,
+   die aus dem Text ein **Paar** `(Tagesbezug, "HH:MM")` zieht (Langform: `morgen`/`heute`/`gestern`/
+   `in N Tagen`; Kurzform: Wochentagskürzel `Mo`…`So`), und ein Gegenstück, das das erwartete Paar
+   aus der Ziel-UTC-Zeit **herleitet** (Datumsvergleich gegen `jetzt` in der Trip-Zone).
+   Damit ist der Tagesbezug erstmals bewacht — das schließt die `source_reach_day_offset`-Lücke.
+2. **Uhr stellen statt Wanduhr.** `frozen_active_window()`
+   (`tests/helpers/nowcast_gate_fixtures.py:438-473`) in den betroffenen Dateien einsetzen.
+3. **Eigener Spätuhr-Testfall je Mechanismus.** Punkt 2 friert den Tagesübergangs-Zweig sonst weg,
+   und Punkt 1 bewachte nichts. Jeder Anker braucht einen Fall mit später Uhr, der den Überlauf
+   tatsächlich durchläuft.
+4. **Fixture-Datum aus der Ortszeit ableiten** (`test_952_onset_alert_fidelity.py:172`), nicht aus
+   `date_type.today()`.
+
+**Warum keine Regex-Aufweichung** (`(?:morgen )?`): sie macht die Ampel grün und lässt den
+Tagesbezug ungeprüft — genau das Muster „Test prüft die Form statt des Werts", das in dieser
+Scheibe schon viermal zugeschlagen hat (`reference_test_prueft_die_form_statt_des_werts`).
+
+**Mechanismus C** (stiller Skip) verschwindet mit Punkt 2 von selbst: bei gestellter Uhr gibt es
+keinen „zu nah an Mitternacht"-Zufall mehr, den der Wächter abfangen müsste.
+
+## Scope
+
+| | |
+|---|---|
+| Dateien | 5 Testdateien (MODIFY) + 1 Helfer (CREATE) + 1–2 latente Zwillinge (MODIFY, falls günstig) |
+| Produktivcode | **keiner** |
+| Geschätzte LoC | ~+220 / -70 — nah am 250er-Limit, `loc_limit_override 500` vermutlich nötig |
+| Risiko | MEDIUM — viele Testdateien, aber kein Produktionsrisiko |
+
+## Offene Punkte
+
+- [x] Urteil des `analysis-challenger` zu Behauptung C — BESTÄTIGT
+- [x] Zuschnitt — die 8 roten plus Mechanismus C; latente Zwillinge nur, wenn der Helfer sie
+      ohnehin abdeckt
+- [ ] Nebenbefund für #1199: Ein Test, der sich bei ungünstiger Uhrzeit still selbst überspringt
+      (`test_starkregen_kurzfristhinweis.py:125`), ist als Bauart ein Wächter-Loch — lohnt eine
+      generelle Prüfung, ob es weitere solcher Selbst-Skips gibt.

--- a/docs/specs/modules/fix_2096_tagesbezug_testwaechter.md
+++ b/docs/specs/modules/fix_2096_tagesbezug_testwaechter.md
@@ -1,0 +1,246 @@
+---
+entity_id: fix_2096_tagesbezug_testwaechter
+type: module
+created: 2026-08-22
+updated: 2026-08-22
+status: draft
+version: "1.0"
+tags: [tests, ci, tagesbezug, alarm]
+---
+
+# Fix #2096 — Tagesbezug-Testwächter (CI-Ampel abends rot)
+
+## Approval
+
+- [x] Approved — PO-Freigabe 2026-08-23
+
+## Purpose
+
+Acht CI-Tests hängen an der Wanduhr und werden ab ~21:05 UTC rot, obwohl der ausgelieferte
+Alarmtext korrekt ist: Fällt eine Uhrzeitangabe (Quellen-Reichweite, Ereignis-Ende, Onset) auf den
+Folgetag, stellt der Renderer korrekt einen Tagesbezug voran (`morgen 00:12` statt `00:12`,
+Kurzform-Wochentagskürzel `So1:35`), aber die Test-Anker greifen per nackter `HH:MM`-Regex und
+treffen dann nicht mehr. Diese Spec liefert einen geteilten Test-Helfer, der den Tagesbezug
+erstmals **bewacht** statt umgeht, stellt die Uhr in den betroffenen Tests fest statt sie laufen zu
+lassen, und ergänzt je Mechanismus einen eigenen Spätuhr-Testfall, der den Tagesübergang tatsächlich
+durchläuft. Kein Produktivcode wird geändert.
+
+## Source
+
+- **File:** `tests/tdd/test_onset_reichweite_guete_kanalparitaet.py`,
+  `tests/tdd/test_onset_ende_kanalparitaet.py`, `tests/tdd/test_alert_preview_nowcast_replay.py`,
+  `tests/tdd/test_onset_ende_textstellen.py`, `tests/tdd/test_952_onset_alert_fidelity.py` (alle
+  MODIFY) sowie ein neuer Helfer unter `tests/helpers/` (CREATE)
+- **Identifier:** neue Funktion `extract_day_and_time(...)` (Text → `(Tagesbezug, "HH:MM")`) und
+  Gegenstück `expected_day_and_time(...)` (Ziel-UTC + Jetzt-UTC + Trip-Zone →
+  `(Tagesbezug, "HH:MM")`), Ort: neue Datei in `tests/helpers/`
+
+## Estimated Scope
+
+- **LoC:** ~+220 / -70 — nah am 250er-Limit, `workflow.py set-field loc_limit_override 500`
+  vermutlich nötig
+- **Files:** 5 Testdateien MODIFY + 1 Helfer CREATE (plus 1–2 latente Zwillinge MODIFY, nur falls
+  der Helfer sie ohnehin abdeckt)
+- **Effort:** medium
+
+### Affected Files
+
+| File | Change Type | Schicht | Description |
+|------|-------------|---------|-------------|
+| `tests/helpers/<neuer Helfer>.py` | CREATE | Test-Infrastruktur | `extract_day_and_time()` + `expected_day_and_time()` für Lang- und Kurzform |
+| `tests/tdd/test_onset_reichweite_guete_kanalparitaet.py` | MODIFY | Test | Anker auf Helfer umgestellt, Uhr per `frozen_active_window()` gestellt, Spätuhr-Fall für Quellen-Reichweite (Mechanismus A) |
+| `tests/tdd/test_onset_ende_kanalparitaet.py` | MODIFY | Test | Anker auf Helfer umgestellt, Uhr gestellt, Spätuhr-Fall für Ereignis-Ende (Mechanismus A) |
+| `tests/tdd/test_alert_preview_nowcast_replay.py` | MODIFY | Test | Anker auf Helfer umgestellt, Uhr gestellt, Spätuhr-Fall für den Replay-Weg (Mechanismus A) |
+| `tests/tdd/test_onset_ende_textstellen.py` | MODIFY | Test | `_LANGFORM_RE`-Anker auf Helfer umgestellt, Uhr gestellt, Spätuhr-Fall (Mechanismus A) |
+| `tests/tdd/test_952_onset_alert_fidelity.py` | MODIFY | Test | `_trip_with_active_segment()` leitet das Fixture-Datum aus der Ortszeit statt `date_type.today()` ab (Mechanismus B); Spätuhr-Regressionsfall |
+| `tests/tdd/test_starkregen_kurzfristhinweis.py` | MODIFY (falls günstig) | Test | Uhr per `frozen_active_window()` gestellt, damit der Mitternachtsgrenze-Skip entfällt (Mechanismus C) |
+
+`src/output/renderers/alert/render.py` (`_time_with_day()`) und
+`src/output/renderers/alert/project.py` (`source_reach_day_offset`) sind **nicht** Bestandteil
+dieses Scopes — sie erscheinen unten in AC-13/AC-14 ausschließlich als temporäre
+Mutations-Gegenprobe (String-Ersetzung mit externer Sicherungskopie, danach vollständig
+zurückgesetzt), nicht als Änderung.
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `frozen_active_window(hour_utc=...)` (`tests/helpers/nowcast_gate_fixtures.py:438-473`) | test helper | Stellt die Systemuhr per `freezegun`, damit Fälle nahe der Mitternachtsgrenze deterministisch werden |
+| `trip_local_today()` (`src/services/trip_day.py:90-96`, ADR-0044) | Produktivfunktion | Referenz für „heute" in Ortszeit — Vorbild für die Herleitung in `expected_day_and_time()` |
+| `_time_with_day()` (`src/output/renderers/alert/render.py:214-240`) | Produktivfunktion | Erzeugt den Tagesbezug in der Langform — Zielverhalten, das der Helfer nachvollzieht, nicht ändert |
+| `source_reach_day_offset` (`src/output/renderers/alert/project.py`) | Produktivfeld | Bisher ungetesteter Zweig, den dieser Zuschnitt erstmals bewacht |
+| Spec `feat_2051_s3_reichweite_und_guete.md` | vorausgehende Spec | Definiert `source_reach_day_offset`, dessen Lücke hier geschlossen wird |
+
+## Implementation Details
+
+Vier Bausteine, die nur zusammen wirken:
+
+1. **Geteilter Test-Helfer statt nackter `HH:MM`-Regexe.** Neue Datei unter `tests/helpers/` mit
+   zwei Funktionen:
+   - `extract_day_and_time(text, style="langform"|"kurzform")` zieht aus dem gerenderten Text ein
+     Paar `(Tagesbezug, "HH:MM")`. Langform erkennt `morgen`/`heute`/`gestern`/`in N Tagen` vor der
+     Uhrzeit (fehlt das Wort, ist der Tagesbezug `None`). Kurzform erkennt das
+     Wochentagskürzel-Präfix im Güte-Zeichen-Token (`So1:35` → `("So", "1:35")`; `23:25?` ohne
+     Kürzel → `(None, "23:25")`).
+   - `expected_day_and_time(target_utc, now_utc, trip_timezone)` bildet das **erwartete** Paar aus
+     dem Datumsvergleich zwischen `target_utc` und `now_utc`, beide auf die Trip-Zeitzone
+     projiziert: gleicher lokaler Kalendertag → `None`, ein Tag später → `"morgen"`, ein Tag früher
+     → `"gestern"`. Der erwartete Wert wird **hergeleitet**, nie als Literal im Testaufbau
+     hinterlegt (vgl. `reference_test_setzt_das_abgeleitete_als_literal`).
+2. **Uhr stellen statt Wanduhr.** In den fünf betroffenen Dateien `frozen_active_window()`
+   einsetzen, damit die bestehenden (bislang wanduhr-abhängigen) Fälle deterministisch werden.
+3. **Eigener Spätuhr-Testfall je Mechanismus.** Punkt 2 friert den Tagesübergangs-Zweig sonst weg
+   und Punkt 1 bewachte allein nichts Neues — jeder Anker (Quellen-Reichweite, Ereignis-Ende in
+   zwei Dateien, Onset/Replay) braucht mindestens einen Fall mit gestellter Uhr kurz vor
+   Mitternacht, der den Überlauf-Zweig tatsächlich durchläuft und Tagesbezug **und** Uhrzeit prüft.
+4. **Fixture-Datum aus der Ortszeit ableiten.** In `test_952_onset_alert_fidelity.py:172`
+   (`_trip_with_active_segment`) das Etappendatum aus derselben Ortszeit-Logik ableiten, die
+   `_active_window` (`:125-148`) bereits für die Fensterberechnung verwendet, statt aus
+   `date_type.today()` (Systemdatum).
+
+**Ausdrücklich verworfen:** eine bloße Regex-Aufweichung (`(?:morgen )?`). Sie macht die Ampel
+grün, lässt den Tagesbezug aber ungeprüft — das Muster „Test prüft die Form statt des Werts", das
+in dieser Scheibe bereits viermal zugeschlagen hat.
+
+## Expected Behavior
+
+- **Input:** Gerenderte Alarmtexte (Langform und Telegram-Kurzstil) aus Trip- und
+  Ortsvergleichs-Pfad, jeweils mit und ohne Tagesübergang; eine gestellte Systemuhr zu
+  verschiedenen Tageszeiten (u. a. 12:00, 21:06, 22:50, 23:58 UTC).
+- **Output:** Alle betroffenen Testdateien laufen zu jeder Tageszeit grün, ohne stillen Skip. Wird
+  der `day_offset == 1`-Zweig im Renderer oder `source_reach_day_offset` im Projektionscode
+  verfälscht, wird mindestens ein Test rot.
+- **Side effects:** keine — reine Test-Infrastruktur, kein Produktivpfad wird berührt.
+
+## Acceptance Criteria
+
+### Geteilter Test-Helfer (neu unter `tests/helpers/`)
+
+- **AC-1:** Given der Langform-Text `... · Radar reicht bis morgen 00:12 · ...` / When der Helfer
+  die Reichweite zieht / Then liefert er das Paar `("morgen", "00:12")`; beim Text
+  `... · Radar reicht bis 23:47 · ...` liefert er `(None, "23:47")`.
+  - Test: `extract_day_and_time()` gegen beide Textvarianten aufgerufen, Rückgabepaar auf Gleichheit
+    geprüft — kein Dateiinhalt-Check.
+
+- **AC-2:** Given der Kurzform-Text `Seg 1: R3.0@23:25@So1:35?` / When der Helfer das
+  Güte-Zeichen-Token zieht / Then liefert er das Paar `("So", "1:35")`; beim Token `@23:25?` ohne
+  Wochentagskürzel liefert er `(None, "23:25")`.
+  - Test: `extract_day_and_time(..., style="kurzform")` gegen beide Tokenvarianten aufgerufen,
+    Rückgabepaar geprüft.
+
+- **AC-3:** Given eine Ziel-UTC-Zeit, eine Jetzt-UTC-Zeit und die Trip-Zeitzone / When der Helfer
+  das ERWARTETE Paar bildet / Then ist das Tageswort `None` bei gleichem lokalen Kalendertag,
+  `"morgen"` bei einem Tag Versatz und `"gestern"` bei minus einem Tag — hergeleitet aus dem
+  Datumsvergleich, nicht als Literal gesetzt.
+  - Test: `expected_day_and_time()` mit drei Datumskombinationen (gleicher Tag, +1 Tag, -1 Tag)
+    aufgerufen, jeweils gegen das erwartete Tageswort geprüft.
+
+- **AC-4:** Given ein Text, dessen Uhrzeit stimmt, dessen Tageswort aber falsch ist (`heute 00:12`
+  statt `morgen 00:12`) / When der Helfer-Vergleich läuft / Then schlägt er fehl.
+  - Test: Positivkontrolle — `extract_day_and_time()` auf den absichtlich falschen Text angewendet
+    und das Ergebnis gegen `expected_day_and_time()` verglichen; der Vergleich muss fehlschlagen,
+    sonst prüft der Helfer nichts.
+
+### Paritäts-Tests auf den Helfer umgestellt
+
+- **AC-5:** Given ein Radar-Alarm, dessen Quellen-Reichweite auf den Folgetag fällt / When Trip und
+  Ortsvergleich in der Langform gerendert werden / Then nennen BEIDE Flächen dasselbe Paar aus
+  Tagesbezug und Uhrzeit.
+  - Test: `test_onset_reichweite_guete_kanalparitaet.py`, beide gerenderten Texte durch den Helfer
+    gezogen und die Paare auf Gleichheit verglichen.
+
+- **AC-6:** Given denselben Aufbau im Telegram-Kurzstil / When beide Alarme abgesetzt werden / Then
+  trägt das Güte-Zeichen in BEIDEN Flächen dasselbe Paar aus Wochentagskürzel und Uhrzeit.
+  - Test: `test_onset_reichweite_guete_kanalparitaet.py`, Kurzform-Zweig über den Helfer verglichen.
+
+- **AC-7:** Given ein Radar-Alarm, dessen Ereignis-Ende auf den Folgetag fällt / When Trip und
+  Ortsvergleich in Lang- und Kurzform gerendert werden / Then nennen beide Flächen in beiden Formen
+  dasselbe Ende-Paar.
+  - Test: `test_onset_ende_kanalparitaet.py` und `test_onset_ende_textstellen.py`, je Form ein
+    Helfer-Vergleich.
+
+- **AC-8:** Given ein Alarm-Replay, dessen Reichweite auf den Folgetag fällt / When der Replay-Weg
+  gerendert wird / Then nennt er Reichweite und Güte-Grenze mit demselben Tagesbezug wie der
+  Live-Weg.
+  - Test: `test_alert_preview_nowcast_replay.py`, Replay-Text und Live-Text über den Helfer
+    verglichen.
+
+- **AC-9:** Given ein Mehr-Orte-Bündel, dessen führender Ort sein Ende am Folgetag hat / When der
+  Text gerendert wird / Then nennt er das Ende mit Tagesbezug.
+  - Test: bestehender Mehr-Orte-Fall in `test_onset_ende_textstellen.py`/
+    `test_onset_ende_kanalparitaet.py`, Ende-Paar über den Helfer geprüft statt per nackter Regex.
+
+### Zeitunabhängigkeit
+
+- **AC-10:** Given die gestellte Uhr auf 12:00, 21:06, 22:50 und 23:58 UTC / When alle betroffenen
+  Testdateien laufen / Then sind sie in ALLEN VIER Läufen grün, mit null übersprungenen Tests.
+  - Test: die 5 Testdateien je einmal mit `frozen_active_window(hour_utc=...)` für jeden der vier
+    Zeitpunkte ausgeführt, Exit-Code und Skip-Zähler geprüft.
+
+- **AC-11:** Given eine gestellte Uhr kurz vor Mitternacht / When
+  `tests/tdd/test_starkregen_kurzfristhinweis.py` läuft / Then läuft er durch, statt sich mit
+  „Testzeitpunkt zu nah an einer Mitternachtsgrenze" selbst zu überspringen.
+  - Test: Testlauf mit gestellter Uhr nahe Mitternacht, Prüfung dass kein `SKIPPED` mit diesem
+    Meldungstext im Ergebnis erscheint.
+
+### Der Tagesübergang ist tatsächlich bewacht
+
+- **AC-12:** Given eine gestellte Uhr, bei der die Zeitangabe auf den Folgetag fällt / When der
+  Alarm gerendert wird / Then existiert je Mechanismus (Langform-Reichweite, Langform-Ende,
+  Kurzform) ein eigener Testfall, der den Überlauf-Zweig durchläuft und Tagesbezug UND Uhrzeit
+  prüft.
+  - Test: je Mechanismus mindestens ein dedizierter Testfall mit gestellter Uhr, der über den
+    Helfer sowohl das Tageswort als auch die Uhrzeit gegen `expected_day_and_time()` verifiziert.
+
+- **AC-13:** Given man entfernt in `src/output/renderers/alert/render.py` den
+  `day_offset == 1`-Zweig von `_time_with_day()`, so dass `00:12` statt `morgen 00:12` gerendert
+  wird / When die Testsuite läuft / Then wird mindestens ein Test ROT.
+  - Test: Mutations-Gegenprobe — temporäre String-Ersetzung (mit externer Sicherungskopie),
+    betroffene Testdateien laufen lassen, mindestens ein Fehlschlag beobachten, danach
+    zurücksetzen. Heute fängt das kein Test.
+
+- **AC-14:** Given man setzt `source_reach_day_offset` in
+  `src/output/renderers/alert/project.py` fest auf `0` / When die Testsuite läuft / Then wird
+  mindestens ein Test ROT.
+  - Test: Mutations-Gegenprobe wie AC-13. Heute liefert `grep -rn "source_reach_day_offset" tests/`
+    null Treffer.
+
+### Fixture-Datum aus der Ortszeit
+
+- **AC-15:** Given eine gestellte Uhr nach 22:00 UTC, bei der Systemdatum und Ortsdatum des Trips
+  auseinanderfallen / When `check_radar_alerts()` in
+  `tests/tdd/test_952_onset_alert_fidelity.py` läuft / Then liefert es einen Alarm, nicht null.
+  - Test: Testlauf mit `frozen_active_window(hour_utc=22 oder später)`, Rückgabewert von
+    `check_radar_alerts()` auf Nicht-Null geprüft.
+
+- **AC-16:** Given man leitet das Etappendatum wieder aus `date.today()` statt aus der Ortszeit ab
+  / When der Test bei gestellter Uhr nach 22:00 UTC läuft / Then wird er ROT.
+  - Test: Mutations-Gegenprobe — temporäre String-Ersetzung in `_trip_with_active_segment()` (mit
+    externer Sicherungskopie), Testlauf beobachtet mindestens einen Fehlschlag, danach
+    zurückgesetzt.
+
+## Known Limitations
+
+- Der Zuschnitt ändert bewusst keinen Produktivcode — das ausgelieferte Verhalten
+  (`_time_with_day()`, `source_reach_day_offset`) ist korrekt und bleibt unverändert. Geliefert
+  wird ausschließlich Test-Infrastruktur, die diesen Zweig erstmals bewacht.
+- Die beiden latenten Zwillinge `tests/tdd/test_onset_kurzform_menge.py` und
+  `tests/tdd/test_onset_reichweite_guete_sms.py` ankern onset-nah (+20 Min) und kippen erst in den
+  letzten 20 Minuten vor Mitternacht. Sie sind heute noch grün und werden nur mitgenommen, wenn der
+  neue Helfer sie ohnehin abdeckt — kein eigener Testfall wird für sie zwingend neu geschrieben.
+- Mechanismus C (`test_starkregen_kurzfristhinweis.py`, stiller Skip nahe der
+  Mitternachtsgrenze) verschwindet als Nebeneffekt von Baustein 2 (Uhr stellen): bei gestellter Uhr
+  gibt es den „zu nah an Mitternacht"-Zufall nicht mehr, den der Wächter abfangen müsste. Ob es
+  weitere solcher Selbst-Skips im Repo gibt, ist ein offener Nebenbefund für das Sammel-Issue #1199,
+  nicht Teil dieses Scopes.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Reine Test-Infrastruktur ohne Berührung einer Entscheidungsfläche (Kanäle,
+  Provider, Datenmodell/Persistenz, Auth, Editor-Paradigma, Test-/Deploy-Strategie). Kein
+  Produktivverhalten ändert sich.
+
+## Changelog
+
+- 2026-08-22: Initial spec created

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -337,9 +337,6 @@ def _reset_telegram_rate_limit():
 # Issue #2096: gestellte Wanduhr fuer den GANZEN Lauf
 # ---------------------------------------------------------------------------
 
-_WANDUHR_ENV = "GZ_TEST_WALL_CLOCK_UTC"
-
-
 @pytest.fixture(scope="session", autouse=True)
 def _gestellte_wanduhr():
     """Stellt die Uhr des gesamten Laufs auf ``GZ_TEST_WALL_CLOCK_UTC``.
@@ -362,23 +359,21 @@ def _gestellte_wanduhr():
 
     Session-Scope und damit AUSSERHALB jedes ``@freeze_time`` einzelner
     Testfaelle: freezegun stapelt, der innere Zeitpunkt gewinnt.
+
+    Selbst bewacht durch ``tests/tdd/test_gestellte_wanduhr_schalter.py``:
+    ein Nachweiswerkzeug ohne Selbsttest ist genau der blinde Waechter,
+    gegen den dieses Ticket geschrieben ist -- legt man diese Fixture stumm,
+    saehen die vier Uhrzeit-Laeufe weiterhin gruen aus und maessen nichts
+    (Adversary-Finding F001 zu #2096).
     """
-    roh = os.environ.get(_WANDUHR_ENV, "").strip()
+    from tests.helpers.wanduhr import anker_aus, roh_wert
+
+    roh = roh_wert()
     if not roh:
         yield
         return
 
-    from datetime import datetime, time, timezone
-
-    if "-" in roh:
-        anker = datetime.fromisoformat(roh)
-    else:
-        stunde, _, minute = roh.partition(":")
-        anker = datetime.combine(
-            datetime.now(timezone.utc).date(),
-            time(int(stunde), int(minute or 0)),
-            tzinfo=timezone.utc,
-        )
+    anker = anker_aus(roh)
 
     # `pydantic.v1.types` leitet Klassen von `datetime.date`/`datetime`
     # AB. Wird das Modul erst WAEHREND des gefrorenen Fensters importiert,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -332,3 +332,62 @@ def _reset_telegram_rate_limit():
     reset_telegram_rate_limit_for_tests()
     yield
     reset_telegram_rate_limit_for_tests()
+
+# ---------------------------------------------------------------------------
+# Issue #2096: gestellte Wanduhr fuer den GANZEN Lauf
+# ---------------------------------------------------------------------------
+
+_WANDUHR_ENV = "GZ_TEST_WALL_CLOCK_UTC"
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _gestellte_wanduhr():
+    """Stellt die Uhr des gesamten Laufs auf ``GZ_TEST_WALL_CLOCK_UTC``.
+
+    Nachweis-Werkzeug fuer die Zeitunabhaengigkeit (#2096 AC-10): dieselbe
+    Testmenge muss um 12:00 UTC dasselbe Ergebnis liefern wie um 23:58 UTC.
+    Ohne diesen Schalter liesse sich das nur belegen, indem man auf die
+    entsprechende Tageszeit wartet oder die SYSTEMzeit des Servers verstellt —
+    beides ist keine Option.
+
+    Ohne gesetzte Variable passiert NICHTS: der Normallauf (CI, lokal) laeuft
+    unveraendert auf der echten Wanduhr. Das ist Absicht — ein dauerhaft
+    gestellter Lauf wuerde genau die Zeitabhaengigkeit verdecken, die hier
+    gefunden werden soll.
+
+    Format: ``HH:MM`` (heutiges Datum, UTC) oder ein vollstaendiger
+    ISO-Zeitstempel. ``tick=True``, damit die Zeit waehrend des Laufs weiter
+    voranschreitet — ein vollstaendig stehender Zaehler waere ein anderer
+    Zustand als "der Lauf startet um 23:58".
+
+    Session-Scope und damit AUSSERHALB jedes ``@freeze_time`` einzelner
+    Testfaelle: freezegun stapelt, der innere Zeitpunkt gewinnt.
+    """
+    roh = os.environ.get(_WANDUHR_ENV, "").strip()
+    if not roh:
+        yield
+        return
+
+    from datetime import datetime, time, timezone
+
+    if "-" in roh:
+        anker = datetime.fromisoformat(roh)
+    else:
+        stunde, _, minute = roh.partition(":")
+        anker = datetime.combine(
+            datetime.now(timezone.utc).date(),
+            time(int(stunde), int(minute or 0)),
+            tzinfo=timezone.utc,
+        )
+
+    # `pydantic.v1.types` leitet Klassen von `datetime.date`/`datetime`
+    # AB. Wird das Modul erst WAEHREND des gefrorenen Fensters importiert,
+    # sind die Basisklassen bereits freezeguns `FakeDate`/`FakeDatetime` und
+    # die Klassendefinition scheitert mit "metaclass conflict" -- ein
+    # Artefakt des Messwerkzeugs, kein Befund. Deshalb vorher laden.
+    import pydantic.v1.types  # noqa: F401
+
+    from freezegun import freeze_time
+
+    with freeze_time(anker, tick=True):
+        yield

--- a/tests/helpers/tagesbezug.py
+++ b/tests/helpers/tagesbezug.py
@@ -1,0 +1,127 @@
+"""Issue #2096: geteilter Testhelfer fuer den TAGESBEZUG von Zeitangaben.
+
+Warum es diesen Helfer gibt: die Alarm-Texte nennen eine Uhrzeit, die auf
+einen anderen Kalendertag fallen kann. Der Renderer stellt dann korrekt einen
+Tagesbezug voran -- Langform `morgen 00:12` (`_time_with_day()`,
+`src/output/renderers/alert/render.py`), Kurzform als vorangestelltes
+DE-Wochentagskuerzel `So1:35` (`_sms_onset_time()`/`_sms_day_prefix()`).
+Testanker, die per nackter `HH:MM`-Regex greifen, treffen dann nicht mehr:
+die CI-Ampel wurde abends rot, ohne dass ein Produktivdefekt vorlag.
+
+Die naheliegende Behebung (Regex zu `(?:morgen )?` aufweichen) waere die
+falsche -- sie macht gruen und laesst den Tagesbezug weiterhin UNGEPRUEFT.
+Dieser Helfer zieht stattdessen ein PAAR aus Tagesbezug und Uhrzeit und
+liefert dazu das aus den Zeitstempeln HERGELEITETE Gegenstueck; verglichen
+wird das ganze Paar. Damit ist der Tagesuebergang erstmals bewacht statt
+umgangen.
+
+Die Wochentagskuerzel werden aus dem Produktivcode IMPORTIERT statt
+abgetippt: eine zweite Liste liefe beim naechsten Umbau auseinander und der
+Vergleich maesse dann die Kopie statt des Renderers.
+"""
+from __future__ import annotations
+
+import re
+from datetime import datetime, tzinfo
+
+from output.renderers.alert.official_alerts import _DE_WEEKDAYS
+
+# `HH:MM` -- die Stunde ein- ODER zweistellig, weil die Kurzform sie ohne
+# fuehrende Null schreibt (`1:35`), die Langform mit (`01:35`).
+_ZEIT = r"\d{1,2}:\d{2}"
+
+# Die Tagesworte der Langform, in genau den Formen, die `_time_with_day()`
+# erzeugt -- plus `heute`, das der Renderer NICHT erzeugt: der Helfer muss es
+# erkennen koennen, sonst faellt ein falsches Tageswort als "kein Tageswort"
+# durch und die Positivkontrolle (AC-4) pruefte nichts.
+_TAGESWORT = r"(?:heute|morgen|gestern|in \d+ Tagen|vor \d+ Tagen)"
+
+_KUERZEL = "|".join(_DE_WEEKDAYS)
+
+# Ein vollstaendiges Kurzform-Zeit-Token samt (optionalem) Tagesbezug --
+# fuer Aufrufer, die die STRUKTUR einer Token-Folge pruefen (z. B. "das
+# Ende-Token haengt unmittelbar am Beginn-Token") und den WERT getrennt
+# davon ueber `extract_day_and_time()` holen. Ohne dieses Fragment muesste
+# jede solche Strukturpruefung die Kuerzel erneut auflisten.
+KURZFORM_ZEIT_TOKEN = rf"(?:{_KUERZEL})?{_ZEIT}"
+
+
+def extract_day_and_time(
+    text: str, anker: str, style: str = "langform",
+) -> tuple[str | None, str]:
+    """Zieht am `anker` das Paar `(Tagesbezug, "HH:MM")` aus `text`.
+
+    * `style="langform"`: der Anker ist die Floskel VOR der Zeitangabe
+      (`"Radar reicht bis"`, `"letzter Regen gegen"`, `"Ortsangabe ab"`).
+      Steht ein Tageswort dazwischen, ist es der erste Wert des Paares, sonst
+      `None`. Der Anker trennt die Zeitangaben eines Textes voneinander --
+      ein Aufruf liefert die Zeit DIESES Ankers, nicht die erstbeste des
+      Textes.
+    * `style="kurzform"`: der Anker ist `"@"`, getroffen wird das Zeit-Token,
+      dem das Guete-Zeichen `?` folgt. Ein vorangestelltes
+      DE-Wochentagskuerzel ist der Tagesbezug (`@So1:35?` ->
+      `("So", "1:35")`), ohne Kuerzel `None`.
+
+    Findet der Anker nichts, ist das Ergebnis `(None, "")` -- ein Paar, das
+    gegen jede Erwartung ungleich ist und die Fundstelle im Assert-Text
+    sichtbar macht.
+    """
+    if style == "kurzform":
+        muster = (
+            re.escape(anker)
+            + rf"(?P<tag>{_KUERZEL})?(?P<zeit>{_ZEIT})\?"
+        )
+    elif style == "langform":
+        muster = (
+            re.escape(anker)
+            + rf"\s+(?:(?P<tag>{_TAGESWORT})\s+)?(?P<zeit>{_ZEIT})"
+        )
+    else:
+        raise ValueError(f"Unbekannter Stil: {style!r}")
+
+    treffer = re.search(muster, text)
+    if treffer is None:
+        return None, ""
+    return treffer.group("tag"), treffer.group("zeit")
+
+
+def expected_day_and_time(
+    target_utc: datetime, now_utc: datetime, tz: tzinfo,
+    style: str = "langform",
+) -> tuple[str | None, str]:
+    """Bildet das ERWARTETE Paar aus dem Datumsvergleich.
+
+    Beide Zeitpunkte werden auf `tz` projiziert -- der Versatz entsteht
+    zwischen den lokalen KALENDERTAGEN, nicht zwischen den UTC-Tagen (genau
+    daran scheiterte das Fixture-Datum in #2096, Mechanismus B). Der Wert
+    wird hergeleitet, nie als Literal gesetzt.
+
+    Langform spiegelt `_time_with_day()`: gleicher Tag -> `None`, `+1` ->
+    `"morgen"`, `-1` -> `"gestern"`, darueber hinaus `"in N Tagen"` bzw.
+    `"vor N Tagen"`. Kurzform spiegelt `_sms_onset_time()`/`_sms_day_prefix()`:
+    statt des Wortes das DE-Wochentagskuerzel des ZIELtages, am Versandtag
+    ersatzlos `None`, und die Stunde ohne fuehrende Null.
+    """
+    ziel = target_utc.astimezone(tz)
+    versatz = (ziel.date() - now_utc.astimezone(tz).date()).days
+
+    if style == "kurzform":
+        kuerzel = _DE_WEEKDAYS[ziel.weekday()] if versatz else None
+        return kuerzel, f"{ziel.hour}:{ziel.minute:02d}"
+    if style != "langform":
+        raise ValueError(f"Unbekannter Stil: {style!r}")
+    return _tageswort(versatz), ziel.strftime("%H:%M")
+
+
+def _tageswort(versatz: int) -> str | None:
+    """Der Wortlaut zu einem Tagesversatz -- Gegenstueck zu `_time_with_day()`,
+    das den Versatz EXAKT aufloest statt ueber seinen Wahrheitswert."""
+    if versatz == 0:
+        return None
+    if versatz == 1:
+        return "morgen"
+    if versatz == -1:
+        return "gestern"
+    if versatz > 1:
+        return f"in {versatz} Tagen"
+    return f"vor {-versatz} Tagen"

--- a/tests/helpers/wanduhr.py
+++ b/tests/helpers/wanduhr.py
@@ -1,0 +1,37 @@
+"""Issue #2096: die Ankerbestimmung des Uhr-Schalters — EINE Stelle.
+
+Der Schalter selbst ist die Session-Fixture ``_gestellte_wanduhr`` in
+``tests/conftest.py``; sein Selbsttest steht in
+``tests/tdd/test_gestellte_wanduhr_schalter.py``. Beide brauchen dieselbe
+Umrechnung ``Roh-Wert -> Ankerzeitpunkt``. Sie liegt deshalb hier und nicht
+zweimal dort: ein Selbsttest, der den Anker NACHRECHNET statt ihn aus
+derselben Quelle zu beziehen, prueft am Ende seine eigene Kopie und wuerde
+eine abweichende Fixture nicht bemerken.
+"""
+from __future__ import annotations
+
+import os
+from datetime import datetime, time, timezone
+
+ENV_NAME = "GZ_TEST_WALL_CLOCK_UTC"
+
+
+def roh_wert() -> str:
+    """Der gesetzte Roh-Wert oder ``""`` (nicht gesetzt)."""
+    return os.environ.get(ENV_NAME, "").strip()
+
+
+def anker_aus(roh: str) -> datetime:
+    """Der Zeitpunkt, auf den der Schalter die Uhr stellt.
+
+    Zwei Formen: ``HH:MM`` meint diese Uhrzeit UTC am heutigen Kalendertag,
+    ein vollstaendiger ISO-Zeitstempel wird unveraendert uebernommen.
+    """
+    if "-" in roh:
+        return datetime.fromisoformat(roh)
+    stunde, _, minute = roh.partition(":")
+    return datetime.combine(
+        datetime.now(timezone.utc).date(),
+        time(int(stunde), int(minute or 0)),
+        tzinfo=timezone.utc,
+    )

--- a/tests/helpers/wanduhr.py
+++ b/tests/helpers/wanduhr.py
@@ -22,13 +22,33 @@ def roh_wert() -> str:
 
 
 def anker_aus(roh: str) -> datetime:
-    """Der Zeitpunkt, auf den der Schalter die Uhr stellt.
+    """Der Zeitpunkt, auf den der Schalter die Uhr stellt — IMMER UTC-behaftet.
 
-    Zwei Formen: ``HH:MM`` meint diese Uhrzeit UTC am heutigen Kalendertag,
-    ein vollstaendiger ISO-Zeitstempel wird unveraendert uebernommen.
+    Zwei Formen:
+
+    * ``HH:MM`` (auch ``HH``) meint diese Uhrzeit UTC am heutigen
+      Kalendertag — die Form der vier Nachweis-Laeufe.
+    * ein ISO-Zeitstempel meint genau diesen Zeitpunkt. Traegt er einen
+      Versatz, wird er auf UTC umgerechnet (derselbe Augenblick, andere
+      Schreibweise); traegt er keinen, gilt er als UTC.
+
+    Warum die Vereinheitlichung: ein naiver Rueckgabewert waere von
+    freezegun als ORTSZEIT verstanden worden. Auf einem Server in einer
+    anderen Zone haette der Schalter die Uhr dann still um den Zonenversatz
+    daneben gestellt — und alle vier Nachweis-Laeufe haetten weiterhin gruen
+    ausgesehen. Der Name der Variablen (``..._UTC``) ist damit auch das
+    tatsaechliche Verhalten.
+
+    Unbrauchbare Eingaben (leer, Unsinn, ``"25:00"``, kaputter ISO-Stempel)
+    loesen ``ValueError`` aus. Bewusst laut: ein Schalter, der bei Unsinn
+    stillschweigend irgendeinen Zeitpunkt nimmt, stellt die Uhr falsch und
+    laesst den Lauf trotzdem gruen aussehen.
     """
     if "-" in roh:
-        return datetime.fromisoformat(roh)
+        zeitpunkt = datetime.fromisoformat(roh)
+        if zeitpunkt.tzinfo is None:
+            return zeitpunkt.replace(tzinfo=timezone.utc)
+        return zeitpunkt.astimezone(timezone.utc)
     stunde, _, minute = roh.partition(":")
     return datetime.combine(
         datetime.now(timezone.utc).date(),

--- a/tests/tdd/test_952_fixture_ortsdatum.py
+++ b/tests/tdd/test_952_fixture_ortsdatum.py
@@ -1,0 +1,135 @@
+"""TDD RED — Issue #2096 AC-15: das Fixture-Etappendatum stammt aus der
+ORTSZEIT, nicht aus dem Systemdatum.
+
+SPEC: docs/specs/modules/fix_2096_tagesbezug_testwaechter.md — AC-15.
+
+Warum das zaehlt: `_active_window()`
+(`tests/tdd/test_952_onset_alert_fidelity.py:125-148`) rechnet das
+Etappenfenster in Ortszeit (Korsika, `Europe/Paris`, UTC+2),
+`_trip_with_active_segment()` (`:150-177`) stempelt es aber mit
+`date_type.today()` -- dem SYSTEMdatum (UTC). Ab 22:00 UTC weichen beide um
+einen Tag ab, das Segment landet rund 24 Stunden in der Vergangenheit, die
+Aktivitaetspruefung `seg.start_time <= now_utc <= seg.end_time` schlaegt fehl
+und `check_radar_alerts()` liefert `0` statt `1` -- zwei rote CI-Tests jeden
+Abend, ohne Produktivdefekt (echte Trips tragen echte `stage.date`-Werte;
+`trip_alert.py:1246-1249` loest "heute" ueber `trip_local_today()` in
+Ortszeit auf, ADR-0044).
+
+Dieser Test haelt die Reparatur fest: bei gestellter Uhr NACH 22:00 UTC, wo
+Systemdatum und Ortsdatum nachweislich auseinanderfallen, muss der 952-Aufbau
+weiterhin einen Alarm liefern.
+
+Mock-frei: echter `TripAlertService`, echter DI-Seam `_GuaranteedWetRadar`
+(echte `RadarNowcastService`-Subklasse), echte Persistenz ueber
+`app.loader.save_trip()`, echte `mail_sink`-Senke statt Versand. Aufbau und
+Radar-Seam werden aus der Bestandsdatei IMPORTIERT statt kopiert -- eine
+Kopie wuerde die Reparatur dort nicht mitbekommen.
+
+RED heute: `_trip_with_active_segment()` verwendet `date_type.today()` --
+`check_radar_alerts()` liefert `0`.
+"""
+from __future__ import annotations
+
+import inspect
+from datetime import datetime, timezone
+from pathlib import Path
+
+from freezegun import freeze_time
+
+from app.config import Settings
+from app.models import TripReportConfig
+from utils.timezone import tz_for_coords
+
+from tests.tdd.test_952_onset_alert_fidelity import (
+    _GuaranteedWetRadar,
+    _clean_user,
+    _trip_with_active_segment,
+)
+
+# 23:30 UTC -- auf Korsika (UTC+2) ist es dann bereits 01:30 des Folgetages.
+_GEFRORENE_UHR = "2026-08-22 23:30:00+00:00"
+
+
+def test_prueling_stammt_aus_diesem_arbeitsbaum():
+    """Vorbedingung (kein AC): der Alarm-Service wird RELATIV ZU DIESER
+    Testdatei aufgeloest, nicht aus dem Hauptrepo-Pfad."""
+    from services import trip_alert as trip_module
+
+    arbeitsbaum = Path(__file__).resolve().parents[2]
+    modul_pfad = Path(inspect.getfile(trip_module)).resolve()
+    assert modul_pfad.is_relative_to(arbeitsbaum), (
+        f"Prueling stammt nicht aus diesem Arbeitsbaum: {modul_pfad}"
+    )
+
+
+@freeze_time(_GEFRORENE_UHR)
+def test_ac15_radar_alarm_feuert_wenn_ortsdatum_vom_systemdatum_abweicht():
+    """AC-15 GIVEN eine gestellte Uhr nach 22:00 UTC, bei der das Systemdatum
+    (UTC) und das Ortsdatum des Trips (Korsika, UTC+2) auseinanderfallen
+    WHEN der 952-Aufbau `check_radar_alerts()` faehrt
+    THEN liefert er 1 statt 0, und genau eine Alarm-Mail geht in die Senke.
+
+    Die Abweichung der beiden Daten wird als Vorbedingung GEMESSEN, nicht
+    behauptet: liefe die Suite in einer Zone, in der beide Daten
+    zusammenfielen, pruefte der Test nichts und muss das sagen
+    (`reference_positivkontrolle_prueft_ob_die_pruefung_misst`).
+
+    RED heute: `_trip_with_active_segment()` stempelt das Etappendatum mit
+    `date_type.today()`; das Segment liegt damit einen Tag zurueck und
+    `check_radar_alerts()` liefert `0`."""
+    uid = "tdd-2096-ac15"
+    trip_id = "trip-2096-ac15"
+    _clean_user(uid)
+    try:
+        config = TripReportConfig(
+            trip_id=trip_id, send_email=True, send_telegram=False,
+            send_sms=False, alert_on_changes=True,
+        )
+        trip = _trip_with_active_segment(trip_id, config)
+
+        # Die Koordinaten kommen aus dem Aufbau selbst, nicht aus einer
+        # zweiten Kopie im Test -- sonst maesse die Vorbedingung eine andere
+        # Zone als die, in der das Segment liegt.
+        wp = trip.stages[0].waypoints[0]
+        jetzt_utc = datetime.now(timezone.utc)
+        ortszeit = jetzt_utc.astimezone(tz_for_coords(wp.lat, wp.lon))
+        assert ortszeit.date() != jetzt_utc.date(), (
+            "Vorbedingung: bei dieser gestellten Uhr MUESSEN Ortsdatum "
+            f"({ortszeit.date()}) und Systemdatum ({jetzt_utc.date()}) "
+            "auseinanderfallen, sonst prueft der Fall den Fehler nicht"
+        )
+
+        from app.loader import save_trip
+        save_trip(trip, user_id=uid)
+
+        settings = Settings().model_copy(update={
+            "smtp_host": "smtp.test.invalid", "smtp_user": "alert@test.invalid",
+            "smtp_pass": "secret", "mail_to": "gregor-test@henemm.com",
+            "smtp_port": 587, "is_test_mode": False,
+            "telegram_bot_token": "", "telegram_chat_id": "",
+            "sms_gateway_url": "", "seven_api_key": "", "sms_to": "",
+        })
+        mail_calls: list[tuple[str, str]] = []
+        from services.trip_alert import TripAlertService
+        svc = TripAlertService(
+            settings=settings, throttle_hours=0, user_id=uid,
+            radar_service=_GuaranteedWetRadar(
+                onset_minutes=12, intensity_label="leichter Regen",
+                is_convective=False,
+            ),
+            mail_sink=lambda subject, body: mail_calls.append((subject, body)),
+        )
+
+        result = svc.check_radar_alerts()
+
+        assert result == 1, (
+            "check_radar_alerts() sollte bei gestellter Uhr "
+            f"{_GEFRORENE_UHR} genau 1 Alarm liefern, war {result} -- das "
+            "Etappendatum stammt aus dem Systemdatum statt aus der Ortszeit "
+            f"(Etappe: {trip.stages[0].date}, Ortsdatum: {ortszeit.date()})"
+        )
+        assert len(mail_calls) == 1, (
+            f"Genau EINE Alarm-Mail erwartet, waren {len(mail_calls)}"
+        )
+    finally:
+        _clean_user(uid)

--- a/tests/tdd/test_952_onset_alert_fidelity.py
+++ b/tests/tdd/test_952_onset_alert_fidelity.py
@@ -27,7 +27,6 @@ from __future__ import annotations
 import json
 import re
 import threading
-from datetime import date as date_type
 from datetime import datetime, timedelta
 from datetime import time as time_type
 from http.server import BaseHTTPRequestHandler, HTTPServer
@@ -155,9 +154,19 @@ def _trip_with_active_segment(trip_id: str, config: TripReportConfig) -> Trip:
     Alert möglich). `arrival_override` auf erstem/letztem Waypoint plus
     passende `stage.start_time` sorgt dafür, dass das Segment zur
     Testlaufzeit aktiv ist (`seg.start_time <= now_utc <= seg.end_time`).
+
+    Issue #2096: das Etappendatum stammt aus derselben ORTSZEIT, aus der
+    `_active_window()` das Fenster rechnet — nicht aus `date_type.today()`
+    (Systemdatum, UTC). Ab 22:00 UTC weichen beide bei Korsika (UTC+2) um
+    einen Tag ab; das Segment landete dann rund 24 Stunden in der
+    Vergangenheit und `check_radar_alerts()` lieferte 0 statt 1. Echte Trips
+    tragen echte `stage.date`-Werte und `trip_alert.py` löst „heute" über
+    `trip_local_today()` in Ortszeit auf (ADR-0044) — der Fehler saß allein
+    im Aufbau.
     """
     lat, lon = 42.20, 9.10
     start_str, end_str, start_time = _active_window(lat, lon)
+    ortsdatum = datetime.now(tz_for_coords(lat, lon)).date()
     wp0 = Waypoint(
         id="G1", name="Start", lat=lat, lon=lon, elevation_m=1000.0,
         time_window=TimeWindow(start=time_type(0, 0), end=time_type(23, 57)),
@@ -169,7 +178,7 @@ def _trip_with_active_segment(trip_id: str, config: TripReportConfig) -> Trip:
         arrival_override=end_str,
     )
     stage = Stage(
-        id="T1", name="Tag 1", date=date_type.today(),
+        id="T1", name="Tag 1", date=ortsdatum,
         start_time=start_time, waypoints=[wp0, wp1],
     )
     trip = Trip(id=trip_id, name="Onset-Fidelity-Trip", stages=[stage])

--- a/tests/tdd/test_alert_preview_nowcast_replay.py
+++ b/tests/tdd/test_alert_preview_nowcast_replay.py
@@ -31,6 +31,11 @@ from pathlib import Path
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from freezegun import freeze_time
+
+from tests.helpers.tagesbezug import (
+    expected_day_and_time, extract_day_and_time,
+)
 
 pytestmark = pytest.mark.real_data_root
 
@@ -279,19 +284,27 @@ def _block_mit_reichweite_frames(now: datetime) -> list[dict]:
     return frames
 
 
-def _minuten(hhmm: str) -> int:
-    stunde, _, minute = hhmm.partition(":")
-    return int(stunde) * 60 + int(minute)
-
-
-def _abstand_minuten(a: str, b: str) -> int:
-    roh = abs(_minuten(a) - _minuten(b))
-    return min(roh, 24 * 60 - roh)
+# Issue #2096: zwei gestellte Uhren statt der Wanduhr. Mittags liegen alle
+# Zeitangaben im selben Kalendertag, um 23:30 fallen Reichweite (+175 Min) und
+# Guete-Grenze (+60 Min) nachweislich auf den FOLGETAG -- derselbe Fall, an
+# dem die frueheren nackten `HH:MM`-Anker ab ~21:05 UTC scheiterten. Beide
+# Faelle fahren denselben Testkoerper: der Ueberlauf soll DURCHLAUFEN werden,
+# nicht weggefroren, und der Normalfall darf dabei nicht verloren gehen.
+#
+# Das zweite Feld ist die Positivkontrolle: es sagt, OB der Fall den
+# Ueberlauf-Zweig erreichen muss. Ohne diese Angabe bliebe offen, ob der
+# zweite Parameterfall ueberhaupt etwas anderes prueft als der erste
+# (`reference_positivkontrolle_prueft_ob_die_pruefung_misst`).
+_GESTELLTE_UHREN = [
+    ("2026-08-22 12:00:00+00:00", False),
+    ("2026-08-22 23:30:00+00:00", True),
+]
 
 
 class TestS3_ReichweiteUndGueteImReplay:
+    @pytest.mark.parametrize("gestellte_uhr,erwartet_ueberlauf", _GESTELLTE_UHREN)
     def test_replay_pfad_zeigt_reichweite_und_guete_wie_der_live_pfad(
-        self, client, stub_trip,
+        self, client, stub_trip, gestellte_uhr, erwartet_ueberlauf,
     ):
         """Issue #2051 S3 GIVEN einen Frame-Mitschnitt mit bekanntem Ende
         (jenseits der Guete-Grenze) und bekannter Reichweite (letzter Frame
@@ -316,30 +329,23 @@ class TestS3_ReichweiteUndGueteImReplay:
         `source_reach_*`/`location_sharpness_*` nicht durch -- `getattr(...,
         default)` liess beide Angaben ersatzlos entfallen."""
         user_id, trip_id = stub_trip
-        request_now = datetime.now(timezone.utc)
-        body = {"nowcast_frames": {
-            "source": "radar", "frames": _block_mit_reichweite_frames(request_now),
-            "km_from": 2.0, "km_to": 6.0,
-        }}
-        resp = client.post(
-            f"/api/trips/{trip_id}/alert-preview",
-            params={"user_id": user_id}, json=body,
-        )
-        assert resp.status_code == 200, f"Body: {resp.text[:300]}"
-        data = resp.json()
-        assert data.get("onset_detected") is True, (
-            f"Voraussetzung: der Beginn bei +20 Min muss erkannt werden: {data!r}"
-        )
-        plain = data["email_plain"]
-
-        reach_treffer = re.search(r"Radar reicht bis (\d{2}:\d{2})", plain)
-        assert reach_treffer is not None, (
-            f"RED: der Replay-Weg nennt keine Reichweite: {plain!r}"
-        )
-        guete_treffer = re.search(r"Ortsangabe ab (\d{2}:\d{2}) unscharf", plain)
-        assert guete_treffer is not None, (
-            f"RED: der Replay-Weg nennt keine Guete-Zeile: {plain!r}"
-        )
+        with freeze_time(gestellte_uhr):
+            request_now = datetime.now(timezone.utc)
+            body = {"nowcast_frames": {
+                "source": "radar",
+                "frames": _block_mit_reichweite_frames(request_now),
+                "km_from": 2.0, "km_to": 6.0,
+            }}
+            resp = client.post(
+                f"/api/trips/{trip_id}/alert-preview",
+                params={"user_id": user_id}, json=body,
+            )
+            assert resp.status_code == 200, f"Body: {resp.text[:300]}"
+            data = resp.json()
+            assert data.get("onset_detected") is True, (
+                f"Voraussetzung: der Beginn bei +20 Min muss erkannt werden: {data!r}"
+            )
+            plain = data["email_plain"]
 
         # F004: beide Werte einzeln gegen die aus den Frames hergeleitete
         # Erwartung pruefen -- Reichweite = letzter Frame (+160) + 15 Min
@@ -347,19 +353,26 @@ class TestS3_ReichweiteUndGueteImReplay:
         # (LOCATION_SHARPNESS_LIMIT_MIN). `_alert_tz_for_trip` liefert UTC
         # fuer diesen wegpunktlosen Fixture-Trip, `request_now` ist bereits
         # UTC -- keine Zonenumrechnung noetig.
-        erwartete_reichweite = (
-            (request_now + timedelta(minutes=175)).strftime("%H:%M")
-        )
-        erwartete_guete_grenze = (
-            (request_now + timedelta(minutes=60)).strftime("%H:%M")
-        )
-        assert _abstand_minuten(reach_treffer.group(1), erwartete_reichweite) <= 1, (
-            f"F004: die Reichweite {reach_treffer.group(1)!r} stammt nicht "
-            f"aus den injizierten Frames (erwartet nahe "
-            f"{erwartete_reichweite!r}): {plain!r}"
-        )
-        assert _abstand_minuten(guete_treffer.group(1), erwartete_guete_grenze) <= 1, (
-            f"F004: die Guete-Grenzzeit {guete_treffer.group(1)!r} stammt "
-            f"nicht aus der 60-Minuten-Grenze (erwartet nahe "
-            f"{erwartete_guete_grenze!r}): {plain!r}"
-        )
+        #
+        # Issue #2096: geprueft wird das PAAR aus Tagesbezug und Uhrzeit. Bei
+        # der spaeten Uhr faellt beides auf den Folgetag; eine Erwartung ohne
+        # Tageswort waere dort schlicht falsch, und eine nackte
+        # `HH:MM`-Erwartung traefe gar nicht erst.
+        for anker, minuten, was in (
+            ("Radar reicht bis", 175, "Reichweite"),
+            ("Ortsangabe ab", 60, "Guete-Grenzzeit"),
+        ):
+            erwartet = expected_day_and_time(
+                request_now + timedelta(minutes=minuten), request_now,
+                timezone.utc,
+            )
+            assert (erwartet[0] is not None) is erwartet_ueberlauf, (
+                f"Positivkontrolle: bei der gestellten Uhr {gestellte_uhr} "
+                f"muss die {was} {'' if erwartet_ueberlauf else 'NICHT '}auf "
+                f"den Folgetag fallen -- hergeleitet wurde {erwartet!r}"
+            )
+            assert extract_day_and_time(plain, anker) == erwartet, (
+                f"F004: die {was} stammt nicht aus den injizierten Frames "
+                f"(erwartet {erwartet!r}, gemessen "
+                f"{extract_day_and_time(plain, anker)!r}): {plain!r}"
+            )

--- a/tests/tdd/test_fixture_wallclock_ratchet.py
+++ b/tests/tdd/test_fixture_wallclock_ratchet.py
@@ -188,18 +188,14 @@ _HEUTE_TRAEGER = {"date", "datetime", "date_type", "datetime_type"}
 #    arrival_local` und deckt damit auch die W1-vs-W2-Sequenz ab.
 #
 # 2) test_starkregen_kurzfristhinweis.py::_trip_with_segment_offset
-#    Die Pruefaussage IST die exakte Vorlaufzeit: 90 Minuten (jenseits von
-#    NOWCAST_HORIZON_MIN=60) darf keinen Nowcast-Abruf ausloesen, 30 Minuten
-#    schon. Jede Klemmung wuerde 90 auf weniger stauchen und den Test ins
-#    Gegenteil verkehren. „Segmentbeginn exakt +90 min, auf dem Etappentag" ist
-#    aber unrepraesentierbar, sobald weniger als 90 Minuten des lokalen Tages
-#    uebrig sind — der erste Wegpunkt MUSS auf dem Etappentag liegen
-#    (`wp_days[0]` ist strukturell 0), und ein Etappendatum ist genau ein
-#    Kalendertag. Keine Zeitzone loest das: sie verschiebt das Fenster nur.
-#    Die Datei erkennt das selbst und ueberspringt an der Grenze laut
-#    (`pytest.skip`) — sie ist dort also nicht still falsch, sondern
-#    hoerbar abwesend. Ein echter Fix braeuchte tagesuebergreifende Etappen,
-#    also Produktivcode — Gegenstand von #1667 S3, nicht von S1.
+#    ERLEDIGT und aus der Liste entfernt (#2096). Die Fixture leitete ihr
+#    Etappendatum aus der Wanduhr ab und uebersprang sich an der
+#    Mitternachtsgrenze laut selbst (`pytest.skip`) — hoerbar abwesend statt
+#    still falsch, aber eben auch: abends bewachte sie nichts. Beide Aufrufer
+#    stellen die Uhr jetzt fest (`freeze_time`); damit entfaellt sowohl der
+#    Skip als auch die Wanduhr-Ableitung des Etappendatums, und der Scanner
+#    findet die Funktion nicht mehr. Der Shrink-Waechter unten hat den
+#    veralteten Eintrag prompt gemeldet — genau seine Aufgabe.
 #
 # 🔴 Der Shrink-Waechter unten faengt nur VERALTETE Eintraege, nicht neue
 # unbegruendete: eine Ausnahmeliste kann sich strukturell nicht selbst gegen
@@ -211,7 +207,6 @@ _HEUTE_TRAEGER = {"date", "datetime", "date_type", "datetime_type"}
 # Format je Eintrag: (repo-relativer Pfad, Funktionsname)
 KNOWN_VIOLATIONS: frozenset[tuple[str, str]] = frozenset({
     ("tests/unit/test_alarm_zeitfenster_ziel.py", "_radar_mails_fuer_spaetankunft"),
-    ("tests/tdd/test_starkregen_kurzfristhinweis.py", "_trip_with_segment_offset"),
 })
 
 

--- a/tests/tdd/test_gestellte_wanduhr_schalter.py
+++ b/tests/tdd/test_gestellte_wanduhr_schalter.py
@@ -1,0 +1,149 @@
+"""Selbsttest des Uhr-Schalters (Issue #2096, Adversary-Finding F001).
+
+Der Schalter ``GZ_TEST_WALL_CLOCK_UTC`` (Session-Fixture
+``_gestellte_wanduhr`` in ``tests/conftest.py``) ist das Werkzeug, mit dem
+AC-10 NACHGEWIESEN wird: dieselbe Testmenge um 12:00, 21:06, 22:50 und 23:58
+UTC, viermal gruen. Der Adversary hat die Fixture komplett stillgelegt
+(``if not roh:`` -> ``if not roh or True:``) und trotzdem 120 passed, 0
+failed gemessen -- kein einziger Test wurde rot.
+
+Der Grund ist harmlos (die Zeitunabhaengigkeit kommt inzwischen aus den
+``@freeze_time``-Dekoratoren der einzelnen Tests, die also robuster sind als
+gefordert), die Folge ist es nicht: hoert der Schalter still auf zu wirken,
+sehen die vier Laeufe weiterhin gruen aus und messen nichts. Ein
+Nachweiswerkzeug ohne Selbsttest ist genau der blinde Waechter, gegen den
+dieses ganze Ticket geschrieben ist.
+
+Zwei Faelle, beide mock-frei:
+
+1. ``test_uhr_folgt_dem_schalter`` prueft den Zustand des LAUFENDEN Prozesses
+   gegen eine von freezegun UNABHAENGIGE Zeitquelle -- den Zeitstempel, den
+   der Kernel einer soeben geschriebenen Datei gibt. Ohne Schalter muss die
+   Prozessuhr dieser Kernel-Uhr folgen, mit Schalter dem Anker.
+2. ``test_schalter_bewegt_die_uhr_im_untergeordneten_lauf`` startet einen
+   ECHTEN zweiten pytest-Lauf ueber genau diesen ersten Fall, mit dem
+   Schalter auf einem festen Zeitpunkt in der VERGANGENHEIT. Nur dieser Fall
+   ist der eigentliche Waechter: er laeuft in jedem Testlauf, unabhaengig
+   davon, ob die Variable von aussen gesetzt ist, und sein Anker kann per
+   Konstruktion nie zufaellig mit der echten Uhr zusammenfallen.
+
+Der Anker wird NICHT nachgerechnet, sondern aus derselben Quelle bezogen,
+aus der ihn die Fixture bildet (``tests/helpers/wanduhr.py``) -- ein
+Selbsttest gegen die eigene Kopie bemerkte eine abweichende Fixture nicht.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+from tests.helpers.wanduhr import ENV_NAME, anker_aus, roh_wert
+
+# Fester Zeitpunkt in der VERGANGENHEIT (voller ISO-Stempel, damit die
+# Tagesableitung der `HH:MM`-Form aussen vor bleibt). Weil er vergangen ist,
+# kann er nie zufaellig der echten Uhr entsprechen -- genau deshalb taugt er
+# als Unterscheidungsmerkmal "Uhr gestellt oder nicht".
+_ANKER_VERGANGENHEIT = "2026-08-22T03:14:00+00:00"
+
+# Die Fixture laeuft mit `tick=True`; zwischen ihrem Start und diesem Test
+# vergeht echte Zeit. Die Toleranz deckt den Aufbau der Session-Fixtures ab
+# und ist trotzdem winzig gegen den Abstand, den eine NICHT gestellte Uhr zu
+# `_ANKER_VERGANGENHEIT` haette (Tage).
+_TOLERANZ_S = 300
+
+_EIGENER_FALL = "test_uhr_folgt_dem_schalter"
+
+
+def _kernel_uhr(tmp_path: Path) -> datetime:
+    """Eine von freezegun UNABHAENGIGE Zeitquelle.
+
+    freezegun ersetzt ``datetime``/``time.time`` im Prozess, nicht aber die
+    Uhr des Kernels: den Zeitstempel einer soeben geschriebenen Datei setzt
+    das Dateisystem. Ohne eine solche zweite Quelle liesse sich "die Uhr ist
+    gestellt" ueberhaupt nicht von "die Uhr laeuft normal" unterscheiden --
+    man haette nur die gestellte Uhr gegen sich selbst geprueft.
+    """
+    probe = tmp_path / "uhr.probe"
+    probe.write_bytes(b"")
+    return datetime.fromtimestamp(probe.stat().st_mtime, timezone.utc)
+
+
+def test_uhr_folgt_dem_schalter(tmp_path):
+    """GIVEN den Uhr-Schalter, gesetzt oder nicht
+    WHEN dieser Lauf die Prozessuhr gegen die Kernel-Uhr haelt
+    THEN folgt sie ohne Schalter der Kernel-Uhr und mit Schalter dem Anker.
+
+    Beide Richtungen in einem Fall: ein Test, der nur den gesetzten Zustand
+    prueft, faellt in der Gegenrichtung nicht auf -- eine Fixture, die die
+    Uhr IMMER stellt, waere ebenso kaputt wie eine, die es nie tut, und
+    verdeckte jede echte Wanduhr-Abhaengigkeit im Bestand.
+    """
+    jetzt = datetime.now(timezone.utc)
+    echt = _kernel_uhr(tmp_path)
+    roh = roh_wert()
+
+    if not roh:
+        assert abs((jetzt - echt).total_seconds()) <= _TOLERANZ_S, (
+            f"Ohne gesetztes {ENV_NAME} darf die Uhr NICHT gestellt sein: "
+            f"Prozessuhr {jetzt.isoformat()} weicht von der Kernel-Uhr "
+            f"{echt.isoformat()} ab"
+        )
+        return
+
+    anker = anker_aus(roh)
+    assert abs((jetzt - anker).total_seconds()) <= _TOLERANZ_S, (
+        f"{ENV_NAME}={roh!r} ist gesetzt, aber die Prozessuhr "
+        f"{jetzt.isoformat()} steht nicht auf dem Anker {anker.isoformat()} "
+        f"(Kernel-Uhr: {echt.isoformat()}) -- der Schalter wirkt nicht"
+    )
+
+
+def test_schalter_bewegt_die_uhr_im_untergeordneten_lauf():
+    """GIVEN einen ECHTEN zweiten pytest-Lauf ueber
+    ``test_uhr_folgt_dem_schalter``, dessen Schalter auf einen festen
+    Zeitpunkt in der Vergangenheit gestellt ist
+    WHEN dieser Lauf faehrt
+    THEN endet er mit Exit 0 -- die Fixture hat die Uhr also tatsaechlich
+    dorthin bewegt.
+
+    Warum ein eigener Prozess: der Schalter wird EINMAL je Session gelesen;
+    innerhalb dieses Laufes laesst er sich nicht mehr umlegen. Ein
+    untergeordneter Lauf ist die einzige Moeglichkeit, den gesetzten Zustand
+    zu pruefen, ohne davon abzuhaengen, wie dieser Lauf gestartet wurde.
+
+    Der Anker liegt in der Vergangenheit: eine NICHT gestellte Uhr steht
+    davon Tage entfernt, der Fall kann also nicht zufaellig bestehen. Legt
+    man die Fixture still, faellt der untergeordnete Lauf durch und dieser
+    Test wird rot.
+    """
+    repo = Path(__file__).resolve().parents[2]
+    ziel = f"tests/tdd/{Path(__file__).name}::{_EIGENER_FALL}"
+
+    umgebung = dict(os.environ)
+    umgebung[ENV_NAME] = _ANKER_VERGANGENHEIT
+
+    lauf = subprocess.run(
+        [
+            sys.executable, "-m", "pytest", ziel,
+            "-p", "no:randomly", "-p", "no:cacheprovider",
+            "--disable-socket", "--allow-unix-socket",
+            "--allow-hosts=127.0.0.1,::1,localhost",
+            # KEIN eigenes `-q`: `addopts` (pyproject.toml) bringt schon eins
+            # mit, ein zweites unterdrueckt die Zusammenfassungszeile, die
+            # unten als Vorbedingung geprueft wird.
+            "--tb=short",
+        ],
+        cwd=repo, env=umgebung, capture_output=True, text=True, timeout=300,
+    )
+
+    assert lauf.returncode == 0, (
+        f"Der untergeordnete Lauf mit {ENV_NAME}={_ANKER_VERGANGENHEIT} ist "
+        f"fehlgeschlagen -- die Fixture stellt die Uhr nicht.\n"
+        f"stdout:\n{lauf.stdout[-3000:]}\nstderr:\n{lauf.stderr[-1500:]}"
+    )
+    assert "1 passed" in lauf.stdout, (
+        "Vorbedingung: der untergeordnete Lauf muss GENAU DIESEN einen Fall "
+        f"ausgefuehrt haben -- sonst belegt sein Exit 0 nichts.\n{lauf.stdout[-3000:]}"
+    )

--- a/tests/tdd/test_gestellte_wanduhr_schalter.py
+++ b/tests/tdd/test_gestellte_wanduhr_schalter.py
@@ -36,8 +36,11 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
+
+import pytest
+from freezegun import freeze_time
 
 from tests.helpers.wanduhr import ENV_NAME, anker_aus, roh_wert
 
@@ -55,6 +58,38 @@ _TOLERANZ_S = 300
 
 _EIGENER_FALL = "test_uhr_folgt_dem_schalter"
 
+# Uhr fuer die `HH:MM`-Faelle des Ankertests unten: die Form leitet ihr Datum
+# aus "heute" ab, ohne gestellte Uhr liesse sich das Ergebnis nicht als
+# Literal hinschreiben.
+_ANKERTEST_UHR = "2026-08-23T06:05:00+00:00"
+
+# Eingabe -> erwarteter Zeitpunkt. Die Erwartung steht hier ausdruecklich als
+# LITERAL, und das ist an dieser einen Stelle richtig statt falsch:
+# `anker_aus()` IST der Prueling und tut nichts anderes, als eine Zeichenkette
+# in einen Zeitpunkt zu wandeln. Jede "Herleitung" wuerde die Funktion
+# nachbauen und damit wieder nur ihre eigene Kopie pruefen -- genau die Falle,
+# aus der dieser Test herausfuehren soll (Adversary-Finding F003 zu #2096:
+# `anker_aus()` stand auf BEIDEN Seiten des Vergleichs, eine Verschiebung um
+# eine Stunde blieb ungefangen).
+_ANKER_PAARE = [
+    # ISO mit `T`-Trenner -- die Form, die der Unterprozess-Fall unten setzt.
+    ("2026-08-22T03:14:00+00:00", datetime(2026, 8, 22, 3, 14, tzinfo=timezone.utc)),
+    # ISO mit Leerzeichen -- die Form, die die Bestandstests als `freeze_time`
+    # Argument fuehren.
+    ("2026-08-22 23:30:00+00:00", datetime(2026, 8, 22, 23, 30, tzinfo=timezone.utc)),
+    # Versatz ungleich UTC: DERSELBE Augenblick, andere Schreibweise.
+    ("2026-08-22T05:14:00+02:00", datetime(2026, 8, 22, 3, 14, tzinfo=timezone.utc)),
+    # Ohne Versatz: gilt als UTC, wird nicht als Ortszeit gedeutet.
+    ("2026-08-22T03:14:00", datetime(2026, 8, 22, 3, 14, tzinfo=timezone.utc)),
+    # `HH:MM` -- heutiger Kalendertag der gestellten Uhr `_ANKERTEST_UHR`.
+    ("23:58", datetime(2026, 8, 23, 23, 58, tzinfo=timezone.utc)),
+    ("12:00", datetime(2026, 8, 23, 12, 0, tzinfo=timezone.utc)),
+    # Nur die Stunde: die Minuten fallen auf 00.
+    ("7", datetime(2026, 8, 23, 7, 0, tzinfo=timezone.utc)),
+]
+
+_UNBRAUCHBAR = ["", "Unsinn", "25:00", "12:99", "2026-13-01T00:00:00+00:00", "-"]
+
 
 def _kernel_uhr(tmp_path: Path) -> datetime:
     """Eine von freezegun UNABHAENGIGE Zeitquelle.
@@ -68,6 +103,52 @@ def _kernel_uhr(tmp_path: Path) -> datetime:
     probe = tmp_path / "uhr.probe"
     probe.write_bytes(b"")
     return datetime.fromtimestamp(probe.stat().st_mtime, timezone.utc)
+
+
+@pytest.mark.parametrize("roh,erwartet", _ANKER_PAARE)
+@freeze_time(_ANKERTEST_UHR)
+def test_anker_aus_wandelt_den_roh_wert_in_den_richtigen_zeitpunkt(roh, erwartet):
+    """GIVEN einen Roh-Wert in einer der beiden Schalter-Formen
+    WHEN `anker_aus()` DIREKT aufgerufen wird -- ohne die Fixture
+    THEN liefert er genau den hinterlegten Zeitpunkt, UTC-behaftet.
+
+    Warum eigens und ohne die Fixture: `anker_aus()` stand bis hierher auf
+    BEIDEN Seiten desselben Vergleichs. Die Fixture friert die Uhr auf seinen
+    Rueckgabewert ein, der Selbsttest bildete seine Erwartung aus demselben
+    Aufruf -- eine Verschiebung der Funktion um eine Stunde blieb dadurch
+    unbemerkt (Adversary-Finding F003). Geprueft war damit nur "die Fixture
+    ruft `anker_aus()` korrekt auf", nicht "`anker_aus()` rechnet korrekt".
+    Dieser Fall schliesst die zweite Haelfte.
+    """
+    ergebnis = anker_aus(roh)
+
+    assert ergebnis == erwartet, (
+        f"anker_aus({roh!r}) lieferte {ergebnis.isoformat()} statt "
+        f"{erwartet.isoformat()}"
+    )
+    # `==` allein genuegt nicht: zwei Zeitpunkte mit verschiedenem Versatz
+    # sind gleich, wenn sie denselben Augenblick meinen. Die Zonenbehaftung
+    # ist aber eine eigene Zusicherung -- ein naiver Wert waere von freezegun
+    # als ORTSZEIT gelesen worden und haette die Uhr auf einem Server in einer
+    # anderen Zone still danebengestellt.
+    assert ergebnis.utcoffset() == timedelta(0), (
+        f"anker_aus({roh!r}) muss UTC-behaftet liefern, war "
+        f"{ergebnis.tzinfo!r}"
+    )
+
+
+@pytest.mark.parametrize("roh", _UNBRAUCHBAR)
+def test_anker_aus_faellt_bei_unbrauchbarer_eingabe_laut_aus(roh):
+    """GIVEN einen Roh-Wert, der keine der beiden Formen ist
+    WHEN `anker_aus()` ihn wandeln soll
+    THEN loest er `ValueError` aus, statt irgendeinen Zeitpunkt zu liefern.
+
+    Festgeschrieben, weil das Schweigen hier teuer waere: ein Schalter, der
+    bei Unsinn stillschweigend einen Zeitpunkt nimmt, stellt die Uhr falsch
+    und laesst die vier Nachweis-Laeufe trotzdem gruen aussehen.
+    """
+    with pytest.raises(ValueError):
+        anker_aus(roh)
 
 
 def test_uhr_folgt_dem_schalter(tmp_path):

--- a/tests/tdd/test_onset_ende_kanalparitaet.py
+++ b/tests/tdd/test_onset_ende_kanalparitaet.py
@@ -42,6 +42,7 @@ from datetime import datetime, time, timedelta, timezone
 from pathlib import Path
 
 import pytest
+from freezegun import freeze_time
 
 import output.channels.telegram as tg_module
 from app.config import Settings
@@ -55,19 +56,34 @@ from tests.helpers.nowcast_gate_fixtures import (
     TRIP_LAT, TRIP_LON, TRIP_ZONE, clean_uid, fresh_uid, make_trip,
     quiet_window_elsewhere, radar_service, reset_radar_cache,
 )
-
-# Langform-Wortlaut (#2020 S2), mit gefangener Uhrzeit.
-_LANGFORM_RE = re.compile(r"letzter Regen gegen (\d{1,2}:\d{2})")
-# Kurzform: Beginn-Token, unmittelbar gefolgt vom MINUTENGENAUEN Ende-Token
-# (`@HH:MM`). Kein optionaler Minutenteil: die Spec ist an dieser Stelle
-# uneinheitlich, den Ausschlag gibt AC-16 (dort, wo die exakte Laenge zaehlt,
-# budgetiert sie `@23:59`) sowie die Konsistenz mit dem Beginn-Token aus #2046
-# (`R2.5@18:00`). Die Toleranz NICHT wiederherstellen — ein Ausdruck, der
-# `@20` und `@20:00` gleichermassen annimmt, bewacht keines der beiden
-# Formate.
-_KURZFORM_RE = re.compile(
-    r"@(?P<beginn>\d{1,2}:\d{2})@(?P<ende>\d{1,2}:\d{2})\b"
+from tests.helpers.tagesbezug import (
+    KURZFORM_ZEIT_TOKEN, expected_day_and_time, extract_day_and_time,
 )
+
+# Issue #2096: der WERT (Tagesbezug + Uhrzeit) kommt aus
+# `tests/helpers/tagesbezug.py` — eine nackte `HH:MM`-Regex traf ab ~21:05
+# UTC nicht mehr, weil der Renderer bei Tagesuebergang korrekt `morgen 00:12`
+# bzw. `Mo1:18` schreibt.
+#
+# Was hier als Regex BLEIBT, ist allein die STRUKTUR: das Ende-Token haengt
+# UNMITTELBAR am Beginn-Token, und beide sind minutengenau (`@HH:MM`, kein
+# optionaler Minutenteil — die Spec ist uneinheitlich, den Ausschlag gibt
+# AC-16, die dort `@23:59` budgetiert). Die Toleranz NICHT wiederherstellen:
+# ein Ausdruck, der `@20` und `@20:00` gleichermassen annimmt, bewacht keines
+# der beiden Formate. Der Tagesbezug ist in diesem Ausdruck bewusst optional
+# — geprueft wird er nicht hier, sondern gegen den hergeleiteten Wert.
+_KURZFORM_STRUKTUR_RE = re.compile(
+    rf"@{KURZFORM_ZEIT_TOKEN}@{KURZFORM_ZEIT_TOKEN}"
+)
+
+# Gestellte Uhr statt Wanduhr (#2096): mittags, weit von beiden
+# Mitternachtsgrenzen. Den Tagesuebergang selbst faehrt
+# `test_tagesbezug_ueberlauf_spaetuhr.py` als eigener Fall — weggefroren
+# waere er nicht bewacht, sondern umgangen. Nebenwirkung: beide Flaechen
+# sehen denselben Zeitpunkt, die frueher noetige Ein-Minuten-Toleranz
+# entfaellt und verglichen wird auf Gleichheit.
+_GEFRORENE_UHR = "2026-08-22 12:00:00+00:00"
+_JETZT_UTC = datetime.fromisoformat(_GEFRORENE_UHR)
 
 # Nasser Block: +20 bis +80 Minuten im 10-Minuten-Raster, danach TROCKEN.
 # Das erwartete Ende ist damit von Hand hergeleitet (letzter nasser Frame vor
@@ -335,29 +351,12 @@ def _text_vom_ortsvergleich_pfad(frames, telegram_stub, monkeypatch, *, stil: st
             shutil.rmtree(d, ignore_errors=True)
 
 
-def _minuten(hhmm: str) -> int:
-    stunde, _, minute = hhmm.partition(":")
-    return int(stunde) * 60 + (int(minute) if minute else 0)
-
-
-def _abstand_minuten(a: str, b: str) -> int:
-    """Abstand zweier `HH:MM`-Angaben in Minuten, ueber Mitternacht hinweg."""
-    roh = abs(_minuten(a) - _minuten(b))
-    return min(roh, 24 * 60 - roh)
-
-
-# Die beiden Laeufe liegen Sekundenbruchteile auseinander; springt dazwischen
-# die Minute um, unterscheiden sich die aus "Minuten ab jetzt" zurueck-
-# gerechneten Uhrzeiten um genau 1 Minute. Groesser darf der Abstand nicht
-# sein — das waere ein echter Wertunterschied zwischen den Flaechen.
-_WANDUHR_TOLERANZ_MIN = 1
-
-
 # ---------------------------------------------------------------------------
 # AC-15 — Langform: Trip und Ortsvergleich nennen dasselbe Ende
 # ---------------------------------------------------------------------------
 
 
+@freeze_time(_GEFRORENE_UHR)
 def test_ac15_langform_traegt_in_beiden_flaechen_dasselbe_ende(
     telegram_stub, monkeypatch,
 ):
@@ -368,12 +367,13 @@ def test_ac15_langform_traegt_in_beiden_flaechen_dasselbe_ende(
     beide auf denselben Koordinaten und im reichen Telegram-Stil
     WHEN beide Alarme tatsaechlich abgesetzt werden
     THEN traegt die Ende-Angabe in BEIDEN Flaechen denselben Wortlaut
-    (`letzter Regen gegen HH:MM`) und denselben Wert — keine Flaeche zeigt
-    das Ende, ohne dass es die andere auch taete.
+    (`letzter Regen gegen ...`) und dasselbe Paar aus Tagesbezug und Uhrzeit —
+    keine Flaeche zeigt das Ende, ohne dass es die andere auch taete.
 
     Zusaetzlich wird der Wert gegen das aus den Frames HERGELEITETE Ende
     (Beginn + 80 Min) geprueft, nicht nur die beiden Flaechen gegeneinander:
-    zwei gleich falsche Angaben waeren sonst gruen.
+    zwei gleich falsche Angaben waeren sonst gruen. Issue #2096: geprueft
+    wird das PAAR — eine Uhrzeit ohne ihren Kalendertag ist keine Aussage.
 
     RED heute: `NowcastResult` kennt `event_end_minutes` nicht — beide Texte
     nennen ueberhaupt kein Ende."""
@@ -384,33 +384,21 @@ def test_ac15_langform_traegt_in_beiden_flaechen_dasselbe_ende(
         frames, telegram_stub, monkeypatch, stil="rich",
     )
 
-    trip_treffer = _LANGFORM_RE.search(trip_text)
-    cmp_treffer = _LANGFORM_RE.search(cmp_text)
-    fehlend = [
-        name for name, t in (("Trip", trip_treffer), ("Ortsvergleich", cmp_treffer))
-        if t is None
-    ]
-    assert not fehlend, (
-        f"RED: diese Flaeche(n) nennen kein Ende: {fehlend}\n"
-        f"  Trip          = {trip_text!r}\n  Ortsvergleich = {cmp_text!r}"
+    erwartet = expected_day_and_time(
+        frames.erwartetes_ende_utc, _JETZT_UTC, TRIP_ZONE,
     )
-
-    erwartet = frames.erwartetes_ende_utc.astimezone(TRIP_ZONE).strftime("%H:%M")
-    for name, treffer, text in (
-        ("Trip", trip_treffer, trip_text),
-        ("Ortsvergleich", cmp_treffer, cmp_text),
-    ):
-        assert _abstand_minuten(treffer.group(1), erwartet) <= _WANDUHR_TOLERANZ_MIN, (
-            f"{name} nennt {treffer.group(1)} statt des aus den Frames "
-            f"hergeleiteten Endes {erwartet}: {text!r}"
+    gemessen = {
+        name: extract_day_and_time(text, "letzter Regen gegen")
+        for name, text in (("Trip", trip_text), ("Ortsvergleich", cmp_text))
+    }
+    for name, paar in gemessen.items():
+        assert paar == erwartet, (
+            f"{name} nennt als Ende {paar!r} statt des aus den Frames "
+            f"hergeleiteten Paares {erwartet!r}: "
+            f"{(trip_text if name == 'Trip' else cmp_text)!r}"
         )
-
-    assert _abstand_minuten(
-        trip_treffer.group(1), cmp_treffer.group(1)
-    ) <= _WANDUHR_TOLERANZ_MIN, (
-        "Trip und Ortsvergleich nennen verschiedene Ende-Uhrzeiten:\n"
-        f"  Trip          = {trip_treffer.group(1)}\n"
-        f"  Ortsvergleich = {cmp_treffer.group(1)}"
+    assert gemessen["Trip"] == gemessen["Ortsvergleich"], (
+        f"Trip und Ortsvergleich nennen verschiedene Enden: {gemessen!r}"
     )
 
 
@@ -419,6 +407,7 @@ def test_ac15_langform_traegt_in_beiden_flaechen_dasselbe_ende(
 # ---------------------------------------------------------------------------
 
 
+@freeze_time(_GEFRORENE_UHR)
 def test_ac15_kurzform_traegt_in_beiden_flaechen_dasselbe_ende_token(
     telegram_stub, monkeypatch,
 ):
@@ -427,7 +416,8 @@ def test_ac15_kurzform_traegt_in_beiden_flaechen_dasselbe_ende_token(
     und Premium-SMS bekommen
     WHEN beide Alarme abgesetzt werden
     THEN traegt das minutengenaue Ende-Token (`@HH:MM`) in BEIDEN Flaechen
-    denselben Wert.
+    dasselbe Paar aus Tagesbezug (DE-Wochentagskuerzel) und Uhrzeit, und es
+    haengt UNMITTELBAR am Beginn-Token.
 
     Warum eigens geprueft: die Kurzform ist ein anderer Codepfad als die
     Langform (`_render_sms_onset` statt `_render_telegram_onset`), und auf der
@@ -449,31 +439,21 @@ def test_ac15_kurzform_traegt_in_beiden_flaechen_dasselbe_ende_token(
         frames, telegram_stub, monkeypatch, stil="kurzform",
     )
 
-    trip_treffer = _KURZFORM_RE.search(trip_text)
-    cmp_treffer = _KURZFORM_RE.search(cmp_text)
-    fehlend = [
-        name for name, t in (("Trip", trip_treffer), ("Ortsvergleich", cmp_treffer))
-        if t is None
-    ]
-    assert not fehlend, (
-        f"RED: diese Flaeche(n) tragen kein Ende-Token: {fehlend}\n"
-        f"  Trip          = {trip_text!r}\n  Ortsvergleich = {cmp_text!r}"
+    erwartet = expected_day_and_time(
+        frames.erwartetes_ende_utc, _JETZT_UTC, TRIP_ZONE, style="kurzform",
     )
-
-    erwartet = frames.erwartetes_ende_utc.astimezone(TRIP_ZONE).strftime("%H:%M")
-    for name, treffer, text in (
-        ("Trip", trip_treffer, trip_text),
-        ("Ortsvergleich", cmp_treffer, cmp_text),
-    ):
-        assert _abstand_minuten(treffer.group("ende"), erwartet) <= _WANDUHR_TOLERANZ_MIN, (
-            f"{name} nennt das Ende {treffer.group('ende')!r} statt des aus "
-            f"den Frames hergeleiteten Endes {erwartet}: {text!r}"
+    gemessen: dict[str, tuple[str | None, str]] = {}
+    for name, text in (("Trip", trip_text), ("Ortsvergleich", cmp_text)):
+        assert _KURZFORM_STRUKTUR_RE.search(text), (
+            f"RED: {name} traegt kein minutengenaues Ende-Token unmittelbar "
+            f"am Beginn-Token: {text!r}"
+        )
+        gemessen[name] = extract_day_and_time(text, "@", style="kurzform")
+        assert gemessen[name] == erwartet, (
+            f"{name} nennt als Ende {gemessen[name]!r} statt des aus den "
+            f"Frames hergeleiteten Paares {erwartet!r}: {text!r}"
         )
 
-    assert _abstand_minuten(
-        trip_treffer.group("ende"), cmp_treffer.group("ende"),
-    ) <= _WANDUHR_TOLERANZ_MIN, (
-        "Trip und Ortsvergleich tragen verschiedene Ende-Token:\n"
-        f"  Trip          = {trip_treffer.group('ende')!r}\n"
-        f"  Ortsvergleich = {cmp_treffer.group('ende')!r}"
+    assert gemessen["Trip"] == gemessen["Ortsvergleich"], (
+        f"Trip und Ortsvergleich tragen verschiedene Ende-Token: {gemessen!r}"
     )

--- a/tests/tdd/test_onset_ende_textstellen.py
+++ b/tests/tdd/test_onset_ende_textstellen.py
@@ -40,11 +40,12 @@ import re
 import socket
 import threading
 import urllib.parse
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from zoneinfo import ZoneInfo
 
 import pytest
+from freezegun import freeze_time
 
 import output.channels.telegram as tg_module
 from app.config import Settings
@@ -55,6 +56,18 @@ from output.renderers.alert.render import (
 from services.notification_service import NotificationService, RadarAlertRequest
 
 from tests.helpers.nowcast_gate_fixtures import clean_uid, fresh_uid, make_trip
+from tests.helpers.tagesbezug import expected_day_and_time, extract_day_and_time
+
+# Issue #2096: zwei gestellte Uhren fuer den Buendel-Fall, dessen
+# Konstruktor die Uhrzeiten aus `datetime.now()` ableitet. Mittags liegt
+# das Ende (+80 Min) im selben Kalendertag, um 23:30 auf dem FOLGETAG --
+# genau der Fall, an dem die frueheren nackten `HH:MM`-Anker ab ~21:05 UTC
+# scheiterten. Das zweite Feld ist die Positivkontrolle: es sagt, OB der
+# Fall den Ueberlauf-Zweig erreichen muss.
+_GESTELLTE_UHREN = [
+    ("2026-08-22 12:00:00+00:00", False),
+    ("2026-08-22 23:30:00+00:00", True),
+]
 
 # Langform-Wortlaut (#2020 S2). Die Uhrzeit wird als Gruppe gefangen, damit
 # der WERT geprueft werden kann und nicht nur die Floskel.
@@ -347,7 +360,10 @@ def test_ac9_die_ende_angabe_steht_auch_im_html_teil():
 # ---------------------------------------------------------------------------
 
 
-def test_ac10_mehr_orte_buendel_traegt_das_ende_des_fuehrenden_ortes():
+@pytest.mark.parametrize("gestellte_uhr,erwartet_ueberlauf", _GESTELLTE_UHREN)
+def test_ac10_mehr_orte_buendel_traegt_das_ende_des_fuehrenden_ortes(
+    gestellte_uhr, erwartet_ueberlauf,
+):
     """AC-10 GIVEN ein Mehr-Orte-Onset-Buendel (Ortsvergleich) mit ZWEI Orten,
     dessen fuehrender Ort ein `NowcastResult` mit gesetztem
     `event_end_minutes=80` traegt
@@ -357,7 +373,12 @@ def test_ac10_mehr_orte_buendel_traegt_das_ende_des_fuehrenden_ortes():
     im Trip-Pfad (AC-9), nicht bloss eine Beginn-Zeile.
 
     Wanduhrfest: der Buendel-Konstruktor leitet die Uhrzeiten aus
-    `datetime.now()` ab, deshalb Struktur- statt Goldstring-Pruefung.
+    `datetime.now()` ab -- die Uhr ist deshalb gestellt (#2096) und das
+    erwartete Paar aus Tagesbezug und Uhrzeit wird aus DIESER Uhr und den
+    injizierten 80 Minuten HERGELEITET, statt nur die Floskel zu suchen. Mit
+    der frueheren nackten `HH:MM`-Regex traf der Anker ab ~21:05 UTC nicht
+    mehr, weil der Renderer dann korrekt `letzter Regen gegen morgen 01:18`
+    schreibt.
 
     RED heute: `NowcastResult` kennt `event_end_minutes` nicht
     (`TypeError`)."""
@@ -373,14 +394,25 @@ def test_ac10_mehr_orte_buendel_traegt_das_ende_des_fuehrenden_ortes():
         is_convective=False, event_end_minutes=95,
     )
 
-    msg = to_multi_location_onset_alert_message(
-        [("Zermatt", fuehrend), ("Chamonix", zweiter)],
-        tz=timezone.utc, stand_at="10:00",
-    )
-    _html, plain = render_email(msg)
+    with freeze_time(gestellte_uhr):
+        msg = to_multi_location_onset_alert_message(
+            [("Zermatt", fuehrend), ("Chamonix", zweiter)],
+            tz=timezone.utc, stand_at="10:00",
+        )
+        _html, plain = render_email(msg)
+        jetzt = datetime.now(timezone.utc)
 
-    assert _LANGFORM_RE.search(plain), (
-        f"RED: das Mehr-Orte-Buendel nennt kein Ende: {plain!r}"
+    erwartet = expected_day_and_time(
+        jetzt + timedelta(minutes=80), jetzt, timezone.utc,
+    )
+    assert (erwartet[0] is not None) is erwartet_ueberlauf, (
+        f"Positivkontrolle: bei der gestellten Uhr {gestellte_uhr} muss das "
+        f"Ende {'' if erwartet_ueberlauf else 'NICHT '}auf den Folgetag "
+        f"fallen -- hergeleitet wurde {erwartet!r}"
+    )
+    assert extract_day_and_time(plain, "letzter Regen gegen") == erwartet, (
+        f"Das Mehr-Orte-Buendel nennt nicht das aus den injizierten 80 "
+        f"Minuten hergeleitete Ende-Paar {erwartet!r}: {plain!r}"
     )
     assert "Zermatt" in plain, (
         f"Voraussetzung: der fuehrende Ort steht im Buendel-Text: {plain!r}"
@@ -395,7 +427,14 @@ def test_ac10_ohne_ende_bleibt_das_buendel_unveraendert():
 
     Bewusst OHNE das neue Feld konstruiert: dieser Waechter bleibt damit
     unabhaengig vom Modell-Erweiterungsstand gruen und faengt spaeter eine
-    erfundene Ende-Angabe."""
+    erfundene Ende-Angabe.
+
+    Issue #2096: geprueft ueber den Helfer, nicht ueber eine nackte
+    `HH:MM`-Regex. Eine erfundene Ende-Angabe MIT Tagesbezug
+    (`letzter Regen gegen morgen 01:18`) waere an der alten Regex
+    vorbeigelaufen -- der Waechter haette sie zu jeder Tageszeit nach ~21:05
+    UTC durchgewunken. `(None, "")` heisst "der Anker kommt im Text gar nicht
+    vor"."""
     from output.renderers.alert.project import to_multi_location_onset_alert_message
     from services.radar_service import NowcastResult
 
@@ -414,7 +453,7 @@ def test_ac10_ohne_ende_bleibt_das_buendel_unveraendert():
     )
     _html, plain = render_email(msg)
 
-    assert _LANGFORM_RE.search(plain) is None, (
+    assert extract_day_and_time(plain, "letzter Regen gegen") == (None, ""), (
         f"Ohne abgeleitetes Ende darf keine Ende-Angabe entstehen: {plain!r}"
     )
 

--- a/tests/tdd/test_onset_kurzform_menge.py
+++ b/tests/tdd/test_onset_kurzform_menge.py
@@ -33,6 +33,8 @@ import pytest
 from output.renderers.alert.model import AlertMessage, OnsetEvent
 from output.renderers.alert.render import render_sms
 
+from tests.helpers.tagesbezug import KURZFORM_ZEIT_TOKEN
+
 # Eine Ziffer UNMITTELBAR hinter dem Kuerzel — die Mengen-Schreibweise des
 # Regen-Falls. Wird von den ZAHLENLOSEN Faellen (AC-4a/AC-4c) benutzt: dort
 # darf hinter KEINEM der beiden Kuerzel eine Ziffer stehen.
@@ -48,7 +50,12 @@ _ZIFFER_HINTER_KUERZEL_RE = re.compile(r"\b(TH|R)(\d)")
 # bleibt fuer AC-4a/AC-4c in Kraft und bewacht dort weiterhin BEIDE Kuerzel.
 _ZIFFER_HINTER_TH_RE = re.compile(r"\bTH(\d)")
 # Vollstaendiger Regen-Mengen-Token: `R<zahl mit einer Nachkommastelle>@HH:MM`.
-_MENGEN_TOKEN_RE = re.compile(r"\bR(\d+)\.(\d)@(\d{1,2}):(\d{2})\b")
+# Issue #2096: der Zeitteil traegt bei Tagesuebergang ein vorangestelltes
+# DE-Wochentagskuerzel (`R2.5@Sa0:15`). Der Ausdruck laesst es deshalb zu --
+# geprueft wird hier die ZAHLFORM, nicht der Tagesbezug; ohne diese
+# Zulassung faende er das Token in den letzten Minuten vor Mitternacht
+# ueberhaupt nicht mehr und meldete einen Defekt, den es nicht gibt.
+_MENGEN_TOKEN_RE = re.compile(rf"\bR(\d+)\.(\d)@{KURZFORM_ZEIT_TOKEN}\b")
 
 _UNSET = object()  # Sentinel: `onset_precip_mm` gar nicht erst uebergeben.
 
@@ -236,7 +243,7 @@ def test_ac4c_nowcast_ohne_belastbare_daten_rendert_ohne_zahl(flag):
     )
     sms = render_sms(msg)
 
-    assert re.search(r"\bR@\d{1,2}:\d{2}", sms), (
+    assert re.search(rf"\bR@{KURZFORM_ZEIT_TOKEN}", sms), (
         f"Erwartet die zahlenlose Form 'R@HH:MM': {sms!r}"
     )
     assert _ZIFFER_HINTER_KUERZEL_RE.search(sms) is None, (

--- a/tests/tdd/test_onset_reichweite_guete_kanalparitaet.py
+++ b/tests/tdd/test_onset_reichweite_guete_kanalparitaet.py
@@ -54,7 +54,6 @@ import dataclasses
 import http.server
 import inspect
 import json
-import re
 import shutil
 import socket
 import threading
@@ -62,6 +61,7 @@ from datetime import datetime, time, timedelta, timezone
 from pathlib import Path
 
 import pytest
+from freezegun import freeze_time
 
 import output.channels.telegram as tg_module
 from app.config import Settings
@@ -75,12 +75,22 @@ from tests.helpers.nowcast_gate_fixtures import (
     TRIP_LAT, TRIP_LON, TRIP_ZONE, clean_uid, fresh_uid, make_trip,
     quiet_window_elsewhere, radar_service, reset_radar_cache,
 )
+from tests.helpers.tagesbezug import expected_day_and_time, extract_day_and_time
 
-# Langform-Wortlaute, mit gefangener Uhrzeit.
-_REACH_RE = re.compile(r"Radar reicht bis (\d{1,2}:\d{2})")
-_GUETE_RE = re.compile(r"Ortsangabe ab (\d{1,2}:\d{2}) unscharf")
-# Kurzform: das Guete-Zeichen `?` unmittelbar hinter einem Zeit-Token.
-_KURZFORM_GUETE_RE = re.compile(r"@(?P<beginn>\d{1,2}:\d{2})\?")
+# Issue #2096: gestellte Uhr statt Wanduhr. Die frueheren nackten
+# `HH:MM`-Regexe trafen ab ~21:05 UTC nicht mehr, weil der Renderer bei
+# Tagesuebergang korrekt `morgen 00:12` schreibt -- die Ampel wurde abends rot
+# ohne Produktivdefekt. Geprueft wird jetzt das PAAR aus Tagesbezug und
+# Uhrzeit (`tests/helpers/tagesbezug.py`), gestellt wird die Uhr auf die
+# Mittagsstunde: der Tagesuebergang selbst laeuft in
+# `test_tagesbezug_ueberlauf_spaetuhr.py` als eigener Fall, der ihn
+# tatsaechlich durchfaehrt statt ihn wegzufrieren.
+#
+# Nebenwirkung, die den Vergleich schaerft: beide Flaechen sehen unter der
+# gestellten Uhr denselben Zeitpunkt. Die frueher noetige Ein-Minuten-Toleranz
+# (`_abstand_minuten`) entfaellt -- verglichen wird auf Gleichheit.
+_GEFRORENE_UHR = "2026-08-22 12:00:00+00:00"
+_JETZT_UTC = datetime.fromisoformat(_GEFRORENE_UHR)
 
 # Nasser Block: +20 bis +150 Minuten im 10-Minuten-Raster, danach TROCKEN,
 # danach KEINE weiteren Frames mehr.
@@ -341,22 +351,6 @@ def _text_vom_ortsvergleich_pfad(frames, telegram_stub, monkeypatch, *, stil: st
             shutil.rmtree(d, ignore_errors=True)
 
 
-def _minuten(hhmm: str) -> int:
-    stunde, _, minute = hhmm.partition(":")
-    return int(stunde) * 60 + (int(minute) if minute else 0)
-
-
-def _abstand_minuten(a: str, b: str) -> int:
-    roh = abs(_minuten(a) - _minuten(b))
-    return min(roh, 24 * 60 - roh)
-
-
-# Die beiden Laeufe liegen Sekundenbruchteile auseinander; springt dazwischen
-# die Minute um, unterscheiden sich die zurueckgerechneten Uhrzeiten um
-# hoechstens 1 Minute -- kein echter Wertunterschied.
-_WANDUHR_TOLERANZ_MIN = 1
-
-
 def test_prueling_stammt_aus_diesem_arbeitsbaum():
     """Vorbedingung (kein AC): Alarm-Services werden RELATIV ZU DIESER
     Testdatei aufgeloest."""
@@ -377,6 +371,7 @@ def test_prueling_stammt_aus_diesem_arbeitsbaum():
 # ---------------------------------------------------------------------------
 
 
+@freeze_time(_GEFRORENE_UHR)
 def test_ac14_langform_traegt_in_beiden_flaechen_reichweite_und_guete(
     telegram_stub, monkeypatch,
 ):
@@ -387,10 +382,14 @@ def test_ac14_langform_traegt_in_beiden_flaechen_reichweite_und_guete(
     (`CompareRadarAlertService.check_all_compare_presets`), beide im reichen
     Telegram-Stil
     WHEN beide Alarme tatsaechlich abgesetzt werden
-    THEN tragen BEIDE Texte dieselbe Reichweite (`Radar reicht bis HH:MM`)
-    UND dieselbe Guete-Grenzzeit (`Ortsangabe ab HH:MM unscharf`) -- gegen
-    das aus den Frames HERGELEITETE Ende geprueft, nicht nur gegeneinander
-    (zwei gleich falsche Angaben waeren sonst gruen).
+    THEN tragen BEIDE Texte dieselbe Reichweite (`Radar reicht bis ...`)
+    UND dieselbe Guete-Grenzzeit (`Ortsangabe ab ... unscharf`) -- gegen
+    das aus den Frames HERGELEITETE Paar aus TAGESBEZUG und Uhrzeit geprueft,
+    nicht nur gegeneinander (zwei gleich falsche Angaben waeren sonst gruen).
+
+    Issue #2096: geprueft wird das Paar, nicht die nackte `HH:MM`-Form. Eine
+    Uhrzeit ohne ihren Kalendertag ist auf der Huette am Karnischen Hoehenweg
+    keine Aussage, sondern eine Vermutung.
 
     RED heute: `RadarAlertRequest`/`NowcastResult`/`OnsetEvent` kennen die
     neuen Felder nicht -- keiner der beiden Texte nennt Reichweite oder
@@ -402,57 +401,24 @@ def test_ac14_langform_traegt_in_beiden_flaechen_reichweite_und_guete(
         frames, telegram_stub, monkeypatch, stil="rich",
     )
 
-    trip_reach = _REACH_RE.search(trip_text)
-    cmp_reach = _REACH_RE.search(cmp_text)
-    fehlend_reach = [
-        n for n, t in (("Trip", trip_reach), ("Ortsvergleich", cmp_reach)) if t is None
-    ]
-    assert not fehlend_reach, (
-        f"RED: diese Flaeche(n) nennen keine Reichweite: {fehlend_reach}\n"
-        f"  Trip          = {trip_text!r}\n  Ortsvergleich = {cmp_text!r}"
-    )
-
-    erwartete_reichweite = (
-        frames.erwartete_reichweite_utc.astimezone(TRIP_ZONE).strftime("%H:%M")
-    )
-    for name, treffer, text in (
-        ("Trip", trip_reach, trip_text), ("Ortsvergleich", cmp_reach, cmp_text),
+    for anker, ziel_utc, was in (
+        ("Radar reicht bis", frames.erwartete_reichweite_utc, "Reichweite"),
+        ("Ortsangabe ab", frames.erwartete_guete_grenze_utc, "Guete-Grenzzeit"),
     ):
-        assert _abstand_minuten(treffer.group(1), erwartete_reichweite) <= _WANDUHR_TOLERANZ_MIN, (
-            f"{name} nennt {treffer.group(1)} statt der aus den Frames "
-            f"hergeleiteten Reichweite {erwartete_reichweite}: {text!r}"
+        erwartet = expected_day_and_time(ziel_utc, _JETZT_UTC, TRIP_ZONE)
+        gemessen = {
+            name: extract_day_and_time(text, anker)
+            for name, text in (("Trip", trip_text), ("Ortsvergleich", cmp_text))
+        }
+        for name, paar in gemessen.items():
+            assert paar == erwartet, (
+                f"{name} nennt als {was} {paar!r} statt des aus den Frames "
+                f"hergeleiteten Paares {erwartet!r}: "
+                f"{(trip_text if name == 'Trip' else cmp_text)!r}"
+            )
+        assert gemessen["Trip"] == gemessen["Ortsvergleich"], (
+            f"Trip und Ortsvergleich nennen verschiedene {was}n: {gemessen!r}"
         )
-    assert _abstand_minuten(trip_reach.group(1), cmp_reach.group(1)) <= _WANDUHR_TOLERANZ_MIN, (
-        "Trip und Ortsvergleich nennen verschiedene Reichweiten:\n"
-        f"  Trip          = {trip_reach.group(1)}\n"
-        f"  Ortsvergleich = {cmp_reach.group(1)}"
-    )
-
-    trip_guete = _GUETE_RE.search(trip_text)
-    cmp_guete = _GUETE_RE.search(cmp_text)
-    fehlend_guete = [
-        n for n, t in (("Trip", trip_guete), ("Ortsvergleich", cmp_guete)) if t is None
-    ]
-    assert not fehlend_guete, (
-        f"RED: diese Flaeche(n) nennen keine Guete-Zeile: {fehlend_guete}\n"
-        f"  Trip          = {trip_text!r}\n  Ortsvergleich = {cmp_text!r}"
-    )
-
-    erwartete_guete = (
-        frames.erwartete_guete_grenze_utc.astimezone(TRIP_ZONE).strftime("%H:%M")
-    )
-    for name, treffer, text in (
-        ("Trip", trip_guete, trip_text), ("Ortsvergleich", cmp_guete, cmp_text),
-    ):
-        assert _abstand_minuten(treffer.group(1), erwartete_guete) <= _WANDUHR_TOLERANZ_MIN, (
-            f"{name} nennt {treffer.group(1)} statt der hergeleiteten "
-            f"Guete-Grenzzeit {erwartete_guete}: {text!r}"
-        )
-    assert _abstand_minuten(trip_guete.group(1), cmp_guete.group(1)) <= _WANDUHR_TOLERANZ_MIN, (
-        "Trip und Ortsvergleich nennen verschiedene Guete-Grenzzeiten:\n"
-        f"  Trip          = {trip_guete.group(1)}\n"
-        f"  Ortsvergleich = {cmp_guete.group(1)}"
-    )
 
 
 # ---------------------------------------------------------------------------
@@ -460,6 +426,7 @@ def test_ac14_langform_traegt_in_beiden_flaechen_reichweite_und_guete(
 # ---------------------------------------------------------------------------
 
 
+@freeze_time(_GEFRORENE_UHR)
 def test_ac14_kurzform_traegt_in_beiden_flaechen_dasselbe_guete_zeichen(
     telegram_stub, monkeypatch,
 ):
@@ -467,13 +434,17 @@ def test_ac14_kurzform_traegt_in_beiden_flaechen_dasselbe_guete_zeichen(
     Telegram-KURZSTIL -- dem Stil, der denselben `sms_body` traegt, den SMS
     und Premium-SMS bekommen
     WHEN beide Alarme abgesetzt werden
-    THEN traegt das Guete-Zeichen `?` in BEIDEN Flaechen denselben
-    Zeit-Token, und die Reichweite steht in KEINER Flaeche in der Kurzform
-    (E6).
+    THEN traegt das Guete-Zeichen `?` in BEIDEN Flaechen dasselbe Paar aus
+    Tagesbezug (DE-Wochentagskuerzel) und Zeit-Token, und die Reichweite
+    steht in KEINER Flaeche in der Kurzform (E6).
 
     Warum eigens geprueft: die Kurzform ist ein anderer Codepfad als die
     Langform, und auf der Huette am Karnischen Hoehenweg kommt NUR
     Premium-SMS an.
+
+    Issue #2096: das Guete-Zeichen haengt am LETZTEN Zeit-Token der Gruppe --
+    hier am Ende-Token. Geprueft wird deshalb gegen das aus den Frames
+    hergeleitete ENDE-Paar, nicht nur Flaeche gegen Flaeche.
 
     RED heute: keiner der beiden Texte traegt ein Guete-Zeichen."""
     frames = _FesterBlockMitReichweite()
@@ -485,28 +456,27 @@ def test_ac14_kurzform_traegt_in_beiden_flaechen_dasselbe_guete_zeichen(
         frames, telegram_stub, monkeypatch, stil="kurzform",
     )
 
-    trip_treffer = _KURZFORM_GUETE_RE.search(trip_text)
-    cmp_treffer = _KURZFORM_GUETE_RE.search(cmp_text)
-    fehlend = [
-        n for n, t in (("Trip", trip_treffer), ("Ortsvergleich", cmp_treffer))
-        if t is None
-    ]
-    assert not fehlend, (
-        f"RED: diese Flaeche(n) tragen kein Guete-Zeichen: {fehlend}\n"
-        f"  Trip          = {trip_text!r}\n  Ortsvergleich = {cmp_text!r}"
+    erwartet = expected_day_and_time(
+        frames.erwartetes_ende_utc, _JETZT_UTC, TRIP_ZONE, style="kurzform",
     )
-    assert _abstand_minuten(
-        trip_treffer.group("beginn"), cmp_treffer.group("beginn"),
-    ) <= _WANDUHR_TOLERANZ_MIN, (
+    gemessen = {
+        name: extract_day_and_time(text, "@", style="kurzform")
+        for name, text in (("Trip", trip_text), ("Ortsvergleich", cmp_text))
+    }
+    for name, paar in gemessen.items():
+        assert paar == erwartet, (
+            f"{name} haengt das Guete-Zeichen an {paar!r} statt an das "
+            f"hergeleitete Ende-Paar {erwartet!r}: "
+            f"{(trip_text if name == 'Trip' else cmp_text)!r}"
+        )
+    assert gemessen["Trip"] == gemessen["Ortsvergleich"], (
         "Trip und Ortsvergleich haengen das Guete-Zeichen an "
-        "unterschiedliche Zeit-Token:\n"
-        f"  Trip          = {trip_treffer.group('beginn')}\n"
-        f"  Ortsvergleich = {cmp_treffer.group('beginn')}"
+        f"unterschiedliche Zeit-Token: {gemessen!r}"
     )
 
-    erwartete_reichweite = (
-        frames.erwartete_reichweite_utc.astimezone(TRIP_ZONE).strftime("%H:%M")
-    )
+    erwartete_reichweite = expected_day_and_time(
+        frames.erwartete_reichweite_utc, _JETZT_UTC, TRIP_ZONE,
+    )[1]
     assert erwartete_reichweite not in trip_text, (
         f"Die Reichweite darf in der Trip-Kurzform nicht auftauchen (E6): "
         f"{trip_text!r}"

--- a/tests/tdd/test_onset_reichweite_guete_sms.py
+++ b/tests/tdd/test_onset_reichweite_guete_sms.py
@@ -39,6 +39,8 @@ from pathlib import Path
 from output.renderers.alert.model import AlertMessage, OnsetEvent
 from output.renderers.alert.render import render_sms
 
+from tests.helpers.tagesbezug import KURZFORM_ZEIT_TOKEN
+
 _UNSET = object()
 
 
@@ -259,7 +261,10 @@ def test_ac12_kurzform_zeigt_kein_drittes_zeit_token_fuer_die_reichweite():
         location_sharpness_limit_time="19:00", source_reach_time="21:00",
     )))
 
-    zeit_token = re.findall(r"@\d{1,2}:\d{2}", sms)
+    # Issue #2096: das Kuerzel des Tagesuebergangs (`@Sa0:15`) gehoert mit
+    # gezaehlt -- sonst zaehlte der Ausdruck abends WENIGER Token, als da
+    # sind, und die Obergrenze waere genau dann wirkungslos.
+    zeit_token = re.findall(rf"@{KURZFORM_ZEIT_TOKEN}", sms)
     assert len(zeit_token) <= 2, (
         f"RED/E6: die Kurzform darf hoechstens zwei Zeit-Token tragen "
         f"(Beginn, Ende), kein drittes fuer die Reichweite: {sms!r} "

--- a/tests/tdd/test_starkregen_kurzfristhinweis.py
+++ b/tests/tdd/test_starkregen_kurzfristhinweis.py
@@ -37,7 +37,6 @@ import uuid
 from datetime import date as date_type, datetime, time, timedelta, timezone
 from pathlib import Path
 
-import pytest
 from freezegun import freeze_time
 
 from app.config import Settings
@@ -113,16 +112,18 @@ def _active_trip(trip_id: str) -> Trip:
 def _trip_with_segment_offset(trip_id: str, *, start_in_min: float, duration_min: float = 20.0) -> Trip:
     """Aktives/naechstes Segment beginnt in `start_in_min` Minuten ab jetzt (UTC).
 
-    Skip statt Fehlschlag, wenn der Offset eine Mitternachtsgrenze (UTC) beruehrt —
-    Stage.date ist ein einzelner Kalendertag, ein Tageswechsel wuerde die
-    HH:MM-Arithmetik verfaelschen (analog dem now.hour<4-Guard in
-    test_issue_818_radar_briefing_integration.py::test_ac5).
+    Issue #2096: der frueher hier stehende Selbst-Skip ("Testzeitpunkt zu nah
+    an einer Mitternachtsgrenze") ist ERSATZLOS entfallen. Er fing einen
+    Zufall der Wanduhr ab; die Aufrufer stellen die Uhr inzwischen fest
+    (`freeze_time`), damit gibt es diesen Zufall nicht mehr. Ein Test, der
+    sich still selbst ueberspringt, ist ein Waechter-Loch: er meldet Gruen,
+    ohne etwas geprueft zu haben. Wer diese Fixture kuenftig ohne gestellte
+    Uhr aufruft, bekommt einen Fehlschlag statt eines stillen Skips -- und
+    das ist die richtige Meldung.
     """
     now = datetime.now(timezone.utc).replace(second=0, microsecond=0)
     start = now + timedelta(minutes=start_in_min)
     end = start + timedelta(minutes=duration_min)
-    if start.date() != end.date() or start.date() != date_type.today():
-        pytest.skip("Testzeitpunkt zu nah an einer Mitternachtsgrenze (UTC) fuer Offset-Segment")
 
     wp0 = Waypoint(
         id="WP0", name="Start", lat=LAT, lon=LON, elevation_m=100.0,
@@ -372,22 +373,30 @@ def test_ac2_zeitfenster_guard_kein_fetch_ausserhalb_horizon(monkeypatch):
         )
 
     # Nah: Segment beginnt in 30 Minuten (<= 180) -> Fetch UND Hinweis.
-    uid_nah = _uid("ac2-nah")
-    trip_nah = _trip_with_segment_offset(f"trip-ac2-nah-{uuid.uuid4().hex[:6]}", start_in_min=30)
-    calls_nah: list = []
-    _install_fake_nowcast(monkeypatch, calls_nah, onset_minutes=10, intensity_label=INTENSITY_HEAVY)
-    rec_nah = _ReportRecorder()
-    rec_nah.install(monkeypatch)
-    _outcome_nah, report_nah = _run_briefing(rec_nah, uid_nah, trip_nah)
+    # Feste Uhr auch hier (#2096): frueher lief dieser Zweig auf der Wanduhr
+    # und uebersprang sich ab ~23:30 UTC still selbst. Ein Test, der abends
+    # nichts prueft und trotzdem gruen meldet, bewacht nichts.
+    with freeze_time("2026-08-17T10:00:00+00:00"):
+        uid_nah = _uid("ac2-nah")
+        trip_nah = _trip_with_segment_offset(
+            f"trip-ac2-nah-{uuid.uuid4().hex[:6]}", start_in_min=30
+        )
+        calls_nah: list = []
+        _install_fake_nowcast(
+            monkeypatch, calls_nah, onset_minutes=10, intensity_label=INTENSITY_HEAVY
+        )
+        rec_nah = _ReportRecorder()
+        rec_nah.install(monkeypatch)
+        _outcome_nah, report_nah = _run_briefing(rec_nah, uid_nah, trip_nah)
 
-    assert len(calls_nah) >= 1, (
-        "AC-2 (Gegenprobe): Segment beginnt in 30 Minuten (<= Horizont) -> "
-        f"get_nowcast() MUSS aufgerufen werden, war {calls_nah!r}."
-    )
-    assert _HINT_MARKER in report_nah.email_plain, (
-        "AC-2 (Gegenprobe): innerhalb des Horizonts MUSS der Hinweis erscheinen.\n"
-        f"{report_nah.email_plain}"
-    )
+        assert len(calls_nah) >= 1, (
+            "AC-2 (Gegenprobe): Segment beginnt in 30 Minuten (<= Horizont) -> "
+            f"get_nowcast() MUSS aufgerufen werden, war {calls_nah!r}."
+        )
+        assert _HINT_MARKER in report_nah.email_plain, (
+            "AC-2 (Gegenprobe): innerhalb des Horizonts MUSS der Hinweis erscheinen.\n"
+            f"{report_nah.email_plain}"
+        )
 
 
 # ══════════════════════════════════ AC-3 ══════════════════════════════════

--- a/tests/tdd/test_tagesbezug_testwaechter.py
+++ b/tests/tdd/test_tagesbezug_testwaechter.py
@@ -1,0 +1,188 @@
+"""TDD RED — Issue #2096: der Vertrag des geteilten Tagesbezug-Testhelfers.
+
+SPEC: docs/specs/modules/fix_2096_tagesbezug_testwaechter.md — AC-1 bis AC-4.
+
+Warum das zaehlt: acht CI-Tests ankern heute per nackter `HH:MM`-Regex auf
+Alarmtexte. Faellt die Zeitangabe auf den Folgetag, stellt der Renderer
+korrekt einen Tagesbezug voran (`morgen 00:12`, Kurzform `So1:35`) und der
+Anker trifft nicht mehr -- die Ampel wird abends rot, ohne dass ein
+Produktivdefekt vorlaege. Die naheliegende Behebung (Regex aufweichen zu
+`(?:morgen )?`) waere die falsche: sie macht gruen und laesst den Tagesbezug
+weiterhin UNGEPRUEFT -- `grep -rn "source_reach_day_offset" tests/` liefert
+heute null Treffer. Dieser Helfer zieht stattdessen ein PAAR aus Tagesbezug
+und Uhrzeit und vergleicht es gegen ein aus den Zeitstempeln HERGELEITETES
+Paar; damit ist der Zweig erstmals bewacht.
+
+Mock-frei: reine Funktionsaufrufe auf echten Strings und echten
+`datetime`-Werten. Kein `Mock()`, kein `patch()`, kein Dateiinhalt-Check.
+
+RED heute: `tests/helpers/tagesbezug.py` existiert nicht -- der Import
+scheitert mit `ModuleNotFoundError`.
+"""
+from __future__ import annotations
+
+import inspect
+from datetime import datetime
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+from tests.helpers.tagesbezug import expected_day_and_time, extract_day_and_time
+
+# Zone MIT Versatz: unter reinem UTC laege der Datumsvergleich in AC-3 in zwei
+# von drei Faellen zufaellig richtig, ohne dass der Helfer die Trip-Zone
+# ueberhaupt beachten muesste.
+_TZ = ZoneInfo("Europe/Vienna")
+
+# Wortlaut und Satzbau stammen aus dem gemessenen Spaetuhr-Lauf (Kontextdatei
+# `docs/context/fix-2096-paritaets-regex-tagesbezug.md`, Abschnitt "Gemessene
+# Ist-Texte"); die Uhrzeiten sind die der Spec-Beispiele aus AC-1.
+_LANGFORM_MIT_TAG = (
+    "23:50 · letzter Regen gegen morgen 02:00 · Radar reicht bis morgen 00:12"
+    " · Ortsangabe ab morgen 00:30 unscharf · mäßiger Regen · Radar (DWD)"
+)
+_LANGFORM_OHNE_TAG = (
+    "14:20 · letzter Regen gegen 22:10 · Radar reicht bis 23:47"
+    " · mäßiger Regen · Radar (DWD)"
+)
+_KURZFORM_MIT_KUERZEL = "Seg 1: R3.0@23:25@So1:35?"
+_KURZFORM_OHNE_KUERZEL = "Seg 1: R3.0@23:25?"
+
+
+def test_prueling_stammt_aus_diesem_arbeitsbaum():
+    """Vorbedingung (kein AC): der Helfer wird RELATIV ZU DIESER Testdatei
+    aufgeloest, nicht aus dem Hauptrepo-Pfad (sonst falsches Gruen aus dem
+    Worktree)."""
+    from tests.helpers import tagesbezug as helper_modul
+
+    arbeitsbaum = Path(__file__).resolve().parents[2]
+    modul_pfad = Path(inspect.getfile(helper_modul)).resolve()
+    assert modul_pfad.is_relative_to(arbeitsbaum), (
+        f"Prueling stammt nicht aus diesem Arbeitsbaum: {modul_pfad}"
+    )
+
+
+def test_ac1_langform_liefert_paar_mit_und_ohne_tagesbezug():
+    """AC-1 GIVEN einen Langform-Text, dessen Reichweite einmal MIT
+    (`Radar reicht bis morgen 00:12`) und einmal OHNE Tagesbezug
+    (`Radar reicht bis 23:47`) steht
+    WHEN der Helfer die Reichweite am Anker zieht
+    THEN liefert er `("morgen", "00:12")` bzw. `(None, "23:47")`.
+
+    Das Tageswort ist hier ausnahmsweise Literal: dieser Test PRUEFT genau
+    diese Zuordnung Text -> Paar, es gibt nichts, woraus er sie ableiten
+    koennte."""
+    assert extract_day_and_time(_LANGFORM_MIT_TAG, "Radar reicht bis") == (
+        "morgen", "00:12",
+    )
+    assert extract_day_and_time(_LANGFORM_OHNE_TAG, "Radar reicht bis") == (
+        None, "23:47",
+    )
+
+
+def test_ac1_langform_anker_trennt_die_zeitangaben_voneinander():
+    """AC-1 (Abgrenzung) GIVEN denselben Text mit MEHREREN Zeitangaben
+    WHEN der Helfer an einem ANDEREN Anker zieht
+    THEN liefert er die Zeitangabe DIESES Ankers, nicht die erstbeste des
+    Textes -- sonst passte jeder Anker auf jede Zahl und der Wachdienst waere
+    reine Form."""
+    assert extract_day_and_time(_LANGFORM_MIT_TAG, "letzter Regen gegen") == (
+        "morgen", "02:00",
+    )
+    assert extract_day_and_time(_LANGFORM_MIT_TAG, "Ortsangabe ab") == (
+        "morgen", "00:30",
+    )
+
+
+def test_ac2_kurzform_liefert_paar_aus_wochentagskuerzel_und_zeit():
+    """AC-2 GIVEN den Kurzform-Text `Seg 1: R3.0@23:25@So1:35?`
+    WHEN der Helfer das Guete-Zeichen-Token zieht (Anker `@`, Treffer ist das
+    Token, dem `?` folgt)
+    THEN liefert er `("So", "1:35")`; ohne Wochentagskuerzel (`@23:25?`)
+    liefert er `(None, "23:25")`.
+
+    Warum eigens geprueft: die Kurzform ist ein anderer Codepfad als die
+    Langform (`_sms_onset_time()` statt `_time_with_day()`), und auf der
+    Huette am Karnischen Hoehenweg kommt NUR Premium-SMS an, die denselben
+    `sms_body` traegt."""
+    assert extract_day_and_time(
+        _KURZFORM_MIT_KUERZEL, "@", style="kurzform",
+    ) == ("So", "1:35")
+    assert extract_day_and_time(
+        _KURZFORM_OHNE_KUERZEL, "@", style="kurzform",
+    ) == (None, "23:25")
+
+
+def test_ac3_erwartetes_paar_wird_aus_dem_datumsvergleich_hergeleitet():
+    """AC-3 GIVEN eine Ziel-UTC-Zeit, eine Jetzt-UTC-Zeit und die Trip-Zone
+    WHEN der Helfer das ERWARTETE Paar bildet
+    THEN ist das Tageswort `None` bei gleichem lokalen Kalendertag, `morgen`
+    bei einem Tag Versatz und `gestern` bei minus einem Tag.
+
+    Alle drei Faelle liegen so, dass der Versatz der Zone (Wien, UTC+2 im
+    August) den Ausschlag gibt: Fall 1 traegt in UTC ZWEI verschiedene
+    Kalendertage und in Ortszeit denselben -- ein Helfer, der die Zone
+    ignoriert, faellt hier durch."""
+    jetzt_utc = datetime.fromisoformat("2026-08-22 23:30:00+00:00")  # lokal 23.08. 01:30
+
+    gleicher_tag = datetime.fromisoformat("2026-08-23 00:30:00+00:00")  # lokal 23.08. 02:30
+    naechster_tag = datetime.fromisoformat("2026-08-23 23:00:00+00:00")  # lokal 24.08. 01:00
+    vortag = datetime.fromisoformat("2026-08-22 03:00:00+00:00")        # lokal 22.08. 05:00
+
+    assert expected_day_and_time(gleicher_tag, jetzt_utc, _TZ) == (None, "02:30")
+    assert expected_day_and_time(naechster_tag, jetzt_utc, _TZ) == ("morgen", "01:00")
+    assert expected_day_and_time(vortag, jetzt_utc, _TZ) == ("gestern", "05:00")
+
+
+def test_ac3_kurzform_erwartung_traegt_kuerzel_und_stunde_ohne_fuehrende_null():
+    """AC-3 (Kurzform-Variante) GIVEN dieselben Zeitstempel
+    WHEN das erwartete Paar im Kurzform-Stil gebildet wird
+    THEN steht statt des Tageswortes das DE-Wochentagskuerzel des ZIELtages,
+    und die Stunde traegt keine fuehrende Null (`1:00`, nicht `01:00`) --
+    genau die Schreibweise, die `_sms_onset_time()` erzeugt
+    (`src/output/renderers/alert/render.py:790-812`). Am Versandtag entfaellt
+    das Kuerzel ersatzlos, dieselbe Regel wie `_sms_day_prefix()` (`:1396`).
+
+    Ohne diese Variante liesse sich der Kurzform-Ueberlauf (AC-12, Fall 3)
+    nur gegen ein Literal pruefen."""
+    jetzt_utc = datetime.fromisoformat("2026-08-22 23:30:00+00:00")  # lokal 23.08. 01:30
+    ziel_utc = datetime.fromisoformat("2026-08-23 23:00:00+00:00")   # lokal 24.08. 01:00
+
+    # Das Kuerzel wird aus dem ZIELdatum hergeleitet, nicht getippt.
+    erwartetes_kuerzel = ["Mo", "Di", "Mi", "Do", "Fr", "Sa", "So"][
+        ziel_utc.astimezone(_TZ).weekday()
+    ]
+    assert expected_day_and_time(
+        ziel_utc, jetzt_utc, _TZ, style="kurzform",
+    ) == (erwartetes_kuerzel, "1:00")
+
+    gleicher_tag = datetime.fromisoformat("2026-08-23 00:30:00+00:00")  # lokal 23.08. 02:30
+    assert expected_day_and_time(
+        gleicher_tag, jetzt_utc, _TZ, style="kurzform",
+    ) == (None, "2:30")
+
+
+def test_ac4_positivkontrolle_falsches_tageswort_faellt_auf():
+    """AC-4 (Positivkontrolle) GIVEN einen Text, dessen UHRZEIT stimmt, dessen
+    TAGESWORT aber falsch ist (`heute 00:12`, wo `morgen 00:12` richtig waere)
+    WHEN das extrahierte Paar gegen das hergeleitete verglichen wird
+    THEN sind die Paare UNGLEICH -- und beim richtigen Text GLEICH.
+
+    Der wichtigste Fall der Datei: er belegt, dass der Vergleich ueberhaupt
+    misst. Ohne ihn bliebe offen, ob ein Helfer, der schlicht immer dasselbe
+    liefert, die anderen ACs ebenfalls bestuende
+    (`reference_positivkontrolle_prueft_ob_die_pruefung_misst`)."""
+    jetzt_utc = datetime.fromisoformat("2026-08-22 21:00:00+00:00")  # lokal 22.08. 23:00
+    ziel_utc = datetime.fromisoformat("2026-08-22 22:12:00+00:00")   # lokal 23.08. 00:12
+    erwartet = expected_day_and_time(ziel_utc, jetzt_utc, _TZ)
+
+    richtig = "Wo & wann: km 2–6 · Radar reicht bis morgen 00:12 · Radar (DWD)"
+    falsch = "Wo & wann: km 2–6 · Radar reicht bis heute 00:12 · Radar (DWD)"
+
+    assert extract_day_and_time(richtig, "Radar reicht bis") == erwartet, (
+        "Vorbedingung: beim RICHTIGEN Text muss der Vergleich aufgehen, sonst "
+        "misst die Gegenprobe unten nur einen kaputten Helfer"
+    )
+    assert extract_day_and_time(falsch, "Radar reicht bis") != erwartet, (
+        "Ein falsches Tageswort bei richtiger Uhrzeit muss auffallen -- sonst "
+        "bewacht der Helfer nur die Form, nicht den Wert"
+    )

--- a/tests/tdd/test_tagesbezug_ueberlauf_spaetuhr.py
+++ b/tests/tdd/test_tagesbezug_ueberlauf_spaetuhr.py
@@ -54,7 +54,7 @@ _JETZT_UTC = datetime.fromisoformat(_GEFRORENE_UHR)
 
 @freeze_time(_GEFRORENE_UHR)
 def test_langform_quellenreichweite_faellt_auf_den_folgetag(
-    telegram_stub, monkeypatch,
+    telegram_stub, monkeypatch,  # noqa: F811 (importierte Fixture)
 ):
     """AC-12 (Mechanismus Langform-Reichweite) GIVEN eine gestellte Uhr, bei
     der die Quellen-Reichweite auf den Folgetag faellt
@@ -88,7 +88,7 @@ def test_langform_quellenreichweite_faellt_auf_den_folgetag(
 
 @freeze_time(_GEFRORENE_UHR)
 def test_langform_ereignisende_faellt_auf_den_folgetag(
-    telegram_stub, monkeypatch,
+    telegram_stub, monkeypatch,  # noqa: F811 (importierte Fixture)
 ):
     """AC-12 (Mechanismus Langform-Ende) GIVEN dieselbe gestellte Uhr, bei der
     das Ereignis-Ende auf den Folgetag faellt
@@ -127,7 +127,7 @@ def test_langform_ereignisende_faellt_auf_den_folgetag(
 
 @freeze_time(_GEFRORENE_UHR)
 def test_kurzform_guete_token_traegt_das_wochentagskuerzel(
-    telegram_stub, monkeypatch,
+    telegram_stub, monkeypatch,  # noqa: F811 (importierte Fixture)
 ):
     """AC-12 (Mechanismus Kurzform) GIVEN dieselbe gestellte Uhr
     WHEN beide Flaechen im Telegram-KURZSTIL gerendert werden -- dem Stil, der

--- a/tests/tdd/test_tagesbezug_ueberlauf_spaetuhr.py
+++ b/tests/tdd/test_tagesbezug_ueberlauf_spaetuhr.py
@@ -1,0 +1,165 @@
+"""TDD RED — Issue #2096 AC-12: der Tagesuebergang wird tatsaechlich
+DURCHLAUFEN, nicht nur weggefroren.
+
+SPEC: docs/specs/modules/fix_2096_tagesbezug_testwaechter.md — AC-12.
+
+Warum diese Datei noetig ist: der Zuschnitt stellt in den Bestandstests die
+Uhr fest (Baustein 2). Damit verschwindet die abendliche Rotfaerbung -- aber
+mit ihr auch der Zweig, der sie ausloest. Ein Testbestand, der den Ueberlauf
+nie mehr erreicht, bewacht ihn nicht; er weicht ihm aus. Je Mechanismus
+(Langform-Reichweite, Langform-Ende, Kurzform-Wochentagskuerzel) laeuft hier
+deshalb ein eigener Fall mit einer Uhr, die so spaet steht, dass die
+Zeitangaben nachweislich auf den Folgetag fallen -- und beide Flaechen (Trip
+UND Ortsvergleich) werden geprueft, weil `source_reach_day_offset` /
+`event_end_day_offset` an ZWEI Stellen entstehen: `trip_alert.py:1753-1758`
+und `project.py:644-653`.
+
+Mock-frei: DIESELBEN echten Radar-Frames laufen durch BEIDE echten
+Produktivpfade (`TripAlertService.check_radar_alerts()` bzw.
+`CompareRadarAlertService.check_all_compare_presets()`) bis zur Nutzlast am
+Draht eines lokalen Aufzeichnungs-Servers. Aufbau und Aufzeichnung werden aus
+`test_onset_reichweite_guete_kanalparitaet.py` IMPORTIERT statt kopiert --
+eine zweite Kopie wuerde beim naechsten Umbau auseinanderlaufen.
+
+Die Uhr steht per `freeze_time` auf einem festen absoluten Zeitpunkt; die
+Erwartung wird aus DIESER Uhr und den Frame-Zeitstempeln hergeleitet, nie als
+Tageswort getippt.
+
+RED heute: `tests/helpers/tagesbezug.py` existiert nicht -- der Import
+scheitert mit `ModuleNotFoundError`.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+
+from freezegun import freeze_time
+
+from tests.helpers.nowcast_gate_fixtures import TRIP_ZONE
+from tests.helpers.tagesbezug import expected_day_and_time, extract_day_and_time
+from tests.tdd.test_onset_reichweite_guete_kanalparitaet import (  # noqa: F401
+    _FesterBlockMitReichweite,
+    _text_vom_ortsvergleich_pfad,
+    _text_vom_trip_pfad,
+    telegram_stub,
+)
+
+# 23:30 UTC == 23:30 Atlantic/Reykjavik (TRIP_ZONE, ganzjaehrig UTC+0). Der
+# Frame-Block reicht von +20 (Beginn, noch am selben Tag) bis +175 Min
+# (Reichweite) -- Ende (+150), Reichweite (+175) und Guete-Grenze (+60) fallen
+# damit alle auf den Folgetag, der Beginn nicht. Genau die Konstellation, an
+# der die Bestandsanker ab ~21:05 UTC scheitern.
+_GEFRORENE_UHR = "2026-08-22 23:30:00+00:00"
+_JETZT_UTC = datetime.fromisoformat(_GEFRORENE_UHR)
+
+
+@freeze_time(_GEFRORENE_UHR)
+def test_langform_quellenreichweite_faellt_auf_den_folgetag(
+    telegram_stub, monkeypatch,
+):
+    """AC-12 (Mechanismus Langform-Reichweite) GIVEN eine gestellte Uhr, bei
+    der die Quellen-Reichweite auf den Folgetag faellt
+    WHEN Trip- UND Ortsvergleich-Pfad in der Langform gerendert werden
+    THEN nennen BEIDE Flaechen dasselbe Paar aus Tagesbezug und Uhrzeit -- und
+    zwar das aus Frame-Zeitstempel und gestellter Uhr HERGELEITETE.
+
+    RED heute: `tests.helpers.tagesbezug` existiert nicht."""
+    frames = _FesterBlockMitReichweite()
+    erwartet = expected_day_and_time(
+        frames.erwartete_reichweite_utc, _JETZT_UTC, TRIP_ZONE,
+    )
+    assert erwartet[0] is not None, (
+        "Vorbedingung: die gestellte Uhr muss den Ueberlauf-Zweig ueberhaupt "
+        f"erreichen -- erwartet wurde {erwartet!r} ohne Tagesbezug"
+    )
+
+    trip_text = _text_vom_trip_pfad(
+        frames, telegram_stub, monkeypatch, stil="rich",
+    )
+    cmp_text = _text_vom_ortsvergleich_pfad(
+        frames, telegram_stub, monkeypatch, stil="rich",
+    )
+
+    for name, text in (("Trip", trip_text), ("Ortsvergleich", cmp_text)):
+        assert extract_day_and_time(text, "Radar reicht bis") == erwartet, (
+            f"{name} nennt nicht das hergeleitete Reichweiten-Paar "
+            f"{erwartet!r}: {text!r}"
+        )
+
+
+@freeze_time(_GEFRORENE_UHR)
+def test_langform_ereignisende_faellt_auf_den_folgetag(
+    telegram_stub, monkeypatch,
+):
+    """AC-12 (Mechanismus Langform-Ende) GIVEN dieselbe gestellte Uhr, bei der
+    das Ereignis-Ende auf den Folgetag faellt
+    WHEN beide Flaechen in der Langform gerendert werden
+    THEN nennen beide dasselbe, aus dem letzten nassen Frame hergeleitete
+    Ende-Paar.
+
+    Eigener Fall statt Zusatz-Assertion im Reichweiten-Test: Ende und
+    Reichweite entstehen aus zwei verschiedenen Feldern
+    (`event_end_day_offset` vs. `source_reach_day_offset`); eine gemeinsame
+    Pruefung liesse offen, welches der beiden den Ausschlag gab.
+
+    RED heute: `tests.helpers.tagesbezug` existiert nicht."""
+    frames = _FesterBlockMitReichweite()
+    erwartet = expected_day_and_time(
+        frames.erwartetes_ende_utc, _JETZT_UTC, TRIP_ZONE,
+    )
+    assert erwartet[0] is not None, (
+        "Vorbedingung: das Ereignis-Ende muss bei dieser Uhr auf den Folgetag "
+        f"fallen -- erwartet wurde {erwartet!r}"
+    )
+
+    trip_text = _text_vom_trip_pfad(
+        frames, telegram_stub, monkeypatch, stil="rich",
+    )
+    cmp_text = _text_vom_ortsvergleich_pfad(
+        frames, telegram_stub, monkeypatch, stil="rich",
+    )
+
+    for name, text in (("Trip", trip_text), ("Ortsvergleich", cmp_text)):
+        assert extract_day_and_time(text, "letzter Regen gegen") == erwartet, (
+            f"{name} nennt nicht das hergeleitete Ende-Paar {erwartet!r}: "
+            f"{text!r}"
+        )
+
+
+@freeze_time(_GEFRORENE_UHR)
+def test_kurzform_guete_token_traegt_das_wochentagskuerzel(
+    telegram_stub, monkeypatch,
+):
+    """AC-12 (Mechanismus Kurzform) GIVEN dieselbe gestellte Uhr
+    WHEN beide Flaechen im Telegram-KURZSTIL gerendert werden -- dem Stil, der
+    denselben `sms_body` traegt, den SMS und Premium-SMS bekommen
+    THEN traegt das Token vor dem Guete-Zeichen `?` in BEIDEN Flaechen das
+    hergeleitete Wochentagskuerzel des Zieltages und dessen Uhrzeit.
+
+    Warum eigens geprueft: auf der Huette am Karnischen Hoehenweg kommt NUR
+    Premium-SMS an -- dort gibt es keinen zweiten Kanal, der eine mehrdeutige
+    Uhrzeit richtigstellt. Der Kurzform-Tagesbezug entsteht ausserdem in einer
+    ANDEREN Funktion als der der Langform (`_sms_onset_time()` statt
+    `_time_with_day()`).
+
+    RED heute: `tests.helpers.tagesbezug` existiert nicht."""
+    frames = _FesterBlockMitReichweite()
+    erwartet = expected_day_and_time(
+        frames.erwartetes_ende_utc, _JETZT_UTC, TRIP_ZONE, style="kurzform",
+    )
+    assert erwartet[0] is not None, (
+        "Vorbedingung: ohne Tagesversatz entfaellt das Wochentagskuerzel "
+        f"ersatzlos, der Fall pruefte dann nichts -- erwartet {erwartet!r}"
+    )
+
+    trip_text = _text_vom_trip_pfad(
+        frames, telegram_stub, monkeypatch, stil="kurzform",
+    )
+    cmp_text = _text_vom_ortsvergleich_pfad(
+        frames, telegram_stub, monkeypatch, stil="kurzform",
+    )
+
+    for name, text in (("Trip", trip_text), ("Ortsvergleich", cmp_text)):
+        assert extract_day_and_time(text, "@", style="kurzform") == erwartet, (
+            f"{name} traegt am Guete-Zeichen nicht das hergeleitete Paar "
+            f"{erwartet!r}: {text!r}"
+        )


### PR DESCRIPTION
Behebt #2096 — die CI-Ampel wurde ab ~21:05 UTC auf **jedem** PR rot, unabhängig vom Inhalt.

## Befund

Acht Tests hingen an der Wanduhr. Der ausgelieferte Alarmtext ist korrekt — **kein Produktivdefekt**,
gegengeprüft durch `analysis-challenger`. Drei Mechanismen, gemessen auf `origin/main`:

| Mechanismus | Was | Betroffen |
|---|---|---|
| **A** | Uhrzeit-Regex trifft den vorangestellten Tagesbezug nicht (`Radar reicht bis morgen 00:12`, Kurzform `@So1:35?`) | 6 Tests, 4 Dateien |
| **B** | Fixture stempelt ein Ortszeit-Fenster mit dem Systemdatum → Segment 24 h in der Vergangenheit, `check_radar_alerts()` liefert 0 | 2 Tests |
| **C** | Test überspringt sich nahe der Mitternachtsgrenze **still selbst** — kein Rot, aber auch keine Prüfung | 1 Test |

## Wächterlücke, die dabei sichtbar wurde

`source_reach_day_offset` kommt im Produktivcode an **neun Stellen in sechs Dateien** vor und in den
Tests **null Mal**. Ausgerechnet der Zweig, der die Ampel rot färbte, war von keinem Test bewacht.

**Ausdrücklich verworfen:** eine Regex-Aufweichung (`(?:morgen )?`). Sie macht die Ampel grün und
lässt den Tagesbezug weiterhin ungeprüft — das Muster „Test prüft die Form statt des Werts".

## Was geliefert wird

**Kein Produktivcode.** `git diff --stat origin/main -- src/ api/ internal/ frontend/ cmd/` ist leer.

- `tests/helpers/tagesbezug.py` — liest eine Zeitangabe als **Paar** `(Tagesbezug, "HH:MM")` und
  **leitet** das erwartete Paar aus den Zeitstempeln her, statt es zu literalisieren.
  Wochentagskürzel per Import aus `official_alerts._DE_WEEKDAYS`, nicht abgetippt.
- `tests/helpers/wanduhr.py` + `tests/conftest.py` — Uhr-Schalter `GZ_TEST_WALL_CLOCK_UTC`.
  Ohne gesetzte Variable passiert nichts; der Normallauf bleibt auf der echten Wanduhr.
- 3 neue Testdateien, 8 Bestandsdateien umgestellt.

## Nachweis

**Vier gestellte Uhren, je 135 bestanden, 0 übersprungen:** 12:00 · 21:06 · 22:50 · 23:58 UTC.
Voller CI-Lauf: 10.955 bestanden, 2 vorbestehend rot (beide bestehen isoliert, beide außerhalb
dieses Zuschnitts, beide strukturell unerreichbar für die Fixture — sie steigt ohne gesetzte
Variable sofort aus).

**Mutations-Gegenproben** — vorher fing keine davon ein einziger Test:

| Verfälschung | Jetzt |
|---|---|
| `_time_with_day()` ohne den `day_offset == 1`-Zweig | 4 rot |
| `source_reach_day_offset = 0` (Ortsvergleich) | 1 rot |
| dasselbe im Trip-Pfad | 1 rot |
| Etappendatum zurück auf `date.today()` | 3 rot |
| Uhr-Schalter stillgelegt | 1 rot (auch **ohne** gesetzte Variable) |
| Ankerberechnung um 1 h verschoben | 7 rot |

Adversary: **VERDICT VERIFIED** über 4 Runden, 19/19 Prüfpunkte belegt. Zwei BROKEN-Runden
unterwegs — beide fanden dieselbe Fehlerklasse eine Ebene tiefer: ein Prüfwerkzeug, das auf beiden
Seiten seiner eigenen Prüfung steht, prüft nichts.

## Hinweis an die nächste Scheibe

`tests/tdd/test_alarm_szenario_tagesbezug_zeitzone.py` (aus #2050 S3a) bewacht dasselbe Thema mit
festen Textbausteinen (`assert "morgen 00:23" in text`). Das fängt den Totalausfall, aber keinen
**falschen** Wert. Für neue Zeitangabe-Prüfungen bitte `expected_day_and_time()` nutzen statt einen
zweiten Baustein anzulegen.

## Offene Kleinbefunde → #1199

- `test_starkregen_kurzfristhinweis.py:104` — Docstring verspricht mehr, als der Test erzwingt (LOW)
- `anker_aus()` akzeptiert ein ISO-Datum ohne Uhrzeit still als Mitternacht statt `ValueError` (LOW)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JMtTnK88ydvxbBug6xUuXQ
