### PR TITLE
fix(#2098): ACC-Spalte und Sonnenstunden im 3-Tages-Ausblick

### DIFF
--- a/docs/context/fix-2098-ausblick-acc-und-sonnenstunden.md
+++ b/docs/context/fix-2098-ausblick-acc-und-sonnenstunden.md
@@ -1,0 +1,283 @@
+# Context: fix-2098-ausblick-acc-und-sonnenstunden
+
+Issue: [#2098](https://github.com/henemm/gregor_zwanzig/issues/2098) · `type:bug` · `priority:high`
+· Milestone „Tour KHW 2026-08"
+
+## Request Summary
+
+In der 3-Tages-Vorschau („AUSBLICK · NÄCHSTE 3 TAGE") der Trip-Briefing-E-Mail sind zwei
+Fehler sichtbar: die Spalte **Sonnenstunden** zeigt in allen drei Zeilen `–`, und die Spalte
+**ACC** (Prognose-Genauigkeit / `confidence_pct`) ist ganz verschwunden. Der PO verlangt: ACC
+muss **immer** erscheinen, unabhängig von der Frontend-Metrik-Auswahl. Für die Sonnenstunden
+ist zu klären, ob die Größe überhaupt verfügbar ist — und ob **weitere Metriken** dasselbe
+Problem haben.
+
+## Beleg aus dem Issue (zwei Screenshots)
+
+| Stand | Kopfzeile der Vorschau | ACC | Sonnenstunden |
+|---|---|---|---|
+| Fr 07:04 | `Tag · N · D · R · PR · Wind · Böen · Gew · ACC` (Kurzform) | ✅ Farbpunkt je Zeile | nicht vorhanden |
+| So 07:05 | `Tag · Gefühlte Temperatur · Wind · Böen · Niederschlag · Regenwahrscheinlichkeit · Gewitter · Sonnenstunden` (Langform) | ❌ fehlt | vorhanden, aber `–` in allen 3 Zeilen |
+
+Die Kopfzeile wechselt zwischen den beiden Ständen von der **festen Kurzform-Liste** auf die
+**Langform der konfigurierten Trip-Metriken**. Beide Befunde entstehen an diesem Wechsel.
+
+## Auslösende Änderungen (zwischen den Screenshots nach `main` gegangen)
+
+| Commit | Titel |
+|---|---|
+| `f66a5457` | feat(#1848 A2): Backend liest und schreibt Ausblick-Kennungen |
+| `2ff3fb44` | feat(#2049): Roh/Einfach-Umschaltung je Ausblick-Metrik |
+
+## Gemeinsame Wurzel (Hypothese für Phase 2)
+
+`render_outlook_table()` hat **zwei Zweige**:
+
+1. **Altform-Zweig** (`metrics is None`) — die sieben festen Spalten, `outlook.py:165-177`
+   (Kopf) und `:231` (Datenzelle). **Nur hier existiert `show_acc`.**
+2. **Konfigurierbarer Zweig** (`metrics is not None`) — `outlook.py:129-163`. Die Kopfzeile
+   entsteht ausschließlich aus `outlook_columns(metrics)`, die Werte ausschließlich aus
+   `stage["cells"]`. **Dieser Zweig kennt ACC überhaupt nicht.**
+
+Der Docstring von `render_outlook_table` bezeichnet `metrics` ausdrücklich als
+„#1361/#1368, **nur Compare**". Seit #1848 A2 fährt aber auch der **Trip** über diesen Zweig.
+Damit erbt der Trip zwei Compare-Eigenschaften, die für ihn falsch sind:
+
+- **ACC:** Der Ortsvergleich ruft bewusst mit `show_acc=False` auf (`compare_html.py:1257`).
+  Der Trip ruft weiterhin mit `show_acc=True` auf (`html.py:1403`) — der Schalter läuft im
+  konfigurierbaren Zweig aber ins Leere, weil dort keine ACC-Zelle gebaut wird.
+- **Sonnenstunden:** Die Zellen entstehen datengetrieben über
+  `MetricDefinition.summary_fields` als `getattr(summary, col["field"])`. Für `sunshine` ist
+  das `summary_fields={"sum": "sunny_hours"}` (`metric_catalog.py:604`), also
+  `SegmentWeatherSummary.sunny_hours` (`models.py:497`). Dieses Feld wird gefüllt von
+  `summarize_points()` (`weather_metrics.py:554`) und vom Ortsvergleich
+  (`comparison_engine.py:261/356/560`) — der Trip-Ausblick nutzt jedoch `aggregate_stage()`
+  (`weather_metrics.py:1352`), das sein Ergebnis **allein aus `aggregation_config`** aufbaut
+  (`models.py:531`). Trägt `sunny_hours` dort keine Aggregationsregel, fällt der auf
+  Segment-Ebene vorhandene Wert auf Etappen-Ebene weg → `None` → `–`.
+
+**Konsequenz für die PO-Frage „gibt es sie nicht in einem größeren Zeitfenster?":** Wenn sich
+das bestätigt, sind die Sonnenstunden **vorhanden** und gehen nur auf der Aggregationsstufe
+verloren. Die vom PO erwogene Alternative — die Metrik aus dem Angebot nehmen — wäre dann
+nicht die richtige Antwort.
+
+**Konsequenz für „trifft das weitere Metriken?":** Die Verdachtsliste ist bestimmbar statt
+geraten — alle Metriken, deren `summary_fields`-Zielfeld in `aggregate_stage`s
+`aggregation_config` fehlt. Das ist in Phase 2 mechanisch abzählbar.
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `src/output/renderers/email/outlook.py:45` | `render_outlook_table()` — beide Zweige, `show_acc` nur im Altform-Zweig |
+| `src/output/renderers/email/outlook.py:103-121` | `_acc_dot()` — 4-stufiger Farbpunkt aus `confidence_pct` |
+| `src/output/renderers/email/outlook.py:129-163` | konfigurierbarer Zweig: Kopf aus `outlook_columns()`, Werte aus `stage["cells"]` |
+| `src/output/renderers/email/outlook.py:263` | `render_outlook_plain()` — Klartext-Fassung, muss mitziehen (HTML=Normalfassung, keine Dopplung) |
+| `src/output/renderers/email/outlook.py:432` | `build_outlook_row()` — baut `cells`, geteilte Naht Trip+Compare |
+| `src/output/renderers/email/outlook.py:634-690` | `cells`-Schleife: `format_outlook_range_cell()` / `format_outlook_value()` |
+| `src/output/renderers/compare_outlook_metric_ids.py:48` | `derived_aggregations()` — Kennung → Auswertungen |
+| `src/output/renderers/compare_outlook_metric_ids.py:194` | `resolve_trip_outlook_metrics()` — Trip-Auflösung |
+| `src/output/renderers/compare_outlook_metric_ids.py:298` | `outlook_columns()` — Spaltenbeschreibung, Quelle der Kopfzeile |
+| `src/app/metric_catalog.py:593-605` | `sunshine`-Definition: `summary_fields={"sum": "sunny_hours"}`, `dp_field="dni_wm2"` |
+| `src/app/metric_catalog.py:999` | `OUTLOOK_FRIENDLY_CAPABLE` — enthält `sunshine` |
+| `src/app/models.py:444/497/531` | `SegmentWeatherSummary`, Feld `sunny_hours`, `aggregation_config` |
+| `src/services/weather_metrics.py:350` | `calculate_sunny_hours()` — DNI-Interpolation |
+| `src/services/weather_metrics.py:534-554` | `summarize_points()` — füllt `sunny_hours` auf Segment-Ebene |
+| `src/services/weather_metrics.py:1352` | `aggregate_stage()` — Etappen-Aggregation über `aggregation_config` |
+| `src/services/trip_report_scheduler.py:2465` | Aufruf `build_outlook_row()` mit Trip-Konfiguration |
+| `src/output/renderers/email/html.py:1403` | Trip: `render_outlook_table(..., show_acc=True)` |
+| `src/output/renderers/email/compare_html.py:1257` | Compare: `render_outlook_table(..., show_acc=False)` |
+
+## Existing Specs
+
+| Spec | Bezug |
+|---|---|
+| `docs/specs/modules/feat_1848_a2_ausblick_kennungen.md` | Auslöser: Ausblick-Kennungen im Backend |
+| `docs/specs/modules/feat_1848_a3_ausblick_erbt_grundauswahl.md` | Trip erbt die Grundauswahl |
+| `docs/specs/modules/feat_1720_s1_trip_ausblick_metriken.md` | Trip-Ausblick-Metriken |
+| `docs/specs/modules/issue_1361_1368_ausblick_konfigurierbar.md` | Ursprung des konfigurierbaren Zweigs (Compare) |
+| `docs/specs/modules/fix_2049_ausblick_darstellungsform.md` | Roh/Einfach je Ausblick-Metrik |
+| `docs/specs/modules/feat_1406a_ausblick_geteiltes_element.md` | Ausblick als geteiltes Element Trip/Compare |
+| `docs/specs/modules/outlook_gehzeit_und_spanne.md` | Gehzeit-Fenster und Spannen im Ausblick |
+| `docs/reference/renderer_email_spec.md` | Mail-Renderer-Referenz |
+
+## Dependencies
+
+- **Upstream:** `metric_catalog` (Metrik-Definitionen, `summary_fields`) · `weather_metrics`
+  (`summarize_points`, `aggregate_stage`, `calculate_sunny_hours`) · `SegmentWeatherSummary`
+  · `trip_report_scheduler` (reicht `display_config` durch)
+- **Downstream:** vier Ausgabeorte teilen sich `build_outlook_row()` — Trip-HTML,
+  Trip-Klartext, Compare-HTML, Compare-Klartext. Eine Änderung an den Zellen wirkt überall.
+
+## Risks & Considerations
+
+- **Trip/Compare-Teilungs-Invariante (CLAUDE.md):** `build_outlook_row()` und
+  `render_outlook_table()` sind bewusst geteilt. Ein Fix darf keine Trip-eigene Kopie
+  erzeugen. ACC ist bereits sauber parametrisiert (`show_acc`) — der Weg ist, diesen
+  Parameter im konfigurierbaren Zweig **wirksam** zu machen, nicht ihn zu umgehen.
+- **#710 (Confidence nicht wählbar):** ACC darf **nicht** als wählbare Metrik in die Auswahl
+  wandern. Der E-Mail-Textblock ist einer der drei erlaubten Orte — die Spalte muss also
+  **neben** der Auswahl stehen, fest angehängt, nicht als Katalog-Eintrag.
+- **HTML=Normalfassung, keine Dopplung:** der Farbpunkt im HTML braucht im Klartext ein
+  **Wort**, keinen Punkt. `render_outlook_plain()` muss mitgeführt werden.
+- **Reihenfolge-Kopplung:** Kopfzeile und Wertzeilen entstehen aus **zwei getrennten**
+  `outlook_columns()`-Aufrufen und sind nur über den Listenindex verbunden
+  (`compare_outlook_metric_ids.py:64-68`). Eine fest angehängte ACC-Spalte muss an **beiden**
+  Enden gleich angehängt werden, sonst verschieben sich Werte gegen Beschriftungen — still.
+- **Renderer-Commit-Gate:** Änderungen an Mail-Inhalts-Dateien blocken den Commit, bis
+  Modus-Matrix-Test und `briefing_mail_validator.py` frisch grün sind.
+- **Nachweis-Pfad:** Trip-Briefing ⇒ `briefing_mail_validator.py` (nicht
+  `email_spec_validator.py`), gegen echt zugestellte Staging-Mail.
+- **Tour läuft ab heute (2026-08-23).** Normal ausliefern, nicht abkürzen und nicht
+  aufschieben.
+- **Fehlender Wert verschluckt still:** Bei `texte = [cells[i] if i < len(cells) else "–"]`
+  erzeugt sowohl eine zu kurze `cells`-Liste als auch ein echter `None`-Wert dasselbe `–`.
+  Tests müssen den **Wert** prüfen, nicht die Form — ein plausibel falscher Wert als
+  Gegenprobe, nicht `None`.
+
+---
+
+## Analysis (Phase 2 — zwei parallele Ermittler, beide mit Beleg)
+
+### Type
+**Bug** (zwei Befunde, gemeinsame Wurzel: der Trip fährt seit #1848 A2/A3 über den
+konfigurierbaren Ausblick-Zweig, der für den Ortsvergleich gebaut wurde).
+
+### Befund 1 — Sonnenstunden: bestätigt, Ursache exakt lokalisiert
+
+`aggregate_stage()` (`weather_metrics.py:1384`) baut das Etappen-Summary **ausschließlich** aus
+Feldern, die in `summaries[0].aggregation_config` eine Regel tragen (Schleife ab `:1385`).
+`sunny_hours` wird zwar gesetzt (`weather_metrics.py:534,554`) und im Extended-Merge mitkopiert
+(`:1002`), trägt aber **weder im Basis-Dict (`:553-569`) noch im Extended-Merge (`:1032-1061`)
+eine Aggregationsregel**. Damit wird es nie iteriert, landet nicht in `result_fields` und bleibt
+auf dem Dataclass-Default `None`.
+
+Zellwert: `outlook.py:401` `return getattr(summary, field, None)` → `None` → `–`.
+
+**Gegenprobe ausgeführt** (nicht nur gelesen): drei Segment-Summaries mit
+`sunny_hours = 2.0 / 3.5 / 4.0` und einer `aggregation_config` ohne `sunny_hours`-Regel durch
+`aggregate_stage()`:
+
+```
+sunny_hours im Ergebnis: None
+temp_min_c im Ergebnis: 10.0     # Feld MIT Regel überlebt
+```
+
+**Sonderfall mit Testrelevanz:** `compact_summary.py:265-268` ruft `aggregate_stage()` nur bei
+**mehr als einem** Segment; bei Einzelsegment-Etappen wird `valid[0].aggregated` unbeschädigt
+durchgereicht und der Wert erscheint. Der Fehler trifft also **nur Mehrsegment-Etappen** — ein
+Test mit einer Einzelsegment-Etappe wäre falsch grün.
+
+### Audit „trifft das weitere Metriken?" — abschließend beantwortet: NEIN
+
+Alle 26 `MetricDefinition`s mit `summary_fields` geprüft (inkl. aller 9
+`OUTLOOK_FRIENDLY_CAPABLE` und aller Grundauswahl-Templates ab `metric_catalog.py:1100`), die
+vollständige Feldliste von `SegmentWeatherSummary` (`models.py:444-531`) gegen die Vereinigung
+beider `aggregation_config`-Dicts abgeglichen: **`sunny_hours` ist das einzige Zielfeld ohne
+Regel.** Alle übrigen (Temperatur, Wind, Böen, Niederschlag, Regenwahrscheinlichkeit, Gewitter,
+CAPE, Bewölkung, Sicht, UV, Druck, Nullgradgrenze, Schneehöhe, Neuschnee …) tragen eine Regel.
+
+`compare_alert.py:61` („`sunny_hours_h`, `uv_index_max`, `snow_depth_cm` bewusst KEIN Mapping")
+betrifft eine **andere** Tabelle (`_SUMMARY_KEY_TO_CATALOG_ID`, Alarm-Zuordnung im
+Ortsvergleich) und hat mit diesem Bug nichts zu tun. UV-Index und Schneehöhe sind im
+Trip-Ausblick nachweislich in Ordnung.
+
+⇒ **Die vom PO erwogene Alternative („Metrik aus dem Angebot nehmen") ist widerlegt** — die
+Daten existieren, sie gehen eine Stufe vor der Anzeige verloren.
+
+**Reichweite:** nur Trip. `aggregate_stage()` wird ausschließlich vom Trip-Pfad gerufen
+(`compact_summary.py:268`, `stage_weather.py:113`, `trip_report_scheduler.py:2422`); der
+Ortsvergleich nutzt `summarize_points()`/`comparison_engine.py` ohne den
+`aggregation_config`-Rebuild und ist strukturell nicht betroffen.
+
+### Befund 2 — ACC: strukturell, nicht zufällig
+
+`show_acc` ist an allen vier Aufrufstellen korrekt gesetzt (Trip `True`, Compare `False`), wird
+aber vom **konfigurierbaren Zweig beider Renderer nicht gelesen** — dieser kehrt vorher zurück
+(Tabelle) bzw. macht `continue` (Klartext). Seit #1848 A3 liefert
+`resolve_trip_outlook_metrics()` für den Trip fast nie mehr `None`, sondern die volle
+Grundauswahl ⇒ der Trip läuft **praktisch immer** über den Zweig ohne ACC.
+
+**ACC kann nie eine wählbare Metrik-Spalte werden:** `confidence` ist `selectable=False`
+(`metric_catalog.py:418-423`, ADR-0005/#710), `derived_aggregations("confidence")` liefert
+darum immer `[]`. Die Wiederherstellung muss **außerhalb** des Metrik-Systems erfolgen — fest
+angehängt neben der Auswahl, exakt wie im Altform-Zweig.
+
+**Der Wert ist vorhanden:** `confidence_pct` wird in `build_outlook_row()` (`outlook.py:586-587,
+:599`) **vor** dem `if metrics is not None:`-Block (`:621`) ins Row-Dict geschrieben, Quelle
+`summary.confidence_pct_min` (gesetzt in `trip_report_scheduler.py:2299,2322`). Die
+wiederhergestellte Spalte trägt also sofort echte Werte.
+
+### Reihenfolge-Kopplung — entwarnt
+
+Die Warnung in `compare_outlook_metric_ids.py:64-68` (Kopf und Werte nur über den Listenindex
+verbunden) betrifft eine fest angehängte ACC-Spalte **nicht**, sofern sie am
+`outlook_columns()`/`cells`-Mechanismus vorbei angehängt wird:
+
+- `render_outlook_table()`: Kopf (`:133-135`) und Zellen (`:140-156`) entstehen bereits aus
+  **einem** `outlook_columns(metrics)`-Aufruf. Zwei Editierstellen in derselben Funktion, beide
+  lesen denselben `show_acc` und dasselbe `stage.get("confidence_pct")` — kein Indexrisiko.
+- `render_outlook_plain()`: Label und Wert entstehen pro Spalte in **einer**
+  `"  ".join(...)`-Zeile (`:301-303`) — eine Editierstelle, ein Auseinanderlaufen ist
+  strukturell unmöglich.
+
+⇒ `show_acc` ist die bereits vorhandene, nur ungenutzte Naht. Kein neuer Kopplungspunkt.
+
+### 🔴 Der Test verankert das Gegenteil
+
+`tests/tdd/test_trip_outlook_dispatch_mail.py:533-558`, Zeile 552, prüft ausdrücklich
+`kopf[1:] != ["N","D","R","PR","Wind","Böen","Gew","ACC"]` mit Kommentar „#1848 A3, AC-3" und
+Verweis auf **„PO-Freigabe 2026-08-21"**. Das Verschwinden von ACC im Trip-Normalfall war eine
+akzeptierte, testverankerte Nebenfolge — keine unbeachtete Lücke. #2098 dreht diese Entscheidung
+zurück; der Test muss mit angepasst werden, sonst blockiert er die eigene Behebung.
+
+**Warum kein Test gefangen hat:** alle ACC-Wächter rufen ohne `metrics=` auf und landen im
+inzwischen toten Altform-Zweig — `test_shared_outlook_renderer.py:132-156` (AC-1) und
+`:163-199` (AC-2), `test_trip_outlook_parity.py:94-122`.
+
+**Zu wahren:** `test_trip_outlook_metric_selection.py:310-325` und `:328-355` (AC-10 a/b)
+bewachen, dass `confidence` nie als **wählbare** Spalte erscheint (#710). Eine strukturell fest
+angehängte ACC-Spalte lässt diese Invariante unberührt — und muss das auch.
+
+### Klartext-ACC: Neuanforderung, keine Wiederherstellung
+
+`render_outlook_plain()` hat ACC **nie** ausgegeben — auch nicht im Altform-Zweig
+(`outlook.py:273-275` Docstring; verifiziert gegen
+`tests/fixtures/outlook_trip_parity/trip_outlook_show_acc_true.txt`, kein ACC-Token). Die
+Projektregel „Farbe im HTML ⇒ WORT im Klartext" ist dort bereits vorbestehend unerfüllt. Im HTML
+ist ACC ein reiner Farbpunkt (`_acc_dot()`, `:103-121`, vier Stufen ≥80 / ≥60 / ≥40 / <40) — die
+Farbe ist der **einzige** Informationsträger, für Klartext-Leser also unsichtbar. Aufnahme
+vorgeschlagen, als Erweiterung ausgewiesen.
+
+### Affected Files
+
+| Datei | Change | Beschreibung |
+|---|---|---|
+| `src/services/weather_metrics.py` | MODIFY | `"sunny_hours": "sum"` in `aggregation_config` (`:553-569`) |
+| `src/output/renderers/email/outlook.py` | MODIFY | `show_acc` im konfigurierbaren Zweig von `render_outlook_table()` (`:129-163`) und `render_outlook_plain()` (`:289-314`) wirksam machen; Klartext-Wort für ACC |
+| `tests/tdd/test_trip_outlook_dispatch_mail.py` | MODIFY | `:552` — verankert das Gegenteil, muss angepasst werden |
+| `tests/…` | CREATE | Wächter: Mehrsegment-Etappe mit Sonnenstunden-Wert; ACC im konfigurierbaren Zweig; #710-Invariante bleibt |
+| `docs/reference/renderer_email_spec.md` | MODIFY | Ausblick-Spaltenbild richtigstellen |
+
+### Scope Assessment
+- Dateien: 5–6 · geschätzt +80/-10 LoC (unter dem 250er-Limit)
+- Risk: **MEDIUM** — kleiner Eingriff, aber im Trip-Briefing (kritischer Ausgabepfad,
+  Renderer-Commit-Gate) und mit einem Test, der die Gegenrichtung festschreibt
+
+### Technical Approach
+1. **Sonnenstunden:** Aggregationsregel `"sunny_hours": "sum"` ergänzen — analog zur
+   Katalog-Regel `summary_fields={"sum": "sunny_hours"}` (`metric_catalog.py:604`). Der
+   Extended-Merge übernimmt sie automatisch über `**basis_summary.aggregation_config` (`:1033`).
+2. **ACC:** `show_acc` im konfigurierbaren Zweig beider Renderer lesen und die Spalte **hinter**
+   den gewählten Metriken anhängen — außerhalb von `outlook_columns()`/`cells`, damit die
+   #710-Invariante unberührt bleibt.
+3. **Klartext:** vierstufiges Wort statt Farbpunkt.
+4. **Test `:552` anpassen** und die Lücke schließen, die ihn entstehen ließ: Wächter, die den
+   **produktiven** Zweig (`metrics=` gesetzt) prüfen, nicht den toten Altform-Zweig.
+
+### Open Questions
+- [x] Trifft das weitere Metriken? → **Nein**, `sunny_hours` ist die einzige Lücke (abgezählt).
+- [x] Gibt es die Sonnenstunden in einem größeren Zeitfenster? → **Ja**, sie existieren; die
+      Metrik gehört nicht aus dem Angebot genommen.
+- [ ] Klartext-ACC aufnehmen? → als Erweiterung vorgeschlagen, PO entscheidet bei der
+      Spec-Freigabe.

--- a/docs/reference/renderer_email_spec.md
+++ b/docs/reference/renderer_email_spec.md
@@ -2,7 +2,11 @@
 
 This document defines how E-Mail reports are generated in Gregor Zwanzig.
 
-**Last Updated:** 2026-08-22 (Issue #2011 — `_thunder_risk_level()` ruft für String-/Enum-Rohwerte
+**Last Updated:** 2026-08-23 (Issue #2098 — ACC-Spalte erscheint jetzt auch im konfigurierbaren
+Ausblick-Zweig, fest hinter den gewählten Metriken, mit Klartext-Wort statt nur Farbpunkt;
+Sonnenstunden werden beim Etappen-Aggregat mit der Regel `sum` zusammengefasst statt `–` zu zeigen)
+
+**Vorher:** 2026-08-22 (Issue #2011 — `_thunder_risk_level()` ruft für String-/Enum-Rohwerte
 jetzt tatsächlich `thunder_ampel_band()` auf statt einer eigenen Stufen-Wort-Kette; nur der
 numerische Legacy-Fallback bleibt hartcodiert, s.u.)
 
@@ -44,7 +48,7 @@ Siehe CLAUDE.md für Scope-Details und Pflicht-Gate-Dokumentation.
 | 3 | **Stirnlampe** | ENTFÄLLT | (PO-Entscheidung aus Issue #790 — nicht mehr in neuem Cloud-Design) |
 | 4 | **Segmente** (Stundentabellen) | LIVE | Pro Etappensegment: Segment-Header + zwei-stufige Desktop-Tabelle (Gruppen-Row TEMP/WIND/NIEDERSCHLAG + Einheiten-Row) + Mobile-Variante (`EmailHourList` zwei-Zeilen-Format) |
 | 5 | **Wetter am Ziel** (abgesetzte Sektion) | LIVE | Eigene abgesetzte Sektion mit accent-Eyebrow, Zielname, Ankunftszeiten-Range, identische Tabelle wie Segmente |
-| 6 | **Ausblick** (Folge-Etappen) | LIVE | Nächste 4 Tage als kompakte Zeilen-Tabelle; jede Etappe mit Wochentag + Code + Name + Temp-Range + Risk-Dot (Farbindikator); Gewitter-Badge falls vorhanden |
+| 6 | **Ausblick** (Folge-Etappen) | LIVE | Nächste 4 Tage als kompakte Zeilen-Tabelle; Trip zeigt Wochentag + Code + Name+Note + Temp-Range + (konfigurierbare Metriken) + ACC-Spalte + Risk-Dot; Ortsvergleich ohne ACC-Spalte; Gewitter-Badge falls vorhanden |
 | 7 | **Antwort-Kommandos** | LIVE | Dedizierte Sektion mit 3-spaltigem Grid der Befehle (HEUTE, MORGEN, JETZT/NOW, GEWITTER, PAUSE 2d, SKIP, STOP/WEITER, STATUS, CONFIG, HELP) + Hinweistext |
 | 8 | **Footer** (zweigeteilt) | LIVE | Obere Zeile: Brand + Briefing-Typ; untere Zeile: Links (Trip-Übersicht, Zeitplan, Abmelden) |
 
@@ -88,13 +92,31 @@ Detaillierte Sektionsspezifikationen: siehe `docs/specs/_archive/modules/issue_8
 
 #### Ausblick (Sektion 6)
 - **Struktur:** `<table>` mit einer `<tr>` pro Folge-Etappe
-- **Desktop:** 5 Spalten – Wochentag · Code · Name+Note+ggf. Gewitter-Badge · Temp-Range · Risk-Dot
-- **Mobile:** 3 Spalten – Wochentag · (Name+Code+Note gestapelt) · (Temp+Risk-Dot übereinander)
+- **Zwei Render-Zweige**, unterschieden am Parameter `metrics` von `render_outlook_table()` /
+  `render_outlook_plain()` — **nicht** an der Mail-Art:
+  - **Altform-Zweig** (`metrics=None`): die sieben festen Spalten `N · D · R · PR · Wind · Böen ·
+    Gew`, ACC-Spalte je nach `show_acc`. Trip und Ortsvergleich fuhren früher hierüber; heute nur
+    noch Altbestand ohne aufgelöste Metrik-Auswahl.
+  - **Konfigurierbarer Zweig** (`metrics` gesetzt): die gewählten Metrik-Spalten in
+    Auswahl-Reihenfolge, dahinter die ACC-Spalte je nach `show_acc`. **Trip** fährt seit #1848 A3
+    hierüber, der **Ortsvergleich** seit #1361/#1368.
+- **ACC je Mail-Art:** Trip `show_acc=True` (Spalte erscheint), Ortsvergleich `show_acc=False`
+  (Kopfzelle UND Datenzellen entfallen vollständig). Gilt in **beiden** Zweigen gleich.
 - **Risk-Dot:** `border-radius:50%`, 10×10px, Farbe aus `_AMPEL_DOT_COLORS` (4-stufig seit #1927):
   - green (ok): `#15803d` + `rgba(21,128,61,0.18)`
   - yellow (watch-mild): `#d69500` + `rgba(214,149,0,0.20)`
   - orange (watch-mittel): `#d4530a` + `rgba(212,83,10,0.20)`
   - red (risk): `#a8104a` + `rgba(168,16,74,0.22)`
+- **ACC-Spalte** (Prognose-Genauigkeit; im konfigurierbaren Zweig seit Issue #2098): vier Stufen
+  aus der kanonischen Quelle `_ACC_STUFEN` — **eigene Farbwerte, nicht `_AMPEL_DOT_COLORS`**:
+  - HTML: Farbpunkt — `#2f8a3e` (≥80) · `#e3b008` (≥60) · `#e07b1a` (≥40) · `#c52a22` (<40)
+  - Klartext: deutsches Wort — **hoch** (≥80) / **mittel** (≥60) / **niedrig** (≥40) /
+    **sehr niedrig** (<40)
+  - Fehlender oder nicht lesbarer Wert: `–` in beiden Fassungen
+  - **Keine wählbare Metrik:** `confidence` trägt `selectable=False` (ADR-0005/#710) und kann in
+    der Metrik-Auswahl nicht erscheinen. Die Spalte wird am `outlook_columns()`/`cells`-Mechanismus
+    vorbei fest hinter den gewählten Metriken angehängt.
+- **Sonnenstunden im Ausblick (seit Issue #2098):** Werden beim Aggregieren mehrerer Segmente zu einer Etappe mit der Regel `sum` zusammengefasst (nicht `–`; `sunny_hours` trägt Katalog-Definition `summary_fields={"sum": "sunny_hours"}`)
 - **Gewitter-Badge:** `⚡ Gewitter {zeitangabe}` in `#a8104a` mit light-red Hintergrund und Border
 
 #### Antwort-Kommandos (Sektion 7 – NEU)

--- a/docs/specs/modules/fix_2098_ausblick_acc_und_sonnenstunden.md
+++ b/docs/specs/modules/fix_2098_ausblick_acc_und_sonnenstunden.md
@@ -1,0 +1,231 @@
+---
+entity_id: fix_2098_ausblick_acc_und_sonnenstunden
+type: bugfix
+created: 2026-08-23
+updated: 2026-08-23
+status: draft
+version: "1.0"
+tags: [ausblick, acc, sonnenstunden, trip-briefing, issue-2098]
+workflow: fix-2098-ausblick-acc-und-sonnenstunden
+---
+
+# #2098 — Ausblick zeigt ACC nicht mehr und Sonnenstunden bleiben `–`
+
+## Approval
+
+- [x] Approved — PO Henning, 2026-08-23, „go" (alle 14 ACs inkl. Befund C)
+
+## Purpose
+
+In der 3-Tages-Vorschau der Trip-Briefing-E-Mail sind zwei Anzeigefehler aufgetreten: die
+Spalte **ACC** (Prognose-Genauigkeit) ist verschwunden, und die Spalte **Sonnenstunden**
+zeigt in allen Zeilen `–`, obwohl beide Werte tatsächlich vorhanden sind. Diese Spec legt
+fest, wie beide Werte wieder zuverlässig in der Mail erscheinen, ohne die Trip/Compare-
+Teilungs-Invariante zu verletzen und ohne die #710-Regel (ACC keine wählbare Metrik) zu
+berühren.
+
+## Source
+
+- **File:** `src/output/renderers/email/outlook.py`
+- **Identifier:** `render_outlook_table()` (`:45`), `render_outlook_plain()` (`:263`) — der
+  konfigurierbare Zweig (`metrics is not None`) beider Funktionen kennt `show_acc` nicht
+- **File:** `src/services/weather_metrics.py`
+- **Identifier:** `summarize_points()` (`:534-568`) — `aggregation_config`-Dict ohne Regel
+  für `sunny_hours`
+
+> **Schicht-Hinweis:** Python-Core/Domain-Backend (`src/services/`,
+> `src/output/renderers/email/`). Kein Frontend-, Go- oder API-Vertrag betroffen.
+
+## Estimated Scope
+
+- **LoC:** ~60–100 (Fix ~15, Tests ~60–80, Doku ~10)
+- **Files:** 5–6 (4 MODIFY, 1 CREATE, 1 Doku-MODIFY)
+- **Effort:** medium
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `render_outlook_table()` / `render_outlook_plain()` (`outlook.py:45,263`) | Funktion | geteilter Renderer Trip+Compare, hier liegt die Wurzel beider Befunde |
+| `build_outlook_row()` (`outlook.py`) | Funktion | schreibt `confidence_pct` bereits ins Row-Dict, unverändert wiederverwendbar |
+| `aggregate_stage()` (`src/services/weather_metrics.py:1352`) | Funktion | Etappen-Aggregation; baut Ergebnis ausschließlich aus Feldern mit Regel in `aggregation_config` |
+| `summarize_points()` (`src/services/weather_metrics.py:534-568`) | Funktion | Segment-Aggregation, Quelle des `aggregation_config`-Dicts, das `aggregate_stage()` weiterverwendet |
+| `metric_catalog.py:604` (`sunshine`-Definition) | Katalog-Eintrag | `summary_fields={"sum": "sunny_hours"}` — Zielfeld, das die Aggregationsregel treffen muss |
+| `metric_catalog.py:418-423` (`confidence`, `selectable=False`) | Katalog-Eintrag | ADR-0005/#710 — ACC darf nie als wählbare Metrik erscheinen, bleibt unverändert |
+| `outlook_columns()` (`compare_outlook_metric_ids.py:298`) | Funktion | Kopfzeilen-Quelle des konfigurierbaren Zweigs; ACC wird NICHT über diesen Pfad angehängt |
+| `compare_html.py:1257` (`show_acc=False`) | Aufrufstelle | Ortsvergleich — muss ohne ACC-Spalte bleiben |
+| `html.py:1403` (`show_acc=True`) | Aufrufstelle | Trip — muss die ACC-Spalte wieder tragen |
+| `tests/tdd/test_trip_outlook_dispatch_mail.py:552` | Test | verankert aktuell das Gegenteil (kein ACC), muss angepasst werden |
+| `tests/tdd/test_trip_outlook_metric_selection.py:310-355` | Test | bewacht die #710-Invariante (ACC nicht wählbar), muss grün bleiben |
+
+## Implementation Details
+
+```
+Befund A — Sonnenstunden:
+  summarize_points() setzt sunny_hours (weather_metrics.py:534), aber die
+  aggregation_config im selben Summary-Objekt (:553-568) trägt dafür keine
+  Regel. aggregate_stage() iteriert ausschließlich Felder mit Regel und
+  überschreibt sunny_hours dadurch mit dem Dataclass-Default None.
+  Fix: "sunny_hours": "sum" ergänzen — Ergebnis ist stets Mehrsegment,
+  weil aggregate_stage() nur bei >1 Segment aufgerufen wird
+  (compact_summary.py:265-268); bei Einzelsegment-Etappen läuft der Wert
+  unbeschädigt durch (kein Fehler, aber auch kein Testnachweis für den Fix).
+
+Befund B — ACC:
+  render_outlook_table()/render_outlook_plain() lesen show_acc NUR im
+  Altform-Zweig (metrics is None). Seit #1848 A3 liefert
+  resolve_trip_outlook_metrics() für den Trip fast immer eine Metrikliste
+  -> Trip läuft praktisch immer über den konfigurierbaren Zweig, der ACC
+  nicht kennt.
+  Fix: show_acc im konfigurierbaren Zweig auswerten, ACC-Spalte fest HINTER
+  den gewählten Metriken anhängen -- außerhalb outlook_columns()/cells,
+  damit die #710-Invariante (ACC nie wählbare Metrik) strukturell
+  unberührt bleibt. confidence_pct steht bereits im Row-Dict
+  (build_outlook_row(), VOR dem metrics-Zweig geschrieben).
+
+Befund C (Erweiterung) — ACC im Klartext:
+  render_outlook_plain() gab ACC noch nie aus, auch nicht im Altform-Zweig
+  vor #1848/#2049. Im HTML ist ACC ein reiner Farbpunkt (_acc_dot(), vier
+  Stufen >=80/>=60/>=40/<40) -- für Klartext-Leser unsichtbar. Ein
+  vierstufiges deutsches Wort schließt die Lücke gemäß Projektregel
+  "HTML=Normalfassung, Farbe im HTML -> Wort im Klartext".
+```
+
+## Expected Behavior
+
+- **Input:** Trip-Briefing-Versand (E-Mail, Modus `full` oder `compact`) mit mehrsegmentigen
+  Etappen im 3-Tages-Ausblick, konfigurierte Ausblick-Metriken (Grundauswahl oder
+  Nutzerauswahl gemäß #1848 A3)
+- **Output:** In der HTML-Fassung erscheint hinter den gewählten Metriken eine ACC-Spalte mit
+  dem bekannten 4-stufigen Farbpunkt; in der Klartext-Fassung erscheint ein 4-stufiges
+  ACC-Wort; die Sonnenstunden-Spalte zeigt einen Zahlenwert statt `–`, sobald die Etappe
+  mehr als ein Segment hat
+- **Side effects:** keine — reine Renderer-/Aggregations-Korrektur, keine Persistenz- oder
+  API-Änderung. Der Ortsvergleich (`show_acc=False`) bleibt unverändert ohne ACC-Spalte.
+
+## Acceptance Criteria
+
+### Befund A — Sonnenstunden
+
+- **AC-1:** Given eine Trip-Etappe mit mehr als einem Segment und unterschiedlichen
+  Sonnenstunden-Werten je Segment / When das Trip-Briefing gerendert wird / Then zeigt die
+  Sonnenstunden-Spalte im 3-Tages-Ausblick einen konkreten Zahlenwert (z. B. `6.5`) statt `–`.
+
+- **AC-2:** Given dieselbe Mehrsegment-Etappe / When die Sonnenstunden-Spalte geprüft wird /
+  Then entspricht der angezeigte Wert der Summe der Segment-Sonnenstunden (Aggregationsregel
+  `sum`, analog zur Katalog-Definition `summary_fields={"sum": "sunny_hours"}`) und nicht
+  einem beliebigen Platzhalter oder dem Wert nur eines Segments.
+
+- **AC-3:** Given eine Trip-Etappe mit genau einem Segment / When das Trip-Briefing gerendert
+  wird / Then bleibt die Sonnenstunden-Anzeige unverändert zum bisherigen Verhalten (dieser
+  Pfad war nie betroffen, da `aggregate_stage()` hier nicht aufgerufen wird) — der Test für
+  diesen Fix MUSS über eine Mehrsegment-Etappe geführt werden, ein Einzelsegment-Test wäre
+  falsch grün.
+
+- **AC-4:** Given den vollständigen Metrik-Katalog mit `summary_fields` / When alle Felder von
+  `SegmentWeatherSummary` gegen die `aggregation_config` von `summarize_points()` abgeglichen
+  werden / Then trägt außer der behobenen Regel für `sunny_hours` keine weitere Metrik eine
+  fehlende Aggregationsregel (Invariante: dieser Fix bleibt die einzige Änderung an
+  `aggregation_config`, keine zweite Metrik wird angefasst).
+
+### Befund B — ACC-Spalte im Trip-Ausblick
+
+- **AC-5:** Given ein Trip mit konfigurierten Ausblick-Metriken (der heute übliche,
+  konfigurierbare Renderer-Zweig, `metrics` gesetzt) / When das Trip-Briefing als HTML-Mail
+  gerendert wird / Then erscheint eine ACC-Spalte mit dem bekannten 4-stufigen Farbpunkt
+  hinter den gewählten Metrik-Spalten, unabhängig davon, welche Metriken der Nutzer gewählt
+  hat.
+
+- **AC-6:** *(gehört zur Erweiterung Befund C — entfällt vollständig, wenn Befund C
+  gestrichen wird)* Given denselben konfigurierbaren Renderer-Zweig / When der Ausblick als
+  Klartext-Mail gerendert wird / Then erscheint eine ACC-Spalte mit einem 4-stufigen
+  deutschen Wort (analog zu den HTML-Farbstufen) hinter den gewählten Metrik-Spalten.
+
+- **AC-7:** Given einen Prognose-Genauigkeits-Wert von 85 % (hohe Stufe) und einen zweiten
+  Wert von 35 % (niedrigste Stufe) / When beide Etappen im selben Ausblick gerendert werden /
+  Then unterscheiden sich die HTML-Farbpunkte beider Zeilen sichtbar (Gegenprobe mit einem
+  plausibel falschen Wert, nicht nur mit `None`) — und, sofern Befund C umgesetzt wird,
+  ebenso die Klartext-Wörter.
+
+- **AC-8:** Given einen Ortsvergleich-Ausblick (`show_acc=False`) / When er im
+  konfigurierbaren Zweig als HTML- und als Klartext-Mail gerendert wird / Then erscheint
+  weder eine ACC-Spalte in der Kopfzeile noch eine ACC-Zelle in den Datenzeilen — der Fix
+  darf die Compare-Fläche nicht verändern.
+
+- **AC-9:** Given die Metrik-Auswahlfläche im Frontend (Backend-Auflösung
+  `available_aggregations`/`derived_aggregations`) / When nach der Behebung geprüft wird,
+  welche Metriken auswählbar sind / Then taucht `confidence`/ACC weiterhin **nicht** in der
+  Liste der wählbaren Ausblick-Metriken auf (ADR-0005/#710 bleibt unberührt, die ACC-Spalte
+  entsteht ausschließlich als fest angehängte Zusatzspalte außerhalb der Auswahl).
+
+- **AC-10:** Given eine Kopfzeile und eine Datenzeile desselben Ausblicks / When beide
+  gerendert werden / Then steht die ACC-Spalte an derselben Position relativ zu den übrigen
+  Spalten in Kopf- und Datenzeile (kein Auseinanderlaufen von Beschriftung und Wert).
+
+### Befund C — ACC-Wort im Klartext (Erweiterung über den gemeldeten Fehler hinaus)
+
+> Dieser Block erweitert den gemeldeten Fehler: die Klartext-Fassung hat ACC auch vor #2098
+> nie gezeigt. Der PO kann diesen Block bei der Freigabe gezielt streichen, ohne Befund A
+> oder B zu beeinträchtigen.
+
+- **AC-11:** Given die vier HTML-Farbstufen (`_acc_dot()`: ≥80 / ≥60 / ≥40 / <40) / When das
+  entsprechende deutsche Klartext-Wort für jede Stufe festgelegt wird / Then ist jede Stufe
+  durch ein eindeutiges, unterscheidbares Wort ohne Handlungsempfehlung repräsentiert (reine
+  Zustandsbeschreibung, ADR-0007) — z. B. „hoch" / „mittel" / „niedrig" / „sehr niedrig", exakte
+  Wortwahl liegt beim Implementierer.
+
+- **AC-12:** Given einen fehlenden `confidence_pct`-Wert (`None`) / When die Klartext-Zeile
+  gerendert wird / Then erscheint für ACC weiterhin `–` wie im HTML-Fall — kein Absturz, kein
+  leeres Feld.
+
+### Abgelöste Entscheidung — #1848 A3 / Test `test_trip_outlook_dispatch_mail.py:552`
+
+- **AC-13:** Given den bestehenden Test `tests/tdd/test_trip_outlook_dispatch_mail.py:552`
+  (prüft aktuell `kopf[1:] != [..., "ACC"]`, Kommentar „#1848 A3, AC-3", PO-Freigabe
+  2026-08-21) / When der Test nach der Behebung läuft / Then ist die Prüfung so angepasst,
+  dass sie das **neue** Verhalten (ACC-Spalte vorhanden) verifiziert, statt weiterhin ihre
+  Abwesenheit zu verlangen. Die übrige #1848-A3-Absicht — Grundauswahl statt fester
+  Sieben-Spalten-Liste — bleibt unverändert gültig; ACC kommt nicht als achte feste
+  Katalog-Spalte zurück, sondern als fest angehängte Zusatzspalte hinter der Grundauswahl.
+
+### Testlücke — produktiver Zweig statt totem Altform-Zweig
+
+- **AC-14:** Given die bestehenden ACC-Wächter (`test_shared_outlook_renderer.py:132-199`,
+  `test_trip_outlook_parity.py:94-122`), die ohne `metrics=`-Parameter aufrufen und damit den
+  inzwischen für den Trip toten Altform-Zweig prüfen / When die neuen bzw. angepassten Tests
+  für diese Spec geschrieben werden / Then rufen sie `render_outlook_table()` /
+  `render_outlook_plain()` ausdrücklich **mit** `metrics` auf (dem produktiven, seit #1848 A3
+  im Trip aktiven Zweig) — ein Test, der nur den Altform-Zweig träfe, gilt als nicht
+  aussagekräftig für diese Spec.
+
+## Known Limitations
+
+- **Nur `sunny_hours` betroffen.** Das Audit über alle 26 `MetricDefinition`s mit
+  `summary_fields` (inkl. aller `OUTLOOK_FRIENDLY_CAPABLE`- und Grundauswahl-Metriken) hat
+  ergeben, dass `sunny_hours` die einzige Lücke in `aggregation_config` ist. Keine weitere
+  Metrik wird im Rahmen dieser Spec angefasst (AC-4).
+- **Nur Trip betroffen, Sonnenstunden.** `aggregate_stage()` läuft ausschließlich im
+  Trip-Pfad; der Ortsvergleich nutzt `summarize_points()`/`comparison_engine.py` ohne den
+  `aggregation_config`-Rebuild und zeigt Sonnenstunden bereits korrekt.
+- **ACC bleibt für den Ortsvergleich unsichtbar** — bewusst, `show_acc=False` bleibt
+  unverändert (AC-8), Confidence ist keine per-Ort-Metrik (#710).
+- **Reihenfolge-Kopplung entwarnt:** Kopf und Zellen entstehen im konfigurierbaren Zweig
+  bereits aus je einer zusammenhängenden Editierstelle pro Funktion; eine fest angehängte
+  ACC-Spalte führt zu keinem neuen Indexrisiko.
+- **Keine Frontend-, Go- oder API-Änderung.** Reine Renderer-/Aggregations-Korrektur im
+  Python-Core.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine neue — wendet ADR-0005/#710 (Confidence nicht wählbar) unverändert an
+- **Rationale:** Diese Spec stellt ein Anzeigeverhalten wieder her, das vor #1848 A2/A3
+  bestand, ohne eine dokumentierte Entscheidung zu ändern. #710 bleibt vollständig in Kraft:
+  ACC entsteht strukturell außerhalb des Metrik-Auswahlsystems (fest angehängt, nicht über
+  `outlook_columns()`/Katalog), kann also nie als wählbare Spalte erscheinen. Die
+  #1848-A3-Entscheidung (Grundauswahl statt feste Sieben-Spalten-Liste) bleibt in ihrem Kern
+  gültig — siehe „Abgelöste Entscheidung" oben für die eine bewusst zurückgenommene
+  Nebenfolge.
+
+## Changelog
+
+- 2026-08-23: Initial spec created

--- a/docs/specs/modules/fix_2098_ausblick_acc_und_sonnenstunden.md
+++ b/docs/specs/modules/fix_2098_ausblick_acc_und_sonnenstunden.md
@@ -116,11 +116,18 @@ Befund C (Erweiterung) — ACC im Klartext:
   `sum`, analog zur Katalog-Definition `summary_fields={"sum": "sunny_hours"}`) und nicht
   einem beliebigen Platzhalter oder dem Wert nur eines Segments.
 
-- **AC-3:** Given eine Trip-Etappe mit genau einem Segment / When das Trip-Briefing gerendert
-  wird / Then bleibt die Sonnenstunden-Anzeige unverändert zum bisherigen Verhalten (dieser
-  Pfad war nie betroffen, da `aggregate_stage()` hier nicht aufgerufen wird) — der Test für
-  diesen Fix MUSS über eine Mehrsegment-Etappe geführt werden, ein Einzelsegment-Test wäre
-  falsch grün.
+- **AC-3:** Given dieselbe Etappe einmal als ein Segment und einmal auf mehrere Segmente
+  verteilt / When beide Fassungen im Ausblick gerendert werden / Then zeigen beide einen
+  Sonnenstunden-Wert, und die mehrteilige Fassung zeigt die Summe ihrer Segmente statt `–` —
+  der Nachweis MUSS über die mehrteilige Fassung geführt werden, weil nur sie den Verlust
+  sichtbar macht.
+
+  > **Richtigstellung (RED-Phase, 2026-08-23):** Die ursprüngliche Begründung („Einzelsegment
+  > war nie betroffen") gilt nur für die Kompaktzeile — dort bremst
+  > `compact_summary.py:262-268` die Aggregation bei einem Segment ab. Der **Ausblick** ruft
+  > `aggregate_stage()` bedingungslos (`trip_report_scheduler.py:2422`) und verliert die
+  > Sonnenstunden daher auch bei Einzelsegment-Etappen. Die Zusicherung bleibt inhaltlich
+  > gleich scharf, die Begründung ist korrigiert.
 
 - **AC-4:** Given den vollständigen Metrik-Katalog mit `summary_fields` / When alle Felder von
   `SegmentWeatherSummary` gegen die `aggregation_config` von `summarize_points()` abgeglichen

--- a/src/output/renderers/email/outlook.py
+++ b/src/output/renderers/email/outlook.py
@@ -39,6 +39,43 @@ from utils.geo import degrees_to_compass
 
 
 # ---------------------------------------------------------------------------
+# ACC-Stufen — EINE Quelle fuer Farbpunkt (HTML) und Wort (Klartext)
+# ---------------------------------------------------------------------------
+
+# Issue #2098 Befund C: der Farbpunkt ist im HTML der einzige Informations-
+# traeger, im Klartext braucht dieselbe Aussage ein Wort ("HTML=Normalfassung,
+# Farbe im HTML ⇒ WORT im Klartext"). Beide lesen dieselben vier Untergrenzen,
+# damit Wort und Punkt nicht auseinanderdriften koennen.
+# (Untergrenze | None = Restfall, Farbe, Klartext-Wort)
+_ACC_STUFEN = (
+    (80, "#2f8a3e", "hoch"),
+    (60, "#e3b008", "mittel"),
+    (40, "#e07b1a", "niedrig"),
+    (None, "#c52a22", "sehr niedrig"),
+)
+_ACC_KEIN_WERT = "–"
+ACC_LABEL = "ACC"
+
+
+def _acc_stufe(conf_pct) -> tuple[str, str] | None:
+    """(Farbe, Klartext-Wort) zu einer Prognose-Genauigkeit; ``None`` ohne Wert."""
+    try:
+        v = float(conf_pct)
+    except (TypeError, ValueError):
+        return None
+    for grenze, farbe, wort in _ACC_STUFEN:
+        if grenze is None or v >= grenze:
+            return farbe, wort
+    return None
+
+
+def _acc_wort(conf_pct) -> str:
+    """Klartext-Entsprechung des ACC-Farbpunkts (#2098 AC-6/AC-11/AC-12)."""
+    stufe = _acc_stufe(conf_pct)
+    return stufe[1] if stufe else _ACC_KEIN_WERT
+
+
+# ---------------------------------------------------------------------------
 # render_outlook_table — extrahiert aus html.py (Z.1116-1271, AC-1/AC-2)
 # ---------------------------------------------------------------------------
 
@@ -100,21 +137,12 @@ def render_outlook_table(
 
     # 4-stufiger ACC-Dot aus confidence_pct
     # hoch>=80=ok, mittel>=60=caution, niedrig>=40=warn, sehr_niedrig<40=danger
+    # #2098: Stufen aus `_ACC_STUFEN` -- dieselbe Quelle wie das Klartext-Wort.
     def _acc_dot(conf_pct) -> str:
-        if conf_pct is None:
-            return "–"
-        try:
-            v = float(conf_pct)
-        except (TypeError, ValueError):
-            return "–"
-        if v >= 80:
-            color = "#2f8a3e"
-        elif v >= 60:
-            color = "#e3b008"
-        elif v >= 40:
-            color = "#e07b1a"
-        else:
-            color = "#c52a22"
+        stufe = _acc_stufe(conf_pct)
+        if stufe is None:
+            return _ACC_KEIN_WERT
+        color = stufe[0]
         return (
             f'<span style="display:inline-block;width:10px;height:10px;'
             f'border-radius:50%;background:{color};"></span>'
@@ -126,6 +154,9 @@ def render_outlook_table(
         f'padding:6px 4px;text-align:center;font-family:{FONT_DATA};'
         f'font-size:10px;font-weight:600;color:#3a3835;white-space:nowrap;"'
     )
+    # #2098 Befund B: die ACC-Kopfzelle gilt fuer BEIDE Zweige -- der Trip
+    # laeuft seit #1848 A3 praktisch immer ueber den konfigurierbaren.
+    _acc_th = f'<th {_oh_style}>{ACC_LABEL}</th>' if show_acc else ""
     if metrics is not None:
         from output.renderers.compare_outlook_metric_ids import outlook_columns
 
@@ -145,6 +176,15 @@ def render_outlook_table(
             texte = [cells[i] if i < len(cells) else "–" for i in range(len(columns))]
             if gew_index is not None:
                 texte[gew_index] = thunder_cell_html(format_trend_tokens(stage), stage)
+            # #2098 Befund B: ACC HINTER den gewaehlten Spalten -- am
+            # `outlook_columns()`/`cells`-Mechanismus vorbei, damit
+            # `confidence` nie eine waehlbare Metrik wird (ADR-0005/#710).
+            # Kopf- und Datenzelle haengen an DEMSELBEN `show_acc`, ein
+            # Auseinanderlaufen von Beschriftung und Wert ist damit
+            # ausgeschlossen (AC-10).
+            acc_td = (
+                _otd(_acc_dot(stage.get("confidence_pct"))) if show_acc else ""
+            )
             body += (
                 '<tr>' + _otd(stage.get("weekday", "–"))
                 + "".join(
@@ -152,17 +192,17 @@ def render_outlook_table(
                          bg=cell_bg[i] if i < len(cell_bg) else "")
                     for i, text in enumerate(texte)
                 )
+                + acc_td
                 + '</tr>'
             )
         return (
             '<table cellpadding="0" cellspacing="0" '
             'style="border-collapse:collapse;width:100%;'
             'border-top:2px solid #1d1c1a;">'
-            f'<thead><tr><th {_oh_style}>Tag</th>{head}</tr></thead>'
+            f'<thead><tr><th {_oh_style}>Tag</th>{head}{_acc_th}</tr></thead>'
             f'<tbody>{body}</tbody></table>'
         )
 
-    _acc_th = f'<th {_oh_style}>ACC</th>' if show_acc else ""
     outlook_thead = (
         f'<thead><tr>'
         f'<th {_oh_style}>Tag</th>'
@@ -270,9 +310,11 @@ def render_outlook_plain(
 ) -> str:
     """Rendert den Klartext-Ausblick-Block.
 
-    ``show_acc`` existiert fuer Signatur-Symmetrie mit
-    ``render_outlook_table``; der Klartext-Ausblick zeigte schon im
-    Ist-Zustand keine ACC-Spalte, daher ohne Effekt.
+    ``show_acc`` haengt im konfigurierbaren Zweig (``metrics`` gesetzt) das
+    ACC-Wort hinter die gewaehlten Spalten -- die Klartext-Entsprechung des
+    HTML-Farbpunkts (#2098 Befund C). Der Altform-Zweig zeigte ACC noch nie
+    und bleibt unveraendert; ``show_acc=False`` (Ortsvergleich) laesst die
+    Spalte in beiden Zweigen entfallen.
 
     ``metrics`` (#1361): gesetzte Auswahl ersetzt die festen Wert-Tokens
     durch die gewaehlten Groessen. ``heading`` (#1368): Compare schreibt
@@ -299,7 +341,13 @@ def render_outlook_plain(
             if gew_index is not None:
                 texte[gew_index] = thunder_cell_plain(format_trend_tokens(stage), stage)
             values = "  ".join(
-                f"{c['label']} {texte[i]}" for i, c in enumerate(columns)
+                [f"{c['label']} {texte[i]}" for i, c in enumerate(columns)]
+                # #2098 Befund C: der ACC-Farbpunkt des HTML ist fuer
+                # Klartext-Leser unsichtbar -- dieselbe Aussage als Wort,
+                # aus derselben Stufenquelle, an derselben Position
+                # (hinter den gewaehlten Spalten) wie im HTML.
+                + ([f"{ACC_LABEL} {_acc_wort(stage.get('confidence_pct'))}"]
+                   if show_acc else [])
             )
             # #1848 A3: Etappenname und Notiz stehen auch hier -- der feste
             # Zweig darunter fuehrt beide seit jeher, und seit A3 laeuft JEDE

--- a/src/services/weather_metrics.py
+++ b/src/services/weather_metrics.py
@@ -569,6 +569,13 @@ class WeatherMetricsService:
                 "visibility_min_m": "min",
                 "dominant_wmo_code": "max_wmo_severity",
                 "dni_avg_wm2": "avg",
+                # Issue #2098 Befund A: ohne diese Regel iteriert
+                # `aggregate_stage()` `sunny_hours` nicht und die Etappe faellt
+                # auf den Dataclass-Default `None` -- die Sonnenstunden-Spalte
+                # des 3-Tages-Ausblicks zeigte in jeder Zeile "–". "sum" folgt
+                # der Katalog-Definition `summary_fields={"sum": "sunny_hours"}`
+                # (metric_catalog.py:604).
+                "sunny_hours": "sum",
             },
         )
 

--- a/tests/tdd/test_ausblick_erbt_grundauswahl.py
+++ b/tests/tdd/test_ausblick_erbt_grundauswahl.py
@@ -50,6 +50,10 @@ from tests.helpers.trip_outlook_selection import (  # noqa: E402
 # -- AC-3 verlangt, dass sie fuer eine Grundauswahl-gebundene Vorschau NICHT
 # mehr erscheinen.
 _FIXED_SEVEN = {"N", "D", "R", "PR", "Wind", "Böen", "Gew"}
+# #2098 AC-13: ACC ist seit der Behebung eine fest angehaengte Zusatzspalte
+# HINTER der Auswahl -- sie stammt nicht aus der Grundauswahl und ist auch
+# keine der abgeloesten sieben festen Spalten.
+_ACC = "ACC"
 
 
 def _soll_ueberschriften(metric_ids: set[str]) -> set[str]:
@@ -80,7 +84,7 @@ def test_ac3_ohne_gesetzte_ausblick_auswahl_zeigt_die_ausblick_tabelle_die_grund
     assert kopf, "Keine Ausblick-Tabelle gerendert -- Vorbedingung von AC-3 verletzt."
     assert kopf[0] == "Tag", kopf
     erwartet = _soll_ueberschriften(enabled)
-    assert set(kopf[1:]) == erwartet, (
+    assert set(kopf[1:]) == erwartet | {_ACC}, (
         f"Ausblick-Kopfzeile {kopf[1:]!r} entspricht nicht der Grundauswahl "
         f"{sorted(erwartet)!r} (AC-3). Ohne gesetzte Auswahl faellt der "
         "Renderer vermutlich noch auf die alten sieben festen Spalten zurueck."
@@ -116,7 +120,7 @@ def test_ac4_in_der_grundauswahl_abgewaehlte_groesse_erscheint_nie_im_ausblick()
         f"Kopfzeile {kopf!r}: 'Gewitter' erscheint, obwohl die Groesse in der "
         "Grundauswahl nicht aktiv ist (AC-4)."
     )
-    assert kopf[1:] == ["Temperatur"], (
+    assert kopf[1:] == ["Temperatur", _ACC], (
         f"Erwartet nur die Grundauswahl-gedeckte Spalte 'Temperatur': {kopf!r}"
     )
     block = plain_outlook_block(plain)
@@ -168,7 +172,7 @@ def test_ac10_vs_ac11_vollstaendig_geschnittene_auswahl_faellt_auf_die_grundausw
         "liefert [] statt None)."
     )
     erwartet = _soll_ueberschriften(enabled)
-    assert set(kopf_ac10[1:]) == erwartet, (
+    assert set(kopf_ac10[1:]) == erwartet | {_ACC}, (
         f"AC-10: nach dem Totalschnitt zeigt der Ausblick {kopf_ac10[1:]!r} "
         f"statt der VOLLEN Grundauswahl {sorted(erwartet)!r}."
     )

--- a/tests/tdd/test_outlook_acc_spalte.py
+++ b/tests/tdd/test_outlook_acc_spalte.py
@@ -1,0 +1,520 @@
+"""TDD RED — #2098 Befund B/C: ACC-Spalte im konfigurierbaren Ausblick-Zweig.
+
+SPEC: docs/specs/modules/fix_2098_ausblick_acc_und_sonnenstunden.md (AC-5..AC-12)
+KONTEXT: docs/context/fix-2098-ausblick-acc-und-sonnenstunden.md
+
+Fehlerbild aus Nutzersicht: die ACC-Spalte (Prognose-Genauigkeit) ist aus der
+3-Tages-Vorschau der Trip-Briefing-Mail verschwunden. ``show_acc`` wird nur im
+ALTFORM-Zweig beider Renderer gelesen (outlook.py:165-178, :231, :316-332);
+der konfigurierbare Zweig (``metrics`` gesetzt, :129-163 und :289-314) kennt
+ACC nicht. Seit #1848 A3 loest ``resolve_trip_outlook_metrics()`` fuer den
+Trip praktisch immer eine Metrikliste auf -- der Trip laeuft damit praktisch
+immer ueber den Zweig ohne ACC.
+
+🔴 AC-14 (Testluecke): alle bestehenden ACC-Waechter
+(``test_shared_outlook_renderer.py:132-199``,
+``test_trip_outlook_parity.py:94-122``) rufen OHNE ``metrics=`` auf und
+pruefen damit den fuer den Trip toten Altform-Zweig. JEDER Test in dieser
+Datei ruft ausdruecklich MIT ``metrics=`` -- dem produktiven Zweig. Der
+Altform-Zweig kommt hier nur einmal vor, als unabhaengige Referenz fuer das
+Aussehen des bekannten Farbpunkts (AC-5).
+
+Kern-Schicht, deterministisch: keine Mocks/``patch()``/``MagicMock``, kein
+Netz, kein Dateiinhalt-Check. Echte ``SegmentWeatherSummary``-/
+``ForecastDataPoint``-Objekte, echte Renderer-Aufrufe.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+from bs4 import BeautifulSoup
+
+# Pfadregel #1409: Pruefling relativ zur eigenen Testdatei aufloesen -- sonst
+# pruefte ein Worktree-Lauf die unveraenderte Hauptrepo-Kopie.
+REPO_ROOT = Path(__file__).resolve().parents[2]
+for _pfad in (REPO_ROOT, REPO_ROOT / "src"):
+    if str(_pfad) not in sys.path:
+        sys.path.insert(0, str(_pfad))
+
+TZ = ZoneInfo("Europe/Berlin")
+
+# Ausblick-Auswahl im Neuformat (#1848 A2: reine Kennungen).
+_AUSWAHL = ["precipitation", "gust"]
+
+# Die vier Stufen des bekannten Farbpunkts (_acc_dot, outlook.py:103-121):
+# >=80 / >=60 / >=40 / <40. Die Klartext-Worte sind PO-festgelegt (AC-11).
+_STUFEN_WORT = {85: "hoch", 65: "mittel", 45: "niedrig", 35: "sehr niedrig"}
+_ACC_LABEL = "ACC"
+_KEIN_WERT = "–"
+
+
+# ---------------------------------------------------------------------------
+# Echte Domaenen-Objekte
+# ---------------------------------------------------------------------------
+
+def _punkte():
+    from app.models import ForecastDataPoint, ThunderLevel
+
+    return [
+        ForecastDataPoint(
+            ts=datetime(2026, 7, 12, stunde, 0, tzinfo=timezone.utc),
+            t2m_c=15.0, wind10m_kmh=12.0, wind_direction_deg=270, gust_kmh=44.0,
+            precip_1h_mm=0.5, pop_pct=55, cloud_total_pct=60,
+            thunder_level=ThunderLevel.NONE, visibility_m=15000.0,
+            humidity_pct=55,
+        )
+        for stunde in range(8, 14)
+    ]
+
+
+def _summary(confidence):
+    """Etappen-Aggregat mit gesetzter Prognose-Genauigkeit.
+
+    ``confidence_pct_min`` ist die Quelle, aus der ``build_outlook_row()``
+    den Schluessel ``confidence_pct`` des Row-Dicts baut (outlook.py:586-587,
+    :599) -- VOR dem ``metrics``-Zweig, der Wert liegt also in beiden Zweigen
+    gleichermassen vor.
+    """
+    from app.models import SegmentWeatherSummary, ThunderLevel
+
+    return SegmentWeatherSummary(
+        temp_min_c=9.0, temp_max_c=21.0, temp_avg_c=15.0,
+        wind_max_kmh=25.0, gust_max_kmh=44.0, precip_sum_mm=2.5,
+        cloud_avg_pct=60, humidity_avg_pct=55,
+        thunder_level_max=ThunderLevel.NONE, pop_max_pct=55,
+        visibility_min_m=9000, confidence_pct_min=confidence,
+    )
+
+
+def _zeilen(confidences, *, metrics=None):
+    """Ausblick-Zeilen ueber den echten Zeilenbau ``build_outlook_row()``."""
+    from output.renderers.email.outlook import build_outlook_row
+
+    auswahl = _AUSWAHL if metrics is None else metrics
+    tage = ("Mo", "Di", "Mi", "Do", "Fr", "Sa", "So")
+    return [
+        build_outlook_row(_summary(conf), _punkte(), tage[i % len(tage)], TZ,
+                          metrics=auswahl)
+        for i, conf in enumerate(confidences)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Auswertung der gerenderten Ausgabe
+# ---------------------------------------------------------------------------
+
+def _kopf(html: str) -> list[str]:
+    return [th.get_text(strip=True)
+            for th in BeautifulSoup(html, "html.parser").find_all("th")]
+
+
+def _datenzellen(html: str) -> list[list]:
+    """Datenzeilen als Liste der ``<td>``-Elemente (Roh-HTML bleibt erhalten --
+    der ACC-Farbpunkt hat KEINEN Text, ein Text-Extrakt saehe ihn nicht)."""
+    koerper = BeautifulSoup(html, "html.parser").find("tbody")
+    return [tr.find_all("td") for tr in koerper.find_all("tr")] if koerper else []
+
+
+def _acc_zelle(html: str, zeile: int = 0):
+    """Die ``<td>`` an der Position, die die Kopfzeile mit ACC beschriftet.
+
+    Bewusst ueber den Kopf-Index statt ueber "die letzte Zelle": genau das
+    Auseinanderlaufen von Beschriftung und Wert ist die Fehlerklasse (AC-10).
+    """
+    kopf = _kopf(html)
+    assert _ACC_LABEL in kopf, (
+        f"Die Kopfzeile des konfigurierbaren Ausblick-Zweigs traegt keine "
+        f"ACC-Spalte: {kopf!r} (#2098 Befund B)."
+    )
+    zellen = _datenzellen(html)[zeile]
+    assert len(zellen) == len(kopf), (
+        f"Kopf ({len(kopf)} Spalten) und Datenzeile ({len(zellen)} Zellen) "
+        f"laufen auseinander: {kopf!r}"
+    )
+    return zellen[kopf.index(_ACC_LABEL)]
+
+
+def _punkt_farbe(td) -> str | None:
+    treffer = re.search(r"background:(#[0-9a-fA-F]{6})", str(td))
+    return treffer.group(1).lower() if treffer else None
+
+
+def _klartext_zeilen(block: str) -> list[str]:
+    """Die Wertzeilen des Klartext-Ausblicks (ohne Leer- und Ueberschriftzeile)."""
+    return [z for z in block.splitlines()[2:] if z.strip()]
+
+
+def _acc_wort(zeile: str) -> str | None:
+    """Das Wort hinter dem ACC-Label einer Klartext-Zeile.
+
+    Die Spalten sind mit zwei Leerzeichen getrennt (outlook.py:301-303), das
+    Wort selbst darf also ein Leerzeichen enthalten ("sehr niedrig").
+    """
+    treffer = re.search(rf"\b{_ACC_LABEL} (\S.*?)(?:\s{{2,}}|$)", zeile)
+    return treffer.group(1) if treffer else None
+
+
+# ---------------------------------------------------------------------------
+# AC-5 — HTML: ACC-Spalte im konfigurierbaren Zweig, bekannter Farbpunkt
+# ---------------------------------------------------------------------------
+
+def test_ac5_html_zeigt_acc_spalte_im_konfigurierbaren_zweig():
+    """AC-5: Given ein Trip mit konfigurierten Ausblick-Metriken (``metrics``
+    gesetzt -- der Zweig, ueber den der Trip seit #1848 A3 laeuft) / When das
+    Briefing als HTML-Mail gerendert wird / Then erscheint eine ACC-Spalte mit
+    dem bekannten 4-stufigen Farbpunkt HINTER den gewaehlten Metrik-Spalten.
+
+    Das Aussehen wird gegen eine UNABHAENGIGE Quelle geprueft: derselbe
+    Zeilensatz durch den Altform-Zweig (``metrics=None``), dessen ACC-Zelle
+    seit jeher der Farbpunkt ist. Damit haengt der Test nicht an einem im
+    Test abgeschriebenen Hex-Wert.
+    """
+    from output.renderers.email.outlook import render_outlook_table
+
+    zeilen = _zeilen([85])
+    html = render_outlook_table(zeilen, show_acc=True, metrics=_AUSWAHL)
+
+    kopf = _kopf(html)
+    assert kopf[-1] == _ACC_LABEL, (
+        f"ACC steht nicht hinter den gewaehlten Metrik-Spalten: {kopf!r} "
+        "(#2098 Befund B: show_acc wird im konfigurierbaren Zweig nicht "
+        "gelesen)."
+    )
+
+    altform = render_outlook_table(zeilen, show_acc=True)
+    erwarteter_punkt = _datenzellen(altform)[0][-1].decode_contents()
+    assert _acc_zelle(html).decode_contents() == erwarteter_punkt, (
+        "Die ACC-Zelle des konfigurierbaren Zweigs zeigt nicht denselben "
+        f"Farbpunkt wie der Altform-Zweig: {_acc_zelle(html).decode_contents()!r} "
+        f"vs. {erwarteter_punkt!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-6 — Klartext: ACC-Spalte mit Wort statt Punkt
+# ---------------------------------------------------------------------------
+
+def test_ac6_klartext_zeigt_acc_wort_hinter_den_gewaehlten_spalten():
+    """AC-6: Given denselben konfigurierbaren Renderer-Zweig / When der
+    Ausblick als Klartext-Mail gerendert wird / Then erscheint eine
+    ACC-Spalte mit einem 4-stufigen deutschen Wort HINTER den gewaehlten
+    Metrik-Spalten.
+
+    Projektregel "HTML = Normalfassung, keine Dopplung": der Farbpunkt ist im
+    HTML der EINZIGE Informationstraeger -- im Klartext braucht dieselbe
+    Aussage ein Wort.
+    """
+    from output.renderers.email.outlook import render_outlook_plain
+
+    block = render_outlook_plain(_zeilen([85]), show_acc=True, metrics=_AUSWAHL)
+    zeile = _klartext_zeilen(block)[0]
+
+    assert _ACC_LABEL in zeile, (
+        f"Die Klartext-Ausblick-Zeile fuehrt keine ACC-Spalte: {zeile!r} "
+        "(#2098 Befund C)."
+    )
+    assert _acc_wort(zeile) == _STUFEN_WORT[85], (
+        f"ACC-Wort {_acc_wort(zeile)!r} statt {_STUFEN_WORT[85]!r} in {zeile!r}."
+    )
+    assert zeile.rstrip().endswith(f"{_ACC_LABEL} {_STUFEN_WORT[85]}"), (
+        f"ACC steht nicht hinter den gewaehlten Metrik-Spalten: {zeile!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-7 — zwei Stufen unterscheiden sich sichtbar (Gegenprobe mit echtem Wert)
+# ---------------------------------------------------------------------------
+
+def test_ac7_hohe_und_niedrigste_stufe_unterscheiden_sich_sichtbar():
+    """AC-7: Given einen Genauigkeits-Wert von 85 % (hohe Stufe) und einen
+    zweiten von 35 % (niedrigste Stufe) / When beide Etappen im selben
+    Ausblick gerendert werden / Then unterscheiden sich die HTML-Farbpunkte
+    sichtbar -- und ebenso die Klartext-Worte.
+
+    Gegenprobe mit einem plausibel FALSCHEN Wert (35 statt 85), nicht mit
+    ``None``: eine Zelle, die immer denselben Punkt zeigte, waere gegen einen
+    Totalausfall geschuetzt, gegen einen falschen Wert aber blind.
+    """
+    from output.renderers.email.outlook import (
+        render_outlook_plain, render_outlook_table,
+    )
+
+    zeilen = _zeilen([85, 35])
+    html = render_outlook_table(zeilen, show_acc=True, metrics=_AUSWAHL)
+
+    hoch, niedrig = _punkt_farbe(_acc_zelle(html, 0)), _punkt_farbe(_acc_zelle(html, 1))
+    assert hoch is not None and niedrig is not None, (
+        f"Mindestens eine ACC-Zelle traegt gar keinen Farbpunkt: "
+        f"85% -> {hoch!r}, 35% -> {niedrig!r}"
+    )
+    assert hoch != niedrig, (
+        f"85 % und 35 % erzeugen denselben Farbpunkt ({hoch!r}) -- die Spalte "
+        "zeigt die Stufe nicht an."
+    )
+
+    worte = [_acc_wort(z) for z in
+             _klartext_zeilen(render_outlook_plain(zeilen, show_acc=True,
+                                                   metrics=_AUSWAHL))]
+    assert worte == [_STUFEN_WORT[85], _STUFEN_WORT[35]], (
+        f"Klartext-Worte {worte!r} statt "
+        f"{[_STUFEN_WORT[85], _STUFEN_WORT[35]]!r}."
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-8 — Ortsvergleich bleibt ohne ACC (mit Positivkontrolle)
+# ---------------------------------------------------------------------------
+
+def test_ac8_ortsvergleich_bleibt_ohne_acc_spalte():
+    """AC-8: Given einen Ortsvergleich-Ausblick (``show_acc=False``, s.
+    compare_html.py:1257 und comparison.py:367) / When er im konfigurierbaren
+    Zweig als HTML- UND als Klartext-Mail gerendert wird / Then erscheint
+    weder eine ACC-Spalte in der Kopfzeile noch eine ACC-Zelle in den
+    Datenzeilen.
+
+    Positivkontrolle: derselbe Zeilensatz mit ``show_acc=True`` MUSS die
+    Spalte zeigen. Ohne diesen Teil waere der Test auch dann gruen, wenn der
+    Renderer ueberhaupt nichts ausgaebe -- ein Ausbleiben-Test ohne Nachweis,
+    dass es sonst geschaehe, bewacht nichts.
+    """
+    from output.renderers.email.outlook import (
+        render_outlook_plain, render_outlook_table,
+    )
+
+    zeilen = _zeilen([85])
+
+    mit_acc = render_outlook_table(zeilen, show_acc=True, metrics=_AUSWAHL)
+    assert _ACC_LABEL in _kopf(mit_acc), (
+        f"Positivkontrolle gescheitert: schon mit show_acc=True fehlt die "
+        f"ACC-Spalte ({_kopf(mit_acc)!r}) -- der Ausbleiben-Nachweis fuer den "
+        "Ortsvergleich waere wertlos (#2098 Befund B)."
+    )
+    mit_acc_klartext = render_outlook_plain(zeilen, show_acc=True,
+                                            metrics=_AUSWAHL, show_name=False)
+    assert _ACC_LABEL in _klartext_zeilen(mit_acc_klartext)[0], (
+        "Positivkontrolle gescheitert: schon mit show_acc=True fehlt die "
+        "ACC-Spalte im Klartext (#2098 Befund C)."
+    )
+
+    ohne_acc = render_outlook_table(zeilen, show_acc=False, metrics=_AUSWAHL)
+    kopf_ohne = _kopf(ohne_acc)
+    assert _ACC_LABEL not in kopf_ohne, (
+        f"Der Ortsvergleich zeigt eine ACC-Spalte: {kopf_ohne!r} (ADR-0005/"
+        "#710: Confidence ist keine per-Ort-Groesse)."
+    )
+    assert len(_datenzellen(ohne_acc)[0]) == len(kopf_ohne), (
+        f"Kopf {kopf_ohne!r} und Datenzeile laufen im Compare-Fall "
+        f"auseinander ({len(_datenzellen(ohne_acc)[0])} Zellen)."
+    )
+    assert len(_datenzellen(ohne_acc)[0]) == len(_datenzellen(mit_acc)[0]) - 1, (
+        "show_acc=False soll genau EINE Zelle weniger tragen als "
+        f"show_acc=True: {len(_datenzellen(ohne_acc)[0])} vs. "
+        f"{len(_datenzellen(mit_acc)[0])}"
+    )
+
+    ohne_acc_klartext = render_outlook_plain(zeilen, show_acc=False,
+                                             metrics=_AUSWAHL, show_name=False)
+    assert _ACC_LABEL not in ohne_acc_klartext, (
+        f"Der Klartext-Ortsvergleich zeigt ACC: {ohne_acc_klartext!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-9 — ACC-Spalte OHNE dass confidence waehlbar wird (#710/ADR-0005)
+# ---------------------------------------------------------------------------
+
+def test_ac9_acc_spalte_ohne_dass_confidence_waehlbar_wird():
+    """AC-9: Given die Backend-Aufloesung der waehlbaren Ausblick-Metriken
+    (``available_aggregations``/``derived_aggregations``) / When nach der
+    Behebung geprueft wird / Then taucht ``confidence``/ACC weiterhin NICHT
+    in der Liste der waehlbaren Ausblick-Metriken auf -- die Spalte entsteht
+    ausschliesslich als fest angehaengte Zusatzspalte AUSSERHALB der Auswahl.
+
+    Beide Haelften stehen bewusst in EINEM Test: "ACC ist da" und "ACC ist
+    nicht waehlbar" muessen GLEICHZEITIG gelten. Getrennt geprueft koennte
+    eine Behebung, die ACC in den Katalog haengt, die eine Haelfte gruen
+    machen, waehrend die andere in einer anderen Datei rot liegt.
+    """
+    from app.metric_catalog import get_metric
+    from output.renderers.compare_outlook_metric_ids import (
+        derived_aggregations, outlook_columns,
+    )
+    from output.renderers.email.outlook import render_outlook_table
+
+    html = render_outlook_table(_zeilen([85]), show_acc=True, metrics=_AUSWAHL)
+    assert _ACC_LABEL in _kopf(html), (
+        f"Die ACC-Spalte fehlt: {_kopf(html)!r} (#2098 Befund B)."
+    )
+
+    assert get_metric("confidence").selectable is False, (
+        "confidence ist waehlbar geworden -- ADR-0005/#710 verlangt "
+        "selectable=False."
+    )
+    assert derived_aggregations("confidence") == [], (
+        "confidence liefert Ausblick-Auswertungen und wuerde damit als "
+        f"waehlbare Spalte erscheinen: {derived_aggregations('confidence')!r}"
+    )
+    assert outlook_columns(["confidence"]) == [], (
+        "confidence erzeugt eine Spalte ueber outlook_columns() -- die "
+        "ACC-Spalte muss AUSSERHALB des Metrik-Systems angehaengt werden "
+        f"(#710): {outlook_columns(['confidence'])!r}"
+    )
+    aus_der_auswahl = [c["label"] for c in outlook_columns(_AUSWAHL)]
+    assert _ACC_LABEL not in aus_der_auswahl, (
+        f"outlook_columns() liefert eine ACC-Spalte ({aus_der_auswahl!r}) -- "
+        "sie gehoert nicht in die Auswahl-Aufloesung, sondern wird vom "
+        "Renderer fest angehaengt (#710)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-10 — Kopf und Wert stehen an derselben Position
+# ---------------------------------------------------------------------------
+
+def test_ac10_acc_steht_in_kopf_und_datenzeile_an_derselben_position():
+    """AC-10: Given eine Kopfzeile und eine Datenzeile desselben Ausblicks /
+    When beide gerendert werden / Then steht die ACC-Spalte an derselben
+    Position relativ zu den uebrigen Spalten -- kein Auseinanderlaufen von
+    Beschriftung und Wert.
+
+    Geprueft ueber ZWEI verschieden lange Auswahlen: die Position wird damit
+    abgeleitet und nicht als Zahl im Test festgeschrieben. Zusaetzlich wird
+    eine Nachbarspalte auf ihren WERT geprueft -- ein reiner Laengenvergleich
+    saehe einen Versatz um eine Spalte nicht.
+    """
+    from output.renderers.compare_outlook_metric_ids import outlook_columns
+    from output.renderers.email.outlook import render_outlook_table
+
+    for auswahl in (["precipitation"], ["precipitation", "gust", "thunder",
+                                        "sunshine"]):
+        html = render_outlook_table(_zeilen([85], metrics=auswahl),
+                                    show_acc=True, metrics=auswahl)
+        kopf = _kopf(html)
+        labels = [c["label"] for c in outlook_columns(auswahl)]
+
+        assert kopf == ["Tag", *labels, _ACC_LABEL], (
+            f"Kopfzeile {kopf!r} statt {['Tag', *labels, _ACC_LABEL]!r} "
+            f"(Auswahl {auswahl!r})."
+        )
+        zellen = _datenzellen(html)[0]
+        assert len(zellen) == len(kopf), (
+            f"{len(zellen)} Zellen zu {len(kopf)} Spalten (Auswahl "
+            f"{auswahl!r}): Kopf und Werte laufen auseinander."
+        )
+        assert _punkt_farbe(zellen[kopf.index(_ACC_LABEL)]) is not None, (
+            f"An der ACC-Position (Index {kopf.index(_ACC_LABEL)}) steht kein "
+            f"Farbpunkt (Auswahl {auswahl!r})."
+        )
+        assert zellen[kopf.index("Niederschlag")].get_text(strip=True) == "2.5 mm", (
+            "Die Niederschlags-Zelle steht nicht unter ihrer Beschriftung: "
+            f"{zellen[kopf.index('Niederschlag')].get_text(strip=True)!r} "
+            f"(Auswahl {auswahl!r}) -- Spaltenversatz."
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-11 — die vier Klartext-Worte
+# ---------------------------------------------------------------------------
+
+def test_ac11_vier_stufen_tragen_vier_eindeutige_klartext_worte():
+    """AC-11: Given die vier HTML-Farbstufen (>=80 / >=60 / >=40 / <40) /
+    When das Klartext-Wort je Stufe gerendert wird / Then ist jede Stufe
+    durch ein eindeutiges, unterscheidbares Wort ohne Handlungsempfehlung
+    vertreten (reine Zustandsbeschreibung, ADR-0007).
+    """
+    from output.renderers.email.outlook import render_outlook_plain
+
+    werte = list(_STUFEN_WORT)
+    block = render_outlook_plain(_zeilen(werte), show_acc=True, metrics=_AUSWAHL)
+    worte = [_acc_wort(z) for z in _klartext_zeilen(block)]
+
+    assert worte == [_STUFEN_WORT[w] for w in werte], (
+        f"Klartext-Worte {worte!r} statt {[_STUFEN_WORT[w] for w in werte]!r} "
+        f"fuer die Stufen {werte!r}."
+    )
+    assert len(set(worte)) == len(werte), (
+        f"Die vier Stufen sind nicht unterscheidbar: {worte!r}"
+    )
+
+
+def test_ac11_klartext_wort_folgt_denselben_stufen_wie_der_farbpunkt():
+    """AC-11 (Kopplung): Given eine Wertereihe quer ueber alle vier Stufen
+    inklusive ihrer Grenzen (80/60/40) / When HTML und Klartext gerendert
+    werden / Then wechselt das Klartext-Wort an GENAU denselben Stellen wie
+    der Farbpunkt.
+
+    Ohne diese Kopplung koennte das Wort eine eigene, abweichende
+    Stufengrenze bekommen -- HTML und Klartext derselben Mail zeigten dann
+    verschiedene Aussagen zur selben Zahl.
+    """
+    from output.renderers.email.outlook import (
+        render_outlook_plain, render_outlook_table,
+    )
+
+    werte = [95, 85, 80, 79, 65, 60, 59, 45, 40, 39, 20, 0]
+    zeilen = _zeilen(werte)
+    html = render_outlook_table(zeilen, show_acc=True, metrics=_AUSWAHL)
+
+    farben = [_punkt_farbe(_acc_zelle(html, i)) for i in range(len(werte))]
+    worte = [_acc_wort(z) for z in
+             _klartext_zeilen(render_outlook_plain(zeilen, show_acc=True,
+                                                   metrics=_AUSWAHL))]
+
+    assert None not in farben and None not in worte, (
+        f"Unvollstaendige Ausgabe -- Farben: {farben!r}, Worte: {worte!r}"
+    )
+    nach_farbe = {farbe: sorted({w for f, w in zip(farben, worte) if f == farbe})
+                  for farbe in set(farben)}
+    assert all(len(w) == 1 for w in nach_farbe.values()), (
+        "Zu einer Farbstufe gehoeren mehrere Klartext-Worte -- Wort und Punkt "
+        f"folgen verschiedenen Grenzen: {nach_farbe!r} (Werte {werte!r})."
+    )
+    assert len(set(worte)) == len(set(farben)), (
+        f"Anzahl Klartext-Worte {sorted(set(worte))!r} passt nicht zur Anzahl "
+        f"Farbstufen {sorted(set(farben))!r} (Werte {werte!r})."
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-12 — fehlender Wert bleibt "–"
+# ---------------------------------------------------------------------------
+
+def test_ac12_fehlende_genauigkeit_zeigt_strich_statt_absturz():
+    """AC-12: Given einen fehlenden ``confidence_pct``-Wert (``None``) / When
+    die Zeile gerendert wird / Then erscheint fuer ACC weiterhin "–" wie im
+    HTML-Fall -- kein Absturz, kein leeres Feld.
+
+    Gegenprobe im selben Test: eine zweite Zeile MIT Wert muss ihr Wort/ihren
+    Punkt zeigen. Sonst waere ein Renderer, der ueberall "–" schreibt, gruen.
+    """
+    from output.renderers.email.outlook import (
+        render_outlook_plain, render_outlook_table,
+    )
+
+    zeilen = _zeilen([None, 85])
+    assert "confidence_pct" not in zeilen[0], (
+        "Vorbedingung: die erste Zeile darf keinen Genauigkeitswert tragen."
+    )
+
+    html = render_outlook_table(zeilen, show_acc=True, metrics=_AUSWAHL)
+    assert _acc_zelle(html, 0).get_text(strip=True) == _KEIN_WERT, (
+        f"HTML-ACC ohne Wert: {_acc_zelle(html, 0).get_text(strip=True)!r} "
+        f"statt {_KEIN_WERT!r}."
+    )
+    assert _punkt_farbe(_acc_zelle(html, 1)) is not None, (
+        "Gegenprobe: die Zeile MIT Wert zeigt keinen Farbpunkt."
+    )
+
+    klartext = _klartext_zeilen(render_outlook_plain(zeilen, show_acc=True,
+                                                     metrics=_AUSWAHL))
+    assert _acc_wort(klartext[0]) == _KEIN_WERT, (
+        f"Klartext-ACC ohne Wert: {_acc_wort(klartext[0])!r} statt "
+        f"{_KEIN_WERT!r} in {klartext[0]!r}."
+    )
+    assert _acc_wort(klartext[1]) == _STUFEN_WORT[85], (
+        f"Gegenprobe: {_acc_wort(klartext[1])!r} statt {_STUFEN_WORT[85]!r}."
+    )

--- a/tests/tdd/test_outlook_columns_from_metric_ids.py
+++ b/tests/tdd/test_outlook_columns_from_metric_ids.py
@@ -307,7 +307,9 @@ def test_ac3_unaufloesbare_auswahl_zeigt_die_grundauswahl_und_warnt(caplog):
          if mc.metric_id in (dc.allowed_metric_ids_for_report_type("evening") or set())]
     )
     erwartet = [c["label"] for c in outlook_columns(grund)]
-    assert kopf == ["Tag"] + erwartet, (
+    # #2098: die fest angehaengte ACC-Zusatzspalte steht hinter der Auswahl
+    # und stammt nicht aus `outlook_columns()` (#710 unberuehrt).
+    assert kopf == ["Tag"] + erwartet + ["ACC"], (
         f"Der Ausblick zeigt die Kopfzeile {kopf!r} statt der Grundauswahl "
         f"{erwartet!r} (AC-3)."
     )

--- a/tests/tdd/test_outlook_darstellungsform.py
+++ b/tests/tdd/test_outlook_darstellungsform.py
@@ -133,9 +133,10 @@ def test_ac5_wind_boeen_zeigt_dieselbe_wortstufe_in_allen_vier_ausgaben():
         "HTML-Mail: Der 3-Tages-Ausblick fehlt vollstaendig -- die "
         f"Kennungsauswahl {AUSWAHL!r} kam nicht an (AC-5)."
     )
-    assert kopf == ["Tag", "Böen"], (
+    # #2098: hinter der Auswahl steht die fest angehaengte ACC-Zusatzspalte.
+    assert kopf == ["Tag", "Böen", "ACC"], (
         f"HTML-Mail: Kopfzeile {kopf!r} -- erwartet 'Tag'+'Böen' aus der "
-        f"Auswahl {AUSWAHL!r}."
+        f"Auswahl {AUSWAHL!r} plus der festen ACC-Spalte."
     )
 
     html_zelle = zeilen[0][1] if len(zeilen[0]) > 1 else ""

--- a/tests/tdd/test_outlook_metric_ampelfarben.py
+++ b/tests/tdd/test_outlook_metric_ampelfarben.py
@@ -88,7 +88,11 @@ def test_ac1_numerische_spalte_ueber_schwelle_bekommt_ampelfarbe_im_trip():
     html = render_outlook_table([row], show_acc=True, metrics=[WIND])
 
     styles = _cell_styles(html)
-    assert len(styles) == 2, f"Erwartet Wochentag + 1 Metrikspalte: {styles!r}"
+    # #2098: seit der Behebung traegt der Trip-Zweig (show_acc=True) hinter
+    # den gewaehlten Spalten die fest angehaengte ACC-Zelle.
+    assert len(styles) == 3, (
+        f"Erwartet Wochentag + 1 Metrikspalte + ACC: {styles!r}"
+    )
     assert _bg_of(styles[1]) == f"background:{tone_css('orange')[0]};", (
         f"Windspalte (55 km/h, orange-Schwelle 50) traegt {styles[1]!r} -- "
         "der Metrik-Zweig faerbt heute KEINE Zelle (AC-1)."
@@ -132,9 +136,11 @@ def test_ac3_ac4_ac5_gewitterspalte_folgt_der_ampelband_zuordnung_je_stufe():
     html = render_outlook_table(rows, show_acc=True, metrics=[GEWITTER])
 
     styles = _cell_styles(html)
-    # Zwei Zellen je Zeile (Wochentag, Gewitter) -- Gewitterspalte ist Index 1
-    # jeder Zeile: 1, 3, 5, 7.
-    gewitter_bg = [_bg_of(styles[i]) for i in (1, 3, 5, 7)]
+    # Gewitterspalte ist Index 1 JEDER Zeile. Die Zahl der Zellen je Zeile
+    # wird abgeleitet statt festgeschrieben -- seit #2098 traegt der
+    # Trip-Zweig hinter der Auswahl zusaetzlich die feste ACC-Zelle.
+    je_zeile = len(styles) // len(stufen)
+    gewitter_bg = [_bg_of(styles[i * je_zeile + 1]) for i in range(len(stufen))]
 
     erwartet = [
         "",  # NONE
@@ -166,7 +172,10 @@ def test_ac6_metrik_ohne_katalogschwellen_bleibt_farblos_trotz_hohem_wert():
     html = render_outlook_table([row], show_acc=True, metrics=auswahl)
 
     styles = _cell_styles(html)
-    assert len(styles) == 3, f"Erwartet Wochentag + 2 Metrikspalten: {styles!r}"
+    # #2098: + die fest angehaengte ACC-Zelle (show_acc=True, Trip).
+    assert len(styles) == 4, (
+        f"Erwartet Wochentag + 2 Metrikspalten + ACC: {styles!r}"
+    )
     assert _bg_of(styles[1]) == f"background:{tone_css('red')[0]};", (
         f"Windspalte (80 km/h, red-Schwelle 70) traegt {styles[1]!r} statt rot."
     )

--- a/tests/tdd/test_outlook_metric_id_all_channels.py
+++ b/tests/tdd/test_outlook_metric_id_all_channels.py
@@ -82,10 +82,14 @@ def test_ac4_temperatur_kennung_zeigt_ueberall_dieselbe_eine_spannen_spalte():
         f"Kennungsauswahl {AUSWAHL!r} wurde verworfen und wie 'bewusst "
         "geleert' behandelt (AC-4)."
     )
-    assert len(kopf) == 2, (
+    # #2098: hinter der Auswahl steht die fest angehaengte ACC-Zusatzspalte
+    # (Tag + 1 Metrikspalte + ACC) -- die Zusicherung "GENAU EINE
+    # Temperatur-Spalte" wird deshalb an der Auswahl-Mitte geprueft.
+    assert kopf == ["Tag", "Temperatur", "ACC"], (
         f"HTML-Mail: Die Ausblick-Tabelle hat die Kopfzeile {kopf!r}. Aus der "
         "einen Kennung 'temperature' muss GENAU EINE Wert-Spalte entstehen "
-        "(neben 'Tag') — Tief und Hoch gehoeren in dieselbe Zelle (AC-4)."
+        "(neben 'Tag' und der festen ACC-Spalte) — Tief und Hoch gehoeren in "
+        "dieselbe Zelle (AC-4)."
     )
 
     zellen = {

--- a/tests/tdd/test_outlook_sonnenstunden_aggregation.py
+++ b/tests/tdd/test_outlook_sonnenstunden_aggregation.py
@@ -1,0 +1,312 @@
+"""TDD RED — #2098 Befund A: Sonnenstunden fallen bei der Etappen-Aggregation weg.
+
+SPEC: docs/specs/modules/fix_2098_ausblick_acc_und_sonnenstunden.md (AC-1..AC-4)
+KONTEXT: docs/context/fix-2098-ausblick-acc-und-sonnenstunden.md
+
+Fehlerbild aus Nutzersicht: die Spalte "Sonnenstunden" im 3-Tages-Ausblick der
+Trip-Briefing-Mail zeigt in JEDER Zeile "–", obwohl der Wert je Segment
+vorhanden ist. Ursache: ``aggregate_stage()`` (weather_metrics.py:1384) baut
+das Etappen-Aggregat ausschliesslich aus Feldern, die in der
+``aggregation_config`` des ersten Segment-Summarys eine Regel tragen --
+``sunny_hours`` hat dort keine (weather_metrics.py:555-572).
+
+🔴 Zwei Fallen, die falsches Gruen erzeugt haetten:
+
+1. **Einzelsegment.** ``CompactSummaryFormatter._aggregate()``
+   (compact_summary.py:262-268) ruft ``aggregate_stage()`` nur bei MEHR ALS
+   EINEM Segment; bei einem Segment reicht es das Aggregat unbeschaedigt
+   durch. Ein Einzelsegment-Fixture zeigt den Wert also auch heute schon.
+   Jeder Nachweis hier laeuft deshalb ueber eine MEHRSEGMENT-Etappe (AC-3
+   sichert genau diese Unterscheidung ab).
+
+2. **Eigene ``aggregation_config`` im Test.** Wer die Regeln im Test selbst
+   hinschreibt (so wie ``tests/helpers/trip_outlook_selection._summary()``),
+   prueft seine eigene Kopie statt des Erzeugers. Die Segment-Summaries
+   entstehen hier deshalb aus dem ECHTEN Erzeuger
+   ``WeatherMetricsService.compute_basis_metrics()`` / ``compute_extended_metrics()``
+   -- nur der Zahlenwert ``sunny_hours`` wird ueber ``dataclasses.replace``
+   auf unterscheidbare Werte gesetzt, damit die Aggregationsregel (Summe vs.
+   Maximum vs. erstes Segment) ueberhaupt unterscheidbar ist.
+
+Kern-Schicht, deterministisch: keine Mocks/``patch()``/``MagicMock``, kein
+Netz, kein Dateiinhalt-Check. Echte ``ForecastDataPoint``-/
+``SegmentWeatherSummary``-/``SegmentWeatherData``-Objekte, echter Renderpfad.
+"""
+from __future__ import annotations
+
+import dataclasses
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+# Pfadregel #1409: Pruefling relativ zur eigenen Testdatei aufloesen -- sonst
+# pruefte ein Worktree-Lauf die unveraenderte Hauptrepo-Kopie.
+REPO_ROOT = Path(__file__).resolve().parents[2]
+for _pfad in (REPO_ROOT, REPO_ROOT / "src"):
+    if str(_pfad) not in sys.path:
+        sys.path.insert(0, str(_pfad))
+
+TZ = ZoneInfo("Europe/Berlin")
+
+# Drei unterscheidbare Segmentwerte: die Summe (7.0) ist von jeder anderen
+# denkbaren Regel verschieden -- Maximum waere 3.5, erstes Segment 2.0,
+# Mittelwert 2.33, Minimum 1.5. Bei zwei gleichen Werten koennte ein Treffer
+# Zufall sein.
+_SONNE_JE_SEGMENT = (2.0, 3.5, 1.5)
+_SONNE_SUMME = 7.0
+
+# Ausblick-Auswahl im Neuformat (#1848 A2: reine Kennungen). "sunshine" ist
+# die Kennung, deren Spalte den Fehler zeigt; "precipitation" steht daneben,
+# damit ein Spaltenversatz sichtbar wuerde.
+_AUSWAHL = ["precipitation", "sunshine"]
+
+
+# ---------------------------------------------------------------------------
+# Echte Domaenen-Objekte
+# ---------------------------------------------------------------------------
+
+def _punkte(tag: int = 12):
+    from app.models import ForecastDataPoint, ThunderLevel
+
+    return [
+        ForecastDataPoint(
+            ts=datetime(2026, 7, tag, stunde, 0, tzinfo=timezone.utc),
+            t2m_c=15.0 + stunde * 0.2, wind10m_kmh=12.0, wind_direction_deg=270,
+            gust_kmh=25.0, precip_1h_mm=0.5, pop_pct=30, cloud_total_pct=40,
+            thunder_level=ThunderLevel.NONE, visibility_m=15000.0,
+            dni_wm2=400.0, humidity_pct=55,
+        )
+        for stunde in range(8, 14)
+    ]
+
+
+def _segment(segment_id: int, sunny_hours: float):
+    """Ein echtes ``SegmentWeatherData`` -- Aggregat vom ECHTEN Erzeuger.
+
+    ``compute_basis_metrics()``/``compute_extended_metrics()`` liefern die
+    ``aggregation_config``, um die es in dieser Spec geht. Nur ``sunny_hours``
+    wird auf einen unterscheidbaren Wert gesetzt (der Erzeuger rechnet aus
+    ``dni_wm2`` fuer alle drei Segmente denselben Wert aus, damit waere Summe
+    von Maximum nicht unterscheidbar).
+    """
+    from app.models import (
+        ForecastMeta, GPXPoint, NormalizedTimeseries, Provider,
+        SegmentWeatherData, TripSegment,
+    )
+    from services.weather_metrics import WeatherMetricsService
+
+    segment = TripSegment(
+        segment_id=segment_id,
+        start_point=GPXPoint(lat=46.65, lon=12.85, elevation_m=1400.0),
+        end_point=GPXPoint(lat=46.70, lon=12.95, elevation_m=2100.0),
+        start_time=datetime(2026, 7, 12, 8, 0, tzinfo=timezone.utc),
+        end_time=datetime(2026, 7, 12, 13, 0, tzinfo=timezone.utc),
+        duration_hours=5.0, distance_km=10.0, ascent_m=700.0, descent_m=120.0,
+    )
+    zeitreihe = NormalizedTimeseries(
+        meta=ForecastMeta(provider=Provider.OPENMETEO, model="icon_d2",
+                          grid_res_km=2.2),
+        data=_punkte(),
+    )
+    dienst = WeatherMetricsService()
+    aggregat = dienst.compute_extended_metrics(
+        zeitreihe, dienst.compute_basis_metrics(zeitreihe, tz=TZ),
+    )
+    assert aggregat.sunny_hours is not None, (
+        "Vorbedingung: der Erzeuger muss auf SEGMENT-Ebene ueberhaupt "
+        "Sonnenstunden liefern -- sonst prueft dieser Test die falsche Stufe."
+    )
+    return SegmentWeatherData(
+        segment=segment, timeseries=zeitreihe,
+        aggregated=dataclasses.replace(aggregat, sunny_hours=sunny_hours),
+        fetched_at=datetime(2026, 7, 12, 6, 0, tzinfo=timezone.utc),
+        provider="openmeteo",
+    )
+
+
+def _mehrsegment_etappe():
+    """Drei Segmente einer Etappe mit unterscheidbaren Sonnenstunden."""
+    return [_segment(i + 1, wert) for i, wert in enumerate(_SONNE_JE_SEGMENT)]
+
+
+def _ausblick_zeile(summary):
+    from output.renderers.email.outlook import build_outlook_row
+
+    return build_outlook_row(summary, _punkte(), "Mo", TZ, metrics=_AUSWAHL)
+
+
+def _spalten_und_zellen(summary) -> tuple[list[str], list[str]]:
+    """Kopfzeilen-Beschriftungen und Zellentexte der gerenderten Tabelle.
+
+    Der konfigurierbare Zweig (``metrics`` gesetzt) ist der Zweig, ueber den
+    der Trip seit #1848 A3 praktisch immer laeuft (AC-14).
+    """
+    import re
+
+    from output.renderers.email.outlook import render_outlook_table
+
+    html = render_outlook_table([_ausblick_zeile(summary)], show_acc=True,
+                                metrics=_AUSWAHL)
+    kopf = [re.sub(r"<[^>]+>", "", t).strip()
+            for t in re.findall(r"<th[^>]*>(.*?)</th>", html, re.DOTALL)]
+    zellen = [re.sub(r"<[^>]+>", "", t).strip()
+              for t in re.findall(r"<td[^>]*>(.*?)</td>", html, re.DOTALL)]
+    return kopf, zellen
+
+
+def _sonnen_zelle(summary) -> str:
+    kopf, zellen = _spalten_und_zellen(summary)
+    assert "Sonnenstunden" in kopf, (
+        f"Vorbedingung: die Sonnenstunden-Spalte muss ueberhaupt im Kopf "
+        f"stehen, sonst prueft der Test nichts. Kopf: {kopf!r}"
+    )
+    assert len(zellen) == len(kopf), (
+        f"Kopf und Datenzeile laufen auseinander: {kopf!r} vs. {zellen!r}"
+    )
+    return zellen[kopf.index("Sonnenstunden")]
+
+
+# ---------------------------------------------------------------------------
+# AC-1 — Mehrsegment-Etappe zeigt einen Zahlenwert statt "–"
+# ---------------------------------------------------------------------------
+
+def test_ac1_mehrsegment_etappe_zeigt_sonnenstunden_statt_strich():
+    """AC-1: Given eine Trip-Etappe mit mehr als einem Segment und
+    unterschiedlichen Sonnenstunden je Segment / When das Trip-Briefing
+    gerendert wird / Then zeigt die Sonnenstunden-Spalte im 3-Tages-Ausblick
+    einen konkreten Zahlenwert statt "–".
+
+    RED-Grund: ``aggregate_stage()`` iteriert nur ueber Felder mit
+    Aggregationsregel; ``sunny_hours`` hat keine und faellt auf den
+    Dataclass-Default ``None`` -- die Zelle zeigt "–".
+    """
+    from services.weather_metrics import aggregate_stage
+
+    segmente = _mehrsegment_etappe()
+    assert len(segmente) > 1, (
+        "Vorbedingung: der Nachweis MUSS ueber eine Mehrsegment-Etappe "
+        "laufen -- bei einem Segment wird gar nicht aggregiert (AC-3)."
+    )
+
+    zelle = _sonnen_zelle(aggregate_stage(segmente))
+
+    assert zelle != "–", (
+        "Die Sonnenstunden-Spalte des 3-Tages-Ausblicks zeigt weiterhin "
+        f"{zelle!r} -- der Segmentwert geht in aggregate_stage() verloren "
+        "(#2098 Befund A)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-2 — der Wert ist die SUMME der Segmentwerte, nicht irgendeine Zahl
+# ---------------------------------------------------------------------------
+
+def test_ac2_sonnenstunden_sind_die_summe_der_segmentwerte():
+    """AC-2: Given dieselbe Mehrsegment-Etappe / When die Sonnenstunden-Spalte
+    geprueft wird / Then entspricht der angezeigte Wert der SUMME der
+    Segment-Sonnenstunden (Katalog-Definition ``summary_fields={"sum":
+    "sunny_hours"}``) und nicht einem Platzhalter oder dem Wert nur eines
+    Segments.
+
+    Die drei Segmentwerte 2.0/3.5/1.5 sind so gewaehlt, dass jede andere
+    denkbare Regel einen anderen Wert ergaebe (Maximum 3.5, erstes Segment
+    2.0, Mittelwert 2.3, Minimum 1.5) -- ein "irgendeine Zahl"-Test waere
+    gegen die falsche Regel blind.
+    """
+    from services.weather_metrics import aggregate_stage
+
+    etappe = aggregate_stage(_mehrsegment_etappe())
+
+    assert etappe.sunny_hours == _SONNE_SUMME, (
+        f"Etappen-Aggregat traegt {etappe.sunny_hours!r} statt der Summe "
+        f"{_SONNE_SUMME} aus {_SONNE_JE_SEGMENT} (Maximum waere "
+        f"{max(_SONNE_JE_SEGMENT)}, erstes Segment {_SONNE_JE_SEGMENT[0]})."
+    )
+    assert _sonnen_zelle(etappe) == f"{_SONNE_SUMME:.1f} h", (
+        f"Die gerenderte Zelle zeigt {_sonnen_zelle(etappe)!r} statt "
+        f"{_SONNE_SUMME:.1f} h -- die Summe erreicht die Mail nicht."
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-3 — Einzelsegment war nie betroffen (und taugt deshalb nicht als Beleg)
+# ---------------------------------------------------------------------------
+
+def test_ac3_einzelsegment_unveraendert_mehrsegment_erst_nach_dem_fix():
+    """AC-3: Given eine Trip-Etappe mit genau einem Segment / When das
+    Briefing gerendert wird / Then bleibt die Sonnenstunden-Anzeige
+    unveraendert -- dieser Pfad war nie betroffen, weil
+    ``CompactSummaryFormatter._aggregate()`` bei einem Segment gar nicht
+    aggregiert (compact_summary.py:262-268).
+
+    Positivkontrolle statt Ausbleiben-Test: Teil 1 (Einzelsegment) ist die
+    Kontrolle -- sie zeigt, dass Fixture und Wertepfad tragen und der Wert
+    ohne Aggregationsschritt ankommt. Teil 2 (drei Segmente, dieselbe
+    Etappe) ist die eigentliche Behauptung und heute rot. Ohne Teil 1 waere
+    Teil 2 auch dann "erklaerbar", wenn das Fixture gar keine Sonnenstunden
+    truege; ohne Teil 2 waere der Test von Anfang an gruen und bewachte
+    nichts.
+    """
+    from output.renderers.compact_summary import CompactSummaryFormatter
+
+    einzeln = CompactSummaryFormatter._aggregate([_segment(1, _SONNE_JE_SEGMENT[0])])
+    assert einzeln is not None and einzeln.sunny_hours == _SONNE_JE_SEGMENT[0], (
+        "Kontrolle gescheitert: schon der Einzelsegment-Pfad liefert keine "
+        f"Sonnenstunden ({einzeln.sunny_hours if einzeln else None!r}) -- dann "
+        "misst dieser Test nicht den Aggregationsfehler, sondern ein kaputtes "
+        "Fixture."
+    )
+
+    mehrere = CompactSummaryFormatter._aggregate(_mehrsegment_etappe())
+    assert mehrere is not None and mehrere.sunny_hours == _SONNE_SUMME, (
+        f"Einzelsegment liefert {einzeln.sunny_hours!r}, dieselbe Etappe auf "
+        f"drei Segmente verteilt aber {mehrere.sunny_hours if mehrere else None!r} "
+        f"statt {_SONNE_SUMME} -- genau dieser Unterschied ist der Fehler "
+        "(#2098 Befund A). Ein Einzelsegment-Test allein waere falsch gruen."
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-4 — Invariante: keine WEITERE Metrik ohne Aggregationsregel
+# ---------------------------------------------------------------------------
+
+def test_ac4_jede_katalog_metrik_mit_summary_field_hat_eine_aggregationsregel():
+    """AC-4: Given den vollstaendigen Metrik-Katalog mit ``summary_fields`` /
+    When alle Zielfelder gegen die ``aggregation_config`` des echten
+    Erzeugers abgeglichen werden / Then traegt jedes Zielfeld eine
+    Aggregationsregel -- ``sunny_hours`` ist die einzige heutige Luecke und
+    bleibt nach der Behebung die einzige Aenderung an der Konfiguration.
+
+    Geprueft wird die Vereinigung beider Erzeugerstellen: ``aggregation_config``
+    aus ``compute_basis_metrics()`` (weather_metrics.py:555-572) und der
+    Extended-Merge in ``compute_extended_metrics()`` (:1032-1062), der jene
+    Basis-Regeln uebernimmt. Ein Zielfeld ohne Regel faellt bei jeder
+    Mehrsegment-Etappe still auf ``None`` -- dieselbe Fehlerklasse wie
+    Befund A, nur an einer anderen Groesse.
+    """
+    from app.metric_catalog import get_all_metrics
+    from app.models import ForecastMeta, NormalizedTimeseries, Provider
+    from services.weather_metrics import WeatherMetricsService
+
+    zeitreihe = NormalizedTimeseries(
+        meta=ForecastMeta(provider=Provider.OPENMETEO, model="icon_d2",
+                          grid_res_km=2.2),
+        data=_punkte(),
+    )
+    dienst = WeatherMetricsService()
+    basis = dienst.compute_basis_metrics(zeitreihe, tz=TZ)
+    regeln = dict(dienst.compute_extended_metrics(zeitreihe, basis).aggregation_config)
+
+    ohne_regel = [
+        (metrik.id, auswertung, feld)
+        for metrik in get_all_metrics()
+        for auswertung, feld in (metrik.summary_fields or {}).items()
+        if feld not in regeln
+    ]
+
+    assert ohne_regel == [], (
+        "Diese Katalog-Metriken haben ein summary_fields-Zielfeld OHNE "
+        "Aggregationsregel und verlieren ihren Wert bei jeder "
+        f"Mehrsegment-Etappe: {ohne_regel!r}"
+    )

--- a/tests/tdd/test_trip_outlook_dispatch_mail.py
+++ b/tests/tdd/test_trip_outlook_dispatch_mail.py
@@ -49,6 +49,13 @@ LAT, LON = 46.65, 12.85
 NIEDERSCHLAG = "precipitation"
 BOEEN = "gust"
 SCHNEEHOEHE = "snow_depth"
+# #2098 AC-13: ACC steht seit der Behebung als fest angehaengte Zusatzspalte
+# HINTER der Auswahl -- ausserhalb des Metrik-Systems, damit ADR-0005/#710
+# (Confidence nicht waehlbar) unberuehrt bleibt. Die Zusicherung dieser Datei
+# bleibt unveraendert scharf: die Kopfzeile wird weiterhin VOLLSTAENDIG
+# verglichen, die Zusatzspalte ist Teil der Erwartung statt aus ihr
+# herausgefiltert.
+_ACC = "ACC"
 
 _MAIL_FIELDS: dict = {
     "smtp_host": "dummy.invalid", "smtp_port": 587,
@@ -250,7 +257,7 @@ def test_ac2_zugestellte_html_mail_zeigt_genau_die_gewaehlten_spalten():
     assert OUTLOOK_EYEBROW in html, (
         "Die zugestellte Mail enthaelt gar keinen Ausblick-Block (AC-2)."
     )
-    assert html_outlook_headers(html) == ["Tag", "Niederschlag", "Böen"], (
+    assert html_outlook_headers(html) == ["Tag", "Niederschlag", "Böen", _ACC], (
         f"Kopfzeile {html_outlook_headers(html)!r} -- die sieben festen "
         "Spalten (N/D/R/PR/Wind/Böen/Gew) waeren der unveraenderte Zustand."
     )
@@ -272,7 +279,7 @@ def test_ac3_zugestellter_klartext_zeigt_dieselben_spalten_wie_das_html():
         "Der Klartext-Teil der zugestellten Mail hat keinen Ausblick (AC-3)."
     )
     kopf = html_outlook_headers(html)[1:]
-    assert kopf == ["Niederschlag", "Böen"], f"Vorbedingung (AC-2): {kopf!r}"
+    assert kopf == ["Niederschlag", "Böen", _ACC], f"Vorbedingung (AC-2): {kopf!r}"
     zeile = block.splitlines()[1]
     positionen = [zeile.find(label) for label in kopf]
     assert all(p >= 0 for p in positionen), (
@@ -322,7 +329,7 @@ def test_ac14_manipulierte_auswahl_erreicht_die_zugestellte_mail_nicht():
                  enabled_ids={"precipitation"})
     html, plain = _zugestellte_teile(trip)
 
-    assert html_outlook_headers(html) == ["Tag", "Niederschlag"], (
+    assert html_outlook_headers(html) == ["Tag", "Niederschlag", _ACC], (
         f"Kopfzeile {html_outlook_headers(html)!r}: die zugestellte Mail zeigt "
         "eine Groesse ausserhalb der Grundauswahl (AC-14)."
     )
@@ -350,7 +357,8 @@ def test_ac15_globale_abwahl_entfernt_die_spalte_im_naechsten_lauf():
     trip = _trip(outlook_metrics=[NIEDERSCHLAG, BOEEN],
                  enabled_ids={"precipitation", "gust"})
     html_vorher, _ = _zugestellte_teile(trip)
-    assert html_outlook_headers(html_vorher) == ["Tag", "Niederschlag", "Böen"], (
+    assert html_outlook_headers(html_vorher) == ["Tag", "Niederschlag", "Böen",
+                                                 _ACC], (
         f"Vorbedingung von AC-15: {html_outlook_headers(html_vorher)!r}"
     )
 
@@ -359,7 +367,7 @@ def test_ac15_globale_abwahl_entfernt_die_spalte_im_naechsten_lauf():
             mc.enabled = False
 
     html_nachher, plain_nachher = _zugestellte_teile(trip)
-    assert html_outlook_headers(html_nachher) == ["Tag", "Niederschlag"], (
+    assert html_outlook_headers(html_nachher) == ["Tag", "Niederschlag", _ACC], (
         "Nach der globalen Abwahl von 'Böen' zeigt die Vorschau die Spalte "
         f"weiterhin: {html_outlook_headers(html_nachher)!r} (AC-15)."
     )
@@ -379,7 +387,7 @@ def test_ac16_leere_grundauswahl_schneidet_auch_die_zugestellte_mail_nicht():
     html, _ = _zugestellte_teile(trip)
 
     assert html_outlook_headers(html) == [
-        "Tag", "Niederschlag", "Böen", "Schneehöhe",
+        "Tag", "Niederschlag", "Böen", "Schneehöhe", _ACC,
     ], (
         f"Kopfzeile {html_outlook_headers(html)!r}: bei leerer Grundauswahl "
         "wurde geschnitten -- Totalausfall fuer jeden Altbestand (AC-16)."
@@ -431,7 +439,7 @@ def test_ac17_eigenes_email_kanal_layout_schneidet_die_vorschau_nicht():
 
     html, plain = _zugestellte_teile(trip)
 
-    assert html_outlook_headers(html) == ["Tag", "Niederschlag", "Böen"], (
+    assert html_outlook_headers(html) == ["Tag", "Niederschlag", "Böen", _ACC], (
         f"Kopfzeile {html_outlook_headers(html)!r}: 'Böen' ist global aktiv "
         "und ausdruecklich gewaehlt, faellt aber wegen des E-Mail-eigenen "
         "Kanal-Layouts aus der Vorschau -- der Ausblick hat keine "
@@ -462,7 +470,7 @@ def test_ac17_ueberschrift_und_zahl_bleiben_bei_engem_kanal_layout_gepaart():
                  email_layout_ids={"gust"})
     html, _ = _zugestellte_teile(trip)
 
-    assert html_outlook_headers(html) == ["Tag", "Niederschlag", "Böen"], (
+    assert html_outlook_headers(html) == ["Tag", "Niederschlag", "Böen", _ACC], (
         f"Kopfzeile {html_outlook_headers(html)!r} (AC-17)."
     )
     zeilen = html_outlook_body_rows(html)
@@ -505,7 +513,8 @@ def test_ac17_vorschau_zeigt_denselben_ausblick_wie_die_zugestellte_mail():
                  report_overrides={"gust": {"evening_enabled": False}},
                  trend_reports=("morning", "evening"), ohne_nachtblock=True)
     html_versand, _ = _zugestellte_teile(trip, report_type="morning")
-    assert html_outlook_headers(html_versand) == ["Tag", "Niederschlag", "Böen"], (
+    assert html_outlook_headers(html_versand) == ["Tag", "Niederschlag", "Böen",
+                                                  _ACC], (
         f"Vorbedingung: {html_outlook_headers(html_versand)!r} (AC-17)."
     )
 
@@ -574,7 +583,15 @@ def test_bestandstrip_zeigt_die_grundauswahl_in_der_zugestellten_mail():
     assert klartext is not None, (
         "Der Klartext-Ausblick eines Bestandstrips fehlt vollstaendig (AC-1)."
     )
-    ohne_acc = [z for z in klartext.splitlines()[1:] if z.strip() and "ACC" not in z]
+    # Notiz-Fortsetzungszeilen ("    ↳ …", outlook.py:311-313) gehoeren zur
+    # Zeile darueber und tragen keine Spalten -- geprueft werden die
+    # WERTZEILEN.
+    wertzeilen = [z for z in klartext.splitlines()[1:]
+                  if z.strip() and not z.lstrip().startswith("↳")]
+    assert wertzeilen, (
+        f"Der Klartext-Ausblick hat gar keine Wertzeile:\n{klartext}\n(AC-1)"
+    )
+    ohne_acc = [z for z in wertzeilen if "ACC" not in z]
     assert not ohne_acc, (
         f"Diese Klartext-Ausblick-Zeilen fuehren kein ACC: {ohne_acc!r} "
         "(#2098 AC-13/Befund C -- der Farbpunkt des HTML braucht im Klartext "

--- a/tests/tdd/test_trip_outlook_dispatch_mail.py
+++ b/tests/tdd/test_trip_outlook_dispatch_mail.py
@@ -533,13 +533,25 @@ def test_ac17_vorschau_zeigt_denselben_ausblick_wie_die_zugestellte_mail():
 def test_bestandstrip_zeigt_die_grundauswahl_in_der_zugestellten_mail():
     """AC-1 (ganze Kette, Bestandsschutz): ohne gesetzte Vorschau-Auswahl
     steht der Ausblick weiterhin in der zugestellten Mail -- mit den Groessen
-    der Grundauswahl.
+    der Grundauswahl UND der fest angehaengten ACC-Spalte dahinter.
 
     Bewachte Fehlerklasse unveraendert (Mutation 1 am Wirkort,
     ``resolve_outlook_metrics(...) or []``): der Ausblick verschwaende fuer
     100 % der heutigen Trips. Nur das ZIEL des Rueckfalls ist seit #1848 A3
     die Grundauswahl statt der sieben festen Spalten (AC-3 dort,
     PO-Freigabe 2026-08-21).
+
+    🔴 #2098 (AC-13) nimmt EINE Nebenfolge von #1848 A3 bewusst zurueck:
+    dieser Test verlangte bis hierher, dass die Kopfzeile NICHT auf "ACC"
+    endet -- das Verschwinden der ACC-Spalte im Trip-Normalfall war eine
+    akzeptierte, testverankerte Nebenwirkung des Wechsels auf den
+    konfigurierbaren Renderer-Zweig. Der PO hat sie als Fehler gemeldet
+    (#2098 Befund B, Freigabe 2026-08-23). Die uebrige A3-Absicht bleibt
+    unveraendert gueltig: die Grundauswahl ersetzt die feste
+    Sieben-Spalten-Liste (Zusicherung darunter unveraendert). ACC kehrt
+    NICHT als achte Katalog-Spalte zurueck, sondern als fest angehaengte
+    Zusatzspalte HINTER der Grundauswahl -- ausserhalb der Metrik-Auswahl,
+    damit ADR-0005/#710 (Confidence nicht waehlbar) unberuehrt bleibt.
     """
     trip = _trip(outlook_metrics=None)
     html, plain = _zugestellte_teile(trip)
@@ -553,6 +565,18 @@ def test_bestandstrip_zeigt_die_grundauswahl_in_der_zugestellten_mail():
         "Der Ausblick zeigt weiterhin die abgeloesten sieben festen Spalten "
         f"statt der Grundauswahl: {kopf!r} (#1848 A3, AC-3)."
     )
-    assert plain_outlook_block(plain) is not None, (
+    assert kopf[-1] == "ACC" and len(kopf) > 2, (
+        f"Kopfzeile {kopf!r}: die zugestellte Mail zeigt keine ACC-Spalte "
+        "hinter der Grundauswahl (#2098 AC-13 -- show_acc wird im "
+        "konfigurierbaren Zweig nicht gelesen)."
+    )
+    klartext = plain_outlook_block(plain)
+    assert klartext is not None, (
         "Der Klartext-Ausblick eines Bestandstrips fehlt vollstaendig (AC-1)."
+    )
+    ohne_acc = [z for z in klartext.splitlines()[1:] if z.strip() and "ACC" not in z]
+    assert not ohne_acc, (
+        f"Diese Klartext-Ausblick-Zeilen fuehren kein ACC: {ohne_acc!r} "
+        "(#2098 AC-13/Befund C -- der Farbpunkt des HTML braucht im Klartext "
+        "ein Wort)."
     )

--- a/tests/tdd/test_trip_outlook_metric_selection.py
+++ b/tests/tdd/test_trip_outlook_metric_selection.py
@@ -50,6 +50,10 @@ TEMPERATUR = "temperature"
 GEWITTER = "thunder"
 SCHNEEHOEHE = "snow_depth"
 CONFIDENCE = "confidence"
+# #2098 AC-13: ACC ist seit der Behebung eine fest angehaengte Zusatzspalte
+# HINTER der Auswahl -- ausserhalb des Metrik-Systems, damit ADR-0005/#710
+# (Confidence nicht waehlbar) unberuehrt bleibt.
+_ACC = "ACC"
 
 # Die EINE dokumentierte Abweichung zwischen Aufzeichnung und Sollstand
 # (AC-8 / Implementation Details 5): `temp_lo` ist `summary.temp_min_c`, das
@@ -202,7 +206,7 @@ def test_ac5_spalten_erscheinen_in_auswahlreihenfolge_im_html():
                                outlook_rows(metrics=auswahl))
 
     assert html_outlook_headers(html) == [
-        "Tag", "Gewitter", "Temperatur", "Niederschlag",
+        "Tag", "Gewitter", "Temperatur", "Niederschlag", _ACC,
     ], (
         f"Kopfzeile {html_outlook_headers(html)!r} folgt nicht der "
         "Auswahlreihenfolge. Katalog-Reihenfolge waere ['Niederschlag', "
@@ -295,7 +299,7 @@ def test_ac9_aktive_auswahl_zeigt_keine_abkuerzungs_legende_mehr():
     html, _ = render_trip_mail(display_config(outlook_metrics=auswahl),
                                outlook_rows(metrics=auswahl))
 
-    assert html_outlook_headers(html) == ["Tag", "Böen", "Niederschlag"], (
+    assert html_outlook_headers(html) == ["Tag", "Böen", "Niederschlag", _ACC], (
         f"Vorbedingung von AC-9: {html_outlook_headers(html)!r}"
     )
     assert html_outlook_legend(html) is None, (
@@ -339,10 +343,27 @@ def test_ac10_manipulierte_confidence_auswahl_wird_beim_rendern_verworfen(caplog
         html, plain = render_trip_mail(display_config(outlook_metrics=auswahl),
                                        outlook_rows(metrics=auswahl))
 
+    # #2098: ACC steht seit der Behebung als fest angehaengte Zusatzspalte
+    # hinter der Auswahl (ausserhalb des Metrik-Systems, #710 unberuehrt).
+    # Massstab ist deshalb der Renderlauf OHNE den manipulierten Eintrag --
+    # abgeleitet statt im Test abgeschrieben: der manipulierte Eintrag darf
+    # die Kopfzeile ueberhaupt nicht veraendern.
     kopf = html_outlook_headers(html)
-    assert kopf == ["Tag", "Niederschlag"], (
+    ohne_manipulation = html_outlook_headers(
+        render_trip_mail(display_config(outlook_metrics=[NIEDERSCHLAG]),
+                         outlook_rows(metrics=[NIEDERSCHLAG]))[0]
+    )
+    assert kopf == ohne_manipulation, (
         f"Der manipulierte 'confidence'-Eintrag hat eine Spalte erzeugt: "
-        f"{kopf!r}. Er muss beim Rendern serverseitig verworfen werden (AC-10)."
+        f"{kopf!r} statt {ohne_manipulation!r}. Er muss beim Rendern "
+        "serverseitig verworfen werden (AC-10)."
+    )
+    from app.metric_catalog import get_metric
+    confidence_label = get_metric(CONFIDENCE).label_de
+    assert confidence_label not in kopf, (
+        f"Die Kopfzeile traegt die Katalog-Beschriftung von 'confidence' "
+        f"({confidence_label!r}) -- der Eintrag ist als waehlbare Spalte "
+        f"durchgeschlagen: {kopf!r} (AC-10/#710)."
     )
     block = plain_outlook_block(plain)
     assert block is not None and "Prognose" not in block, (
@@ -389,7 +410,10 @@ def test_ac11_jede_angebotene_groesse_erscheint_auch_als_spalte():
     # Auswertung an ("Temperatur Maximum") -- PO-Vorgabe 2026-07-27, keine
     # zwei gleich beschrifteten Spalten. Gegen ``label`` verglichen forderte
     # der Test dreimal "Temperatur" und damit das Gegenteil der Vorgabe.
-    assert kopf[1:] == [e["ueberschrift"] for e in soll], (
+    # #2098: die fest angehaengte ACC-Zusatzspalte steht HINTER der Auswahl
+    # und stammt nicht aus dem Picker-Katalog (#710) -- sie gehoert deshalb
+    # zur Erwartung, nicht zum Soll aus dem Katalog.
+    assert kopf[1:] == [e["ueberschrift"] for e in soll] + [_ACC], (
         "Gerenderte Spalten weichen von den im Picker angebotenen Groessen ab. "
         f"Fehlend: {[e['ueberschrift'] for e in soll if e['ueberschrift'] not in kopf]!r} "
         f"(AC-11)"
@@ -412,7 +436,7 @@ def test_ac14_nicht_grundausgewaehlte_groesse_erscheint_in_keinem_teil():
     # Zeilen wie ein korrekt schneidender Scheduler sie baut (s. Dateikopf).
     html, plain = render_trip_mail(dc, outlook_rows(metrics=[NIEDERSCHLAG]))
 
-    assert html_outlook_headers(html) == ["Tag", "Niederschlag"], (
+    assert html_outlook_headers(html) == ["Tag", "Niederschlag", _ACC], (
         f"Kopfzeile {html_outlook_headers(html)!r}: eine Groesse ausserhalb "
         "der Grundauswahl erscheint. Die Vorschau darf nur abwaehlen, nie "
         "hinzufuegen (AC-14)."
@@ -458,7 +482,7 @@ def test_ac16_leere_grundauswahl_schneidet_die_vorschau_nicht():
     html, plain = render_trip_mail(dc, outlook_rows(metrics=auswahl))
 
     assert html_outlook_headers(html) == [
-        "Tag", "Niederschlag", "Böen", "Schneehöhe",
+        "Tag", "Niederschlag", "Böen", "Schneehöhe", _ACC,
     ], (
         f"Kopfzeile {html_outlook_headers(html)!r}: bei leerer Grundauswahl "
         "wurde geschnitten. D4: kein Maximum definiert -> nicht schneiden, "

--- a/tests/tdd/test_vorschau_metrik_tagesfenster.py
+++ b/tests/tdd/test_vorschau_metrik_tagesfenster.py
@@ -163,7 +163,8 @@ def test_ac1_tagesgewitter_sichtbar_trotz_none_im_aggregat():
     erwartet_html = stufe_mit_herkunft.replace("hoch", "hoch @14", 1)
     erwartet_plain = "⚡" + stufe_mit_herkunft.replace("hoch", "hoch@14", 1)
 
-    assert html_outlook_headers(html) == ["Tag", "Gewitter"], (
+    # #2098: hinter der Auswahl steht die fest angehaengte ACC-Zusatzspalte.
+    assert html_outlook_headers(html) == ["Tag", "Gewitter", "ACC"], (
         f"Testaufbau: unerwartete Kopfzeile {html_outlook_headers(html)!r}."
     )
     zeilen = html_outlook_body_rows(html)

--- a/tests/unit/test_weather_metrics.py
+++ b/tests/unit/test_weather_metrics.py
@@ -126,7 +126,7 @@ class TestWeatherMetricsServiceKnownValues:
         """
         GIVEN: Timeseries
         WHEN: compute_basis_metrics(timeseries, tz=None)
-        THEN: aggregation_config has 16 entries with correct functions
+        THEN: aggregation_config has 17 entries with correct functions
 
         Issue #1475 S5a: 12 -> 13 Eintraege — `hail_flag` ("hail_priority")
         ist als Tages-/Etappen-Aggregat hinzugekommen (Spec AC-4).
@@ -135,10 +135,14 @@ class TestWeatherMetricsServiceKnownValues:
         Gewitter-Tagesmaximum tragen (Spec AC-10).
         Issue #1468: 14 -> 16 Eintraege — die beiden Beginn-Zeitpunkte
         ("onset") sind eigene Tages-Aggregate.
+        Issue #2098: 16 -> 17 Eintraege — ohne `sunny_hours` ("sum") fiel der
+        Segmentwert bei jeder Mehrsegment-Etappe still auf `None` und die
+        Sonnenstunden-Spalte des 3-Tages-Ausblicks zeigte "–" (Befund A).
         """
         result = service.compute_basis_metrics(known_timeseries, tz=None)
 
-        assert len(result.aggregation_config) == 16
+        assert len(result.aggregation_config) == 17
+        assert result.aggregation_config["sunny_hours"] == "sum"
         assert result.aggregation_config["temp_min_c"] == "min"
         assert result.aggregation_config["temp_max_c"] == "max"
         assert result.aggregation_config["temp_avg_c"] == "avg"


### PR DESCRIPTION
Behebt #2098.

## Zwei Befunde, eine Wurzel

Der Trip faehrt seit #1848 A2/A3 ueber den konfigurierbaren Ausblick-Zweig, der urspruenglich fuer den Ortsvergleich gebaut wurde. Dadurch erbte er zwei Compare-Eigenschaften, die fuer ihn falsch sind.

**Sonnenstunden zeigten `–`.** `aggregate_stage()` uebertraegt nur Felder mit einer Regel in `aggregation_config`; `sunny_hours` hatte keine und fiel still auf `None`. Der Wert wurde also korrekt berechnet und eine Stufe vor der Anzeige verworfen. Fix: Regel `"sunny_hours": "sum"`, passend zur Katalog-Definition `summary_fields={"sum": "sunny_hours"}`.

**ACC-Spalte fehlte.** `show_acc` wurde nur im Altform-Zweig gelesen; der konfigurierbare Zweig ignorierte ihn, obwohl der Trip korrekt `show_acc=True` uebergibt. Der Wert (`confidence_pct`) lag bereits im Row-Dict. Fix: `show_acc` in beiden Renderern wirksam gemacht, Spalte **fest hinter** den gewaehlten Metriken angehaengt — am `outlook_columns()`/`cells`-Mechanismus vorbei, damit `confidence` nicht zur waehlbaren Metrik wird (ADR-0005/#710 unberuehrt).

Zusaetzlich: ACC im **Klartext** als Wort (hoch/mittel/niedrig/sehr niedrig) statt nur als Farbpunkt — PO-freigegebene Erweiterung. Farbpunkt und Wort stammen aus **einer** Quelle (`_ACC_STUFEN`), nicht aus zwei Kopien.

## Audit — PO-Rueckfrage "trifft das weitere Metriken?"

Alle 26 `MetricDefinition`s mit `summary_fields` gegen beide `aggregation_config`-Dicts abgeglichen: **`sunny_hours` ist die einzige Luecke.** Keine weitere Metrik angefasst; AC-4 zaehlt das als Invariante nach.

## Nachweis

- 14 ACs, RED zuerst (14/14 rot), dann GREEN
- Adversary: **VERIFIED**, **7/7 Mutationen gefangen**. Die aussagekraeftigste (`sum` -> `max`) wurde unabhaengig nachgemessen: 3 Tests rot mit `assert 'max' == 'sum'` — die Tests pruefen den **Wert**, nicht die Form
- Neun angepasste Bestandstests einzeln auf Aufweichung geprueft: alle erweitert, keiner gelockert
- Echt zugestellte Mail (Testpostfach): `Sonnenstunden 11.0 h … ACC mittel`, `briefing_mail_validator.py` Exit 0
- Regression: 230 Tests grueen, plus breiter Konsumenten-Lauf ueber 24 weitere Dateien

## Nebenbefund

Kein Ketten-Test weist die Sonnenstunden bis in die zugestellte Mail nach — genau die Fehlerklasse, die #2098 ausgeloest hat. Kein Produktivdefekt, in #1196 gebucht.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKqBwij23vo2q4DUmPPhtr