### PR TITLE
feat 2051 s2 raeumliche ausdehnung

### DIFF
--- a/docs/context/fix-2051-s2-raeumliche-ausdehnung.md
+++ b/docs/context/fix-2051-s2-raeumliche-ausdehnung.md
@@ -1,0 +1,327 @@
+# Context: #2051 S2 — Räumliche Ausdehnung des Regenereignisses
+
+**Issue:** #2051 (Scheiben-Ticket, bleibt offen) · **Scheibe:** S2 · **Track:** Full Process
+**Branch:** `feat-2051-s2-raeumliche-ausdehnung` · **Basis:** `origin/main` @ `eed94a8f`
+**Erstellt:** 2026-08-23
+
+## Request Summary
+
+Ein Regenereignis wird heute als **Punkt** gemeldet („Regen bei km 10 in 90 Minuten"). S2 soll
+die **räumliche Ausdehnung** ergänzen — als km-Spanne entlang der Reststrecke („Nass km 8–12"),
+damit der Nutzer sie selbst mit seiner Route verschneiden kann. Laut Ticket ist das „der
+eigentliche Kern" des Vorgangs.
+
+Grundprinzip aus dem Ticket: **nur Daten über das Wetter, keine Rechnung über den Nutzer.**
+Keine Ankunftszeiten, keine Handlungsempfehlung.
+
+## Related Files
+
+### Abruf-Seite (hier entsteht die Ausdehnung neu)
+| Datei | Relevanz |
+|---|---|
+| `src/services/radar_service.py:465` | `get_nowcast(lat, lon, …)` — nimmt **genau einen** Punkt. Kein Bulk-/Grid-Weg bei keinem Provider. |
+| `src/services/radar_service.py:692-722` | Provider-Fallbackkette nach Bounding-Box: BrightSky/RADOLAN · GeoSphere INCA (AT) · ARPAE · AROME-FR · ICON-D2 · Open-Meteo `minutely_15` |
+| `src/services/radar_service.py:806-884` | `_fetch_openmeteo_15` — gemeinsamer Funnel aller Open-Meteo-Zweige, **einziger Ort mit Budget-Gate** (`:828`) |
+| `src/services/radar_service.py:736-769` | `_fetch_geosphere_inca` — **ungegated**, nur der Convective-Sidecar läuft übers Budget |
+| `src/services/radar_service.py:927-1139` | `_derive_result()` — leitet alle Felder aus **derselben** Frame-Liste ab |
+| `src/services/trip_alert.py:1408-1472` | Trip-Alarm: **ein** `get_nowcast`-Call an der interpolierten Planposition zur Fenstermitte (`now + 27 Min`) |
+| `src/services/compare_radar_alert.py:382-392` | Ortsvergleich: Schleife über Preset-Orte → **mehrere** Calls, sequenziell. Muster existiert bereits. |
+| `src/services/trip_report_scheduler.py:1880` | Briefing-Kurzfristhinweis, ebenfalls ein Call |
+
+### Streckengeometrie
+| Datei | Relevanz |
+|---|---|
+| `src/services/trip_segments.py:555-627` | `position_at_time()` — liefert lat/lon/`distance_from_start_km` zu einem Zeitpunkt. Baustein für Punktwahl. |
+| `src/services/trip_segments.py:516-552` | `_interpolate_point()` — lineare Interpolation zwischen Segmentgrenzen |
+| `src/services/trip_segments.py:113-151` | `stage_measured_distances` — **km sind je Etappe neu normiert** („jeder Tag zählt neu seine Kilometer") |
+| `src/services/trip_segments.py:154` | `measured_segment_km()` — nur bei `seg.distance_measured` |
+| `src/app/trip.py:61-131` | `Waypoint` (`distance_from_start_km`, seit #2036) und `Stage` (typ. 3–7 Waypoints) |
+| `src/app/models.py:364-441` | `GPXPoint`/`GPXTrack` (dichter Track, 400–650 Punkte, separat unter `data/users/<u>/gpx/`), `TripSegment` |
+| `src/utils/geo.py` | `haversine_km` (Luftlinie) |
+
+### Render-Seite (kann km-Spannen bereits)
+| Datei | Relevanz |
+|---|---|
+| `src/output/renderers/alert/segments.py:91-128` | `format_alert_location()` — 4 Stufen: Label > **gemessene km-Spanne** > Segmentkennung > Luftlinien-Rückfall. `:108` nennt die geschätzte Zahl selbst „glaubwürdig aussehender Unsinn". |
+| `src/output/renderers/alert/model.py:314` | `km_span(events)` — reine Min/Max-Hülle über eine gegebene Eventliste, **keine** Nachbarschaftslogik |
+| `src/output/renderers/alert/render.py:188-207` | `_location_of()` — speist Betreff, Mailkörper und Telegram-Langform gemeinsam |
+| `src/services/notification_service.py:1436-1490` | `_dispatch_alert_message()` — **die geteilte Naht** Trip ↔ Ortsvergleich (ADR-0021) |
+
+### Die sieben Textstellen
+1. Betreff — `render.py:967` → `_render_subject_onset()` `:474`
+2. E-Mail Trip **und** Mehr-Orte — `render.py:1146` (eine Funktion für beide)
+3. Telegram rich — `render.py:1288` → `_render_telegram_onset()` `:771`
+4. Telegram Kurzstil — **keine eigene Stelle**: schickt den fertigen `sms_body` (`notification_service.py:1596-1601`). KHW fährt diesen Stil.
+5. SMS / Premium-SMS — `render.py:1450` → `_render_sms_onset()` `:895-964`
+6. Briefing-Kurzfristhinweis — `src/output/renderers/email/starkregen_hint.py:19-89`, eigenständig, **trägt heute keine km-Angabe**
+7. Kommando-Antwort `/jetzt` — `radar_service.py:563` `format_now_text()`, eigenständig
+
+## Existing Patterns
+
+- **Additive Feldergänzung am `NowcastResult`** — so liefen S1 (`event_end_minutes`,
+  `event_ongoing_beyond_horizon`) und S3 (`source_reach_minutes`,
+  `LOCATION_SHARPNESS_LIMIT_MIN`). S2 folgt demselben Muster mit **eigenem Feldnamen**.
+- **Kanal-Kaskade** (S3, E6): Langform bekommt alles, Kurzform wählt ab. Grundauswahl ist das
+  Maximum, der Kanal darf nur streichen.
+- **Mehrere Punkte in einer Schleife** — `compare_radar_alert.py:382` macht das heute schon
+  pro Preset-Ort. Kein Bulk-Request, sequenziell, jeder Punkt zahlt eigenes Cache-Lookup.
+- **Budget-Gate** — `ForecastBudgetGate` (`forecast_budget.py:36-74`): `DAILY_BUDGET=9000`,
+  `polling` ab 80 % geblockt, `alert_check` ab 95 %, `user_briefing` nie. Fail-open.
+  Zähler `<data_root>/diagnostics/forecast_budget.json`, UTC-Tagesgrenze.
+
+## Messgrundlage (Produktion, KHW 403, Trip `5f534011`, 13 Etappen)
+
+| Größe | Wert |
+|---|---|
+| Etappenlänge Luftlinie | Min 4,99 · Median 9,21 · Max 12,74 km |
+| Etappenlänge gemessen (4 Etappen) | 6,11 – 14,03 km |
+| **Vermessungsgrad** | **4 von 13 Etappen (31 %)** haben `distance_from_start_km` an allen Waypoints |
+| Gehzeit je Etappe | Min 1,7 h · Median 5,23 h · Max 7,0 h |
+| Radar-Horizont | 180 Min (`_NOWCAST_HORIZON_MIN`, seit #1945) |
+
+**Folgerung:** Der 3-h-Horizont deckt typischerweise **weniger als eine Etappe** ab. „Reststrecke"
+kann deshalb sinnvoll als *Rest der aktiven Etappe* geschnitten werden — was auch nötig ist, weil
+es keine über Etappen hinweg kumulierte km-Zählung gibt.
+
+### Abruf-Volumen (Produktion, `diagnostics/enrichment_calls.jsonl`, `path=radar_nowcast`)
+
+| Tag | echte Radar-Fetches |
+|---|---|
+| 2026-08-20 | 68 |
+| 2026-08-21 | 161 |
+| 2026-08-22 | 127 |
+| 2026-08-23 (bis 05:52 UTC) | 29 |
+
+- Trip-Alarm-Poll: `7,22,37,52 * * * *` = **96 Läufe/Tag** (`internal/scheduler/scheduler.go:199-202`)
+- Ortsvergleich-Poll: ebenfalls 96/Tag, zeitgleich
+- Briefing-Hinweis: ≤ 1×/Tag pro Trip (innerhalb `briefing_dispatch`)
+- **Cache-Trefferquote 1,5 %** — strukturell, weil die Abfrageposition mit der geplanten Gehzeit
+  mitwandert (`trip_alert.py:1421-1425`) und das Poll-Intervall (900 s) die Cache-TTL (300 s)
+  ohnehin überschreitet.
+- **Multiplikator:** ≈ 95 × (N−1) zusätzliche echte Calls pro Tag und Trip.
+  N=3 → ≈ 190/Tag · N=5 → ≈ 380/Tag. Gegen 9000 Budget: unkritisch.
+
+## Rasterauflösung der Quellen
+
+| Quelle | Zellgröße | Fundstelle |
+|---|---|---|
+| GeoSphere INCA (AT — **KHW**) | 1 km | `providers/geosphere.py:71` (`nowcast-v1-15min-1km`) |
+| AROME-FR | 1,3 km | `providers/openmeteo.py:127` |
+| ICON-D2 | 2 km | `providers/openmeteo.py:132-135` |
+| ARPAE ICON-2I | 2 km | `radar_service.py:250` |
+
+Ein Punktabstand von 2 km liefert bei INCA (1 km) unterscheidbare Werte; bei ICON-D2/ARPAE
+(2 km Zellen) liegt er genau an der Zellgröße und ist grenzwertig. 5 km wäre bei allen Quellen
+klar über der Zellgröße — aber bei 5–13 km Etappenlänge blieben davon nur 1–3 Punkte.
+
+## Dependencies
+
+- **Upstream:** `position_at_time()`, `haversine_km()`, `RadarNowcastCacheService` (TTL 300 s,
+  Schlüssel = Koordinate auf 4 Nachkommastellen ≈ 11 m), `ForecastBudgetGate`
+- **Downstream:** `NowcastResult` → `OnsetEvent` → `_dispatch_alert_message()` → alle vier Kanäle;
+  zusätzlich die zwei eigenständigen Formulierer (`starkregen_hint.py`, `format_now_text()`)
+
+## Existing Specs
+
+| Spec | Bezug |
+|---|---|
+| `docs/specs/modules/fix_2017_nowcast_messpunkt.md` | **AC-12 Budget-Invariante** („genau ein Abruf"), Variante-3-Ablehnung, Known Limitation 5 (`km_from`/`km_to` = Segment-Lage) und 7 (Cache-Sharing) |
+| `docs/specs/modules/feat_2051_s1_dauer_und_ende.md` | S1, live: `event_end_minutes`, `event_ongoing_beyond_horizon` |
+| `docs/specs/modules/feat_2051_s3_reichweite_und_guete.md` | S3, live: `source_reach_minutes`, `LOCATION_SHARPNESS_LIMIT_MIN=60`, Kanal-Kaskade E6 |
+| `docs/specs/modules/fix_1948_s4_nowcast_sms_zielbild.md` | SMS-Zielbild, Token-Grammatik, `km5-18:`-Form |
+| `docs/specs/modules/fix_1945_nowcast_horizon.md` | Horizont 60 → 180 Min |
+| ADR-0021 | Trip und Ortsvergleich teilen Rendering/Versand |
+
+## Risks & Considerations
+
+### R1 — AC-12 aus #2017 wird zwangsläufig gebrochen (muss bewusst abgelöst werden)
+Die #2017-Spec (`created: 2026-08-20`) schreibt „genau **ein** `get_nowcast()`-Aufruf je Trip"
+als Test-Invariante fest und verwarf die Mehrfach-Abfrage als „unverhältnismäßig". Das Ticket
+#2051 ist vom **2026-08-21** — einen Tag jünger — und beauftragt genau diese Mehrfach-Abfrage
+ausdrücklich, samt Hinweis auf die nötige Budget-Entscheidung. Der Auftrag sticht die Ablehnung,
+aber die Ablösung muss **dokumentiert** erfolgen (Projektregel: keine stille Rücknahme).
+
+**Betroffene Wächter:**
+| Test | Assert |
+|---|---|
+| `tests/tdd/test_issue_822_radar_nowcast_segment.py:532` `test_ac3_nowcast_called_at_segment_coordinates` | `call_count == 1` (`:611`) |
+| `tests/tdd/test_issue_822_radar_nowcast_segment.py:1282` `test_2017_ac12_genau_ein_get_nowcast_aufruf_je_lauf` | `== 1` (`:1304`, `:1308`) |
+| `tests/tdd/test_issue_822_radar_nowcast_segment.py:1329` `test_2017_fadv1_…` | `call_count == 1` (`:1417`) |
+| `tests/tdd/test_trip_report_scheduler_starkregen_hint.py:331` `test_ac12_starkregen_hinweis_ruft_get_nowcast_genau_einmal` | `len(calls) == 1` (`:360`) |
+| `tests/unit/test_radar_nowcast_cache_sharing.py` (11 Funktionen, Z.82-537) | feste Aufrufzahlen 1 bzw. 2 |
+
+`tests/tdd/test_starkregen_kurzfristhinweis.py` prüft nur `>= 1` und kollidiert **nicht**.
+Der Ortsvergleich hat **keinen** „genau 1"-Wächter — dort sind mehrere Calls bereits normal.
+
+### R2 — 9 von 13 Etappen sind unvermessen
+`format_alert_location()` gibt eine km-Spanne nur bei `km_measured=True` aus und verwirft die
+Schätzung sonst bewusst. Auf 69 % der KHW-Etappen läge damit **keine belastbare km-Spanne** vor.
+Die Spec braucht eine definierte Antwort für diesen Fall. Denkbare Richtung (in der Analyse zu
+prüfen): Ausdehnung über **Wegpunktnamen** statt Kilometer ausdrücken — Waypoints existieren auf
+allen Etappen, und `format_alert_location()` kennt die Segmentkennungs-Stufe bereits.
+Keine Bewertung der Trip-Konfiguration des PO; das ist reine Messgrundlage.
+
+### R3 — Es gibt keinen „betroffene Punkte → Spanne"-Baustein
+Weder in `corridor_threshold.py` noch sonst im Code existiert eine Verschmelzungs-/Cluster-Logik.
+`km_span(events)` ist eine reine Min/Max-Hülle über eine vorgegebene Liste. Die Punkt-zu-Spanne-
+Logik entsteht neu — inklusive der Frage, wie **mehrere getrennte Zonen** (nass bei km 2–4 *und*
+km 9–11) behandelt werden: zwei Spannen, oder eine Hülle km 2–11? Eine Hülle würde trockene
+Strecke als nass ausweisen.
+
+### R4 — SMS schneidet hart bei 140 Zeichen ab
+`render_sms(limit=140)` → `_render_sms_onset()` endet mit `body[:limit]` (`render.py:964`) —
+reine Abschneidung, kein Soft-Wrap. Eine breitere Ortsangabe (`km 8-12` statt `km 10`) kann
+hinten Information verdrängen. Die Kanal-Kaskade muss das entscheiden, und ein AC muss den
+Grenzfall messen.
+
+### R5 — GeoSphere INCA hat kein dokumentiertes Kontingent
+Der für Österreich (und damit den KHW) maßgebliche Pfad läuft **ungegated**. Bei N=5 wären es
+≈ 480 Abrufe/Tag/Trip gegen eine Behörden-API ohne bekanntes Limit. Kein Budget-Problem im Sinne
+des Open-Meteo-Deckels, aber ein eigenes Betriebsrisiko — die Spec sollte den Radar-Pfad
+ebenfalls unter ein Gate stellen oder die Punktzahl konservativ wählen.
+
+### R6 — `km_from`/`km_to` sind bereits belegt
+Sie tragen die **Segment-Lage der Etappe** (`notification_service.py:189-190`, gesetzt in
+`trip_alert.py`, gelesen in `segments.py:91-111`). #2017 Known Limitation 5 hält ausdrücklich
+fest, dass sie **nicht** verändert werden. Die Ereignis-Ausdehnung braucht ein **eigenes
+Feldpaar** — sonst laufen zwei Bedeutungen auf denselben Namen.
+
+### R7 — Der Cache trägt nicht
+1,5 % Trefferquote, strukturell bedingt. Zusätzliche Punkte kosten real. Zugleich brechen
+zusätzliche Koordinaten pro Lauf die Erwartungen in `test_radar_nowcast_cache_sharing.py`,
+soweit diese auf festen Aufrufzahlen statt auf Schlüsselgleichheit beharren.
+
+### R8 — #2036 liefert keinen Baustein für S2 (geklärt)
+Beide Aussagen stimmten, sie betrafen Verschiedenes. #2036 (Spec
+`docs/specs/modules/fix_2036_alarm_kilometer_ortsangabe.md`, GREEN-Commit `b6ca31e3`, PR #2055)
+ersetzt die auf einem Garmin inReach unverortbare Segmentnummer (`Seg 3`) durch eine **gemessene**
+Kilometerangabe — und regelt allein die **Quellenqualität eines einzelnen km-Werts** je Wegpunkt
+(`Waypoint.distance_from_start_km`, `TripSegment.distance_measured`, `km_measured` an den vier
+Event-Typen). `km_from`/`km_to` waren auch vorher schon die Distanzen der beiden Segment-Grenzen;
+#2036 ändert nur, **wie** sie ermittelt werden und **ob** sie gezeigt werden dürfen.
+
+**Für S2 folgt daraus kein Baustein.** Es gibt keine Funktion, die aus „betroffen / nicht
+betroffen je Punkt" eine zusammenhängende Zone ableitet. Die nächstliegende Funktion
+`stage_measured_distances()` (`trip_segments.py:113-151`) normiert und validiert
+Track-Koordinaten einer Etappe (strikt monoton, nie kürzer als Luftlinie, Etappenstart = 0 km),
+kennt aber keine Wetterwerte und keine Schwellen. R3 bleibt damit unverändert bestehen.
+
+**Nebenbefund (nicht Teil dieses Zuschnitts):** `evaluate_corridor_thresholds()`
+(`src/services/corridor_threshold.py:68`) hat seit #1460 **keinen Aufrufer in `src/`** — belegt
+per `grep -rn "evaluate_corridor_thresholds(" --include="*.py" src/ tests/`: nur die Definition
+selbst plus zwei Testdateien. #2036 hat an diesem unerreichbaren Renderpfad dennoch
+Konsistenzpflege betrieben (Commit `7a0f8ca9`). → Sammel-Issue #1199.
+
+## Analysis (Phase 2, 2026-08-23)
+
+### Type
+**Feature** (Scheibe eines Scheiben-Tickets, additiv zu S1/S3)
+
+### Technischer Ansatz
+
+**Abfragepunkte:** Fester **Abstand von 2 km** statt fester Punktzahl — bei 5–13 km Etappenlänge
+skaliert ein Abstand automatisch, eine feste Zahl tastet kurze Etappen zu dicht und lange zu grob
+ab. Gedeckelt bei **6 Punkten je Lauf**; das deckt 12 km Reststrecke ab (Etappen-Median 9,2 km).
+Untergrenze 1 Punkt bei Reststrecke < 2 km — dort bleibt das heutige Verhalten exakt erhalten.
+2 km liegt über der INCA-Zellgröße (1 km), liefert dort also unterscheidbare Werte.
+
+**Andockstelle:** Die Schleife entsteht am Aufrufort in `trip_alert.py:1408-1472`, nach dem
+Muster von `compare_radar_alert.py:382-392`. `get_nowcast()` bleibt Ein-Punkt-API — **keine
+Signaturänderung** an `radar_service.py`. Das Budget-Gate greift automatisch je Aufruf.
+
+**Wichtige Erkenntnis zur Geometrie:** Die Abfragepunkte brauchen **kein**
+`distance_from_start_km`. `position_at_time()` interpoliert lat/lon über die GPX-Geometrie
+unabhängig vom Vermessungsgrad. Die **Messung** funktioniert damit auf allen 13 Etappen — nur
+die **Beschriftung** unterscheidet sich. Für die Platzierung der Punkte genügt eine
+Luftlinien-Distanz zwischen Wegpunkten (`haversine_km`); das ist zulässig, weil sie nie als Zahl
+ausgegeben wird. Nur die *ausgegebene* km-Zahl braucht echte Messung — genau die Trennung, die
+#2036 eingeführt hat.
+
+**Punkt → Zone:** Neue, eigenständige Logik (kein Baustein vorhanden, R3/R8). Benachbarte nasse
+Punkte verschmelzen; **ein trockener Punkt trennt**, er überbrückt nicht. Begründung: Der
+Punktabstand liegt bereits an der Auflösungsgrenze der Quelle, ein trockener Messpunkt ist echtes
+Signal. Überbrücken würde trockene Strecke als nass ausweisen — das wäre eine erfundene Aussage.
+
+**Mehrere Zonen:** **Getrennt ausweisen, nie als Hülle.** Eine Hülle km 2–11 bei nass km 2–4 und
+km 9–11 würde die trockene Mitte falsch darstellen. Die Kanal-Kaskade kürzt: Langform zeigt alle
+Zonen, Kurzform maximal eine (die nächstgelegene).
+
+**Zeitangabe:** **Pro Zone**, nicht global — früheste `onset_minutes` und späteste
+`event_end_minutes` unter den Punkten der jeweiligen Zone. Eine globale Spanne über getrennte
+Zonen ordnete Zeiten der falschen Zone zu. Reine Min/Max-Aggregation über Wetterdaten, keine
+Rechnung über den Nutzer.
+
+**Teilausfall:** Punkte ohne Daten werden aus der Zonenbildung ausgeschlossen — weder nass noch
+trocken, echte Lücke. Bei Totalausfall kein S2-Text, wie heute.
+
+### Gemessenes Zeichenbudget (echte Renderfunktionen, nicht geschätzt)
+
+| Fall | String | Länge | Rest bis 140 |
+|---|---|---|---|
+| Regen, nur Beginn | `Ziel: R2.5@18:00` | 16 | 124 |
+| Regen, Beginn+Ende | `Ziel: R2.5@18:00@20:00` | 22 | 118 |
+| km-Spanne statt Punkt | `km 8-12: R3.1@18:00` | 19 | 121 |
+| Worst-Case Einzelereignis | `km 8-12: TH@Sa0:23 >@Sa4:47? R12.5` | 34 | 106 |
+
+**Spanne statt Punkt kostet 1 Zeichen** (`km 8-12` = 7 gegen `🏁 Ziel` = 6). Platz ist reichlich.
+**Premium-SMS fährt dasselbe Limit** — `notification_service.py:1666` (SMS) und `:1680` (Premium)
+senden denselben gerenderten String, ohne zweite Kürzung.
+
+**Randbedingung aus #2078 (Parallelsession, Merge heute):** Der Ortsname im Onset-Pfad wird
+künftig auf **24 Zeichen** gekappt (`render.py:958/960/962`, `_render_sms_onset` und
+`_render_sms_onset_shift_only`). `format_alert_location()` bleibt unangetastet. S2 läuft über
+diese Kopf-Zweige, ist also automatisch geschützt — **aber** eine Wegpunktnamen-Darstellung
+(„zwischen Obstanser-See-Hütte und Porzehütte", ~44 Zeichen) würde dort mitten im Wort
+abgeschnitten. Das entscheidet die Kanal-Kaskade für R2: Namen nur in der Langform.
+
+### Abzulösende Zusicherung (R1, präzisiert)
+
+Die vier `== 1`-Tests werden auf eine **belegbare Obergrenze** umgeschrieben
+(`<= MAX_NOWCAST_CALLS_PER_TRIP_RUN`, per Modulreferenz gelesen, nicht als Literal dupliziert).
+Drei Ergänzungen, ohne die der Umbau die Zusicherung verwässern würde:
+
+1. **Zwei Zähl-Nähte, nicht eine.** `test_2017_ac12_…` und `test_ac12_starkregen_hinweis_…`
+   zählen sowohl am `get_nowcast`-Seam (`dienst.calls`) als auch am `frame_source`-Seam
+   (`frames.call_count`). Beide müssen wachsen.
+2. **Koordinaten-Menge mitprüfen.** Jeder umgebaute Test braucht einen neuen Assert, dass alle
+   abgefragten Punkte auf der erwarteten Reststrecke liegen und keine Duplikate enthalten —
+   sonst geht beim Lockern der Zahl die heutige Ortsschärfe-Zusicherung („ein Abruf, und zwar am
+   richtigen Ort") still verloren.
+3. **Positivkontrolle:** Bei Reststrecke < 2 km bleibt `== 1`. Ohne diesen Randfall misst der
+   Obergrenzen-Assert nicht, ob überhaupt gedeckelt wird.
+
+`test_2017_fadv1_…` (`:1329`) zählt nicht pro Trip getrennt — muss beim Umbau aufgetrennt werden,
+damit „kaputter Trip verbraucht 0 Kontingent" bei N > 1 erhalten bleibt.
+Von den 11 Cache-Sharing-Tests ist einer zu prüfen:
+`test_end_to_end_trip_and_compare_radar_paths_share_one_fetch` (`:329`) bricht, wenn keine der N
+neuen Trip-Koordinaten mehr exakt auf der Compare-Koordinate liegt.
+
+### Scope Assessment
+
+| | |
+|---|---|
+| Produktiv | ~300–350 LoC |
+| Tests | ~200 LoC |
+| Risiko | **MEDIUM–HIGH** (Alarmkette im laufenden Betrieb, neue Abrufstrategie) |
+
+**Über dem 250-LoC-Limit.** Empfohlener Unter-Zuschnitt:
+- **S2a** — Mehrpunktabfrage (`trip_segments.py`, `trip_alert.py`), Punkt-zu-Zone-Verschmelzung
+  (neues Modul), Ablösung der AC-12-Wächter, neue `NowcastResult`/`OnsetEvent`-Felder, **eine**
+  Textstelle als End-to-End-Beweis. ~180–220 produktiv + ~150 Test.
+- **S2b** — restliche sechs Textstellen, Kanal-Kaskade, km/Wegpunktname-Darstellung für
+  unvermessene Etappen, Paritätstest. ~120–150 produktiv + ~100 Test.
+
+### Dependencies
+Unverändert (siehe oben). **Zeitliche Abhängigkeit:** #2078 merged heute und etabliert die
+24-Zeichen-Konvention im Kopf — S2 setzt darauf auf, fasst die Kurzfassung vorher nicht an.
+
+## Offene Entscheidungen (kommen mit den ACs zur PO-Freigabe)
+
+1. **Abrufbudget:** Wie viele Punkte entlang der Reststrecke (N), in welchem Abstand, mit
+   welcher Priorität? Empfehlungsgrundlage: Budget unkritisch, Rasterauflösung INCA 1 km,
+   Etappen 5–13 km.
+2. **Unvermessene Etappen:** km-Spanne unterdrücken, oder Ausdehnung über Wegpunktnamen
+   ausdrücken?
+3. **Mehrere getrennte Zonen:** getrennt ausweisen oder als Hülle zusammenfassen?
+4. **Kanal-Kaskade:** Trägt die SMS-Kurzform die Spanne, angesichts des harten 140-Zeichen-
+   Schnitts? (Auf der Hütte ist Premium-SMS die einzige ankommende Fassung.)

--- a/docs/specs/modules/feat_2051_s2a_raeumliche_ausdehnung.md
+++ b/docs/specs/modules/feat_2051_s2a_raeumliche_ausdehnung.md
@@ -47,8 +47,10 @@ allein, dem Nutzer eine Zeit-Ort-Rechnung über ihn selbst auszugeben.
   Limit** in Summe, `workflow.py set-field loc_limit_override 500` vor
   `/40-tdd-red` einplanen (Muster wie S1/S3).
 - **Files:** `trip_segments.py`, `src/services/rain_extent.py` (neu),
-  `trip_alert.py`, `src/output/renderers/alert/model.py`,
-  `src/output/renderers/alert/project.py`, `src/output/renderers/alert/render.py`
+  `trip_alert.py`, `src/services/radar_alert_service.py` (Trip-Onset-
+  Eventbau — Fundstellen-Korrektur, s. Implementation Details),
+  `src/output/renderers/alert/model.py`,
+  `src/output/renderers/alert/render.py`
   + `tests/tdd/test_issue_822_radar_nowcast_segment.py` (Umbau),
   `tests/unit/test_radar_nowcast_cache_sharing.py` (Prüfung),
   1-2 neue Testdateien.
@@ -210,9 +212,23 @@ E-Mail-Trip-Langform-Stelle (`render.py:~601`, dieselbe wie S3s
 `_onset_reach_suffix`). Die übrigen sechs Textstellen bleiben in S2a
 unangetastet.
 
-**Datenweg außerhalb der Renderer**: Trip-Pfad in `project.py` befüllt
-`rain_zones` neben den bestehenden Feldern; der Ortsvergleich-Pfad setzt es
-nie (AC-15, kein Streckenkonzept).
+**Datenweg außerhalb der Renderer**: Der Trip-Onset-Pfad baut das
+`OnsetEvent` NICHT in `project.py`, sondern in
+`src/services/radar_alert_service.py:60` (`build_onset_alert_message`) —
+dort wird `rain_zones` neben den bestehenden Feldern befüllt. Der
+Ortsvergleich-Bündel-Pfad (`project.py:621`,
+`to_multi_location_onset_alert_message`) setzt es nie (AC-15, kein
+Streckenkonzept). *(Fundstellen-Korrektur nach der Kartierung; die
+Zusicherungen AC-7/AC-15 sind unverändert.)*
+
+**Draht-Lücke `km_measured` (Befund aus der Kartierung, S2a-Scope):**
+`build_onset_alert_message` setzt `km_measured` heute **nie** — das Feld
+bleibt im Trip-Onset-Pfad auf dem Default `False`. Ohne Behebung wäre AC-9
+zwar auf Renderer-Ebene erfüllbar, die Ausdehnung erschiene aber in
+Produktion auf **keiner** Etappe, auch nicht auf den 4 vermessenen. S2a
+verdrahtet daher `TripSegment.distance_measured` → `OnsetEvent.km_measured`
+im Trip-Onset-Pfad mit; AC-9 bekommt zusätzlich zum Renderer-Test einen
+Draht-Test über `check_radar_alerts` (siehe AC-9-Testnotiz).
 
 ## Expected Behavior
 
@@ -300,6 +316,11 @@ nie (AC-15, kein Streckenkonzept).
   wird / Then enthält der Text die Zusatzzeile mit exakt `Nass km 8-12`.
   - Test: Unit-Test gegen die Trip-E-Mail-Renderfunktion mit konstruiertem
     Event, Substring-Prüfung auf den exakten String `Nass km 8-12`.
+  - **Zusätzlicher Draht-Test (Befund Kartierung):** derselbe Nachweis über
+    `check_radar_alerts` mit einer Etappe, die `distance_measured=True`
+    trägt — belegt, dass `km_measured` im Trip-Onset-Pfad überhaupt aus der
+    Etappe abgeleitet wird. Ohne ihn prüft AC-9 nur den Renderer, nicht die
+    Stelle, an der die Zusicherung wirkt.
 
 - **AC-10:** Given zwei getrennte Zonen (km 2-4 und km 9-11) auf einer
   vermessenen Etappe / When dieselbe E-Mail-Langform gerendert wird / Then

--- a/docs/specs/modules/feat_2051_s2a_raeumliche_ausdehnung.md
+++ b/docs/specs/modules/feat_2051_s2a_raeumliche_ausdehnung.md
@@ -1,0 +1,404 @@
+---
+entity_id: feat_2051_s2a_raeumliche_ausdehnung
+type: feature
+created: 2026-08-23
+updated: 2026-08-23
+status: draft
+version: "1.0"
+tags: [alarm, nowcast, radar, ausdehnung, zone]
+---
+
+# Räumliche Ausdehnung des Regenereignisses — #2051 Scheibe S2a
+
+## Approval
+
+- [x] Approved — PO-Freigabe 2026-08-23 ("go", alle 16 ACs)
+
+## Purpose
+
+Ein Regenereignis wird heute als **Punkt** gemeldet ("Regen bei km 10 in 90
+Minuten"). Der Nutzer erfährt nichts über die **räumliche Ausdehnung** entlang
+der Reststrecke. S2a legt den Kern dafür: mehrere Abfragepunkte statt einem,
+eine Nass/Trocken-Zonenbildung daraus, und **eine** Textstelle (E-Mail-Trip-
+Langform) als End-to-End-Beweis. Die restlichen sechs Textstellen, die
+Kanal-Kaskade und die Darstellung für unvermessene Etappen folgen in S2b.
+
+Grundprinzip aus dem Ticket (unverändert bindend): **nur Daten über das
+Wetter, keine Rechnung über den Nutzer.** Die Planposition darf intern
+bestimmen, *wo* gemessen wird (gelebte Praxis seit #2017) — verboten ist
+allein, dem Nutzer eine Zeit-Ort-Rechnung über ihn selbst auszugeben.
+
+## Source
+
+- **File:** `src/services/trip_segments.py` (Punktbildung), neues Modul
+  `src/services/rain_extent.py` (Zonenbildung), `src/services/trip_alert.py`
+  (Andockstelle, `:1408-1472`)
+- **Identifier:** `points_along_remaining_route()` (neu, `trip_segments.py`),
+  `derive_rain_zones()` (neu, `rain_extent.py`), `RainZone` (neu,
+  `rain_extent.py`)
+
+> **Schicht-Hinweis:** Alle Änderungen liegen ausschließlich im Python-Core
+> (`src/services/`, `src/output/renderers/alert/`) — kein Go-API-, kein
+> Frontend-Anteil.
+
+## Estimated Scope
+
+- **LoC:** ~180-220 produktiv, ~150 Tests — **über dem 250-LoC-Workflow-
+  Limit** in Summe, `workflow.py set-field loc_limit_override 500` vor
+  `/40-tdd-red` einplanen (Muster wie S1/S3).
+- **Files:** `trip_segments.py`, `src/services/rain_extent.py` (neu),
+  `trip_alert.py`, `src/output/renderers/alert/model.py`,
+  `src/output/renderers/alert/project.py`, `src/output/renderers/alert/render.py`
+  + `tests/tdd/test_issue_822_radar_nowcast_segment.py` (Umbau),
+  `tests/unit/test_radar_nowcast_cache_sharing.py` (Prüfung),
+  1-2 neue Testdateien.
+- **Effort:** medium-high — neue Geometrie- und Zonenlogik, aber nur eine
+  Andockstelle und eine Textstelle.
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `position_at_time()` | function (`trip_segments.py:555`) | Liefert die interpolierte Position je Abfragepunkt — Baustein der neuen Punktbildung. |
+| `haversine_km()` | function (`src/utils/geo.py`) | Luftlinien-Abstand für die Punkt-**Platzierung** (zulässig, da nie als Zahl ausgegeben — nur die ausgegebene km-Zahl braucht echte Messung). |
+| `compare_radar_alert.py:382-392` | function (`_detect_triggered_locations`) | Bestehendes Muster für mehrere `get_nowcast`-Aufrufe in einer Schleife — S2a übernimmt die Sequenzierung, **rührt die Datei selbst nicht an** (kein Streckenkonzept im Ortsvergleich). |
+| `ForecastBudgetGate` | class (`forecast_budget.py:36-74`) | Greift automatisch je Aufruf, unverändert — kein neues Gate für S2a. |
+| `RadarNowcastCacheService` | class | TTL 300s, Schlüssel = Koordinate auf 4 Nachkommastellen — mehr Punkte bedeuten mehr Schlüssel, keine Änderung an der Cache-Logik selbst. |
+| `TripSegment.distance_measured` / `km_measured` | field/concept (#2036) | Gate für die **Ausgabe** von km-Zahlen — S2a-Zonen tragen km-Werte nur auf vermessenen Etappen im gerenderten Text (AC-8/AC-9). |
+| `fix_2017_nowcast_messpunkt.md` AC-12 | spec (existing) | "Genau ein `get_nowcast`-Aufruf je Trip" — wird durch S2a bewusst auf eine Obergrenze abgelöst (dokumentiert, siehe Abschnitt unten), nicht stillschweigend zurückgenommen. |
+
+## Getroffene Entscheidungen (E1–E4, aus Phase 2 — nicht erneut vorlegen)
+
+**E1 — Abrufbudget: 2 km Abstand, Deckel 6 Punkte, Priorität `polling`.**
+Ein fester Abstand statt einer festen Punktzahl, weil Etappen 5-13 km lang
+sind (Median 9,2 km) — eine feste Zahl würde kurze Etappen zu dicht und
+lange zu grob abtasten. 2 km liegt über der feinsten Rasterauflösung (INCA
+1 km) und liefert dort unterscheidbare Werte; 2 km läge bei ICON-D2/ARPAE
+(2 km Zellen) an der Grenze, aber diese Quellen sind nicht der KHW-Pfad.
+Deckel 6 Punkte deckt bis zu 12 km Reststrecke ab (über dem Etappen-Median)
+und hält das Abrufvolumen weit unter dem 9000er-Tagesbudget (Ist-Werte
+68-161 echte Fetches/Tag, Multiplikator ≈95×(N-1)/Trip/Tag — bei N=6 also
+weit unkritisch). Priorität bleibt `polling` (drosselbar bei Budget-Druck,
+unverändert gegenüber dem heutigen Einzelabruf) — kein Nutzer-Briefing, das
+nie gedrosselt werden dürfte. Untergrenze 1 Punkt bei Reststrecke < 2 km:
+dort bleibt das heutige Verhalten (ein Abruf an der Fenstermitte-Position)
+exakt erhalten, kein Sonderfall in der Wirkkette.
+
+**E2 — Zonentrennung: ein trockener Punkt trennt, er überbrückt nicht.**
+Der Punktabstand liegt bereits an der Auflösungsgrenze der Quelle — ein
+trockener Messpunkt ist echtes Signal, kein Rauschen. Würde ein trockener
+Punkt zwischen zwei nassen überbrückt, entstünde eine Hülle, die trockene
+Strecke als nass ausweist — eine erfundene Aussage über das Wetter, die dem
+Ticket-Grundprinzip widerspräche.
+
+**E3 — Unvermessene Etappen: gemessen wird überall, ausgegeben nur bei
+`km_measured`.** `position_at_time()` braucht kein
+`distance_from_start_km` — die Platzierung der Punkte läuft über
+`haversine_km` und funktioniert auf allen 13 KHW-Etappen. Die
+**ausgegebene** km-Zahl einer Zone erscheint aber nur, wenn die aktive
+Etappe `distance_measured=True` trägt (#2036-Muster) — auf 9 von 13
+KHW-Etappen also vorerst gar nicht (AC-8). Die Beschriftung dieser Etappen
+über Wegpunktnamen ist ausdrücklich **S2b**, keine stille Lücke dieser
+Scheibe.
+
+**E4 — Teilausfall: Punkte ohne Daten fallen aus der Zonenbildung.** Ein
+Punkt, für den `get_nowcast()` keine verwertbaren Frames liefert (Fehler,
+`data_unavailable`, Providerlücke an genau diesem Punkt), wird **weder als
+nass noch als trocken** gewertet — er trennt keine Zone und erweitert
+keine, er ist eine echte Lücke. Totalausfall (kein Punkt liefert Daten)
+ergibt weiterhin keinen S2a-Text, wie heute beim Einzelpunkt-Ausfall.
+
+## Abgelöste Zusicherung (AC-12 aus `fix_2017_nowcast_messpunkt.md`)
+
+Die #2017-Spec (`created: 2026-08-20`) legt "genau **ein**
+`get_nowcast()`-Aufruf je Trip" als Test-Invariante fest und lehnte eine
+Mehrfach-Abfrage ausdrücklich als unverhältnismäßig ab (Variante 3). Das
+Ticket #2051 (2026-08-21, einen Tag jünger) beauftragt genau diese
+Mehrfach-Abfrage — die Ablösung erfolgt hiermit **bewusst und dokumentiert**,
+keine stille Rücknahme.
+
+Betroffen sind ausschließlich Tests am `trip_alert.py`-Aufrufort (S2a rührt
+nur diese Andockstelle an, **nicht** `trip_report_scheduler.py`):
+
+| Test | Datei:Zeile | Alter Assert | Neuer Assert |
+|---|---|---|---|
+| `test_ac3_nowcast_called_at_segment_coordinates` | `test_issue_822_radar_nowcast_segment.py:532` | `call_count == 1` (`:611`) | `<= MAX_NOWCAST_CALLS_PER_TRIP_RUN` + Koordinaten-Assert |
+| `test_2017_ac12_genau_ein_get_nowcast_aufruf_je_lauf` | `test_issue_822_radar_nowcast_segment.py:1282` | `== 1` (`:1304`, `:1308`) | `<=` an BEIDEN Seams (`dienst.calls`, `frames.call_count`) |
+| `test_2017_fadv1_...` | `test_issue_822_radar_nowcast_segment.py:1329` | `call_count == 1` gemeinsam gezählt (`:1417`) | pro Trip GETRENNT gezählt (AC-14) |
+
+**Nicht betroffen** (S2a ändert `trip_report_scheduler.py` nicht):
+`test_ac12_starkregen_hinweis_ruft_get_nowcast_genau_einmal`
+(`test_trip_report_scheduler_starkregen_hint.py:331`) bleibt bei `== 1` —
+der Briefing-Kurzfristhinweis läuft über einen anderen Aufrufort und ist
+S2b-Scope.
+
+**Zu prüfen, nicht Teil des Testumbaus:**
+`test_end_to_end_trip_and_compare_radar_paths_share_one_fetch`
+(`tests/unit/test_radar_nowcast_cache_sharing.py:329`) setzt voraus, dass
+eine Trip-Koordinate exakt auf der Compare-Koordinate liegt. Im Ein-Punkt-
+Regime (Reststrecke < 2 km) bleibt das unverändert möglich; im
+Mehr-Punkt-Regime (N > 1) ist eine zufällige Koordinatenübereinstimmung
+strukturell unwahrscheinlich. Das ist eine erwartete Konsequenz von S2a,
+keine Regression — der Test muss beim Implementieren auf den Ein-Punkt-Fall
+verengt oder als bekannte Einschränkung dokumentiert werden (siehe Known
+Limitations).
+
+## Implementation Details
+
+**Neue Punktbildung** (`trip_segments.py`, additiv, pure Funktion):
+
+```python
+RADAR_ZONE_POINT_SPACING_KM = 2.0
+RADAR_ZONE_MAX_POINTS = 6
+# Issue #2051 S2a: Abstand ueber der INCA-Zellgroesse (1 km), Deckel deckt
+# bis zu 12 km Reststrecke ab (ueber dem Etappen-Median 9,2 km). Downstream-
+# Leser referenzieren die MODUL-Variable, kein Bindezeit-Import.
+
+def points_along_remaining_route(
+    trip, active, segment_date, at: datetime,
+) -> list[GPXPoint]:
+    """Bis zu RADAR_ZONE_MAX_POINTS Punkte im Abstand
+    RADAR_ZONE_POINT_SPACING_KM entlang der Reststrecke der AKTIVEN Etappe
+    ab `at`. Reststrecke < 2 km -> genau 1 Punkt (heutiges Verhalten
+    unveraendert). Platzierung ueber Luftlinie zulaessig (nie ausgegeben),
+    siehe E3."""
+```
+
+**Neues Modul** `src/services/rain_extent.py` (Zonenbildung, kein
+bestehender Baustein — siehe #2051-Kontext R3/R8):
+
+```python
+@dataclass(frozen=True)
+class RainZone:
+    km_from: float
+    km_to: float
+    onset_minutes: int
+    event_end_minutes: int | None
+
+def derive_rain_zones(
+    points: list[GPXPoint], results: list[NowcastResult | None],
+) -> list[RainZone]:
+    """Benachbarte NASSE Punkte (onset_minutes gesetzt) verschmelzen zu
+    einer Zone; ein TROCKENER Punkt trennt (E2). Punkte ohne Daten
+    (results[i] is None) fallen aus der Bildung heraus (E4). Zeitangabe je
+    Zone: fruehester onset_minutes, spaetester event_end_minutes unter den
+    Punkten DIESER Zone (keine globale Spanne)."""
+```
+
+**Andockstelle** (`trip_alert.py:1408-1472`): Der heutige Einzelabruf wird
+durch eine Schleife über `points_along_remaining_route(...)` ersetzt, nach
+dem Muster von `compare_radar_alert.py:382-392` (sequenziell, `priority=
+"polling"`, kein Bulk-Request). `get_nowcast()` bleibt Ein-Punkt-API — keine
+Signaturänderung an `radar_service.py`. Ergebnisse gehen an
+`derive_rain_zones()`.
+
+**Neues Feld auf `OnsetEvent`** (`model.py`, additiv, Default leer — R6:
+`km_from`/`km_to` bleiben unangetastet die Segment-Lage):
+
+```python
+rain_zones: tuple[RainZone, ...] = ()
+# Issue #2051 S2a: eigenes Feld fuer die Ereignis-Ausdehnung. km_from/km_to
+# bleiben die Segment-Grenzen (#2017 Known Limitation 5) -- zwei
+# Bedeutungen, zwei Namen.
+```
+
+**Eine Textstelle** (`render.py`, Muster `_onset_end_suffix`): neuer Helfer
+`_onset_extent_suffix(e) -> str` — `" · Nass km 8-12"` bei einer Zone,
+`" · Nass km 2-4, km 9-11"` bei mehreren, leer wenn `rain_zones` leer ODER
+die aktive Etappe unvermessen ist (AC-8). Angehängt an der bestehenden
+E-Mail-Trip-Langform-Stelle (`render.py:~601`, dieselbe wie S3s
+`_onset_reach_suffix`). Die übrigen sechs Textstellen bleiben in S2a
+unangetastet.
+
+**Datenweg außerhalb der Renderer**: Trip-Pfad in `project.py` befüllt
+`rain_zones` neben den bestehenden Feldern; der Ortsvergleich-Pfad setzt es
+nie (AC-15, kein Streckenkonzept).
+
+## Expected Behavior
+
+- **Input:** aktive Etappe mit Reststrecke ab der Fensterzeit, N
+  Nowcast-Ergebnisse (eines je Abfragepunkt), `distance_measured`-Flag der
+  Etappe.
+- **Output:**
+  - `rain_zones` ist eine Liste getrennter, nie zu einer Hülle vereinter
+    Zonen mit eigenen km- und Zeitgrenzen.
+  - Die E-Mail-Trip-Langform trägt die Zusatzzeile nur bei vermessener
+    Etappe; sonst byte-identisch zum Stand vor dieser Spec.
+  - Die übrigen sechs Textstellen und der Ortsvergleich bleiben unverändert
+    (S2b).
+- **Side effects:** zusätzliche `get_nowcast`-Aufrufe je Trip-Lauf (gedeckelt
+  auf `RADAR_ZONE_MAX_POINTS`), unverändert `priority="polling"`. Keine
+  Persistenz betroffen, keine Änderung an der Auslöseregel.
+
+## Acceptance Criteria
+
+- **AC-1:** Given eine aktive Etappe mit einer Reststrecke von 12,0 km ab
+  der aktuellen Fensterzeit / When die Abfragepunkte entlang der
+  Reststrecke gebildet werden / Then entstehen genau 6 Punkte bei km 0, 2,
+  4, 6, 8, 10 — der Deckel `RADAR_ZONE_MAX_POINTS=6` greift, die letzten 2 km
+  der Reststrecke bleiben unabgefragt.
+  - Test: Unit-Test gegen `points_along_remaining_route` mit synthetischer
+    12-km-Etappe, Assert auf exakt diese 6 km-Werte in dieser Reihenfolge.
+
+- **AC-2:** Given dieselbe Etappe, aber mit einer Reststrecke von 1,9 km
+  (unterhalb der 2-km-Schwelle) / When die Abfragepunkte gebildet werden /
+  Then entsteht GENAU EIN Punkt an der heutigen Fenstermitte-Position —
+  unverändertes Verhalten gegenüber dem Stand vor dieser Spec.
+  - Test: Gleicher Testaufbau wie AC-1, nur die Reststrecke auf 1,9 km
+    verschoben; Anzahl kippt von 6 auf 1 (Positivkontrolle zu AC-1).
+
+- **AC-3:** Given eine Reststrecke von 8,0 km / When die Abfragepunkte
+  gebildet werden / Then liegen alle 5 Punkte (km 0/2/4/6/8) auf der
+  interpolierten Streckengeometrie der aktiven Etappe und keine zwei
+  Koordinaten sind identisch.
+  - Test: Unit-Test mit 8-km-Etappe, Assert auf 5 unterschiedliche
+    Koordinaten, jede gegen die erwartete Interpolationsposition geprüft.
+
+- **AC-4:** Given 6 Abfragepunkte mit dem Nass/Trocken-Muster Nass, Nass,
+  Trocken, Nass, Nass, Trocken (Positionen km 0, 2, 4, 6, 8, 10) / When die
+  Zonenbildung läuft / Then entstehen genau zwei Zonen: km 0-2 und km 6-8.
+  - Test: Unit-Test gegen `derive_rain_zones` mit synthetischen
+    NowcastResults, Assert auf genau die zwei km-Spannen.
+
+- **AC-5:** Given 3 Abfragepunkte mit dem Muster Nass, Trocken, Nass (km 0,
+  2, 4) / When die Zonenbildung läuft / Then entstehen ZWEI getrennte Zonen
+  (km 0-0 und km 4-4), NIEMALS eine Hülle km 0-4 — der trockene Mittelpunkt
+  widerlegt eine durchgehende Nässe.
+  - Test: Unit-Test mit genau diesem Dreier-Muster, Assert auf zwei Zonen
+    mit den exakten Grenzen; Negativ-Assert, dass keine Zone gleichzeitig
+    `km_from=0` und `km_to=4` trägt.
+
+- **AC-6:** Given zwei Zonen aus AC-4 mit unterschiedlichen Onset-/Ende-
+  Zeiten je Punkt (Zone A: onset 10 Min / Ende 20 Min, Zone B: onset 45 Min
+  / Ende 60 Min) / When die Zonenbildung die Zeitspanne ableitet / Then
+  trägt Zone A `onset_minutes=10` und Zone B `onset_minutes=45` — jede Zone
+  bekommt ihre eigene früheste/späteste Zeit, keine globale Spanne über
+  beide Zonen.
+  - Test: Unit-Test mit den vier Zeitwerten aus dem AC, beide Zonen einzeln
+    auf ihre Min/Max-Werte geprüft.
+
+- **AC-7:** Given ein `OnsetEvent` mit gesetzten `km_from`/`km_to`
+  (Segment-Lage, unverändert) UND gesetzten Zonen aus der neuen
+  Ausdehnungs-Logik / When das Event gebaut wird / Then bleiben
+  `km_from`/`km_to` unverändert die Segment-Grenzen, während die Zonen unter
+  dem eigenen Feld `rain_zones` liegen — kein Test darf beide Bedeutungen
+  über denselben Namen lesen.
+  - Test: Unit-Test, der ein `OnsetEvent` mit beiden Wertepaaren
+    konstruiert und prüft, dass `event.km_from`/`km_to` den Segmentwerten
+    entsprechen, `event.rain_zones[0].km_from`/`km_to` den Zonenwerten.
+
+- **AC-8:** Given eine aktive Etappe mit `distance_measured=False`
+  (unvermessen) UND einer erkannten Nass-Zone / When die E-Mail-Trip-
+  Langform gerendert wird / Then erscheint KEINE zusätzliche
+  Ausdehnungs-Zeile — der Text bleibt byte-identisch zum Stand vor dieser
+  Spec.
+  - Test: Unit-Test mit `distance_measured=False`, Volltextvergleich des
+    gerenderten E-Mail-Abschnitts gegen den Stand vor dieser Spec.
+
+- **AC-9:** Given eine aktive Etappe mit `distance_measured=True` und einer
+  einzelnen Nass-Zone km 8-12 / When die E-Mail-Trip-Langform gerendert
+  wird / Then enthält der Text die Zusatzzeile mit exakt `Nass km 8-12`.
+  - Test: Unit-Test gegen die Trip-E-Mail-Renderfunktion mit konstruiertem
+    Event, Substring-Prüfung auf den exakten String `Nass km 8-12`.
+
+- **AC-10:** Given zwei getrennte Zonen (km 2-4 und km 9-11) auf einer
+  vermessenen Etappe / When dieselbe E-Mail-Langform gerendert wird / Then
+  zeigt der Text beide Zonen getrennt (`Nass km 2-4, km 9-11`), NIEMALS eine
+  zusammengefasste Hülle `km 2-11`.
+  - Test: Unit-Test mit zwei Zonen, Substring-Prüfung auf den getrennten
+    String, Negativ-Prüfung dass `km 2-11` nicht vorkommt.
+
+- **AC-11:** Given 5 Abfragepunkte, von denen einer keine Nowcast-Daten
+  liefert (Providerfehler an genau diesem Punkt, die übrigen vier liefern
+  normal) / When die Zonenbildung läuft / Then wird der datenlose Punkt
+  weder als nass noch als trocken gewertet und fällt aus der
+  Zonengrenzenbildung heraus.
+  - Test: Unit-Test mit `results[2] = None` bei 5 Punkten, Assert dass die
+    umgebenden Zonen identisch zu einem Vergleichslauf ohne den Ausfall
+    bleiben.
+
+- **AC-12:** Given eine Etappe mit Reststrecke 12 km (wie AC-1) / When
+  `trip_alert.check_radar_alerts` läuft / Then ist die Anzahl der
+  `get_nowcast`-Aufrufe UND die Anzahl der `frame_source`-Aufrufe je Trip
+  `<= MAX_NOWCAST_CALLS_PER_TRIP_RUN` (aus derselben Modulreferenz gelesen,
+  nicht als Literal dupliziert), und alle abgefragten Koordinaten liegen auf
+  der erwarteten Reststrecke ohne Duplikate.
+  - Test: Umbau von `test_2017_ac12_genau_ein_get_nowcast_aufruf_je_lauf`
+    (und `test_ac3_nowcast_called_at_segment_coordinates`) auf `<=`-Vergleich
+    an beiden Seams (`dienst.calls`, `frames.call_count`) plus neuem
+    Koordinaten-Assert.
+
+- **AC-13:** Given dieselbe Testkonstruktion wie AC-12, aber mit
+  Reststrecke 1,9 km (unterhalb der 2-km-Schwelle, wie AC-2) / When derselbe
+  Ablauf läuft / Then bleibt die Aufrufzahl exakt 1.
+  - Test: Gleicher Testaufbau wie AC-12 mit 1,9-km-Reststrecke, Assert
+    `== 1` statt `<=` (Positivkontrolle — ohne diesen Fall misst AC-12
+    nicht, ob überhaupt gedeckelt wird).
+
+- **AC-14:** Given zwei Trips, wobei die Positionsbestimmung
+  (`position_at_time`) für Trip A wirft, während Trip B eine normale
+  Reststrecke von 8 km hat / When der Lauf durch beide Trips geht / Then
+  verbraucht Trip A keinen einzigen `get_nowcast`-Aufruf, während Trip B
+  alle 5 erwarteten Punkte abfragt.
+  - Test: Umbau von `test_2017_fadv1_...` auf zwei getrennt gezählte Trips
+    (bisher gemeinsam gezählt), Assert 0 für Trip A, 5 für Trip B.
+
+- **AC-15:** Given denselben Nowcast-Abruf über den Ortsvergleich-Pfad
+  (`compare_radar_alert.py`) / When das Event für den Ortsvergleich gebaut
+  wird / Then bleibt `rain_zones` leer (`()`) — S2a ändert
+  `compare_radar_alert.py` nicht.
+  - Test: Regressionslauf des bestehenden Ortsvergleich-Tests, zusätzlicher
+    Assert `event.rain_zones == ()`.
+
+- **AC-16:** Given einen beliebigen gerenderten Text mit gesetzten Zonen /
+  When der Text auf Formulierungen mit einer Ankunftszeit-Rechnung oder
+  einer Handlungsempfehlung geprüft wird / Then enthält er keine solche
+  Formulierung — nur Wetter-km-Spannen und -Zeiten, keine Aussage darüber,
+  wann der Nutzer eine Zone erreicht.
+  - Test: Unit-Test mit Negativ-Prüfung auf eine Liste verbotener Muster
+    (Muster wie S3-AC-15).
+
+## Known Limitations
+
+- **Nur eine von sieben Textstellen wired.** Betreff, Telegram rich/Kurzstil,
+  SMS/Premium-SMS, Briefing-Kurzfristhinweis, `/jetzt`-Kommando bekommen
+  in S2a keine Ausdehnungs-Angabe — das ist S2b.
+- **Kanal-Kaskade nicht entschieden.** Ob und wie die SMS-Kurzform eine
+  Zonen-Spanne trägt (harter 140-Zeichen-Schnitt), entscheidet S2b.
+- **Unvermessene Etappen bleiben stumm.** 9 von 13 KHW-Etappen zeigen in
+  S2a keine Ausdehnung (AC-8) — die Wegpunktnamen-Darstellung ist S2b.
+- **Cache-Sharing zwischen Trip- und Compare-Pfad gilt nur im
+  Ein-Punkt-Regime.** `test_end_to_end_trip_and_compare_radar_paths_
+  share_one_fetch` muss beim Implementieren auf den Reststrecke-<2-km-Fall
+  verengt werden; bei N > 1 ist eine zufällige Koordinatenübereinstimmung
+  nicht mehr zu erwarten — das ist eine erwartete Folge, keine Regression.
+- **GeoSphere INCA bleibt ungegated** (R5 aus dem Kontextdokument). Der
+  Deckel auf 6 Punkte hält das Abrufvolumen konservativ, S2a führt aber kein
+  eigenes Gate für den INCA-Pfad ein.
+
+## Nicht-Ziele
+
+- Die restlichen sechs Textstellen (Betreff, Telegram rich/Kurzstil,
+  SMS/Premium-SMS, Briefing-Kurzfristhinweis, `/jetzt`) — S2b.
+- Kanal-Kaskade und SMS-Zonenkappung — S2b.
+- Wegpunktnamen-Darstellung für unvermessene Etappen — S2b.
+- Änderungen am Ortsvergleich (`compare_radar_alert.py` hat kein
+  Streckenkonzept, neue Felder bleiben dort leer, AC-15).
+- Signaturänderung an `get_nowcast()` — bleibt Ein-Punkt-API.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Additive Feld-Durchreichung entlang derselben, bereits in
+  S1/S3 etablierten Wirkkette (`OnsetEvent` → Renderer), plus eine neue
+  reine Geometrie-/Zonenfunktion ohne bestehenden Baustein. Berührt keine
+  der vier Entscheidungsflächen, die ein neues ADR verlangen würden:
+  ADR-0011 (ein Backend-Renderer) bleibt gültig; ADR-0021 (geteilter Code
+  Trip/Compare) wird angewendet, nicht verändert (Ortsvergleich bekommt
+  bewusst keine Zonen, AC-15); kein neuer Kanal, kein neuer Provider, keine
+  Persistenz-Änderung.
+
+## Changelog
+
+- 2026-08-23: Initial spec created (#2051 Scheibe S2a, räumliche Ausdehnung
+  — Mehrpunktabfrage, Zonenbildung, eine Textstelle als E2E-Beweis).

--- a/docs/specs/modules/feat_2051_s2a_raeumliche_ausdehnung.md
+++ b/docs/specs/modules/feat_2051_s2a_raeumliche_ausdehnung.md
@@ -47,9 +47,9 @@ allein, dem Nutzer eine Zeit-Ort-Rechnung über ihn selbst auszugeben.
   Limit** in Summe, `workflow.py set-field loc_limit_override 500` vor
   `/40-tdd-red` einplanen (Muster wie S1/S3).
 - **Files:** `trip_segments.py`, `src/services/rain_extent.py` (neu),
-  `trip_alert.py`, `src/services/radar_alert_service.py` (Trip-Onset-
-  Eventbau — Fundstellen-Korrektur, s. Implementation Details),
-  `src/output/renderers/alert/model.py`,
+  `trip_alert.py`, `src/services/notification_service.py` (Trip-Onset-
+  Eventbau `:1386` + `RadarAlertRequest` `:177` — verifizierte Fundstelle,
+  s. Implementation Details), `src/output/renderers/alert/model.py`,
   `src/output/renderers/alert/render.py`
   + `tests/tdd/test_issue_822_radar_nowcast_segment.py` (Umbau),
   `tests/unit/test_radar_nowcast_cache_sharing.py` (Prüfung),
@@ -212,23 +212,44 @@ E-Mail-Trip-Langform-Stelle (`render.py:~601`, dieselbe wie S3s
 `_onset_reach_suffix`). Die übrigen sechs Textstellen bleiben in S2a
 unangetastet.
 
-**Datenweg außerhalb der Renderer**: Der Trip-Onset-Pfad baut das
-`OnsetEvent` NICHT in `project.py`, sondern in
-`src/services/radar_alert_service.py:60` (`build_onset_alert_message`) —
-dort wird `rain_zones` neben den bestehenden Feldern befüllt. Der
-Ortsvergleich-Bündel-Pfad (`project.py:621`,
-`to_multi_location_onset_alert_message`) setzt es nie (AC-15, kein
-Streckenkonzept). *(Fundstellen-Korrektur nach der Kartierung; die
-Zusicherungen AC-7/AC-15 sind unverändert.)*
+**Datenweg außerhalb der Renderer** *(zweifach korrigiert, Stand verifiziert
+in der RED-Phase — die ursprüngliche Spec-Angabe `project.py` und die erste
+Korrektur `radar_alert_service.py` waren BEIDE falsch)*:
 
-**Draht-Lücke `km_measured` (Befund aus der Kartierung, S2a-Scope):**
-`build_onset_alert_message` setzt `km_measured` heute **nie** — das Feld
-bleibt im Trip-Onset-Pfad auf dem Default `False`. Ohne Behebung wäre AC-9
-zwar auf Renderer-Ebene erfüllbar, die Ausdehnung erschiene aber in
-Produktion auf **keiner** Etappe, auch nicht auf den 4 vermessenen. S2a
-verdrahtet daher `TripSegment.distance_measured` → `OnsetEvent.km_measured`
-im Trip-Onset-Pfad mit; AC-9 bekommt zusätzlich zum Renderer-Test einen
-Draht-Test über `check_radar_alerts` (siehe AC-9-Testnotiz).
+Der produktive Trip-Onset-Draht lautet
+`trip_alert.py:1831` (`self._notification_service.send_radar_alert(...)`)
+→ `notification_service.py:1374` (`send_radar_alert`, gefüttert über
+`RadarAlertRequest`, `notification_service.py:177`, befüllt in
+`trip_alert.py:1726`) → `notification_service.py:1386` (`OnsetEvent(...)`).
+**Dort** wird `rain_zones` befüllt, was neue Felder auf `RadarAlertRequest`
+plus Durchreichung in `send_radar_alert` bedeutet.
+
+`radar_alert_service.py:31` (`build_onset_alert_message`) ist **nicht** der
+Produktivpfad: einziger Aufrufer ist der Debug-Endpunkt
+`api/routers/debug.py:110`. Eine Implementierung dort wäre wirkungslos.
+
+Der Ortsvergleich-Bündel-Pfad (`project.py:621`,
+`to_multi_location_onset_alert_message`) setzt `rain_zones` nie (AC-15, kein
+Streckenkonzept). Die Zusicherungen AC-7/AC-15 sind von beiden Korrekturen
+unberührt.
+
+**Draht-Lücke `km_measured` (in der RED-Phase belegt, S2a-Scope):**
+Der Trip-Onset-Pfad setzt `km_measured` heute **nie** — das Feld bleibt auf
+dem Default `False`. Ohne Behebung wäre AC-9 auf Renderer-Ebene erfüllbar,
+die Ausdehnung erschiene aber in Produktion auf **keiner** Etappe, auch
+nicht auf den 4 vermessenen. S2a verdrahtet daher
+`TripSegment.distance_measured` → `OnsetEvent.km_measured` mit. Der
+Draht-Test `test_ac9_draht_km_measured_erreicht_das_gerenderte_onset_event`
+belegt die Lücke: er scheitert mit `AssertionError` (nicht `ImportError`),
+erreicht also den Renderer und findet die Zeile nicht.
+
+**Offener Umbaupunkt für die GREEN-Phase (in RED nicht angefasst):**
+`tests/tdd/test_radar_alert_follows_ortstag.py:240` (`_assert_messpunkt`,
+gemeinsamer Helfer, Aufrufstellen `:317`, `:393`, `:994`, `:1016`) assertet
+`len(calls) == 1` generisch für den Nowcast-Abruf über
+`check_radar_alerts()`. Die Datei ist heute grün (34 Tests) und wird durch
+S2a rot, sobald die dortigen Etappen ≥ 2 km Reststrecke haben — dann mit
+demselben `<=`-Muster umbauen wie die Tests der Ablösungstabelle.
 
 ## Expected Behavior
 

--- a/docs/specs/modules/feat_2051_s2a_raeumliche_ausdehnung.md
+++ b/docs/specs/modules/feat_2051_s2a_raeumliche_ausdehnung.md
@@ -418,6 +418,32 @@ demselben `<=`-Muster umbauen wie die Tests der Ablösungstabelle.
   Deckel auf 6 Punkte hält das Abrufvolumen konservativ, S2a führt aber kein
   eigenes Gate für den INCA-Pfad ein.
 
+- **Messlücken bleiben unmarkiert und verzerren die Zonenaussage in BEIDE
+  Richtungen** *(nachgetragen 2026-08-23 nach Abstimmung mit der #2050-S4a-
+  Sitzung; keine AC-Änderung, dokumentiert eine durch die Implementierung
+  sichtbar gewordene Grenze).* Ein Punkt ohne verwertbare Daten fällt in
+  `derive_rain_zones` still heraus (`rain_extent.py:77-78`, `continue`). Aus
+  dem gerenderten Text ist ein Ausfall nicht von einem gemessenen
+  Trockenpunkt zu unterscheiden — weder `RainZone` noch `RadarAlertRequest`
+  tragen ein Kennzeichen, an welchem Punkt nicht nachgesehen wurde. Die
+  Ausdehnung kann dadurch
+  - **zu klein** werden (nass, nass, Lücke, trocken → die Zone endet am
+    letzten nassen Punkt, obwohl der Regen über die Lücke hinaus reichen
+    könnte), und
+  - **zu groß** werden (nass, Lücke, nass → beide Punkte landen in EINER
+    Zone, der Text behauptet durchgehende Nässe über die nicht gemessene
+    Strecke).
+
+  In der extremsten Form (erster Punkt nass, alle Folgepunkte aus) schrumpft
+  die Aussage still auf `km X-X` zusammen. Das ist mit E4 vereinbar — E4
+  sichert zu, dass die Lücke nicht selbst als Messwert zählt
+  (`km_from`/`km_to` speisen sich ausschließlich aus nassen Punkten, AC-11),
+  nicht, dass sie zwei Zonen getrennt hält. Die **Nachvollziehbarkeit**
+  (Protokolleintrag mit Zahl und Lage der Lücken) übernimmt **#2050 S4a**,
+  die **Textaussage** beider Verzerrungsrichtungen **#2050 S4b**. Beide
+  Richtungen brauchen getrennte Prüfungen — ein zusammengefasstes Kriterium
+  fängt nur eine davon.
+
 ## Nicht-Ziele
 
 - Die restlichen sechs Textstellen (Betreff, Telegram rich/Kurzstil,

--- a/docs/specs/modules/fix_2017_nowcast_messpunkt.md
+++ b/docs/specs/modules/fix_2017_nowcast_messpunkt.md
@@ -285,6 +285,22 @@ Segment-Startpunkt.
   pro Trip an Segment-Startpunkt") hielt diese Zusicherung bislang nur als Prosa fest; da genau
   diese Zeile durch Scheibe B angefasst wird, verliert der Kommentar seinen Anker — die
   Invariante gehört ab jetzt in einen Test, nicht in einen Kommentar.
+
+  > **⚠️ Für den Alarm-Pfad ABGELÖST durch #2051 S2a** (`feat_2051_s2a_raeumliche_ausdehnung.md`,
+  > Abschnitt „Abgelöste Zusicherung"). `check_radar_alerts()` fragt seit S2a **mehrere** Punkte
+  > entlang der Reststrecke ab — die räumliche Ausdehnung des Regenereignisses lässt sich aus
+  > einem Punkt nicht bilden. An die Stelle von „genau ein Abruf" tritt eine **Obergrenze**
+  > (`trip_segments.RADAR_ZONE_MAX_POINTS`); der **erste** Punkt bleibt unverändert der hier
+  > spezifizierte #2017-Messpunkt und trägt allein die Auslöseregel, die übrigen liefern nur die
+  > Zonen. Bei einer Reststrecke unterhalb des Punktabstands bleibt es faktisch bei einem Abruf.
+  >
+  > **Unverändert gültig** bleibt AC-12 für den **Starkregen-Hinweis-Pfad**
+  > (`trip_report_scheduler.py`, Wächter `test_ac12_starkregen_hinweis_ruft_get_nowcast_genau_einmal`)
+  > und für den `/jetzt`-Pfad. Die Ablösung ist eng auf den Alarm-Pfad begrenzt.
+  >
+  > Den Alarm-Pfad bewacht seither `tests/unit/test_alert_log_capture_correlation.py`
+  > (`test_ac4_e2e_zweig_c_...`): Budget-Deckel eingehalten **und** der auslösende Datensatz ist
+  > der #2017-Messpunkt, nicht ein Zonen-Folgepunkt.
   - Test: Aufruf-Zähler am `get_nowcast`-Seam (DI-Seam, kein Mock der Entscheidungslogik) über
     einen vollständigen `check_radar_alerts()`-Lauf, Assert `== 1`. Analoger Zähler-Assert für
     den Starkregen-Hinweis-Lauf in `trip_report_scheduler.py`.

--- a/src/output/renderers/alert/model.py
+++ b/src/output/renderers/alert/model.py
@@ -6,6 +6,10 @@ Radar-Pfad (#919) ohne Modell-Bruch zu konvergieren.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover — nur fuer Typpruefung
+    from services.rain_extent import RainZone
 
 
 @dataclass(frozen=True)
@@ -165,6 +169,13 @@ class OnsetEvent:
     # hier (sonst zwei Wahrheiten, Muster AC-20).
     location_sharpness_limit_time: str | None = None
     location_sharpness_limit_day_offset: int = 0
+    # Issue #2051 S2a: raeumliche Ausdehnung des Regenereignisses entlang der
+    # Reststrecke — eigenes Feld, weil `km_from`/`km_to` die Segment-Lage
+    # bleiben (#2017 Known Limitation 5): zwei Bedeutungen, zwei Namen (AC-7).
+    # Gesetzt NUR vom Trip-Onset-Pfad; der Ortsvergleich hat kein
+    # Streckenkonzept und laesst das Feld leer (AC-15). Die km-Zahlen
+    # erscheinen im Text erst, wenn `km_measured` gesetzt ist (AC-8).
+    rain_zones: tuple["RainZone", ...] = ()
 
 
 @dataclass(frozen=True)

--- a/src/output/renderers/alert/render.py
+++ b/src/output/renderers/alert/render.py
@@ -611,6 +611,34 @@ def _onset_sharpness_suffix(e: OnsetEvent) -> str:
     return f" · Ortsangabe ab {limit} unscharf"
 
 
+def _onset_extent_suffix(e: OnsetEvent) -> str:
+    """Issue #2051 S2a: Langform-Ausdehnungs-Angabe als anhaengbares Stueck
+    oder LEER (Muster `_onset_end_suffix`).
+
+    Leer in ZWEI Faellen:
+
+    * keine Zonen (`rain_zones` leer) — die Mehrpunkt-Abfrage hat keine
+      zusammenhaengend nasse Strecke gefunden, oder der Pfad setzt das Feld
+      gar nicht (Ortsvergleich, AC-15);
+    * unvermessene Etappe (`km_measured` aus, AC-8) — die km-Lage der Zonen
+      stammt dann aus geschaetzter Kilometrierung und waere glaubwuerdig
+      aussehender Unsinn (dieselbe Regel wie #2036 fuer die Ortsangabe). Die
+      Beschriftung solcher Etappen ueber Wegpunktnamen ist S2b.
+
+    Mehrere Zonen bleiben GETRENNT aufgezaehlt (`km 2-4, km 9-11`) — eine
+    zusammengefasste Huelle wuerde die trockene Strecke dazwischen als nass
+    ausweisen (AC-10, E2). Rundung und ASCII-Bindestrich wie die gemessene
+    km-Spanne in `segments.format_alert_location`.
+    """
+    zonen = getattr(e, "rain_zones", ())
+    if not zonen or not getattr(e, "km_measured", False):
+        return ""
+    spannen = ", ".join(
+        f"km {int(round(z.km_from))}-{int(round(z.km_to))}" for z in zonen
+    )
+    return f" · Nass {spannen}"
+
+
 def _render_email_onset_multi(msg: AlertMessage) -> tuple[str, str]:
     """Bündel-Zweig (Issue #1041 Slice 1a): je Ort eine Zeile mit Onset-Zeit
     und Intensität (Muster `loc_prefix`, render_email:328-333).
@@ -705,9 +733,13 @@ def _render_email_onset(msg: AlertMessage) -> tuple[str, str]:
         # Issue #2051 S1: Beginn und Ende gehoeren in DIESELBE "Wo & wann"-
         # Zeile -- eine eigene Datenzeile nur fuer das Ende waere im
         # Ende-losen Normalfall eine leere Zeile (ADR-0052, Label-Wert-Form).
+        # Issue #2051 S2a: die raeumliche Ausdehnung an DERSELBEN Stelle wie
+        # die uebrigen additiven Angaben dieser Zeile -- ohne Zonen oder auf
+        # unvermessener Etappe bleibt sie byte-identisch (AC-8).
         ("Wo & wann",
          f"{km} · {_onset_wann_zeile(e, praefix='ab ')}{_onset_end_suffix(e)}"
-         f"{_onset_reach_suffix(e)}{_onset_sharpness_suffix(e)}"),
+         f"{_onset_reach_suffix(e)}{_onset_sharpness_suffix(e)}"
+         f"{_onset_extent_suffix(e)}"),
         ("Intensität", e.intensity_label),
         ("Quelle", e.source_label),
     ]

--- a/src/services/notification_service.py
+++ b/src/services/notification_service.py
@@ -256,6 +256,15 @@ class RadarAlertRequest:
     # Beginn noch Ende liegen jenseits der Grenze".
     location_sharpness_limit_time: str | None = None
     location_sharpness_limit_day_offset: int = 0
+    # Issue #2036/#2051 S2a: stammen `km_from`/`km_to` aus echter GPX-
+    # Wegstrecke (`TripSegment.distance_measured`)? Der Trip-Onset-Pfad hat
+    # das Flag bis S2a NIE gesetzt -- ohne es bliebe die Ausdehnung auf JEDER
+    # Etappe stumm, auch auf den vermessenen.
+    km_measured: bool = False
+    # Issue #2051 S2a: die Nass-Zonen der Reststrecke, gebildet aus der
+    # Mehrpunkt-Abfrage (`rain_extent.derive_rain_zones`). Additiv, Default
+    # leer -> ohne sie bleibt der Versand byte-identisch.
+    rain_zones: tuple = ()
 
 
 def build_service_error_email_html(trip_name: str, report_type: str, error_lines: str) -> str:
@@ -1410,6 +1419,11 @@ class NotificationService:
             source_reach_day_offset=request.source_reach_day_offset,
             location_sharpness_limit_time=request.location_sharpness_limit_time,
             location_sharpness_limit_day_offset=request.location_sharpness_limit_day_offset,
+            # Issue #2051 S2a: Ausdehnung und die Echtheitspruefung der
+            # km-Zahlen reisen GEMEINSAM -- die Zonen ohne `km_measured`
+            # blieben im Text stumm, das Flag ohne Zonen wirkungslos.
+            km_measured=request.km_measured,
+            rain_zones=tuple(request.rain_zones),
         )
         # Issue #1402: kein stiller Rueckfall mehr -- `request.tz` ist seit
         # `RadarAlertRequest` ein Pflichtfeld.

--- a/src/services/rain_extent.py
+++ b/src/services/rain_extent.py
@@ -1,0 +1,91 @@
+"""Nass/Trocken-Zonenbildung entlang der Reststrecke (Issue #2051 S2a).
+
+Reine Auswertung: aus den Abfragepunkten (`points_along_remaining_route`,
+`trip_segments.py`) und ihren Nowcast-Ergebnissen entstehen getrennte
+Nass-Zonen mit eigener km-Lage und eigener Zeitspanne.
+
+Zwei Entscheidungen der Spec wohnen hier (E2/E4):
+
+* Ein TROCKENER Punkt trennt zwei Zonen, er ueberbrueckt sie nie. Der
+  Punktabstand liegt an der Aufloesungsgrenze der Quelle — ein trockener
+  Messpunkt ist echtes Signal. Eine Huelle ueber ihn hinweg wuerde trockene
+  Strecke als nass ausweisen, also eine Aussage ueber das Wetter erfinden.
+* Ein Punkt OHNE Daten (`results[i] is None`) faellt heraus: er trennt keine
+  Zone und erweitert keine. Er ist eine Luecke, kein Messwert.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Sequence
+
+if TYPE_CHECKING:  # pragma: no cover — nur fuer Typpruefung
+    from app.models import GPXPoint
+    from services.radar_service import NowcastResult
+
+
+@dataclass(frozen=True)
+class RainZone:
+    """Ein zusammenhaengend nasser Abschnitt der Reststrecke.
+
+    `km_from`/`km_to` sind die Kilometrierung der beteiligten Punkte
+    (`GPXPoint.distance_from_start_km`) — NICHT die Segment-Grenzen. Die
+    beiden Bedeutungen haben bewusst zwei Namen (`OnsetEvent.km_from` bleibt
+    die Segment-Lage, Spec AC-7).
+
+    `onset_minutes`/`event_end_minutes` gelten fuer DIESE Zone: fruehester
+    Beginn und spaetestes Ende unter ihren eigenen Punkten, nie eine globale
+    Spanne ueber mehrere Zonen (AC-6). `event_end_minutes` ist `None`, wenn
+    kein Punkt der Zone ein Ende kennt.
+    """
+    km_from: float
+    km_to: float
+    onset_minutes: int
+    event_end_minutes: int | None
+
+
+def derive_rain_zones(
+    points: "Sequence[GPXPoint]",
+    results: "Sequence[NowcastResult | None]",
+) -> list[RainZone]:
+    """Benachbarte NASSE Punkte zu Zonen verschmelzen (E2/E4, s. Modulkopf).
+
+    Nass heisst: das Ergebnis dieses Punktes traegt einen Beginn
+    (`onset_minutes is not None`). Punkte ohne Ergebnis (`None`) werden
+    uebersprungen, jeder uebrige trockene Punkt schliesst die laufende Zone.
+    """
+    zonen: list[RainZone] = []
+    laufend: list[tuple[float, int, int | None]] = []
+
+    def _abschliessen() -> None:
+        if not laufend:
+            return
+        zonen.append(
+            RainZone(
+                km_from=min(k for k, _o, _e in laufend),
+                km_to=max(k for k, _o, _e in laufend),
+                onset_minutes=min(o for _k, o, _e in laufend),
+                event_end_minutes=(
+                    max(e for _k, _o, e in laufend if e is not None)
+                    if any(e is not None for _k, _o, e in laufend)
+                    else None
+                ),
+            )
+        )
+        laufend.clear()
+
+    for punkt, ergebnis in zip(points, results):
+        if ergebnis is None:
+            continue  # E4: echte Luecke — weder nass noch trocken
+        onset = getattr(ergebnis, "onset_minutes", None)
+        if onset is None:
+            _abschliessen()  # E2: der trockene Punkt TRENNT
+            continue
+        laufend.append(
+            (
+                punkt.distance_from_start_km,
+                onset,
+                getattr(ergebnis, "event_end_minutes", None),
+            )
+        )
+    _abschliessen()
+    return zonen

--- a/src/services/trip_alert.py
+++ b/src/services/trip_alert.py
@@ -38,6 +38,7 @@ from services.notification_service import (
     RadarAlertRequest,
 )
 from output.renderers.alert.segments import normalize_segment_id
+from services.rain_extent import derive_rain_zones  # Issue #2051 S2a
 from services.trip_segments import measured_segment_km  # Issue #2036
 from services.point_weather import AlertEvaluationConfig, TripSegmentWeatherAdapter
 from services.corridor_threshold import CorridorHit
@@ -158,6 +159,22 @@ def radar_alert_due(result: object, threshold_min: int) -> bool:
     if onset is not None and onset <= threshold_min:
         return True
     return bool(getattr(result, "already_running", False))
+
+
+def _zonen_messwert(result):
+    """Issue #2051 S2a (E4): ein Nowcast-Ergebnis OHNE verwertbare Frames ist
+    fuer die Zonenbildung `None`, kein "trocken".
+
+    `throttled` (Budget-Drosselung) und `data_unavailable` (Ausfall der
+    Quelle) heissen beide "keine Beobachtung an diesem Punkt". Als trocken
+    gewertet wuerden sie eine Nass-Zone TRENNEN und damit eine Aussage ueber
+    das Wetter erfinden, die die Daten nicht hergeben.
+    """
+    if result is None:
+        return None
+    if getattr(result, "throttled", False) or getattr(result, "data_unavailable", False):
+        return None
+    return result
 
 
 def _radar_e1_fields(
@@ -1564,12 +1581,21 @@ class TripAlertService:
                 )
                 continue
 
-            # Genau EIN get_nowcast-Call pro Trip (Budget, #1329) — seit
-            # Issue #2017 an dem Ort, an dem der Nutzer zur MITTE des
+            # Bis zu RADAR_ZONE_MAX_POINTS get_nowcast-Calls pro Trip
+            # (Budget, #1329; Deckel und Abstand aus `trip_segments`) — seit
+            # Issue #2017 ab dem Ort, an dem der Nutzer zur MITTE des
             # Vorwarnfensters sein wird, nicht mehr am Startpunkt des
             # Segments (den hat er zu diesem Zeitpunkt laengst verlassen;
-            # gemessener Median-Versatz 1,99 km). Die Zusicherung "ein
-            # Abruf" ist damit nicht beruehrt — sie wandert nur mit.
+            # gemessener Median-Versatz 1,99 km).
+            #
+            # Issue #2051 S2a: die #2017-Zusicherung "genau EIN Abruf" ist
+            # BEWUSST auf eine Obergrenze abgeloest (Spec, Abschnitt
+            # "Abgeloeste Zusicherung") — die raeumliche Ausdehnung des
+            # Ereignisses braucht mehrere Messpunkte entlang der
+            # Reststrecke. Der ERSTE Punkt bleibt der #2017-Messpunkt und
+            # traegt unveraendert die Ausloeseregel; die uebrigen liefern
+            # ausschliesslich die Zonen. Unterhalb des Punktabstands
+            # (Reststrecke < 2 km) bleibt es bei genau einem Abruf.
             #
             # Onset-frei: `_at` ist ein FESTER Zeitpunkt (halbes Fenster),
             # kein aus dem Nowcast-Ergebnis abgeleiteter. Der Onset entsteht
@@ -1580,7 +1606,7 @@ class TripAlertService:
             # `from ... import` gebunden: eine beim Import gebundene Kopie
             # liefe still am Drift-Schutz aus #2009 vorbei.
             from services import radar_service as radar_service_mod
-            from services.trip_segments import position_at_time
+            from services import trip_segments as trip_segments_mod
 
             _at = now_utc + timedelta(
                 minutes=radar_service_mod.RADAR_ONSET_THRESHOLD_MIN // 2
@@ -1599,7 +1625,12 @@ class TripAlertService:
             # UNTERSCHEIDBARE Meldung. Unter "Radar nowcast failed" abgelegt
             # waere er stiller als vorher — er kommt gar nicht vom Abruf.
             try:
-                _pos = position_at_time(trip, active, segment_date, _at)
+                # Issue #2051 S2a: die Punktbildung ruft `position_at_time()`
+                # selbst — der erste Punkt IST der bisherige Messpunkt.
+                _punkte = trip_segments_mod.points_along_remaining_route(
+                    trip, active, segment_date, _at,
+                )
+                _pos = _punkte[0]
             except Exception as e:
                 logger.error(
                     "Radar alert: Positionsbestimmung fuer Trip %s "
@@ -1638,6 +1669,43 @@ class TripAlertService:
                         trip, gate.reason, effective_channels,
                     )
                 continue
+
+            # Issue #2051 S2a: die uebrigen Punkte der Reststrecke, sequenziell
+            # und mit derselben Prioritaet (Muster
+            # `compare_radar_alert._detect_triggered_locations`).
+            #
+            # Anders als der ERSTE Abruf (oben, traegt die Ausloeseregel)
+            # bricht ein Fehler hier den Trip NICHT ab: ein Punkt ohne
+            # verwertbare Daten ist eine Luecke, weder nass noch trocken (E4),
+            # und darf den Alarm nicht kosten. `throttled`/`data_unavailable`
+            # sind derselbe Fall in Feldform — keine Frames, aber eben auch
+            # kein belegtes "trocken", das eine Zone trennen duerfte.
+            _zonen_ergebnisse: list = [_zonen_messwert(result)]
+            for _p in _punkte[1:]:
+                try:
+                    _zonen_ergebnisse.append(
+                        _zonen_messwert(
+                            radar_svc.get_nowcast(
+                                _p.lat, _p.lon,
+                                elevation_m=(
+                                    int(round(_p.elevation_m))
+                                    if _p.elevation_m is not None else None
+                                ),
+                                priority="polling",
+                            )
+                        )
+                    )
+                except Exception as e:
+                    logger.warning(
+                        "Radar alert: Nowcast fuer Zonenpunkt (%.4f, %.4f) des "
+                        "Trips %s fehlgeschlagen (%s) — der Punkt faellt aus "
+                        "der Ausdehnung heraus, der Alarm laeuft weiter.",
+                        _p.lat, _p.lon, trip.id, e,
+                    )
+                    _zonen_ergebnisse.append(None)
+            _rain_zones = tuple(
+                derive_rain_zones(_punkte, _zonen_ergebnisse)
+            )
 
             # Issue #2065: die gemessene Menge wird HIER festgehalten --
             # `result` traegt weiter unten die NotificationResult, die
@@ -1945,6 +2013,13 @@ class TripAlertService:
                 ),
                 km_from=active.start_point.distance_from_start_km,
                 km_to=active.end_point.distance_from_start_km,
+                # Issue #2036/#2051 S2a: stammen diese km-Zahlen aus echter
+                # GPX-Wegstrecke? Die Etappe weiss es (`distance_measured`),
+                # der Onset-Pfad hat sie bis hierher nie gefragt — ohne die
+                # Antwort bliebe die Ausdehnung unten auf jeder Etappe stumm.
+                km_measured=getattr(active, "distance_measured", False),
+                # Issue #2051 S2a: die Nass-Zonen der Reststrecke.
+                rain_zones=_rain_zones,
                 # Issue #1744 A1: dieselbe Etappe, die schon die km-Spanne
                 # liefert — nur zusaetzlich mit ihrer Kennung, damit der
                 # Nowcast denselben Ort benennt wie die amtliche Warnung.

--- a/src/services/trip_segments.py
+++ b/src/services/trip_segments.py
@@ -30,6 +30,12 @@ logger = logging.getLogger("trip_segments")
 # ist ein Nachbearbeitungs-Artefakt und macht die Etappe unvermessen.
 _MEASURED_SLACK_KM = 0.01
 
+# Issue #2051 S2a: Abstand ueber der INCA-Zellgroesse (1 km), Deckel deckt bis
+# zu 12 km Reststrecke ab (ueber dem Etappen-Median 9,2 km). Downstream-Leser
+# referenzieren die MODUL-Variable, kein Bindezeit-Import (Drift-Schutz #2009).
+RADAR_ZONE_POINT_SPACING_KM = 2.0
+RADAR_ZONE_MAX_POINTS = 6
+
 
 def _parse_hhmm(value: str) -> Optional[time]:
     """Parse 'HH:MM' to a time object; returns None on malformed input."""
@@ -633,3 +639,77 @@ def position_at_time(
         _LOOKAHEAD_DAYS, last_end_point.lat, last_end_point.lon,
     )
     return last_end_point
+
+
+def _lerp_point(a: GPXPoint, b: GPXPoint, frac: float) -> GPXPoint:
+    """Punkt zwischen ``a`` und ``b`` beim Streckenanteil ``frac`` (Issue #2051
+    S2a). Dieselbe lineare Naeherung wie ``_interpolate_point()`` — dort nach
+    dem Zeitanteil, hier nach dem Streckenanteil."""
+    frac = max(0.0, min(1.0, frac))
+    if a.elevation_m is None and b.elevation_m is None:
+        elev = None
+    else:
+        elev_a = a.elevation_m if a.elevation_m is not None else b.elevation_m
+        elev_b = b.elevation_m if b.elevation_m is not None else a.elevation_m
+        elev = elev_a + frac * (elev_b - elev_a)
+    return GPXPoint(
+        lat=a.lat + frac * (b.lat - a.lat),
+        lon=a.lon + frac * (b.lon - a.lon),
+        elevation_m=elev,
+        distance_from_start_km=(
+            a.distance_from_start_km
+            + frac * (b.distance_from_start_km - a.distance_from_start_km)
+        ),
+    )
+
+
+def _remaining_km(active: TripSegment, at: datetime) -> float:
+    """Reststrecke der AKTIVEN Etappe ab ``at`` (Issue #2051 S2a).
+
+    Ueber den Zeitanteil des Segments, nicht ueber die Luftlinie zum Endpunkt:
+    ``distance_km`` ist auf vermessenen Etappen die echte Wegstrecke, eine
+    Luftlinie waere dort systematisch zu kurz. Liegt ``at`` hinter dem
+    Segmentende (die Vorwaertssuche von ``position_at_time()`` greift dann),
+    ist die Reststrecke 0 — es bleibt beim heutigen Einzelabruf.
+    """
+    if not isinstance(active.segment_id, int) or active.distance_km <= 0.0:
+        return 0.0
+    span_s = (active.end_time - active.start_time).total_seconds()
+    p = 0.0 if span_s <= 0 else (at - active.start_time).total_seconds() / span_s
+    p = max(0.0, min(1.0, p))
+    return (1.0 - p) * active.distance_km
+
+
+def points_along_remaining_route(
+    trip: "Trip", active: TripSegment, segment_date: date, at: datetime,
+) -> List[GPXPoint]:
+    """Bis zu ``RADAR_ZONE_MAX_POINTS`` Punkte im Abstand
+    ``RADAR_ZONE_POINT_SPACING_KM`` entlang der Reststrecke der AKTIVEN Etappe
+    ab ``at`` (Issue #2051 S2a).
+
+    Der ERSTE Punkt ist unveraendert ``position_at_time()`` — der heutige
+    Messpunkt (#2017). Liegt die Reststrecke unter dem Punktabstand, bleibt es
+    bei genau diesem einen Punkt, das Verhalten ist dann bit-identisch zum
+    Stand vor dieser Scheibe.
+
+    Die Platzierung der Folgepunkte laeuft ueber die Geometrie (lineare
+    Interpolation zum Endpunkt), nicht ueber ``distance_from_start_km`` —
+    unvermessene Etappen tragen dort keine echte Wegstrecke, gemessen wird
+    aber ueberall (E3). Die km-Zahl einer Zone erscheint erst im Text, wenn
+    die Etappe vermessen ist.
+    """
+    start = position_at_time(trip, active, segment_date, at)
+    rest_km = _remaining_km(active, at)
+    if rest_km < RADAR_ZONE_POINT_SPACING_KM:
+        return [start]
+    anzahl = min(
+        RADAR_ZONE_MAX_POINTS,
+        int(rest_km // RADAR_ZONE_POINT_SPACING_KM) + 1,
+    )
+    return [start] + [
+        _lerp_point(
+            start, active.end_point,
+            (i * RADAR_ZONE_POINT_SPACING_KM) / rest_km,
+        )
+        for i in range(1, anzahl)
+    ]

--- a/tests/tdd/test_alert_quiet_hours_robustness.py
+++ b/tests/tdd/test_alert_quiet_hours_robustness.py
@@ -239,12 +239,25 @@ class _CoordFrameSource:
         self._toleranz = toleranz
         self.calls: list[tuple[float, float]] = []
         self.unbekannt: list[tuple[float, float]] = []
+        # Welche HINTERLEGTEN Koordinaten real getroffen wurden — in
+        # Aufrufreihenfolge. `calls` allein beantwortet nicht, ob ein
+        # hinterlegter Messpunkt ueberhaupt drankam (s.
+        # `_keine_unbekannten_koordinaten`).
+        self.getroffen: list[tuple[float, float]] = []
+
+    def _treffer(self, lat: float, lon: float) -> tuple[float, float] | None:
+        """Der hinterlegte Schluessel zu (lat, lon) — ``None``, wenn keiner passt."""
+        for k_lat, k_lon in self._by_coord:
+            if abs(lat - k_lat) <= self._toleranz and abs(lon - k_lon) <= self._toleranz:
+                return (k_lat, k_lon)
+        return None
 
     def __call__(self, lat: float, lon: float) -> list:
         self.calls.append((lat, lon))
-        for (k_lat, k_lon), frames in self._by_coord.items():
-            if abs(lat - k_lat) <= self._toleranz and abs(lon - k_lon) <= self._toleranz:
-                return frames
+        key = self._treffer(lat, lon)
+        if key is not None:
+            self.getroffen.append(key)
+            return self._by_coord[key]
         self.unbekannt.append((lat, lon))
         raise AssertionError(
             f"_CoordFrameSource: fuer ({lat:.5f}, {lon:.5f}) ist nichts "
@@ -255,17 +268,76 @@ class _CoordFrameSource:
         )
 
 
-def _keine_unbekannten_koordinaten(frame_source: "_CoordFrameSource") -> None:
+def _keine_unbekannten_koordinaten(
+    frame_source: "_CoordFrameSource",
+    *,
+    messpunkte: list[tuple[float, float]],
+    zonen_folgepunkte_erlaubt: bool = False,
+) -> None:
     """Der laute Fehlschlag aus ``_CoordFrameSource`` wird vom ``except
     Exception`` der Alarm-Pfade geschluckt (``trip_alert.py``:
     "Radar nowcast failed", ``compare_radar_alert.py`` analog) und kaeme sonst
     nur als "kein Alarm" an. Diese Zusicherung holt den Grund zurueck an die
-    Oberflaeche — sie steht VOR der eigentlichen Fachzusicherung."""
-    assert not frame_source.unbekannt, (
-        f"Der Pruefling hat an {frame_source.unbekannt!r} abgefragt — dort ist "
-        f"in der Fixture nichts hinterlegt. Alle Abrufe: "
-        f"{frame_source.calls!r}. Ein nachfolgendes 'kein Alarm' waere die "
-        f"Folge dieses Verdrahtungs-Befunds, nicht der geprueften Fachlogik."
+    Oberflaeche — sie steht VOR der eigentlichen Fachzusicherung.
+
+    Bewacht werden die AUSLOESENDEN Abrufe (``messpunkte``): jeder muss real
+    stattgefunden haben, und der allererste Abruf ueberhaupt muss einer von
+    ihnen sein. Wandert der Messpunkt (wie in #2017 von ``start_point`` auf die
+    interpolierte Position), fehlt sein Treffer — der Test faellt dann mit dem
+    GRUND durch, nicht mit dem Symptom "kein Alarm".
+
+    ``zonen_folgepunkte_erlaubt`` (Issue #2051 S2a): seit dieser Scheibe fragt
+    ``check_radar_alerts()`` nach dem Messpunkt bis zu
+    ``RADAR_ZONE_MAX_POINTS - 1`` weitere Punkte entlang der Reststrecke ab —
+    ausschliesslich fuer die raeumliche AUSDEHNUNG. Ihr Ausfall ist laut Spec
+    fail-soft (``trip_alert.py``: "der Punkt faellt aus der Ausdehnung heraus,
+    der Alarm laeuft weiter") und verfaelscht keine Fachaussage. Ihre
+    Koordinaten haengen an der Laufzeit-Position und sind zwischen zwei Laeufen
+    nicht stabil (CI 65.04110…, lokal 65.04106…), lassen sich also nicht
+    hinterlegen. Sie duerfen deshalb — und NUR sie — unbekannt bleiben; ihre
+    Anzahl bleibt auf das gedeckelt, was S2a je erzeugen kann. Das ist keine
+    Aufweichung: der ausloesende Abruf wird unveraendert scharf bewacht.
+    """
+    from services import trip_segments as trip_segments_mod
+
+    assert frame_source.calls, (
+        "Der Pruefling hat ueberhaupt keine Koordinate abgefragt — dann bewacht "
+        "diese Zusicherung nichts (Positivkontrolle)."
+    )
+    assert frame_source._treffer(*frame_source.calls[0]) is not None, (
+        f"Der ERSTE Abruf {frame_source.calls[0]!r} traegt die Ausloeseregel und "
+        f"muss an einem hinterlegten Messpunkt stattfinden — dort ist nichts "
+        f"hinterlegt. Erwartete Messpunkte: {messpunkte!r}, alle Abrufe: "
+        f"{frame_source.calls!r}."
+    )
+    fehlend = [
+        p for p in messpunkte
+        if not any(
+            abs(p[0] - g[0]) <= 1e-9 and abs(p[1] - g[1]) <= 1e-9
+            for g in frame_source.getroffen
+        )
+    ]
+    assert not fehlend, (
+        f"Diese hinterlegten Messpunkte wurden NIE abgefragt: {fehlend!r}. "
+        f"Getroffen wurden {frame_source.getroffen!r}, alle Abrufe: "
+        f"{frame_source.calls!r}. Der ausloesende Abruf steht damit an einer "
+        f"anderen Koordinate als gedacht — ein Verdrahtungs-Befund (#2017)."
+    )
+    if not zonen_folgepunkte_erlaubt:
+        assert not frame_source.unbekannt, (
+            f"Der Pruefling hat an {frame_source.unbekannt!r} abgefragt — dort ist "
+            f"in der Fixture nichts hinterlegt. Alle Abrufe: "
+            f"{frame_source.calls!r}. Ein nachfolgendes 'kein Alarm' waere die "
+            f"Folge dieses Verdrahtungs-Befunds, nicht der geprueften Fachlogik."
+        )
+        return
+    obergrenze = (trip_segments_mod.RADAR_ZONE_MAX_POINTS - 1) * len(messpunkte)
+    assert len(frame_source.unbekannt) <= obergrenze, (
+        f"{len(frame_source.unbekannt)} unbekannte Abrufe "
+        f"({frame_source.unbekannt!r}) — mehr als die hoechstens {obergrenze} "
+        f"Zonen-Folgepunkte, die S2a fuer {len(messpunkte)} Messpunkt(e) "
+        f"erzeugen kann. Das ist kein fail-soft-Zonenpunkt mehr, sondern ein "
+        f"Verdrahtungs-Befund. Alle Abrufe: {frame_source.calls!r}."
     )
 
 
@@ -592,7 +664,13 @@ def test_ac3_broken_quiet_value_does_not_abort_trip_radar_run():
     )
     sent = svc.check_radar_alerts()
 
-    _keine_unbekannten_koordinaten(frame_source)
+    # Beide Messpunkte MUESSEN abgefragt worden sein (je Trip der ausloesende
+    # Abruf); die Zonen-Folgepunkte aus #2051 S2a duerfen unbekannt sein.
+    _keine_unbekannten_koordinaten(
+        frame_source,
+        messpunkte=[_mp_gesund, _mp_kaputt],
+        zonen_folgepunkte_erlaubt=True,
+    )
     assert sent >= 1 and mail_calls, (
         f"Der gesunde Trip {tid_healthy!r} MUSS seinen Regen-Beginn-Alarm "
         f"zustellen, obwohl {tid_broken!r} einen unbrauchbaren Ruhezeit-Wert "
@@ -972,7 +1050,12 @@ def test_ac8_effect_nowcast_compare_run_names_the_affected_preset(caplog):
         with caplog.at_level(logging.WARNING):
             svc.check_all_compare_presets()
 
-        _keine_unbekannten_koordinaten(frame_source)
+        # Ortsvergleich-Pfad: keine Zonen-Folgepunkte (#2051 S2a betrifft nur
+        # `check_radar_alerts()`) — hier bleibt JEDE unbekannte Koordinate ein
+        # Befund.
+        _keine_unbekannten_koordinaten(
+            frame_source, messpunkte=[(LAT_BROKEN, LON_BROKEN)],
+        )
         engine_warnings = _engine_quiet_warnings(caplog)
         assert engine_warnings, (
             "Die Engine hat beim echten Nowcast-Lauf keine Warnzeile "

--- a/tests/tdd/test_issue_822_radar_nowcast_segment.py
+++ b/tests/tdd/test_issue_822_radar_nowcast_segment.py
@@ -608,8 +608,20 @@ def test_ac3_nowcast_called_at_segment_coordinates():
         now_ref = datetime.now(timezone.utc)
         svc.check_radar_alerts()
 
-        assert call_count[0] == 1, (
-            f"AC-3: get_nowcast muss genau 1× aufgerufen werden, war {call_count[0]}"
+        # Issue #2051 S2a: die #2017-Zusicherung "genau 1 Aufruf" wird
+        # BEWUSST auf eine Obergrenze abgeloest (Spec, Abschnitt "Abgeloeste
+        # Zusicherung") — S2a fragt bis zu RADAR_ZONE_MAX_POINTS Punkte
+        # entlang der Reststrecke ab. Ueber die Modulreferenz gelesen, nicht
+        # als Literal dupliziert (Drift-Schutz #2009-Muster).
+        from services.trip_segments import RADAR_ZONE_MAX_POINTS
+
+        assert call_count[0] <= RADAR_ZONE_MAX_POINTS, (
+            f"AC-3/#2051 AC-12: get_nowcast darf hoechstens "
+            f"{RADAR_ZONE_MAX_POINTS}× aufgerufen werden (Deckel), war "
+            f"{call_count[0]}"
+        )
+        assert call_count[0] >= 1, (
+            "AC-3: get_nowcast muss mindestens 1× aufgerufen werden, war 0"
         )
 
         from app.loader import load_all_trips
@@ -1280,48 +1292,73 @@ def test_2017_ac10_spaeter_onset_wird_nicht_mehr_pauschal_unterdrueckt():
 
 
 def test_2017_ac12_genau_ein_get_nowcast_aufruf_je_lauf():
-    """AC-12 (Budget-Invariante, Alarm-Pfad): genau EIN `get_nowcast()`-Aufruf
-    pro Trip und Durchlauf — die Verlegung des Abrufpunkts erhoeht die Zahl
-    der Abrufe nicht.
+    """#2051 S2a AC-12 (vormals #2017 AC-12, hier bewusst UMGEBAUT statt
+    ersetzt — Spec-Abschnitt "Abgeloeste Zusicherung"): die #2017-Aussage
+    "genau EIN `get_nowcast()`-Aufruf pro Trip" wird auf eine OBERGRENZE
+    abgeloest. #2051 fragt bis zu `RADAR_ZONE_MAX_POINTS` Punkte entlang der
+    Reststrecke ab statt eines einzigen Messpunkts.
 
-    Gezaehlt wird an ZWEI Naehten: am `get_nowcast()`-Seam (die Zusicherung
-    selbst) und am `frame_source`-Seam (dort entstehen die realen Kosten).
-    Der Kommentar `trip_alert.py` ("Genau EIN get_nowcast-Call pro Trip an
-    Segment-Startpunkt") hielt das bisher nur als Prosa fest und verliert mit
-    dieser Aenderung seinen Anker.
+    Gezaehlt wird weiterhin an ZWEI Naehten: am `get_nowcast()`-Seam (die
+    Zusicherung selbst) und am `frame_source`-Seam (dort entstehen die
+    realen Kosten) — beide muessen die Obergrenze einhalten, KEINER darf sie
+    unbemerkt umgehen.
 
-    RED heute nicht wegen der ZAHL — die stimmt bereits —, sondern weil der
-    eine Aufruf am falschen Ort erfolgt. Beides gehoert in EINE Zusicherung:
-    "ein Abruf, und zwar am neuen Messpunkt". Ein iteratives Nachfassen an der
-    Onset-Position (Variante 2, in der Spec ausgeschlossen) risse die
-    Zaehlung, ein unveraenderter Startpunkt die Ortsangabe.
+    RED heute: `services.trip_segments.RADAR_ZONE_MAX_POINTS` existiert noch
+    nicht -> ImportError.
     """
+    from services.trip_segments import RADAR_ZONE_MAX_POINTS
+    from utils.geo import haversine_km
+
     uid = fresh_uid("2017-ac12")
     try:
         sent, _mails, dienst, frames, trip, now_utc = _alarm_lauf_2017(
             uid, "trip-2017-ac12", start="11:00", ende="15:00",
         )
-        assert len(dienst.calls) == 1, (
-            f"AC-12: erwartet genau EIN get_nowcast() je Trip und Lauf, "
-            f"erhalten {len(dienst.calls)} (sent={sent}): {dienst.calls!r}"
+        assert len(dienst.calls) <= RADAR_ZONE_MAX_POINTS, (
+            f"AC-12: erwartet hoechstens {RADAR_ZONE_MAX_POINTS} "
+            f"get_nowcast()-Aufrufe je Trip und Lauf (Deckel), erhalten "
+            f"{len(dienst.calls)} (sent={sent}): {dienst.calls!r}"
         )
-        assert frames.call_count == 1, (
-            f"AC-12: erwartet genau EINEN echten Frame-Abruf (Kostenstelle), "
-            f"erhalten {frames.call_count}"
+        assert frames.call_count <= RADAR_ZONE_MAX_POINTS, (
+            f"AC-12: erwartet hoechstens {RADAR_ZONE_MAX_POINTS} echte "
+            f"Frame-Abrufe (Kostenstelle), erhalten {frames.call_count}"
+        )
+        assert len(dienst.calls) >= 1, (
+            "AC-12: mindestens EIN Aufruf wird weiterhin erwartet, war 0"
         )
         _active, p, (soll_lat, soll_lon, _h) = _erwartete_messposition(
             trip, now_utc, _alarm_offset_minuten(),
         )
         ruf = dienst.calls[0]
         assert abs(ruf["lat"] - soll_lat) < 1e-6 and abs(ruf["lon"] - soll_lon) < 1e-6, (
-            f"AC-12: der EINE Abruf muss am neuen Messpunkt erfolgen — "
+            f"AC-12: der ERSTE Abruf muss am neuen Messpunkt erfolgen — "
             f"({ruf['lat']:.5f}, {ruf['lon']:.5f}) statt erwartet "
             f"({soll_lat:.5f}, {soll_lon:.5f}), p={p:.4f}"
         )
-        assert ruf["priority"] == "polling", (
-            f"AC-12: der Scheduler-Abruf bleibt drosselbar (`polling`), war "
-            f"{ruf['priority']!r} — sonst umgeht die Verlegung das Budget-Gate"
+        for r in dienst.calls:
+            assert r["priority"] == "polling", (
+                f"AC-12: jeder Scheduler-Abruf bleibt drosselbar (`polling`), "
+                f"war {r['priority']!r} — sonst umgeht die Verlegung das "
+                f"Budget-Gate"
+            )
+        # AC-12: alle abgefragten Koordinaten liegen auf der erwarteten
+        # Reststrecke (hoechstens `active.distance_km` vom Segment-Start
+        # entfernt) und keine zwei sind identisch.
+        alle_coords = [(r["lat"], r["lon"]) for r in dienst.calls]
+        assert len(set(alle_coords)) == len(alle_coords), (
+            f"AC-12: keine zwei abgefragten Koordinaten duerfen identisch "
+            f"sein, erhalten {alle_coords!r}"
         )
+        for lat, lon in alle_coords:
+            abstand_vom_start = haversine_km(
+                _active.start_point.lat, _active.start_point.lon, lat, lon,
+            )
+            assert abstand_vom_start <= _active.distance_km + 0.05, (
+                f"AC-12: Koordinate ({lat:.5f},{lon:.5f}) liegt "
+                f"{abstand_vom_start:.3f} km vom Segment-Start entfernt — "
+                f"mehr als die Segmentlaenge {_active.distance_km:.3f} km "
+                f"(nicht auf der Reststrecke)"
+            )
     finally:
         clean_uid(uid)
 
@@ -1403,6 +1440,7 @@ def test_2017_fadv1_positionsfehler_eines_trips_kostet_den_anderen_nicht_den_ala
                 mail_sink=lambda subject, body: mails.append((subject, body)),
             )
             sent = svc.check_radar_alerts()
+            now_utc = datetime.now(timezone.utc)
 
         assert sent == 1, (
             f"F-ADV1: der gesunde Trip {gesund_id!r} MUSS seinen Alarm "
@@ -1414,10 +1452,42 @@ def test_2017_fadv1_positionsfehler_eines_trips_kostet_den_anderen_nicht_den_ala
             f"F-ADV1: erwartet genau EINE zugestellte Mail (die des gesunden "
             f"Trips), erhalten {len(mails)}"
         )
-        assert frames.call_count == 1, (
-            f"F-ADV1: der kaputte Trip darf kein Kontingent verbrauchen — "
-            f"sein Abruf kommt gar nicht erst zustande. Frame-Abrufe: "
-            f"{frames.call_count}"
+
+        # Issue #2051 S2a AC-14 (Umbau, Spec "Abgeloeste Zusicherung"):
+        # bisher gemeinsam gezaehlt (`frames.call_count == 1`, weil der
+        # Einzelpunkt-Abruf des #2017-Standes nur EINE Zahl kannte). Seit
+        # S2a fragt der gesunde Trip bis zu RADAR_ZONE_MAX_POINTS Punkte ab
+        # -- der kaputte Trip verbraucht strukturell weiterhin NULL Punkte,
+        # weil seine Ausnahme VOR jeder Koordinatenberechnung greift (er
+        # kann also gar keinen der gezaehlten Aufrufe beigetragen haben).
+        # Damit sind beide Trips GETRENNT nachweisbar, obwohl `frames` ein
+        # einziges, geteiltes Zaehlobjekt bleibt (derselbe Lauf, dieselbe
+        # Aussage wie das AC: "der Lauf durch beide Trips").
+        #
+        # Die erwartete Punktzahl fuer den GESUNDEN Trip wird ANALYTISCH aus
+        # seiner tatsaechlichen Reststrecke abgeleitet (nicht als Literal
+        # dupliziert) -- dieselbe Formel, die `points_along_remaining_route`
+        # laut Spec implementiert.
+        from app.loader import load_all_trips
+        from services.trip_segments import RADAR_ZONE_MAX_POINTS, RADAR_ZONE_POINT_SPACING_KM
+
+        trip_gesund = next(t for t in load_all_trips(user_id=uid) if t.id == gesund_id)
+        _active, p, _pos = _erwartete_messposition(
+            trip_gesund, now_utc, _alarm_offset_minuten(),
+        )
+        reststrecke_km = (1.0 - p) * _active.distance_km
+        erwartete_punkte = min(
+            RADAR_ZONE_MAX_POINTS,
+            int(reststrecke_km // RADAR_ZONE_POINT_SPACING_KM) + 1,
+        )
+        assert frames.call_count == erwartete_punkte, (
+            f"AC-14: der gesunde Trip {gesund_id!r} muss ALLE erwarteten "
+            f"Punkte seiner Reststrecke ({reststrecke_km:.3f} km) abfragen — "
+            f"erwartet {erwartete_punkte} (Abstand "
+            f"{RADAR_ZONE_POINT_SPACING_KM} km, Deckel "
+            f"{RADAR_ZONE_MAX_POINTS}), erhalten {frames.call_count}. Der "
+            f"kaputte Trip {kaputt_id!r} muss dabei NULL Punkte verbraucht "
+            f"haben (s. Testvoraussetzung sent==1/mails==1 oben)."
         )
     finally:
         clean_uid(uid)

--- a/tests/tdd/test_radar_alert_follows_ortstag.py
+++ b/tests/tdd/test_radar_alert_follows_ortstag.py
@@ -236,18 +236,30 @@ def _assert_messpunkt(calls, erwartet, now_utc, *, label: str, alternative: str 
     Stufe 1 trennt "falsche Etappe/falscher Ortstag" von Stufe 2 "richtige
     Etappe, falsche Stelle darauf" — zwei verschiedene Befunde, zwei
     verschiedene Meldungen.
+
+    Issue #2051 S2a: die Aufrufzahl ist eine OBERGRENZE statt einer festen 1
+    (Spec-Abschnitt "Abgeloeste Zusicherung") — entlang der Reststrecke der
+    aktiven Etappe werden bis zu ``RADAR_ZONE_MAX_POINTS`` Punkte abgefragt.
+    Die Aussage dieser Datei bleibt unberuehrt: JEDER dieser Punkte muss auf
+    der erwarteten Etappe liegen, und der ERSTE ist unveraendert der
+    #2017-Messpunkt. Die Obergrenze kommt ueber die Modulreferenz, nicht als
+    Literal (Drift-Schutz #2009-Muster).
     """
-    assert len(calls) == 1, (
-        f"{label}: erwartet war GENAU EIN Nowcast-Abruf an der Etappe "
-        f"{erwartet.segment_id!r}, erhalten {len(calls)}: {calls!r}. {alternative}"
+    from services.trip_segments import RADAR_ZONE_MAX_POINTS
+
+    assert 1 <= len(calls) <= RADAR_ZONE_MAX_POINTS, (
+        f"{label}: erwartet waren 1 bis {RADAR_ZONE_MAX_POINTS} Nowcast-"
+        f"Abrufe an der Etappe {erwartet.segment_id!r} (Deckel #2051 S2a), "
+        f"erhalten {len(calls)}: {calls!r}. {alternative}"
     )
     punkt = calls[0]
     sp, ep = erwartet.start_point, erwartet.end_point
-    assert _liegt_auf_etappe(punkt, erwartet), (
-        f"{label}: der Abrufpunkt {punkt!r} liegt nicht auf der erwarteten "
-        f"Etappe {erwartet.segment_id!r} "
-        f"(({sp.lat}, {sp.lon}) → ({ep.lat}, {ep.lon})). {alternative}"
-    )
+    for i, kandidat in enumerate(calls):
+        assert _liegt_auf_etappe(kandidat, erwartet), (
+            f"{label}: der Abrufpunkt {kandidat!r} (Nr. {i}) liegt nicht auf "
+            f"der erwarteten Etappe {erwartet.segment_id!r} "
+            f"(({sp.lat}, {sp.lon}) → ({ep.lat}, {ep.lon})). {alternative}"
+        )
     soll, p = _messpunkt_der_etappe(erwartet, now_utc)
     assert punkt == pytest.approx(soll, abs=1e-6), (
         f"{label}: der Abrufpunkt {punkt!r} liegt zwar auf der erwarteten "

--- a/tests/tdd/test_regen_ausdehnung_messpunkte.py
+++ b/tests/tdd/test_regen_ausdehnung_messpunkte.py
@@ -1,0 +1,175 @@
+"""TDD RED — Issue #2051 Scheibe S2a: Mehrpunkt-Abfrage entlang der
+Reststrecke der aktiven Etappe.
+
+SPEC: docs/specs/modules/feat_2051_s2a_raeumliche_ausdehnung.md — AC-1, AC-2,
+AC-3.
+
+RED-Ursache: `services.trip_segments.points_along_remaining_route` (und die
+Modulkonstanten `RADAR_ZONE_POINT_SPACING_KM`/`RADAR_ZONE_MAX_POINTS`)
+existieren noch nicht -> ImportError.
+
+Mock-frei: echte `TripSegment`/`GPXPoint`-Objekte, echte `haversine_km()` zur
+Verifikation (kein Mock). `trip=None` ist fuer diese Faelle zulaessig, weil
+`points_along_remaining_route()` laut Spec `position_at_time()` als Baustein
+nutzt — dessen Vorschau-/Interpolations-Zweige (`at <= active.end_time`)
+lesen `trip` nicht, nur die Vorwaertssuche ueber Segment-/Tagesgrenzen tut
+das, die hier nie erreicht wird (`at` liegt stets innerhalb des Segments).
+"""
+from __future__ import annotations
+
+import math
+from datetime import date, datetime, timedelta, timezone
+
+from app.models import GPXPoint, TripSegment
+from utils.geo import haversine_km
+
+# Muss zu `utils.geo._EARTH_KM` passen — dort steht der Referenzwert; hier
+# nur zur Konstruktion, nicht als zweite Quelle der Wahrheit (die tatsaechlich
+# gemessene Distanz wird unten per `haversine_km()` GEGENGEPRUEFT, s.
+# `_aequator_segment`).
+_EARTH_KM = 6371.0088
+_UTC = timezone.utc
+
+
+def _aequator_segment(distance_km: float, *, segment_id: int = 1) -> TripSegment:
+    """Ein `TripSegment` entlang des Aequators (lat=0).
+
+    Am Aequator faellt die Grosskreis-Distanz (`haversine_km`) mit der
+    linearen Laengengrad-Interpolation zusammen (dlat=0, cos(0)=1 in der
+    Formel) — der Test wird dadurch unabhaengig davon, ob die Punktbildung
+    linear in Grad oder ueber wiederholte `haversine_km`-Schritte
+    interpoliert.
+    """
+    delta_lon = math.degrees(distance_km / _EARTH_KM)
+    start = GPXPoint(lat=0.0, lon=0.0, elevation_m=1000.0, distance_from_start_km=0.0)
+    end = GPXPoint(
+        lat=0.0, lon=delta_lon, elevation_m=1000.0,
+        distance_from_start_km=distance_km,
+    )
+    gemessen = haversine_km(start.lat, start.lon, end.lat, end.lon)
+    assert abs(gemessen - distance_km) < 1e-6, (
+        f"Testvoraussetzung: die konstruierte Strecke muss {distance_km} km "
+        f"messen, misst tatsaechlich {gemessen} km"
+    )
+    start_time = datetime(2026, 8, 23, 8, 0, tzinfo=_UTC)
+    end_time = start_time + timedelta(hours=4)
+    return TripSegment(
+        segment_id=segment_id, start_point=start, end_point=end,
+        start_time=start_time, end_time=end_time, duration_hours=4.0,
+        distance_km=distance_km, ascent_m=0.0, descent_m=0.0,
+    )
+
+
+def test_ac1_zwoelf_km_reststrecke_ergibt_sechs_gedeckelte_punkte():
+    """AC-1: Reststrecke 12,0 km -> genau 6 Punkte bei km 0/2/4/6/8/10 — der
+    Deckel `RADAR_ZONE_MAX_POINTS=6` greift, die letzten 2 km bleiben
+    unabgefragt."""
+    from services.trip_segments import (
+        RADAR_ZONE_MAX_POINTS,
+        RADAR_ZONE_POINT_SPACING_KM,
+        points_along_remaining_route,
+    )
+
+    assert RADAR_ZONE_POINT_SPACING_KM == 2.0, (
+        f"Testvoraussetzung: Abstand muss 2.0 km sein, war "
+        f"{RADAR_ZONE_POINT_SPACING_KM}"
+    )
+    assert RADAR_ZONE_MAX_POINTS == 6, (
+        f"Testvoraussetzung: Deckel muss 6 sein, war {RADAR_ZONE_MAX_POINTS}"
+    )
+
+    seg = _aequator_segment(12.0)
+    at = seg.start_time  # Vorschau-Zweig von position_at_time: p=0, Reststrecke = volle Laenge.
+
+    pts = points_along_remaining_route(None, seg, date(2026, 8, 23), at)
+
+    assert len(pts) == RADAR_ZONE_MAX_POINTS, (
+        f"AC-1: erwartet genau {RADAR_ZONE_MAX_POINTS} Punkte (Deckel), "
+        f"erhalten {len(pts)}"
+    )
+    erwartete_km = [i * RADAR_ZONE_POINT_SPACING_KM for i in range(RADAR_ZONE_MAX_POINTS)]
+    gemessene_km = [
+        haversine_km(seg.start_point.lat, seg.start_point.lon, p.lat, p.lon)
+        for p in pts
+    ]
+    for i, (soll, ist) in enumerate(zip(erwartete_km, gemessene_km)):
+        assert abs(soll - ist) < 0.05, (
+            f"AC-1: Punkt {i} liegt bei km {ist:.3f}, erwartet km {soll:.1f} "
+            f"(alle Punkte: {gemessene_km})"
+        )
+    # Negativkontrolle gegen die Formeigenschaft "Form statt Wert": eine
+    # Implementierung, die z.B. km 0/2/4/6/8/9 (falsch geraster) liefert,
+    # faellt hier durch, nicht nur eine, die die Punktzahl verfehlt.
+    assert abs(gemessene_km[-1] - 10.0) < 0.05, (
+        f"AC-1: der letzte der 6 Punkte muss bei km 10 liegen (nicht bei km "
+        f"12, dem Etappenende), erhalten km {gemessene_km[-1]:.3f}"
+    )
+
+
+def test_ac2_unter_zwei_km_reststrecke_ergibt_genau_einen_punkt():
+    """AC-2 (Positivkontrolle zu AC-1): Reststrecke 1,9 km (unter der 2-km-
+    Schwelle) -> genau EIN Punkt an der heutigen Fenstermitte-Position
+    (unveraendertes Verhalten gegenueber dem Stand vor dieser Spec)."""
+    from services.trip_segments import points_along_remaining_route
+
+    seg = _aequator_segment(1.9)
+    at = seg.start_time
+
+    pts = points_along_remaining_route(None, seg, date(2026, 8, 23), at)
+
+    assert len(pts) == 1, (
+        f"AC-2: erwartet genau 1 Punkt unterhalb der 2-km-Schwelle, erhalten "
+        f"{len(pts)}: {pts!r}"
+    )
+    # Der eine Punkt IST die heutige Fenstermitte-Position — hier per
+    # Konstruktion `start_point` (Vorschau-Zweig).
+    assert abs(pts[0].lat - seg.start_point.lat) < 1e-9, (
+        f"AC-2: der einzige Punkt muss die Fenstermitte-Position sein "
+        f"(lat={seg.start_point.lat}), erhalten lat={pts[0].lat}"
+    )
+    assert abs(pts[0].lon - seg.start_point.lon) < 1e-9, (
+        f"AC-2: der einzige Punkt muss die Fenstermitte-Position sein "
+        f"(lon={seg.start_point.lon}), erhalten lon={pts[0].lon}"
+    )
+
+
+def test_ac3_acht_km_reststrecke_liegt_auf_der_geometrie_ohne_duplikate():
+    """AC-3: Reststrecke 8,0 km -> alle 5 Punkte (km 0/2/4/6/8) liegen auf
+    der interpolierten Streckengeometrie der aktiven Etappe, keine zwei
+    Koordinaten sind identisch."""
+    from services.trip_segments import (
+        RADAR_ZONE_POINT_SPACING_KM,
+        points_along_remaining_route,
+    )
+
+    seg = _aequator_segment(8.0)
+    at = seg.start_time
+
+    pts = points_along_remaining_route(None, seg, date(2026, 8, 23), at)
+
+    assert len(pts) == 5, f"AC-3: erwartet 5 Punkte, erhalten {len(pts)}"
+
+    # "Auf der Geometrie" der Aequator-Etappe: lat bleibt 0.0 fuer jeden
+    # Punkt (die Etappe verlaeuft rein in Laengengrad-Richtung).
+    for i, p in enumerate(pts):
+        assert abs(p.lat - 0.0) < 1e-6, (
+            f"AC-3: Punkt {i} liegt nicht auf der Streckengeometrie "
+            f"(lat={p.lat}, erwartet 0.0)"
+        )
+
+    # Keine zwei Koordinaten identisch.
+    lons = [round(p.lon, 8) for p in pts]
+    assert len(set(lons)) == len(lons), (
+        f"AC-3: mindestens zwei Punkte sind identisch: {lons}"
+    )
+
+    # Jeder Punkt an der erwarteten Distanz-vom-Start.
+    gemessene_km = [
+        haversine_km(seg.start_point.lat, seg.start_point.lon, p.lat, p.lon)
+        for p in pts
+    ]
+    erwartete_km = [i * RADAR_ZONE_POINT_SPACING_KM for i in range(5)]
+    for i, (soll, ist) in enumerate(zip(erwartete_km, gemessene_km)):
+        assert abs(soll - ist) < 0.05, (
+            f"AC-3: Punkt {i} liegt bei km {ist:.3f}, erwartet km {soll:.1f}"
+        )

--- a/tests/tdd/test_regen_ausdehnung_textstellen.py
+++ b/tests/tdd/test_regen_ausdehnung_textstellen.py
@@ -1,0 +1,352 @@
+"""TDD RED — Issue #2051 Scheibe S2a: EINE Textstelle (E-Mail-Trip-Langform)
+zeigt die raeumliche Ausdehnung, plus die Modell-/Verdrahtungs-Zusicherungen
+drumherum.
+
+SPEC: docs/specs/modules/feat_2051_s2a_raeumliche_ausdehnung.md — AC-7, AC-8,
+AC-9, AC-10, AC-15, AC-16.
+
+RED-Ursache: `OnsetEvent.rain_zones` (additives Feld, `model.py`) existiert
+noch nicht -> `TypeError` bei der Konstruktion; der Renderer-Helfer
+`_onset_extent_suffix` existiert noch nicht.
+
+Mock-frei: echte `OnsetEvent`/`AlertMessage`-Objekte durch die echten
+Renderer (Muster `test_onset_ende_textstellen.py`), echter
+`TripAlertService.check_radar_alerts()`-Lauf fuer den Draht-Test (AC-9,
+Muster `test_issue_822_radar_nowcast_segment.py`).
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
+
+from app.config import Settings
+from app.models import TripReportConfig
+from app.trip import Stage, Trip, Waypoint
+from output.renderers.alert.model import AlertMessage, OnsetEvent
+from output.renderers.alert.render import render_email
+from services.radar_service import NowcastResult
+from utils.geo import haversine_km
+
+from tests.helpers.arrival_window_fixtures import active_window_offsets, stage_date
+
+_TZ = ZoneInfo("Europe/Vienna")
+
+_MINIMAL_FIELDS = dict(
+    onset_minutes=30, onset_time="18:00", km_from=8.0, km_to=8.0,
+    is_convective=False, intensity_label="Mäßiger Regen",
+    source_label="Radar (DWD)", segment_id="Ziel",
+)
+
+
+def _onset_event(**overrides) -> OnsetEvent:
+    fields = dict(_MINIMAL_FIELDS)
+    fields.update(overrides)
+    return OnsetEvent(**fields)
+
+
+def _onset_msg(*events: OnsetEvent) -> AlertMessage:
+    return AlertMessage(
+        trip_short="KHW 403", stand_at="17:30", events=tuple(events),
+        source="Radar (DWD)",
+    )
+
+
+# --------------------------------------------------------------------------
+# AC-7: km_from/km_to bleiben die Segment-Grenzen, rain_zones ein EIGENES
+#       Feld — kein Test darf beide Bedeutungen ueber denselben Namen lesen.
+# --------------------------------------------------------------------------
+
+def test_ac7_km_von_bis_und_rain_zones_sind_getrennte_bedeutungen():
+    from services.rain_extent import RainZone
+
+    zone = RainZone(km_from=2.0, km_to=4.0, onset_minutes=15, event_end_minutes=25)
+    event = _onset_event(km_from=0.0, km_to=13.0, rain_zones=(zone,))
+
+    assert event.km_from == 0.0 and event.km_to == 13.0, (
+        f"AC-7: km_from/km_to muessen die Segment-Grenzen bleiben, waren "
+        f"{event.km_from}/{event.km_to}"
+    )
+    assert event.rain_zones[0].km_from == 2.0 and event.rain_zones[0].km_to == 4.0, (
+        f"AC-7: rain_zones[0] muss die Zonen-Grenzen tragen, waren "
+        f"{event.rain_zones[0].km_from}/{event.rain_zones[0].km_to}"
+    )
+    # Gegenprobe: die beiden Wertepaare duerfen nicht zusammenfallen — sonst
+    # koennte ein Pruefling still beide ueber denselben Namen lesen, ohne
+    # dass der Test es merkt.
+    assert (event.km_from, event.km_to) != (
+        event.rain_zones[0].km_from, event.rain_zones[0].km_to,
+    ), "AC-7: Testvoraussetzung verletzt — die beiden Wertepaare muessen sich unterscheiden"
+
+
+# --------------------------------------------------------------------------
+# AC-8: unvermessene Etappe (km_measured=False) -> KEINE Zusatzzeile, Text
+#       bleibt byte-identisch zum Stand vor dieser Spec.
+# --------------------------------------------------------------------------
+
+def test_ac8_unvermessene_etappe_zeigt_keine_ausdehnung_byte_identisch():
+    from services.rain_extent import RainZone
+
+    zone = RainZone(km_from=8.0, km_to=12.0, onset_minutes=20, event_end_minutes=40)
+
+    baseline = _onset_msg(_onset_event(km_measured=False))
+    mit_zonen_unvermessen = _onset_msg(
+        _onset_event(km_measured=False, rain_zones=(zone,))
+    )
+
+    _html_base, plain_base = render_email(baseline)
+    _html_zonen, plain_zonen = render_email(mit_zonen_unvermessen)
+
+    assert plain_zonen == plain_base, (
+        f"AC-8: unvermessene Etappe muss byte-identisch zum Stand ohne "
+        f"Zonen-Feld bleiben.\nMit Zonen:\n{plain_zonen}\nBaseline:\n{plain_base}"
+    )
+    assert "Nass km" not in plain_zonen, (
+        f"AC-8: keine Ausdehnungs-Zeile bei unvermessener Etappe erlaubt:\n{plain_zonen}"
+    )
+
+
+# --------------------------------------------------------------------------
+# AC-9: vermessene Etappe (km_measured=True) + eine Zone -> Zusatzzeile mit
+#       exakt "Nass km 8-12".
+# --------------------------------------------------------------------------
+
+def test_ac9_vermessene_etappe_zeigt_die_nasszone():
+    """AC-9 (Renderer-Ebene). Positivkontrolle zu AC-8: ohne diesen Fall
+    waere AC-8s Abwesenheits-Pruefung trivial wahr."""
+    from services.rain_extent import RainZone
+
+    zone = RainZone(km_from=8.0, km_to=12.0, onset_minutes=20, event_end_minutes=40)
+    msg = _onset_msg(_onset_event(km_measured=True, rain_zones=(zone,)))
+
+    _html, plain = render_email(msg)
+
+    assert "Nass km 8-12" in plain, (
+        f"AC-9: erwartet die Zusatzzeile 'Nass km 8-12' im Text:\n{plain}"
+    )
+
+
+def test_ac9_draht_km_measured_erreicht_das_gerenderte_onset_event():
+    """AC-9 (Draht-Test, Kartierungs-Befund): `check_radar_alerts()` muss
+    `TripSegment.distance_measured` bis in das gerenderte `OnsetEvent`
+    tragen — sonst waere AC-9 nur auf Renderer-Ebene erfuellt, waehrend die
+    Ausdehnung in Produktion auf KEINER Etappe erschiene (auch nicht auf den
+    vermessenen).
+
+    RED heute: weder `RadarAlertRequest` noch `OnsetEvent`-Konstruktion in
+    `notification_service.py::send_radar_alert` (die tatsaechliche
+    Trip-Onset-Baustelle — nicht `radar_alert_service.py:60`, das ist toter
+    Code, s. Ruecklauf an den Auftraggeber) reichen `km_measured`/
+    `rain_zones` durch. Der Body enthaelt deshalb heute KEINE 'Nass km'-Zeile,
+    obwohl die Etappe hier bewusst vermessen ist (`distance_from_start_km`
+    auf beiden Wegpunkten monoton, >= Luftlinie).
+    """
+    from services.trip_alert import TripAlertService
+    from services.radar_service import RadarNowcastService
+
+    uid = f"tdd-2051-s2a-ac9-{uuid.uuid4().hex[:6]}"
+    lat0, lon0 = 47.0, 11.0
+    lat1, lon1 = 47.05, 11.05
+    luftlinie = haversine_km(lat0, lon0, lat1, lon1)
+
+    from app.loader import get_briefings_dir
+    import shutil
+    from pathlib import Path
+
+    def _clean(u: str) -> None:
+        d = Path(__file__).resolve().parents[2] / "data" / "users" / u
+        if d.exists():
+            shutil.rmtree(d, ignore_errors=True)
+
+    _clean(uid)
+    try:
+        today = stage_date(lat0, lon0)
+        arr0, arr1 = active_window_offsets(lat0, lon0, -60, 60)
+
+        wp0 = Waypoint(
+            id="WP0", name="WP0", lat=lat0, lon=lon0, elevation_m=1000.0,
+            arrival_calculated=arr0, distance_from_start_km=0.0,
+        )
+        wp1 = Waypoint(
+            id="WP1", name="WP1", lat=lat1, lon=lon1, elevation_m=1000.0,
+            arrival_calculated=arr1, distance_from_start_km=round(luftlinie, 3),
+        )
+        stage = Stage(id="S1", name="Tag 1", date=today, waypoints=[wp0, wp1])
+        trip_id = f"tdd-2051-s2a-ac9-trip-{uuid.uuid4().hex[:6]}"
+        trip = Trip(id=trip_id, name="AC9 Draht Trip", stages=[stage])
+        trip.report_config = TripReportConfig(
+            trip_id=trip_id, send_email=True, send_telegram=False,
+            alert_on_changes=False,
+        )
+
+        trips_dir = get_briefings_dir(uid)
+        trips_dir.mkdir(parents=True, exist_ok=True)
+        import json
+        data = {
+            "id": trip.id, "name": trip.name,
+            "stages": [{
+                "id": stage.id, "name": stage.name, "date": stage.date.isoformat(),
+                "waypoints": [
+                    {
+                        "id": w.id, "name": w.name, "lat": w.lat, "lon": w.lon,
+                        "elevation_m": w.elevation_m,
+                        "arrival_calculated": w.arrival_calculated,
+                        "distance_from_start_km": w.distance_from_start_km,
+                    }
+                    for w in stage.waypoints
+                ],
+            }],
+            "report_config": {
+                "trip_id": trip.report_config.trip_id,
+                "send_email": True, "send_telegram": False,
+            },
+        }
+        (trips_dir / f"{trip.id}.json").write_text(json.dumps(data))
+
+        captured: list[dict] = []
+
+        def _sink(subject: str, body: str) -> None:
+            captured.append({"subject": subject, "body": body})
+
+        def _wet_frames(la: float, lo: float) -> list:
+            from providers.brightsky import RadarFrame
+            now = datetime.now(timezone.utc)
+            return [RadarFrame(timestamp=now + timedelta(minutes=5), precip_mm_h=4.0)]
+
+        svc = TripAlertService(
+            throttle_hours=2, user_id=uid,
+            radar_service=RadarNowcastService(frame_source=_wet_frames),
+            settings=Settings(
+                smtp_host="test.invalid", smtp_user="u", smtp_pass="p",
+                mail_to="x@example.com",
+            ),
+            mail_sink=_sink,
+        )
+        svc.clear_radar_throttle(trip_id)
+        sent = svc.check_radar_alerts()
+
+        assert sent >= 1 and captured, (
+            f"Testvoraussetzung: der Alarm muss ausgeloest worden sein "
+            f"(sent={sent}, captured={len(captured)}) — ohne Mail ist AC-9 "
+            f"am Draht nicht pruefbar"
+        )
+        body = captured[0]["body"]
+        assert "Nass km" in body, (
+            "AC-9 (Draht): die vermessene Etappe (distance_measured=True) "
+            f"muss eine 'Nass km'-Zeile tragen — km_measured erreicht das "
+            f"gerenderte OnsetEvent nicht.\nBody:\n{body}"
+        )
+    finally:
+        _clean(uid)
+
+
+# --------------------------------------------------------------------------
+# AC-10: zwei getrennte Zonen -> "Nass km 2-4, km 9-11", NIEMALS eine
+#        zusammengefasste Huelle "km 2-11".
+# --------------------------------------------------------------------------
+
+def test_ac10_zwei_zonen_bleiben_getrennt_keine_huelle():
+    from services.rain_extent import RainZone
+
+    zone_a = RainZone(km_from=2.0, km_to=4.0, onset_minutes=10, event_end_minutes=20)
+    zone_b = RainZone(km_from=9.0, km_to=11.0, onset_minutes=40, event_end_minutes=55)
+    msg = _onset_msg(_onset_event(km_measured=True, rain_zones=(zone_a, zone_b)))
+
+    _html, plain = render_email(msg)
+
+    assert "Nass km 2-4, km 9-11" in plain, (
+        f"AC-10: erwartet 'Nass km 2-4, km 9-11' im Text:\n{plain}"
+    )
+    assert "km 2-11" not in plain, (
+        f"AC-10: KEINE zusammengefasste Huelle 'km 2-11' erlaubt:\n{plain}"
+    )
+
+
+# --------------------------------------------------------------------------
+# AC-15: Ortsvergleich-Pfad (`to_multi_location_onset_alert_message`) setzt
+#        `rain_zones` nie — S2a aendert `compare_radar_alert.py` nicht.
+# --------------------------------------------------------------------------
+
+def test_ac15_ortsvergleich_pfad_setzt_rain_zones_nie():
+    from output.renderers.alert.project import to_multi_location_onset_alert_message
+
+    nc = NowcastResult(
+        onset_minutes=15, intensity_label="Mäßiger Regen", source="radar",
+    )
+    msg = to_multi_location_onset_alert_message(
+        [("Sillian", nc)], tz=_TZ, stand_at="17:55",
+    )
+
+    assert len(msg.events) == 1, f"Testvoraussetzung: genau 1 Event, war {msg.events!r}"
+    assert msg.events[0].rain_zones == (), (
+        f"AC-15: der Ortsvergleich-Pfad darf rain_zones NIE setzen, erhalten "
+        f"{msg.events[0].rain_zones!r}"
+    )
+
+
+# --------------------------------------------------------------------------
+# AC-16: keine Ankunftszeit-Rechnung/Handlungsempfehlung in der gerenderten
+#        Ausdehnungs-Zeile.
+# --------------------------------------------------------------------------
+
+# Muster wie S3-AC-15 (test_onset_reichweite_guete_keine_bevormundung.py)
+# plus arrival-time-calculation-spezifische Ergaenzungen fuer S2a.
+_VERBOTENE_MUSTER = [
+    "verlass dich nicht",
+    "solltest du",
+    "bis dahin solltest",
+    "rechne damit, dass du",
+    "sei vorsichtig",
+    "achte darauf, dass du",
+    "plane damit",
+    "du erreichst",
+    "wirst du dort",
+    "wirst du diese zone",
+    "bist du dort",
+    "kommst du dort an",
+    "wenn du ankommst",
+]
+
+
+def _pruefe(kandidaten: dict[str, str]) -> dict[str, list[str]]:
+    gefunden: dict[str, list[str]] = {}
+    for name, text in kandidaten.items():
+        text_klein = text.lower()
+        treffer = [m for m in _VERBOTENE_MUSTER if m in text_klein]
+        if treffer:
+            gefunden[name] = treffer
+    return gefunden
+
+
+def test_ac16_keine_ankunftszeit_rechnung_oder_handlungsempfehlung():
+    """AC-16 GIVEN einen gerenderten Text mit gesetzten Zonen / WHEN er auf
+    verbotene Formulierungen geprueft wird / THEN enthaelt er keine.
+
+    Positivkontrolle des DETEKTORS selbst (Lehre aus #2054): ein
+    synthetischer, ABSICHTLICH verbotener Satz muss von DERSELBEN
+    Pruefschleife erkannt werden — sonst waere die Negativpruefung unten
+    trivial wahr."""
+    from services.rain_extent import RainZone
+
+    zone = RainZone(km_from=8.0, km_to=12.0, onset_minutes=20, event_end_minutes=40)
+    msg = _onset_msg(_onset_event(km_measured=True, rain_zones=(zone,)))
+    _html, plain = render_email(msg)
+
+    assert "Nass km 8-12" in plain, (
+        f"Testvoraussetzung: die Ausdehnungs-Zeile muss ueberhaupt im Text "
+        f"stehen, sonst prueft dieser Test nichts:\n{plain}"
+    )
+
+    synthetischer_verstoss = _pruefe({
+        "synthetisch": "Nass km 8-12. Du erreichst diese Zone in 45 Minuten.",
+    })
+    assert synthetischer_verstoss, (
+        "Vorbedingung: der Detektor muss einen ABSICHTLICH eingebauten "
+        "Verstoss erkennen — sonst waere die Negativpruefung unten trivial "
+        "wahr."
+    )
+
+    treffer = _pruefe({"email_trip_plain": plain})
+    assert not treffer, (
+        f"AC-16: verbotene Formulierung gefunden: {treffer}\nText:\n{plain}"
+    )

--- a/tests/tdd/test_regen_ausdehnung_textstellen.py
+++ b/tests/tdd/test_regen_ausdehnung_textstellen.py
@@ -25,7 +25,7 @@ from app.models import TripReportConfig
 from app.trip import Stage, Trip, Waypoint
 from output.renderers.alert.model import AlertMessage, OnsetEvent
 from output.renderers.alert.render import render_email
-from services.radar_service import NowcastResult
+from services.radar_service import NowcastResult, RadarNowcastService
 from utils.geo import haversine_km
 
 from tests.helpers.arrival_window_fixtures import active_window_offsets, stage_date
@@ -349,4 +349,358 @@ def test_ac16_keine_ankunftszeit_rechnung_oder_handlungsempfehlung():
     treffer = _pruefe({"email_trip_plain": plain})
     assert not treffer, (
         f"AC-16: verbotene Formulierung gefunden: {treffer}\nText:\n{plain}"
+    )
+
+
+# --------------------------------------------------------------------------
+# E4 am WIRKORT (Adversary-Finding F001) und der Ausnahme-Zweig des
+# Folgepunkt-Abrufs (F002). Beide nur am Draht pruefbar: die Zusicherung
+# entsteht in `check_radar_alerts()`, nicht im Renderer.
+# --------------------------------------------------------------------------
+
+# Europe/Vienna (UTC+2 im August) -> 12:00 Ortszeit. Feste Uhr wie
+# `test_issue_822_radar_nowcast_segment.UHR_TIROL`: die Punktzahl der
+# Mehrpunkt-Abfrage haengt am Zeitanteil des Segments, ohne gestellte Uhr
+# waere sie wanduhrabhaengig.
+_UHR_TIROL = "2026-08-18T10:00:00+00:00"
+
+# Etappe rein in Nord-Richtung, ~24 km — bei Zeitanteil 87/360 bleiben
+# ~18,2 km Reststrecke und damit die vollen sechs Messpunkte (Deckel).
+_ZONEN_LAT0, _ZONEN_LON0 = 47.0, 11.0
+_ZONEN_LAT1, _ZONEN_LON1 = 47.2158, 11.0
+
+
+def _nass_spannen(plain: str) -> list[str]:
+    """Die einzelnen `km A-B`-Spannen der Ausdehnungs-Angabe (leer: keine)."""
+    import re
+
+    treffer = re.search(r"· Nass (km .*)$", plain, re.MULTILINE)
+    if not treffer:
+        return []
+    return [s.strip() for s in treffer.group(1).split(",")]
+
+
+class _ZonenRadar(RadarNowcastService):
+    """Echte `RadarNowcastService`-Unterklasse am DI-Seam von
+    `TripAlertService` (Muster `_FixedRadar`,
+    `test_alert_log_ereignisgroessen.py`) — liefert je Abruf ein ECHTES
+    `NowcastResult`, gesteuert ueber die Reihenfolge der Abrufe.
+
+    Kein Mock: die zurueckgegebenen Objekte sind die Produktiv-Dataclass mit
+    ihren echten Feldern; gesteuert wird ausschliesslich, WELCHES Ergebnis ein
+    Punkt bekommt.
+    """
+
+    def __init__(
+        self,
+        *,
+        trocken_index: int | None = None,
+        trocken_felder: dict | None = None,
+        ausnahme_index: int | None = None,
+        weitere_trockene: tuple[int, ...] = (),
+    ) -> None:
+        super().__init__()
+        self.aufrufe: list[tuple[float, float]] = []
+        self._trocken_index = trocken_index
+        self._trocken_felder = dict(trocken_felder or {})
+        self._ausnahme_index = ausnahme_index
+        self._weitere_trockene = set(weitere_trockene)
+
+    def get_nowcast(self, lat, lon, elevation_m=None, priority="user_briefing"):
+        i = len(self.aufrufe)
+        self.aufrufe.append((lat, lon))
+        if i == self._ausnahme_index:
+            raise RuntimeError(
+                f"Nowcast-Abruf fuer Zonenpunkt {i} absichtlich fehlgeschlagen"
+            )
+        if i == self._trocken_index:
+            return NowcastResult(
+                onset_minutes=None, intensity_label="Kein Regen", source="radar",
+                **self._trocken_felder,
+            )
+        if i in self._weitere_trockene:
+            return NowcastResult(
+                onset_minutes=None, intensity_label="Kein Regen", source="radar",
+            )
+        return NowcastResult(
+            onset_minutes=10, intensity_label="Mäßiger Regen", source="radar",
+            window_precip_mm=3.0, event_end_minutes=40,
+        )
+
+
+def _zonen_lauf(radar: _ZonenRadar) -> tuple[int, list[str], str]:
+    """Ein echter `check_radar_alerts()`-Lauf auf der Etappe oben.
+
+    Liefert `(sent, nass_spannen, body)`. Der Trip wird als Datei geschrieben
+    und vom Pruefling selbst geladen — dieselbe Strecke wie in Produktion.
+    """
+    import json
+    import shutil
+    from pathlib import Path
+
+    from freezegun import freeze_time
+
+    from app.loader import get_briefings_dir
+    from services.trip_alert import TripAlertService
+
+    uid = f"tdd-2051-s2a-zonen-{uuid.uuid4().hex[:8]}"
+    verzeichnis = (
+        Path(__file__).resolve().parents[2] / "data" / "users" / uid
+    )
+    try:
+        with freeze_time(_UHR_TIROL):
+            luftlinie = haversine_km(
+                _ZONEN_LAT0, _ZONEN_LON0, _ZONEN_LAT1, _ZONEN_LON1,
+            )
+            trip_id = f"tdd-2051-s2a-zonen-trip-{uuid.uuid4().hex[:6]}"
+            trips_dir = get_briefings_dir(uid)
+            trips_dir.mkdir(parents=True, exist_ok=True)
+            data = {
+                "id": trip_id, "name": "Zonen Draht Trip",
+                "stages": [{
+                    "id": "S1", "name": "Tag 1",
+                    "date": stage_date(_ZONEN_LAT0, _ZONEN_LON0).isoformat(),
+                    "waypoints": [
+                        {
+                            "id": "WP0", "name": "WP0",
+                            "lat": _ZONEN_LAT0, "lon": _ZONEN_LON0,
+                            "elevation_m": 1000.0, "arrival_calculated": "11:00",
+                            "distance_from_start_km": 0.0,
+                        },
+                        {
+                            "id": "WP1", "name": "WP1",
+                            "lat": _ZONEN_LAT1, "lon": _ZONEN_LON1,
+                            "elevation_m": 1000.0, "arrival_calculated": "17:00",
+                            "distance_from_start_km": round(luftlinie, 3),
+                        },
+                    ],
+                }],
+                "report_config": {
+                    "trip_id": trip_id, "send_email": True, "send_telegram": False,
+                },
+            }
+            (trips_dir / f"{trip_id}.json").write_text(json.dumps(data))
+
+            captured: list[dict] = []
+            svc = TripAlertService(
+                throttle_hours=2, user_id=uid, radar_service=radar,
+                settings=Settings(
+                    smtp_host="test.invalid", smtp_user="u", smtp_pass="p",
+                    mail_to="x@example.com",
+                ),
+                mail_sink=lambda subject, body: captured.append(
+                    {"subject": subject, "body": body}
+                ),
+            )
+            svc.clear_radar_throttle(trip_id)
+            sent = svc.check_radar_alerts()
+            body = captured[0]["body"] if captured else ""
+            return sent, _nass_spannen(body), body
+    finally:
+        shutil.rmtree(verzeichnis, ignore_errors=True)
+
+
+def test_e4_punkt_ohne_frames_trennt_die_nasszone_nicht():
+    """E4 am Wirkort (Adversary-Finding F001): ein Folgepunkt, dessen Ergebnis
+    `throttled` bzw. `data_unavailable` traegt, ist eine LUECKE — er darf die
+    umgebende Nass-Zone nicht trennen.
+
+    `radar_service.py:987-1001` belegt, dass beide Merkmale immer mit
+    `onset_minutes=None` einhergehen. Ohne den Filter in `_zonen_messwert()`
+    faellt so ein Punkt in den "trocken"-Zweig von `derive_rain_zones()` und
+    erfindet eine trockene Strecke, die niemand gemessen hat.
+
+    Positivkontrolle im dritten Lauf: ein ECHT trockener Punkt an derselben
+    Stelle MUSS die Zone trennen — sonst waere die Nicht-Trennungs-Pruefung
+    oben trivial wahr, weil dieser Aufbau ueberhaupt nie zwei Zonen erzeugt.
+    """
+    for merkmal in ("throttled", "data_unavailable"):
+        radar = _ZonenRadar(trocken_index=2, trocken_felder={merkmal: True})
+        sent, spannen, body = _zonen_lauf(radar)
+        assert len(radar.aufrufe) == 6, (
+            f"Testvoraussetzung ({merkmal}): sechs Messpunkte erwartet, "
+            f"gesehen {len(radar.aufrufe)}: {radar.aufrufe}"
+        )
+        assert sent >= 1 and spannen, (
+            f"Testvoraussetzung ({merkmal}): der Alarm muss ausgeloest und "
+            f"eine Ausdehnung gerendert worden sein (sent={sent}, "
+            f"spannen={spannen})\nBody:\n{body}"
+        )
+        assert len(spannen) == 1, (
+            f"E4/{merkmal}: der Punkt ohne verwertbare Frames darf die "
+            f"Nass-Zone NICHT trennen — erhalten {len(spannen)} Zonen "
+            f"{spannen}, erwartet genau eine.\nBody:\n{body}"
+        )
+
+    sent_dry, spannen_dry, body_dry = _zonen_lauf(_ZonenRadar(trocken_index=2))
+    assert sent_dry >= 1, (
+        f"Positivkontrolle: der Alarm muss auch hier ausgeloest haben "
+        f"(sent={sent_dry})\nBody:\n{body_dry}"
+    )
+    assert len(spannen_dry) == 2, (
+        f"Positivkontrolle: ein ECHT trockener Punkt an derselben Stelle muss "
+        f"die Zone trennen — sonst misst die Pruefung oben nichts. Erhalten "
+        f"{len(spannen_dry)} Zonen {spannen_dry}, erwartet zwei.\n"
+        f"Body:\n{body_dry}"
+    )
+
+
+def test_ausnahme_beim_folgepunkt_ist_eine_luecke_und_kostet_den_alarm_nicht():
+    """Adversary-Finding F002: wirft der Nowcast-Abruf eines FOLGEPUNKTES,
+    laeuft der Alarm weiter und der Punkt wird zur Luecke — er wird weder als
+    trocken gewertet noch mit dem Ergebnis eines anderen Punktes aufgefuellt.
+
+    Aufbau (sechs Messpunkte): Punkt 0 nass, Punkt 1 wirft, Punkt 2 trocken,
+    Punkte 3+4 nass, Punkt 5 trocken. Korrekt ergibt das zwei Zonen, deren
+    ERSTE aus dem einzelnen Punkt 0 besteht und deshalb identische Grenzen
+    traegt (`km N-N`). Wuerde der Ausnahme-Zweig statt einer Luecke ein
+    fremdes (nasses) Ergebnis anhaengen, waere Punkt 1 Teil der ersten Zone
+    und ihre Grenzen liefen auseinander — genau daran haengt die Pruefung.
+
+    Pendant zu AC-14 (werfendes `position_at_time`); der Fall fuer
+    `get_nowcast` auf Folgepunkten fehlte.
+    """
+    radar = _ZonenRadar(ausnahme_index=1, weitere_trockene=(2, 5))
+    sent, spannen, body = _zonen_lauf(radar)
+
+    assert sent >= 1, (
+        f"Der Fehler EINES Folgepunktes darf den Alarm nicht kosten — "
+        f"sent={sent}\nBody:\n{body}"
+    )
+    assert len(radar.aufrufe) == 6, (
+        f"Testvoraussetzung: sechs Messpunkte erwartet (der Aufbau haengt "
+        f"daran), gesehen {len(radar.aufrufe)}: {radar.aufrufe}"
+    )
+    assert len(spannen) == 2, (
+        f"Erwartet zwei getrennte Zonen (Punkt 0 / Punkte 3+4), erhalten "
+        f"{len(spannen)}: {spannen}\nBody:\n{body}"
+    )
+    von, bis = spannen[0].removeprefix("km ").split("-")
+    assert von == bis, (
+        f"Der werfende Punkt 1 muss eine LUECKE sein: die erste Zone besteht "
+        f"dann allein aus Punkt 0 und traegt identische Grenzen. Erhalten "
+        f"'{spannen[0]}' — der Punkt wurde offenbar mit einem fremden "
+        f"Ergebnis aufgefuellt.\nBody:\n{body}"
+    )
+    zweite_von, zweite_bis = spannen[1].removeprefix("km ").split("-")
+    assert zweite_von != zweite_bis, (
+        f"Positivkontrolle: die zweite Zone (Punkte 3+4) muss auseinander"
+        f"laufende Grenzen tragen — sonst koennte die Pruefung oben schon an "
+        f"der Rundung haengen. Erhalten '{spannen[1]}'.\nBody:\n{body}"
+    )
+
+
+# --------------------------------------------------------------------------
+# Die km-Grenzen an ihrer BILDUNGSSTELLE (Mutations-Befund): alle Tests oben
+# setzen ihre Zonen als Literal und bewachen damit nur den Renderer. Eine
+# Verschiebung jeder Zonengrenze um 1 km in `rain_extent.derive_rain_zones()`
+# bleibt dort unbemerkt.
+# --------------------------------------------------------------------------
+
+
+def _zonen_km_aus_geometrie(radar: _ZonenRadar) -> list[float]:
+    """Kilometrierung der TATSAECHLICH abgefragten Punkte, unabhaengig vom
+    Pruefling gerechnet.
+
+    Der Produktivweg bildet die km-Lage eines Punktes durch Interpolation von
+    `distance_from_start_km` (`trip_segments._lerp_point`). Hier laeuft sie
+    ueber die GEOMETRIE: `radar.aufrufe` haelt die Koordinaten, mit denen der
+    Nowcast wirklich abgerufen wurde, und die Etappe oben ist eine gerade
+    Nord-Strecke mit `distance_from_start_km` 0 am Startwegpunkt. Die
+    Kilometrierung eines Punktes ist damit schlicht seine Entfernung von WP0.
+
+    Bewusst NICHT ueber `derive_rain_zones()` oder
+    `points_along_remaining_route()` — ein Sollwert, den der Pruefling selbst
+    liefert, prueft nichts.
+    """
+    return [
+        haversine_km(_ZONEN_LAT0, _ZONEN_LON0, lat, lon)
+        for lat, lon in radar.aufrufe
+    ]
+
+
+def test_zonengrenzen_werden_aus_der_kilometrierung_der_nassen_punkte_gebildet():
+    """Die im Text stehenden km-Grenzen muessen den nassen Punkten der
+    jeweiligen Zone entsprechen — kleinster km-Wert vorn, groesster hinten.
+
+    Aufbau: sechs Messpunkte, Punkt 2 echt trocken. Er trennt (E2), also zwei
+    Zonen aus den Punkten 0+1 bzw. 3+4+5. Der Sollwert wird aus den
+    Koordinaten der tatsaechlichen Abrufe abgeleitet, nicht hingeschrieben:
+    ein Literal wuerde genau die Stelle ungeprueft lassen, um die es hier
+    geht.
+    """
+    radar = _ZonenRadar(trocken_index=2)
+    sent, spannen, body = _zonen_lauf(radar)
+
+    assert sent >= 1 and len(radar.aufrufe) == 6, (
+        f"Testvoraussetzung: Alarm ausgeloest und sechs Messpunkte erwartet — "
+        f"sent={sent}, Abrufe={radar.aufrufe}\nBody:\n{body}"
+    )
+
+    km = _zonen_km_aus_geometrie(radar)
+    assert all(a < b for a, b in zip(km, km[1:])), (
+        f"Testvoraussetzung: die Messpunkte muessen streckenweise vorwaerts "
+        f"laufen, sonst taugt die abgeleitete Kilometrierung nicht: {km}"
+    )
+
+    # Gruppierung wie E2: der trockene Punkt trennt, alle uebrigen sind nass.
+    nass = [i for i in range(len(km)) if i != 2]
+    gruppen: list[list[int]] = []
+    for i in nass:
+        if gruppen and gruppen[-1][-1] == i - 1:
+            gruppen[-1].append(i)
+        else:
+            gruppen.append([i])
+
+    erwartet = []
+    for gruppe in gruppen:
+        von_km = min(km[i] for i in gruppe)
+        bis_km = max(km[i] for i in gruppe)
+        for wert in (von_km, bis_km):
+            assert abs(wert - round(wert)) < 0.35, (
+                f"Testvoraussetzung: {wert:.3f} km liegt zu dicht an der "
+                f"Rundungsgrenze — der Sollwert waere nicht eindeutig."
+            )
+        erwartet.append(f"km {int(round(von_km))}-{int(round(bis_km))}")
+
+    assert spannen == erwartet, (
+        f"Die km-Grenzen der Nass-Zonen muessen aus der Kilometrierung der "
+        f"nassen Punkte entstehen.\nErwartet {erwartet} (abgeleitet aus den "
+        f"Abruf-Koordinaten: {[round(k, 3) for k in km]}, trocken ist Punkt "
+        f"2)\nErhalten {spannen}\nBody:\n{body}"
+    )
+
+    # Von/Bis-Zuordnung eigens: eine Vertauschung der beiden Grenzen ergaebe
+    # eine rueckwaerts laufende Spanne. Der Vergleich oben faengt das mit,
+    # diese Pruefung benennt es.
+    for spanne in spannen:
+        von, bis = (int(t) for t in spanne.removeprefix("km ").split("-"))
+        assert von < bis, (
+            f"Die kleinere km-Grenze gehoert nach vorn — '{spanne}' laeuft "
+            f"rueckwaerts (km_from/km_to vertauscht).\nBody:\n{body}"
+        )
+
+
+# --------------------------------------------------------------------------
+# Rundung der Zonengrenzen (Adversary-Finding F003): in Produktion sind die
+# km-Werte Interpolations-Ergebnisse und damit grundsaetzlich fraktional.
+# --------------------------------------------------------------------------
+
+def test_fraktionale_zonengrenzen_werden_gerundet_nicht_abgeschnitten():
+    """`8.6/11.4` muss als `km 9-11` erscheinen. Die Werte sind so gewaehlt,
+    dass Runden und Abschneiden AUSEINANDERLAUFEN (abschneiden ergaebe
+    `km 8-11`) — sonst pruefte der Test die Form statt des Werts."""
+    from services.rain_extent import RainZone
+
+    zone = RainZone(km_from=8.6, km_to=11.4, onset_minutes=20, event_end_minutes=40)
+    msg = _onset_msg(_onset_event(km_measured=True, rain_zones=(zone,)))
+
+    _html, plain = render_email(msg)
+
+    assert "Nass km 9-11" in plain, (
+        f"Fraktionale Zonengrenzen 8.6/11.4 muessen gerundet als 'Nass km 9-11' "
+        f"erscheinen:\n{plain}"
+    )
+    assert "km 8-11" not in plain, (
+        f"Abgeschnitten statt gerundet ('km 8-11') ist falsch:\n{plain}"
     )

--- a/tests/tdd/test_regen_ausdehnung_zonenbildung.py
+++ b/tests/tdd/test_regen_ausdehnung_zonenbildung.py
@@ -1,0 +1,174 @@
+"""TDD RED — Issue #2051 Scheibe S2a: Nass/Trocken-Zonenbildung aus mehreren
+Abfragepunkten (E2/E4).
+
+SPEC: docs/specs/modules/feat_2051_s2a_raeumliche_ausdehnung.md — AC-4, AC-5,
+AC-6, AC-11.
+
+RED-Ursache: `src/services/rain_extent.py` (Modul `derive_rain_zones()`,
+`RainZone`) existiert noch nicht -> ImportError.
+
+Mock-frei: echte `GPXPoint`- und `NowcastResult`-Objekte, keine
+Mock()/patch()/MagicMock.
+
+Kontraktannahme (aus der Spec-Signatur `derive_rain_zones(points, results)`,
+kein weiterer km-Parameter): die km-Lage einer Zone stammt aus
+`points[i].distance_from_start_km` der beteiligten Punkte — dasselbe Feld,
+das `GPXPoint` bereits fuer die Kilometrierung traegt. Die Tests setzen es
+deshalb explizit auf die im jeweiligen AC genannten km-Werte.
+"""
+from __future__ import annotations
+
+from app.models import GPXPoint
+from services.radar_service import NowcastResult
+
+
+def _punkt(km: float) -> GPXPoint:
+    return GPXPoint(lat=0.0, lon=km / 111.0, elevation_m=1000.0, distance_from_start_km=km)
+
+
+def _nass(onset_minutes: int, event_end_minutes: int | None = None) -> NowcastResult:
+    return NowcastResult(
+        onset_minutes=onset_minutes, intensity_label="Mäßiger Regen", source="radar",
+        event_end_minutes=event_end_minutes,
+    )
+
+
+def _trocken() -> NowcastResult:
+    return NowcastResult(onset_minutes=None, intensity_label="Kein Niederschlag", source="radar")
+
+
+# --------------------------------------------------------------------------
+# AC-4: Nass, Nass, Trocken, Nass, Nass, Trocken (km 0,2,4,6,8,10)
+#       -> genau zwei Zonen km 0-2 und km 6-8.
+# --------------------------------------------------------------------------
+
+def test_ac4_zwei_getrennte_nasszonen_aus_sechs_punkten():
+    from services.rain_extent import derive_rain_zones
+
+    points = [_punkt(km) for km in (0, 2, 4, 6, 8, 10)]
+    results = [_nass(10), _nass(12), _trocken(), _nass(20), _nass(22), _trocken()]
+
+    zones = derive_rain_zones(points, results)
+
+    assert len(zones) == 2, f"AC-4: erwartet 2 Zonen, erhalten {len(zones)}: {zones!r}"
+    a, b = zones
+    assert (a.km_from, a.km_to) == (0.0, 2.0), (
+        f"AC-4: erste Zone muss km 0-2 sein, war km {a.km_from}-{a.km_to}"
+    )
+    assert (b.km_from, b.km_to) == (6.0, 8.0), (
+        f"AC-4: zweite Zone muss km 6-8 sein, war km {b.km_from}-{b.km_to}"
+    )
+    # Gegenprobe "Form statt Wert": eine Implementierung, die stattdessen
+    # ALLES zu einer Huelle km 0-8 verschmilzt (den trockenen Trenner bei
+    # km 4 ignoriert), muss hier durchfallen.
+    assert not any(z.km_from == 0.0 and z.km_to == 8.0 for z in zones), (
+        "AC-4: der trockene Punkt bei km 4 muss trennen — keine Huelle km 0-8"
+    )
+
+
+# --------------------------------------------------------------------------
+# AC-5: Nass, Trocken, Nass (km 0,2,4) -> ZWEI Zonen km 0-0 und km 4-4,
+#       NIEMALS eine Huelle km 0-4.
+# --------------------------------------------------------------------------
+
+def test_ac5_trockener_mittelpunkt_trennt_statt_zu_ueberbruecken():
+    from services.rain_extent import derive_rain_zones
+
+    points = [_punkt(km) for km in (0, 2, 4)]
+    results = [_nass(5), _trocken(), _nass(15)]
+
+    zones = derive_rain_zones(points, results)
+
+    assert len(zones) == 2, f"AC-5: erwartet 2 Zonen, erhalten {len(zones)}: {zones!r}"
+    a, b = zones
+    assert (a.km_from, a.km_to) == (0.0, 0.0), (
+        f"AC-5: erste Zone muss km 0-0 sein, war km {a.km_from}-{a.km_to}"
+    )
+    assert (b.km_from, b.km_to) == (4.0, 4.0), (
+        f"AC-5: zweite Zone muss km 4-4 sein, war km {b.km_from}-{b.km_to}"
+    )
+    assert not any(z.km_from == 0.0 and z.km_to == 4.0 for z in zones), (
+        "AC-5: der trockene Mittelpunkt (km 2) widerlegt eine durchgehende "
+        "Naesse — es darf KEINE Zone km 0-4 geben"
+    )
+
+
+# --------------------------------------------------------------------------
+# AC-6: dieselben zwei Zonen aus AC-4, aber mit unterschiedlichen
+#       Onset-/Ende-Zeiten je Punkt — jede Zone bekommt ihre EIGENE
+#       fruehste/spaeteste Zeit, keine globale Spanne.
+# --------------------------------------------------------------------------
+
+def test_ac6_jede_zone_traegt_ihre_eigene_zeitspanne():
+    from services.rain_extent import derive_rain_zones
+
+    points = [_punkt(km) for km in (0, 2, 4, 6, 8, 10)]
+    # Zone A (km 0-2): Punkt 0 -> onset 15/ende 20, Punkt 1 -> onset 10/ende 18
+    #   => Zone A: onset=min(15,10)=10, ende=max(20,18)=20
+    # Zone B (km 6-8): Punkt 3 -> onset 50/ende 55, Punkt 4 -> onset 45/ende 60
+    #   => Zone B: onset=min(50,45)=45, ende=max(55,60)=60
+    results = [
+        _nass(15, 20), _nass(10, 18), _trocken(),
+        _nass(50, 55), _nass(45, 60), _trocken(),
+    ]
+
+    zones = derive_rain_zones(points, results)
+
+    assert len(zones) == 2, f"AC-6: erwartet 2 Zonen, erhalten {len(zones)}: {zones!r}"
+    zone_a, zone_b = zones
+
+    assert zone_a.onset_minutes == 10, (
+        f"AC-6: Zone A muss onset_minutes=10 tragen (fruehester Wert der "
+        f"Zone), war {zone_a.onset_minutes}"
+    )
+    assert zone_a.event_end_minutes == 20, (
+        f"AC-6: Zone A muss event_end_minutes=20 tragen (spaetester Wert der "
+        f"Zone), war {zone_a.event_end_minutes}"
+    )
+    assert zone_b.onset_minutes == 45, (
+        f"AC-6: Zone B muss onset_minutes=45 tragen, war {zone_b.onset_minutes}"
+    )
+    assert zone_b.event_end_minutes == 60, (
+        f"AC-6: Zone B muss event_end_minutes=60 tragen, war "
+        f"{zone_b.event_end_minutes}"
+    )
+    # Gegenprobe: eine globale Spanne ueber BEIDE Zonen wuerde Zone A faelschlich
+    # onset_minutes=10 UND event_end_minutes=60 zuweisen (Zone B's Ende).
+    assert zone_a.event_end_minutes != 60, (
+        "AC-6: Zone A darf NICHT das Ende von Zone B uebernehmen — jede Zone "
+        "ihre eigene Spanne, keine globale ueber beide"
+    )
+
+
+# --------------------------------------------------------------------------
+# AC-11: ein datenloser Punkt (results[i] is None) faellt aus der
+#        Zonenbildung heraus — weder nass noch trocken gewertet.
+# --------------------------------------------------------------------------
+
+def test_ac11_datenloser_punkt_faellt_aus_der_zonenbildung_heraus():
+    from services.rain_extent import derive_rain_zones
+
+    # 5 Punkte, km 0/2/4/6/8. Punkt bei km 4 liefert keine Daten (None).
+    points = [_punkt(km) for km in (0, 2, 4, 6, 8)]
+    results = [_nass(5), _nass(8), None, _trocken(), _nass(30)]
+
+    zones_mit_luecke = derive_rain_zones(points, results)
+
+    # Vergleichslauf OHNE den datenlosen Punkt (komplett entfernt statt nur
+    # trocken gewertet) — AC-11 verlangt identische umgebende Zonen.
+    points_ohne_luecke = [points[0], points[1], points[3], points[4]]
+    results_ohne_luecke = [results[0], results[1], results[3], results[4]]
+    zones_ohne_luecke = derive_rain_zones(points_ohne_luecke, results_ohne_luecke)
+
+    assert zones_mit_luecke == zones_ohne_luecke, (
+        f"AC-11: der datenlose Punkt (km 4) darf das Ergebnis NICHT "
+        f"veraendern — mit Luecke: {zones_mit_luecke!r}, ohne Luecke (Punkt "
+        f"entfernt): {zones_ohne_luecke!r}"
+    )
+    # Positivkontrolle: der Testaufbau muss ueberhaupt mehrere Zonen ergeben,
+    # sonst waere die Gleichheit oben trivial (leer == leer).
+    assert len(zones_mit_luecke) == 2, (
+        f"Testvoraussetzung: erwartet 2 Zonen (km 0-2 nass, km 8-8 nass, "
+        f"getrennt durch den trockenen Punkt bei km 6), erhalten "
+        f"{zones_mit_luecke!r}"
+    )

--- a/tests/unit/test_alert_log_capture_correlation.py
+++ b/tests/unit/test_alert_log_capture_correlation.py
@@ -258,7 +258,26 @@ def test_ac4_e2e_zweig_c_alert_log_capture_id_matches_written_input_record():
     Capture-Datei existiert" waere die Aufweichung, die hier ausdruecklich
     NICHT stattfindet: der Fall verlangt genau eine Datei, deren
     ``source_key`` auf den interpolierten Punkt zeigt UND messbar vom
-    Startpunkt abweicht. Wird der Messpunkt verfaelscht, reisst er."""
+    Startpunkt abweicht. Wird der Messpunkt verfaelscht, reisst er.
+
+    #2017 -> #2051 S2a: Die #2017-Zusicherung "genau EIN Abruf je Lauf"
+    (AC-12) ist im ALARM-Pfad bewusst abgeloest (Spec
+    ``docs/specs/modules/feat_2051_s2a_raeumliche_ausdehnung.md``, Abschnitt
+    "Abgeloeste Zusicherung"): fuer die raeumliche Ausdehnung des
+    Regenereignisses wird an mehreren Punkten entlang der Reststrecke
+    abgefragt. Im /jetzt-Pfad und im Briefing-Kurzfristhinweis gilt der eine
+    Abruf unveraendert weiter — deren Waechter liegen woanders.
+
+    Der Waechter hier zieht deshalb um, statt sich aufzuweichen:
+    (1) das BUDGET bleibt gedeckelt (``RADAR_ZONE_MAX_POINTS``, ueber die
+    Modul-Referenz gelesen, damit eine Laufzeit-Umstellung der Konstante
+    nicht an einer beim Import gebundenen Kopie vorbeilaeuft);
+    (2) der AUSLOESENDE Datensatz wird ueber die Naehe seines ``source_key``
+    zum analytisch gerechneten #2017-Messpunkt identifiziert — nicht ueber
+    ``sorted(...)[0]``, denn dass der lexikografisch erste Dateiname der
+    Messpunkt ist, gilt nur fuer eine nach Nordosten laufende Route;
+    (3) die ``capture_id`` im ``alert_log`` gehoert zu GENAU DIESEM
+    Datensatz und zu keinem der Folgepunkte."""
     from datetime import datetime, timedelta, timezone
     from datetime import time as time_type
 
@@ -270,6 +289,10 @@ def test_ac4_e2e_zweig_c_alert_log_capture_id_matches_written_input_record():
     from services.radar_cache import RadarNowcastCacheService
     from services.radar_service import RadarNowcastService, _nowcast_source_key
     from services.trip_alert import TripAlertService
+    # Modul-Referenz, KEIN `from ... import RADAR_ZONE_MAX_POINTS`: eine beim
+    # Import gebundene Kopie liefe am Laufzeit-Drift-Schutz vorbei (dasselbe
+    # Muster wie in `src/services/trip_alert.py`).
+    from services import trip_segments as trip_segments_mod
 
     from tests.helpers.alert_log_fixtures import fresh_user
     from tests.helpers.arrival_window_fixtures import active_window_offsets, stage_date
@@ -342,19 +365,47 @@ def test_ac4_e2e_zweig_c_alert_log_capture_id_matches_written_input_record():
 
     capture_dir = get_data_root() / "debug" / "alert_input" / "nowcast"
     capture_files = sorted(capture_dir.glob("*.json"))
-    assert len(capture_files) == 1, (
-        f"Erwartet wird GENAU EIN Eingangs-Datensatz unter "
-        f"data/debug/alert_input/nowcast/ (ein Abruf je Lauf, #2017 AC-12), "
-        f"gefunden: {[f.name for f in capture_files]!r}"
+    assert capture_files, (
+        "Kein Eingangs-Datensatz unter data/debug/alert_input/nowcast/ gefunden."
     )
-    datensatz = json.loads(capture_files[0].read_text())
-    ist_lat, ist_lon = (float(x) for x in datensatz["source_key"].split("_")[:2])
-    assert (abs(ist_lat - soll_lat) < 5e-4 and abs(ist_lon - soll_lon) < 5e-4), (
-        f"Der Eingangs-Datensatz gehoert nicht zu diesem Abruf: sein "
-        f"source_key zeigt auf ({ist_lat}, {ist_lon}), abgefragt wurde der "
-        f"zur Fenstermitte interpolierte Punkt ({soll_lat:.5f}, "
-        f"{soll_lon:.5f}). ({lat}, {lon}) waere der Segment-Startpunkt, also "
-        f"der Messpunkt VOR #2017."
+    datensaetze = [json.loads(f.read_text()) for f in capture_files]
+
+    def _koordinaten(ds: dict) -> tuple:
+        return tuple(float(x) for x in ds["source_key"].split("_")[:2])
+
+    # (1) Budget-Deckel: die Zonen-Abfrage darf sich nicht zu einer offenen
+    # Schleife auswachsen. Die Obergrenze kommt aus dem Produktivmodul.
+    deckel = trip_segments_mod.RADAR_ZONE_MAX_POINTS
+    assert len(datensaetze) <= deckel, (
+        f"Die Zonen-Abfrage hat ihr Budget gesprengt: {len(datensaetze)} "
+        f"Eingangs-Datensaetze unter data/debug/alert_input/nowcast/, erlaubt "
+        f"sind hoechstens RADAR_ZONE_MAX_POINTS={deckel} (#2051 S2a). "
+        f"Gefunden: {[f.name for f in capture_files]!r}"
+    )
+
+    # (2) Der AUSLOESENDE Datensatz wird ueber den Ort identifiziert, nicht
+    # ueber die Dateinamen-Reihenfolge: der erste Punkt der Reststrecke ist
+    # unveraendert der #2017-Messpunkt, die uebrigen liefern nur die Zonen.
+    ausloesende = [
+        ds for ds in datensaetze
+        if abs(_koordinaten(ds)[0] - soll_lat) < 5e-4
+        and abs(_koordinaten(ds)[1] - soll_lon) < 5e-4
+    ]
+    assert len(ausloesende) == 1, (
+        f"Genau EIN Eingangs-Datensatz muss auf den zur Fenstermitte "
+        f"interpolierten Messpunkt ({soll_lat:.5f}, {soll_lon:.5f}) zeigen — "
+        f"er traegt die Ausloeseregel. Gefunden wurden {len(ausloesende)} "
+        f"passende unter den source_keys "
+        f"{[ds['source_key'] for ds in datensaetze]!r}. ({lat}, {lon}) waere "
+        f"der Segment-Startpunkt, also der Messpunkt VOR #2017."
+    )
+    datensatz = ausloesende[0]
+    ist_lat, ist_lon = _koordinaten(datensatz)
+    assert datensatz is min(datensaetze, key=lambda ds: ds["captured_at"]), (
+        f"Der Messpunkt-Datensatz ist nicht der ZUERST geschriebene: #2051 S2a "
+        f"sichert zu, dass der erste abgefragte Punkt der #2017-Messpunkt "
+        f"bleibt. Reihenfolge war "
+        f"{[(ds['source_key'], ds['captured_at']) for ds in datensaetze]!r}"
     )
     assert datensatz["source_key"] == _nowcast_source_key(ist_lat, ist_lon), (
         f"source_key {datensatz['source_key']!r} folgt nicht der geteilten "
@@ -363,11 +414,26 @@ def test_ac4_e2e_zweig_c_alert_log_capture_id_matches_written_input_record():
     )
     written_capture_id = datensatz["capture_id"]
     assert written_capture_id, "Eingangs-Datensatz traegt keine capture_id."
+    folgepunkt_ids = {
+        ds["capture_id"] for ds in datensaetze if ds is not datensatz
+    }
+    assert written_capture_id not in folgepunkt_ids, (
+        f"Vorbedingung: jeder Abruf braucht eine EIGENE capture_id, sonst "
+        f"kann der Fall unten Messpunkt und Folgepunkt nicht unterscheiden. "
+        f"capture_ids: {[ds['capture_id'] for ds in datensaetze]!r}"
+    )
 
+    # (3) Der alert_log-Eintrag zeigt auf den AUSLOESENDEN Datensatz — nicht
+    # auf einen der Zonen-Folgepunkte.
     log_entry = _read_log(uid)["entries"][-1]
     assert log_entry.get("reason") == alert_log.REASON_NOWCAST
     assert log_entry.get("capture_id") == written_capture_id, (
         f"alert_log-Eintrag (Zweig c) traegt eine ANDERE capture_id als der "
-        f"Eingangs-Datensatz: log={log_entry.get('capture_id')!r} != "
-        f"input={written_capture_id!r}"
+        f"ausloesende Eingangs-Datensatz: log={log_entry.get('capture_id')!r} "
+        f"!= input={written_capture_id!r}"
+        + (
+            " — er zeigt auf einen Zonen-Folgepunkt statt auf den "
+            "#2017-Messpunkt."
+            if log_entry.get("capture_id") in folgepunkt_ids else ""
+        )
     )

--- a/tests/unit/test_radar_nowcast_cache_sharing.py
+++ b/tests/unit/test_radar_nowcast_cache_sharing.py
@@ -254,7 +254,22 @@ def test_two_default_instances_mimicking_trip_and_compare_construction_share_cac
 
 def _e2e_trip(lat: float, lon: float):
     """Trip mit einer ganztaegigen Etappe -- gemeinsamer Aufbau der beiden
-    End-to-End-Faelle unten (Wegpunkt 1 bei ``(lat, lon)``, 1000 m)."""
+    End-to-End-Faelle unten (Wegpunkt 1 bei ``(lat, lon)``, 1000 m).
+
+    Issue #2051 S2a: das Segment ist ABSICHTLICH kurz gehalten (Delta 0.005°
+    statt vormals 0.02°, volle Segmentlaenge < 0.7 km). S2a fragt entlang der
+    Reststrecke bis zu ``RADAR_ZONE_MAX_POINTS`` Punkte ab, sobald die
+    Reststrecke >= 2 km ist (``RADAR_ZONE_POINT_SPACING_KM``) -- bei 0.02°
+    (~2,7 km volle Segmentlaenge) waere das Ein-Punkt-Regime, das beide
+    Tests unten voraussetzen ("EIN Fetch teilen sich"/"ZWEI Fetches"),
+    abhaengig von der WANDUHR (dieser Test friert die Zeit nicht ein) nicht
+    mehr garantiert. Mit < 0.7 km voller Segmentlaenge bleibt die
+    Reststrecke IMMER < 2 km, unabhaengig vom Zeitanteil `p` -- das
+    Ein-Punkt-Regime ist damit deterministisch, nicht nur zufaellig
+    zutreffend. Beide Tests pruefen weiterhin den Cache-TEIL-Mechanismus,
+    nicht die S2a-Mehrpunkt-Logik (die hat ihre eigenen Tests in
+    ``tests/tdd/test_regen_ausdehnung_messpunkte.py``).
+    """
     from app.trip import Stage, Trip, Waypoint
 
     return Trip(
@@ -272,7 +287,7 @@ def _e2e_trip(lat: float, lon: float):
                         arrival_override="00:00",
                     ),
                     Waypoint(
-                        id="W2", name="Ziel", lat=lat + 0.02, lon=lon + 0.02,
+                        id="W2", name="Ziel", lat=lat + 0.005, lon=lon + 0.005,
                         elevation_m=1100, arrival_override="23:59",
                     ),
                 ],


### PR DESCRIPTION
- **docs(#2051): S2a — Spec raeumliche Ausdehnung (PO-freigegeben, 16 ACs)**
- **docs(#2051): S2a — Spec-Fundstellen nach Kartierung korrigiert**
- **test(#2051): S2a RED — raeumliche Ausdehnung des Regenereignisses**
- **docs(#2051): S2a — Trip-Onset-Draht verifiziert korrigiert**
- **feat(#2051): S2a — raeumliche Ausdehnung des Regenereignisses**
