### PR TITLE
feat(#2050 S4c): Abweichungs-Zweig an der Ereignis-Identitaet — ein Ereignis, ein Alarm

### DIFF
--- a/docs/adr/0021-shared-deviation-alert-engine.md
+++ b/docs/adr/0021-shared-deviation-alert-engine.md
@@ -370,3 +370,69 @@ dieser Scheibe (Scheibe 2, #1169).
   lebt die Ausnahme Caller-seitig im Trip-Pfad, exakt wie schon bei #2065 und
   S3b. Details:
   `docs/specs/modules/feat_2050_s3c_abweichung_ueberholt_sperrzeit.md`.
+
+- **Nachtrag (Issue #2050 S4c, 2026-08-23):** die quellenübergreifende
+  Ereignis-Identität (Nachträge zu #1467 S4b/S4b-2 und #2018) galt bisher
+  ausschließlich zwischen **Radar** und **amtlich**. Diese Scheibe schließt
+  einen dritten Aufrufer an denselben, unveränderten Mechanismus an: den
+  **Abweichungs-Zweig** (Vorhersage-Änderungsalarm,
+  `trip_alert.py::check_and_send_alerts`).
+
+  **Dritter Auflösungsweg für die Gefahrenklasse.** `resolve_hazard_class()`
+  bekommt einen dritten, optionalen Parameter `metrics` — eine Metrik-Liste
+  statt `is_convective`/`hazard`. Neuer Kanon `_WET_METRICS` (`precip_sum_mm`,
+  `precip_heavy_onset_utc`, `thunder_level_max`, `thunder_onset_utc`),
+  eigenständig neben `_WET_HAZARDS` (amtliche Hazard-STRINGS, anderer
+  Namensraum). Die Klasse ist nur dann `wet`, wenn die Metrik-Liste nicht leer
+  ist UND JEDE Metrik zum Kanon gehört — ein einziger Anteil außerhalb (z. B.
+  Wind oder Schnee) macht die Klasse `None`; Schnee-Metriken gehören
+  ausdrücklich NICHT zum Kanon (physikalisch Niederschlag, aber außerhalb des
+  T2-Kanons).
+
+  **Expliziter Quellenvermerk statt Ableitung.** `check_event_identity_gate()`
+  und `record_event_identity()` bekommen einen additiven, optionalen Parameter
+  `source: "official" | "nowcast" | "deviation"`. Radar und amtlich lassen ihn
+  weiterhin weg — der Fallback (Ableitung aus der Anwesenheit von `point_at`)
+  bleibt für sie identisch, die Signatur bricht für sie nicht. Der
+  Abweichungs-Zweig trägt (wie ein amtlicher Eintrag) ein Zeitintervall statt
+  eines Einzelzeitpunkts und übergibt deshalb IMMER `source="deviation"`
+  explizit — sonst läse ihn die alte Ableitung fälschlich als `"official"`.
+  `addendum_direction` erweitert sich entsprechend um den Fall
+  `match["source"] == "deviation" and new_source == "nowcast"` (bisher nur
+  `"official"`); ein nachfolgender, eskalierender Radar-Alarm nennt dann die
+  gemeldete Wetterabweichung statt einer nie vorliegenden amtlichen Warnung.
+
+  **Zeitbezug aus Segmentfenstern statt `occurred_at`.** `WeatherChange.
+  occurred_at` ist in drei von vier Erzeugungspfaden `None` und als Zeitbezug
+  ungeeignet. Der Δ-Zweig bildet `window_start`/`window_end` stattdessen aus
+  den Start-/Endzeitpunkten der Trip-Segmente der NASSEN Änderungen
+  (`trip_alert.py::_delta_event_window`); `point_at` bleibt für ihn immer
+  `None`. Lässt sich kein Segment mit Zeitfenster auffinden, bleiben beide
+  Werte `None` — `_times_overlap()` liefert dafür fail-soft `False`.
+
+  **Streng prüfen, großzügig registrieren.** Geprüft (Aufruf von
+  `check_event_identity_gate()`) wird nur, wenn die Gefahrenklasse des
+  GESAMTEN Bündels `wet` ist — ein einziger nicht-nasser Anteil lässt die
+  Meldung immer durch, ohne das Register überhaupt zu lesen. Registriert wird
+  dagegen unabhängig vom Prüfergebnis, sobald das Bündel NACH erfolgreicher
+  Zustellung mindestens eine nasse Änderung enthält — Eskalationen, die
+  V1-Ausnahme und gemischte Bündel hinterlassen damit ebenfalls einen
+  Registereintrag für die nassen Anteile.
+
+  **Ablösung des Doppel-Alarm-Wächters (#818).** Der seit #818 zur Hälfte tote
+  Wächter (`trip_alert.py`, Schlüssel `precip:<segment>`/
+  `thunder_level_max:<segment>` — `"precip"` ist kein Metrik-Schlüssel, der
+  reale heißt `precip_sum_mm`) ist ENTFERNT, nicht repariert. Die Paarung
+  „Δ meldete, Radar zieht nach" läuft jetzt ausschließlich über die
+  Ereignis-Identität; der protokollierte Grund wechselt für diese Paarung von
+  `double_alert_guard` auf `event_duplicate`, und — anders als beim alten
+  Wächter — eine echte Eskalation kommt jetzt durch (Verbindung zu #2065/
+  S3c). Der Grund-Code `double_alert_guard` selbst bleibt in `alert_log.py`/
+  `undelivered_hint.py` für historische Einträge erhalten.
+
+  **Ortsvergleich bleibt unberührt.** `compare_alert.py` ruft weder
+  `check_event_identity_gate()` noch `record_event_identity()` auf —
+  Ortsvergleich-Themen sind PO-seitig zurückgestellt, die Anschlussstelle ist
+  kartiert (`docs/context/feat-2050-s4c-ein-ereignis-ein-alarm.md`) und geht
+  als benannte Folgescheibe ins Issue. Details:
+  `docs/specs/modules/feat_2050_s4c_ein_ereignis_ein_alarm.md`.

--- a/docs/context/feat-2050-s4c-ein-ereignis-ein-alarm.md
+++ b/docs/context/feat-2050-s4c-ein-ereignis-ein-alarm.md
@@ -1,0 +1,328 @@
+# Context: feat-2050-s4c-ein-ereignis-ein-alarm
+
+**Issue:** #2050, Scheibe **S4c** · Szenario **5** · Anforderung **C-2**
+**Stand der Kartierung:** `origin/main` = `791ef6bc` (23.08.2026)
+
+## Request Summary
+
+Melden amtliche Warnung, Vorhersage-Abweichung und Radar dieselbe Gewitterzelle, soll **eine**
+Nachricht herausgehen statt zwei bis drei — danach nur noch Verschärfungen. Heute greift die
+quellenübergreifende Entdopplung nur zwischen **Radar** und **amtlich**; der **Abweichungs-Zweig
+(Δ)** ist an sie nicht angeschlossen und meldet an ihr vorbei.
+
+## Zuschnitt-Vorgeschichte
+
+Der ursprüngliche Schnitt „S4 = Szenarien 5, 6, 12" ist beim Intake (23.08.) aufgeteilt worden,
+weil Szenario 6 zu diesem Zeitpunkt bereits in einer Parallelsitzung lief:
+
+| Scheibe | Szenario | Stand |
+|---|---|---|
+| S4a | 6 — Radar-Teilausfall (B-4) | läuft, Branch `feat-2050-s4a-radar-teilausfall` |
+| **S4c** | **5 — ein Ereignis, ein Alarm (C-2)** | **diese Scheibe**, Full Process |
+| S4b | 12 — nie stilles Nichts (D-2/E-1) | offen, vom PO nachrangig gestellt |
+
+## Der Ist-Zustand — was bereits existiert
+
+Die quellenübergreifende Entdopplung ist **gebaut und in Betrieb** (#1467 S4b-1, erweitert durch
+#2018 und #2065). Sie ist von Anfang an entitätsparametrisiert, gilt also für Trip **und**
+Ortsvergleich.
+
+| Baustein | Ort |
+|---|---|
+| Leseprüfung | `src/services/alert_gate.py:736` `check_event_identity_gate()` |
+| Registrierung nach Zustellung | `src/services/alert_gate.py:823` `record_event_identity()` |
+| Gefahrenklassen-Auflösung | `src/services/alert_gate.py:547` `resolve_hazard_class()` |
+| Kandidatensuche | `src/services/alert_gate.py:634` `_find_matching_entry()` |
+| Zeitüberlappung | `src/services/alert_gate.py:589` `_times_overlap()` |
+| Wesentlich-mehr-Abdeckung (V1) | `src/services/alert_gate.py:720` `_covers_materially_more()` |
+
+**Wie zwei Meldungen als „dasselbe Ereignis" gelten** — alle drei Bedingungen zugleich:
+
+1. **Gefahrenklasse gleich.** Es gibt genau eine: `HAZARD_CLASS_WET` (`:543`). PO-Entscheid
+   2026-08-16: konvektiv/nicht-konvektiv unterscheidet nur die Erscheinungsform derselben Zelle.
+   Unbekannte Gefahrenart ⇒ `None` ⇒ **nie** entdoppelt (`:779-780`).
+2. **Ortsbezug überlappt.** Schnittmenge der `segment_ids` nicht leer (`:670`, `isdisjoint`).
+   Leere Menge auf einer der beiden Seiten ⇒ **nie** Match (`:657-659`).
+3. **Zeitbezug überlappt.** Punkt gegen Punkt / Punkt gegen Intervall (mit Nowcast-Horizont als
+   Puffer) / Intervall gegen Intervall (`:589-631`).
+
+**Reihenfolge nach einem Treffer, strukturell fest** (`:761-770`):
+Eskalation (V2, immer zuerst) → V1-Ausnahme „deckt wesentlich mehr Zeit ab" → Unterdrückung mit
+`REASON_EVENT_DUPLICATE`.
+
+Bereits verdrahtet an vier Stellen:
+
+| Zweig | Prüfung | Registrierung |
+|---|---|---|
+| Radar/Trip | `src/services/trip_alert.py:1995` | `:2120` |
+| Amtlich/Trip | `src/services/trip_alert.py:2448` | `:2575` |
+| Radar/Compare | `src/services/compare_radar_alert.py:245` | `:396` |
+| Amtlich/Compare | `src/services/compare_official_alert.py:222` | `:346` |
+
+## Die Lücke
+
+Der **Δ-Zweig ruft weder die Prüfung noch die Registrierung**:
+
+- Trip: `src/services/trip_alert.py:310` `check_and_send_alerts()` — kein Aufruf im ganzen Block
+  `:310-657`
+- Ortsvergleich: `src/services/compare_alert.py:122` `check_all_compare_presets()` /
+  `:471` `_evaluate_one_location()` — ebenso nicht
+
+Das ist **dokumentiert und bewusst zurückgestellt**, nicht übersehen:
+`docs/specs/modules/rework_1467_s4b_entdopplung.md:382` — „Änderungsalarm (Δ) als dritte
+Prüfrichtung bleibt offen, S4b-3".
+
+**Folge im Szenario** (amtlich 10:00 → Δ 11:15 → Radar 12:30, dieselbe Zelle): Der amtliche Alarm
+geht raus und registriert sich. Der Δ-Alarm um 11:15 sieht das Register nicht und geht als zweite
+volle Nachricht raus — und registriert sich auch nicht. Der Radar-Alarm um 12:30 wird vom
+**amtlichen** Eintrag gefangen (sofern Segment und Zeitfenster passen) und kommt als Nachtrag.
+Ergebnis heute: **zwei** Nachrichten statt einer, und das Register kennt den Δ-Alarm nicht.
+
+## Zwei Stellen, an denen der Δ-Zweig strukturell anders ist
+
+### a) Die Gefahrenklasse ist über Metriken zu bestimmen
+
+`resolve_hazard_class()` kennt genau zwei Eingänge: `is_convective` (Radar) und `hazard`
+(amtlich). Der Δ-Zweig hat weder das eine noch das andere — er trägt **Metrik-Änderungen**
+(`change.metric`, `src/services/trip_alert.py:621`). Ein dritter Auflösungsweg ist nötig, und mit
+ihm die Festlegung, welche Metriken zum `wet`-Kanon gehören. Alles außerhalb ⇒ `None` ⇒ nie
+entdoppelt; das ist die sichere Richtung und deckt sich mit AC-4 der Bestandsscheibe.
+
+### b) Δ meldet gebündelt — mehrere Segmente, mehrere Metriken in EINER Nachricht
+
+`to_report` ist eine Liste; ein Alarm kann mehrere Streckenabschnitte und mehrere Metriken
+zugleich tragen (sichtbar an `unique_or_none(...)` in `src/services/trip_alert.py:574-575`, das
+genau deshalb existiert). Die Ereignis-Identität ist auf Segment-**Mengen** ausgelegt (Schnittmenge
+genügt), das passt strukturell — aber die Zeitangabe muss aus mehreren Änderungen gebildet werden,
+und die Frage „was, wenn nur ein Teil der Bündelung ein Duplikat ist?" hat der Bestand noch nie
+beantworten müssen. Das ist die zentrale Entwurfsfrage dieser Scheibe.
+
+### c) Der Quellenvermerk wird heute aus der Zeitform abgeleitet
+
+`src/services/alert_gate.py:794` und `:858`: `"nowcast" if point_at is not None else "official"`.
+Ein Δ-Eintrag, der (wie ein amtlicher) ein Zeit**intervall** trägt, würde damit fälschlich als
+`official` registriert. Das beeinflusst die Nachtrags-Richtung (`:795`) und die Auswertbarkeit des
+Protokolls. Ein expliziter `source`-Parameter ist der saubere Weg — **Signaturänderung**, also mit
+Referenzfeger über `tests/` (siehe Risiken).
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `src/services/alert_gate.py` | Ereignis-Identität: Prüfung, Registrierung, Gefahrenklasse, Quellenvermerk |
+| `src/services/trip_alert.py` | Δ-Zweig `check_and_send_alerts():310-657`; Einbauorte: Prüfung vor `:538`, Registrierung nach `:617` |
+| `src/services/compare_alert.py` | Δ-Pendant im Ortsvergleich (`:122`, `:471`, `_finalize_triggered_state`) |
+| `src/services/deviation_alert_engine.py` | gemeinsamer Auswertungskern des Δ-Zweigs (`:264` `evaluate()`) |
+| `src/services/alert_state.py` | Registerablage, Präfix `event_identity:` (`:44`) |
+| `src/services/alert_log.py` | `REASON_EVENT_DUPLICATE` (`:63`), Protokolleintrag |
+| `src/output/renderers/email/undelivered_hint.py` | `_REASON_LABELS`/`_REASON_BLOCK` (`:48-77`) — `event_duplicate` fehlt dort |
+| `src/services/alert_urgency.py` | geteilte Rangordnung `exceeds()` / `highest_urgency()` |
+
+## Existing Patterns
+
+- **Prüfen vor dem Versand, registrieren erst nach erfolgreicher Zustellung** (F001-Symmetrie zu
+  `record_nowcast_sent`) — bei allen vier Bestandsstellen gleich.
+- **Eskalation bricht immer durch**, als strukturell erster Zweig mit eigenem `return`
+  (`alert_gate.py:797`). Dieselbe Politik wie Sperrzeit-Überholung (#2065, #2050 S3c).
+- **Fail-soft im Register:** kaputter Eintrag ⇒ überspringen und protokollieren, nie Absturz
+  (`:696-708`).
+- **Read-Modify-Write mit Merge** beim Registerschreiben (`:837-840`) — Pflicht laut CLAUDE.md.
+- **Caller-seitige Entscheidung nach dem Wetterabruf** statt hartem Abbruch im Gate — das Muster
+  aus #2065 / S3b / S3c, das auch hier trägt.
+
+## Dependencies
+
+- **Upstream:** `AlertStateService` (Registerablage), `alert_urgency` (Rangordnung),
+  `alert_daily_limit`, `ThrottleStore`, Wetter-Anker über `_get_cached_weather()`
+- **Downstream:** alle vier Kanäle über `_send_alert()`; `alert_log` (Protokoll, von der Go-Seite
+  gelesen — `internal/store/log.go` liest nur bestehende Felder, Ergänzungen nur additiv);
+  E-Mail-Baustein `undelivered_hint.py`
+
+## Existing Specs
+
+- `docs/specs/modules/rework_1467_s4b_entdopplung.md` — die Bestandsscheibe samt der ausdrücklich
+  offen gelassenen dritten Prüfrichtung (`:382`)
+- `docs/specs/modules/alarm_pruefstrecke.md` — Prüfstrecke aus #2050 S1
+- `docs/specs/modules/alarm_szenarien_waechter_4_9_11.md`, `alarm_szenario_laufendes_ereignis.md` —
+  Muster für Szenario-Wächter
+- `docs/specs/modules/feat_2050_s4a_radar_teilausfall.md` — Parallelscheibe, berührt
+  `alert_log.py` und `undelivered_hint.py`
+
+## Risks & Considerations
+
+1. **🔴 Die gefährlichste Fehlerrichtung ist der ausbleibende Alarm.** Diese Scheibe baut eine
+   **Unterdrückungs**-Regel, und die Tour des PO läuft ab heute (23.08.). Jede AC muss die
+   Gegenrichtung mitsichern: Verschärfung kommt durch, unbekannte Gefahrenart wird nie entdoppelt,
+   leere Segmentmenge erzeugt nie ein Match, kaputter Registereintrag unterdrückt nichts.
+2. **Zwei Mechanismen für dieselbe Paarung.** Der Doppel-Alarm-Guard
+   (`src/services/trip_alert.py:1835-1861`) verbindet Radar und Δ bereits — aber nur in einer
+   Richtung (Radar liest, was Δ geschrieben hat). Wird Δ zusätzlich an die Ereignis-Identität
+   angeschlossen, gibt es zwei Wächter für dieselbe Paarung. Das Verhältnis muss die Spec klären,
+   sonst entsteht eine doppelte Unterdrückung, deren Grund im Protokoll uneindeutig ist.
+3. **Gebündelte Δ-Meldungen sind nicht teilbar.** Fällt ein Teil der Bündelung unter ein
+   registriertes Ereignis und ein anderer nicht, darf die Unterdrückung nicht die ganze Nachricht
+   verschlucken. Entwurfsentscheidung mit Nutzerwirkung.
+4. **Ortsvergleich-Fernwirkung.** `entity_id` ist dort `f"{preset_id}:{location_id}"` — der
+   Namensraum ist bereits kompatibel. Trotzdem gilt die Trip/Compare-Teilungsvorgabe: gemeinsame
+   Auflösung, kein zweiter Mechanismus.
+5. **Signaturänderung an `record_event_identity()` / `resolve_hazard_class()`** zieht einen
+   Referenzfeger über `tests/` nach sich (`grep -rln` über die Testbäume) — Signatur-Wächter
+   liegen in fremden Testdateien.
+6. **Berührung mit der Parallelscheibe S4a:** beide fassen `alert_log.py` (Grund-Register) und
+   `undelivered_hint.py` (Beschriftungen) an. Kleine, aber reale Merge-Berührung — vor dem Merge
+   gegen `origin/main` rebasen und den Diff auf gelöschte Fremdarbeit prüfen.
+7. **Prüfstrecken-Grenze:** `alert_state.reset()` verwirft `event_identity:`-Schlüssel still
+   (`src/services/alert_state.py:38-45`). Szenarien über eine Briefing-Grenze verlieren ihre
+   Vorbelegung unbemerkt — bei Zeitreihen-Tests beachten.
+8. **Nebenbefund (nicht Ziel dieser Scheibe):** `event_duplicate` fehlt in `_REASON_LABELS` von
+   `undelivered_hint.py` und fällt dort auf „Versand fehlgeschlagen" zurück — der Nutzer liest
+   einen Fehler, wo bewusst entdoppelt wurde. Kandidat für diese Scheibe, weil sie den Grund
+   erstmals im Δ-Zweig auslöst.
+
+## Analysis (Phase 2, 23.08.2026)
+
+### Type
+
+**Feature** — Anschluss eines bestehenden, in Betrieb befindlichen Mechanismus an einen bisher
+nicht angeschlossenen Zweig. Kein Neubau.
+
+### Befund A — Der Metrik-Kanon ist abschließbar
+
+`change.metric` ist **nie Freitext**: Ein Metrik-Schlüssel, der sich nicht als `AlertMetric`
+parsen lässt, erzeugt gar keine Alarm-Regel (`src/services/alert_preset.py:236-252`) und kann
+`to_report` nicht erreichen. Die real erreichbaren Werte stammen aus `_METRICS`
+(`src/app/metric_catalog.py:111ff`).
+
+**Dem `wet`-Kanon zuzuordnen (vier Schlüssel):**
+`precip_sum_mm` · `precip_heavy_onset_utc` · `thunder_level_max` · `thunder_onset_utc`
+
+**Ausdrücklich nicht:** Temperatur (`temp_*`), Wind (`wind_max_kmh`, `gust_max_kmh`), Sicht,
+UV, Nullgradgrenze sowie **Schnee** (`snow_depth_cm`, `snow_new_sum_cm`, `snowfall_limit_m`) —
+Schnee ist physikalisch Niederschlag, steht aber nicht im T2-Kanon `_WET_HAZARDS`
+(`src/services/alert_gate.py:544`) und bleibt deshalb außen vor. `cape_max_jkg` ist im Live-Pfad
+unerreichbar (`selectable=False`, #710).
+
+Nicht verwendbar wäre `MetricDefinition.category` — dort liegen `snowfall_limit` und
+`rain_probability` mit unter `"precipitation"`, was nicht deckungsgleich mit dem Kanon ist.
+
+### Befund B — Der Zeitbezug muss aus dem Segmentfenster kommen, nicht aus `occurred_at`
+
+`WeatherChange.occurred_at` (`src/app/models.py:603`) ist der Zeitpunkt des Spitzenwerts, **aber
+in drei von vier Erzeugungspfaden gar nicht gesetzt**: Beginn-Verschiebung setzt ausdrücklich
+`None` (`weather_change_detection.py:951`), Absolut-Regeln (`:1048-1059`) und
+Schwellwert-Unterschreitung (`:1090-1099`) übergeben es nie.
+
+Ein Zeitbezug aus `occurred_at` liefe deshalb überwiegend leer — `_times_overlap()` gibt ohne
+Zeitbezug `False` zurück, es käme nie zu einem Match. Der Δ-Zweig muss daher das
+**Zeitintervall** übergeben (`window_start`/`window_end`), gebildet aus den Segmenten der
+betroffenen Änderungen. Das ist zugleich semantisch richtig: Der Δ-Zweig sagt „in diesem
+Streckenabschnitt", nicht „um 14:12".
+
+Zusätzlich zwingend: `point_at` **darf nicht** gesetzt werden, denn daraus leitet der Bestand
+heute den Quellenvermerk ab (`alert_gate.py:794`, `:858`).
+
+### Befund C — Der Quellenvermerk muss ein echter Parameter werden
+
+Heute: `"nowcast" if point_at is not None else "official"`. Ein Δ-Eintrag ohne `point_at` würde
+damit als **`official`** registriert. Folge: Ein späterer Radar-Alarm käme als „Nachtrag zur
+amtlichen Warnung", obwohl nie eine amtliche Warnung vorlag — eine **falsche Aussage im
+Nutzertext** (Verstoß gegen B-2). `record_event_identity()` und `check_event_identity_gate()`
+brauchen deshalb einen expliziten `source`-Parameter mit dem dritten Wert `"deviation"`.
+Signaturänderung ⇒ Referenzfeger über `tests/` ist Pflicht.
+
+### Befund D — Der bestehende Doppel-Alarm-Wächter ist halb tot und hat keine Eskalations-Ausnahme
+
+`src/services/trip_alert.py:1839` liest zwei Schlüssel: `precip:<segment_id>` und
+`thunder_level_max:<segment_id>`. Geschrieben wird das Melde-Gedächtnis aber als
+`f"{change.metric}:{change.segment_id}"` (`:621`) — und **`"precip"` ist kein Metrik-Schlüssel**;
+der reale Name lautet `precip_sum_mm`. Im gesamten `src/`-Baum existiert kein Schreiber für
+`precip:`. Der Niederschlags-Teil dieses Wächters ist damit **seit seiner Einführung (#818) toter
+Code**; nur die Gewitter-Hälfte wirkt.
+
+Praktische Folge heute: Meldet der Δ-Zweig Regen und zieht danach der Radar nach, geht die
+zweite Nachricht ungebremst raus — **genau der Doppel-Alarm, den Szenario 5 verhindern soll.**
+
+Zweiter, gewichtigerer Punkt: Der Wächter kennt **keine Eskalations-Ausnahme**. Er vergleicht nur
+Zeitabstand gegen die Sperrzeit. Eine echte Verschärfung schluckt er — Verstoß gegen A-3, die in
+S3c gerade erst für den Abweichungs-Zweig hergestellt wurde.
+
+### Befund E — Die Richtung „Radar/amtlich bremst den Abweichungs-Alarm" entsteht neu
+
+Bisher gibt es sie nicht: Der Doppel-Alarm-Wächter liest ausschließlich im Radar-Zweig. Ein
+zuerst gesendeter Radar- oder amtlicher Alarm bremst heute **nie** einen nachfolgenden
+Δ-Alarm. Mit dem Anschluss entsteht dieses Verhalten — es ist der Kern von C-2, aber es ist eine
+**neue Unterdrückung** und braucht die volle Absicherung der Gegenrichtung.
+
+Kein bestehender Test sichert zu, dass der Δ-Alarm unabhängig von Radar/amtlich herausgeht — die
+Unabhängigkeit war bisher nur ein Nebeneffekt des fehlenden Anschlusses.
+
+### Entscheidung 1 — Gemischte Bündel werden nie unterdrückt
+
+`to_report` kann mehrere Streckenabschnitte **und** mehrere Messgrößen zugleich tragen, und es
+gibt **kein** bestehendes Muster, einzelne Änderungen vor dem Versand herauszufiltern
+(`_send_alert` bekommt die Liste als Ganzes, `trip_alert.py:561`). Eine teilweise Unterdrückung
+wäre also ein neuer Mechanismus mit eigener Fehlerfläche.
+
+**Regel:** Die Gefahrenklasse ist nur dann `wet`, wenn **jede** Änderung im Bündel zum
+`wet`-Kanon gehört. Trägt das Bündel auch nur eine nicht-nasse Änderung (Wind, Temperatur,
+Schnee …), ist die Klasse `None` und die Nachricht geht **immer** durch — sie enthält
+Information, die kein Radar- und kein amtlicher Alarm je gemeldet hat.
+
+**Registriert** wird dagegen großzügiger: Jede zugestellte Nachricht mit Nass-Anteil hinterlässt
+einen Eintrag über **die Segmente ihrer nassen Änderungen** — damit ein späterer Radar-Alarm für
+dieselbe Zelle überhaupt etwas findet. Streng prüfen, großzügig registrieren: Beide Richtungen
+zeigen von der Unterdrückung weg.
+
+### Entscheidung 2 — Der Doppel-Alarm-Wächter wird abgelöst, nicht repariert
+
+Der tote `precip:`-Schlüssel wird **nicht** geflickt. Stattdessen übernimmt die Ereignis-Identität
+diese Paarung vollständig, und der Wächter entfällt. Begründung: Zwei Wächter für dieselbe
+Paarung machen den Unterdrückungsgrund im Protokoll uneindeutig, und der ältere kennt keine
+Eskalations-Ausnahme — er würde eine Verschärfung schlucken, die der neue durchließe. Ein bloßes
+Reparieren des Schlüsselnamens würde eine seit Jahren stumme Bremse ohne Eskalations-Ausnahme
+scharf schalten; das ist die falsche Richtung.
+
+### Entscheidung 3 — Diese Scheibe liefert die Trip-Fläche
+
+Der Ortsvergleich bleibt außen vor, mit demselben Schnitt wie in S3c („Der Ortsvergleich erbt die
+Ausnahme nicht"). Gründe: Ortsvergleich-Themen sind vom PO zurückgestellt, der Umfang bliebe sonst
+nicht beherrschbar, und die Trip-Fläche ist die, auf der die laufende Tour stattfindet. Die
+Anschlussstellen im Ortsvergleich sind kartiert (`compare_alert.py`: Prüfung vor dem Versand
+`:312-334`, Registrierung nach `_finalize_triggered_state` `:405`, `entity_id=f"{preset_id}:{loc.id}"`,
+`segment_ids=[loc.id]`) und gehen als benannte Folgescheibe ins Issue.
+
+### Affected Files
+
+| Datei | Änderung | Beschreibung |
+|---|---|---|
+| `src/services/alert_gate.py` | MODIFY | dritter Auflösungsweg Metrik→Gefahrenklasse; expliziter `source`-Parameter mit Wert `deviation`; Nachtrags-Richtung um Δ erweitern |
+| `src/services/trip_alert.py` | MODIFY | Gate-Aufruf vor `_send_alert` (`:558`), Registrierung nach erfolgreicher Zustellung (`:617`); Doppel-Alarm-Wächter `:1835-1861` entfernen |
+| `src/output/renderers/email/undelivered_hint.py` | MODIFY | `event_duplicate` beschriften (fällt heute auf „Versand fehlgeschlagen" zurück) |
+| `tests/tdd/test_alarm_szenario_ein_ereignis_ein_alarm.py` | CREATE | Szenario-5-Wächter über die Prüfstrecke |
+| `tests/tdd/test_issue_818_radar_briefing_integration.py` | MODIFY | Wächter des abgelösten Doppel-Alarm-Guards umstellen |
+| `tests/tdd/test_alert_gate.py` | MODIFY | neue Auflösung + Quellenparameter |
+
+### Scope Assessment
+
+- Dateien: 3 Produktivdateien, 3–4 Testdateien
+- Geschätzte LoC: **+150/−30** Produktivcode ⇒ LoC-Limit 250 reicht voraussichtlich, sonst
+  `set-field loc_limit_override 500`
+- Risiko: **HOCH** — es entsteht eine neue Unterdrückungsregel, und die Tour läuft
+
+### Open Questions (mit der Spec zur PO-Freigabe)
+
+- [ ] Kommt ein Radar-Alarm, der auf einen Abweichungs-Alarm für dieselbe Zelle folgt, als
+      **Nachtrag** (kurze Zusatzmeldung mit Bezug auf die frühere) oder wird er ganz
+      unterdrückt? Empfehlung: **Nachtrag** — dieselbe Behandlung wie bei einer vorangegangenen
+      amtlichen Warnung (#2018), weil die Radar-Beobachtung die konkretere Information ist.
+
+## Bestehende Testabdeckung
+
+- `tests/tdd/test_alert_gate.py` (AC-1…AC-19 zur Ereignis-Identität, ab `:394`)
+- `tests/tdd/test_compare_radar_alert_event_identity.py`,
+  `tests/tdd/test_compare_official_alert_event_identity.py`
+- `tests/tdd/test_alert_addendum_failsoft.py`, `test_alert_addendum_sms.py` (#2018-Nachtrag)
+- `tests/tdd/test_cooldown_quellenuebergreifend.py` — sichert die Textzusicherung „Cooldown gilt
+  nur quelleneigen"; muss beim Anschluss des Δ-Zweigs auf Widerspruchsfreiheit geprüft werden
+- `tests/tdd/test_issue_818_radar_briefing_integration.py` — Doppel-Alarm-Guard
+- **Nicht abgedeckt:** kein `test_alarm_szenario_*` für Szenario 5

--- a/docs/specs/modules/feat_2050_s4c_ein_ereignis_ein_alarm.md
+++ b/docs/specs/modules/feat_2050_s4c_ein_ereignis_ein_alarm.md
@@ -1,0 +1,468 @@
+---
+entity_id: feat_2050_s4c_ein_ereignis_ein_alarm
+type: feature
+created: 2026-08-23
+updated: 2026-08-23
+status: draft
+workflow: feat-2050-s4c-ein-ereignis-ein-alarm
+version: "1.0"
+tags: [alarm, entdopplung, ereignis-identitaet, abweichung, nowcast]
+---
+
+# Ein Ereignis, ein Alarm — Abweichungs-Zweig anschließen (Issue #2050, Scheibe S4c)
+
+## Approval
+
+- [x] Approved (PO, 2026-08-23)
+
+## Purpose
+
+Issue #2050, Szenario 5, Anforderung **C-2**: Melden amtliche Warnung, Vorhersage-Abweichung
+(Δ) und Radar dieselbe Gewitter-/Regenzelle, soll **eine** Nachricht herausgehen statt zwei bis
+drei — danach nur noch Verschärfungen. Die quellenübergreifende Ereignis-Identität
+(`check_event_identity_gate()`/`record_event_identity()`, #1467 S4b, erweitert #2018/#2065) ist
+bereits gebaut und in Betrieb, gilt aber bislang nur zwischen **Radar** und **amtlich**. Der
+**Abweichungs-Zweig** ruft sie weder zum Prüfen noch zum Registrieren auf und meldet an ihr
+vorbei — dokumentierte, bewusst zurückgestellte Lücke (`rework_1467_s4b_entdopplung.md:382`).
+Diese Scheibe schließt den Δ-Zweig an denselben, unveränderten Mechanismus an: ein dritter
+Auflösungsweg von Metrik-Änderungen zur Gefahrenklasse, ein aus Segmentfenstern gebildeter
+Zeitbezug (statt eines meist fehlenden Einzelzeitpunkts) und ein expliziter Quellenvermerk
+`"deviation"`. Zugleich löst sie den seit #818 halb toten Doppel-Alarm-Wächter
+(`trip_alert.py:1835-1861`) ab, der dieselbe Paarung bisher einseitig und ohne
+Eskalations-Ausnahme behandelt hat.
+
+## Non-Goals
+
+- **Ortsvergleich.** `compare_alert.py` bleibt unangetastet (Entscheidung 3) — Ortsvergleich-
+  Themen sind PO-seitig zurückgestellt. Die Anschlussstellen sind kartiert
+  (`docs/context/feat-2050-s4c-ein-ereignis-ein-alarm.md`, Entscheidung 3) und gehen als benannte
+  Folgescheibe ins Issue. AC-19 sichert die Unberührtheit als Wächter zu.
+- **Keine neuen Alarmarten.** Es entsteht kein neuer Alarm-Trigger, nur eine zusätzliche
+  Anbindung des Δ-Zweigs an einen bestehenden Entdopplungs-Mechanismus.
+- **Keine Änderung an Sperrzeit, Tagesbudget oder Ruhezeit.** Diese Stufen (#2065, #2050 S3b/S3c)
+  laufen VOR der Ereignis-Identität und bleiben strukturell unverändert.
+- **Kein Flicken des toten `precip:`-Schlüssels** im Doppel-Alarm-Wächter (Befund D). Der
+  Wächter wird abgelöst, nicht repariert (Entscheidung 2) — ein bloßer Namens-Fix würde eine seit
+  Jahren stumme Bremse ohne Eskalations-Ausnahme scharf schalten.
+- **Keine Aufteilung gebündelter Meldungen in Teilnachrichten.** `to_report` bleibt eine
+  atomare Sendeeinheit; es gibt kein Muster, einzelne Änderungen vor dem Versand
+  herauszufiltern (Entscheidung 1).
+
+## Source
+
+- **File:** `src/services/alert_gate.py` — `resolve_hazard_class()` (`:547`, dritter
+  Auflösungsweg über Metrik-Liste), `check_event_identity_gate()` (`:736`, expliziter
+  `source`-Parameter, erweiterte Nachtrags-Richtung), `record_event_identity()` (`:823`,
+  expliziter `source`-Parameter statt Ableitung aus `point_at`)
+- **File:** `src/services/trip_alert.py` — `check_and_send_alerts()` (`:310-657`, Gate-Aufruf vor
+  `_send_alert` bei `:558`, Registrierung nach erfolgreicher Zustellung bei `:617`), Radar-Zweig
+  `check_radar_alerts()` (`:1990-2039`, quellenabhängige Nachtrags-Formulierung), Doppel-Alarm-
+  Wächter (`:1835-1861`, ENTFERNT)
+- **File:** `src/output/renderers/email/undelivered_hint.py` — `_REASON_LABELS`/`_REASON_BLOCK`
+  (`:48-77`, neuer Eintrag `event_duplicate`)
+- **Identifier:** siehe Implementation Details
+
+Schicht: ausschließlich Python-Core (`src/services/`, `src/output/renderers/email/`). Kein Go-,
+kein Frontend-Anteil.
+
+## Estimated Scope
+
+- **LoC:** ~+150 / −30 (Produktivcode + Tests, ohne Doku) — voraussichtlich innerhalb des
+  250-LoC-Standardlimits; falls überschritten `loc_limit_override 500` vor `/40-tdd-red` setzen
+- **Files:** 3 Produktivdateien (`alert_gate.py`, `trip_alert.py`, `undelivered_hint.py`) + 3
+  Testdateien (1 CREATE, 2 MODIFY) + 1 ADR-Nachtrag
+- **Effort:** high
+- **Risiko:** HIGH — es entsteht eine neue Unterdrückungsregel im Abweichungs-Zweig, und die
+  Tour des PO läuft bereits (Start 2026-08-23)
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `src/services/alert_gate.py::check_event_identity_gate`/`record_event_identity` | function | Bestehender, unveränderter Kernmechanismus — wird um einen dritten Aufrufer (Δ-Zweig) UND einen expliziten `source`-Parameter erweitert |
+| `src/services/alert_gate.py::resolve_hazard_class` | function | Bekommt einen dritten Auflösungsweg über eine Metrik-Liste; Radar (`is_convective`) und amtlich (`hazard`) bleiben unverändert |
+| `src/services/alert_gate.py::_find_matching_entry`/`_times_overlap`/`_covers_materially_more` | function | Unverändert wiederverwendet — Fail-soft- und V1-Verhalten gilt automatisch auch für Δ-Kandidaten |
+| `src/services/alert_urgency.py::exceeds`/`urgency_from_changes`/`highest_urgency` | function | Geteilte Rangordnung — dieselbe Dringlichkeit, die bereits Sperrzeit (#2050 S3c) und Tagesbudget (#2050 S3b) entscheidet, wird für die Eskalations-Prüfung (V2) wiederverwendet, nicht neu berechnet |
+| `src/services/trip_alert.py::check_and_send_alerts` | method | Δ-Zweig — neuer Gate-Aufruf vor `_send_alert`, neue Registrierung nach erfolgreicher Zustellung, Entfernung des Doppel-Alarm-Wächters |
+| `src/services/trip_alert.py::check_radar_alerts` | method | Bestehender Aufrufer der Ereignis-Identität — Nachtrags-Formulierung wird quellenabhängig statt hartkodiert „amtlich" |
+| `src/services/alert_log.py::REASON_EVENT_DUPLICATE`/`append_suppressed_entry`/`append_entry` | constant/function | Bestehender Grund-Code und Protokollpfad — kein neuer Code, nur ein neuer Aufrufer |
+| `src/services/deviation_alert_engine.py::evaluate` | function | Bleibt UNVERÄNDERT — mit dem PO-zurückgestellten Ortsvergleich geteilt (`compare_alert.py:509`); die Ereignis-Identität wird ausschließlich im Trip-Caller angeschlossen |
+| `src/services/compare_alert.py::check_all_compare_presets`/`_evaluate_one_location` | function | Bleibt UNVERÄNDERT (Non-Goal) — AC-19 sichert das als Wächter zu |
+| `src/output/renderers/email/undelivered_hint.py::_REASON_LABELS`/`_REASON_BLOCK` | constant | Neuer Eintrag `event_duplicate` → Block „ZURÜCKGEHALTEN", analog dem bestehenden Eintrag `double_alert_guard` (#2050 S3b) |
+| `tests/helpers/alarm_pruefstrecke.py::AlarmPruefstrecke` | test helper | Zeitreihen-Harness gegen die echte Service-Kette (#2050 S1) — Werkzeug für alle Mehrläufer-Szenarien dieser Spec |
+| `docs/adr/0021-shared-deviation-alert-engine.md` | doc | Trägt bereits Nachträge zu #2018 (Nachtragsform), #2065 und #2050 S3c (Sperrzeit-Überholung); braucht einen weiteren, datierten Nachtrag für den Δ-Anschluss und den expliziten `source`-Parameter |
+
+## Implementation Details
+
+### 1. Dritter Auflösungsweg — Metrik-Liste statt `is_convective`/`hazard`
+
+`resolve_hazard_class()` bekommt einen dritten, optionalen Parameter `metrics: Optional[Iterable[str]]
+= None`. Neue Konstante `_WET_METRICS = frozenset({"precip_sum_mm", "precip_heavy_onset_utc",
+"thunder_level_max", "thunder_onset_utc"})` — eigener Kanon, NICHT identisch mit `_WET_HAZARDS`
+(das sind amtliche Hazard-**Strings**, ein anderer Namensraum). Regel (Entscheidung 1): die
+Klasse ist nur dann `"wet"`, wenn die übergebene Metrik-Liste nicht leer ist UND **jede** Metrik
+in ihr zum `_WET_METRICS`-Kanon gehört; sonst `None`. Schnee-Metriken (`snow_depth_cm`,
+`snow_new_sum_cm`, `snowfall_limit_m`) gehören ausdrücklich nicht dazu (AC-7) — physikalisch
+Niederschlag, aber außerhalb des T2-Kanons.
+
+### 2. Zeitintervall aus Segmentfenstern statt `occurred_at`
+
+`WeatherChange.occurred_at` ist in drei von vier Erzeugungspfaden `None` (Befund B) und daher als
+Zeitbezug ungeeignet. Der Δ-Zweig bildet `window_start`/`window_end` stattdessen aus den
+Start-/Endzeitpunkten der betroffenen Segmente (Trip-Streckenabschnitte der NASSEN Änderungen,
+s. Punkt 4). `point_at` bleibt für den Δ-Zweig immer `None` — sonst würde der Bestandscode den
+Eintrag fälschlich als `nowcast` einordnen (Befund C). Lässt sich für keine der nassen Änderungen
+ein Segment mit Start-/Endzeit auffinden, bleiben beide Werte `None`; `_times_overlap()` liefert
+dafür fail-soft `False` — kein Match (AC-9).
+
+### 3. Expliziter Quellenvermerk statt Ableitung aus `point_at`
+
+`check_event_identity_gate()` und `record_event_identity()` bekommen einen expliziten Parameter
+`source: str` mit den Werten `"official"` | `"nowcast"` | `"deviation"`. Die bestehende Ableitung
+`"nowcast" if point_at is not None else "official"` (`alert_gate.py:794`, `:858`) bleibt als
+Fallback für Aufrufer, die (wie Radar und amtlich unverändert) keinen expliziten Wert übergeben —
+Signaturänderung additiv, kein Bruch der beiden Bestandsaufrufer. Der Δ-Zweig übergibt IMMER
+`source="deviation"` explizit. **Signaturänderung ⇒ Referenzfeger** (`grep -rln` über `tests/`)
+vor dem Commit Pflicht.
+
+### 4. Kontrollfluss im Δ-Zweig — streng prüfen, großzügig registrieren
+
+In `check_and_send_alerts()`, nach `DeviationAlertEngine.evaluate()` und vor `_send_alert`
+(`:558`):
+
+- `wet_changes = [c for c in to_report if c.metric in _WET_METRICS]`.
+- **Prüfung (streng, Entscheidung 1):** Gefahrenklasse ist nur dann `"wet"`, wenn `to_report`
+  NICHT leer ist und JEDE Änderung (nicht nur die nassen) zum `wet`-Kanon gehört — ein einziger
+  nicht-nasser Anteil macht die Klasse `None` (AC-5). Nur bei Klasse `"wet"` wird
+  `check_event_identity_gate()` überhaupt aufgerufen; sonst (AC-6) entfällt der Aufruf
+  vollständig, kein `AlertStateService.load()`. Segmente/Zeitfenster für den Aufruf kommen aus
+  den (in diesem Fall ausschließlich nassen) Änderungen.
+- Ergebnis `not allowed` ⇒ derselbe Unterdrückungs-Protokollpfad wie bei Radar/amtlich
+  (`alert_log.append_suppressed_entry(..., gate_reason=alert_log.REASON_EVENT_DUPLICATE)`),
+  `return False` (AC-1).
+- **Registrierung (großzügig, Entscheidung 1):** NACH erfolgreicher Zustellung (`:617`, nach dem
+  bestehenden `delivered`-Guard), unabhängig vom Ergebnis der Prüfung oben: ist `wet_changes`
+  nicht leer, wird EIN `record_event_identity(..., hazard_class="wet", segment_ids=<Segmente der
+  nassen Änderungen>, severity=<Dringlichkeit dieses Laufs, bereits vorhanden als `_urgency`>,
+  source="deviation", window_start=…, window_end=…)` geschrieben (AC-2). Ist `wet_changes` leer,
+  entfällt die Registrierung — es gibt nichts Nasses zu vermerken (AC-6/AC-7 konsistent
+  fortgesetzt). Lässt sich für die nassen Änderungen kein Zeitfenster bilden, entfällt die
+  Registrierung ebenfalls (nichts Sinnvolles zu schreiben).
+
+### 5. Ablösung des Doppel-Alarm-Wächters (Befund D, Entscheidung 2)
+
+`trip_alert.py:1835-1861` (der `precip:`/`thunder_level_max:`-Wächter, seit #818 zur Hälfte toter
+Code) wird ENTFERNT, nicht repariert. Die Paarung Radar→vorheriger-Δ-Alarm läuft ab jetzt
+AUSSCHLIESSLICH über `check_event_identity_gate()` im bestehenden Radar-Aufruf (`:1995`) — der
+sieht dank Punkt 4 jetzt auch Δ-Registereinträge. Der protokollierte Grund wechselt für diese
+Paarung von `double_alert_guard` auf `event_duplicate` (AC-14); eine Verschärfung, die der alte
+Wächter geschluckt hätte, kommt jetzt durch (AC-15, Verbindung zu A-3/#2065/#2050 S3c). Der
+bestehende Grund-Code `double_alert_guard` selbst bleibt in `alert_log.py`/`undelivered_hint.py`
+erhalten (historische Einträge, andere Aufrufstellen betroffen dieser Wächter nicht).
+
+### 6. Quellenabhängige Nachtrags-Formulierung
+
+`check_radar_alerts()` (`:2033-2039`) formuliert den Nachtrags-Bezug heute hartkodiert als
+„Ergänzung zur amtlichen Warnung", unabhängig von `_identity_gate.addendum_source`. Das ist für
+einen Δ-Vorgänger falsch (AC-13: keine amtliche Warnung lag vor). Die Formulierung wird
+quellenabhängig: `addendum_source == "official"` ⇒ unverändert „Ergänzung zur amtlichen
+Warnung", `addendum_source == "deviation"` ⇒ neue Bezeichnung „Ergänzung zur gemeldeten
+Wetterabweichung". Dazu wird `addendum_direction` in `check_event_identity_gate()` (`:795`) um
+den Fall `match["source"] == "deviation" and new_source == "nowcast"` erweitert — bisher nur
+`match["source"] == "official"`.
+
+### 7. Beschriftung `event_duplicate`
+
+`undelivered_hint.py`: `_REASON_LABELS["event_duplicate"] = "bereits als anderes Ereignis
+gemeldet"` (Formulierung final beim Implementieren gegen den bestehenden Wortlaut abzustimmen),
+`_REASON_BLOCK["event_duplicate"] = "withheld"` — analog dem bestehenden Eintrag
+`double_alert_guard` (#2050 S3b), damit der Nutzer keinen Fehler liest, wo bewusst entdoppelt
+wurde (AC-16).
+
+## Expected Behavior
+
+- **Input:** ein Abweichungs-Alarm-Lauf (`check_and_send_alerts`) mit mindestens einer Änderung
+  aus dem `wet`-Kanon, für ein Segment/Zeitfenster, für das bereits ein Ereignis-Identitäts-
+  Registereintrag (beliebiger Quelle) existiert.
+- **Output:** bei gleicher oder niedrigerer Dringlichkeit und rein nassem Bündel: Stille,
+  `gate_reason=event_duplicate` im Protokoll, kein Kanalversand. Bei Verschärfung, gemischtem
+  Bündel, fehlendem/kaputtem Registereintrag oder fehlendem Zeitbezug: normaler Versand wie
+  heute. Nach erfolgreicher Zustellung mit Nass-Anteil: genau ein neuer Registereintrag mit
+  `source="deviation"`.
+- **Side effects:** der Doppel-Alarm-Wächter entfällt als Codepfad; ein nachfolgender Radar-
+  Alarm derselben Zelle kann jetzt durch einen Δ-Registereintrag zum Nachtrag statt zum
+  Vollalarm werden; das Briefing zeigt zurückgehaltene Δ-Alarme im Block „ZURÜCKGEHALTEN" statt
+  gar nicht bzw. als Fehler.
+
+## Acceptance Criteria
+
+- **AC-1:** Given ein amtlicher Alarm hat für Segment S bereits ein Ereignis der Gefahrenklasse
+  `wet` registriert (Quelle `official`, überlappendes Zeitfenster), When im Abweichungs-Zweig ein
+  Alarm ausschließlich mit nassen Änderungen (Metriken aus dem `wet`-Kanon) für dasselbe Segment
+  mit überlappendem Zeitfenster und NICHT höherer Dringlichkeit als der Registereintrag geprüft
+  wird, Then bleibt der Abweichungs-Alarm unterdrückt — kein Versand auf irgendeinem der vier
+  Kanäle, `triggered_count == 0`, im Protokoll ein Eintrag mit `gate_reason == "event_duplicate"`.
+  - Test: `AlarmPruefstrecke`, zwei Läufe (`zweig="official"` dann `zweig="deviation"`) gegen die
+    echte Service-Kette, kein Mock.
+
+- **AC-2:** Given ein Abweichungs-Alarm mit mindestens einer nassen Änderung wird erfolgreich auf
+  mindestens einem Kanal zugestellt, When das Ereignis-Identitäts-Register danach gelesen wird,
+  Then existiert GENAU EIN neuer Eintrag mit `source == "deviation"`, dessen `segment_ids`
+  ausschließlich die Segmente der NASSEN Änderungen dieses Laufs trägt (nicht-nasse Änderungen
+  desselben Bündels fehlen darin), dessen `severity` der Dringlichkeit dieses Laufs entspricht
+  und dessen Zeitintervall (`window_start`/`window_end`) aus den betroffenen Segmenten gebildet
+  ist.
+  - Test: gemischtes Bündel (eine nasse + eine nicht-nasse Änderung, zwei verschiedene
+    Segmente), Registereintrag danach gegen `AlertStateService` gelesen und feldweise geprüft —
+    erwartete `severity` über `alert_urgency.urgency_from_changes(to_report)` abgeleitet, kein
+    Literal.
+
+- **AC-3:** Given ein Abweichungs-Alarm mit Nass-Anteil wurde erfolgreich zugestellt und
+  registriert, When danach ein Radar-Alarm für dieselbe Zelle (überlappendes Segment/Zeitfenster)
+  OHNE höhere Dringlichkeit als der Registereintrag geprüft wird, Then bleibt der Radar-Alarm als
+  vollständige zweite Nachricht aus — er geht höchstens als Nachtrag (AC-13), niemals als
+  zweiter voller Versand mit eigenem Kanal-Zuwachs auf allen Kanälen (heute ginge er ungebremst
+  raus, der tote `precip:`-Schlüssel, Befund D).
+  - Test: `AlarmPruefstrecke`, Lauf `zweig="deviation"` gefolgt von Lauf `zweig="radar"`,
+    Kanal-Zustellungen des zweiten Laufs gezählt und gegen `triggered_count == 0` bzw. Nachtrag
+    geprüft.
+
+- **AC-4:** Given ein Ereignis-Identitäts-Registereintrag (gleich welcher Quelle) mit einer
+  bestimmten Dringlichkeit existiert für Segment/Zeitfenster, When ein Abweichungs-Alarm mit
+  einer ECHT höheren Dringlichkeit als der Registereintrag für dasselbe Segment/Zeitfenster
+  geprüft wird, Then wird dieser Alarm IMMER zugestellt — unabhängig davon, ob ein passender
+  Registereintrag existiert.
+  - Test: Registereintrag mit Dringlichkeit `MODERATE`, Folgelauf mit Änderungen, deren
+    abgeleitete Dringlichkeit `HIGH` ist; `triggered_count == 1`, Positivkontrolle über einen
+    gleichrangigen Kontroll-Lauf ohne Durchbruch.
+
+- **AC-5:** Given ein Abweichungs-Alarm bündelt mindestens eine NICHT-nasse Änderung (z. B.
+  `wind_max_kmh` oder `temp_max_c`) neben nassen Änderungen für ein Segment, für das bereits ein
+  passender Registereintrag existiert, When dieser Alarm geprüft wird, Then wird er NIE
+  unterdrückt — die Gefahrenklasse des Laufs ist `None`, `triggered_count` steigt wie ohne
+  Registereintrag.
+  - Test: gemischtes Bündel gegen einen vorbereiteten passenden Registereintrag geprüft;
+    Kontroll-Lauf mit rein nassem Bündel (identische nasse Änderung) bleibt still —
+    Positivkontrolle, dass allein die Beimischung entscheidet.
+
+- **AC-6:** Given ein Abweichungs-Alarm enthält AUSSCHLIESSLICH nicht-nasse Änderungen (kein
+  Metrik-Schlüssel aus dem `wet`-Kanon), When dieser Alarm geprüft wird, Then liefert die
+  Gefahrenklassen-Auflösung `None`, das Ereignis-Identitäts-Register wird für diesen Lauf gar
+  nicht gelesen (kein `AlertStateService.load()`-Aufruf für die Ereignis-Identität), und die
+  Meldung geht durch.
+  - Test: Bündel nur mit `wind_max_kmh`/`temp_max_c`; Zähl-Spion auf `check_event_identity_gate`
+    (NICHT auf `AlertStateService.load` — die Ladefunktion wird im selben Lauf ohnehin für das
+    Melde-Gedächtnis gerufen und könnte den Befund nicht trennen), Zähler bleibt `0`, Zustellung
+    geprüft. Positivkontrolle: derselbe Aufbau mit einer nassen Änderung ruft das Gate genau
+    einmal.
+
+- **AC-7:** Given ein Abweichungs-Alarm enthält ausschließlich Schnee-Änderungen
+  (`snow_depth_cm`, `snow_new_sum_cm` oder `snowfall_limit_m`), When dieser Alarm geprüft wird,
+  Then gehören diese Metriken NICHT zum `wet`-Kanon, die Gefahrenklasse ist `None`, und die
+  Meldung wird nie durch die Ereignis-Identität unterdrückt — auch nicht bei passendem
+  Registereintrag.
+  - Test: `resolve_hazard_class(metrics=["snow_depth_cm"])` direkt gegen `None` geprüft, plus ein
+    End-zu-End-Lauf mit Schnee-Bündel gegen einen vorbereiteten passenden Registereintrag.
+
+- **AC-8:** Given der Ereignis-Identitäts-Registereintrag für ein Segment ist kaputt oder
+  unvollständig (z. B. fehlendes `segment_ids`- oder unparsbares Zeitfeld), When ein
+  Abweichungs-Alarm für dieses Segment geprüft wird, Then unterdrückt dieser Eintrag NICHTS
+  (fail-soft) — die Meldung geht durch, wie im Bestand für Radar/amtlich.
+  - Test: manipulierter `throttle`-/`alert_state`-Registereintrag mit fehlendem Feld, danach ein
+    Δ-Lauf gegen die echte Service-Kette; Zustellung geprüft, kein Absturz.
+
+- **AC-9:** Given eine nasse Änderung referenziert eine `segment_id`, die im Trip nicht
+  auffindbar ist (kein Start-/Endzeitpunkt bildbar), When aus den nassen Änderungen dieses Laufs
+  ein Zeitintervall gebildet werden soll, Then entsteht KEIN Zeitintervall (`window_start`/
+  `window_end` bleiben `None`), die Ereignis-Identitäts-Prüfung erzeugt dadurch fail-soft KEIN
+  Match, und die Meldung geht durch.
+  - Test: `WeatherChange` mit einer im Trip nicht existierenden `segment_id`, danach ein Lauf
+    gegen einen vorbereiteten passenden Registereintrag (der ohne die Lücke gematcht hätte).
+
+- **AC-10:** Given ein Registereintrag deckt ein Zeitfenster ab, When ein Abweichungs-Alarm
+  dasselbe Segment betrifft, in Dringlichkeit nicht höher ist, aber ein Zeitfenster meldet, das
+  WESENTLICH mehr Zeit abdeckt als der Registereintrag (V1-Ausnahme, mehr als der
+  Nowcast-Horizont über das bereits abgedeckte Ende hinaus), Then kommt dieser Alarm trotzdem
+  durch.
+  - Test: Registereintrag mit kurzem `window_end`, Δ-Lauf mit deutlich späterem `window_end`
+    (Segmentfenster reicht wesentlich weiter), `triggered_count == 1`.
+
+- **AC-11:** Given ein Abweichungs-Alarm mit Nass-Anteil wird erfolgreich zugestellt, When der
+  zugehörige Registereintrag gelesen wird, Then trägt er `source == "deviation"` — NICHT
+  `"official"` — auch wenn er (wie ein amtlicher Eintrag) ein Zeitintervall statt eines
+  Einzelzeitpunkts trägt.
+  - Test: Registereintrag nach einem Δ-Lauf feldweise gelesen, `source`-Feld gegen
+    `"deviation"` geprüft, Gegenprobe gegen die ALTE Ableitung (`point_at is not None`), die hier
+    fälschlich `"official"` liefern würde.
+
+- **AC-12:** Given ein Bestandseintrag im Register wurde vor dieser Scheibe geschrieben und
+  trägt kein `source`-Feld, When dieser Eintrag als Kandidat für einen neuen Alarm gelesen wird,
+  Then bleibt er lesbar, seine Quelle wird weiterhin fail-soft aus der Anwesenheit von `point_at`
+  bzw. `window_*` abgeleitet, und sein Unterdrückungs-/Match-Verhalten ist gegenüber dem Stand
+  vor dieser Scheibe UNVERÄNDERT.
+  - Test: vorbereiteter Alt-Registereintrag (Format vor #2018, ohne `source`-Feld) gegen einen
+    Radar- UND einen amtlichen Folgelauf geprüft — beide Bestandswächter bleiben grün.
+
+- **AC-13:** Given ein Abweichungs-Alarm mit Nass-Anteil wurde registriert (`source ==
+  "deviation"`), When danach ein Radar-Alarm derselben Zelle mit ECHTER Verschärfung (höhere
+  Dringlichkeit) geprüft wird, Then geht er in NACHTRAGSFORM heraus (wie nach einer
+  vorangegangenen amtlichen Warnung, #2018) — mit einer korrekten deutschen Bezeichnung für die
+  Vorhersage-Abweichung als Quelle im Nutzertext (NICHT „Ergänzung zur amtlichen Warnung", wenn
+  keine amtliche Warnung vorlag).
+  - Test: `AlarmPruefstrecke`, Δ-Lauf gefolgt von eskalierendem Radar-Lauf; gerenderter
+    Alarm-Text auf die neue, quellenabhängige Formulierung geprüft (Code-Referenz:
+    `src/services/trip_alert.py:2033-2039`, `addendum_source` aus `check_event_identity_gate()`).
+
+- **AC-14:** Given der Doppel-Alarm-Wächter (`src/services/trip_alert.py:1835-1861`) ist aus dem
+  Code entfernt, When ein Radar-Alarm auf einen zuvor registrierten Abweichungs-Alarm für
+  dieselbe Zelle trifft, Then läuft die Paarung ausschließlich über die Ereignis-Identität, und
+  der protokollierte Unterdrückungsgrund lautet `event_duplicate` — der alte Grund
+  `double_alert_guard` entsteht für diese Paarung nicht mehr neu.
+  - Test: `tests/tdd/test_issue_818_radar_briefing_integration.py` umgeschrieben (nicht
+    gelöscht) auf die neue Grund-Erwartung; Quellcode-Grep bestätigt das Fehlen der Zeilen
+    `1835-1861` im alten Wortlaut.
+
+- **AC-15:** Given eine Gewitter-Verschärfung, die der alte Doppel-Alarm-Wächter (ohne
+  Eskalations-Ausnahme) geschluckt hätte, When dieselbe Verschärfung nach der Ablösung geprüft
+  wird, Then kommt sie DURCH — Verbindung zu Anforderung A-3 (#2065/#2050 S3c), keine Sperre
+  bricht hier mehr eine echte Eskalation.
+  - Test: Δ-Lauf mit `thunder_level_max`-Eskalation innerhalb des alten Wächter-Cooldown-Fensters
+    (Gewitterstufe steigt gegenüber dem vorherigen Registereintrag); Zustellung geprüft.
+
+- **AC-16:** Given ein Abweichungs-Alarm wurde wegen `event_duplicate` zurückgehalten, When das
+  Trip-Briefing den Abschnitt „was hat dich nicht erreicht" rendert, Then erscheint der Vorfall
+  im Block „ZURÜCKGEHALTEN" mit einer deutschen Beschriftung für `event_duplicate` — NICHT im
+  Block „FEHLGESCHLAGEN" bzw. als „Versand fehlgeschlagen" (heute fällt der Grund mangels
+  Eintrag in `_REASON_LABELS` genau darauf zurück).
+  - Test: `UndeliveredIncident` mit `reasons=["event_duplicate"]` gegen `has_undelivered()`,
+    `_incident_block()`/Rendering geprüft — Block und Beschriftungstext.
+
+- **AC-17:** Given ein Abweichungs-Alarm mit Nass-Anteil hat keinen einzigen zustellbaren Kanal
+  (`notif_result.sent == False`), When der Lauf abgeschlossen ist, Then entsteht KEIN neuer
+  Ereignis-Identitäts-Registereintrag — Registrierung bleibt an erfolgreiche Zustellung gebunden
+  (F001-Symmetrie).
+  - Test: Trip ohne konfigurierte Empfänger auf allen Kanälen, Δ-Lauf mit nasser Änderung,
+    Register vor/nach dem Lauf verglichen — keine neue `event_identity:`-Schlüssel.
+
+- **AC-18:** Given zwei Nutzer A und B mit Trips in derselben geografischen Zone, von denen A
+  einen Ereignis-Identitäts-Registereintrag für ein Segment hinterlassen hat, When B einen
+  inhaltsgleichen Abweichungs-Alarm für sein eigenes, gleich benanntes Segment prüft, Then bleibt
+  B's Alarm UNBEEINFLUSST von A's Registereintrag — eigener Registerpfad unter
+  `data/users/<user_id_b>/`, kein Cross-User-Datenleck.
+  - Test: zwei getrennte `AlarmPruefstrecke`-Instanzen mit unterschiedlichen `user_id`, A's
+    Registereintrag geschrieben, dann B's inhaltsgleicher Lauf geprüft — `triggered_count == 1`
+    für B.
+
+- **AC-19:** Given der Ortsvergleich (`compare_alert.py`) ist von dieser Scheibe nicht betroffen,
+  When `check_all_compare_presets()`/`_evaluate_one_location()` nach dieser Änderung laufen, Then
+  rufen sie WEDER `check_event_identity_gate()` NOCH `record_event_identity()` auf — unverändert
+  gegenüber dem Stand vor dieser Scheibe, geprüft durch einen Signatur-/Aufruf-Wächter.
+  - Test: Aufruf-Spion (kein Mock des Verhaltens, nur Zählung) um `check_event_identity_gate`/
+    `record_event_identity` während eines vollständigen Ortsvergleich-Laufs; Zähler bleibt `0`.
+
+## Known Limitations
+
+- **Gebündelte Δ-Meldungen bleiben atomar.** Fällt nur ein Teil eines Bündels unter ein
+  registriertes Ereignis, wird die GANZE Meldung nicht unterdrückt, solange auch nur eine
+  Änderung nicht zum `wet`-Kanon gehört (AC-5) — bewusste Entscheidung (Entscheidung 1), kein
+  Mechanismus für Teil-Unterdrückung existiert.
+- **Zwei parallele Reihenfolgen der Δ-Prüfung.** Die Ereignis-Identität sitzt strukturell NACH
+  Sperrzeit/Tagesbudget/Ruhezeit (unverändert) — eine Δ-Meldung, die dort bereits unterdrückt
+  wird, erreicht die Ereignis-Identität gar nicht. Das ist Bestandsverhalten, keine neue
+  Einschränkung dieser Scheibe.
+- **Rollout-Effekt am Deploy-Tag (bewusst in Kauf genommen).** Der Doppel-Alarm-Wächter entfällt
+  sofort mit dem Deploy, aber das Ereignis-Register kennt zu diesem Zeitpunkt noch keinen einzigen
+  Abweichungs-Eintrag — registriert wird erst ab dem ersten zugestellten Δ-Alarm nach dem Deploy.
+  In diesem Übergangsfenster ist die Paarung „Δ meldete Gewitter, Radar zieht nach" **ungebremst**,
+  ein zusätzlicher Radar-Alarm ist möglich. Das ist die **sichere Richtung** (eine Nachricht zu
+  viel, keine zu wenig) und gilt nur bis zum nächsten zugestellten Abweichungs-Alarm desselben
+  Trips. Dieselbe Abwägung wie beim Rollout von #2050 S3b.
+- **Die V1-Ausnahme („wesentlich mehr Zeit") bleibt unverändert übernommen** — für den Δ-Zweig
+  bedeutet das: ein Δ-Alarm mit deutlich weiter reichendem Segmentfenster als der
+  Registereintrag kommt durch, auch ohne Dringlichkeits-Sprung (AC-10). Diese Grenze war bereits
+  vor dieser Scheibe für Radar/amtlich so definiert und wird nur vererbt.
+
+## Abgelöste Zusicherungen
+
+| Spec/Code | Sagt heute | Wird |
+|---|---|---|
+| `src/services/trip_alert.py:1835-1861` (Doppel-Alarm-Wächter, #818) — Testdatei `tests/tdd/test_issue_818_radar_briefing_integration.py` | Radar liest `precip:<segment_id>`/`thunder_level_max:<segment_id>` gegen einen eigenen Cooldown-Topf, unabhängig von der Ereignis-Identität; kein Eskalations-Durchbruch möglich | **entfernt, nicht repariert** (Entscheidung 2) — dieselbe Paarung läuft künftig ausschließlich über `check_event_identity_gate()`, Grund `event_duplicate` statt `double_alert_guard`; Testdatei umgeschrieben, nicht gelöscht (AC-14/AC-15) |
+| `src/services/alert_gate.py:858` (Kommentar „kein neuer Parameter, Signatur unveraendert", Issue #2018) | Quelle wird ausschließlich aus der Anwesenheit von `point_at` abgeleitet — kein expliziter Parameter | **um einen expliziten, additiven `source`-Parameter erweitert** — Radar/amtlich rufen weiterhin ohne den Parameter auf (Fallback bleibt identisch), der Δ-Zweig übergibt ihn immer explizit (AC-11/AC-12) |
+| `src/services/trip_alert.py:2034` (hartkodiert „Ergänzung zur amtlichen Warnung") | jeder Nachtrag wird unabhängig von `addendum_source` als Ergänzung zur amtlichen Warnung formuliert | **quellenabhängig formuliert** — Δ-Vorgänger erzeugen eine eigene, korrekte Bezeichnung statt einer falschen Behauptung über eine nie vorliegende amtliche Warnung (AC-13) |
+
+**Müssen unverändert grün bleiben** (aktive Gegenproben gegen eine zu weite Lösung):
+
+- Bestehende Radar/amtlich-Ereignis-Identitäts-Tests in `tests/tdd/test_alert_gate.py`
+  (AC-1…AC-19 der Bestandsscheibe #1467 S4b) — der Fallback ohne expliziten `source`-Parameter
+  muss identisch bleiben.
+- `tests/tdd/test_compare_radar_alert_event_identity.py`,
+  `tests/tdd/test_compare_official_alert_event_identity.py` — unverändert, Ortsvergleich bleibt
+  außen vor (AC-19).
+- `tests/tdd/test_cooldown_quellenuebergreifend.py` — Textzusicherung „Cooldown gilt nur
+  quelleneigen" darf durch den Δ-Anschluss der Ereignis-Identität nicht widersprüchlich werden
+  (unterschiedliche Mechanismen: Sperrzeit bleibt quelleneigen, Ereignis-Identität war schon vor
+  dieser Scheibe quellenübergreifend).
+
+## Risks
+
+1. **🔴 Die gefährlichste Fehlerrichtung ist der ausbleibende Alarm.** Diese Scheibe baut eine
+   NEUE Unterdrückungsregel im Abweichungs-Zweig, während die Tour des PO bereits läuft (Start
+   2026-08-23). Jede AC dieser Spec sichert explizit eine Gegenrichtung mit ab (AC-4/AC-5/AC-6/
+   AC-7/AC-8/AC-9/AC-10) — keine AC prüft nur die Unterdrückung ohne Positivkontrolle.
+2. **Signaturänderung an `check_event_identity_gate()`/`record_event_identity()`.** Der neue
+   `source`-Parameter zieht einen Referenzfeger über `tests/` nach sich (`grep -rln` über die
+   Testbäume) — Signatur-Wächter für diese Funktionen liegen in fremden Testdateien
+   (`test_compare_radar_alert_event_identity.py`, `test_compare_official_alert_event_identity.py`
+   u. a.).
+3. **Berührung mit der Parallelscheibe S4a.** Beide Scheiben fassen `alert_log.py`
+   (Grund-Register) und `undelivered_hint.py` (Beschriftungen) an. Vor dem Merge gegen
+   `origin/main` rebasen und den Diff auf gelöschte Fremdarbeit prüfen
+   (`git diff origin/main --diff-filter=D`).
+4. **Zwei Mechanismen für dieselbe Paarung während der Übergangsphase.** Solange der
+   Doppel-Alarm-Wächter noch nicht entfernt ist (Zwischenstand innerhalb der Implementierung),
+   existieren kurzzeitig zwei Wächter für Radar↔Δ — die Reihenfolge in dieser Scheibe entfernt
+   den alten VOR dem ersten grünen Lauf, damit kein uneindeutiger Protokollgrund entsteht.
+5. **Prüfstrecken-Grenze.** `alert_state.reset()` verwirft `event_identity:`-Schlüssel still
+   (`src/services/alert_state.py:38-45`) — Szenarien über eine Briefing-Grenze verlieren ihre
+   Vorbelegung unbemerkt. Bei Mehrläufer-Tests mit `AlarmPruefstrecke` beachten.
+6. **Gebündelte Δ-Meldungen sind nicht teilbar** (s. Known Limitations) — eine falsch verstandene
+   Teil-Unterdrückung wäre ein neuer Mechanismus mit eigener Fehlerfläche und ist ausdrücklich
+   nicht Ziel dieser Scheibe.
+
+## Test Plan
+
+Kern-Schicht (deterministisch, kein Netz/Live-Dienst), Werkzeug `AlarmPruefstrecke`
+(`tests/helpers/alarm_pruefstrecke.py`, #2050 S1) für alle Mehrläufer-Zeitreihen-Szenarien gegen
+die echte Service-Kette — kein Mock.
+
+| Testdatei | Änderung | Deckt |
+|---|---|---|
+| `tests/tdd/test_alarm_szenario_ein_ereignis_ein_alarm.py` | CREATE | AC-1, AC-3, AC-4, AC-5, AC-9, AC-10, AC-13, AC-15, AC-18 (Szenario-5-Wächter über die Prüfstrecke) |
+| `tests/tdd/test_alert_gate.py` | MODIFY | AC-2, AC-6, AC-7, AC-8, AC-11, AC-12, AC-17 (dritter Auflösungsweg, expliziter `source`-Parameter, Fail-soft-Regression) |
+| `tests/tdd/test_issue_818_radar_briefing_integration.py` | MODIFY | AC-14 (Doppel-Alarm-Wächter-Ablösung, umgeschriebener Wortlaut statt Löschung) |
+| `tests/tdd/test_undelivered_hint.py` (oder bestehende Äquivalent-Datei) | MODIFY | AC-16 (Beschriftung/Block für `event_duplicate`) |
+| `tests/tdd/test_compare_alert_event_identity_unberuehrt.py` | CREATE oder Ergänzung in bestehender Compare-Testdatei | AC-19 (Aufruf-Spion, Ortsvergleich unberührt) |
+
+Testdateien werden nach Verhalten benannt (`test_alarm_szenario_ein_ereignis_ein_alarm.py`),
+NICHT nach Issue-Nummer. Jede AC hat mindestens einen Test mit Positivkontrolle (ein Aufbau, der
+ohne die geprüfte Bedingung tatsächlich anders ausgehen würde) — Muster aus #2050 S1/S2b/S3c.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** ADR-0021 (weiterer Nachtrag, nach #2065, #2050 S3b und #2050 S3c)
+- **Rationale:** ADR-0021 hält bereits die quellenübergreifende Ereignis-Identität als geteilten
+  Baustein für Trip und Ortsvergleich fest (Nachträge zu #1467 S4b-1/S4b-2 und #2018). Diese
+  Scheibe fügt keine neue Architektur hinzu, sondern schließt einen bisher nicht angeschlossenen
+  dritten Aufrufer (Δ-Zweig) an denselben, unveränderten Mechanismus an — mit einem additiven
+  dritten Auflösungsweg für die Gefahrenklasse (Metrik-Liste statt `is_convective`/`hazard`) und
+  einem additiven expliziten `source`-Parameter. Nach der Projektregel („Abweichung ⇒ neues ADR
+  bzw. datierter Nachtrag") braucht das einen weiteren, datierten Nachtrag, der den
+  Δ-Anschluss, den `wet`-Metrik-Kanon, die Ablösung des Doppel-Alarm-Wächters und die
+  Nicht-Betroffenheit des Ortsvergleichs festhält — einsortiert nach dem letzten bestehenden
+  Nachtrag (#2050 S3c, 2026-08-23).
+
+## Changelog
+
+- 2026-08-23: Initial spec created (aus
+  `docs/context/feat-2050-s4c-ein-ereignis-ein-alarm.md`, Analyse-Phase 2026-08-23, Befunde A-E,
+  Entscheidungen 1-3).

--- a/src/output/renderers/email/undelivered_hint.py
+++ b/src/output/renderers/email/undelivered_hint.py
@@ -59,6 +59,11 @@ _REASON_LABELS = {
     # #2050 S4a: die Wetterquelle war nicht erreichbar — ohne Beschriftung
     # stuende der rohe Code in der Mail.
     "data_unavailable": "Wetterdaten nicht verfügbar",
+    # #2050 S4c: der Abweichungs-Zweig entdoppelt jetzt an derselben
+    # quellenuebergreifenden Ereignis-Identitaet wie Radar/amtlich (analog
+    # `double_alert_guard`) — ohne eigenen Eintrag fiele der Grund auf
+    # "Versand fehlgeschlagen" zurueck, wo bewusst entdoppelt wurde.
+    "event_duplicate": "bereits als anderes Ereignis gemeldet",
 }
 
 # #1750 E2: Einsortierung je Grund in einen der zwei Bloecke. Ein Vorfall mit
@@ -83,6 +88,8 @@ _REASON_BLOCK = {
     # eine Entscheidung ist und nicht dem Zufall eines Rueckfalls ueberlassen
     # bleiben darf.
     "data_unavailable": "failed",
+    # #2050 S4c: Nutzer-Absicht wie `double_alert_guard`, kein Zustellfehler.
+    "event_duplicate": "withheld",
 }
 
 _TRIGGER_LABELS = {

--- a/src/services/alert_gate.py
+++ b/src/services/alert_gate.py
@@ -107,7 +107,7 @@ class GateResult(NamedTuple):
     # `if not gate.allowed`-Zweige sind unveraendert (Muster
     # `AlertMessage.reference_at`, #1916).
     is_addendum: bool = False
-    addendum_source: Optional[str] = None       # nur "official" erreichbar
+    addendum_source: Optional[str] = None       # "official" | "deviation" erreichbar (Issue #2050 S4c)
     addendum_reported_at: Optional[datetime] = None
 
 
@@ -543,21 +543,44 @@ def last_deviation_urgency(
 HAZARD_CLASS_WET = "wet"
 _WET_HAZARDS = frozenset({"thunderstorm", "flood", "rain"})
 
+# Issue #2050 S4c: dritter Auflösungsweg — der Abweichungs-Zweig kennt weder
+# `is_convective` noch `hazard`, sondern eine Liste von Metrik-Schlüsseln.
+# EIGENER Kanon, NICHT identisch mit `_WET_HAZARDS` (das sind amtliche
+# Hazard-STRINGS, ein anderer Namensraum). Schnee-Metriken gehören
+# ausdrücklich NICHT dazu (AC-7) — physikalisch Niederschlag, aber außerhalb
+# des T2-Kanons.
+_WET_METRICS = frozenset({
+    "precip_sum_mm", "precip_heavy_onset_utc", "thunder_level_max",
+    "thunder_onset_utc",
+})
+
 
 def resolve_hazard_class(
     *, is_convective: Optional[bool] = None, hazard: Optional[str] = None,
+    metrics: Optional[Iterable[str]] = None,
 ) -> Optional[str]:
     """T2-Kanon. Genau EIN Identifikationsweg pro Aufrufer: Nowcast liefert
-    `is_convective`, amtlich liefert `hazard`. Unbekannter/anderer Hazard
-    -> None (keine Klasse, nie entdoppelt, AC-4).
+    `is_convective`, amtlich liefert `hazard`, der Abweichungs-Zweig liefert
+    `metrics` (Issue #2050 S4c). Unbekannter/anderer Hazard bzw. Metrik-Mix
+    -> None (keine Klasse, nie entdoppelt, AC-4/AC-7).
 
     Ein Nowcast ist IMMER Niederschlag — `is_convective` unterscheidet nur
     die Erscheinungsform derselben Zelle, nicht das Ereignis (PO-Entscheid
-    2026-08-16, Messung s. Spec Implementation Details T2, AC-4b)."""
+    2026-08-16, Messung s. Spec Implementation Details T2, AC-4b).
+
+    `metrics` ist nur dann `wet` (Entscheidung 1, Spec Implementation Details
+    Punkt 1), wenn die Liste NICHT leer ist UND JEDE Metrik zum
+    `_WET_METRICS`-Kanon gehört — ein einziger Anteil außerhalb des Kanons
+    (z.B. eine Schnee- oder Windböen-Metrik) macht die Klasse `None` (AC-7).
+    Eine leere Liste liefert ebenfalls `None` (`all([])` wäre sonst `True`)."""
     if is_convective is not None:
         return HAZARD_CLASS_WET
     if hazard in _WET_HAZARDS:
         return HAZARD_CLASS_WET
+    if metrics is not None:
+        metrics_list = list(metrics)
+        if metrics_list and all(m in _WET_METRICS for m in metrics_list):
+            return HAZARD_CLASS_WET
     return None
 
 
@@ -746,6 +769,7 @@ def check_event_identity_gate(
     window_end: Optional[datetime] = None,
     cooldown_minutes: Optional[int] = None,
     quantitative_escalation: bool = False,
+    source: Optional[str] = None,
 ) -> GateResult:
     """Darf diese Meldung raus, oder ist sie ein quellenuebergreifendes
     Duplikat einer bereits gemeldeten Meldung (Issue #1467 Scheibe S4b-1)?
@@ -775,7 +799,14 @@ def check_event_identity_gate(
     LOW/MODERATE/HIGH bei 4 mm/h saettigt: eine Verdreifachung von 11 auf
     30 mm/h ist zweimal `HIGH`, `exceeds("HIGH","HIGH")` also False — die
     Verschaerfung ist an dieser Stelle strukturell unsichtbar. Vorbelegt mit
-    `False`: kein Bestandsaufrufer aendert sein Verhalten."""
+    `False`: kein Bestandsaufrufer aendert sein Verhalten.
+
+    Issue #2050 S4c: `source` ist additiv. Radar und amtlich lassen ihn
+    unveraendert weg -- der Fallback (Ableitung aus der Anwesenheit von
+    `point_at`) bleibt fuer sie identisch (AC-12). Der Abweichungs-Zweig
+    uebergibt IMMER `source="deviation"` explizit (AC-11), sonst laese ihn die
+    alte Ableitung -- er traegt ein Zeitintervall wie ein amtlicher Eintrag --
+    faelschlich als `"official"`."""
     if hazard_class is None:
         return _ALLOWED
 
@@ -788,11 +819,18 @@ def check_event_identity_gate(
         return _ALLOWED
 
     # Issue #2018: die Richtung entscheidet ausschliesslich ueber die FORM der
-    # Zustellung, nie ueber ihr Ob. Nur "amtlich zuerst, Nowcast danach" kennt
-    # den dritten Ausgang -- die Gegenrichtung ist eigenstaendig ueber #1467
-    # S4b PO-freigegeben und bleibt hier unangetastet.
-    new_source = "nowcast" if point_at is not None else "official"
-    addendum_direction = match["source"] == "official" and new_source == "nowcast"
+    # Zustellung, nie ueber ihr Ob. Nur "amtlich/Abweichung zuerst, Nowcast
+    # danach" kennt den dritten Ausgang -- die Gegenrichtung ist eigenstaendig
+    # ueber #1467 S4b PO-freigegeben und bleibt hier unangetastet.
+    new_source = source if source is not None else (
+        "nowcast" if point_at is not None else "official"
+    )
+    # Issue #2050 S4c: der Δ-Zweig ist jetzt ein zweiter moeglicher Vorgaenger
+    # eines Nachtrags (bisher nur "official") -- Spec Implementation Details
+    # Punkt 6.
+    addendum_direction = (
+        match["source"] in ("official", "deviation") and new_source == "nowcast"
+    )
 
     if quantitative_escalation or alert_urgency.exceeds(severity, match["severity"]):
         # V2 — struktureller erster Zweig, bricht IMMER durch. In der
@@ -831,6 +869,7 @@ def record_event_identity(
     point_at: Optional[datetime] = None,
     window_start: Optional[datetime] = None,
     window_end: Optional[datetime] = None,
+    source: Optional[str] = None,
 ) -> None:
     """Legt GENAU EINEN Registereintrag an (AC-2) -- AUSSCHLIESSLICH nach
     erfolgreicher Zustellung aufzurufen (F001-Symmetrie zu
@@ -841,7 +880,14 @@ def record_event_identity(
 
     Registerschluessel `event_identity:<hazard_class>:<segment_ids>:<now>`
     (analog `_identity_hazard_prefix()` in `official_alerts.py`) -- eindeutig
-    je Meldung, damit spaetere Registrierungen einander nicht ueberschreiben."""
+    je Meldung, damit spaetere Registrierungen einander nicht ueberschreiben.
+
+    Issue #2050 S4c: `source` ist additiv (AC-11/AC-12). Radar und amtlich
+    lassen ihn weiterhin weg -- der Fallback (Ableitung aus der Anwesenheit
+    von `point_at`) bleibt fuer sie identisch, die Signatur bricht fuer sie
+    nicht. Der Abweichungs-Zweig traegt ein Zeitintervall wie ein amtlicher
+    Eintrag und uebergibt deshalb IMMER `source="deviation"` explizit --
+    sonst wuerde die alte Ableitung ihn faelschlich als `"official"` lesen."""
     segments = sorted({s for s in (segment_ids or []) if s})
     key = f"event_identity:{hazard_class}:{','.join(segments)}:{now.isoformat()}"
 
@@ -851,11 +897,12 @@ def record_event_identity(
         "hazard_class": hazard_class,
         "segment_ids": segments,
         "severity": severity,
-        # Issue #2018 (AC-A2): Quellenvermerk, abgeleitet aus derselben
-        # Fallunterscheidung, die T2/T4 bereits treffen -- Nowcast setzt NUR
-        # `point_at`, amtlich NUR `window_*`. Kein neuer Parameter, damit die
-        # Signatur unveraendert bleibt (AC-A11).
-        "source": "nowcast" if point_at is not None else "official",
+        # Issue #2018 (AC-A2) / #2050 S4c: expliziter Quellenvermerk, sonst
+        # (Radar/amtlich, additiv unveraendert) dieselbe Fallunterscheidung
+        # wie T2/T4 -- Nowcast setzt NUR `point_at`, amtlich NUR `window_*`.
+        "source": source if source is not None else (
+            "nowcast" if point_at is not None else "official"
+        ),
         "point_at": point_at.isoformat() if point_at is not None else None,
         "window_start": window_start.isoformat() if window_start is not None else None,
         "window_end": window_end.isoformat() if window_end is not None else None,

--- a/src/services/trip_alert.py
+++ b/src/services/trip_alert.py
@@ -20,6 +20,8 @@ from services import alert_channel_threshold, alert_daily_limit, alert_input_cap
 from services.alert_briefing_anchor import record_alert_anchor_rejected
 import services.alert_urgency as alert_urgency
 from services.alert_gate import (
+    HAZARD_CLASS_WET,
+    _WET_METRICS,
     check_event_identity_gate,
     check_nowcast_gate,
     check_official_alert_gate,
@@ -131,6 +133,35 @@ def _change_to_capture_dict(change: WeatherChange) -> dict:
         "direction": change.direction,
         "segment_id": change.segment_id,
     }
+
+
+def _delta_event_window(
+    changes: List[WeatherChange], weather: List[SegmentWeatherData],
+) -> tuple[Optional[datetime], Optional[datetime]]:
+    """Zeitintervall aus den Segmentfenstern der NASSEN Aenderungen (Issue
+    #2050 S4c, Spec Implementation Details Punkt 2).
+
+    `WeatherChange.occurred_at` ist in drei von vier Erzeugungspfaden `None`
+    (Befund B der Kontext-Kartierung) und deshalb als Zeitbezug fuer den
+    Δ-Zweig ungeeignet. Stattdessen werden `window_start`/`window_end` aus den
+    Start-/Endzeitpunkten der betroffenen Trip-Segmente gebildet. Laesst sich
+    fuer KEINE der uebergebenen Aenderungen ein Segment mit vollstaendiger
+    Start-/Endzeit auffinden, bleiben beide Werte `None` -- `_times_overlap()`
+    liefert dafuer fail-soft `False` (AC-9), kein Absturz."""
+    segments = {
+        normalize_segment_id(sw.segment.segment_id): sw.segment for sw in weather
+    }
+    starts: list[datetime] = []
+    ends: list[datetime] = []
+    for change in changes:
+        segment = segments.get(normalize_segment_id(change.segment_id))
+        if segment is None or segment.start_time is None or segment.end_time is None:
+            continue
+        starts.append(segment.start_time)
+        ends.append(segment.end_time)
+    if not starts or not ends:
+        return None, None
+    return min(starts), max(ends)
 
 
 @dataclass(frozen=True)
@@ -623,6 +654,44 @@ class TripAlertService:
                 ),
             )
 
+        # Issue #2050 S4c: der Δ-Zweig an der quellenuebergreifenden
+        # Ereignis-Identitaet -- streng pruefen, grosszuegig registrieren
+        # (Spec Implementation Details Punkt 4). Der Zeitbezug entsteht aus
+        # den Segmentfenstern der NASSEN Aenderungen (`_delta_event_window`),
+        # `point_at` bleibt fuer diesen Zweig immer `None` (Befund C) -- sonst
+        # laese der Bestandscode den Eintrag faelschlich als `nowcast` ein.
+        _wet_changes = [c for c in to_report if c.metric in _WET_METRICS]
+        _delta_window_start, _delta_window_end = _delta_event_window(
+            _wet_changes, fresh_weather,
+        )
+        _delta_segment_ids = sorted({
+            sid for sid in (
+                normalize_segment_id(c.segment_id) for c in _wet_changes
+            ) if sid
+        })
+        # Streng (Entscheidung 1): die Klasse ist nur dann 'wet', wenn KEINE
+        # Aenderung des Buendels ausserhalb des `wet`-Kanons liegt -- ein
+        # einziger nicht-nasser Anteil (auch neben nassen Anteilen) macht die
+        # Klasse `None` (AC-5). Nur dann wird die Ereignis-Identitaet
+        # ueberhaupt gefragt (AC-6: kein `AlertStateService.load()` sonst).
+        _delta_hazard_class = resolve_hazard_class(
+            metrics=[c.metric for c in to_report],
+        )
+        if _delta_hazard_class is not None:
+            _identity_gate = check_event_identity_gate(
+                user_id=self._user_id, entity_id=trip.id,
+                hazard_class=_delta_hazard_class, segment_ids=_delta_segment_ids,
+                severity=_urgency, now=now_utc,
+                window_start=_delta_window_start, window_end=_delta_window_end,
+                source="deviation",
+            )
+            if not _identity_gate.allowed:
+                self._protokolliere_unterdrueckung(
+                    trip, reason=alert_log.REASON_FORECAST_CHANGE,
+                    gate_reason=_identity_gate.reason,
+                )
+                return False
+
         # 5. Send alert; guard: only record throttle/log when at least one
         # configured channel was reachable (AC-1 symmetry with Telegram/Radar).
         notif_result = self._send_alert(
@@ -691,6 +760,26 @@ class TripAlertService:
                 "reported_at": now_iso,
             }
         state_svc.save(trip.id, alert_state)
+
+        # Issue #2050 S4c: grosszuegige Registrierung (Entscheidung 1) --
+        # NACH erfolgreicher Zustellung, unabhaengig vom Ergebnis der Pruefung
+        # oben (Eskalation, V1-Ausnahme, gemischtes Buendel kommen hier alle
+        # an). Ist `_wet_changes` leer, gibt es nichts Nasses zu vermerken;
+        # laesst sich kein Zeitfenster bilden, gibt es nichts Sinnvolles zu
+        # schreiben (AC-6/AC-7/AC-9 konsistent fortgesetzt). ERST NACH dem
+        # obigen `state_svc.save()`: der haelt noch die VOR dieser Scheibe
+        # geladene `alert_state`-Momentaufnahme und wuerde einen zuvor
+        # geschriebenen `event_identity:`-Schluessel sonst mit ihr
+        # ueberschreiben (Read-Modify-Write-Kollision zweier Schreiber auf
+        # demselben Zustand).
+        if _wet_changes and _delta_window_start is not None and _delta_window_end is not None:
+            record_event_identity(
+                user_id=self._user_id, entity_id=trip.id,
+                hazard_class=HAZARD_CLASS_WET, segment_ids=_delta_segment_ids,
+                severity=_urgency, now=datetime.now(timezone.utc),
+                window_start=_delta_window_start, window_end=_delta_window_end,
+                source="deviation",
+            )
 
         # 7. Update throttle (only on success) + persist
         # Issue #2050 S3c: die Sperrzeit wird MIT der Dringlichkeit dieses
@@ -2006,38 +2095,19 @@ class TripAlertService:
                     )
                 continue
 
-            # Doppel-Alert-Guard (Issue #818 AC-4)
-            from services.alert_state import AlertStateService
-            _guard_state = AlertStateService(self._user_id).load(trip.id)
-            _double_suppressed = False
-            for _gkey in [f"precip:{active.segment_id}", f"thunder_level_max:{active.segment_id}"]:
-                _gentry = _guard_state.get(_gkey)
-                if _gentry:
-                    try:
-                        _glast = datetime.fromisoformat(_gentry["reported_at"])
-                        if _glast.tzinfo is None:
-                            _glast = _glast.replace(tzinfo=timezone.utc)
-                        if datetime.now(timezone.utc) - _glast < timedelta(minutes=cooldown_min):
-                            _double_suppressed = True
-                            break
-                    except (KeyError, ValueError):
-                        pass
-            if _double_suppressed:
-                logger.debug(f"Radar alert suppressed by double-alert guard for {trip.id}")
-                # Issue #2050 S3b (Szenario 10, AC-4): eigener Grund, nicht
-                # `cooldown` — der Guard sitzt auf `AlertStateService`-Ebene,
-                # nicht auf dem Sperrzeit-Topf. `_e1` liegt hier bereits vor
-                # und geht mit, wie an den uebrigen Stellen dieses Zweigs.
-                # Issue #2050 S4a (AC-9): fiel die Gewitterpruefung dieses
-                # Abrufs aus, haelt der Eintrag das fest — die Entscheidung
-                # fiel dann ohne Gewitterinformation, und das muss nachtraeglich
-                # belegbar sein (D-2), nicht nur der Sperrgrund.
-                self._protokolliere_unterdrueckung(
-                    trip, reason=alert_log.REASON_NOWCAST,
-                    gate_reason=alert_log.REASON_DOUBLE_ALERT_GUARD,
-                    convective_checked=result.convective_checked, **_e1,
-                )
-                continue
+            # Issue #2050 S4c (Entscheidung 2): der Doppel-Alert-Guard (#818)
+            # ist HIER entfernt, nicht repariert -- er las `precip:<segment>`,
+            # geschrieben wird das Melde-Gedaechtnis aber als
+            # `<change.metric>:<segment_id>` (der reale Schluessel heisst
+            # `precip_sum_mm:<segment>`); der Niederschlags-Teil war seit #818
+            # toter Code, ohne Eskalations-Ausnahme. Die Paarung "Δ meldete,
+            # Radar zieht nach" laeuft ab jetzt ausschliesslich ueber
+            # `check_event_identity_gate()` weiter unten -- der Δ-Zweig
+            # registriert seine nassen Alarme jetzt dort (`check_and_send_alerts`),
+            # der Grund heisst fuer diese Paarung `event_duplicate` statt
+            # `double_alert_guard` (AC-14/AC-15). Der Grund-Code selbst bleibt
+            # in `alert_log.py`/`undelivered_hint.py` fuer historische
+            # Eintraege erhalten.
 
             # Kein Kanal konfiguriert → kein Alert (nichts zu recorden).
             # Spec-Nachtrag 2026-08-11 (#1701, "die achte Stelle"): bewusst
@@ -2200,6 +2270,14 @@ class TripAlertService:
                         self._user_id, entity_id=trip.id, entity_type="trip",
                         reason=alert_log.REASON_NOWCAST, gate_reason=_identity_gate.reason,
                         effective_channels=effective_channels,
+                        # Issue #2050 S4a (AC-9): reist an JEDER Radar-
+                        # Unterdrueckungsstelle mit, auch hier -- diese Stufe
+                        # liegt NACH dem Abruf, die Angabe ist also bekannt.
+                        # Ohne sie waere ein Δ-Registereintrag, der einen Lauf
+                        # mit ausgefallener Gewitterpruefung unterdrueckt, vom
+                        # Eintrag eines mit durchgefuehrter Pruefung nicht
+                        # mehr unterscheidbar.
+                        convective_checked=result.convective_checked,
                         **_e1,
                     )
                 except Exception as e:
@@ -2212,12 +2290,19 @@ class TripAlertService:
                 continue
 
             # Issue #2018: das Gate hat diese Meldung als NACHTRAG zu einer
-            # bereits zugestellten AMTLICHEN Warnung eingestuft — dieselbe
-            # Zustellung wie bisher, nur in anderer FORM. Fehlt der
-            # Meldezeitpunkt (fail-soft aus dem Register), entfaellt die
-            # Uhrzeit ersatzlos statt eines erfundenen Platzhalters.
+            # bereits zugestellten Meldung eingestuft — dieselbe Zustellung
+            # wie bisher, nur in anderer FORM. Fehlt der Meldezeitpunkt
+            # (fail-soft aus dem Register), entfaellt die Uhrzeit ersatzlos
+            # statt eines erfundenen Platzhalters.
+            # Issue #2050 S4c (AC-13): die Formulierung wird quellenabhaengig
+            # -- ein Δ-Vorgaenger ist KEINE amtliche Warnung, die alte,
+            # hartkodierte Formulierung waere fuer ihn falsch.
             if _identity_gate.is_addendum:
-                _bezug = "Ergänzung zur amtlichen Warnung"
+                _bezug = (
+                    "Ergänzung zur gemeldeten Wetterabweichung"
+                    if _identity_gate.addendum_source == "deviation"
+                    else "Ergänzung zur amtlichen Warnung"
+                )
                 if _identity_gate.addendum_reported_at is not None:
                     _bezug += (
                         f" von {local_fmt(_identity_gate.addendum_reported_at, tz)}"

--- a/tests/tdd/test_alarm_szenario_ein_ereignis_ein_alarm.py
+++ b/tests/tdd/test_alarm_szenario_ein_ereignis_ein_alarm.py
@@ -684,6 +684,18 @@ def test_ac13_radar_nachtrag_nennt_die_wetterabweichung_statt_einer_amtlichen_wa
     Nachtrags-Mechanismus im Aufbau ueberhaupt greift und der Test nicht nur
     einen abwesenden Text feiert.
 
+    Gemessen wird die BEZUGSFORMULIERUNG selbst ("Ergänzung zur gemeldeten
+    Wetterabweichung" vs. "Ergänzung zur amtlichen Warnung"), NICHT das bloße
+    Vorkommen des Wortes "amtlich" im Gesamttext: die statische
+    Cooldown-Fusszeile ("Bei Meldungen aus anderen Quellen (amtliche
+    Warnung/Radar) greift dieser Cooldown nicht.",
+    `src/output/renderers/alert/render.py:674`) enthaelt das Wort in JEDEM
+    Radar-Alarm mit Cooldown-Anzeige, unabhaengig von der Quelle des
+    Vorgaengers — sie behauptet nichts ueber einen Vorgaenger und ist kein
+    Defekt. Eine Pruefung auf das blosse Wort waere in BEIDE Richtungen blind:
+    der Hauptlauf waere immer rot, die Positivkontrolle immer gruen, ganz
+    unabhaengig von der tatsaechlichen Bezugsformulierung.
+
     RED heute: der Radar-Alarm nach einem Δ-Alarm ist ueberhaupt kein Nachtrag
     (kein Bezugstext im Kanalinhalt), weil der Δ-Zweig nichts registriert."""
     uid, ctrl = _uid("ac13"), _uid("ac13-ctrl")
@@ -714,7 +726,11 @@ def test_ac13_radar_nachtrag_nennt_die_wetterabweichung_statt_einer_amtlichen_wa
             f"AC-13: der Radar-Alarm muss als NACHTRAG mit Bezug auf die "
             f"vorherige Meldung herausgehen: {text!r}"
         )
-        assert "amtlich" not in text.lower(), (
+        assert "Ergänzung zur gemeldeten Wetterabweichung" in text, (
+            f"AC-13: der Bezug muss die Vorhersage-Abweichung als Quelle "
+            f"nennen: {text!r}"
+        )
+        assert "Ergänzung zur amtlichen Warnung" not in text, (
             f"AC-13: der Bezug darf keine amtliche Warnung behaupten — es lag "
             f"keine vor: {text!r}"
         )
@@ -729,10 +745,17 @@ def test_ac13_radar_nachtrag_nennt_die_wetterabweichung_statt_einer_amtlichen_wa
             radar_service=_radar(_quelle(RATE_MODERAT_MM_H, konvektiv=True)),
         )
         ktext = "\n".join(kradar.telegram + [b for _s, b in kradar.mail])
-        assert kradar.triggered_count == 1 and "amtlich" in ktext.lower(), (
+        assert kradar.triggered_count == 1, (
+            f"AC-13 Positivkontrolle: der Radar-Lauf muss zustellen (war "
+            f"{kradar.triggered_count})."
+        )
+        assert "Ergänzung zur amtlichen Warnung" in ktext, (
             f"AC-13 Positivkontrolle: nach einer amtlichen Warnung muss der "
-            f"Nachtrag sie weiterhin nennen (count={kradar.triggered_count}): "
-            f"{ktext!r}"
+            f"Nachtrag sie weiterhin nennen: {ktext!r}"
+        )
+        assert "Ergänzung zur gemeldeten Wetterabweichung" not in ktext, (
+            f"AC-13 Positivkontrolle: nach einem amtlichen Vorgaenger darf "
+            f"nicht die Δ-Formulierung erscheinen: {ktext!r}"
         )
     finally:
         _clean_user(uid)

--- a/tests/tdd/test_alarm_szenario_ein_ereignis_ein_alarm.py
+++ b/tests/tdd/test_alarm_szenario_ein_ereignis_ein_alarm.py
@@ -1,0 +1,878 @@
+"""TDD RED — Issue #2050 Scheibe S4c: ein Ereignis, ein Alarm (Szenario 5,
+Anforderung C-2) — der ABWEICHUNGS-Zweig am quellenuebergreifenden
+Ereignis-Identitaets-Register.
+
+SPEC: docs/specs/modules/feat_2050_s4c_ein_ereignis_ein_alarm.md
+(AC-1, AC-3, AC-4, AC-5, AC-9, AC-10, AC-13, AC-15, AC-18)
+
+Heutiger Stand (gemessen 2026-08-23 gegen die echte Kette): der Δ-Zweig
+`check_and_send_alerts()` ruft die Ereignis-Identitaet WEDER zum Pruefen NOCH
+zum Registrieren (`trip_alert.py:310-657`, kein Aufruf im ganzen Block). Eine
+amtliche Warnung um 10:00 und ein inhaltsgleicher Abweichungs-Alarm um 10:20
+gehen deshalb als ZWEI volle Nachrichten raus, und das Register kennt den
+Δ-Alarm hinterher nicht (Sonde: `register danach` unveraendert).
+
+Die Paarung „Δ meldete, Radar zieht nach" bewacht heute allein der
+Doppel-Alarm-Waechter (`trip_alert.py:1955-1984`) — halb tot (`precip:` ist
+kein Metrik-Schluessel, der reale heisst `precip_sum_mm`) und ohne
+Eskalations-Ausnahme. Gemessen: Regen-Δ -> Radar geht ungebremst raus
+(AC-3 rot), Gewitter-Δ -> konvektiver Radar wird mit Grund
+`double_alert_guard` GESCHLUCKT, obwohl er eine echte Verschaerfung ist
+(AC-15 rot).
+
+MESSGRUNDLAGE (Sonde 2026-08-23 gegen die ECHTE Engine, nicht angenommen):
+
+* `precip_sum_mm` 2->18 mm = MODERATE, 2->45 mm = HIGH; `gust_max_kmh`
+  10->90 km/h = HIGH; `thunder_level` auf Stufe „sensibel" NONE->MED =
+  MODERATE (auf „standard" loest MED gar nicht aus).
+* `alert_urgency.urgency_from_official_level`: Stufe 3 = MODERATE, Stufe 4 =
+  HIGH. Daraus die Registereintraege unten.
+* Radar: nicht-konvektiv bei 2,0 mm/h = MODERATE, konvektiv = HIGH.
+* Die Segment-Kennung ist auf BEIDEN Seiten `"1"` — der Radar-Zweig
+  normalisiert `active.segment_id`, der Δ-Zweig traegt `change.segment_id`.
+  Nur deshalb koennen sich beide Zweige einen Registereintrag teilen.
+* Das Melde-Gedaechtnis ist deltabasiert: eine WIEDERHOLUNG desselben Werts
+  faellt schon dort heraus. Zweitlaeufe desselben Nutzers liegen deshalb
+  immer weit vom zuletzt gemeldeten Wert entfernt.
+
+🔴 Jede AC dieser Datei, die ein AUSBLEIBEN prueft, traegt eine
+Positivkontrolle: derselbe Aufbau OHNE die gepruefte Bedingung (zweiter
+Nutzer, eigener Datenpfad) muss zustellen. Ohne sie bewiese ein stiller Lauf
+nichts — er koennte auch an der Sperrzeit, am Budget oder am Melde-
+Gedaechtnis haengen.
+
+Mock-frei: echte Trips, echte Zustandsdateien unter `get_data_dir(user_id)`,
+echte `RadarNowcastService`-Instanz an ihrer DI-Naht `frame_source=`, alle
+vier Kanaele ueber die Prüfstrecke (`tests/helpers/alarm_pruefstrecke.py`,
+#2050 S1) an lokalen Loopback-Stubs. Kein `Mock()`/`patch()`/`MagicMock`,
+kein Netz.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import date as date_type, datetime, timedelta, timezone
+
+import pytest
+from freezegun import freeze_time
+
+from app.loader import save_trip
+from app.models import (
+    ForecastMeta,
+    GPXPoint,
+    MetricConfig,
+    NormalizedTimeseries,
+    Provider,
+    SegmentWeatherData,
+    SegmentWeatherSummary,
+    ThunderLevel,
+    TripReportConfig,
+    TripSegment,
+    UnifiedWeatherDisplayConfig,
+)
+from app.trip import Stage, Trip, Waypoint
+from services import alert_log, alert_urgency
+from services.alert_state import AlertStateService
+from services.deviation_alert_engine import DeviationAlertEngine
+from services.official_alerts.models import OfficialAlert
+from services.point_weather import AlertEvaluationConfig, TripSegmentWeatherAdapter
+from services.trip_day import anchor_tz
+
+from tests.helpers.alarm_pruefstrecke import AlarmPruefstrecke
+from tests.tdd.test_952_onset_alert_fidelity import (
+    _clean_user, _trip_with_active_segment,
+)
+from tests.tdd.test_alarm_pruefstrecke_selbstschutz import (
+    _AT, _settings_all_channels, _write_tier,
+)
+from tests.tdd.test_alarm_szenario_briefing_ueberholung_zeitreihe import _radar
+from tests.tdd.test_daily_budget_escalation import RATE_MODERAT_MM_H, _quelle
+from tests.tdd.test_issue_1070_daily_alert_limit import LAT, LON
+
+# Segmentfenster der synthetischen Wetterdaten (UTC) — es umschliesst `_AT`
+# (10:00) und liefert damit den Zeitbezug, den der Δ-Zweig kuenftig statt des
+# meist fehlenden `occurred_at` uebergibt (Befund B der Kontext-Kartierung).
+_SEG_START = datetime(2026, 4, 5, 8, 0, tzinfo=timezone.utc)
+_SEG_END = datetime(2026, 4, 5, 12, 0, tzinfo=timezone.utc)
+
+
+def _uid(tag: str) -> str:
+    return f"tdd-2050s4c-{tag}-{uuid.uuid4().hex[:6]}"
+
+
+def _wd(
+    segment_id: int | str = 1, *,
+    start: datetime | None = _SEG_START, end: datetime | None = _SEG_END,
+    **summary,
+) -> SegmentWeatherData:
+    """Wetterdaten EINES Segments mit frei setzbarem Zeitfenster.
+
+    `start`/`end` sind hier bewusst steuerbar (anders als im Bestandsfixture
+    `test_issue_1070_daily_alert_limit._weather_data`): der Δ-Zweig bildet
+    seinen Zeitbezug kuenftig aus genau diesen beiden Werten, und AC-9/AC-10
+    haengen daran."""
+    segment = TripSegment(
+        segment_id=segment_id,
+        start_point=GPXPoint(
+            lat=LAT, lon=LON, elevation_m=1000, distance_from_start_km=12.0,
+        ),
+        end_point=GPXPoint(
+            lat=LAT + 0.1, lon=LON + 0.1, elevation_m=1500,
+            distance_from_start_km=18.0,
+        ),
+        start_time=start, end_time=end, duration_hours=4.0, distance_km=6.0,
+        ascent_m=500, descent_m=0,
+    )
+    return SegmentWeatherData(
+        segment=segment,
+        timeseries=NormalizedTimeseries(
+            meta=ForecastMeta(provider=Provider.OPENMETEO, model="test", grid_res_km=1.0),
+            data=[],
+        ),
+        aggregated=SegmentWeatherSummary(**summary),
+        fetched_at=datetime.now(timezone.utc), provider="openmeteo",
+    )
+
+
+_ALARM_METRIKEN = {
+    "precipitation_sum": "standard",
+    # „sensibel", damit eine MITTLERE Gewitterstufe ueberhaupt meldefaehig
+    # ist (gemessen: auf „standard" loest NONE->MED nicht aus). AC-15 braucht
+    # einen Δ-Gewitteralarm, der UNTER der konvektiven Radar-Stufe liegt.
+    "thunder_level": "sensibel",
+    "wind_gust": "standard",
+}
+_ANZEIGE_METRIKEN = ("precipitation", "thunder", "gust")
+
+
+def _trip_delta(
+    trip_id: str, *, cooldown: int = 0, levels: dict | None = None,
+    metrics: tuple = _ANZEIGE_METRIKEN, kanaele: bool = True,
+) -> Trip:
+    """Reiner Abweichungs-Trip (nur im Speicher, wie `_deviation_trip` aus
+    #1070): `check_and_send_alerts()` bekommt ihn direkt uebergeben.
+
+    `levels`/`metrics` sind steuerbar, weil AC-7 (Schnee) eine Metrik ausserhalb
+    des Standardsatzes braucht; `kanaele=False` erzeugt einen Trip ohne jeden
+    Versandkanal (AC-17)."""
+    stage = Stage(
+        id="T1", name="Tag 1", date=date_type(2026, 4, 5),
+        waypoints=[Waypoint(id="G1", name="Start", lat=LAT, lon=LON, elevation_m=1000.0)],
+    )
+    trip = Trip(
+        id=trip_id, name="S4c Abweichungs-Trip", stages=[stage],
+        display_config=UnifiedWeatherDisplayConfig(
+            trip_id=trip_id,
+            metrics=[MetricConfig(metric_id=m, enabled=True) for m in metrics],
+            metric_alert_levels=dict(levels if levels is not None else _ALARM_METRIKEN),
+        ),
+    )
+    trip.report_config = TripReportConfig(
+        trip_id=trip_id, send_email=False, send_telegram=kanaele,
+        alert_on_changes=True,
+    )
+    trip.alert_cooldown_minutes = cooldown
+    return trip
+
+
+def _trip_delta_und_radar(uid: str, trip_id: str, *, cooldown: int = 120) -> Trip:
+    """Trip, der BEIDE Zweige traegt: aktives Segment fuer `check_radar_alerts()`
+    (das seine Trips von PLATTE liest) und Alarm-Metriken fuer den Δ-Zweig.
+
+    Ohne diesen gemeinsamen Trip liefen Δ und Radar auf verschiedenen
+    `entity_id` — das Register ist pro Trip gefuehrt, und die Paarung waere
+    strukturell gar nicht herstellbar."""
+    config = TripReportConfig(
+        trip_id=trip_id, alert_on_changes=True, send_email=True, send_telegram=True,
+    )
+    with freeze_time(_AT):
+        trip = _trip_with_active_segment(trip_id, config)
+    trip.display_config = UnifiedWeatherDisplayConfig(
+        trip_id=trip_id,
+        metrics=[MetricConfig(metric_id=m, enabled=True) for m in _ANZEIGE_METRIKEN],
+        metric_alert_levels=dict(_ALARM_METRIKEN),
+    )
+    trip.alert_cooldown_minutes = cooldown
+    with freeze_time(_AT):
+        save_trip(trip, user_id=uid)
+    return trip
+
+
+def _strecke(uid: str) -> AlarmPruefstrecke:
+    _write_tier(uid, "premium")
+    return AlarmPruefstrecke(user_id=uid, settings=_settings_all_channels())
+
+
+def _amtlich(level: int, *, von: datetime, bis: datetime) -> OfficialAlert:
+    return OfficialAlert(
+        source="tdd-2050-s4c", hazard="thunderstorm", level=level,
+        label="Gewitterwarnung", valid_from=von, valid_to=bis,
+    )
+
+
+def _amtlicher_vorlauf(
+    strecke: AlarmPruefstrecke, uid: str, trip: Trip, *, level: int = 3,
+    von: datetime | None = None, bis: datetime | None = None, at: datetime = _AT,
+) -> dict:
+    """ECHTER amtlicher Alarm-Lauf — er legt den Registereintrag ueber den
+    produktiven Weg an (`_send_official_alert_only` -> `record_event_identity`),
+    nicht per Hand. Liefert den entstandenen Eintrag zurueck."""
+    alert = _amtlich(
+        level,
+        von=von if von is not None else at - timedelta(hours=1),
+        bis=bis if bis is not None else at + timedelta(hours=6),
+    )
+    lauf = strecke.lauf(
+        at=at, zweig="official", trip=trip, official_notices=[(alert, ["1"])],
+    )
+    assert lauf.triggered_count == 1, (
+        f"Testaufbau: der amtliche Vorlauf muss zustellen und registrieren "
+        f"(war {lauf.triggered_count})."
+    )
+    eintraege = _register(uid, trip.id)
+    assert len(eintraege) == 1, (
+        f"Testaufbau: genau EIN Registereintrag nach dem amtlichen Lauf, "
+        f"gefunden: {eintraege!r}"
+    )
+    return next(iter(eintraege.values()))
+
+
+def _register(uid: str, trip_id: str) -> dict:
+    state = AlertStateService(user_id=uid).load(trip_id)
+    return {k: v for k, v in state.items() if k.startswith("event_identity:")}
+
+
+def _gruende(uid: str, trip_id: str, seit: datetime) -> set:
+    """Nicht-Zustellungs-Gruende, die der PRUEFLING selbst protokolliert hat —
+    kein Dateiinhalt-Check."""
+    vorfaelle = alert_log.read_undelivered(
+        uid, entity_id=trip_id, entity_type="trip", since=seit,
+    )
+    return {g for v in vorfaelle for g in v.reasons}
+
+
+def _dringlichkeit(uid: str, trip: Trip, cached: list, fresh: list, at: datetime) -> str:
+    """Die Stufe, mit der ein Prueflauf zu `at` TATSAECHLICH rechnet — aus der
+    ECHTEN Engine mit dem Melde-Gedaechtnis von Platte und der produktiven
+    Ableitung `alert_urgency.urgency_from_changes()`. Kein Literal, sonst
+    bliebe die Bildungsstelle unbewacht."""
+    config = AlertEvaluationConfig(
+        cooldown_minutes=trip.alert_cooldown_minutes,
+        metric_alert_levels=(
+            getattr(trip.display_config, "metric_alert_levels", None)
+            if trip.display_config else None
+        ),
+        display_config=trip.display_config, zone=anchor_tz(trip, at),
+    )
+    with freeze_time(at):
+        ergebnis = DeviationAlertEngine().evaluate(
+            cached=TripSegmentWeatherAdapter.to_points(cached),
+            fresh=TripSegmentWeatherAdapter.to_points(fresh),
+            config=config,
+            alert_state=AlertStateService(user_id=uid).load(trip.id),
+        )
+    return alert_urgency.urgency_from_changes(list(ergebnis.changes))
+
+
+def _kanaele(lauf) -> dict:
+    return {
+        "mail": len(lauf.mail), "telegram": len(lauf.telegram),
+        "sms": len(lauf.sms), "premium_sms": len(lauf.premium_sms),
+    }
+
+
+# Die drei gemessenen Lagen (s. Moduldoku).
+def _regen(von: float, nach: float, **kw) -> tuple[list, list]:
+    return [_wd(1, precip_sum_mm=von, **kw)], [_wd(1, precip_sum_mm=nach, **kw)]
+
+
+# ─────────────────────────────── AC-1 ────────────────────────────────────────
+
+
+@pytest.mark.timeout(120)
+def test_ac1_amtlicher_alarm_entdoppelt_den_nachfolgenden_abweichungsalarm():
+    """AC-1. GIVEN eine amtliche Warnung (Klasse `wet`, Segment 1,
+    ueberlappendes Zeitfenster, MODERATE) wurde zugestellt und registriert,
+    WHEN 20 Minuten spaeter ein Abweichungs-Alarm mit AUSSCHLIESSLICH nassen
+    Aenderungen fuer dasselbe Segment und ohne hoehere Dringlichkeit geprueft
+    wird, THEN bleibt er still — auf KEINEM der vier Kanaele, und im Protokoll
+    steht `event_duplicate`.
+
+    Positivkontrolle (Pflicht, es wird ein AUSBLEIBEN geprueft): ein zweiter
+    Nutzer mit identischem Δ-Lauf, aber OHNE amtlichen Vorlauf, stellt zu.
+    Ohne sie koennte die Stille auch von Sperrzeit, Budget oder Melde-
+    Gedaechtnis stammen.
+
+    RED heute: der Δ-Zweig fragt das Register gar nicht — der Alarm geht raus
+    (gemessen: `triggered_count == 1`, Telegram bedient)."""
+    uid, ctrl = _uid("ac1"), _uid("ac1-ctrl")
+    try:
+        trip = _trip_delta("trip-s4c-ac1")
+        strecke = _strecke(uid)
+        eintrag = _amtlicher_vorlauf(strecke, uid, trip, level=3)
+
+        at2 = _AT + timedelta(minutes=20)
+        cached, fresh = _regen(2.0, 18.0)
+        stufe = _dringlichkeit(uid, trip, cached, fresh, at2)
+        assert not alert_urgency.exceeds(stufe, eintrag["severity"]), (
+            f"Testkonstruktion: der Δ-Lauf ({stufe!r}) darf den Registereintrag "
+            f"({eintrag['severity']!r}) NICHT im Rang uebersteigen — sonst "
+            f"maesse der Test die Eskalations-Ausnahme statt der Entdopplung."
+        )
+
+        lauf = strecke.lauf(
+            at=at2, zweig="deviation", trip=trip,
+            cached_weather=cached, fresh_weather=fresh,
+        )
+
+        assert lauf.triggered_count == 0, (
+            f"AC-1: der Abweichungs-Alarm muss als Duplikat der amtlichen "
+            f"Warnung still bleiben (war {lauf.triggered_count})."
+        )
+        assert _kanaele(lauf) == {
+            "mail": 0, "telegram": 0, "sms": 0, "premium_sms": 0,
+        }, f"AC-1: kein Kanal darf bedient werden: {_kanaele(lauf)!r}"
+        assert alert_log.REASON_EVENT_DUPLICATE in _gruende(
+            uid, trip.id, _AT - timedelta(hours=1),
+        ), (
+            f"AC-1: der Vorfall muss mit gate_reason="
+            f"{alert_log.REASON_EVENT_DUPLICATE!r} protokolliert sein, "
+            f"gefunden: {_gruende(uid, trip.id, _AT - timedelta(hours=1))!r}"
+        )
+
+        # Positivkontrolle: derselbe Δ-Lauf ohne amtlichen Vorlauf.
+        kontrolle = _strecke(ctrl).lauf(
+            at=at2, zweig="deviation", trip=_trip_delta("trip-s4c-ac1"),
+            cached_weather=cached, fresh_weather=fresh,
+        )
+        assert kontrolle.triggered_count == 1, (
+            f"AC-1 Positivkontrolle: ohne den amtlichen Registereintrag MUSS "
+            f"derselbe Lauf zustellen (war {kontrolle.triggered_count}) — "
+            f"sonst prueft der Test die Entdopplung gar nicht."
+        )
+    finally:
+        _clean_user(uid)
+        _clean_user(ctrl)
+
+
+# ─────────────────────────────── AC-3 ────────────────────────────────────────
+
+
+@pytest.mark.timeout(120)
+def test_ac3_radar_nach_registriertem_abweichungsalarm_wird_keine_zweite_vollnachricht():
+    """AC-3. GIVEN ein Abweichungs-Alarm mit Nass-Anteil wurde zugestellt und
+    registriert, WHEN danach ein Radar-Alarm derselben Zelle OHNE hoehere
+    Dringlichkeit geprueft wird, THEN geht er nicht als zweite VOLLE Nachricht
+    raus.
+
+    Positivkontrolle: derselbe Radar-Lauf bei einem zweiten Nutzer ohne
+    Δ-Vorlauf stellt zu.
+
+    RED heute: der Δ-Alarm registriert nichts, und der Doppel-Alarm-Waechter
+    liest den toten Schluessel `precip:<segment>` (der reale Name lautet
+    `precip_sum_mm`) — der Radar-Alarm geht ungebremst als zweite volle
+    Nachricht raus (gemessen: `triggered_count == 1`)."""
+    uid, ctrl = _uid("ac3"), _uid("ac3-ctrl")
+    try:
+        strecke = _strecke(uid)
+        trip = _trip_delta_und_radar(uid, "trip-s4c-ac3")
+        cached, fresh = _regen(2.0, 18.0)
+        delta = strecke.lauf(
+            at=_AT, zweig="deviation", trip=trip,
+            cached_weather=cached, fresh_weather=fresh,
+        )
+        assert delta.triggered_count == 1, (
+            f"AC-3 Vorbedingung: der Δ-Lauf muss zustellen (war "
+            f"{delta.triggered_count})."
+        )
+
+        at2 = _AT + timedelta(minutes=30)
+        radar = strecke.lauf(
+            at=at2, zweig="radar", trip=trip,
+            radar_service=_radar(_quelle(RATE_MODERAT_MM_H)),
+        )
+        assert radar.triggered_count == 0, (
+            f"AC-3: der Radar-Alarm derselben Zelle darf keine zweite volle "
+            f"Nachricht sein (war {radar.triggered_count}, Kanaele "
+            f"{_kanaele(radar)!r})."
+        )
+        assert _kanaele(radar) == {
+            "mail": 0, "telegram": 0, "sms": 0, "premium_sms": 0,
+        }, f"AC-3: kein Kanal-Zuwachs erlaubt: {_kanaele(radar)!r}"
+
+        # Positivkontrolle: gleicher Radar-Lauf ohne Δ-Vorlauf.
+        kstrecke = _strecke(ctrl)
+        _trip_delta_und_radar(ctrl, "trip-s4c-ac3")
+        kontrolle = kstrecke.lauf(
+            at=at2, zweig="radar", trip=trip,
+            radar_service=_radar(_quelle(RATE_MODERAT_MM_H)),
+        )
+        assert kontrolle.triggered_count == 1, (
+            f"AC-3 Positivkontrolle: ohne den Δ-Vorlauf MUSS derselbe "
+            f"Radar-Lauf zustellen (war {kontrolle.triggered_count})."
+        )
+    finally:
+        _clean_user(uid)
+        _clean_user(ctrl)
+
+
+# ─────────────────────────────── AC-4 ────────────────────────────────────────
+
+
+@pytest.mark.timeout(120)
+def test_ac4_echte_verschaerfung_bricht_durch_die_ereignis_identitaet():
+    """AC-4. GIVEN ein Registereintrag mit MODERATE existiert fuer
+    Segment/Zeitfenster, WHEN ein Abweichungs-Alarm mit ECHT hoeherer
+    Dringlichkeit (HIGH) fuer dasselbe Segment geprueft wird, THEN wird er
+    IMMER zugestellt.
+
+    Positivkontrolle: derselbe Aufbau mit einem GLEICHRANGIGEN Δ-Lauf bleibt
+    still — nur so ist belegt, dass die Zustellung an der Verschaerfung haengt
+    und nicht daran, dass die Entdopplung ueberhaupt nicht greift.
+
+    RED heute: die Positivkontrolle stellt zu (kein Gate im Δ-Zweig)."""
+    uid, ctrl = _uid("ac4"), _uid("ac4-ctrl")
+    try:
+        trip = _trip_delta("trip-s4c-ac4")
+        strecke = _strecke(uid)
+        eintrag = _amtlicher_vorlauf(strecke, uid, trip, level=3)
+
+        at2 = _AT + timedelta(minutes=20)
+        cached, fresh = _regen(2.0, 45.0)
+        stufe = _dringlichkeit(uid, trip, cached, fresh, at2)
+        assert alert_urgency.exceeds(stufe, eintrag["severity"]), (
+            f"Testkonstruktion: der Δ-Lauf ({stufe!r}) MUSS den Registereintrag "
+            f"({eintrag['severity']!r}) im Rang echt uebersteigen."
+        )
+
+        lauf = strecke.lauf(
+            at=at2, zweig="deviation", trip=trip,
+            cached_weather=cached, fresh_weather=fresh,
+        )
+        assert lauf.triggered_count == 1, (
+            f"AC-4: eine echte Verschaerfung muss IMMER zugestellt werden "
+            f"(war {lauf.triggered_count}, Gruende "
+            f"{_gruende(uid, trip.id, _AT - timedelta(hours=1))!r})."
+        )
+        assert lauf.telegram, (
+            f"AC-4: der Durchbruch muss den konfigurierten Kanal erreichen: "
+            f"{_kanaele(lauf)!r}"
+        )
+
+        # Positivkontrolle: gleichrangiger Lauf im selben Aufbau bleibt still.
+        ktrip = _trip_delta("trip-s4c-ac4")
+        kstrecke = _strecke(ctrl)
+        keintrag = _amtlicher_vorlauf(kstrecke, ctrl, ktrip, level=3)
+        kcached, kfresh = _regen(2.0, 18.0)
+        kstufe = _dringlichkeit(ctrl, ktrip, kcached, kfresh, at2)
+        assert not alert_urgency.exceeds(kstufe, keintrag["severity"]), (
+            f"Testkonstruktion der Positivkontrolle: {kstufe!r} darf "
+            f"{keintrag['severity']!r} nicht uebersteigen."
+        )
+        kontrolle = kstrecke.lauf(
+            at=at2, zweig="deviation", trip=ktrip,
+            cached_weather=kcached, fresh_weather=kfresh,
+        )
+        assert kontrolle.triggered_count == 0, (
+            f"AC-4 Positivkontrolle: ein GLEICHRANGIGER Δ-Lauf muss im selben "
+            f"Aufbau still bleiben (war {kontrolle.triggered_count}) — sonst "
+            f"belegt der Durchbruch oben nichts."
+        )
+    finally:
+        _clean_user(uid)
+        _clean_user(ctrl)
+
+
+# ─────────────────────────────── AC-5 ────────────────────────────────────────
+
+
+@pytest.mark.timeout(120)
+def test_ac5_gemischtes_buendel_wird_nie_unterdrueckt():
+    """AC-5. GIVEN ein passender Registereintrag (HIGH) existiert, WHEN ein
+    Abweichungs-Alarm neben der nassen Aenderung auch eine NICHT-nasse
+    (`gust_max_kmh`) buendelt, THEN wird er NIE unterdrueckt — die
+    Gefahrenklasse des Laufs ist `None`.
+
+    Positivkontrolle: derselbe Aufbau mit rein nassem Buendel derselben
+    Dringlichkeit bleibt still. Allein die Beimischung entscheidet — die
+    Dringlichkeit ist in beiden Faellen HIGH und damit als Erklaerung
+    ausgeschlossen (Registereintrag ebenfalls HIGH, `exceeds` also False).
+
+    RED heute: die Positivkontrolle stellt zu (kein Gate im Δ-Zweig)."""
+    uid, ctrl = _uid("ac5"), _uid("ac5-ctrl")
+    try:
+        trip = _trip_delta("trip-s4c-ac5")
+        strecke = _strecke(uid)
+        eintrag = _amtlicher_vorlauf(strecke, uid, trip, level=4)
+
+        at2 = _AT + timedelta(minutes=20)
+        cached = [_wd(1, precip_sum_mm=2.0, gust_max_kmh=10.0)]
+        fresh = [_wd(1, precip_sum_mm=45.0, gust_max_kmh=90.0)]
+        stufe = _dringlichkeit(uid, trip, cached, fresh, at2)
+        assert not alert_urgency.exceeds(stufe, eintrag["severity"]), (
+            f"Testkonstruktion: das gemischte Buendel ({stufe!r}) darf den "
+            f"Registereintrag ({eintrag['severity']!r}) NICHT uebersteigen — "
+            f"sonst kaeme es schon ueber die Eskalation durch und der Test "
+            f"maesse die Beimischung nicht."
+        )
+
+        lauf = strecke.lauf(
+            at=at2, zweig="deviation", trip=trip,
+            cached_weather=cached, fresh_weather=fresh,
+        )
+        assert lauf.triggered_count == 1, (
+            f"AC-5: ein Buendel mit nicht-nassem Anteil darf NIE entdoppelt "
+            f"werden (war {lauf.triggered_count}, Gruende "
+            f"{_gruende(uid, trip.id, _AT - timedelta(hours=1))!r})."
+        )
+
+        # Positivkontrolle: rein nasses Buendel derselben Stufe bleibt still.
+        ktrip = _trip_delta("trip-s4c-ac5")
+        kstrecke = _strecke(ctrl)
+        keintrag = _amtlicher_vorlauf(kstrecke, ctrl, ktrip, level=4)
+        kcached, kfresh = _regen(2.0, 45.0)
+        kstufe = _dringlichkeit(ctrl, ktrip, kcached, kfresh, at2)
+        assert kstufe == stufe and not alert_urgency.exceeds(
+            kstufe, keintrag["severity"],
+        ), (
+            f"Testkonstruktion der Positivkontrolle: dieselbe Stufe wie oben "
+            f"({kstufe!r} vs. {stufe!r}), kein Rang-Durchbruch."
+        )
+        kontrolle = kstrecke.lauf(
+            at=at2, zweig="deviation", trip=ktrip,
+            cached_weather=kcached, fresh_weather=kfresh,
+        )
+        assert kontrolle.triggered_count == 0, (
+            f"AC-5 Positivkontrolle: das rein nasse Buendel muss still bleiben "
+            f"(war {kontrolle.triggered_count}) — sonst belegt der Durchlass "
+            f"oben nicht, dass die Beimischung entschieden hat."
+        )
+    finally:
+        _clean_user(uid)
+        _clean_user(ctrl)
+
+
+# ─────────────────────────────── AC-9 ────────────────────────────────────────
+
+
+@pytest.mark.timeout(120)
+def test_ac9_ohne_bildbares_zeitfenster_entsteht_kein_match():
+    """AC-9. GIVEN die nasse Aenderung haengt an einem Segment, fuer das KEIN
+    Start-/Endzeitpunkt auffindbar ist, WHEN ein Abweichungs-Alarm dafuer
+    geprueft wird, THEN entsteht kein Zeitintervall, die Ereignis-Identitaet
+    erzeugt fail-soft KEIN Match, und die Meldung geht durch.
+
+    Positivkontrolle: dasselbe Segment MIT Zeitfenster wird im identischen
+    Aufbau unterdrueckt — der Registereintrag haette also gematcht.
+
+    RED heute: die Positivkontrolle stellt zu (kein Gate im Δ-Zweig)."""
+    uid, ctrl = _uid("ac9"), _uid("ac9-ctrl")
+    try:
+        trip = _trip_delta("trip-s4c-ac9")
+        strecke = _strecke(uid)
+        _amtlicher_vorlauf(strecke, uid, trip, level=3)
+
+        at2 = _AT + timedelta(minutes=20)
+        ohne_zeiten_cached = [_wd(1, start=None, end=None, precip_sum_mm=2.0)]
+        ohne_zeiten_fresh = [_wd(1, start=None, end=None, precip_sum_mm=18.0)]
+        lauf = strecke.lauf(
+            at=at2, zweig="deviation", trip=trip,
+            cached_weather=ohne_zeiten_cached, fresh_weather=ohne_zeiten_fresh,
+        )
+        assert lauf.triggered_count == 1, (
+            f"AC-9: ohne bildbares Zeitfenster darf NICHTS unterdrueckt werden "
+            f"(war {lauf.triggered_count}, Gruende "
+            f"{_gruende(uid, trip.id, _AT - timedelta(hours=1))!r})."
+        )
+
+        # Positivkontrolle: identischer Aufbau, aber MIT Segmentzeiten.
+        ktrip = _trip_delta("trip-s4c-ac9")
+        kstrecke = _strecke(ctrl)
+        _amtlicher_vorlauf(kstrecke, ctrl, ktrip, level=3)
+        kcached, kfresh = _regen(2.0, 18.0)
+        kontrolle = kstrecke.lauf(
+            at=at2, zweig="deviation", trip=ktrip,
+            cached_weather=kcached, fresh_weather=kfresh,
+        )
+        assert kontrolle.triggered_count == 0, (
+            f"AC-9 Positivkontrolle: MIT Segmentzeiten muss derselbe Lauf "
+            f"unterdrueckt werden (war {kontrolle.triggered_count}) — sonst "
+            f"beweist der Durchlass oben nichts ueber den fehlenden Zeitbezug."
+        )
+    finally:
+        _clean_user(uid)
+        _clean_user(ctrl)
+
+
+# ─────────────────────────────── AC-10 ───────────────────────────────────────
+
+
+@pytest.mark.timeout(120)
+def test_ac10_wesentlich_weiter_reichendes_segmentfenster_kommt_durch():
+    """AC-10 (V1-Ausnahme, unveraendert vererbt). GIVEN ein Registereintrag
+    deckt nur eine kurze Zeitspanne ab, WHEN ein gleichrangiger
+    Abweichungs-Alarm ein Segmentfenster meldet, das WESENTLICH weiter reicht,
+    THEN kommt er durch.
+
+    Positivkontrolle: derselbe Δ-Lauf gegen einen Registereintrag, der bis
+    ueber das Segmentende hinaus abdeckt, bleibt still.
+
+    RED heute: die Positivkontrolle stellt zu (kein Gate im Δ-Zweig)."""
+    uid, ctrl = _uid("ac10"), _uid("ac10-ctrl")
+    try:
+        # Weit reichendes Segmentfenster (bis _AT + 10 h) gegen einen
+        # Registereintrag, der nur bis _AT + 10 min abdeckt.
+        weit_start, weit_ende = _AT - timedelta(hours=2), _AT + timedelta(hours=10)
+        cached = [_wd(1, start=weit_start, end=weit_ende, precip_sum_mm=2.0)]
+        fresh = [_wd(1, start=weit_start, end=weit_ende, precip_sum_mm=18.0)]
+
+        trip = _trip_delta("trip-s4c-ac10")
+        strecke = _strecke(uid)
+        eintrag = _amtlicher_vorlauf(
+            strecke, uid, trip, level=3,
+            von=_AT - timedelta(hours=1), bis=_AT + timedelta(minutes=10),
+        )
+        at2 = _AT + timedelta(minutes=20)
+        stufe = _dringlichkeit(uid, trip, cached, fresh, at2)
+        assert not alert_urgency.exceeds(stufe, eintrag["severity"]), (
+            f"Testkonstruktion: {stufe!r} darf {eintrag['severity']!r} nicht "
+            f"uebersteigen — sonst maesse der Test die Eskalation statt V1."
+        )
+
+        lauf = strecke.lauf(
+            at=at2, zweig="deviation", trip=trip,
+            cached_weather=cached, fresh_weather=fresh,
+        )
+        assert lauf.triggered_count == 1, (
+            f"AC-10: ein wesentlich weiter reichendes Segmentfenster ist neue "
+            f"Information und muss durchkommen (war {lauf.triggered_count})."
+        )
+
+        # Positivkontrolle: Registereintrag deckt ueber das Segmentende hinaus.
+        ktrip = _trip_delta("trip-s4c-ac10")
+        kstrecke = _strecke(ctrl)
+        _amtlicher_vorlauf(
+            kstrecke, ctrl, ktrip, level=3,
+            von=_AT - timedelta(hours=1), bis=weit_ende + timedelta(hours=2),
+        )
+        kontrolle = kstrecke.lauf(
+            at=at2, zweig="deviation", trip=ktrip,
+            cached_weather=cached, fresh_weather=fresh,
+        )
+        assert kontrolle.triggered_count == 0, (
+            f"AC-10 Positivkontrolle: deckt der Registereintrag das ganze "
+            f"Segmentfenster ab, muss der Lauf still bleiben (war "
+            f"{kontrolle.triggered_count})."
+        )
+    finally:
+        _clean_user(uid)
+        _clean_user(ctrl)
+
+
+# ─────────────────────────────── AC-13 ───────────────────────────────────────
+
+
+@pytest.mark.timeout(120)
+def test_ac13_radar_nachtrag_nennt_die_wetterabweichung_statt_einer_amtlichen_warnung():
+    """AC-13. GIVEN ein Abweichungs-Alarm wurde registriert (Quelle
+    `deviation`), WHEN danach ein Radar-Alarm derselben Zelle mit ECHTER
+    Verschaerfung geprueft wird, THEN geht er in NACHTRAGSFORM heraus — mit
+    einer Bezeichnung fuer die Vorhersage-Abweichung, NICHT als „Ergaenzung
+    zur amtlichen Warnung" (es lag keine amtliche Warnung vor, B-2).
+
+    Positivkontrolle: nach einer echten AMTLICHEN Warnung traegt derselbe
+    Radar-Lauf weiterhin den amtlichen Nachtragsbezug — sie belegt, dass der
+    Nachtrags-Mechanismus im Aufbau ueberhaupt greift und der Test nicht nur
+    einen abwesenden Text feiert.
+
+    RED heute: der Radar-Alarm nach einem Δ-Alarm ist ueberhaupt kein Nachtrag
+    (kein Bezugstext im Kanalinhalt), weil der Δ-Zweig nichts registriert."""
+    uid, ctrl = _uid("ac13"), _uid("ac13-ctrl")
+    try:
+        strecke = _strecke(uid)
+        trip = _trip_delta_und_radar(uid, "trip-s4c-ac13")
+        cached, fresh = _regen(2.0, 18.0)
+        delta = strecke.lauf(
+            at=_AT, zweig="deviation", trip=trip,
+            cached_weather=cached, fresh_weather=fresh,
+        )
+        assert delta.triggered_count == 1, (
+            f"AC-13 Vorbedingung: der Δ-Lauf muss zustellen (war "
+            f"{delta.triggered_count})."
+        )
+
+        at2 = _AT + timedelta(minutes=30)
+        radar = strecke.lauf(
+            at=at2, zweig="radar", trip=trip,
+            radar_service=_radar(_quelle(RATE_MODERAT_MM_H, konvektiv=True)),
+        )
+        assert radar.triggered_count == 1, (
+            f"AC-13: die Verschaerfung muss zugestellt werden (war "
+            f"{radar.triggered_count})."
+        )
+        text = "\n".join(radar.telegram + [b for _s, b in radar.mail])
+        assert "Ergänzung" in text, (
+            f"AC-13: der Radar-Alarm muss als NACHTRAG mit Bezug auf die "
+            f"vorherige Meldung herausgehen: {text!r}"
+        )
+        assert "amtlich" not in text.lower(), (
+            f"AC-13: der Bezug darf keine amtliche Warnung behaupten — es lag "
+            f"keine vor: {text!r}"
+        )
+
+        # Positivkontrolle: nach einer ECHTEN amtlichen Warnung bleibt der
+        # amtliche Nachtragsbezug erhalten.
+        kstrecke = _strecke(ctrl)
+        ktrip = _trip_delta_und_radar(ctrl, "trip-s4c-ac13")
+        _amtlicher_vorlauf(kstrecke, ctrl, ktrip, level=3)
+        kradar = kstrecke.lauf(
+            at=at2, zweig="radar", trip=ktrip,
+            radar_service=_radar(_quelle(RATE_MODERAT_MM_H, konvektiv=True)),
+        )
+        ktext = "\n".join(kradar.telegram + [b for _s, b in kradar.mail])
+        assert kradar.triggered_count == 1 and "amtlich" in ktext.lower(), (
+            f"AC-13 Positivkontrolle: nach einer amtlichen Warnung muss der "
+            f"Nachtrag sie weiterhin nennen (count={kradar.triggered_count}): "
+            f"{ktext!r}"
+        )
+    finally:
+        _clean_user(uid)
+        _clean_user(ctrl)
+
+
+# ─────────────────────────────── AC-15 ───────────────────────────────────────
+
+
+@pytest.mark.timeout(120)
+def test_ac15_gewitter_verschaerfung_kommt_nach_der_abloesung_durch():
+    """AC-15. GIVEN ein Abweichungs-Alarm hat eine mittlere Gewitterstufe
+    gemeldet (MODERATE) und damit genau den Schluessel geschrieben, auf den
+    der alte Doppel-Alarm-Waechter anspringt
+    (`thunder_level_max:<segment_id>`), WHEN innerhalb desselben
+    Sperrzeit-Fensters ein KONVEKTIVER Radar-Alarm (HIGH) geprueft wird,
+    THEN kommt die Verschaerfung DURCH — der abgeloeste Waechter kannte keine
+    Eskalations-Ausnahme und haette sie geschluckt (Anforderung A-3).
+
+    Der Test prueft ein EINTRETEN; die Zustellung ist selbst der Nachweis.
+    Die Vorbedingung („der alte Waechter waere hier scharf gewesen") wird
+    ausdruecklich gemessen: der Schluessel steht im Zustand, und die Sperrzeit
+    des Trips ist laenger als der Abstand der beiden Laeufe.
+
+    RED heute (gemessen): `triggered_count == 0`, protokollierter Grund
+    `double_alert_guard`."""
+    uid = _uid("ac15")
+    try:
+        strecke = _strecke(uid)
+        trip = _trip_delta_und_radar(uid, "trip-s4c-ac15", cooldown=120)
+        cached = [_wd(1, thunder_level_max=ThunderLevel.NONE)]
+        fresh = [_wd(1, thunder_level_max=ThunderLevel.MED)]
+        at2 = _AT + timedelta(minutes=30)
+
+        delta_stufe = _dringlichkeit(uid, trip, cached, fresh, _AT)
+        delta = strecke.lauf(
+            at=_AT, zweig="deviation", trip=trip,
+            cached_weather=cached, fresh_weather=fresh,
+        )
+        assert delta.triggered_count == 1, (
+            f"AC-15 Vorbedingung: der Gewitter-Δ muss zustellen (war "
+            f"{delta.triggered_count})."
+        )
+        zustand = AlertStateService(user_id=uid).load(trip.id)
+        assert "thunder_level_max:1" in zustand, (
+            f"AC-15 Vorbedingung: der Δ-Lauf muss genau den Schluessel "
+            f"schreiben, auf den der alte Doppel-Alarm-Waechter anspringt — "
+            f"sonst waere er im Aufbau gar nicht scharf: {sorted(zustand)!r}"
+        )
+        assert (at2 - _AT) < timedelta(minutes=trip.alert_cooldown_minutes), (
+            "AC-15 Vorbedingung: der zweite Lauf muss INNERHALB des alten "
+            "Waechter-Fensters liegen."
+        )
+
+        radar = strecke.lauf(
+            at=at2, zweig="radar", trip=trip,
+            radar_service=_radar(_quelle(RATE_MODERAT_MM_H, konvektiv=True)),
+        )
+        assert radar.triggered_count == 1, (
+            f"AC-15: die Gewitter-Verschaerfung gegenueber {delta_stufe!r} "
+            f"muss durchkommen (war {radar.triggered_count}, Gruende "
+            f"{_gruende(uid, trip.id, _AT - timedelta(hours=1))!r})."
+        )
+        assert alert_log.REASON_DOUBLE_ALERT_GUARD not in _gruende(
+            uid, trip.id, _AT - timedelta(hours=1),
+        ), (
+            "AC-15: der abgeloeste Doppel-Alarm-Waechter darf fuer diese "
+            "Paarung keinen Grund mehr erzeugen."
+        )
+    finally:
+        _clean_user(uid)
+
+
+# ─────────────────────────────── AC-18 ───────────────────────────────────────
+
+
+@pytest.mark.timeout(120)
+def test_ac18_registereintrag_von_nutzer_a_wirkt_nicht_auf_nutzer_b():
+    """AC-18. GIVEN Nutzer A hat einen Ereignis-Identitaets-Registereintrag
+    aus einem eigenen Abweichungs-Alarm hinterlassen, WHEN Nutzer B einen
+    inhaltsgleichen Abweichungs-Alarm fuer sein eigenes, gleich benanntes
+    Segment prueft, THEN bleibt B's Alarm unbeeinflusst — getrennte
+    Registerpfade unter `data/users/<user_id>/`.
+
+    Positivkontrolle: A's EIGENER Folgelauf derselben Stufe bleibt still.
+    Ohne sie waere „B stellt zu" auch dann wahr, wenn die Entdopplung gar
+    nicht existiert (heute genau der Fall — daher RED)."""
+    a, b = _uid("ac18-a"), _uid("ac18-b")
+    try:
+        trip_a = _trip_delta("trip-s4c-ac18")
+        strecke_a = _strecke(a)
+        cached, fresh = _regen(2.0, 18.0)
+        # VOR dem Lauf gemessen: danach steht der gemeldete Wert im
+        # deltabasierten Melde-Gedaechtnis und dieselbe Lage ergaebe eine
+        # andere Stufe.
+        erst_stufe = _dringlichkeit(a, trip_a, cached, fresh, _AT)
+        lauf_a1 = strecke_a.lauf(
+            at=_AT, zweig="deviation", trip=trip_a,
+            cached_weather=cached, fresh_weather=fresh,
+        )
+        assert lauf_a1.triggered_count == 1, (
+            f"AC-18 Vorbedingung: A's erster Lauf muss zustellen und "
+            f"registrieren (war {lauf_a1.triggered_count})."
+        )
+
+        at2 = _AT + timedelta(minutes=20)
+        # B: gleich benannter Trip, gleich benanntes Segment, gleiche Lage.
+        trip_b = _trip_delta("trip-s4c-ac18")
+        lauf_b = _strecke(b).lauf(
+            at=at2, zweig="deviation", trip=trip_b,
+            cached_weather=cached, fresh_weather=fresh,
+        )
+        assert lauf_b.triggered_count == 1, (
+            f"AC-18: B's Alarm darf von A's Registereintrag nicht beruehrt "
+            f"werden (war {lauf_b.triggered_count})."
+        )
+        assert not _register(b, trip_b.id) or all(
+            e.get("segment_ids") for e in _register(b, trip_b.id).values()
+        ), "AC-18: B's Register darf nur B's eigene Eintraege fuehren."
+
+        # Positivkontrolle: A's eigener Folgelauf derselben Stufe (weit genug
+        # vom zuletzt gemeldeten Wert entfernt, damit nicht schon das
+        # deltabasierte Melde-Gedaechtnis greift) bleibt still.
+        a_cached, a_fresh = _regen(30.0, 47.0)
+        a_stufe = _dringlichkeit(a, trip_a, a_cached, a_fresh, at2)
+        assert a_stufe == erst_stufe, (
+            f"Testkonstruktion: A's Folgelage muss dieselbe Stufe tragen wie "
+            f"sein Ersteintrag ({a_stufe!r} vs. {erst_stufe!r}) — sonst maesse "
+            f"die Kontrolle einen Rang-Unterschied statt der Entdopplung."
+        )
+        lauf_a2 = strecke_a.lauf(
+            at=at2, zweig="deviation", trip=trip_a,
+            cached_weather=a_cached, fresh_weather=a_fresh,
+        )
+        assert lauf_a2.triggered_count == 0, (
+            f"AC-18 Positivkontrolle: A's eigener, gleichrangiger Folgelauf "
+            f"muss an A's eigenem Registereintrag scheitern (war "
+            f"{lauf_a2.triggered_count}) — sonst belegt B's Zustellung keine "
+            f"Mandantentrennung."
+        )
+    finally:
+        _clean_user(a)
+        _clean_user(b)

--- a/tests/tdd/test_alert_gate.py
+++ b/tests/tdd/test_alert_gate.py
@@ -2009,3 +2009,507 @@ def test_ac14_2065_adr_0021_und_s3_spec_tragen_einen_datierten_nachtrag():
     assert re.search(r"\d{4}-\d{2}-\d{2}", spec_absatz), (
         "Der #2065-Nachtrag in rework_1467_s3_nowcast.md muss DATIERT sein."
     )
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Issue #2050 Scheibe S4c — der ABWEICHUNGS-Zweig an der Ereignis-Identitaet
+# SPEC: docs/specs/modules/feat_2050_s4c_ein_ereignis_ein_alarm.md
+# (AC-2, AC-6, AC-7, AC-8, AC-11, AC-12, AC-17)
+#
+# Gemessener Ist-Stand (2026-08-23): `resolve_hazard_class()` kennt genau zwei
+# Eingaenge (`is_convective`, `hazard`) — eine Metrik-Liste nimmt sie nicht
+# entgegen (TypeError). `check_and_send_alerts()` ruft weder
+# `check_event_identity_gate()` noch `record_event_identity()`; nach einem
+# zugestellten Abweichungs-Alarm bleibt das Register leer (Sonde: `register`
+# unveraendert `{}`).
+#
+# Die Trip-Fixtures dieser Scheibe werden GELIEHEN statt nachgebaut
+# (`test_alarm_szenario_ein_ereignis_ein_alarm`): zwei Fassungen derselben
+# Messgrundlage liefen auseinander.
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def _s4c():
+    """Die geteilten Fixtures der Scheibe (Import in der Funktion, damit die
+    Bestandsdatei ihre Importliste unveraendert behaelt)."""
+    from tests.tdd import test_alarm_szenario_ein_ereignis_ein_alarm as s4c
+
+    return s4c
+
+
+def _zaehl_spion(monkeypatch):
+    """Zaehlt Aufrufe von `check_event_identity_gate` IM PRUEFLING und
+    delegiert an die ECHTE Funktion — kein Mock, das Verhalten bleibt
+    unveraendert. Gepatcht wird das Modul-Attribut in `services.trip_alert`
+    (dort ist die Funktion gebunden, `trip_alert.py:23`)."""
+    import services.trip_alert as trip_alert_mod
+
+    echte = trip_alert_mod.check_event_identity_gate
+    aufrufe: list = []
+
+    def _spion(**kw):
+        aufrufe.append(kw)
+        return echte(**kw)
+
+    monkeypatch.setattr(trip_alert_mod, "check_event_identity_gate", _spion)
+    return aufrufe
+
+
+# ─────────────────────────────── AC-2 ────────────────────────────────────────
+
+
+@pytest.mark.timeout(120)
+def test_s4c_ac2_zugestellter_abweichungsalarm_registriert_genau_die_nassen_segmente(
+):
+    """AC-2. GIVEN ein Abweichungs-Alarm mit einer nassen (Segment 1) und einer
+    nicht-nassen Aenderung (Segment 2) wird zugestellt, WHEN das Register
+    danach gelesen wird, THEN steht dort GENAU EIN neuer Eintrag mit
+    `source == "deviation"`, dessen `segment_ids` nur das Segment der NASSEN
+    Aenderung traegt, dessen `severity` die Dringlichkeit dieses Laufs ist und
+    dessen Zeitintervall aus dem Segmentfenster der nassen Aenderung stammt.
+
+    Erwartete `severity` und Fenstergrenzen werden ABGELEITET (aus der echten
+    Engine bzw. den uebergebenen Segmenten), nie als Literal gesetzt — sonst
+    bliebe die Bildungsstelle unbewacht.
+
+    RED heute: das Register bleibt leer, der Δ-Zweig registriert nicht."""
+    s4c = _s4c()
+    _AT = s4c._AT
+    uid = s4c._uid("gate-ac2")
+    try:
+        trip = s4c._trip_delta("trip-s4c-ac2")
+        strecke = s4c._strecke(uid)
+        nass_start = s4c._SEG_START
+        nass_ende = s4c._SEG_END
+        trocken_start = nass_ende + timedelta(hours=4)
+        trocken_ende = trocken_start + timedelta(hours=4)
+        cached = [
+            s4c._wd(1, start=nass_start, end=nass_ende, precip_sum_mm=2.0),
+            s4c._wd(2, start=trocken_start, end=trocken_ende, gust_max_kmh=10.0),
+        ]
+        fresh = [
+            s4c._wd(1, start=nass_start, end=nass_ende, precip_sum_mm=18.0),
+            s4c._wd(2, start=trocken_start, end=trocken_ende, gust_max_kmh=90.0),
+        ]
+        erwartete_stufe = s4c._dringlichkeit(uid, trip, cached, fresh, _AT)
+
+        lauf = strecke.lauf(
+            at=_AT, zweig="deviation", trip=trip,
+            cached_weather=cached, fresh_weather=fresh,
+        )
+        assert lauf.triggered_count == 1, (
+            f"AC-2 Vorbedingung: der Lauf muss zustellen (war "
+            f"{lauf.triggered_count})."
+        )
+
+        eintraege = s4c._register(uid, trip.id)
+        assert len(eintraege) == 1, (
+            f"AC-2: genau EIN neuer Registereintrag erwartet, gefunden "
+            f"{len(eintraege)}: {eintraege!r}"
+        )
+        (eintrag,) = eintraege.values()
+        assert eintrag["source"] == "deviation", (
+            f"AC-2: der Eintrag muss die Quelle 'deviation' tragen: {eintrag!r}"
+        )
+        assert set(eintrag["segment_ids"]) == {"1"}, (
+            f"AC-2: nur das Segment der NASSEN Aenderung gehoert in den "
+            f"Eintrag (Segment 2 traegt nur eine Boee): {eintrag!r}"
+        )
+        assert eintrag["severity"] == erwartete_stufe, (
+            f"AC-2: severity muss die Dringlichkeit DIESES Laufs sein "
+            f"({erwartete_stufe!r}): {eintrag!r}"
+        )
+        assert eintrag["window_start"] is not None and eintrag["window_end"] is not None, (
+            f"AC-2: der Δ-Zweig muss ein Zeitintervall registrieren: {eintrag!r}"
+        )
+        assert datetime.fromisoformat(eintrag["window_start"]) == nass_start, (
+            f"AC-2: window_start muss der Beginn des NASSEN Segments sein "
+            f"({nass_start.isoformat()}): {eintrag!r}"
+        )
+        assert datetime.fromisoformat(eintrag["window_end"]) == nass_ende, (
+            f"AC-2: window_end muss das Ende des NASSEN Segments sein "
+            f"({nass_ende.isoformat()}) — nicht das des trockenen: {eintrag!r}"
+        )
+    finally:
+        s4c._clean_user(uid)
+
+
+# ─────────────────────────────── AC-6 ────────────────────────────────────────
+
+
+@pytest.mark.timeout(120)
+def test_s4c_ac6_rein_nicht_nasses_buendel_fragt_das_register_gar_nicht(monkeypatch):
+    """AC-6. GIVEN ein Abweichungs-Alarm enthaelt AUSSCHLIESSLICH nicht-nasse
+    Aenderungen, WHEN er geprueft wird, THEN wird die Ereignis-Identitaet fuer
+    diesen Lauf gar nicht gerufen und die Meldung geht durch.
+
+    Gezaehlt wird `check_event_identity_gate` — NICHT `AlertStateService.load`:
+    die Ladefunktion wird im selben Lauf ohnehin fuer das Melde-Gedaechtnis
+    gerufen und koennte den Befund nicht trennen.
+
+    Positivkontrolle: derselbe Aufbau mit einer NASSEN Aenderung ruft das Gate
+    genau einmal. Ohne sie bewiese der Zaehler `0` nichts (er ist heute in
+    beiden Faellen `0` — genau das ist der RED-Grund)."""
+    s4c = _s4c()
+    _AT = s4c._AT
+    uid, ctrl = s4c._uid("gate-ac6"), s4c._uid("gate-ac6-ctrl")
+    try:
+        aufrufe = _zaehl_spion(monkeypatch)
+
+        trip = s4c._trip_delta("trip-s4c-ac6")
+        cached = [s4c._wd(1, gust_max_kmh=10.0, temp_max_c=10.0)]
+        fresh = [s4c._wd(1, gust_max_kmh=90.0, temp_max_c=40.0)]
+        lauf = s4c._strecke(uid).lauf(
+            at=_AT, zweig="deviation", trip=trip,
+            cached_weather=cached, fresh_weather=fresh,
+        )
+        assert lauf.triggered_count == 1, (
+            f"AC-6: eine rein nicht-nasse Meldung muss durchgehen (war "
+            f"{lauf.triggered_count})."
+        )
+        assert len(aufrufe) == 0, (
+            f"AC-6: fuer ein Buendel ausserhalb des `wet`-Kanons darf die "
+            f"Ereignis-Identitaet gar nicht gerufen werden, gezaehlt: "
+            f"{len(aufrufe)} ({aufrufe!r})"
+        )
+
+        # Positivkontrolle: eine nasse Aenderung ruft das Gate genau einmal.
+        aufrufe.clear()
+        ktrip = s4c._trip_delta("trip-s4c-ac6")
+        kcached = [s4c._wd(1, precip_sum_mm=2.0)]
+        kfresh = [s4c._wd(1, precip_sum_mm=18.0)]
+        klauf = s4c._strecke(ctrl).lauf(
+            at=_AT, zweig="deviation", trip=ktrip,
+            cached_weather=kcached, fresh_weather=kfresh,
+        )
+        assert klauf.triggered_count == 1, (
+            f"AC-6 Positivkontrolle: der nasse Lauf muss zustellen (war "
+            f"{klauf.triggered_count})."
+        )
+        assert len(aufrufe) == 1, (
+            f"AC-6 Positivkontrolle: ein nasses Buendel MUSS die "
+            f"Ereignis-Identitaet genau einmal fragen, gezaehlt: "
+            f"{len(aufrufe)} — der Zaehler oben belegt sonst nichts."
+        )
+    finally:
+        s4c._clean_user(uid)
+        s4c._clean_user(ctrl)
+
+
+# ─────────────────────────────── AC-7 ────────────────────────────────────────
+
+
+@pytest.mark.parametrize("metrik", ["snow_depth_cm", "snow_new_sum_cm", "snowfall_limit_m"])
+def test_s4c_ac7_schnee_metriken_gehoeren_nicht_zum_wet_kanon(metrik):
+    """AC-7 (Baustein). Schnee ist physikalisch Niederschlag, steht aber nicht
+    im T2-Kanon — `resolve_hazard_class(metrics=[<schnee>])` liefert `None`.
+
+    Gegenprobe mit einem plausibel RICHTIGEN Wert (nicht mit `None`): die vier
+    Kanon-Metriken liefern `HAZARD_CLASS_WET`; eine Mischung aus nass und
+    Schnee liefert `None` (die Klasse gilt nur, wenn JEDE Metrik zum Kanon
+    gehoert).
+
+    RED heute: `resolve_hazard_class()` nimmt gar kein `metrics=` entgegen
+    (TypeError)."""
+    from services.alert_gate import HAZARD_CLASS_WET, resolve_hazard_class
+
+    assert resolve_hazard_class(metrics=[metrik]) is None, (
+        f"AC-7: {metrik!r} darf keine Gefahrenklasse ergeben."
+    )
+    assert resolve_hazard_class(metrics=["precip_sum_mm"]) == HAZARD_CLASS_WET, (
+        "AC-7 Gegenprobe: eine echte Kanon-Metrik MUSS `wet` ergeben — sonst "
+        "prueft der Test nur, dass die Funktion immer `None` sagt."
+    )
+    assert resolve_hazard_class(metrics=["precip_sum_mm", metrik]) is None, (
+        f"AC-7: schon EIN Anteil ausserhalb des Kanons ({metrik!r}) macht die "
+        f"Klasse `None` — gemischte Buendel werden nie entdoppelt."
+    )
+
+
+def test_s4c_ac7_leere_metrikliste_ergibt_keine_klasse():
+    """AC-7 (Randfall): eine LEERE Metrik-Liste ist kein `wet` — sonst
+    entstuende eine Klasse aus dem Nichts (`all([])` ist `True`)."""
+    from services.alert_gate import resolve_hazard_class
+
+    assert resolve_hazard_class(metrics=[]) is None
+
+
+@pytest.mark.timeout(120)
+def test_s4c_ac7_schnee_buendel_wird_nie_entdoppelt():
+    """AC-7 (end-to-end). GIVEN ein passender Registereintrag existiert, WHEN
+    ein Abweichungs-Alarm ausschliesslich Schnee meldet, THEN geht er durch.
+
+    Positivkontrolle: derselbe Aufbau mit einer nassen Aenderung derselben
+    Stufe bleibt still."""
+    from services import alert_urgency
+
+    s4c = _s4c()
+    _AT = s4c._AT
+    uid, ctrl = s4c._uid("gate-ac7"), s4c._uid("gate-ac7-ctrl")
+    schnee_levels = {"fresh_snow": "standard", "precipitation_sum": "standard"}
+    schnee_metriken = ("fresh_snow", "precipitation")
+    try:
+        trip = s4c._trip_delta(
+            "trip-s4c-ac7", levels=schnee_levels, metrics=schnee_metriken,
+        )
+        strecke = s4c._strecke(uid)
+        eintrag = s4c._amtlicher_vorlauf(strecke, uid, trip, level=4)
+
+        at2 = _AT + timedelta(minutes=20)
+        cached = [s4c._wd(1, snow_new_sum_cm=0.0)]
+        fresh = [s4c._wd(1, snow_new_sum_cm=40.0)]
+        stufe = s4c._dringlichkeit(uid, trip, cached, fresh, at2)
+        assert not alert_urgency.exceeds(stufe, eintrag["severity"]), (
+            f"Testkonstruktion: der Schnee-Lauf ({stufe!r}) darf den "
+            f"Registereintrag ({eintrag['severity']!r}) nicht uebersteigen."
+        )
+        lauf = strecke.lauf(
+            at=at2, zweig="deviation", trip=trip,
+            cached_weather=cached, fresh_weather=fresh,
+        )
+        assert lauf.triggered_count == 1, (
+            f"AC-7: ein Schnee-Buendel darf nie entdoppelt werden (war "
+            f"{lauf.triggered_count})."
+        )
+
+        ktrip = s4c._trip_delta(
+            "trip-s4c-ac7", levels=schnee_levels, metrics=schnee_metriken,
+        )
+        kstrecke = s4c._strecke(ctrl)
+        s4c._amtlicher_vorlauf(kstrecke, ctrl, ktrip, level=4)
+        kcached = [s4c._wd(1, precip_sum_mm=2.0)]
+        kfresh = [s4c._wd(1, precip_sum_mm=45.0)]
+        kontrolle = kstrecke.lauf(
+            at=at2, zweig="deviation", trip=ktrip,
+            cached_weather=kcached, fresh_weather=kfresh,
+        )
+        assert kontrolle.triggered_count == 0, (
+            f"AC-7 Positivkontrolle: eine NASSE Aenderung derselben Stufe muss "
+            f"im selben Aufbau still bleiben (war {kontrolle.triggered_count})."
+        )
+    finally:
+        s4c._clean_user(uid)
+        s4c._clean_user(ctrl)
+
+
+# ─────────────────────────────── AC-8 ────────────────────────────────────────
+
+
+@pytest.mark.timeout(120)
+def test_s4c_ac8_kaputter_registereintrag_unterdrueckt_nichts():
+    """AC-8 (Fail-soft). GIVEN der Registereintrag ist unvollstaendig (das
+    Feld `segment_ids` fehlt), WHEN ein Abweichungs-Alarm dafuer geprueft
+    wird, THEN unterdrueckt er NICHTS und nichts stuerzt ab.
+
+    Positivkontrolle: derselbe, INTAKTE Eintrag unterdrueckt den identischen
+    Lauf.
+
+    RED heute: die Positivkontrolle stellt zu (kein Gate im Δ-Zweig)."""
+    from services.alert_state import AlertStateService
+
+    s4c = _s4c()
+    _AT = s4c._AT
+    uid, ctrl = s4c._uid("gate-ac8"), s4c._uid("gate-ac8-ctrl")
+    try:
+        trip = s4c._trip_delta("trip-s4c-ac8")
+        strecke = s4c._strecke(uid)
+        s4c._amtlicher_vorlauf(strecke, uid, trip, level=3)
+
+        dienst = AlertStateService(user_id=uid)
+        zustand = dienst.load(trip.id)
+        for schluessel, eintrag in list(zustand.items()):
+            if schluessel.startswith("event_identity:"):
+                eintrag.pop("segment_ids", None)
+        dienst.save(trip.id, zustand)
+
+        at2 = _AT + timedelta(minutes=20)
+        cached, fresh = s4c._regen(2.0, 18.0)
+        lauf = strecke.lauf(
+            at=at2, zweig="deviation", trip=trip,
+            cached_weather=cached, fresh_weather=fresh,
+        )
+        assert lauf.triggered_count == 1, (
+            f"AC-8: ein kaputter Registereintrag darf nichts unterdruecken "
+            f"(war {lauf.triggered_count})."
+        )
+
+        ktrip = s4c._trip_delta("trip-s4c-ac8")
+        kstrecke = s4c._strecke(ctrl)
+        s4c._amtlicher_vorlauf(kstrecke, ctrl, ktrip, level=3)
+        kontrolle = kstrecke.lauf(
+            at=at2, zweig="deviation", trip=ktrip,
+            cached_weather=cached, fresh_weather=fresh,
+        )
+        assert kontrolle.triggered_count == 0, (
+            f"AC-8 Positivkontrolle: der INTAKTE Eintrag muss denselben Lauf "
+            f"unterdruecken (war {kontrolle.triggered_count}) — sonst belegt "
+            f"der Durchlass oben kein Fail-soft."
+        )
+    finally:
+        s4c._clean_user(uid)
+        s4c._clean_user(ctrl)
+
+
+# ─────────────────────────────── AC-11 ───────────────────────────────────────
+
+
+@pytest.mark.timeout(120)
+def test_s4c_ac11_registereintrag_traegt_deviation_statt_der_alten_ableitung():
+    """AC-11. GIVEN ein Abweichungs-Alarm mit Nass-Anteil wurde zugestellt,
+    WHEN sein Registereintrag gelesen wird, THEN traegt er
+    `source == "deviation"` — obwohl er (wie ein amtlicher Eintrag) ein
+    Zeitintervall statt eines Einzelzeitpunkts fuehrt.
+
+    Gegenprobe gegen die ALTE Ableitung (`"nowcast" if point_at is not None
+    else "official"`): sie wird im Test nachvollzogen und liefert fuer diesen
+    Eintrag `"official"` — der Wert muss also aus einem expliziten Parameter
+    stammen, nicht aus der Zeitform.
+
+    RED heute: es entsteht gar kein Eintrag."""
+    s4c = _s4c()
+    _AT = s4c._AT
+    uid = s4c._uid("gate-ac11")
+    try:
+        trip = s4c._trip_delta("trip-s4c-ac11")
+        cached, fresh = s4c._regen(2.0, 18.0)
+        lauf = s4c._strecke(uid).lauf(
+            at=_AT, zweig="deviation", trip=trip,
+            cached_weather=cached, fresh_weather=fresh,
+        )
+        assert lauf.triggered_count == 1, (
+            f"AC-11 Vorbedingung: der Lauf muss zustellen (war "
+            f"{lauf.triggered_count})."
+        )
+        eintraege = s4c._register(uid, trip.id)
+        assert len(eintraege) == 1, (
+            f"AC-11 Vorbedingung: genau ein Eintrag erwartet: {eintraege!r}"
+        )
+        (eintrag,) = eintraege.values()
+
+        alte_ableitung = "nowcast" if eintrag.get("point_at") is not None else "official"
+        assert alte_ableitung == "official", (
+            f"AC-11 Gegenprobe: der Δ-Eintrag darf KEIN `point_at` fuehren "
+            f"(sonst laese ihn der Bestand als Nowcast): {eintrag!r}"
+        )
+        assert eintrag["source"] == "deviation", (
+            f"AC-11: die Quelle muss explizit 'deviation' sein — die alte "
+            f"Ableitung aus der Zeitform haette hier faelschlich "
+            f"{alte_ableitung!r} geliefert: {eintrag!r}"
+        )
+    finally:
+        s4c._clean_user(uid)
+
+
+# ─────────────────────────────── AC-12 ───────────────────────────────────────
+
+
+def test_s4c_ac12_altbestand_ohne_quellenfeld_verhaelt_sich_unveraendert():
+    """AC-12 (Bestandswaechter). GIVEN ein Registereintrag im Format VOR dieser
+    Scheibe (ohne `source`-Feld), WHEN ein amtlicher und ein Radar-Kandidat
+    dagegen geprueft werden — beide OHNE expliziten `source`-Parameter, wie die
+    Bestandsaufrufer —, THEN bleibt sein Verhalten unveraendert: der
+    gleichrangige amtliche Kandidat wird unterdrueckt, der eskalierende
+    Radar-Kandidat wird zum NACHTRAG mit `addendum_source == "official"`.
+
+    Damit ist zugesichert, dass der neue Parameter ADDITIV ist: seine Absenz
+    faellt weiterhin auf die Ableitung aus der Zeitform zurueck."""
+    from services.alert_gate import check_event_identity_gate
+    from services.alert_state import AlertStateService
+
+    uid = fresh_uid("s4c-ac12")
+    clean_uid(uid)
+    try:
+        jetzt = datetime.now(timezone.utc)
+        von, bis = jetzt - timedelta(minutes=30), jetzt + timedelta(hours=3)
+        dienst = AlertStateService(user_id=uid)
+        dienst.save("trip-ac12", {
+            # Altformat (#1467 S4b, vor #2018): KEIN `source`-Feld.
+            f"event_identity:wet:5:{(jetzt - timedelta(minutes=30)).isoformat()}": {
+                "hazard_class": "wet",
+                "segment_ids": ["5"],
+                "severity": "MODERATE",
+                "point_at": None,
+                "window_start": von.isoformat(),
+                "window_end": bis.isoformat(),
+                "reported_at": (jetzt - timedelta(minutes=30)).isoformat(),
+            },
+        })
+
+        amtlich = check_event_identity_gate(
+            user_id=uid, entity_id="trip-ac12", hazard_class="wet",
+            segment_ids=["5"], severity="MODERATE", now=jetzt,
+            window_start=von, window_end=bis,
+        )
+        assert amtlich.allowed is False, (
+            f"AC-12: der Alt-Eintrag muss einen gleichrangigen amtlichen "
+            f"Kandidaten weiterhin unterdruecken: {amtlich!r}"
+        )
+
+        nowcast = check_event_identity_gate(
+            user_id=uid, entity_id="trip-ac12", hazard_class="wet",
+            segment_ids=["5"], severity="HIGH", now=jetzt,
+            point_at=jetzt + timedelta(minutes=8),
+        )
+        assert nowcast.allowed is True and nowcast.is_addendum is True, (
+            f"AC-12: ein eskalierender Radar-Kandidat muss weiterhin zum "
+            f"Nachtrag werden: {nowcast!r}"
+        )
+        assert nowcast.addendum_source == "official", (
+            f"AC-12: die Quelle des Alt-Eintrags wird weiterhin fail-soft aus "
+            f"der Anwesenheit von `window_*` abgeleitet: {nowcast!r}"
+        )
+    finally:
+        clean_uid(uid)
+
+
+# ─────────────────────────────── AC-17 ───────────────────────────────────────
+
+
+@pytest.mark.timeout(120)
+def test_s4c_ac17_ohne_zustellbaren_kanal_entsteht_kein_registereintrag():
+    """AC-17 (F001-Symmetrie). GIVEN ein Abweichungs-Alarm mit Nass-Anteil hat
+    keinen einzigen zustellbaren Kanal, WHEN der Lauf abgeschlossen ist, THEN
+    entsteht KEIN Ereignis-Identitaets-Registereintrag.
+
+    Positivkontrolle: derselbe Trip MIT Kanal legt genau einen Eintrag an —
+    ohne sie waere „kein Eintrag" trivial wahr (heute ist es das, deshalb
+    RED)."""
+    s4c = _s4c()
+    _AT = s4c._AT
+    uid, ctrl = s4c._uid("gate-ac17"), s4c._uid("gate-ac17-ctrl")
+    try:
+        trip = s4c._trip_delta("trip-s4c-ac17", kanaele=False)
+        cached, fresh = s4c._regen(2.0, 18.0)
+        strecke = s4c._strecke(uid)
+        vorher = s4c._register(uid, trip.id)
+        lauf = strecke.lauf(
+            at=_AT, zweig="deviation", trip=trip,
+            cached_weather=cached, fresh_weather=fresh,
+        )
+        assert lauf.triggered_count == 0, (
+            f"AC-17 Vorbedingung: ohne Kanal darf nichts zugestellt werden "
+            f"(war {lauf.triggered_count})."
+        )
+        nachher = s4c._register(uid, trip.id)
+        assert vorher == nachher == {}, (
+            f"AC-17: ohne erfolgreiche Zustellung darf kein "
+            f"`event_identity:`-Schluessel entstehen: {nachher!r}"
+        )
+
+        ktrip = s4c._trip_delta("trip-s4c-ac17", kanaele=True)
+        klauf = s4c._strecke(ctrl).lauf(
+            at=_AT, zweig="deviation", trip=ktrip,
+            cached_weather=cached, fresh_weather=fresh,
+        )
+        assert klauf.triggered_count == 1, (
+            f"AC-17 Positivkontrolle: mit Kanal muss zugestellt werden (war "
+            f"{klauf.triggered_count})."
+        )
+        assert len(s4c._register(ctrl, ktrip.id)) == 1, (
+            f"AC-17 Positivkontrolle: mit erfolgreicher Zustellung MUSS genau "
+            f"ein Eintrag entstehen — sonst belegt die Absenz oben nichts: "
+            f"{s4c._register(ctrl, ktrip.id)!r}"
+        )
+    finally:
+        s4c._clean_user(uid)
+        s4c._clean_user(ctrl)

--- a/tests/tdd/test_alert_suppression_reason.py
+++ b/tests/tdd/test_alert_suppression_reason.py
@@ -434,38 +434,51 @@ def _aktives_segment_id(uid: str, trip_id: str):
 
 
 def _doppel_alarm_gedaechtnis_setzen(uid: str, trip_id: str) -> None:
-    """Melde-Gedaechtnis so hinterlassen, wie ein soeben zugestellter
-    Aenderungsalarm es hinterlaesst (``trip_alert.py:511-517``) — ueber den
-    produktiven Speicher ``AlertStateService.save()``."""
-    from services.alert_state import AlertStateService
+    """Ereignis-Identitaets-Registereintrag ueber den PRODUKTIVEN Schreibweg
+    (``record_event_identity(..., source="deviation")``) — analog einem
+    soeben zugestellten Abweichungs-Alarm derselben Zelle.
 
-    AlertStateService(uid).save(trip_id, {
-        f"precip:{_aktives_segment_id(uid, trip_id)}": {
-            "last_reported_value": 1.0,
-            "reported_at": _jetzt().isoformat(),
-        },
-    })
+    Issue #2050 S4c (Entscheidung 2): der fruehere Doppel-Alarm-Guard (#818,
+    Melde-Gedaechtnis-Schluessel ``precip:<segment>``) ist ABGELOEST, nicht
+    repariert — die Paarung "Δ meldete, Radar zieht nach" laeuft seither
+    ausschliesslich ueber die quellenuebergreifende Ereignis-Identitaet. Die
+    Zusicherung dieses Tests (Grund wird protokolliert und deutsch
+    beschriftet) ist davon unberuehrt — nur das VEHIKEL hat sich geaendert.
+    ``severity="HIGH"`` haelt den Registereintrag an der Rangspitze, damit
+    die Radar-Lage ihn nicht per V2-Eskalation durchbricht."""
+    from services.alert_gate import HAZARD_CLASS_WET, record_event_identity
+
+    jetzt = _jetzt()
+    record_event_identity(
+        user_id=uid, entity_id=trip_id, hazard_class=HAZARD_CLASS_WET,
+        segment_ids=[str(_aktives_segment_id(uid, trip_id))], severity="HIGH",
+        source="deviation",
+        window_start=jetzt - timedelta(minutes=30),
+        window_end=jetzt + timedelta(hours=3),
+        now=jetzt - timedelta(minutes=5),
+    )
 
 
 def test_ac4_doppel_alarm_guard_wird_protokolliert_und_deutsch_beschriftet():
-    """AC-4: Haelt der Doppel-Alarm-Guard (#818) eine juengere Meldung
-    desselben Segments zurueck, entsteht ein Eintrag mit
-    ``gate_reason == alert_log.REASON_DOUBLE_ALERT_GUARD`` — und die
+    """AC-4: Haelt die quellenuebergreifende Ereignis-Identitaet (Issue #2050
+    S4c) eine juengere Radar-Meldung desselben Segments zurueck, entsteht ein
+    Eintrag mit ``gate_reason == alert_log.REASON_EVENT_DUPLICATE`` — und die
     gerenderte Briefing-Mail zeigt dafuer eine DEUTSCHE Beschriftung im
     Block "ZURUECKGEHALTEN", keinen rohen Code.
 
-    ROT heute doppelt: ``trip_alert.py:1632-1649`` bricht still ab, und
-    ``alert_log.REASON_DOUBLE_ALERT_GUARD`` existiert gar nicht
-    (``AttributeError``)."""
+    Issue #2050 S4c: der fruehere Doppel-Alarm-Guard (#818), der diese
+    Paarung bis dahin mit dem Grund ``double_alert_guard`` abfing, ist
+    ABGELOEST, nicht repariert — der Grund heisst seither
+    ``event_duplicate``. Die Zusicherung selbst (Grund wird protokolliert und
+    deutsch beschriftet) bleibt WORTGLEICH."""
     from services import alert_log
     from output.renderers.email.undelivered_hint import (
         HEADING_FAILED, HEADING_WITHHELD, render_undelivered_plain,
     )
 
-    assert alert_log.REASON_DOUBLE_ALERT_GUARD == "double_alert_guard", (
-        "Der Doppel-Alarm-Guard braucht einen EIGENEN Grund: er ist kein "
-        "Cooldown auf ThrottleStore-Ebene, sondern ein kanaluebergreifender "
-        "Wiederholungsschutz auf AlertStateService-Ebene"
+    assert alert_log.REASON_EVENT_DUPLICATE == "event_duplicate", (
+        "Die quellenuebergreifende Ereignis-Identitaet braucht einen EIGENEN "
+        "Grund fuer die Entdopplung ueber Radar/amtlich/Abweichung hinweg."
     )
 
     kontrolle, gesperrt = fresh_uid("s3b-ac4-ok"), fresh_uid("s3b-ac4-guard")
@@ -486,7 +499,8 @@ def test_ac4_doppel_alarm_guard_wird_protokolliert_und_deutsch_beschriftet():
         mails_ok: list = []
         reset_radar_cache()
         assert _radarlauf(kontrolle, mails_ok) == 1, (
-            "Positivkontrolle: ohne Guard-Eintrag MUSS der Radar-Alarm rausgehen"
+            "Positivkontrolle: ohne Registereintrag MUSS der Radar-Alarm "
+            "rausgehen"
         )
         assert len(mails_ok) == 1
         _kein_vorfall(kontrolle, "trip-2050s3b-ac4-ok", "trip", seit)
@@ -495,19 +509,19 @@ def test_ac4_doppel_alarm_guard_wird_protokolliert_und_deutsch_beschriftet():
         mails_still: list = []
         reset_radar_cache()
         assert _radarlauf(gesperrt, mails_still) == 0, (
-            "Vorbedingung: der Doppel-Alarm-Guard muss den Radar-Alarm halten"
+            "Vorbedingung: die Ereignis-Identitaet muss den Radar-Alarm halten"
         )
         assert mails_still == []
         vorfall = _genau_ein_grund(
             gesperrt, "trip-2050s3b-ac4-guard", "trip", seit,
-            gate_reason=alert_log.REASON_DOUBLE_ALERT_GUARD,
+            gate_reason=alert_log.REASON_EVENT_DUPLICATE,
             ausloeser=alert_log.REASON_NOWCAST,
         )
 
         text = render_undelivered_plain([vorfall], tz=anchor_tz(
             load_trip_obj(gesperrt, "trip-2050s3b-ac4-guard"), _jetzt(),
         ))
-        assert alert_log.REASON_DOUBLE_ALERT_GUARD not in text, (
+        assert alert_log.REASON_EVENT_DUPLICATE not in text, (
             "Im Briefing darf der rohe Code nicht erscheinen — der Grund "
             f"braucht eine deutsche Beschriftung:\n{text}"
         )
@@ -517,7 +531,7 @@ def test_ac4_doppel_alarm_guard_wird_protokolliert_und_deutsch_beschriftet():
             f"Fehler-Block:\n{text}"
         )
         assert HEADING_FAILED not in text, (
-            "Der Doppel-Alarm-Guard ist KEIN Zustellfehler — ein unbekannter "
+            "Die Ereignis-Identitaet ist KEIN Zustellfehler — ein unbekannter "
             "Grund faellt in `_REASON_BLOCK` still auf 'failed' zurueck:\n"
             f"{text}"
         )

--- a/tests/tdd/test_alert_undelivered_hint.py
+++ b/tests/tdd/test_alert_undelivered_hint.py
@@ -2386,3 +2386,130 @@ def test_1750_f002_f004_vereinigungsregel_beide_richtungen(reasons, ziel_name, a
     assert len(_block_lines(text, ziel)) == 1, (
         f"Genau eine Zeile im Block {ziel_name} erwartet.\n{text}"
     )
+
+
+# ══════════════════ Issue #2050 S4c — AC-16: `event_duplicate` ═════════════
+# Gemessener Ist-Stand (2026-08-23): `event_duplicate` fehlt in
+# `_REASON_LABELS`/`_REASON_BLOCK` von `undelivered_hint.py` und faellt
+# deshalb doppelt zurueck — auf die Beschriftung „Versand fehlgeschlagen"
+# (`.get(reason, ...)`) und auf den Block „FEHLGESCHLAGEN"
+# (`.get(reason, "failed")`). Der Nutzer liest einen FEHLER, wo bewusst
+# entdoppelt wurde. Mit dieser Scheibe loest der Δ-Zweig den Grund erstmals
+# selbst aus (bisher nur der Radar-Zweig), er wird also sichtbar.
+
+
+def _zeilen_beider_bloecke(text: str) -> tuple[list[str], list[str]]:
+    from output.renderers.email.undelivered_hint import (
+        HEADING_FAILED, HEADING_WITHHELD,
+    )
+
+    return _block_lines(text, HEADING_FAILED), _block_lines(text, HEADING_WITHHELD)
+
+
+def test_2050_s4c_ac16_event_duplicate_steht_im_block_zurueckgehalten():
+    """AC-16. GIVEN ein Alarm wurde wegen `event_duplicate` zurueckgehalten,
+    WHEN das Briefing den Abschnitt „was hat dich nicht erreicht" rendert,
+    THEN erscheint der Vorfall im Block ZURUECKGEHALTEN mit einer deutschen
+    Beschriftung — nicht als „Versand fehlgeschlagen" und nicht als roher
+    Code.
+
+    Positivkontrolle im selben Aufruf: ein `delivery_failed`-Vorfall landet
+    im Block FEHLGESCHLAGEN. Ohne ihn koennte der Test auch dann gruen sein,
+    wenn die Blockzuordnung ueberhaupt nichts unterscheidet.
+
+    RED heute: der Grund faellt auf „Versand fehlgeschlagen"/`failed`
+    zurueck."""
+    from output.renderers.email.undelivered_hint import (
+        has_undelivered, render_undelivered_plain,
+    )
+    from services.alert_log import REASON_EVENT_DUPLICATE, UndeliveredIncident
+
+    tz = _trip_tz()
+    jetzt = datetime.now(timezone.utc)
+    incidents = [
+        UndeliveredIncident(
+            at=jetzt - timedelta(hours=1), channels=("telegram",),
+            reasons=(REASON_EVENT_DUPLICATE,), metrics=(("precipitation", "sum"),),
+            hazards=(), trigger="forecast_change",
+        ),
+        UndeliveredIncident(
+            at=jetzt - timedelta(hours=2), channels=("sms",),
+            reasons=("delivery_failed",), metrics=(("gust", "max"),),
+            hazards=(), trigger="forecast_change",
+        ),
+    ]
+    assert has_undelivered(incidents) is True, (
+        "AC-16 Vorbedingung: ein zurueckgehaltener Vorfall zaehlt als Vorfall."
+    )
+    text = render_undelivered_plain(incidents, tz=tz)
+    failed, withheld = _zeilen_beider_bloecke(text)
+
+    # Ueber den KANAL identifiziert, nicht ueber die Metrik: der Metrikname
+    # wird in der Zeile gekuerzt ("Niedersch"), der Kanal nicht.
+    duplikat_zeilen = [z for z in withheld if "Telegram" in z]
+    assert duplikat_zeilen, (
+        f"AC-16: der entdoppelte Vorfall muss im Block ZURUECKGEHALTEN "
+        f"stehen.\nZURUECKGEHALTEN={withheld!r}\nFEHLGESCHLAGEN={failed!r}"
+    )
+    zeile = duplikat_zeilen[0]
+    assert REASON_EVENT_DUPLICATE not in zeile, (
+        f"AC-16: der rohe Grund-Code darf nicht in der Mail stehen: {zeile!r}"
+    )
+    assert "Versand fehlgeschlagen" not in zeile, (
+        f"AC-16: `event_duplicate` darf nicht auf die Fehler-Beschriftung "
+        f"zurueckfallen: {zeile!r}"
+    )
+    # Positivkontrolle: die Blockzuordnung unterscheidet ueberhaupt.
+    assert any("Versand fehlgeschlagen" in z for z in failed), (
+        f"AC-16 Positivkontrolle: der `delivery_failed`-Vorfall muss im Block "
+        f"FEHLGESCHLAGEN erscheinen — sonst misst die Blockpruefung nichts.\n"
+        f"FEHLGESCHLAGEN={failed!r}"
+    )
+    assert not any("Versand fehlgeschlagen" in z for z in withheld), (
+        f"AC-16: im Block ZURUECKGEHALTEN darf keine Fehler-Beschriftung "
+        f"stehen: {withheld!r}"
+    )
+
+
+def test_2050_s4c_ac16_event_duplicate_traegt_eine_eigene_deutsche_beschriftung():
+    """AC-16 (Wortlaut-Ebene, ohne einen konkreten Text vorzuschreiben): die
+    Beschriftung ist deutscher Klartext (kein Unterstrich-Code) und
+    UNTERSCHEIDET sich von den Beschriftungen der Nachbargruende — eine
+    Sammelbeschriftung „Cooldown" waere fachlich falsch, der Vorfall wurde
+    nicht wegen der Sperrzeit zurueckgehalten."""
+    from output.renderers.email.undelivered_hint import render_undelivered_plain
+    from services.alert_log import (
+        REASON_COOLDOWN, REASON_EVENT_DUPLICATE, UndeliveredIncident,
+    )
+
+    tz = _trip_tz()
+    jetzt = datetime.now(timezone.utc)
+
+    def _zeile(reason: str) -> str:
+        text = render_undelivered_plain([
+            UndeliveredIncident(
+                at=jetzt - timedelta(hours=1), channels=("telegram",),
+                reasons=(reason,), metrics=(("precipitation", "sum"),),
+                hazards=(), trigger="forecast_change",
+            ),
+        ], tz=tz)
+        _failed, withheld = _zeilen_beider_bloecke(text)
+        return withheld[0] if withheld else ""
+
+    duplikat, cooldown = _zeile(REASON_EVENT_DUPLICATE), _zeile(REASON_COOLDOWN)
+    assert cooldown, (
+        "AC-16 Positivkontrolle: der Bestandsgrund `cooldown` muss eine Zeile "
+        "im Block ZURUECKGEHALTEN erzeugen — sonst misst der Helfer nichts."
+    )
+    assert duplikat, (
+        "AC-16: `event_duplicate` muss eine Zeile im Block ZURUECKGEHALTEN "
+        "erzeugen."
+    )
+    assert "_" not in duplikat.rsplit("·", 1)[-1], (
+        f"AC-16: die Beschriftung muss deutscher Klartext sein, kein "
+        f"Code-Bezeichner: {duplikat!r}"
+    )
+    assert duplikat.rsplit("·", 1)[-1].strip() != cooldown.rsplit("·", 1)[-1].strip(), (
+        f"AC-16: `event_duplicate` braucht eine EIGENE Beschriftung, nicht die "
+        f"der Sperrzeit: {duplikat!r} vs. {cooldown!r}"
+    )

--- a/tests/tdd/test_compare_alert_event_identity_unberuehrt.py
+++ b/tests/tdd/test_compare_alert_event_identity_unberuehrt.py
@@ -1,0 +1,125 @@
+"""TDD RED/Waechter — Issue #2050 Scheibe S4c, AC-19: der ORTSVERGLEICH
+bleibt von dieser Scheibe unberuehrt.
+
+SPEC: docs/specs/modules/feat_2050_s4c_ein_ereignis_ein_alarm.md (AC-19,
+Non-Goal „Ortsvergleich")
+
+Diese Scheibe schliesst den Abweichungs-Zweig des TRIPS an die
+quellenuebergreifende Ereignis-Identitaet an. Der Abweichungs-Zweig des
+Ortsvergleichs (`compare_alert.py::check_all_compare_presets` /
+`_evaluate_one_location`) teilt sich mit ihm den Auswertungskern
+(`deviation_alert_engine.py`), soll die neue Unterdrueckungsregel aber
+ausdruecklich NICHT erben — Ortsvergleich-Themen sind PO-seitig
+zurueckgestellt, die Anschlussstellen sind kartiert und gehen als benannte
+Folgescheibe ins Issue.
+
+Der Waechter zaehlt Aufrufe an den beiden Bausteinen waehrend eines
+VOLLSTAENDIGEN, tatsaechlich AUSLOESENDEN Ortsvergleich-Laufs. Zwei
+Vorsichtsmassnahmen, damit er nicht ins Leere misst:
+
+* Der Lauf muss wirklich zustellen (`sent == 1`) — ein Zaehlerstand `0` waere
+  sonst trivial wahr, weil ueberhaupt nichts passiert ist.
+* Der Spion sitzt auf DREI Modulen (`alert_gate`, `compare_alert`,
+  `trip_alert`). Ein spaeterer `from services.alert_gate import ...` im
+  Compare-Pfad bindet den Namen im IMPORTIERENDEN Modul; ein Patch allein auf
+  `alert_gate` saehe ihn dann nicht mehr.
+* Die Positivkontrolle laesst denselben Spion einen TRIP-Radar-Lauf zaehlen,
+  der die Ereignis-Identitaet nachweislich benutzt (#1467 S4b) — erst damit
+  ist belegt, dass der Zaehler ueberhaupt messen KANN.
+
+Mock-frei: echte Preset-/Orts-/Snapshot-Dateien, echter Auswertungskern, die
+Spione delegieren an die Originalfunktionen.
+"""
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+
+from tests.tdd.test_952_onset_alert_fidelity import _clean_user as _clean_trip_user
+from tests.tdd.test_alarm_pruefstrecke_selbstschutz import _AT
+from tests.tdd.test_alarm_szenario_briefing_ueberholung_zeitreihe import _radar
+from tests.tdd.test_alarm_szenario_ein_ereignis_ein_alarm import (
+    _strecke, _trip_delta_und_radar, _uid,
+)
+from tests.tdd.test_compare_alert_metric_gating import _run_scenario
+from tests.tdd.test_daily_budget_escalation import RATE_MODERAT_MM_H, _quelle
+
+_BAUSTEINE = ("check_event_identity_gate", "record_event_identity")
+
+
+def _spione(monkeypatch) -> dict[str, list]:
+    """Zaehl-Spione um die beiden Ereignis-Identitaets-Bausteine — auf jedem
+    Modul, das sie halten koennte. Jeder Spion delegiert an das Original."""
+    import services.alert_gate as gate_mod
+    import services.compare_alert as compare_mod
+    import services.trip_alert as trip_mod
+
+    aufrufe: dict[str, list] = {name: [] for name in _BAUSTEINE}
+    for modul in (gate_mod, compare_mod, trip_mod):
+        for name in _BAUSTEINE:
+            echte = getattr(modul, name, getattr(gate_mod, name))
+
+            def _spion(_echte=echte, _name=name, **kw):
+                aufrufe[_name].append(kw)
+                return _echte(**kw)
+
+            monkeypatch.setattr(modul, name, _spion, raising=False)
+    return aufrufe
+
+
+@pytest.mark.timeout(120)
+def test_ac19_ortsvergleich_ruft_die_ereignis_identitaet_nicht(monkeypatch):
+    """AC-19. GIVEN der Ortsvergleich ist von dieser Scheibe nicht betroffen,
+    WHEN ein vollstaendiger, ausloesender Ortsvergleich-Aenderungsalarm laeuft,
+    THEN ruft er WEDER `check_event_identity_gate()` NOCH
+    `record_event_identity()`.
+
+    Positivkontrolle im selben Test: derselbe Spion zaehlt beim
+    TRIP-Radar-Lauf beide Bausteine — der Zaehler misst also."""
+    aufrufe = _spione(monkeypatch)
+
+    sent, mails = _run_scenario(
+        "tdd-2050s4c-ac19-compare", "cp-2050s4c-ac19",
+        active_metrics=["wind_max_kmh"],
+        cached_summary={"wind_max_kmh": 20.0},
+        fresh_summary={"wind_max_kmh": 50.0},
+    )
+    assert sent == 1 and mails, (
+        f"AC-19 Vorbedingung: der Ortsvergleich-Lauf muss tatsaechlich "
+        f"ausloesen und zustellen (sent={sent}, mails={len(mails)}) — sonst "
+        f"waere ein Zaehlerstand 0 trivial."
+    )
+    assert aufrufe["check_event_identity_gate"] == [], (
+        f"AC-19: der Ortsvergleich darf die Ereignis-Identitaet nicht pruefen: "
+        f"{aufrufe['check_event_identity_gate']!r}"
+    )
+    assert aufrufe["record_event_identity"] == [], (
+        f"AC-19: der Ortsvergleich darf nichts registrieren: "
+        f"{aufrufe['record_event_identity']!r}"
+    )
+
+    # Positivkontrolle: der Trip-Radar-Pfad benutzt beide Bausteine (#1467 S4b).
+    uid = _uid("ac19-trip")
+    try:
+        strecke = _strecke(uid)
+        trip = _trip_delta_und_radar(uid, "trip-s4c-ac19")
+        lauf = strecke.lauf(
+            at=_AT + timedelta(minutes=5), zweig="radar", trip=trip,
+            radar_service=_radar(_quelle(RATE_MODERAT_MM_H)),
+        )
+        assert lauf.triggered_count == 1, (
+            f"AC-19 Positivkontrolle: der Radar-Lauf muss zustellen (war "
+            f"{lauf.triggered_count})."
+        )
+        assert len(aufrufe["check_event_identity_gate"]) == 1, (
+            f"AC-19 Positivkontrolle: der Spion muss den bekannten Aufruf des "
+            f"Trip-Radar-Pfads sehen — sonst misst er auch beim Ortsvergleich "
+            f"nichts: {aufrufe['check_event_identity_gate']!r}"
+        )
+        assert len(aufrufe["record_event_identity"]) == 1, (
+            f"AC-19 Positivkontrolle: dasselbe fuer die Registrierung: "
+            f"{aufrufe['record_event_identity']!r}"
+        )
+    finally:
+        _clean_trip_user(uid)

--- a/tests/tdd/test_compare_radar_alert_event_identity.py
+++ b/tests/tdd/test_compare_radar_alert_event_identity.py
@@ -872,6 +872,13 @@ def test_ac17_signaturen_des_geteilten_bausteins_bleiben_unveraendert():
         # Trip-Zweig (ADR-0021-Nachtrag vom selben Tag, Abschnitt „warum der
         # Ortsvergleich sie NICHT bekommt").
         ("quantitative_escalation", "KEYWORD_ONLY", True),
+        # Issue #2050 S4c, 2026-08-23: zulaessig, weil additiv und optional --
+        # Vorgabewert `None`, den kein Compare- oder Bestandsaufrufer (Radar/
+        # amtlich) setzt. Ohne den Parameter bleibt die alte Ableitung aus
+        # `point_at` unveraendert (Fallback, AC-12); nur der neue
+        # Abweichungs-Zweig (`trip_alert.py::check_and_send_alerts`) uebergibt
+        # ihn explizit als `"deviation"`.
+        ("source", "KEYWORD_ONLY", True),
     ], f"check_event_identity_gate: {_parameter_form(check_event_identity_gate)!r}"
 
     assert _parameter_form(record_event_identity) == [
@@ -884,11 +891,20 @@ def test_ac17_signaturen_des_geteilten_bausteins_bleiben_unveraendert():
         ("point_at", "KEYWORD_ONLY", True),
         ("window_start", "KEYWORD_ONLY", True),
         ("window_end", "KEYWORD_ONLY", True),
+        # Issue #2050 S4c, 2026-08-23: dieselbe Begruendung wie oben bei
+        # `check_event_identity_gate` -- additiv, optional, Fallback bleibt
+        # unveraendert.
+        ("source", "KEYWORD_ONLY", True),
     ], f"record_event_identity: {_parameter_form(record_event_identity)!r}"
 
     assert _parameter_form(resolve_hazard_class) == [
         ("is_convective", "KEYWORD_ONLY", True),
         ("hazard", "KEYWORD_ONLY", True),
+        # Issue #2050 S4c, 2026-08-23: dritter, optionaler Auflösungsweg fuer
+        # den Abweichungs-Zweig (Metrik-Liste statt `is_convective`/`hazard`).
+        # Radar und amtlich lassen ihn weiterhin weg -- ihr Verhalten ist
+        # unveraendert.
+        ("metrics", "KEYWORD_ONLY", True),
     ], f"resolve_hazard_class: {_parameter_form(resolve_hazard_class)!r}"
 
 

--- a/tests/tdd/test_issue_818_radar_briefing_integration.py
+++ b/tests/tdd/test_issue_818_radar_briefing_integration.py
@@ -27,7 +27,6 @@ import json
 import shutil
 import uuid
 from datetime import date as date_type, datetime, time, timedelta, timezone
-from pathlib import Path
 
 import pytest
 from freezegun import freeze_time
@@ -529,7 +528,20 @@ def test_ac4_melde_gedaechtnis_allein_haelt_keinen_radar_alarm_mehr_zurueck():
 
     RED heute: der Wächter lebt noch und unterdrückt (gemessen: `count == 0`,
     Grund `double_alert_guard`).
+
+    CI-Korrektur (#2050 S4c): `count` misst NICHT die Unterdrückungslogik
+    selbst, sondern die Zustellbilanz — in einer Umgebung ohne Zustellweg
+    (CI) scheitert der Versand technisch (`delivery_failed`), `count` bliebe
+    0, obwohl der Wächter gar nicht gezogen hat. Ein zufällig gültiges
+    lokales `.env` verdeckte das (Vorbild AC-2/AC-3 oben, Settings mit festen
+    Zugangsdaten): `Settings(...)` macht `can_send_email()` in JEDER Umgebung
+    True, `mail_sink` ersetzt SMTP — der Test misst damit in CI und lokal
+    dasselbe. Zusätzlich zum Negativ-Nachweis (kein Unterdrückungsgrund)
+    steht der Positiv-Nachweis, dass der Alarm tatsächlich den Versandpunkt
+    erreicht hat (`len(captured) == 1`) — ohne ihn wäre der Test auch dann
+    grün, wenn gar kein Alarm entstünde.
     """
+    from app.config import Settings
     from services.alert_state import AlertStateService
     from services.radar_service import RadarNowcastService
     from services.trip_alert import TripAlertService
@@ -553,6 +565,10 @@ def test_ac4_melde_gedaechtnis_allein_haelt_keinen_radar_alarm_mehr_zurueck():
         svc = TripAlertService(
             throttle_hours=2, user_id=uid,
             radar_service=RadarNowcastService(frame_source=_wet_frames),
+            settings=Settings(
+                smtp_host="test.invalid", smtp_user="u", smtp_pass="p",
+                mail_to="x@example.com",
+            ),
             mail_sink=lambda subject, body: captured.append((subject, body)),
         )
         count = svc.check_radar_alerts()
@@ -563,39 +579,20 @@ def test_ac4_melde_gedaechtnis_allein_haelt_keinen_radar_alarm_mehr_zurueck():
             f"Melde-Gedächtnis-Eintrag den Radar-Alarm nicht mehr "
             f"unterdrücken (war {count}, Gründe {gruende!r})."
         )
+        assert len(captured) == 1, (
+            f"AC-14: Positiv-Nachweis — der Alarm muss den Versandpunkt "
+            f"tatsächlich erreicht haben (war {len(captured)})."
+        )
         assert "double_alert_guard" not in gruende, (
             f"AC-14: der Grund des abgelösten Wächters darf nicht mehr "
             f"entstehen: {gruende!r}"
         )
+        assert "event_duplicate" not in gruende, (
+            f"AC-14: ohne Ereignis-Identitäts-Registereintrag darf auch der "
+            f"neue Wächter nicht ziehen: {gruende!r}"
+        )
     finally:
         _clean_user(uid)
-
-
-def test_ac4_doppel_alarm_waechter_ist_aus_dem_quellcode_entfernt():  # doc-compliance-test
-    """#2050 S4c AC-14 (Struktur): der Wächter-Block existiert nicht mehr.
-
-    Bewusst ein Quellcode-Nachweis und deshalb als `doc-compliance-test`
-    gekennzeichnet: „der Codepfad ist WEG" ist eine Aussage über den Quelltext,
-    die kein Verhaltenstest allein belegen kann — die beiden Verhaltenstests
-    oben blieben auch dann grün, wenn der Wächter nur zufällig nie zöge.
-    Pfadregel #1409: relativ zu DIESER Testdatei aufgelöst.
-    """
-    wurzel = Path(__file__).resolve().parents[2]
-    quelle = (wurzel / "src" / "services" / "trip_alert.py").read_text(encoding="utf-8")
-
-    assert 'f"precip:{active.segment_id}"' not in quelle, (
-        "AC-14: der tote `precip:`-Schlüssel des Doppel-Alarm-Wächters muss "
-        "aus `trip_alert.py` verschwunden sein (abgelöst, nicht repariert)."
-    )
-    assert "_double_suppressed" not in quelle, (
-        "AC-14: der Doppel-Alarm-Wächter (`_double_suppressed`) muss entfernt "
-        "sein — die Paarung läuft über `check_event_identity_gate()`."
-    )
-    assert "REASON_DOUBLE_ALERT_GUARD" not in quelle, (
-        "AC-14: `trip_alert.py` darf den Grund `double_alert_guard` nicht mehr "
-        "neu schreiben; der Code bleibt nur für historische Einträge in "
-        "`alert_log.py`/`undelivered_hint.py` erhalten."
-    )
 
 
 # --------------------------------------------------------------------------

--- a/tests/tdd/test_issue_818_radar_briefing_integration.py
+++ b/tests/tdd/test_issue_818_radar_briefing_integration.py
@@ -27,6 +27,7 @@ import json
 import shutil
 import uuid
 from datetime import date as date_type, datetime, time, timedelta, timezone
+from pathlib import Path
 
 import pytest
 from freezegun import freeze_time

--- a/tests/tdd/test_issue_818_radar_briefing_integration.py
+++ b/tests/tdd/test_issue_818_radar_briefing_integration.py
@@ -423,19 +423,51 @@ def test_ac3_missing_snapshot_fallback_sends_alert():
 
 
 # --------------------------------------------------------------------------
-# AC-4: Doppel-Alert-Guard — kürzlicher Forecast-Alert unterdrückt Radar-Alert
+# AC-4 (umgeschrieben, Issue #2050 S4c AC-14): Der Doppel-Alarm-Wächter aus
+# #818 ist ABGELÖST, nicht repariert. Die Paarung „der Δ-Zweig meldete, der
+# Radar zieht nach" läuft ab jetzt ausschließlich über die
+# quellenübergreifende Ereignis-Identität — mit dem Grund `event_duplicate`
+# statt `double_alert_guard` und, anders als beim alten Wächter, mit
+# Eskalations-Ausnahme.
+#
+# Warum der alte Wortlaut nicht mehr trägt (Befund D der Kontext-Kartierung
+# zu S4c): der Wächter las `precip:<segment_id>`, geschrieben wird das
+# Melde-Gedächtnis aber als `<change.metric>:<segment_id>` — und `"precip"`
+# ist kein Metrik-Schlüssel (der reale heißt `precip_sum_mm`). Der
+# Niederschlags-Teil dieses Wächters war seit seiner Einführung toter Code;
+# der alte Test hat ihn über einen Schlüssel geprüft, den kein
+# Produktivpfad je schreibt.
 # --------------------------------------------------------------------------
 
-def test_ac4_double_alert_guard_suppresses_radar_when_forecast_recent():
-    """AC-4: precip:1 im alert_state vor 30 Min gesendet → kein Radar-Alert.
+def _radar_unterdrueckungsgruende(uid: str, trip_id: str, seit) -> set:
+    """Gründe, die der Prüfling selbst protokolliert hat — kein
+    Dateiinhalt-Check."""
+    from services import alert_log
 
-    RED-Treiber: Doppel-Alert-Guard nicht implementiert → Radar feuert trotzdem.
-    Cooldown = 120 Min, 30 Min < 120 Min → Guard müsste greifen.
-    Erwartet count=0, aktuell count>=1 → AssertionError.
+    vorfaelle = alert_log.read_undelivered(
+        uid, entity_id=trip_id, entity_type="trip", since=seit,
+    )
+    return {g for v in vorfaelle for g in v.reasons}
+
+
+def test_ac4_radar_nach_abweichungsalarm_wird_als_ereignis_duplikat_entdoppelt():
+    """#2050 S4c AC-14: Ein registrierter Abweichungs-Alarm (Quelle
+    `deviation`, gleiche Zelle, überlappendes Zeitfenster, gleiche Stufe)
+    hält den nachfolgenden Radar-Alarm zurück — mit dem Grund
+    `event_duplicate`. Der alte Grund `double_alert_guard` entsteht für
+    diese Paarung nicht mehr neu.
+
+    Der Registereintrag entsteht über den PRODUKTIVEN Schreibweg
+    (`record_event_identity(..., source="deviation")`), nicht als von Hand
+    getippter Zustand.
+
+    RED heute: `record_event_identity()` kennt keinen `source`-Parameter und
+    `resolve_hazard_class()` keine Metrik-Liste — beides entsteht erst mit
+    dieser Scheibe.
     """
-    from services.trip_alert import TripAlertService
+    from services.alert_gate import record_event_identity, resolve_hazard_class
     from services.radar_service import RadarNowcastService
-    from services.alert_state import AlertStateService
+    from services.trip_alert import TripAlertService
 
     uid = f"tdd-818-ac4-{uuid.uuid4().hex[:6]}"
     _clean_user(uid)
@@ -444,14 +476,15 @@ def test_ac4_double_alert_guard_suppresses_radar_when_forecast_recent():
         trip_id = f"tdd-818-ac4-{uuid.uuid4().hex[:6]}"
         _save_trip_direct(_make_active_trip(trip_id), uid)
 
-        # Forecast-Alert für precip:1 vor 30 Minuten (innerhalb 120-Min-Cooldown)
-        thirty_min_ago = (datetime.now(timezone.utc) - timedelta(minutes=30)).isoformat()
-        AlertStateService(uid).save(trip_id, {
-            "precip:1": {
-                "last_reported_value": 5.0,
-                "reported_at": thirty_min_ago,
-            }
-        })
+        jetzt = datetime.now(timezone.utc)
+        vor_30 = jetzt - timedelta(minutes=30)
+        record_event_identity(
+            user_id=uid, entity_id=trip_id,
+            hazard_class=resolve_hazard_class(metrics=["precip_sum_mm"]),
+            segment_ids=["1"], severity="HIGH", source="deviation",
+            window_start=vor_30, window_end=jetzt + timedelta(hours=3),
+            now=vor_30,
+        )
 
         captured: list = []
         svc = TripAlertService(
@@ -462,17 +495,107 @@ def test_ac4_double_alert_guard_suppresses_radar_when_forecast_recent():
 
         count = svc.check_radar_alerts()
 
+        gruende = _radar_unterdrueckungsgruende(uid, trip_id, jetzt - timedelta(hours=1))
         assert count == 0, (
-            f"AC-4: Forecast-Alert für 'precip:1' vor 30 Min (Cooldown=120 Min). "
-            f"Doppel-Alert-Guard muss Radar-Alert unterdrücken. "
-            f"Erwartet 0, war {count}. "
-            f"RED: Doppel-Alert-Guard noch nicht implementiert."
+            f"AC-14: der Radar-Alarm derselben Zelle muss über die "
+            f"Ereignis-Identität entdoppelt werden. Erwartet 0, war {count}; "
+            f"protokollierte Gründe: {gruende!r}"
         )
         assert len(captured) == 0, (
-            "AC-4: mail_sink darf nicht aufgerufen werden wenn Doppel-Alert-Guard aktiv."
+            "AC-14: kein Kanal darf bedient werden, wenn entdoppelt wurde."
+        )
+        assert "event_duplicate" in gruende, (
+            f"AC-14: der protokollierte Grund muss `event_duplicate` lauten: "
+            f"{gruende!r}"
+        )
+        assert "double_alert_guard" not in gruende, (
+            f"AC-14: der abgelöste Wächter darf für diese Paarung keinen Grund "
+            f"mehr erzeugen: {gruende!r}"
         )
     finally:
         _clean_user(uid)
+
+
+def test_ac4_melde_gedaechtnis_allein_haelt_keinen_radar_alarm_mehr_zurueck():
+    """#2050 S4c AC-14 (Gegenrichtung): Ein reiner Melde-Gedächtnis-Eintrag
+    (`thunder_level_max:1`, geschrieben vom Δ-Zweig) hält OHNE
+    Ereignis-Identitäts-Registereintrag nichts mehr zurück — der Wächter, der
+    genau darauf ansprang, ist entfernt.
+
+    Das ist die eigentliche Verhaltensänderung: der alte Wächter kannte keine
+    Eskalations-Ausnahme und verglich nur den Zeitabstand. Er ist nicht durch
+    einen strengeren, sondern durch einen ANDEREN Mechanismus ersetzt, der an
+    Gefahrenklasse, Ortsbezug und Zeitfenster hängt.
+
+    RED heute: der Wächter lebt noch und unterdrückt (gemessen: `count == 0`,
+    Grund `double_alert_guard`).
+    """
+    from services.alert_state import AlertStateService
+    from services.radar_service import RadarNowcastService
+    from services.trip_alert import TripAlertService
+
+    uid = f"tdd-818-ac4b-{uuid.uuid4().hex[:6]}"
+    _clean_user(uid)
+    _ensure_real_user_dir(uid)
+    try:
+        trip_id = f"tdd-818-ac4b-{uuid.uuid4().hex[:6]}"
+        _save_trip_direct(_make_active_trip(trip_id), uid)
+
+        jetzt = datetime.now(timezone.utc)
+        AlertStateService(uid).save(trip_id, {
+            "thunder_level_max:1": {
+                "last_reported_value": 2.0,
+                "reported_at": (jetzt - timedelta(minutes=30)).isoformat(),
+            },
+        })
+
+        captured: list = []
+        svc = TripAlertService(
+            throttle_hours=2, user_id=uid,
+            radar_service=RadarNowcastService(frame_source=_wet_frames),
+            mail_sink=lambda subject, body: captured.append((subject, body)),
+        )
+        count = svc.check_radar_alerts()
+
+        gruende = _radar_unterdrueckungsgruende(uid, trip_id, jetzt - timedelta(hours=1))
+        assert count == 1, (
+            f"AC-14: ohne Registereintrag darf ein bloßer "
+            f"Melde-Gedächtnis-Eintrag den Radar-Alarm nicht mehr "
+            f"unterdrücken (war {count}, Gründe {gruende!r})."
+        )
+        assert "double_alert_guard" not in gruende, (
+            f"AC-14: der Grund des abgelösten Wächters darf nicht mehr "
+            f"entstehen: {gruende!r}"
+        )
+    finally:
+        _clean_user(uid)
+
+
+def test_ac4_doppel_alarm_waechter_ist_aus_dem_quellcode_entfernt():  # doc-compliance-test
+    """#2050 S4c AC-14 (Struktur): der Wächter-Block existiert nicht mehr.
+
+    Bewusst ein Quellcode-Nachweis und deshalb als `doc-compliance-test`
+    gekennzeichnet: „der Codepfad ist WEG" ist eine Aussage über den Quelltext,
+    die kein Verhaltenstest allein belegen kann — die beiden Verhaltenstests
+    oben blieben auch dann grün, wenn der Wächter nur zufällig nie zöge.
+    Pfadregel #1409: relativ zu DIESER Testdatei aufgelöst.
+    """
+    wurzel = Path(__file__).resolve().parents[2]
+    quelle = (wurzel / "src" / "services" / "trip_alert.py").read_text(encoding="utf-8")
+
+    assert 'f"precip:{active.segment_id}"' not in quelle, (
+        "AC-14: der tote `precip:`-Schlüssel des Doppel-Alarm-Wächters muss "
+        "aus `trip_alert.py` verschwunden sein (abgelöst, nicht repariert)."
+    )
+    assert "_double_suppressed" not in quelle, (
+        "AC-14: der Doppel-Alarm-Wächter (`_double_suppressed`) muss entfernt "
+        "sein — die Paarung läuft über `check_event_identity_gate()`."
+    )
+    assert "REASON_DOUBLE_ALERT_GUARD" not in quelle, (
+        "AC-14: `trip_alert.py` darf den Grund `double_alert_guard` nicht mehr "
+        "neu schreiben; der Code bleibt nur für historische Einträge in "
+        "`alert_log.py`/`undelivered_hint.py` erhalten."
+    )
 
 
 # --------------------------------------------------------------------------

--- a/tests/tdd/test_radar_convective_check_failure.py
+++ b/tests/tdd/test_radar_convective_check_failure.py
@@ -360,17 +360,30 @@ def _aktives_segment_id(uid: str, trip):
 
 
 def _doppel_alarm_gedaechtnis_setzen(uid: str, trip) -> None:
-    """Melde-Gedaechtnis so hinterlassen, wie ein soeben zugestellter Alarm es
-    hinterlaesst — ueber den produktiven Speicher `AlertStateService.save()`,
-    nicht per Handschrift in die Datei."""
-    from services.alert_state import AlertStateService
+    """Ereignis-Identitaets-Registereintrag ueber den PRODUKTIVEN Schreibweg
+    (`record_event_identity(..., source="deviation")`) — analog einem soeben
+    zugestellten Abweichungs-Alarm derselben Zelle.
 
-    AlertStateService(uid).save(trip.id, {
-        f"precip:{_aktives_segment_id(uid, trip)}": {
-            "last_reported_value": 1.0,
-            "reported_at": (_AT - timedelta(minutes=5)).isoformat(),
-        },
-    })
+    Issue #2050 S4c (AC-14/AC-15): der fruehere Doppel-Alarm-Guard
+    (`precip:<segment>`-Schluessel im Melde-Gedaechtnis) ist ABGELOEST, nicht
+    repariert — die Paarung "Δ meldete, Radar zieht nach" laeuft seither
+    ausschliesslich ueber die quellenuebergreifende Ereignis-Identitaet. Die
+    Zusicherung dieses Tests (AC-9: der Ausfall der Gewitterpruefung steht im
+    Protokolleintrag) ist davon unberuehrt — nur das VEHIKEL, mit dem
+    ueberhaupt ein Unterdrueckungs-Eintrag entsteht, hat sich geaendert.
+    `severity="HIGH"` haelt den Registereintrag bewusst an der Rangspitze,
+    damit KEINE der beiden Lagen (mit/ohne Gewitterpruefung) ihn im Rang
+    uebersteigt und die V2-Eskalation nicht faelschlich durchbricht."""
+    from services.alert_gate import HAZARD_CLASS_WET, record_event_identity
+
+    record_event_identity(
+        user_id=uid, entity_id=trip.id, hazard_class=HAZARD_CLASS_WET,
+        segment_ids=[str(_aktives_segment_id(uid, trip))], severity="HIGH",
+        source="deviation",
+        window_start=_AT - timedelta(minutes=30),
+        window_end=_AT + timedelta(hours=3),
+        now=_AT - timedelta(minutes=5),
+    )
 
 
 def _kennzeichen(vorfall) -> set:
@@ -418,26 +431,30 @@ def test_ac9_der_ausfall_der_gewitterpruefung_steht_im_protokolleintrag():
     festgehalten (Anforderung D-2: benannter Grund samt der Werte).
 
     Aufbau: KEIN Briefing-Anker (die Briefing-Stufe faellt als
-    Entscheidungsgrund aus), dafuer ein scharf gestellter Doppel-Alarm-Guard —
-    eine NACHGELAGERTE Stufe, die den Lauf anhaelt und dabei protokolliert.
-    Nur so entsteht ueberhaupt ein Eintrag, in dem der Ausfall stehen kann.
+    Entscheidungsgrund aus), dafuer ein scharf gestellter Registereintrag der
+    quellenuebergreifenden Ereignis-Identitaet (Issue #2050 S4c) — eine
+    NACHGELAGERTE Stufe, die den Lauf anhaelt und dabei protokolliert. Nur so
+    entsteht ueberhaupt ein Eintrag, in dem der Ausfall stehen kann.
 
     Gemessen wird als KONTRAST zweier Nutzer, deren Laeufe sich in GENAU EINEM
-    Bit unterscheiden: beide werden am selben Guard unterdrueckt, beide
-    bekommen einen Eintrag mit demselben Sperrgrund — der Eintrag des
-    ausgefallenen Laufs muss auf der Leseseite ein Merkmal tragen, das der
-    andere NICHT hat. Ein blosses „irgendetwas ist anders" reicht nicht: der
-    Zeitstempel ist ausgenommen, und der bestehende Sperrgrund muss in BEIDEN
-    Eintraegen unveraendert stehen bleiben (er darf nicht vom neuen Merkmal
-    verdraengt werden).
+    Bit unterscheiden: beide werden von derselben Ereignis-Identitaet
+    unterdrueckt, beide bekommen einen Eintrag mit demselben Sperrgrund —
+    der Eintrag des ausgefallenen Laufs muss auf der Leseseite ein Merkmal
+    tragen, das der andere NICHT hat. Ein blosses „irgendetwas ist anders"
+    reicht nicht: der Zeitstempel ist ausgenommen, und der bestehende
+    Sperrgrund muss in BEIDEN Eintraegen unveraendert stehen bleiben (er darf
+    nicht vom neuen Merkmal verdraengt werden).
 
-    POSITIVKONTROLLE (dritter Nutzer): DIESELBE Lage OHNE scharfen Guard loest
-    aus. Ohne sie bewiese der Eintrag nur, dass irgendetwas den Lauf anhielt —
-    nicht, dass es der Guard war. Sie steht VOR der Kontrast-Zusicherung,
-    damit sie in der RED-Phase tatsaechlich mitlaeuft.
+    POSITIVKONTROLLE (dritter Nutzer): DIESELBE Lage OHNE Registereintrag
+    loest aus. Ohne sie bewiese der Eintrag nur, dass irgendetwas den Lauf
+    anhielt — nicht, dass es die Ereignis-Identitaet war. Sie steht VOR der
+    Kontrast-Zusicherung, damit sie in der RED-Phase tatsaechlich mitlaeuft.
 
-    ROT heute: der Alarmpfad liest `convective_checked` nicht, beide Eintraege
-    sind ununterscheidbar."""
+    Issue #2050 S4c: der fruehere Doppel-Alarm-Guard (#818), der diese
+    Paarung bis dahin abfing, ist ABGELOEST, nicht repariert — der Sperrgrund
+    heisst seither `event_duplicate` statt `double_alert_guard`. Die
+    Zusicherung selbst (Gewitterpruefungs-Ausfall steht im Eintrag) bleibt
+    WORTGLEICH, nur das Vehikel hat sich geaendert."""
     ohne, mit, frei = _uid("ac9-ohne"), _uid("ac9-mit"), _uid("ac9-frei")
     try:
         seit = _AT - timedelta(minutes=1)
@@ -449,20 +466,20 @@ def test_ac9_der_ausfall_der_gewitterpruefung_steht_im_protokolleintrag():
         lauf_ohne = _guard_lauf(ohne, trip_ohne, gewitterpruefung_lief=False)
         lauf_mit = _guard_lauf(mit, trip_mit, gewitterpruefung_lief=True)
         assert (lauf_ohne.triggered_count, lauf_mit.triggered_count) == (0, 0), (
-            f"AC-9 Vorbedingung: beide Laeufe muessen am Doppel-Alarm-Guard "
-            f"haengen bleiben (war {lauf_ohne.triggered_count} bzw. "
+            f"AC-9 Vorbedingung: beide Laeufe muessen an der Ereignis-"
+            f"Identitaet haengen bleiben (war {lauf_ohne.triggered_count} bzw. "
             f"{lauf_mit.triggered_count})."
         )
 
         # Positivkontrolle VOR der eigentlichen Zusicherung: sonst liefe sie
-        # in der RED-Phase nie mit, und der Nachweis „der Guard ist es, der
-        # anhaelt" faellt genau dann aus, wenn er gebraucht wird.
+        # in der RED-Phase nie mit, und der Nachweis „die Ereignis-Identitaet
+        # ist es, die anhaelt" faellt genau dann aus, wenn er gebraucht wird.
         trip_frei = _aufbau(frei, "ac9-frei", briefing_mm=None)
         lauf_frei = _guard_lauf(frei, trip_frei, gewitterpruefung_lief=False)
         assert lauf_frei.triggered_count == 1, (
-            f"AC-9 Positivkontrolle: dieselbe Lage OHNE scharfen "
-            f"Doppel-Alarm-Guard MUSS ausloesen — sonst sagt die Stille oben "
-            f"nichts ueber den Guard aus (war {lauf_frei.triggered_count}, "
+            f"AC-9 Positivkontrolle: dieselbe Lage OHNE Registereintrag MUSS "
+            f"ausloesen — sonst sagt die Stille oben nichts ueber die "
+            f"Ereignis-Identitaet aus (war {lauf_frei.triggered_count}, "
             f"Gruende: {_gruende(frei, trip_frei, seit)!r})."
         )
 
@@ -475,11 +492,12 @@ def test_ac9_der_ausfall_der_gewitterpruefung_steht_im_protokolleintrag():
         )
         vorfall_ohne, vorfall_mit = vorfaelle_ohne[0], vorfaelle_mit[0]
         for vorfall in (vorfall_ohne, vorfall_mit):
-            assert alert_log.REASON_DOUBLE_ALERT_GUARD in vorfall.reasons, (
+            assert alert_log.REASON_EVENT_DUPLICATE in vorfall.reasons, (
                 f"AC-9 Vorbedingung: der Eintrag muss weiterhin den Sperrgrund "
-                f"{alert_log.REASON_DOUBLE_ALERT_GUARD!r} tragen — der Ausfall "
-                f"der Gewitterpruefung kommt HINZU, er ersetzt den Grund "
-                f"nicht. Gefunden: {sorted(vorfall.reasons)!r}"
+                f"{alert_log.REASON_EVENT_DUPLICATE!r} tragen (Issue #2050 "
+                f"S4c — der fruehere `double_alert_guard` ist abgeloest) — "
+                f"der Ausfall der Gewitterpruefung kommt HINZU, er ersetzt "
+                f"den Grund nicht. Gefunden: {sorted(vorfall.reasons)!r}"
             )
 
         zusatz = _kennzeichen(vorfall_ohne) - _kennzeichen(vorfall_mit)


### PR DESCRIPTION
## Was

Der Vorhersage-Abweichungs-Zweig (Δ) des Trip-Alarms ist an die quellenübergreifende Ereignis-Identität angeschlossen. Amtliche Warnung + Vorhersage-Abweichung + Radar für dieselbe Zelle ergeben jetzt **eine** Nachricht statt zwei bis drei.

Der halb tote Doppel-Alarm-Wächter (#818) ist ersatzlos entfernt — dieselbe Paarung läuft über `check_event_identity_gate()` mit dem Grund `event_duplicate` statt `double_alert_guard`.

## Änderungen

- `resolve_hazard_class()`: dritter Auflösungsweg über eine Metrik-Liste (`_WET_METRICS`), additiv neben `_WET_HAZARDS`
- Unterdrückungspfad der Ereignis-Identität trägt jetzt die E-1-Nachweisfelder (u.a. `convective_checked`) mit — ohne das wäre die S4a-Zusicherung dort still verloren gegangen
- `undelivered_hint.py`: Beschriftung und Klasse für `event_duplicate`
- ADR-0021: datierter Nachtrag (#2050 S4c)

## Nachweise

- AC-1..AC-19 erfüllt, Adversary **VERIFIED** (19 Punkte bewiesen, 9 Mutationen gefahren, 9 gefangen)
- Feature-Tests 40/40 grün
- Regression: 550 Tests über 47 Dateien grün
- Renderer-Mail-Gate: Modus-Matrix-Test grün, `briefing_mail_validator.py` Exit 0 gegen echt zugestellte Test-Mail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQYNeC66VrnBe7Pm7qK7vY