### PR TITLE
feat(#2050): S4b — Messluecken der Radar-Ausdehnung landen im Alarmprotokoll

### DIFF
--- a/docs/artifacts/feat-2050-s4b-messluecken-protokoll/adversary-verdict.json
+++ b/docs/artifacts/feat-2050-s4b-messluecken-protokoll/adversary-verdict.json
@@ -1,0 +1,69 @@
+# Adversary Dialog — feat-2050-s4b-messluecken-protokoll
+
+Spec: docs/specs/modules/feat_2050_s4b_messluecken_protokoll.md
+Datum: 2026-08-23
+Iteration: 1 / 3
+Testlauf: `uv run pytest tests/tdd/test_radar_messluecken_protokoll.py tests/tdd/test_regen_ausdehnung_zonenbildung.py tests/tdd/test_regen_ausdehnung_textstellen.py -v` → 27 passed, 0 failed (12 in der neuen Datei + 4 Zonenbildung + 11 Textstellen)
+
+## Checkliste
+
+- [x] AC-1: Lücke am mittleren von drei Zonenpunkten — Beweis: `test_luecke_in_der_mitte_haelt_zahl_und_km_lage_fest`, Wertevergleich gegen aus der Geometrie abgeleitete km-Lage
+- [x] AC-2: alle Folgepunkte ausgefallen (Extremfall, points_measured=1, 5× gap_km) — Beweis: `test_alle_folgepunkte_ausgefallen_ist_der_extremfall`
+- [x] AC-3: echter Ein-Kilometer-Befund vom Extremfall strukturell unterscheidbar — Beweis: `test_echter_befund_ein_kilometer_ist_vom_extremfall_unterscheidbar`, Nebeneinander-Vergleich bei identischem Text
+- [x] AC-4: `measurement_gaps` immer vorhanden, auch ohne Lücke — Beweis: `test_luecken_feld_ist_auch_ohne_luecke_vorhanden`, mit Positivkontrolle (derselbe Aufbau MIT Lücke füllt gap_km)
+- [x] AC-5: geworfene Ausnahme erscheint als Lücke — Beweis: `test_geworfene_ausnahme_erscheint_als_luecke`
+- [x] AC-6: `throttled=True` erscheint als Lücke — Beweis: `test_throttled_erscheint_als_luecke`
+- [x] AC-7: `data_unavailable=True` erscheint als Lücke — Beweis: `test_data_unavailable_erscheint_als_luecke`
+- [x] AC-8: Ausfall am ersten Messpunkt erzeugt keine Ausdehnungszeile (Positivkontrolle je Ausfallweg) — Beweis: `test_ausfall_am_ersten_punkt_erzeugt_keine_ausdehnungszeile`, R3-Begründung am Code verifiziert (`check_radar_alerts` `continue`t vor `_zonen_ergebnisse`-Existenz bzw. vor `radar_alert_due()`)
+- [x] AC-9: gescheiterte Ableitung kostet den Alarm nicht, nur `measurement_gaps` fehlt — Beweis: `test_scheiternde_luecken_ableitung_kostet_den_alarm_nicht`; Mutation 7 (gemeinsamer Auffang statt eigenem) macht genau diesen Test rot
+- [x] AC-10: Mandantentrennung, zwei echte `user_id` (uuid4, kein `"default"`) — Beweis: `test_zwei_nutzer_teilen_sich_keinen_luecken_eintrag`
+- [x] AC-11: Alteinträge ohne `measurement_gaps` bleiben byte-identisch (Read-Modify-Write) — Beweis: `test_alteintrag_ohne_messluecken_feld_bleibt_unveraendert`, `_append()` in `src/services/alert_log.py:521-533` unverändert
+- [x] AC-12: Regression — `rain_extent.py` unangetastet, beide S2a-Wächter grün — Beweis: `git diff --name-only` enthält `rain_extent.py` nicht; `test_ac11_datenloser_punkt_faellt_aus_der_zonenbildung_heraus` und `test_e4_punkt_ohne_frames_trennt_die_nasszone_nicht` grün
+
+## Findings
+
+### F001: Forwarding von `measurement_gaps` in `append_suppressed_entry()` war ungetestet
+- **Severity:** HIGH
+- **Category:** edge_case
+- **Evidence:** src/services/alert_log.py:638 (Forwarding-Zeile `measurement_gaps=measurement_gaps,` im `_apply_e1_fields(...)`-Aufruf von `append_suppressed_entry()`); reale Erreichbarkeit über die Aufrufstellen src/services/trip_alert.py:1994 (briefing_announced-Unterdrückung) und src/services/trip_alert.py:2199 (Identitäts-/Cooldown-Gate), beide rufen `alert_log.append_suppressed_entry(..., **_e1)` NACH Berechnung von `_e1`
+- **Description:** Runde 1: das Entfernen der Forwarding-Zeile in `append_suppressed_entry()` (String-Mutation, externe Sicherungskopie, md5-Rücknahme belegt) ließ die volle Zielsuite (26 Tests) grün — kein einziger Test prüfte den Suppressed-Pfad (`not_delivered`) auf `measurement_gaps`. Die vorbestehende Datei `tests/tdd/test_alert_log_unterdrueckung_groessen.py` (#2050 S6) deckt zwar `not_delivered`-Einträge ab, aber ohne Bezug zu `measurement_gaps` (grep leer). Implementierung war zu diesem Zeitpunkt korrekt — reine Testlücke, kein Spec-Verstoß im Code.
+- **Remediation:** GESCHLOSSEN in Runde 2. Neuer Test `test_unterdrueckter_alarm_haelt_die_luecke_genauso_fest` (`tests/tdd/test_radar_messluecken_protokoll.py:829-844`) fährt den `briefing_announced`-Unterdrückungspfad und prüft den `not_delivered`-Eintrag mit derselben Wertprüfung (`_pruefe_luecken(..., eintrag=eintrag)`) wie der zugestellte Pfad. Eigenständig gegengeprüft (siehe Runde 2): Mutation an alert_log.py:638 selbst wiederholt → jetzt genau 1 Test rot (der neue); zwei zusätzliche Wert-Mutationen (`points_measured`, `gap_km`-Index) isoliert gegen nur diesen Test ausgeführt → beide rot, mit falschem WERT in der Fehlermeldung, keine reine Präsenzprüfung. Pfadwahl (`briefing_announced` statt früherer Gates über `_protokolliere_radar_unterdrueckung()`, das `measurement_gaps` konstruktiv nie mitgibt, `trip_alert.py:1438-1465`) am Produktivcode verifiziert, nicht nur am Testkommentar geglaubt.
+
+## Mutations-Gegenprobe — 10 dokumentierte Mutations-Ausführungen (Pflicht laut CLAUDE.md)
+
+Alle Mutationen per String-Ersetzung mit externer Sicherungskopie im Scratchpad, jede Rücknahme per `diff`/`md5sum` byte-identisch belegt. Produktivcode am Ende beider Runden unverändert (`trip_alert.py` md5 `eb82f1e7cf1145794416d5a814afb113`, `alert_log.py` md5 `8eae988afe5c2c3769f5083f9bb5aeee`).
+
+| # | Runde | Mutation | Ort | Ergebnis |
+|---|---|---|---|---|
+| 1 | 1 | `points_measured = len(ergebnisse)` statt Differenz | trip_alert.py:207 | 9 Tests rot — falscher WERT, nicht nur Abwesenheit |
+| 2 | 1 | `gap_km`-Rundung auf 2 statt 1 Nachkommastelle | trip_alert.py:201 | 1 Test rot (AC-1); übrige Tests landen zufällig auf identischen Rundungswerten bei dieser Geometrie — dokumentierter Nebenbefund, kein Finding, da real gefangen |
+| 3 | 1 | `gap_km`-Index verschoben (`punkte[i+1]`) | trip_alert.py:200-203 | 9 Tests rot |
+| 4 | 1 | Feld nur bei vorhandener Lücke setzen | trip_alert.py:204-210 | 2 Tests rot (AC-3, AC-4) |
+| 5 | 1 | `"measurement_gaps": dict` aus `_E1_FIELD_TYPES` entfernt | alert_log.py:342 | 15 Tests rot (harter KeyError-Crash statt fail-soft — vorbestehende Design-Eigenschaft von `_apply_e1_fields()`, nicht S4b-spezifisch, kein eigenes Finding) |
+| 6 | 1 | Forwarding `measurement_gaps=measurement_gaps` in `append_suppressed_entry()` entfernt | alert_log.py:638 | **0 Tests rot → F001** |
+| 7 | 1 | Eigenen `except` durch gemeinsamen `return {}` ersetzt | trip_alert.py:269-274 | 1 Test rot (AC-9, exakt der dafür gebaute Test) |
+| 8 | 1 | Aufrufstelle `punkte=_punkte, zonen_ergebnisse=_zonen_ergebnisse` entfernt | trip_alert.py:1954-1957 | 10 Tests rot |
+| 9 | 1 | `_zonen_messwert`: throttled/data_unavailable nicht mehr als Lücke werten | trip_alert.py:170-175 | 10 Tests rot, inkl. S2a-Regressionswächter `test_e4_punkt_ohne_frames_trennt_die_nasszone_nicht` |
+| 10 | 2 | Mutation 6 wiederholt (nach Testergänzung), eigenständig, nicht auf Selbstbericht verlassen | alert_log.py:638 | **1 Test rot** (der neue `test_unterdrueckter_alarm_haelt_die_luecke_genauso_fest`) — F001 geschlossen |
+
+Ergänzend in Runde 2 (nicht separat gezählt, da Wiederholung von #1/#3 isoliert gegen nur den neuen Test): `points_measured`-Falschberechnung und `gap_km`-Indexverschiebung erneut ausgeführt, jeweils NUR gegen `test_unterdrueckter_alarm_haelt_die_luecke_genauso_fest` — beide rot mit falschem Wert am `not_delivered`-Eintrag, bestätigt dass der neue Test am WERT prüft, nicht nur an der Präsenz.
+
+## Referenzfeger-Beurteilung (Runde 2)
+
+Verzicht auf vollen Referenzfeger trägt: Produktivcode (`trip_alert.py`, `alert_log.py`) ist zwischen Runde 1 und Runde 2 byte-identisch (md5 oben), einzige Änderung war `tests/tdd/test_radar_messluecken_protokoll.py`. `grep -rln "test_radar_messluecken_protokoll" tests/ --include="*.py"` findet außer der Datei selbst keinen Treffer — keine fremde Testdatei importiert Helfer daraus, ein Referenzfeger hätte strukturell nichts zu finden.
+
+## Dialog
+
+### Runde 1
+**Adversary:** 9 Mutationsfamilien gegen die uncommittete Implementierung (`trip_alert.py`/`alert_log.py`, +71/−2) durchgespielt, AC-1..AC-12 einzeln mit Code-Referenz geprüft, `rain_extent.py`-Unangetastetheit per `git diff --name-only` verifiziert.
+**Implementierer:** —
+**Bewertung:** BROKEN — F001 (Forwarding in `append_suppressed_entry()` ungetestet), sonst 11/12 ACs PROVEN, 8/9 Mutationsfamilien robust gefangen.
+
+### Runde 2
+**Adversary:** Mutation 6 eigenständig wiederholt (nicht auf Selbstbericht verlassen), Pfadwahl des neuen Tests am Produktivcode verifiziert (`_protokolliere_radar_unterdrueckung()` vs. die zwei `**_e1`-Aufrufstellen), zwei isolierte Wert-Mutationen gegen den neuen Test, Referenzfeger-Verzicht per `grep` bestätigt.
+**Implementierer:** Testdatei um `test_unterdrueckter_alarm_haelt_die_luecke_genauso_fest` ergänzt (`tests/tdd/test_radar_messluecken_protokoll.py`, +152/−15), Produktivcode unverändert (md5-Nachweis).
+**Bewertung:** VERIFIED — F001 geschlossen, 12/12 ACs PROVEN, alle 10 dokumentierten Mutations-Ausführungen gefangen, 27/27 Tests grün.
+
+## Verdict
+**VERIFIED**
+Offene Punkte: 0 / 12

--- a/docs/artifacts/feat-2050-s4b-messluecken-protokoll/test-green-output.txt
+++ b/docs/artifacts/feat-2050-s4b-messluecken-protokoll/test-green-output.txt
@@ -1,0 +1,15 @@
+============================= test session starts ==============================
+platform linux -- Python 3.12.3, pytest-8.4.1, pluggy-1.6.0
+rootdir: /home/hem/gregor_zwanzig/.claude/worktrees/ws-2050-s4b
+configfile: pyproject.toml
+plugins: anyio-4.12.0, timeout-2.4.0, socket-0.8.0
+timeout: 30.0s
+timeout method: signal
+timeout func_only: False
+collected 27 items
+
+tests/tdd/test_radar_messluecken_protokoll.py ............               [ 44%]
+tests/tdd/test_regen_ausdehnung_zonenbildung.py ....                     [ 59%]
+tests/tdd/test_regen_ausdehnung_textstellen.py ...........               [100%]
+
+============================== 27 passed in 1.67s ==============================

--- a/docs/artifacts/feat-2050-s4b-messluecken-protokoll/test-red-output.txt
+++ b/docs/artifacts/feat-2050-s4b-messluecken-protokoll/test-red-output.txt
@@ -28,14 +28,14 @@ _____________ test_luecke_in_der_mitte_haelt_zahl_und_km_lage_fest _____________
 >       luecken = _pruefe_luecken(lauf, radar, punkte_erwartet=3)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-tests/tdd/test_radar_messluecken_protokoll.py:322: 
+tests/tdd/test_radar_messluecken_protokoll.py:371: 
 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
-tests/tdd/test_radar_messluecken_protokoll.py:286: in _pruefe_luecken
+tests/tdd/test_radar_messluecken_protokoll.py:335: in _pruefe_luecken
     luecken = _messluecken(lauf)
               ^^^^^^^^^^^^^^^^^^
 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
 
-lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-7 · ab 12:10 · letzter Regen gegen 12:40 · Nas...999996884, 3.5949999999998226, 5.594999999999956], uid='tdd-2050-s4b-ac1-98305284', trip_id='tdd-2050-s4b-trip-ce10fb')
+lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-7 · ab 12:10 · letzter Regen gegen 12:40 · Nas...999996884, 3.5949999999998226, 5.594999999999956], uid='tdd-2050-s4b-ac1-565b36f1', trip_id='tdd-2050-s4b-trip-18679f')
 
     def _messluecken(lauf: _Lauf) -> dict:
         eintrag = _versand_eintrag(lauf)
@@ -44,10 +44,10 @@ lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-7
             f"nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die "
             f"Ausdehnung stammt. Eintrag: {eintrag!r}"
         )
-E       AssertionError: Der Protokoll-Eintrag muss `measurement_gaps` fuehren — sonst ist nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die Ausdehnung stammt. Eintrag: {'entity_id': 'tdd-2050-s4b-trip-ce10fb', 'entity_type': 'trip', 'sent_at': '2026-08-18T10:00:00+00:00', 'changes_count': 1, 'severity': 'MODERATE', 'metrics': [{'metric_id': 'precipitation', 'aggregation': 'sum'}], 'hazards': [], 'reason': 'nowcast', 'channels_sent': ['email'], 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', 'reason': 'channel_disabled'}, {'channel': 'premium_sms', 'reason': 'channel_disabled'}], 'lead_time_minutes': 10, 'event_at': '2026-08-18T10:10:00+00:00', 'event_end_at': '2026-08-18T10:40:00+00:00', 'measurement_point': {'segment_id': '1', 'km_from': 0.0, 'km_to': 6.6}, 'source': 'radar'}
-E       assert 'measurement_gaps' in {'changes_count': 1, 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', '...premium_sms', 'reason': 'channel_disabled'}], 'channels_sent': ['email'], 'entity_id': 'tdd-2050-s4b-trip-ce10fb', ...}
+E       AssertionError: Der Protokoll-Eintrag muss `measurement_gaps` fuehren — sonst ist nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die Ausdehnung stammt. Eintrag: {'entity_id': 'tdd-2050-s4b-trip-18679f', 'entity_type': 'trip', 'sent_at': '2026-08-18T10:00:00+00:00', 'changes_count': 1, 'severity': 'MODERATE', 'metrics': [{'metric_id': 'precipitation', 'aggregation': 'sum'}], 'hazards': [], 'reason': 'nowcast', 'channels_sent': ['email'], 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', 'reason': 'channel_disabled'}, {'channel': 'premium_sms', 'reason': 'channel_disabled'}], 'lead_time_minutes': 10, 'event_at': '2026-08-18T10:10:00+00:00', 'event_end_at': '2026-08-18T10:40:00+00:00', 'measurement_point': {'segment_id': '1', 'km_from': 0.0, 'km_to': 6.6}, 'source': 'radar'}
+E       assert 'measurement_gaps' in {'changes_count': 1, 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', '...premium_sms', 'reason': 'channel_disabled'}], 'channels_sent': ['email'], 'entity_id': 'tdd-2050-s4b-trip-18679f', ...}
 
-tests/tdd/test_radar_messluecken_protokoll.py:244: AssertionError
+tests/tdd/test_radar_messluecken_protokoll.py:293: AssertionError
 _____________ test_alle_folgepunkte_ausgefallen_ist_der_extremfall _____________
 
     def test_alle_folgepunkte_ausgefallen_ist_der_extremfall():
@@ -61,14 +61,14 @@ _____________ test_alle_folgepunkte_ausgefallen_ist_der_extremfall _____________
 >       luecken = _pruefe_luecken(lauf, radar, punkte_erwartet=6)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-tests/tdd/test_radar_messluecken_protokoll.py:347: 
+tests/tdd/test_radar_messluecken_protokoll.py:396: 
 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
-tests/tdd/test_radar_messluecken_protokoll.py:286: in _pruefe_luecken
+tests/tdd/test_radar_messluecken_protokoll.py:335: in _pruefe_luecken
     luecken = _messluecken(lauf)
               ^^^^^^^^^^^^^^^^^^
 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
 
-lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-24 · ab 12:10 · letzter Regen gegen 12:40 · Na...333791165, 13.797641530778028, 15.79729972364441], uid='tdd-2050-s4b-ac2-0f911f03', trip_id='tdd-2050-s4b-trip-69ea63')
+lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-24 · ab 12:10 · letzter Regen gegen 12:40 · Na...333791165, 13.797641530778028, 15.79729972364441], uid='tdd-2050-s4b-ac2-66be95b1', trip_id='tdd-2050-s4b-trip-9c82dc')
 
     def _messluecken(lauf: _Lauf) -> dict:
         eintrag = _versand_eintrag(lauf)
@@ -77,10 +77,10 @@ lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-2
             f"nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die "
             f"Ausdehnung stammt. Eintrag: {eintrag!r}"
         )
-E       AssertionError: Der Protokoll-Eintrag muss `measurement_gaps` fuehren — sonst ist nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die Ausdehnung stammt. Eintrag: {'entity_id': 'tdd-2050-s4b-trip-69ea63', 'entity_type': 'trip', 'sent_at': '2026-08-18T10:00:00+00:00', 'changes_count': 1, 'severity': 'MODERATE', 'metrics': [{'metric_id': 'precipitation', 'aggregation': 'sum'}], 'hazards': [], 'reason': 'nowcast', 'channels_sent': ['email'], 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', 'reason': 'channel_disabled'}, {'channel': 'premium_sms', 'reason': 'channel_disabled'}], 'lead_time_minutes': 10, 'event_at': '2026-08-18T10:10:00+00:00', 'event_end_at': '2026-08-18T10:40:00+00:00', 'measurement_point': {'segment_id': '1', 'km_from': 0.0, 'km_to': 23.996}, 'source': 'radar'}
-E       assert 'measurement_gaps' in {'changes_count': 1, 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', '...premium_sms', 'reason': 'channel_disabled'}], 'channels_sent': ['email'], 'entity_id': 'tdd-2050-s4b-trip-69ea63', ...}
+E       AssertionError: Der Protokoll-Eintrag muss `measurement_gaps` fuehren — sonst ist nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die Ausdehnung stammt. Eintrag: {'entity_id': 'tdd-2050-s4b-trip-9c82dc', 'entity_type': 'trip', 'sent_at': '2026-08-18T10:00:00+00:00', 'changes_count': 1, 'severity': 'MODERATE', 'metrics': [{'metric_id': 'precipitation', 'aggregation': 'sum'}], 'hazards': [], 'reason': 'nowcast', 'channels_sent': ['email'], 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', 'reason': 'channel_disabled'}, {'channel': 'premium_sms', 'reason': 'channel_disabled'}], 'lead_time_minutes': 10, 'event_at': '2026-08-18T10:10:00+00:00', 'event_end_at': '2026-08-18T10:40:00+00:00', 'measurement_point': {'segment_id': '1', 'km_from': 0.0, 'km_to': 23.996}, 'source': 'radar'}
+E       assert 'measurement_gaps' in {'changes_count': 1, 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', '...premium_sms', 'reason': 'channel_disabled'}], 'channels_sent': ['email'], 'entity_id': 'tdd-2050-s4b-trip-9c82dc', ...}
 
-tests/tdd/test_radar_messluecken_protokoll.py:244: AssertionError
+tests/tdd/test_radar_messluecken_protokoll.py:293: AssertionError
 ______ test_echter_befund_ein_kilometer_ist_vom_extremfall_unterscheidbar ______
 
     def test_echter_befund_ein_kilometer_ist_vom_extremfall_unterscheidbar():
@@ -109,14 +109,14 @@ ______ test_echter_befund_ein_kilometer_ist_vom_extremfall_unterscheidbar ______
 >       luecken_echt = _pruefe_luecken(lauf_echt, echt, punkte_erwartet=6)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-tests/tdd/test_radar_messluecken_protokoll.py:378: 
+tests/tdd/test_radar_messluecken_protokoll.py:427: 
 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
-tests/tdd/test_radar_messluecken_protokoll.py:286: in _pruefe_luecken
+tests/tdd/test_radar_messluecken_protokoll.py:335: in _pruefe_luecken
     luecken = _messluecken(lauf)
               ^^^^^^^^^^^^^^^^^^
 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
 
-lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-24 · ab 12:10 · letzter Regen gegen 12:40 · Na...1165, 13.797641530778028, 15.79729972364441], uid='tdd-2050-s4b-ac3-echt-b1ccec85', trip_id='tdd-2050-s4b-trip-31d474')
+lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-24 · ab 12:10 · letzter Regen gegen 12:40 · Na...1165, 13.797641530778028, 15.79729972364441], uid='tdd-2050-s4b-ac3-echt-e897b968', trip_id='tdd-2050-s4b-trip-2a0bb4')
 
     def _messluecken(lauf: _Lauf) -> dict:
         eintrag = _versand_eintrag(lauf)
@@ -125,10 +125,10 @@ lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-2
             f"nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die "
             f"Ausdehnung stammt. Eintrag: {eintrag!r}"
         )
-E       AssertionError: Der Protokoll-Eintrag muss `measurement_gaps` fuehren — sonst ist nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die Ausdehnung stammt. Eintrag: {'entity_id': 'tdd-2050-s4b-trip-31d474', 'entity_type': 'trip', 'sent_at': '2026-08-18T10:00:00+00:00', 'changes_count': 1, 'severity': 'MODERATE', 'metrics': [{'metric_id': 'precipitation', 'aggregation': 'sum'}], 'hazards': [], 'reason': 'nowcast', 'channels_sent': ['email'], 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', 'reason': 'channel_disabled'}, {'channel': 'premium_sms', 'reason': 'channel_disabled'}], 'lead_time_minutes': 10, 'event_at': '2026-08-18T10:10:00+00:00', 'event_end_at': '2026-08-18T10:40:00+00:00', 'measurement_point': {'segment_id': '1', 'km_from': 0.0, 'km_to': 23.996}, 'source': 'radar'}
-E       assert 'measurement_gaps' in {'changes_count': 1, 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', '...premium_sms', 'reason': 'channel_disabled'}], 'channels_sent': ['email'], 'entity_id': 'tdd-2050-s4b-trip-31d474', ...}
+E       AssertionError: Der Protokoll-Eintrag muss `measurement_gaps` fuehren — sonst ist nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die Ausdehnung stammt. Eintrag: {'entity_id': 'tdd-2050-s4b-trip-2a0bb4', 'entity_type': 'trip', 'sent_at': '2026-08-18T10:00:00+00:00', 'changes_count': 1, 'severity': 'MODERATE', 'metrics': [{'metric_id': 'precipitation', 'aggregation': 'sum'}], 'hazards': [], 'reason': 'nowcast', 'channels_sent': ['email'], 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', 'reason': 'channel_disabled'}, {'channel': 'premium_sms', 'reason': 'channel_disabled'}], 'lead_time_minutes': 10, 'event_at': '2026-08-18T10:10:00+00:00', 'event_end_at': '2026-08-18T10:40:00+00:00', 'measurement_point': {'segment_id': '1', 'km_from': 0.0, 'km_to': 23.996}, 'source': 'radar'}
+E       assert 'measurement_gaps' in {'changes_count': 1, 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', '...premium_sms', 'reason': 'channel_disabled'}], 'channels_sent': ['email'], 'entity_id': 'tdd-2050-s4b-trip-2a0bb4', ...}
 
-tests/tdd/test_radar_messluecken_protokoll.py:244: AssertionError
+tests/tdd/test_radar_messluecken_protokoll.py:293: AssertionError
 _______________ test_luecken_feld_ist_auch_ohne_luecke_vorhanden _______________
 
     def test_luecken_feld_ist_auch_ohne_luecke_vorhanden():
@@ -145,14 +145,14 @@ _______________ test_luecken_feld_ist_auch_ohne_luecke_vorhanden _______________
 >       luecken_ohne = _pruefe_luecken(lauf_ohne, ohne, punkte_erwartet=6)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-tests/tdd/test_radar_messluecken_protokoll.py:412: 
+tests/tdd/test_radar_messluecken_protokoll.py:461: 
 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
-tests/tdd/test_radar_messluecken_protokoll.py:286: in _pruefe_luecken
+tests/tdd/test_radar_messluecken_protokoll.py:335: in _pruefe_luecken
     luecken = _messluecken(lauf)
               ^^^^^^^^^^^^^^^^^^
 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
 
-lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-24 · ab 12:10 · letzter Regen gegen 12:40 · Na...1165, 13.797641530778028, 15.79729972364441], uid='tdd-2050-s4b-ac4-ohne-effef469', trip_id='tdd-2050-s4b-trip-e43df5')
+lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-24 · ab 12:10 · letzter Regen gegen 12:40 · Na...1165, 13.797641530778028, 15.79729972364441], uid='tdd-2050-s4b-ac4-ohne-33df6c5d', trip_id='tdd-2050-s4b-trip-6244ac')
 
     def _messluecken(lauf: _Lauf) -> dict:
         eintrag = _versand_eintrag(lauf)
@@ -161,10 +161,10 @@ lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-2
             f"nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die "
             f"Ausdehnung stammt. Eintrag: {eintrag!r}"
         )
-E       AssertionError: Der Protokoll-Eintrag muss `measurement_gaps` fuehren — sonst ist nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die Ausdehnung stammt. Eintrag: {'entity_id': 'tdd-2050-s4b-trip-e43df5', 'entity_type': 'trip', 'sent_at': '2026-08-18T10:00:00+00:00', 'changes_count': 1, 'severity': 'MODERATE', 'metrics': [{'metric_id': 'precipitation', 'aggregation': 'sum'}], 'hazards': [], 'reason': 'nowcast', 'channels_sent': ['email'], 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', 'reason': 'channel_disabled'}, {'channel': 'premium_sms', 'reason': 'channel_disabled'}], 'lead_time_minutes': 10, 'event_at': '2026-08-18T10:10:00+00:00', 'event_end_at': '2026-08-18T10:40:00+00:00', 'measurement_point': {'segment_id': '1', 'km_from': 0.0, 'km_to': 23.996}, 'source': 'radar'}
-E       assert 'measurement_gaps' in {'changes_count': 1, 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', '...premium_sms', 'reason': 'channel_disabled'}], 'channels_sent': ['email'], 'entity_id': 'tdd-2050-s4b-trip-e43df5', ...}
+E       AssertionError: Der Protokoll-Eintrag muss `measurement_gaps` fuehren — sonst ist nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die Ausdehnung stammt. Eintrag: {'entity_id': 'tdd-2050-s4b-trip-6244ac', 'entity_type': 'trip', 'sent_at': '2026-08-18T10:00:00+00:00', 'changes_count': 1, 'severity': 'MODERATE', 'metrics': [{'metric_id': 'precipitation', 'aggregation': 'sum'}], 'hazards': [], 'reason': 'nowcast', 'channels_sent': ['email'], 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', 'reason': 'channel_disabled'}, {'channel': 'premium_sms', 'reason': 'channel_disabled'}], 'lead_time_minutes': 10, 'event_at': '2026-08-18T10:10:00+00:00', 'event_end_at': '2026-08-18T10:40:00+00:00', 'measurement_point': {'segment_id': '1', 'km_from': 0.0, 'km_to': 23.996}, 'source': 'radar'}
+E       assert 'measurement_gaps' in {'changes_count': 1, 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', '...premium_sms', 'reason': 'channel_disabled'}], 'channels_sent': ['email'], 'entity_id': 'tdd-2050-s4b-trip-6244ac', ...}
 
-tests/tdd/test_radar_messluecken_protokoll.py:244: AssertionError
+tests/tdd/test_radar_messluecken_protokoll.py:293: AssertionError
 _________________ test_geworfene_ausnahme_erscheint_als_luecke _________________
 
     def test_geworfene_ausnahme_erscheint_als_luecke():
@@ -174,14 +174,14 @@ _________________ test_geworfene_ausnahme_erscheint_als_luecke _________________
         lauf = _lauf(radar, tag="ac5")
 >       _pruefe_luecken(lauf, radar, punkte_erwartet=6)
 
-tests/tdd/test_radar_messluecken_protokoll.py:440: 
+tests/tdd/test_radar_messluecken_protokoll.py:489: 
 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
-tests/tdd/test_radar_messluecken_protokoll.py:286: in _pruefe_luecken
+tests/tdd/test_radar_messluecken_protokoll.py:335: in _pruefe_luecken
     luecken = _messluecken(lauf)
               ^^^^^^^^^^^^^^^^^^
 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
 
-lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-24 · ab 12:10 · letzter Regen gegen 12:40 · Na...333791165, 13.797641530778028, 15.79729972364441], uid='tdd-2050-s4b-ac5-5b14c066', trip_id='tdd-2050-s4b-trip-b34235')
+lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-24 · ab 12:10 · letzter Regen gegen 12:40 · Na...333791165, 13.797641530778028, 15.79729972364441], uid='tdd-2050-s4b-ac5-d03930cc', trip_id='tdd-2050-s4b-trip-c74d96')
 
     def _messluecken(lauf: _Lauf) -> dict:
         eintrag = _versand_eintrag(lauf)
@@ -190,12 +190,12 @@ lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-2
             f"nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die "
             f"Ausdehnung stammt. Eintrag: {eintrag!r}"
         )
-E       AssertionError: Der Protokoll-Eintrag muss `measurement_gaps` fuehren — sonst ist nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die Ausdehnung stammt. Eintrag: {'entity_id': 'tdd-2050-s4b-trip-b34235', 'entity_type': 'trip', 'sent_at': '2026-08-18T10:00:00+00:00', 'changes_count': 1, 'severity': 'MODERATE', 'metrics': [{'metric_id': 'precipitation', 'aggregation': 'sum'}], 'hazards': [], 'reason': 'nowcast', 'channels_sent': ['email'], 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', 'reason': 'channel_disabled'}, {'channel': 'premium_sms', 'reason': 'channel_disabled'}], 'lead_time_minutes': 10, 'event_at': '2026-08-18T10:10:00+00:00', 'event_end_at': '2026-08-18T10:40:00+00:00', 'measurement_point': {'segment_id': '1', 'km_from': 0.0, 'km_to': 23.996}, 'source': 'radar'}
-E       assert 'measurement_gaps' in {'changes_count': 1, 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', '...premium_sms', 'reason': 'channel_disabled'}], 'channels_sent': ['email'], 'entity_id': 'tdd-2050-s4b-trip-b34235', ...}
+E       AssertionError: Der Protokoll-Eintrag muss `measurement_gaps` fuehren — sonst ist nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die Ausdehnung stammt. Eintrag: {'entity_id': 'tdd-2050-s4b-trip-c74d96', 'entity_type': 'trip', 'sent_at': '2026-08-18T10:00:00+00:00', 'changes_count': 1, 'severity': 'MODERATE', 'metrics': [{'metric_id': 'precipitation', 'aggregation': 'sum'}], 'hazards': [], 'reason': 'nowcast', 'channels_sent': ['email'], 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', 'reason': 'channel_disabled'}, {'channel': 'premium_sms', 'reason': 'channel_disabled'}], 'lead_time_minutes': 10, 'event_at': '2026-08-18T10:10:00+00:00', 'event_end_at': '2026-08-18T10:40:00+00:00', 'measurement_point': {'segment_id': '1', 'km_from': 0.0, 'km_to': 23.996}, 'source': 'radar'}
+E       assert 'measurement_gaps' in {'changes_count': 1, 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', '...premium_sms', 'reason': 'channel_disabled'}], 'channels_sent': ['email'], 'entity_id': 'tdd-2050-s4b-trip-c74d96', ...}
 
-tests/tdd/test_radar_messluecken_protokoll.py:244: AssertionError
+tests/tdd/test_radar_messluecken_protokoll.py:293: AssertionError
 ------------------------------ Captured log call -------------------------------
-WARNING  trip_alert:trip_alert.py:1714 Radar alert: Nowcast fuer Zonenpunkt (47.0881, 11.0000) des Trips tdd-2050-s4b-trip-b34235 fehlgeschlagen (Nowcast-Abruf fuer Zonenpunkt 2 absichtlich fehlgeschlagen) — der Punkt faellt aus der Ausdehnung heraus, der Alarm laeuft weiter.
+WARNING  trip_alert:trip_alert.py:1714 Radar alert: Nowcast fuer Zonenpunkt (47.0881, 11.0000) des Trips tdd-2050-s4b-trip-c74d96 fehlgeschlagen (Nowcast-Abruf fuer Zonenpunkt 2 absichtlich fehlgeschlagen) — der Punkt faellt aus der Ausdehnung heraus, der Alarm laeuft weiter.
 _____________________ test_throttled_erscheint_als_luecke ______________________
 
     def test_throttled_erscheint_als_luecke():
@@ -206,14 +206,14 @@ _____________________ test_throttled_erscheint_als_luecke ______________________
         lauf = _lauf(radar, tag="ac6")
 >       _pruefe_luecken(lauf, radar, punkte_erwartet=6)
 
-tests/tdd/test_radar_messluecken_protokoll.py:449: 
+tests/tdd/test_radar_messluecken_protokoll.py:498: 
 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
-tests/tdd/test_radar_messluecken_protokoll.py:286: in _pruefe_luecken
+tests/tdd/test_radar_messluecken_protokoll.py:335: in _pruefe_luecken
     luecken = _messluecken(lauf)
               ^^^^^^^^^^^^^^^^^^
 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
 
-lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-24 · ab 12:10 · letzter Regen gegen 12:40 · Na...333791165, 13.797641530778028, 15.79729972364441], uid='tdd-2050-s4b-ac6-f2cbb5da', trip_id='tdd-2050-s4b-trip-845857')
+lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-24 · ab 12:10 · letzter Regen gegen 12:40 · Na...333791165, 13.797641530778028, 15.79729972364441], uid='tdd-2050-s4b-ac6-fd6db6e3', trip_id='tdd-2050-s4b-trip-3d3992')
 
     def _messluecken(lauf: _Lauf) -> dict:
         eintrag = _versand_eintrag(lauf)
@@ -222,10 +222,10 @@ lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-2
             f"nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die "
             f"Ausdehnung stammt. Eintrag: {eintrag!r}"
         )
-E       AssertionError: Der Protokoll-Eintrag muss `measurement_gaps` fuehren — sonst ist nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die Ausdehnung stammt. Eintrag: {'entity_id': 'tdd-2050-s4b-trip-845857', 'entity_type': 'trip', 'sent_at': '2026-08-18T10:00:00+00:00', 'changes_count': 1, 'severity': 'MODERATE', 'metrics': [{'metric_id': 'precipitation', 'aggregation': 'sum'}], 'hazards': [], 'reason': 'nowcast', 'channels_sent': ['email'], 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', 'reason': 'channel_disabled'}, {'channel': 'premium_sms', 'reason': 'channel_disabled'}], 'lead_time_minutes': 10, 'event_at': '2026-08-18T10:10:00+00:00', 'event_end_at': '2026-08-18T10:40:00+00:00', 'measurement_point': {'segment_id': '1', 'km_from': 0.0, 'km_to': 23.996}, 'source': 'radar'}
-E       assert 'measurement_gaps' in {'changes_count': 1, 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', '...premium_sms', 'reason': 'channel_disabled'}], 'channels_sent': ['email'], 'entity_id': 'tdd-2050-s4b-trip-845857', ...}
+E       AssertionError: Der Protokoll-Eintrag muss `measurement_gaps` fuehren — sonst ist nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die Ausdehnung stammt. Eintrag: {'entity_id': 'tdd-2050-s4b-trip-3d3992', 'entity_type': 'trip', 'sent_at': '2026-08-18T10:00:00+00:00', 'changes_count': 1, 'severity': 'MODERATE', 'metrics': [{'metric_id': 'precipitation', 'aggregation': 'sum'}], 'hazards': [], 'reason': 'nowcast', 'channels_sent': ['email'], 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', 'reason': 'channel_disabled'}, {'channel': 'premium_sms', 'reason': 'channel_disabled'}], 'lead_time_minutes': 10, 'event_at': '2026-08-18T10:10:00+00:00', 'event_end_at': '2026-08-18T10:40:00+00:00', 'measurement_point': {'segment_id': '1', 'km_from': 0.0, 'km_to': 23.996}, 'source': 'radar'}
+E       assert 'measurement_gaps' in {'changes_count': 1, 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', '...premium_sms', 'reason': 'channel_disabled'}], 'channels_sent': ['email'], 'entity_id': 'tdd-2050-s4b-trip-3d3992', ...}
 
-tests/tdd/test_radar_messluecken_protokoll.py:244: AssertionError
+tests/tdd/test_radar_messluecken_protokoll.py:293: AssertionError
 __________________ test_data_unavailable_erscheint_als_luecke __________________
 
     def test_data_unavailable_erscheint_als_luecke():
@@ -236,14 +236,14 @@ __________________ test_data_unavailable_erscheint_als_luecke __________________
         lauf = _lauf(radar, tag="ac7")
 >       _pruefe_luecken(lauf, radar, punkte_erwartet=6)
 
-tests/tdd/test_radar_messluecken_protokoll.py:458: 
+tests/tdd/test_radar_messluecken_protokoll.py:507: 
 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
-tests/tdd/test_radar_messluecken_protokoll.py:286: in _pruefe_luecken
+tests/tdd/test_radar_messluecken_protokoll.py:335: in _pruefe_luecken
     luecken = _messluecken(lauf)
               ^^^^^^^^^^^^^^^^^^
 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
 
-lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-24 · ab 12:10 · letzter Regen gegen 12:40 · Na...333791165, 13.797641530778028, 15.79729972364441], uid='tdd-2050-s4b-ac7-ecdc7aa5', trip_id='tdd-2050-s4b-trip-08b973')
+lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-24 · ab 12:10 · letzter Regen gegen 12:40 · Na...333791165, 13.797641530778028, 15.79729972364441], uid='tdd-2050-s4b-ac7-5935148f', trip_id='tdd-2050-s4b-trip-11170b')
 
     def _messluecken(lauf: _Lauf) -> dict:
         eintrag = _versand_eintrag(lauf)
@@ -252,10 +252,10 @@ lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-2
             f"nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die "
             f"Ausdehnung stammt. Eintrag: {eintrag!r}"
         )
-E       AssertionError: Der Protokoll-Eintrag muss `measurement_gaps` fuehren — sonst ist nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die Ausdehnung stammt. Eintrag: {'entity_id': 'tdd-2050-s4b-trip-08b973', 'entity_type': 'trip', 'sent_at': '2026-08-18T10:00:00+00:00', 'changes_count': 1, 'severity': 'MODERATE', 'metrics': [{'metric_id': 'precipitation', 'aggregation': 'sum'}], 'hazards': [], 'reason': 'nowcast', 'channels_sent': ['email'], 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', 'reason': 'channel_disabled'}, {'channel': 'premium_sms', 'reason': 'channel_disabled'}], 'lead_time_minutes': 10, 'event_at': '2026-08-18T10:10:00+00:00', 'event_end_at': '2026-08-18T10:40:00+00:00', 'measurement_point': {'segment_id': '1', 'km_from': 0.0, 'km_to': 23.996}, 'source': 'radar'}
-E       assert 'measurement_gaps' in {'changes_count': 1, 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', '...premium_sms', 'reason': 'channel_disabled'}], 'channels_sent': ['email'], 'entity_id': 'tdd-2050-s4b-trip-08b973', ...}
+E       AssertionError: Der Protokoll-Eintrag muss `measurement_gaps` fuehren — sonst ist nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die Ausdehnung stammt. Eintrag: {'entity_id': 'tdd-2050-s4b-trip-11170b', 'entity_type': 'trip', 'sent_at': '2026-08-18T10:00:00+00:00', 'changes_count': 1, 'severity': 'MODERATE', 'metrics': [{'metric_id': 'precipitation', 'aggregation': 'sum'}], 'hazards': [], 'reason': 'nowcast', 'channels_sent': ['email'], 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', 'reason': 'channel_disabled'}, {'channel': 'premium_sms', 'reason': 'channel_disabled'}], 'lead_time_minutes': 10, 'event_at': '2026-08-18T10:10:00+00:00', 'event_end_at': '2026-08-18T10:40:00+00:00', 'measurement_point': {'segment_id': '1', 'km_from': 0.0, 'km_to': 23.996}, 'source': 'radar'}
+E       assert 'measurement_gaps' in {'changes_count': 1, 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', '...premium_sms', 'reason': 'channel_disabled'}], 'channels_sent': ['email'], 'entity_id': 'tdd-2050-s4b-trip-11170b', ...}
 
-tests/tdd/test_radar_messluecken_protokoll.py:244: AssertionError
+tests/tdd/test_radar_messluecken_protokoll.py:293: AssertionError
 _________ test_ausfall_am_ersten_punkt_erzeugt_keine_ausdehnungszeile __________
 
     def test_ausfall_am_ersten_punkt_erzeugt_keine_ausdehnungszeile():
@@ -298,14 +298,14 @@ _________ test_ausfall_am_ersten_punkt_erzeugt_keine_ausdehnungszeile __________
 >           luecken = _pruefe_luecken(lauf_zweiter, radar_zweiter, punkte_erwartet=6)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-tests/tdd/test_radar_messluecken_protokoll.py:503: 
+tests/tdd/test_radar_messluecken_protokoll.py:552: 
 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
-tests/tdd/test_radar_messluecken_protokoll.py:286: in _pruefe_luecken
+tests/tdd/test_radar_messluecken_protokoll.py:335: in _pruefe_luecken
     luecken = _messluecken(lauf)
               ^^^^^^^^^^^^^^^^^^
 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
 
-lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-24 · ab 12:10 · letzter Regen gegen 12:40 · Na...5, 13.797641530778028, 15.79729972364441], uid='tdd-2050-s4b-ac8-zweiter-4ab01027', trip_id='tdd-2050-s4b-trip-f8ca8d')
+lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-24 · ab 12:10 · letzter Regen gegen 12:40 · Na...5, 13.797641530778028, 15.79729972364441], uid='tdd-2050-s4b-ac8-zweiter-8726eb9d', trip_id='tdd-2050-s4b-trip-72f497')
 
     def _messluecken(lauf: _Lauf) -> dict:
         eintrag = _versand_eintrag(lauf)
@@ -314,16 +314,16 @@ lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-2
             f"nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die "
             f"Ausdehnung stammt. Eintrag: {eintrag!r}"
         )
-E       AssertionError: Der Protokoll-Eintrag muss `measurement_gaps` fuehren — sonst ist nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die Ausdehnung stammt. Eintrag: {'entity_id': 'tdd-2050-s4b-trip-f8ca8d', 'entity_type': 'trip', 'sent_at': '2026-08-18T10:00:00+00:00', 'changes_count': 1, 'severity': 'MODERATE', 'metrics': [{'metric_id': 'precipitation', 'aggregation': 'sum'}], 'hazards': [], 'reason': 'nowcast', 'channels_sent': ['email'], 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', 'reason': 'channel_disabled'}, {'channel': 'premium_sms', 'reason': 'channel_disabled'}], 'lead_time_minutes': 10, 'event_at': '2026-08-18T10:10:00+00:00', 'event_end_at': '2026-08-18T10:40:00+00:00', 'measurement_point': {'segment_id': '1', 'km_from': 0.0, 'km_to': 23.996}, 'source': 'radar'}
-E       assert 'measurement_gaps' in {'changes_count': 1, 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', '...premium_sms', 'reason': 'channel_disabled'}], 'channels_sent': ['email'], 'entity_id': 'tdd-2050-s4b-trip-f8ca8d', ...}
+E       AssertionError: Der Protokoll-Eintrag muss `measurement_gaps` fuehren — sonst ist nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die Ausdehnung stammt. Eintrag: {'entity_id': 'tdd-2050-s4b-trip-72f497', 'entity_type': 'trip', 'sent_at': '2026-08-18T10:00:00+00:00', 'changes_count': 1, 'severity': 'MODERATE', 'metrics': [{'metric_id': 'precipitation', 'aggregation': 'sum'}], 'hazards': [], 'reason': 'nowcast', 'channels_sent': ['email'], 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', 'reason': 'channel_disabled'}, {'channel': 'premium_sms', 'reason': 'channel_disabled'}], 'lead_time_minutes': 10, 'event_at': '2026-08-18T10:10:00+00:00', 'event_end_at': '2026-08-18T10:40:00+00:00', 'measurement_point': {'segment_id': '1', 'km_from': 0.0, 'km_to': 23.996}, 'source': 'radar'}
+E       assert 'measurement_gaps' in {'changes_count': 1, 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', '...premium_sms', 'reason': 'channel_disabled'}], 'channels_sent': ['email'], 'entity_id': 'tdd-2050-s4b-trip-72f497', ...}
 
-tests/tdd/test_radar_messluecken_protokoll.py:244: AssertionError
+tests/tdd/test_radar_messluecken_protokoll.py:293: AssertionError
 ------------------------------ Captured log call -------------------------------
-ERROR    trip_alert:trip_alert.py:1673 Radar nowcast failed for trip tdd-2050-s4b-trip-762496: Nowcast-Abruf fuer Zonenpunkt 0 absichtlich fehlgeschlagen
-WARNING  trip_alert:trip_alert.py:1714 Radar alert: Nowcast fuer Zonenpunkt (47.0701, 11.0000) des Trips tdd-2050-s4b-trip-f8ca8d fehlgeschlagen (Nowcast-Abruf fuer Zonenpunkt 1 absichtlich fehlgeschlagen) — der Punkt faellt aus der Ausdehnung heraus, der Alarm laeuft weiter.
+ERROR    trip_alert:trip_alert.py:1673 Radar nowcast failed for trip tdd-2050-s4b-trip-2dd385: Nowcast-Abruf fuer Zonenpunkt 0 absichtlich fehlgeschlagen
+WARNING  trip_alert:trip_alert.py:1714 Radar alert: Nowcast fuer Zonenpunkt (47.0701, 11.0000) des Trips tdd-2050-s4b-trip-72f497 fehlgeschlagen (Nowcast-Abruf fuer Zonenpunkt 1 absichtlich fehlgeschlagen) — der Punkt faellt aus der Ausdehnung heraus, der Alarm laeuft weiter.
 __________ test_scheiternde_luecken_ableitung_kostet_den_alarm_nicht ___________
 
-monkeypatch = <_pytest.monkeypatch.MonkeyPatch object at 0x73d1cdf6cb60>
+monkeypatch = <_pytest.monkeypatch.MonkeyPatch object at 0x701c3b1b5160>
 
     def test_scheiternde_luecken_ableitung_kostet_den_alarm_nicht(monkeypatch):
         """AC-9 GIVEN die Ableitung von `measurement_gaps` scheitert / WHEN der
@@ -346,25 +346,34 @@ monkeypatch = <_pytest.monkeypatch.MonkeyPatch object at 0x73d1cdf6cb60>
         Praesenz-Pruefung fiele auf einen Eintrag herein, der die Groessen zwar
         fuehrt, aber mit anderen Zahlen.
     
-        `reference_at` ist die sechste E-1-Groesse und fehlt in DIESEM Aufbau
-        zurecht (kein Briefing-Schnappschuss -> `None` -> Absenz, `_apply_e1_fields`
-        schreibt sie dann gar nicht). Sie steht deshalb nicht in der Liste; die
-        Testvoraussetzung unten haelt fest, welche Groessen der Referenzlauf
-        wirklich fuehrt, damit die Pruefung nicht still leerlaeuft.
+        Beide Laeufe legen eigens einen Briefing-Schnappschuss an: ohne ihn bliebe
+        `reference_at` unbestimmbar (`None` -> Absenz, `_apply_e1_fields` schreibt
+        sie dann gar nicht) und die Zusicherung waere fuer die sechste Groesse
+        leer. Die Zeitreihe des Schnappschusses bleibt leer, damit die
+        Briefing-Unterdrueckung nicht greift und der Alarm durchlaeuft. Die
+        Testvoraussetzung unten haelt fest, dass der Referenzlauf wirklich ALLE
+        gepruefen Groessen fuehrt — sonst liefe der Vergleich still leer.
         """
         from services import trip_alert as trip_alert_mod
     
         # Referenzlauf ZUERST, mit identischem Aufbau und noch UNBERUEHRTER
         # Ableitung: er liefert die Sollwerte der bestehenden E-1-Groessen. Ein
         # Literal waere hier wertlos — die Werte haengen an Geometrie und Uhr.
-        referenz = _versand_eintrag(
-            _lauf(_LueckenRadar(luecken={2: {"data_unavailable": True}}), tag="ac9-ref")
-        )
+        referenz = _versand_eintrag(_lauf(
+            _LueckenRadar(luecken={2: {"data_unavailable": True}}), tag="ac9-ref",
+            vergleichsbasis_at=_VERGLEICHSBASIS_AT,
+        ))
         fehlend = [n for n in _E1_GROESSEN if n not in referenz]
         assert not fehlend, (
             f"Testvoraussetzung: der Referenzlauf muss alle gepruefen "
             f"E-1-Groessen fuehren, es fehlen {fehlend} — sonst prueft der "
             f"Vergleich unten nichts. Eintrag: {referenz!r}"
+        )
+        assert datetime.fromisoformat(referenz["reference_at"]) == _VERGLEICHSBASIS_AT, (
+            f"Testvoraussetzung: `reference_at` muss der Erhebungszeitpunkt des "
+            f"geschriebenen Schnappschusses sein ({_VERGLEICHSBASIS_AT.isoformat()}), "
+            f"war {referenz['reference_at']!r} — sonst misst der Vergleich unten "
+            f"einen Wert, den dieser Test gar nicht gesetzt hat."
         )
     
         def _explodiert(*args, **kwargs):
@@ -373,7 +382,7 @@ monkeypatch = <_pytest.monkeypatch.MonkeyPatch object at 0x73d1cdf6cb60>
 >       monkeypatch.setattr(trip_alert_mod, "_messluecken_felder", _explodiert)
 E       AttributeError: <module 'services.trip_alert' from '/home/hem/gregor_zwanzig/.claude/worktrees/ws-2050-s4b/src/services/trip_alert.py'> has no attribute '_messluecken_felder'
 
-tests/tdd/test_radar_messluecken_protokoll.py:560: AttributeError
+tests/tdd/test_radar_messluecken_protokoll.py:618: AttributeError
 _____________ test_zwei_nutzer_teilen_sich_keinen_luecken_eintrag ______________
 
     def test_zwei_nutzer_teilen_sich_keinen_luecken_eintrag():
@@ -395,14 +404,14 @@ _____________ test_zwei_nutzer_teilen_sich_keinen_luecken_eintrag ______________
 >       luecken_a = _pruefe_luecken(lauf_a, radar_a, punkte_erwartet=6)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-tests/tdd/test_radar_messluecken_protokoll.py:607: 
+tests/tdd/test_radar_messluecken_protokoll.py:668: 
 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
-tests/tdd/test_radar_messluecken_protokoll.py:286: in _pruefe_luecken
+tests/tdd/test_radar_messluecken_protokoll.py:335: in _pruefe_luecken
     luecken = _messluecken(lauf)
               ^^^^^^^^^^^^^^^^^^
 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
 
-lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-24 · ab 12:10 · letzter Regen gegen 12:40 · Na...791165, 13.797641530778028, 15.79729972364441], uid='tdd-2050-s4b-ac10-a-d1030da9', trip_id='tdd-2050-s4b-trip-3e2116')
+lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-24 · ab 12:10 · letzter Regen gegen 12:40 · Na...791165, 13.797641530778028, 15.79729972364441], uid='tdd-2050-s4b-ac10-a-a5e97a28', trip_id='tdd-2050-s4b-trip-d48533')
 
     def _messluecken(lauf: _Lauf) -> dict:
         eintrag = _versand_eintrag(lauf)
@@ -411,10 +420,10 @@ lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-2
             f"nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die "
             f"Ausdehnung stammt. Eintrag: {eintrag!r}"
         )
-E       AssertionError: Der Protokoll-Eintrag muss `measurement_gaps` fuehren — sonst ist nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die Ausdehnung stammt. Eintrag: {'entity_id': 'tdd-2050-s4b-trip-3e2116', 'entity_type': 'trip', 'sent_at': '2026-08-18T10:00:00+00:00', 'changes_count': 1, 'severity': 'MODERATE', 'metrics': [{'metric_id': 'precipitation', 'aggregation': 'sum'}], 'hazards': [], 'reason': 'nowcast', 'channels_sent': ['email'], 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', 'reason': 'channel_disabled'}, {'channel': 'premium_sms', 'reason': 'channel_disabled'}], 'lead_time_minutes': 10, 'event_at': '2026-08-18T10:10:00+00:00', 'event_end_at': '2026-08-18T10:40:00+00:00', 'measurement_point': {'segment_id': '1', 'km_from': 0.0, 'km_to': 23.996}, 'source': 'radar'}
-E       assert 'measurement_gaps' in {'changes_count': 1, 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', '...premium_sms', 'reason': 'channel_disabled'}], 'channels_sent': ['email'], 'entity_id': 'tdd-2050-s4b-trip-3e2116', ...}
+E       AssertionError: Der Protokoll-Eintrag muss `measurement_gaps` fuehren — sonst ist nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die Ausdehnung stammt. Eintrag: {'entity_id': 'tdd-2050-s4b-trip-d48533', 'entity_type': 'trip', 'sent_at': '2026-08-18T10:00:00+00:00', 'changes_count': 1, 'severity': 'MODERATE', 'metrics': [{'metric_id': 'precipitation', 'aggregation': 'sum'}], 'hazards': [], 'reason': 'nowcast', 'channels_sent': ['email'], 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', 'reason': 'channel_disabled'}, {'channel': 'premium_sms', 'reason': 'channel_disabled'}], 'lead_time_minutes': 10, 'event_at': '2026-08-18T10:10:00+00:00', 'event_end_at': '2026-08-18T10:40:00+00:00', 'measurement_point': {'segment_id': '1', 'km_from': 0.0, 'km_to': 23.996}, 'source': 'radar'}
+E       assert 'measurement_gaps' in {'changes_count': 1, 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', '...premium_sms', 'reason': 'channel_disabled'}], 'channels_sent': ['email'], 'entity_id': 'tdd-2050-s4b-trip-d48533', ...}
 
-tests/tdd/test_radar_messluecken_protokoll.py:244: AssertionError
+tests/tdd/test_radar_messluecken_protokoll.py:293: AssertionError
 __________ test_alteintrag_ohne_messluecken_feld_bleibt_unveraendert ___________
 
     def test_alteintrag_ohne_messluecken_feld_bleibt_unveraendert():
@@ -447,14 +456,14 @@ __________ test_alteintrag_ohne_messluecken_feld_bleibt_unveraendert ___________
         )
 >       _pruefe_luecken(lauf, radar, punkte_erwartet=6)
 
-tests/tdd/test_radar_messluecken_protokoll.py:657: 
+tests/tdd/test_radar_messluecken_protokoll.py:718: 
 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
-tests/tdd/test_radar_messluecken_protokoll.py:286: in _pruefe_luecken
+tests/tdd/test_radar_messluecken_protokoll.py:335: in _pruefe_luecken
     luecken = _messluecken(lauf)
               ^^^^^^^^^^^^^^^^^^
 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
 
-lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-24 · ab 12:10 · letzter Regen gegen 12:40 · Na...33791165, 13.797641530778028, 15.79729972364441], uid='tdd-2050-s4b-ac11-1e7c130e', trip_id='tdd-2050-s4b-trip-46dd9d')
+lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-24 · ab 12:10 · letzter Regen gegen 12:40 · Na...33791165, 13.797641530778028, 15.79729972364441], uid='tdd-2050-s4b-ac11-f2630f22', trip_id='tdd-2050-s4b-trip-6b1fc2')
 
     def _messluecken(lauf: _Lauf) -> dict:
         eintrag = _versand_eintrag(lauf)
@@ -463,10 +472,10 @@ lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-2
             f"nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die "
             f"Ausdehnung stammt. Eintrag: {eintrag!r}"
         )
-E       AssertionError: Der Protokoll-Eintrag muss `measurement_gaps` fuehren — sonst ist nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die Ausdehnung stammt. Eintrag: {'entity_id': 'tdd-2050-s4b-trip-46dd9d', 'entity_type': 'trip', 'sent_at': '2026-08-18T10:00:00+00:00', 'changes_count': 1, 'severity': 'MODERATE', 'metrics': [{'metric_id': 'precipitation', 'aggregation': 'sum'}], 'hazards': [], 'reason': 'nowcast', 'channels_sent': ['email'], 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', 'reason': 'channel_disabled'}, {'channel': 'premium_sms', 'reason': 'channel_disabled'}], 'lead_time_minutes': 10, 'event_at': '2026-08-18T10:10:00+00:00', 'event_end_at': '2026-08-18T10:40:00+00:00', 'measurement_point': {'segment_id': '1', 'km_from': 0.0, 'km_to': 23.996}, 'source': 'radar'}
-E       assert 'measurement_gaps' in {'changes_count': 1, 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', '...premium_sms', 'reason': 'channel_disabled'}], 'channels_sent': ['email'], 'entity_id': 'tdd-2050-s4b-trip-46dd9d', ...}
+E       AssertionError: Der Protokoll-Eintrag muss `measurement_gaps` fuehren — sonst ist nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die Ausdehnung stammt. Eintrag: {'entity_id': 'tdd-2050-s4b-trip-6b1fc2', 'entity_type': 'trip', 'sent_at': '2026-08-18T10:00:00+00:00', 'changes_count': 1, 'severity': 'MODERATE', 'metrics': [{'metric_id': 'precipitation', 'aggregation': 'sum'}], 'hazards': [], 'reason': 'nowcast', 'channels_sent': ['email'], 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', 'reason': 'channel_disabled'}, {'channel': 'premium_sms', 'reason': 'channel_disabled'}], 'lead_time_minutes': 10, 'event_at': '2026-08-18T10:10:00+00:00', 'event_end_at': '2026-08-18T10:40:00+00:00', 'measurement_point': {'segment_id': '1', 'km_from': 0.0, 'km_to': 23.996}, 'source': 'radar'}
+E       assert 'measurement_gaps' in {'changes_count': 1, 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', '...premium_sms', 'reason': 'channel_disabled'}], 'channels_sent': ['email'], 'entity_id': 'tdd-2050-s4b-trip-6b1fc2', ...}
 
-tests/tdd/test_radar_messluecken_protokoll.py:244: AssertionError
+tests/tdd/test_radar_messluecken_protokoll.py:293: AssertionError
 =========================== short test summary info ============================
 FAILED tests/tdd/test_radar_messluecken_protokoll.py::test_luecke_in_der_mitte_haelt_zahl_und_km_lage_fest
 FAILED tests/tdd/test_radar_messluecken_protokoll.py::test_alle_folgepunkte_ausgefallen_ist_der_extremfall
@@ -479,4 +488,4 @@ FAILED tests/tdd/test_radar_messluecken_protokoll.py::test_ausfall_am_ersten_pun
 FAILED tests/tdd/test_radar_messluecken_protokoll.py::test_scheiternde_luecken_ableitung_kostet_den_alarm_nicht
 FAILED tests/tdd/test_radar_messluecken_protokoll.py::test_zwei_nutzer_teilen_sich_keinen_luecken_eintrag
 FAILED tests/tdd/test_radar_messluecken_protokoll.py::test_alteintrag_ohne_messluecken_feld_bleibt_unveraendert
-============================== 11 failed in 1.36s ==============================
+============================== 11 failed in 1.38s ==============================

--- a/docs/artifacts/feat-2050-s4b-messluecken-protokoll/test-red-output.txt
+++ b/docs/artifacts/feat-2050-s4b-messluecken-protokoll/test-red-output.txt
@@ -28,14 +28,14 @@ _____________ test_luecke_in_der_mitte_haelt_zahl_und_km_lage_fest _____________
 >       luecken = _pruefe_luecken(lauf, radar, punkte_erwartet=3)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-tests/tdd/test_radar_messluecken_protokoll.py:310: 
+tests/tdd/test_radar_messluecken_protokoll.py:322: 
 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
-tests/tdd/test_radar_messluecken_protokoll.py:274: in _pruefe_luecken
+tests/tdd/test_radar_messluecken_protokoll.py:286: in _pruefe_luecken
     luecken = _messluecken(lauf)
               ^^^^^^^^^^^^^^^^^^
 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
 
-lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-7 · ab 12:10 · letzter Regen gegen 12:40 · Nas...999996884, 3.5949999999998226, 5.594999999999956], uid='tdd-2050-s4b-ac1-5f73556f', trip_id='tdd-2050-s4b-trip-620490')
+lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-7 · ab 12:10 · letzter Regen gegen 12:40 · Nas...999996884, 3.5949999999998226, 5.594999999999956], uid='tdd-2050-s4b-ac1-98305284', trip_id='tdd-2050-s4b-trip-ce10fb')
 
     def _messluecken(lauf: _Lauf) -> dict:
         eintrag = _versand_eintrag(lauf)
@@ -44,10 +44,10 @@ lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-7
             f"nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die "
             f"Ausdehnung stammt. Eintrag: {eintrag!r}"
         )
-E       AssertionError: Der Protokoll-Eintrag muss `measurement_gaps` fuehren — sonst ist nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die Ausdehnung stammt. Eintrag: {'entity_id': 'tdd-2050-s4b-trip-620490', 'entity_type': 'trip', 'sent_at': '2026-08-18T10:00:00+00:00', 'changes_count': 1, 'severity': 'MODERATE', 'metrics': [{'metric_id': 'precipitation', 'aggregation': 'sum'}], 'hazards': [], 'reason': 'nowcast', 'channels_sent': ['email'], 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', 'reason': 'channel_disabled'}, {'channel': 'premium_sms', 'reason': 'channel_disabled'}], 'lead_time_minutes': 10, 'event_at': '2026-08-18T10:10:00+00:00', 'event_end_at': '2026-08-18T10:40:00+00:00', 'measurement_point': {'segment_id': '1', 'km_from': 0.0, 'km_to': 6.6}, 'source': 'radar'}
-E       assert 'measurement_gaps' in {'changes_count': 1, 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', '...premium_sms', 'reason': 'channel_disabled'}], 'channels_sent': ['email'], 'entity_id': 'tdd-2050-s4b-trip-620490', ...}
+E       AssertionError: Der Protokoll-Eintrag muss `measurement_gaps` fuehren — sonst ist nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die Ausdehnung stammt. Eintrag: {'entity_id': 'tdd-2050-s4b-trip-ce10fb', 'entity_type': 'trip', 'sent_at': '2026-08-18T10:00:00+00:00', 'changes_count': 1, 'severity': 'MODERATE', 'metrics': [{'metric_id': 'precipitation', 'aggregation': 'sum'}], 'hazards': [], 'reason': 'nowcast', 'channels_sent': ['email'], 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', 'reason': 'channel_disabled'}, {'channel': 'premium_sms', 'reason': 'channel_disabled'}], 'lead_time_minutes': 10, 'event_at': '2026-08-18T10:10:00+00:00', 'event_end_at': '2026-08-18T10:40:00+00:00', 'measurement_point': {'segment_id': '1', 'km_from': 0.0, 'km_to': 6.6}, 'source': 'radar'}
+E       assert 'measurement_gaps' in {'changes_count': 1, 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', '...premium_sms', 'reason': 'channel_disabled'}], 'channels_sent': ['email'], 'entity_id': 'tdd-2050-s4b-trip-ce10fb', ...}
 
-tests/tdd/test_radar_messluecken_protokoll.py:232: AssertionError
+tests/tdd/test_radar_messluecken_protokoll.py:244: AssertionError
 _____________ test_alle_folgepunkte_ausgefallen_ist_der_extremfall _____________
 
     def test_alle_folgepunkte_ausgefallen_ist_der_extremfall():
@@ -61,14 +61,14 @@ _____________ test_alle_folgepunkte_ausgefallen_ist_der_extremfall _____________
 >       luecken = _pruefe_luecken(lauf, radar, punkte_erwartet=6)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-tests/tdd/test_radar_messluecken_protokoll.py:335: 
+tests/tdd/test_radar_messluecken_protokoll.py:347: 
 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
-tests/tdd/test_radar_messluecken_protokoll.py:274: in _pruefe_luecken
+tests/tdd/test_radar_messluecken_protokoll.py:286: in _pruefe_luecken
     luecken = _messluecken(lauf)
               ^^^^^^^^^^^^^^^^^^
 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
 
-lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-24 · ab 12:10 · letzter Regen gegen 12:40 · Na...333791165, 13.797641530778028, 15.79729972364441], uid='tdd-2050-s4b-ac2-5b4fea74', trip_id='tdd-2050-s4b-trip-9303cf')
+lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-24 · ab 12:10 · letzter Regen gegen 12:40 · Na...333791165, 13.797641530778028, 15.79729972364441], uid='tdd-2050-s4b-ac2-0f911f03', trip_id='tdd-2050-s4b-trip-69ea63')
 
     def _messluecken(lauf: _Lauf) -> dict:
         eintrag = _versand_eintrag(lauf)
@@ -77,10 +77,10 @@ lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-2
             f"nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die "
             f"Ausdehnung stammt. Eintrag: {eintrag!r}"
         )
-E       AssertionError: Der Protokoll-Eintrag muss `measurement_gaps` fuehren — sonst ist nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die Ausdehnung stammt. Eintrag: {'entity_id': 'tdd-2050-s4b-trip-9303cf', 'entity_type': 'trip', 'sent_at': '2026-08-18T10:00:00+00:00', 'changes_count': 1, 'severity': 'MODERATE', 'metrics': [{'metric_id': 'precipitation', 'aggregation': 'sum'}], 'hazards': [], 'reason': 'nowcast', 'channels_sent': ['email'], 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', 'reason': 'channel_disabled'}, {'channel': 'premium_sms', 'reason': 'channel_disabled'}], 'lead_time_minutes': 10, 'event_at': '2026-08-18T10:10:00+00:00', 'event_end_at': '2026-08-18T10:40:00+00:00', 'measurement_point': {'segment_id': '1', 'km_from': 0.0, 'km_to': 23.996}, 'source': 'radar'}
-E       assert 'measurement_gaps' in {'changes_count': 1, 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', '...premium_sms', 'reason': 'channel_disabled'}], 'channels_sent': ['email'], 'entity_id': 'tdd-2050-s4b-trip-9303cf', ...}
+E       AssertionError: Der Protokoll-Eintrag muss `measurement_gaps` fuehren — sonst ist nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die Ausdehnung stammt. Eintrag: {'entity_id': 'tdd-2050-s4b-trip-69ea63', 'entity_type': 'trip', 'sent_at': '2026-08-18T10:00:00+00:00', 'changes_count': 1, 'severity': 'MODERATE', 'metrics': [{'metric_id': 'precipitation', 'aggregation': 'sum'}], 'hazards': [], 'reason': 'nowcast', 'channels_sent': ['email'], 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', 'reason': 'channel_disabled'}, {'channel': 'premium_sms', 'reason': 'channel_disabled'}], 'lead_time_minutes': 10, 'event_at': '2026-08-18T10:10:00+00:00', 'event_end_at': '2026-08-18T10:40:00+00:00', 'measurement_point': {'segment_id': '1', 'km_from': 0.0, 'km_to': 23.996}, 'source': 'radar'}
+E       assert 'measurement_gaps' in {'changes_count': 1, 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', '...premium_sms', 'reason': 'channel_disabled'}], 'channels_sent': ['email'], 'entity_id': 'tdd-2050-s4b-trip-69ea63', ...}
 
-tests/tdd/test_radar_messluecken_protokoll.py:232: AssertionError
+tests/tdd/test_radar_messluecken_protokoll.py:244: AssertionError
 ______ test_echter_befund_ein_kilometer_ist_vom_extremfall_unterscheidbar ______
 
     def test_echter_befund_ein_kilometer_ist_vom_extremfall_unterscheidbar():
@@ -109,14 +109,14 @@ ______ test_echter_befund_ein_kilometer_ist_vom_extremfall_unterscheidbar ______
 >       luecken_echt = _pruefe_luecken(lauf_echt, echt, punkte_erwartet=6)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-tests/tdd/test_radar_messluecken_protokoll.py:366: 
+tests/tdd/test_radar_messluecken_protokoll.py:378: 
 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
-tests/tdd/test_radar_messluecken_protokoll.py:274: in _pruefe_luecken
+tests/tdd/test_radar_messluecken_protokoll.py:286: in _pruefe_luecken
     luecken = _messluecken(lauf)
               ^^^^^^^^^^^^^^^^^^
 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
 
-lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-24 · ab 12:10 · letzter Regen gegen 12:40 · Na...1165, 13.797641530778028, 15.79729972364441], uid='tdd-2050-s4b-ac3-echt-0e8a34fc', trip_id='tdd-2050-s4b-trip-c78afa')
+lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-24 · ab 12:10 · letzter Regen gegen 12:40 · Na...1165, 13.797641530778028, 15.79729972364441], uid='tdd-2050-s4b-ac3-echt-b1ccec85', trip_id='tdd-2050-s4b-trip-31d474')
 
     def _messluecken(lauf: _Lauf) -> dict:
         eintrag = _versand_eintrag(lauf)
@@ -125,10 +125,10 @@ lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-2
             f"nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die "
             f"Ausdehnung stammt. Eintrag: {eintrag!r}"
         )
-E       AssertionError: Der Protokoll-Eintrag muss `measurement_gaps` fuehren — sonst ist nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die Ausdehnung stammt. Eintrag: {'entity_id': 'tdd-2050-s4b-trip-c78afa', 'entity_type': 'trip', 'sent_at': '2026-08-18T10:00:00+00:00', 'changes_count': 1, 'severity': 'MODERATE', 'metrics': [{'metric_id': 'precipitation', 'aggregation': 'sum'}], 'hazards': [], 'reason': 'nowcast', 'channels_sent': ['email'], 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', 'reason': 'channel_disabled'}, {'channel': 'premium_sms', 'reason': 'channel_disabled'}], 'lead_time_minutes': 10, 'event_at': '2026-08-18T10:10:00+00:00', 'event_end_at': '2026-08-18T10:40:00+00:00', 'measurement_point': {'segment_id': '1', 'km_from': 0.0, 'km_to': 23.996}, 'source': 'radar'}
-E       assert 'measurement_gaps' in {'changes_count': 1, 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', '...premium_sms', 'reason': 'channel_disabled'}], 'channels_sent': ['email'], 'entity_id': 'tdd-2050-s4b-trip-c78afa', ...}
+E       AssertionError: Der Protokoll-Eintrag muss `measurement_gaps` fuehren — sonst ist nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die Ausdehnung stammt. Eintrag: {'entity_id': 'tdd-2050-s4b-trip-31d474', 'entity_type': 'trip', 'sent_at': '2026-08-18T10:00:00+00:00', 'changes_count': 1, 'severity': 'MODERATE', 'metrics': [{'metric_id': 'precipitation', 'aggregation': 'sum'}], 'hazards': [], 'reason': 'nowcast', 'channels_sent': ['email'], 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', 'reason': 'channel_disabled'}, {'channel': 'premium_sms', 'reason': 'channel_disabled'}], 'lead_time_minutes': 10, 'event_at': '2026-08-18T10:10:00+00:00', 'event_end_at': '2026-08-18T10:40:00+00:00', 'measurement_point': {'segment_id': '1', 'km_from': 0.0, 'km_to': 23.996}, 'source': 'radar'}
+E       assert 'measurement_gaps' in {'changes_count': 1, 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', '...premium_sms', 'reason': 'channel_disabled'}], 'channels_sent': ['email'], 'entity_id': 'tdd-2050-s4b-trip-31d474', ...}
 
-tests/tdd/test_radar_messluecken_protokoll.py:232: AssertionError
+tests/tdd/test_radar_messluecken_protokoll.py:244: AssertionError
 _______________ test_luecken_feld_ist_auch_ohne_luecke_vorhanden _______________
 
     def test_luecken_feld_ist_auch_ohne_luecke_vorhanden():
@@ -145,14 +145,14 @@ _______________ test_luecken_feld_ist_auch_ohne_luecke_vorhanden _______________
 >       luecken_ohne = _pruefe_luecken(lauf_ohne, ohne, punkte_erwartet=6)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-tests/tdd/test_radar_messluecken_protokoll.py:400: 
+tests/tdd/test_radar_messluecken_protokoll.py:412: 
 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
-tests/tdd/test_radar_messluecken_protokoll.py:274: in _pruefe_luecken
+tests/tdd/test_radar_messluecken_protokoll.py:286: in _pruefe_luecken
     luecken = _messluecken(lauf)
               ^^^^^^^^^^^^^^^^^^
 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
 
-lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-24 · ab 12:10 · letzter Regen gegen 12:40 · Na...1165, 13.797641530778028, 15.79729972364441], uid='tdd-2050-s4b-ac4-ohne-ff611c84', trip_id='tdd-2050-s4b-trip-23328f')
+lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-24 · ab 12:10 · letzter Regen gegen 12:40 · Na...1165, 13.797641530778028, 15.79729972364441], uid='tdd-2050-s4b-ac4-ohne-effef469', trip_id='tdd-2050-s4b-trip-e43df5')
 
     def _messluecken(lauf: _Lauf) -> dict:
         eintrag = _versand_eintrag(lauf)
@@ -161,10 +161,10 @@ lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-2
             f"nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die "
             f"Ausdehnung stammt. Eintrag: {eintrag!r}"
         )
-E       AssertionError: Der Protokoll-Eintrag muss `measurement_gaps` fuehren — sonst ist nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die Ausdehnung stammt. Eintrag: {'entity_id': 'tdd-2050-s4b-trip-23328f', 'entity_type': 'trip', 'sent_at': '2026-08-18T10:00:00+00:00', 'changes_count': 1, 'severity': 'MODERATE', 'metrics': [{'metric_id': 'precipitation', 'aggregation': 'sum'}], 'hazards': [], 'reason': 'nowcast', 'channels_sent': ['email'], 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', 'reason': 'channel_disabled'}, {'channel': 'premium_sms', 'reason': 'channel_disabled'}], 'lead_time_minutes': 10, 'event_at': '2026-08-18T10:10:00+00:00', 'event_end_at': '2026-08-18T10:40:00+00:00', 'measurement_point': {'segment_id': '1', 'km_from': 0.0, 'km_to': 23.996}, 'source': 'radar'}
-E       assert 'measurement_gaps' in {'changes_count': 1, 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', '...premium_sms', 'reason': 'channel_disabled'}], 'channels_sent': ['email'], 'entity_id': 'tdd-2050-s4b-trip-23328f', ...}
+E       AssertionError: Der Protokoll-Eintrag muss `measurement_gaps` fuehren — sonst ist nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die Ausdehnung stammt. Eintrag: {'entity_id': 'tdd-2050-s4b-trip-e43df5', 'entity_type': 'trip', 'sent_at': '2026-08-18T10:00:00+00:00', 'changes_count': 1, 'severity': 'MODERATE', 'metrics': [{'metric_id': 'precipitation', 'aggregation': 'sum'}], 'hazards': [], 'reason': 'nowcast', 'channels_sent': ['email'], 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', 'reason': 'channel_disabled'}, {'channel': 'premium_sms', 'reason': 'channel_disabled'}], 'lead_time_minutes': 10, 'event_at': '2026-08-18T10:10:00+00:00', 'event_end_at': '2026-08-18T10:40:00+00:00', 'measurement_point': {'segment_id': '1', 'km_from': 0.0, 'km_to': 23.996}, 'source': 'radar'}
+E       assert 'measurement_gaps' in {'changes_count': 1, 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', '...premium_sms', 'reason': 'channel_disabled'}], 'channels_sent': ['email'], 'entity_id': 'tdd-2050-s4b-trip-e43df5', ...}
 
-tests/tdd/test_radar_messluecken_protokoll.py:232: AssertionError
+tests/tdd/test_radar_messluecken_protokoll.py:244: AssertionError
 _________________ test_geworfene_ausnahme_erscheint_als_luecke _________________
 
     def test_geworfene_ausnahme_erscheint_als_luecke():
@@ -174,14 +174,14 @@ _________________ test_geworfene_ausnahme_erscheint_als_luecke _________________
         lauf = _lauf(radar, tag="ac5")
 >       _pruefe_luecken(lauf, radar, punkte_erwartet=6)
 
-tests/tdd/test_radar_messluecken_protokoll.py:428: 
+tests/tdd/test_radar_messluecken_protokoll.py:440: 
 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
-tests/tdd/test_radar_messluecken_protokoll.py:274: in _pruefe_luecken
+tests/tdd/test_radar_messluecken_protokoll.py:286: in _pruefe_luecken
     luecken = _messluecken(lauf)
               ^^^^^^^^^^^^^^^^^^
 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
 
-lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-24 · ab 12:10 · letzter Regen gegen 12:40 · Na...333791165, 13.797641530778028, 15.79729972364441], uid='tdd-2050-s4b-ac5-f0e5c274', trip_id='tdd-2050-s4b-trip-4426a3')
+lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-24 · ab 12:10 · letzter Regen gegen 12:40 · Na...333791165, 13.797641530778028, 15.79729972364441], uid='tdd-2050-s4b-ac5-5b14c066', trip_id='tdd-2050-s4b-trip-b34235')
 
     def _messluecken(lauf: _Lauf) -> dict:
         eintrag = _versand_eintrag(lauf)
@@ -190,12 +190,12 @@ lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-2
             f"nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die "
             f"Ausdehnung stammt. Eintrag: {eintrag!r}"
         )
-E       AssertionError: Der Protokoll-Eintrag muss `measurement_gaps` fuehren — sonst ist nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die Ausdehnung stammt. Eintrag: {'entity_id': 'tdd-2050-s4b-trip-4426a3', 'entity_type': 'trip', 'sent_at': '2026-08-18T10:00:00+00:00', 'changes_count': 1, 'severity': 'MODERATE', 'metrics': [{'metric_id': 'precipitation', 'aggregation': 'sum'}], 'hazards': [], 'reason': 'nowcast', 'channels_sent': ['email'], 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', 'reason': 'channel_disabled'}, {'channel': 'premium_sms', 'reason': 'channel_disabled'}], 'lead_time_minutes': 10, 'event_at': '2026-08-18T10:10:00+00:00', 'event_end_at': '2026-08-18T10:40:00+00:00', 'measurement_point': {'segment_id': '1', 'km_from': 0.0, 'km_to': 23.996}, 'source': 'radar'}
-E       assert 'measurement_gaps' in {'changes_count': 1, 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', '...premium_sms', 'reason': 'channel_disabled'}], 'channels_sent': ['email'], 'entity_id': 'tdd-2050-s4b-trip-4426a3', ...}
+E       AssertionError: Der Protokoll-Eintrag muss `measurement_gaps` fuehren — sonst ist nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die Ausdehnung stammt. Eintrag: {'entity_id': 'tdd-2050-s4b-trip-b34235', 'entity_type': 'trip', 'sent_at': '2026-08-18T10:00:00+00:00', 'changes_count': 1, 'severity': 'MODERATE', 'metrics': [{'metric_id': 'precipitation', 'aggregation': 'sum'}], 'hazards': [], 'reason': 'nowcast', 'channels_sent': ['email'], 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', 'reason': 'channel_disabled'}, {'channel': 'premium_sms', 'reason': 'channel_disabled'}], 'lead_time_minutes': 10, 'event_at': '2026-08-18T10:10:00+00:00', 'event_end_at': '2026-08-18T10:40:00+00:00', 'measurement_point': {'segment_id': '1', 'km_from': 0.0, 'km_to': 23.996}, 'source': 'radar'}
+E       assert 'measurement_gaps' in {'changes_count': 1, 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', '...premium_sms', 'reason': 'channel_disabled'}], 'channels_sent': ['email'], 'entity_id': 'tdd-2050-s4b-trip-b34235', ...}
 
-tests/tdd/test_radar_messluecken_protokoll.py:232: AssertionError
+tests/tdd/test_radar_messluecken_protokoll.py:244: AssertionError
 ------------------------------ Captured log call -------------------------------
-WARNING  trip_alert:trip_alert.py:1714 Radar alert: Nowcast fuer Zonenpunkt (47.0881, 11.0000) des Trips tdd-2050-s4b-trip-4426a3 fehlgeschlagen (Nowcast-Abruf fuer Zonenpunkt 2 absichtlich fehlgeschlagen) — der Punkt faellt aus der Ausdehnung heraus, der Alarm laeuft weiter.
+WARNING  trip_alert:trip_alert.py:1714 Radar alert: Nowcast fuer Zonenpunkt (47.0881, 11.0000) des Trips tdd-2050-s4b-trip-b34235 fehlgeschlagen (Nowcast-Abruf fuer Zonenpunkt 2 absichtlich fehlgeschlagen) — der Punkt faellt aus der Ausdehnung heraus, der Alarm laeuft weiter.
 _____________________ test_throttled_erscheint_als_luecke ______________________
 
     def test_throttled_erscheint_als_luecke():
@@ -206,14 +206,14 @@ _____________________ test_throttled_erscheint_als_luecke ______________________
         lauf = _lauf(radar, tag="ac6")
 >       _pruefe_luecken(lauf, radar, punkte_erwartet=6)
 
-tests/tdd/test_radar_messluecken_protokoll.py:437: 
+tests/tdd/test_radar_messluecken_protokoll.py:449: 
 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
-tests/tdd/test_radar_messluecken_protokoll.py:274: in _pruefe_luecken
+tests/tdd/test_radar_messluecken_protokoll.py:286: in _pruefe_luecken
     luecken = _messluecken(lauf)
               ^^^^^^^^^^^^^^^^^^
 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
 
-lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-24 · ab 12:10 · letzter Regen gegen 12:40 · Na...333791165, 13.797641530778028, 15.79729972364441], uid='tdd-2050-s4b-ac6-c3794531', trip_id='tdd-2050-s4b-trip-d9d734')
+lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-24 · ab 12:10 · letzter Regen gegen 12:40 · Na...333791165, 13.797641530778028, 15.79729972364441], uid='tdd-2050-s4b-ac6-f2cbb5da', trip_id='tdd-2050-s4b-trip-845857')
 
     def _messluecken(lauf: _Lauf) -> dict:
         eintrag = _versand_eintrag(lauf)
@@ -222,10 +222,10 @@ lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-2
             f"nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die "
             f"Ausdehnung stammt. Eintrag: {eintrag!r}"
         )
-E       AssertionError: Der Protokoll-Eintrag muss `measurement_gaps` fuehren — sonst ist nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die Ausdehnung stammt. Eintrag: {'entity_id': 'tdd-2050-s4b-trip-d9d734', 'entity_type': 'trip', 'sent_at': '2026-08-18T10:00:00+00:00', 'changes_count': 1, 'severity': 'MODERATE', 'metrics': [{'metric_id': 'precipitation', 'aggregation': 'sum'}], 'hazards': [], 'reason': 'nowcast', 'channels_sent': ['email'], 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', 'reason': 'channel_disabled'}, {'channel': 'premium_sms', 'reason': 'channel_disabled'}], 'lead_time_minutes': 10, 'event_at': '2026-08-18T10:10:00+00:00', 'event_end_at': '2026-08-18T10:40:00+00:00', 'measurement_point': {'segment_id': '1', 'km_from': 0.0, 'km_to': 23.996}, 'source': 'radar'}
-E       assert 'measurement_gaps' in {'changes_count': 1, 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', '...premium_sms', 'reason': 'channel_disabled'}], 'channels_sent': ['email'], 'entity_id': 'tdd-2050-s4b-trip-d9d734', ...}
+E       AssertionError: Der Protokoll-Eintrag muss `measurement_gaps` fuehren — sonst ist nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die Ausdehnung stammt. Eintrag: {'entity_id': 'tdd-2050-s4b-trip-845857', 'entity_type': 'trip', 'sent_at': '2026-08-18T10:00:00+00:00', 'changes_count': 1, 'severity': 'MODERATE', 'metrics': [{'metric_id': 'precipitation', 'aggregation': 'sum'}], 'hazards': [], 'reason': 'nowcast', 'channels_sent': ['email'], 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', 'reason': 'channel_disabled'}, {'channel': 'premium_sms', 'reason': 'channel_disabled'}], 'lead_time_minutes': 10, 'event_at': '2026-08-18T10:10:00+00:00', 'event_end_at': '2026-08-18T10:40:00+00:00', 'measurement_point': {'segment_id': '1', 'km_from': 0.0, 'km_to': 23.996}, 'source': 'radar'}
+E       assert 'measurement_gaps' in {'changes_count': 1, 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', '...premium_sms', 'reason': 'channel_disabled'}], 'channels_sent': ['email'], 'entity_id': 'tdd-2050-s4b-trip-845857', ...}
 
-tests/tdd/test_radar_messluecken_protokoll.py:232: AssertionError
+tests/tdd/test_radar_messluecken_protokoll.py:244: AssertionError
 __________________ test_data_unavailable_erscheint_als_luecke __________________
 
     def test_data_unavailable_erscheint_als_luecke():
@@ -236,14 +236,14 @@ __________________ test_data_unavailable_erscheint_als_luecke __________________
         lauf = _lauf(radar, tag="ac7")
 >       _pruefe_luecken(lauf, radar, punkte_erwartet=6)
 
-tests/tdd/test_radar_messluecken_protokoll.py:446: 
+tests/tdd/test_radar_messluecken_protokoll.py:458: 
 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
-tests/tdd/test_radar_messluecken_protokoll.py:274: in _pruefe_luecken
+tests/tdd/test_radar_messluecken_protokoll.py:286: in _pruefe_luecken
     luecken = _messluecken(lauf)
               ^^^^^^^^^^^^^^^^^^
 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
 
-lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-24 · ab 12:10 · letzter Regen gegen 12:40 · Na...333791165, 13.797641530778028, 15.79729972364441], uid='tdd-2050-s4b-ac7-795b5703', trip_id='tdd-2050-s4b-trip-5b7ed3')
+lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-24 · ab 12:10 · letzter Regen gegen 12:40 · Na...333791165, 13.797641530778028, 15.79729972364441], uid='tdd-2050-s4b-ac7-ecdc7aa5', trip_id='tdd-2050-s4b-trip-08b973')
 
     def _messluecken(lauf: _Lauf) -> dict:
         eintrag = _versand_eintrag(lauf)
@@ -252,10 +252,10 @@ lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-2
             f"nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die "
             f"Ausdehnung stammt. Eintrag: {eintrag!r}"
         )
-E       AssertionError: Der Protokoll-Eintrag muss `measurement_gaps` fuehren — sonst ist nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die Ausdehnung stammt. Eintrag: {'entity_id': 'tdd-2050-s4b-trip-5b7ed3', 'entity_type': 'trip', 'sent_at': '2026-08-18T10:00:00+00:00', 'changes_count': 1, 'severity': 'MODERATE', 'metrics': [{'metric_id': 'precipitation', 'aggregation': 'sum'}], 'hazards': [], 'reason': 'nowcast', 'channels_sent': ['email'], 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', 'reason': 'channel_disabled'}, {'channel': 'premium_sms', 'reason': 'channel_disabled'}], 'lead_time_minutes': 10, 'event_at': '2026-08-18T10:10:00+00:00', 'event_end_at': '2026-08-18T10:40:00+00:00', 'measurement_point': {'segment_id': '1', 'km_from': 0.0, 'km_to': 23.996}, 'source': 'radar'}
-E       assert 'measurement_gaps' in {'changes_count': 1, 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', '...premium_sms', 'reason': 'channel_disabled'}], 'channels_sent': ['email'], 'entity_id': 'tdd-2050-s4b-trip-5b7ed3', ...}
+E       AssertionError: Der Protokoll-Eintrag muss `measurement_gaps` fuehren — sonst ist nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die Ausdehnung stammt. Eintrag: {'entity_id': 'tdd-2050-s4b-trip-08b973', 'entity_type': 'trip', 'sent_at': '2026-08-18T10:00:00+00:00', 'changes_count': 1, 'severity': 'MODERATE', 'metrics': [{'metric_id': 'precipitation', 'aggregation': 'sum'}], 'hazards': [], 'reason': 'nowcast', 'channels_sent': ['email'], 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', 'reason': 'channel_disabled'}, {'channel': 'premium_sms', 'reason': 'channel_disabled'}], 'lead_time_minutes': 10, 'event_at': '2026-08-18T10:10:00+00:00', 'event_end_at': '2026-08-18T10:40:00+00:00', 'measurement_point': {'segment_id': '1', 'km_from': 0.0, 'km_to': 23.996}, 'source': 'radar'}
+E       assert 'measurement_gaps' in {'changes_count': 1, 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', '...premium_sms', 'reason': 'channel_disabled'}], 'channels_sent': ['email'], 'entity_id': 'tdd-2050-s4b-trip-08b973', ...}
 
-tests/tdd/test_radar_messluecken_protokoll.py:232: AssertionError
+tests/tdd/test_radar_messluecken_protokoll.py:244: AssertionError
 _________ test_ausfall_am_ersten_punkt_erzeugt_keine_ausdehnungszeile __________
 
     def test_ausfall_am_ersten_punkt_erzeugt_keine_ausdehnungszeile():
@@ -298,14 +298,14 @@ _________ test_ausfall_am_ersten_punkt_erzeugt_keine_ausdehnungszeile __________
 >           luecken = _pruefe_luecken(lauf_zweiter, radar_zweiter, punkte_erwartet=6)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-tests/tdd/test_radar_messluecken_protokoll.py:491: 
+tests/tdd/test_radar_messluecken_protokoll.py:503: 
 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
-tests/tdd/test_radar_messluecken_protokoll.py:274: in _pruefe_luecken
+tests/tdd/test_radar_messluecken_protokoll.py:286: in _pruefe_luecken
     luecken = _messluecken(lauf)
               ^^^^^^^^^^^^^^^^^^
 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
 
-lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-24 · ab 12:10 · letzter Regen gegen 12:40 · Na...5, 13.797641530778028, 15.79729972364441], uid='tdd-2050-s4b-ac8-zweiter-8f0f2b9d', trip_id='tdd-2050-s4b-trip-652ceb')
+lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-24 · ab 12:10 · letzter Regen gegen 12:40 · Na...5, 13.797641530778028, 15.79729972364441], uid='tdd-2050-s4b-ac8-zweiter-4ab01027', trip_id='tdd-2050-s4b-trip-f8ca8d')
 
     def _messluecken(lauf: _Lauf) -> dict:
         eintrag = _versand_eintrag(lauf)
@@ -314,35 +314,58 @@ lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-2
             f"nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die "
             f"Ausdehnung stammt. Eintrag: {eintrag!r}"
         )
-E       AssertionError: Der Protokoll-Eintrag muss `measurement_gaps` fuehren — sonst ist nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die Ausdehnung stammt. Eintrag: {'entity_id': 'tdd-2050-s4b-trip-652ceb', 'entity_type': 'trip', 'sent_at': '2026-08-18T10:00:00+00:00', 'changes_count': 1, 'severity': 'MODERATE', 'metrics': [{'metric_id': 'precipitation', 'aggregation': 'sum'}], 'hazards': [], 'reason': 'nowcast', 'channels_sent': ['email'], 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', 'reason': 'channel_disabled'}, {'channel': 'premium_sms', 'reason': 'channel_disabled'}], 'lead_time_minutes': 10, 'event_at': '2026-08-18T10:10:00+00:00', 'event_end_at': '2026-08-18T10:40:00+00:00', 'measurement_point': {'segment_id': '1', 'km_from': 0.0, 'km_to': 23.996}, 'source': 'radar'}
-E       assert 'measurement_gaps' in {'changes_count': 1, 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', '...premium_sms', 'reason': 'channel_disabled'}], 'channels_sent': ['email'], 'entity_id': 'tdd-2050-s4b-trip-652ceb', ...}
+E       AssertionError: Der Protokoll-Eintrag muss `measurement_gaps` fuehren — sonst ist nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die Ausdehnung stammt. Eintrag: {'entity_id': 'tdd-2050-s4b-trip-f8ca8d', 'entity_type': 'trip', 'sent_at': '2026-08-18T10:00:00+00:00', 'changes_count': 1, 'severity': 'MODERATE', 'metrics': [{'metric_id': 'precipitation', 'aggregation': 'sum'}], 'hazards': [], 'reason': 'nowcast', 'channels_sent': ['email'], 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', 'reason': 'channel_disabled'}, {'channel': 'premium_sms', 'reason': 'channel_disabled'}], 'lead_time_minutes': 10, 'event_at': '2026-08-18T10:10:00+00:00', 'event_end_at': '2026-08-18T10:40:00+00:00', 'measurement_point': {'segment_id': '1', 'km_from': 0.0, 'km_to': 23.996}, 'source': 'radar'}
+E       assert 'measurement_gaps' in {'changes_count': 1, 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', '...premium_sms', 'reason': 'channel_disabled'}], 'channels_sent': ['email'], 'entity_id': 'tdd-2050-s4b-trip-f8ca8d', ...}
 
-tests/tdd/test_radar_messluecken_protokoll.py:232: AssertionError
+tests/tdd/test_radar_messluecken_protokoll.py:244: AssertionError
 ------------------------------ Captured log call -------------------------------
-ERROR    trip_alert:trip_alert.py:1673 Radar nowcast failed for trip tdd-2050-s4b-trip-825ebc: Nowcast-Abruf fuer Zonenpunkt 0 absichtlich fehlgeschlagen
-WARNING  trip_alert:trip_alert.py:1714 Radar alert: Nowcast fuer Zonenpunkt (47.0701, 11.0000) des Trips tdd-2050-s4b-trip-652ceb fehlgeschlagen (Nowcast-Abruf fuer Zonenpunkt 1 absichtlich fehlgeschlagen) — der Punkt faellt aus der Ausdehnung heraus, der Alarm laeuft weiter.
+ERROR    trip_alert:trip_alert.py:1673 Radar nowcast failed for trip tdd-2050-s4b-trip-762496: Nowcast-Abruf fuer Zonenpunkt 0 absichtlich fehlgeschlagen
+WARNING  trip_alert:trip_alert.py:1714 Radar alert: Nowcast fuer Zonenpunkt (47.0701, 11.0000) des Trips tdd-2050-s4b-trip-f8ca8d fehlgeschlagen (Nowcast-Abruf fuer Zonenpunkt 1 absichtlich fehlgeschlagen) — der Punkt faellt aus der Ausdehnung heraus, der Alarm laeuft weiter.
 __________ test_scheiternde_luecken_ableitung_kostet_den_alarm_nicht ___________
 
-monkeypatch = <_pytest.monkeypatch.MonkeyPatch object at 0x72898e910c50>
+monkeypatch = <_pytest.monkeypatch.MonkeyPatch object at 0x73d1cdf6cb60>
 
     def test_scheiternde_luecken_ableitung_kostet_den_alarm_nicht(monkeypatch):
         """AC-9 GIVEN die Ableitung von `measurement_gaps` scheitert / WHEN der
         Radar-Alarmpfad laeuft / THEN wird der Alarm trotzdem versendet und
-        protokolliert, nur ohne das Feld.
+        protokolliert — NUR ohne dieses eine Feld.
     
         Der Fehler wird an der ABLEITUNG selbst ausgeloest (`_messluecken_felder`),
         nicht an `_radar_e1_fields` als Ganzem — sonst pruefte der Test die
-        bestehende Absicherung der fuenf E-1-Groessen aus #2050 S6 statt der neuen
+        bestehende Absicherung der E-1-Groessen aus #2050 S6 statt der neuen
         Ableitung.
     
-        Bewusst NICHT mitgeprueft: ob die uebrigen E-1-Groessen den Fehlschlag
-        ueberleben. Die Spec sagt an einer Stelle "nur ohne `measurement_gaps`"
-        (das verlangt einen eigenen Auffang) und an anderer "innerhalb des
-        bestehenden `try`-Blocks" (dann fielen alle fuenf mit weg). AC-9 im
-        Wortlaut fordert nur, dass Alarm und Eintrag entstehen — genau das steht
-        hier.
+        Kern der Zusicherung ist die zweite Haelfte: die BESTEHENDEN E-1-Groessen
+        muessen den Fehlschlag ueberleben. Liegt die neue Ableitung im gemeinsamen
+        `try` von `_radar_e1_fields()`, gibt die Funktion `{}` zurueck und reisst
+        alle fuenf mit — ein Fehler in der nachrangigen Luecken-Buchfuehrung
+        loeschte dann Messpunkt, Ereigniszeit und Quelle aus dem Eintrag. Das waere
+        eine Regression gegen #2050 S6, also schlechter als der Stand vor dieser
+        Scheibe. Geprueft wird deshalb namentlich und am WERT (gegen einen
+        Referenzlauf mit identischem Aufbau), nicht als Sammelaussage: eine reine
+        Praesenz-Pruefung fiele auf einen Eintrag herein, der die Groessen zwar
+        fuehrt, aber mit anderen Zahlen.
+    
+        `reference_at` ist die sechste E-1-Groesse und fehlt in DIESEM Aufbau
+        zurecht (kein Briefing-Schnappschuss -> `None` -> Absenz, `_apply_e1_fields`
+        schreibt sie dann gar nicht). Sie steht deshalb nicht in der Liste; die
+        Testvoraussetzung unten haelt fest, welche Groessen der Referenzlauf
+        wirklich fuehrt, damit die Pruefung nicht still leerlaeuft.
         """
         from services import trip_alert as trip_alert_mod
+    
+        # Referenzlauf ZUERST, mit identischem Aufbau und noch UNBERUEHRTER
+        # Ableitung: er liefert die Sollwerte der bestehenden E-1-Groessen. Ein
+        # Literal waere hier wertlos — die Werte haengen an Geometrie und Uhr.
+        referenz = _versand_eintrag(
+            _lauf(_LueckenRadar(luecken={2: {"data_unavailable": True}}), tag="ac9-ref")
+        )
+        fehlend = [n for n in _E1_GROESSEN if n not in referenz]
+        assert not fehlend, (
+            f"Testvoraussetzung: der Referenzlauf muss alle gepruefen "
+            f"E-1-Groessen fuehren, es fehlen {fehlend} — sonst prueft der "
+            f"Vergleich unten nichts. Eintrag: {referenz!r}"
+        )
     
         def _explodiert(*args, **kwargs):
             raise ValueError("absichtlich unerwartete Datenform")
@@ -350,7 +373,7 @@ monkeypatch = <_pytest.monkeypatch.MonkeyPatch object at 0x72898e910c50>
 >       monkeypatch.setattr(trip_alert_mod, "_messluecken_felder", _explodiert)
 E       AttributeError: <module 'services.trip_alert' from '/home/hem/gregor_zwanzig/.claude/worktrees/ws-2050-s4b/src/services/trip_alert.py'> has no attribute '_messluecken_felder'
 
-tests/tdd/test_radar_messluecken_protokoll.py:525: AttributeError
+tests/tdd/test_radar_messluecken_protokoll.py:560: AttributeError
 _____________ test_zwei_nutzer_teilen_sich_keinen_luecken_eintrag ______________
 
     def test_zwei_nutzer_teilen_sich_keinen_luecken_eintrag():
@@ -372,14 +395,14 @@ _____________ test_zwei_nutzer_teilen_sich_keinen_luecken_eintrag ______________
 >       luecken_a = _pruefe_luecken(lauf_a, radar_a, punkte_erwartet=6)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-tests/tdd/test_radar_messluecken_protokoll.py:560: 
+tests/tdd/test_radar_messluecken_protokoll.py:607: 
 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
-tests/tdd/test_radar_messluecken_protokoll.py:274: in _pruefe_luecken
+tests/tdd/test_radar_messluecken_protokoll.py:286: in _pruefe_luecken
     luecken = _messluecken(lauf)
               ^^^^^^^^^^^^^^^^^^
 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
 
-lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-24 · ab 12:10 · letzter Regen gegen 12:40 · Na...791165, 13.797641530778028, 15.79729972364441], uid='tdd-2050-s4b-ac10-a-7849898d', trip_id='tdd-2050-s4b-trip-3d9b0b')
+lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-24 · ab 12:10 · letzter Regen gegen 12:40 · Na...791165, 13.797641530778028, 15.79729972364441], uid='tdd-2050-s4b-ac10-a-d1030da9', trip_id='tdd-2050-s4b-trip-3e2116')
 
     def _messluecken(lauf: _Lauf) -> dict:
         eintrag = _versand_eintrag(lauf)
@@ -388,10 +411,10 @@ lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-2
             f"nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die "
             f"Ausdehnung stammt. Eintrag: {eintrag!r}"
         )
-E       AssertionError: Der Protokoll-Eintrag muss `measurement_gaps` fuehren — sonst ist nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die Ausdehnung stammt. Eintrag: {'entity_id': 'tdd-2050-s4b-trip-3d9b0b', 'entity_type': 'trip', 'sent_at': '2026-08-18T10:00:00+00:00', 'changes_count': 1, 'severity': 'MODERATE', 'metrics': [{'metric_id': 'precipitation', 'aggregation': 'sum'}], 'hazards': [], 'reason': 'nowcast', 'channels_sent': ['email'], 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', 'reason': 'channel_disabled'}, {'channel': 'premium_sms', 'reason': 'channel_disabled'}], 'lead_time_minutes': 10, 'event_at': '2026-08-18T10:10:00+00:00', 'event_end_at': '2026-08-18T10:40:00+00:00', 'measurement_point': {'segment_id': '1', 'km_from': 0.0, 'km_to': 23.996}, 'source': 'radar'}
-E       assert 'measurement_gaps' in {'changes_count': 1, 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', '...premium_sms', 'reason': 'channel_disabled'}], 'channels_sent': ['email'], 'entity_id': 'tdd-2050-s4b-trip-3d9b0b', ...}
+E       AssertionError: Der Protokoll-Eintrag muss `measurement_gaps` fuehren — sonst ist nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die Ausdehnung stammt. Eintrag: {'entity_id': 'tdd-2050-s4b-trip-3e2116', 'entity_type': 'trip', 'sent_at': '2026-08-18T10:00:00+00:00', 'changes_count': 1, 'severity': 'MODERATE', 'metrics': [{'metric_id': 'precipitation', 'aggregation': 'sum'}], 'hazards': [], 'reason': 'nowcast', 'channels_sent': ['email'], 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', 'reason': 'channel_disabled'}, {'channel': 'premium_sms', 'reason': 'channel_disabled'}], 'lead_time_minutes': 10, 'event_at': '2026-08-18T10:10:00+00:00', 'event_end_at': '2026-08-18T10:40:00+00:00', 'measurement_point': {'segment_id': '1', 'km_from': 0.0, 'km_to': 23.996}, 'source': 'radar'}
+E       assert 'measurement_gaps' in {'changes_count': 1, 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', '...premium_sms', 'reason': 'channel_disabled'}], 'channels_sent': ['email'], 'entity_id': 'tdd-2050-s4b-trip-3e2116', ...}
 
-tests/tdd/test_radar_messluecken_protokoll.py:232: AssertionError
+tests/tdd/test_radar_messluecken_protokoll.py:244: AssertionError
 __________ test_alteintrag_ohne_messluecken_feld_bleibt_unveraendert ___________
 
     def test_alteintrag_ohne_messluecken_feld_bleibt_unveraendert():
@@ -424,14 +447,14 @@ __________ test_alteintrag_ohne_messluecken_feld_bleibt_unveraendert ___________
         )
 >       _pruefe_luecken(lauf, radar, punkte_erwartet=6)
 
-tests/tdd/test_radar_messluecken_protokoll.py:610: 
+tests/tdd/test_radar_messluecken_protokoll.py:657: 
 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
-tests/tdd/test_radar_messluecken_protokoll.py:274: in _pruefe_luecken
+tests/tdd/test_radar_messluecken_protokoll.py:286: in _pruefe_luecken
     luecken = _messluecken(lauf)
               ^^^^^^^^^^^^^^^^^^
 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
 
-lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-24 · ab 12:10 · letzter Regen gegen 12:40 · Na...33791165, 13.797641530778028, 15.79729972364441], uid='tdd-2050-s4b-ac11-7b0e9619', trip_id='tdd-2050-s4b-trip-f6c919')
+lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-24 · ab 12:10 · letzter Regen gegen 12:40 · Na...33791165, 13.797641530778028, 15.79729972364441], uid='tdd-2050-s4b-ac11-1e7c130e', trip_id='tdd-2050-s4b-trip-46dd9d')
 
     def _messluecken(lauf: _Lauf) -> dict:
         eintrag = _versand_eintrag(lauf)
@@ -440,10 +463,10 @@ lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-2
             f"nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die "
             f"Ausdehnung stammt. Eintrag: {eintrag!r}"
         )
-E       AssertionError: Der Protokoll-Eintrag muss `measurement_gaps` fuehren — sonst ist nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die Ausdehnung stammt. Eintrag: {'entity_id': 'tdd-2050-s4b-trip-f6c919', 'entity_type': 'trip', 'sent_at': '2026-08-18T10:00:00+00:00', 'changes_count': 1, 'severity': 'MODERATE', 'metrics': [{'metric_id': 'precipitation', 'aggregation': 'sum'}], 'hazards': [], 'reason': 'nowcast', 'channels_sent': ['email'], 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', 'reason': 'channel_disabled'}, {'channel': 'premium_sms', 'reason': 'channel_disabled'}], 'lead_time_minutes': 10, 'event_at': '2026-08-18T10:10:00+00:00', 'event_end_at': '2026-08-18T10:40:00+00:00', 'measurement_point': {'segment_id': '1', 'km_from': 0.0, 'km_to': 23.996}, 'source': 'radar'}
-E       assert 'measurement_gaps' in {'changes_count': 1, 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', '...premium_sms', 'reason': 'channel_disabled'}], 'channels_sent': ['email'], 'entity_id': 'tdd-2050-s4b-trip-f6c919', ...}
+E       AssertionError: Der Protokoll-Eintrag muss `measurement_gaps` fuehren — sonst ist nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die Ausdehnung stammt. Eintrag: {'entity_id': 'tdd-2050-s4b-trip-46dd9d', 'entity_type': 'trip', 'sent_at': '2026-08-18T10:00:00+00:00', 'changes_count': 1, 'severity': 'MODERATE', 'metrics': [{'metric_id': 'precipitation', 'aggregation': 'sum'}], 'hazards': [], 'reason': 'nowcast', 'channels_sent': ['email'], 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', 'reason': 'channel_disabled'}, {'channel': 'premium_sms', 'reason': 'channel_disabled'}], 'lead_time_minutes': 10, 'event_at': '2026-08-18T10:10:00+00:00', 'event_end_at': '2026-08-18T10:40:00+00:00', 'measurement_point': {'segment_id': '1', 'km_from': 0.0, 'km_to': 23.996}, 'source': 'radar'}
+E       assert 'measurement_gaps' in {'changes_count': 1, 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', '...premium_sms', 'reason': 'channel_disabled'}], 'channels_sent': ['email'], 'entity_id': 'tdd-2050-s4b-trip-46dd9d', ...}
 
-tests/tdd/test_radar_messluecken_protokoll.py:232: AssertionError
+tests/tdd/test_radar_messluecken_protokoll.py:244: AssertionError
 =========================== short test summary info ============================
 FAILED tests/tdd/test_radar_messluecken_protokoll.py::test_luecke_in_der_mitte_haelt_zahl_und_km_lage_fest
 FAILED tests/tdd/test_radar_messluecken_protokoll.py::test_alle_folgepunkte_ausgefallen_ist_der_extremfall
@@ -456,4 +479,4 @@ FAILED tests/tdd/test_radar_messluecken_protokoll.py::test_ausfall_am_ersten_pun
 FAILED tests/tdd/test_radar_messluecken_protokoll.py::test_scheiternde_luecken_ableitung_kostet_den_alarm_nicht
 FAILED tests/tdd/test_radar_messluecken_protokoll.py::test_zwei_nutzer_teilen_sich_keinen_luecken_eintrag
 FAILED tests/tdd/test_radar_messluecken_protokoll.py::test_alteintrag_ohne_messluecken_feld_bleibt_unveraendert
-============================== 11 failed in 1.29s ==============================
+============================== 11 failed in 1.36s ==============================

--- a/docs/artifacts/feat-2050-s4b-messluecken-protokoll/test-red-output.txt
+++ b/docs/artifacts/feat-2050-s4b-messluecken-protokoll/test-red-output.txt
@@ -1,0 +1,459 @@
+============================= test session starts ==============================
+platform linux -- Python 3.12.3, pytest-8.4.1, pluggy-1.6.0
+rootdir: /home/hem/gregor_zwanzig/.claude/worktrees/ws-2050-s4b
+configfile: pyproject.toml
+plugins: anyio-4.12.0, timeout-2.4.0, socket-0.8.0
+timeout: 30.0s
+timeout method: signal
+timeout func_only: False
+collected 11 items
+
+tests/tdd/test_radar_messluecken_protokoll.py FFFFFFFFFFF                [100%]
+
+=================================== FAILURES ===================================
+_____________ test_luecke_in_der_mitte_haelt_zahl_und_km_lage_fest _____________
+
+    def test_luecke_in_der_mitte_haelt_zahl_und_km_lage_fest():
+        """AC-1 GIVEN drei Zonenpunkte, der mittlere ausgefallen / WHEN der Alarm
+        protokolliert wird / THEN nennt `measurement_gaps` Zahl UND km-Lage genau
+        dieses Punkts.
+    
+        Geprueft werden die WERTE, nicht die Form: ein `gap_km` mit der km-Lage
+        eines FALSCHEN Punkts (z.B. des ersten statt des mittleren) faellt hier
+        durch, weil der Sollwert aus den Abruf-Koordinaten abgeleitet wird.
+        """
+        radar = _LueckenRadar(luecken={1: {"data_unavailable": True}})
+        lauf = _lauf(radar, tag="ac1", strecke_km=_DREI_PUNKTE_KM)
+    
+>       luecken = _pruefe_luecken(lauf, radar, punkte_erwartet=3)
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+tests/tdd/test_radar_messluecken_protokoll.py:310: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+tests/tdd/test_radar_messluecken_protokoll.py:274: in _pruefe_luecken
+    luecken = _messluecken(lauf)
+              ^^^^^^^^^^^^^^^^^^
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+
+lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-7 · ab 12:10 · letzter Regen gegen 12:40 · Nas...999996884, 3.5949999999998226, 5.594999999999956], uid='tdd-2050-s4b-ac1-5f73556f', trip_id='tdd-2050-s4b-trip-620490')
+
+    def _messluecken(lauf: _Lauf) -> dict:
+        eintrag = _versand_eintrag(lauf)
+>       assert "measurement_gaps" in eintrag, (
+            f"Der Protokoll-Eintrag muss `measurement_gaps` fuehren — sonst ist "
+            f"nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die "
+            f"Ausdehnung stammt. Eintrag: {eintrag!r}"
+        )
+E       AssertionError: Der Protokoll-Eintrag muss `measurement_gaps` fuehren — sonst ist nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die Ausdehnung stammt. Eintrag: {'entity_id': 'tdd-2050-s4b-trip-620490', 'entity_type': 'trip', 'sent_at': '2026-08-18T10:00:00+00:00', 'changes_count': 1, 'severity': 'MODERATE', 'metrics': [{'metric_id': 'precipitation', 'aggregation': 'sum'}], 'hazards': [], 'reason': 'nowcast', 'channels_sent': ['email'], 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', 'reason': 'channel_disabled'}, {'channel': 'premium_sms', 'reason': 'channel_disabled'}], 'lead_time_minutes': 10, 'event_at': '2026-08-18T10:10:00+00:00', 'event_end_at': '2026-08-18T10:40:00+00:00', 'measurement_point': {'segment_id': '1', 'km_from': 0.0, 'km_to': 6.6}, 'source': 'radar'}
+E       assert 'measurement_gaps' in {'changes_count': 1, 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', '...premium_sms', 'reason': 'channel_disabled'}], 'channels_sent': ['email'], 'entity_id': 'tdd-2050-s4b-trip-620490', ...}
+
+tests/tdd/test_radar_messluecken_protokoll.py:232: AssertionError
+_____________ test_alle_folgepunkte_ausgefallen_ist_der_extremfall _____________
+
+    def test_alle_folgepunkte_ausgefallen_ist_der_extremfall():
+        """AC-2 GIVEN der ausloesende erste Messpunkt meldet Regen, alle fuenf
+        Folgepunkte fallen aus / WHEN der Alarm protokolliert wird / THEN weist
+        `measurement_gaps` `points_measured=1` und alle fuenf Folgepunkte als
+        `gap_km` aus."""
+        radar = _LueckenRadar(luecken={i: {"data_unavailable": True} for i in range(1, 6)})
+        lauf = _lauf(radar, tag="ac2")
+    
+>       luecken = _pruefe_luecken(lauf, radar, punkte_erwartet=6)
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+tests/tdd/test_radar_messluecken_protokoll.py:335: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+tests/tdd/test_radar_messluecken_protokoll.py:274: in _pruefe_luecken
+    luecken = _messluecken(lauf)
+              ^^^^^^^^^^^^^^^^^^
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+
+lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-24 · ab 12:10 · letzter Regen gegen 12:40 · Na...333791165, 13.797641530778028, 15.79729972364441], uid='tdd-2050-s4b-ac2-5b4fea74', trip_id='tdd-2050-s4b-trip-9303cf')
+
+    def _messluecken(lauf: _Lauf) -> dict:
+        eintrag = _versand_eintrag(lauf)
+>       assert "measurement_gaps" in eintrag, (
+            f"Der Protokoll-Eintrag muss `measurement_gaps` fuehren — sonst ist "
+            f"nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die "
+            f"Ausdehnung stammt. Eintrag: {eintrag!r}"
+        )
+E       AssertionError: Der Protokoll-Eintrag muss `measurement_gaps` fuehren — sonst ist nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die Ausdehnung stammt. Eintrag: {'entity_id': 'tdd-2050-s4b-trip-9303cf', 'entity_type': 'trip', 'sent_at': '2026-08-18T10:00:00+00:00', 'changes_count': 1, 'severity': 'MODERATE', 'metrics': [{'metric_id': 'precipitation', 'aggregation': 'sum'}], 'hazards': [], 'reason': 'nowcast', 'channels_sent': ['email'], 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', 'reason': 'channel_disabled'}, {'channel': 'premium_sms', 'reason': 'channel_disabled'}], 'lead_time_minutes': 10, 'event_at': '2026-08-18T10:10:00+00:00', 'event_end_at': '2026-08-18T10:40:00+00:00', 'measurement_point': {'segment_id': '1', 'km_from': 0.0, 'km_to': 23.996}, 'source': 'radar'}
+E       assert 'measurement_gaps' in {'changes_count': 1, 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', '...premium_sms', 'reason': 'channel_disabled'}], 'channels_sent': ['email'], 'entity_id': 'tdd-2050-s4b-trip-9303cf', ...}
+
+tests/tdd/test_radar_messluecken_protokoll.py:232: AssertionError
+______ test_echter_befund_ein_kilometer_ist_vom_extremfall_unterscheidbar ______
+
+    def test_echter_befund_ein_kilometer_ist_vom_extremfall_unterscheidbar():
+        """AC-3 (Gegenprobe zu AC-2) GIVEN dieselbe Strecke, aber alle sechs
+        Punkte liefern ein Ergebnis und nur der erste ist nass / WHEN der Alarm
+        protokolliert wird / THEN zeigt `measurement_gaps`
+        `points_total == points_measured` und eine LEERE `gap_km`-Liste.
+    
+        Beide Laeufe stehen hier NEBENEINANDER: die Zusicherung ist nicht "leere
+        Liste", sondern "an den Zahlen unterscheidbar, obwohl der TEXT beide Male
+        dieselbe Ausdehnungsangabe traegt". Ohne den Extremfall im selben Test
+        waere die leere Liste ein Wert ohne Aussage.
+        """
+        echt = _LueckenRadar(trockene=(1, 2, 3, 4, 5))
+        lauf_echt = _lauf(echt, tag="ac3-echt")
+        extrem = _LueckenRadar(luecken={i: {"data_unavailable": True} for i in range(1, 6)})
+        lauf_extrem = _lauf(extrem, tag="ac3-extrem")
+    
+        assert lauf_echt.spannen and lauf_echt.spannen == lauf_extrem.spannen, (
+            f"Testvoraussetzung: beide Laeufe muessen DIESELBE Ausdehnungsangabe "
+            f"im Text erzeugen — genau darum muss der Unterschied an den Zahlen "
+            f"haengen. Echt: {lauf_echt.spannen!r}, Extremfall: "
+            f"{lauf_extrem.spannen!r}"
+        )
+    
+>       luecken_echt = _pruefe_luecken(lauf_echt, echt, punkte_erwartet=6)
+                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+tests/tdd/test_radar_messluecken_protokoll.py:366: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+tests/tdd/test_radar_messluecken_protokoll.py:274: in _pruefe_luecken
+    luecken = _messluecken(lauf)
+              ^^^^^^^^^^^^^^^^^^
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+
+lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-24 · ab 12:10 · letzter Regen gegen 12:40 · Na...1165, 13.797641530778028, 15.79729972364441], uid='tdd-2050-s4b-ac3-echt-0e8a34fc', trip_id='tdd-2050-s4b-trip-c78afa')
+
+    def _messluecken(lauf: _Lauf) -> dict:
+        eintrag = _versand_eintrag(lauf)
+>       assert "measurement_gaps" in eintrag, (
+            f"Der Protokoll-Eintrag muss `measurement_gaps` fuehren — sonst ist "
+            f"nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die "
+            f"Ausdehnung stammt. Eintrag: {eintrag!r}"
+        )
+E       AssertionError: Der Protokoll-Eintrag muss `measurement_gaps` fuehren — sonst ist nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die Ausdehnung stammt. Eintrag: {'entity_id': 'tdd-2050-s4b-trip-c78afa', 'entity_type': 'trip', 'sent_at': '2026-08-18T10:00:00+00:00', 'changes_count': 1, 'severity': 'MODERATE', 'metrics': [{'metric_id': 'precipitation', 'aggregation': 'sum'}], 'hazards': [], 'reason': 'nowcast', 'channels_sent': ['email'], 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', 'reason': 'channel_disabled'}, {'channel': 'premium_sms', 'reason': 'channel_disabled'}], 'lead_time_minutes': 10, 'event_at': '2026-08-18T10:10:00+00:00', 'event_end_at': '2026-08-18T10:40:00+00:00', 'measurement_point': {'segment_id': '1', 'km_from': 0.0, 'km_to': 23.996}, 'source': 'radar'}
+E       assert 'measurement_gaps' in {'changes_count': 1, 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', '...premium_sms', 'reason': 'channel_disabled'}], 'channels_sent': ['email'], 'entity_id': 'tdd-2050-s4b-trip-c78afa', ...}
+
+tests/tdd/test_radar_messluecken_protokoll.py:232: AssertionError
+_______________ test_luecken_feld_ist_auch_ohne_luecke_vorhanden _______________
+
+    def test_luecken_feld_ist_auch_ohne_luecke_vorhanden():
+        """AC-4 GIVEN ein Lauf ohne jeden Ausfall / WHEN der Alarm protokolliert
+        wird / THEN ist `measurement_gaps` trotzdem vorhanden, mit leerer
+        `gap_km`-Liste.
+    
+        Positivkontrolle im zweiten Lauf: derselbe Aufbau MIT einer Luecke muss
+        eine gefuellte `gap_km`-Liste liefern — sonst waere die leere Liste oben
+        trivial wahr (ein Pruefling, der die Liste nie fuellt, kaeme durch).
+        """
+        ohne = _LueckenRadar()
+        lauf_ohne = _lauf(ohne, tag="ac4-ohne")
+>       luecken_ohne = _pruefe_luecken(lauf_ohne, ohne, punkte_erwartet=6)
+                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+tests/tdd/test_radar_messluecken_protokoll.py:400: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+tests/tdd/test_radar_messluecken_protokoll.py:274: in _pruefe_luecken
+    luecken = _messluecken(lauf)
+              ^^^^^^^^^^^^^^^^^^
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+
+lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-24 · ab 12:10 · letzter Regen gegen 12:40 · Na...1165, 13.797641530778028, 15.79729972364441], uid='tdd-2050-s4b-ac4-ohne-ff611c84', trip_id='tdd-2050-s4b-trip-23328f')
+
+    def _messluecken(lauf: _Lauf) -> dict:
+        eintrag = _versand_eintrag(lauf)
+>       assert "measurement_gaps" in eintrag, (
+            f"Der Protokoll-Eintrag muss `measurement_gaps` fuehren — sonst ist "
+            f"nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die "
+            f"Ausdehnung stammt. Eintrag: {eintrag!r}"
+        )
+E       AssertionError: Der Protokoll-Eintrag muss `measurement_gaps` fuehren — sonst ist nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die Ausdehnung stammt. Eintrag: {'entity_id': 'tdd-2050-s4b-trip-23328f', 'entity_type': 'trip', 'sent_at': '2026-08-18T10:00:00+00:00', 'changes_count': 1, 'severity': 'MODERATE', 'metrics': [{'metric_id': 'precipitation', 'aggregation': 'sum'}], 'hazards': [], 'reason': 'nowcast', 'channels_sent': ['email'], 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', 'reason': 'channel_disabled'}, {'channel': 'premium_sms', 'reason': 'channel_disabled'}], 'lead_time_minutes': 10, 'event_at': '2026-08-18T10:10:00+00:00', 'event_end_at': '2026-08-18T10:40:00+00:00', 'measurement_point': {'segment_id': '1', 'km_from': 0.0, 'km_to': 23.996}, 'source': 'radar'}
+E       assert 'measurement_gaps' in {'changes_count': 1, 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', '...premium_sms', 'reason': 'channel_disabled'}], 'channels_sent': ['email'], 'entity_id': 'tdd-2050-s4b-trip-23328f', ...}
+
+tests/tdd/test_radar_messluecken_protokoll.py:232: AssertionError
+_________________ test_geworfene_ausnahme_erscheint_als_luecke _________________
+
+    def test_geworfene_ausnahme_erscheint_als_luecke():
+        """AC-5 GIVEN der Abruf eines Folgepunkts wirft / WHEN der Alarm
+        protokolliert wird / THEN erscheint dieser Punkt in `gap_km`."""
+        radar = _LueckenRadar(ausnahmen=(2,))
+        lauf = _lauf(radar, tag="ac5")
+>       _pruefe_luecken(lauf, radar, punkte_erwartet=6)
+
+tests/tdd/test_radar_messluecken_protokoll.py:428: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+tests/tdd/test_radar_messluecken_protokoll.py:274: in _pruefe_luecken
+    luecken = _messluecken(lauf)
+              ^^^^^^^^^^^^^^^^^^
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+
+lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-24 · ab 12:10 · letzter Regen gegen 12:40 · Na...333791165, 13.797641530778028, 15.79729972364441], uid='tdd-2050-s4b-ac5-f0e5c274', trip_id='tdd-2050-s4b-trip-4426a3')
+
+    def _messluecken(lauf: _Lauf) -> dict:
+        eintrag = _versand_eintrag(lauf)
+>       assert "measurement_gaps" in eintrag, (
+            f"Der Protokoll-Eintrag muss `measurement_gaps` fuehren — sonst ist "
+            f"nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die "
+            f"Ausdehnung stammt. Eintrag: {eintrag!r}"
+        )
+E       AssertionError: Der Protokoll-Eintrag muss `measurement_gaps` fuehren — sonst ist nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die Ausdehnung stammt. Eintrag: {'entity_id': 'tdd-2050-s4b-trip-4426a3', 'entity_type': 'trip', 'sent_at': '2026-08-18T10:00:00+00:00', 'changes_count': 1, 'severity': 'MODERATE', 'metrics': [{'metric_id': 'precipitation', 'aggregation': 'sum'}], 'hazards': [], 'reason': 'nowcast', 'channels_sent': ['email'], 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', 'reason': 'channel_disabled'}, {'channel': 'premium_sms', 'reason': 'channel_disabled'}], 'lead_time_minutes': 10, 'event_at': '2026-08-18T10:10:00+00:00', 'event_end_at': '2026-08-18T10:40:00+00:00', 'measurement_point': {'segment_id': '1', 'km_from': 0.0, 'km_to': 23.996}, 'source': 'radar'}
+E       assert 'measurement_gaps' in {'changes_count': 1, 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', '...premium_sms', 'reason': 'channel_disabled'}], 'channels_sent': ['email'], 'entity_id': 'tdd-2050-s4b-trip-4426a3', ...}
+
+tests/tdd/test_radar_messluecken_protokoll.py:232: AssertionError
+------------------------------ Captured log call -------------------------------
+WARNING  trip_alert:trip_alert.py:1714 Radar alert: Nowcast fuer Zonenpunkt (47.0881, 11.0000) des Trips tdd-2050-s4b-trip-4426a3 fehlgeschlagen (Nowcast-Abruf fuer Zonenpunkt 2 absichtlich fehlgeschlagen) — der Punkt faellt aus der Ausdehnung heraus, der Alarm laeuft weiter.
+_____________________ test_throttled_erscheint_als_luecke ______________________
+
+    def test_throttled_erscheint_als_luecke():
+        """AC-6 GIVEN der Abruf eines Folgepunkts liefert `throttled=True` /
+        WHEN der Alarm protokolliert wird / THEN erscheint dieser Punkt in
+        `gap_km` — die Budget-Drosselung ist kein belegtes "trocken"."""
+        radar = _LueckenRadar(luecken={2: {"throttled": True}})
+        lauf = _lauf(radar, tag="ac6")
+>       _pruefe_luecken(lauf, radar, punkte_erwartet=6)
+
+tests/tdd/test_radar_messluecken_protokoll.py:437: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+tests/tdd/test_radar_messluecken_protokoll.py:274: in _pruefe_luecken
+    luecken = _messluecken(lauf)
+              ^^^^^^^^^^^^^^^^^^
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+
+lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-24 · ab 12:10 · letzter Regen gegen 12:40 · Na...333791165, 13.797641530778028, 15.79729972364441], uid='tdd-2050-s4b-ac6-c3794531', trip_id='tdd-2050-s4b-trip-d9d734')
+
+    def _messluecken(lauf: _Lauf) -> dict:
+        eintrag = _versand_eintrag(lauf)
+>       assert "measurement_gaps" in eintrag, (
+            f"Der Protokoll-Eintrag muss `measurement_gaps` fuehren — sonst ist "
+            f"nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die "
+            f"Ausdehnung stammt. Eintrag: {eintrag!r}"
+        )
+E       AssertionError: Der Protokoll-Eintrag muss `measurement_gaps` fuehren — sonst ist nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die Ausdehnung stammt. Eintrag: {'entity_id': 'tdd-2050-s4b-trip-d9d734', 'entity_type': 'trip', 'sent_at': '2026-08-18T10:00:00+00:00', 'changes_count': 1, 'severity': 'MODERATE', 'metrics': [{'metric_id': 'precipitation', 'aggregation': 'sum'}], 'hazards': [], 'reason': 'nowcast', 'channels_sent': ['email'], 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', 'reason': 'channel_disabled'}, {'channel': 'premium_sms', 'reason': 'channel_disabled'}], 'lead_time_minutes': 10, 'event_at': '2026-08-18T10:10:00+00:00', 'event_end_at': '2026-08-18T10:40:00+00:00', 'measurement_point': {'segment_id': '1', 'km_from': 0.0, 'km_to': 23.996}, 'source': 'radar'}
+E       assert 'measurement_gaps' in {'changes_count': 1, 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', '...premium_sms', 'reason': 'channel_disabled'}], 'channels_sent': ['email'], 'entity_id': 'tdd-2050-s4b-trip-d9d734', ...}
+
+tests/tdd/test_radar_messluecken_protokoll.py:232: AssertionError
+__________________ test_data_unavailable_erscheint_als_luecke __________________
+
+    def test_data_unavailable_erscheint_als_luecke():
+        """AC-7 GIVEN der Abruf eines Folgepunkts liefert `data_unavailable=True` /
+        WHEN der Alarm protokolliert wird / THEN erscheint dieser Punkt in
+        `gap_km` — der Quellenausfall ist kein belegtes "trocken"."""
+        radar = _LueckenRadar(luecken={2: {"data_unavailable": True}})
+        lauf = _lauf(radar, tag="ac7")
+>       _pruefe_luecken(lauf, radar, punkte_erwartet=6)
+
+tests/tdd/test_radar_messluecken_protokoll.py:446: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+tests/tdd/test_radar_messluecken_protokoll.py:274: in _pruefe_luecken
+    luecken = _messluecken(lauf)
+              ^^^^^^^^^^^^^^^^^^
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+
+lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-24 · ab 12:10 · letzter Regen gegen 12:40 · Na...333791165, 13.797641530778028, 15.79729972364441], uid='tdd-2050-s4b-ac7-795b5703', trip_id='tdd-2050-s4b-trip-5b7ed3')
+
+    def _messluecken(lauf: _Lauf) -> dict:
+        eintrag = _versand_eintrag(lauf)
+>       assert "measurement_gaps" in eintrag, (
+            f"Der Protokoll-Eintrag muss `measurement_gaps` fuehren — sonst ist "
+            f"nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die "
+            f"Ausdehnung stammt. Eintrag: {eintrag!r}"
+        )
+E       AssertionError: Der Protokoll-Eintrag muss `measurement_gaps` fuehren — sonst ist nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die Ausdehnung stammt. Eintrag: {'entity_id': 'tdd-2050-s4b-trip-5b7ed3', 'entity_type': 'trip', 'sent_at': '2026-08-18T10:00:00+00:00', 'changes_count': 1, 'severity': 'MODERATE', 'metrics': [{'metric_id': 'precipitation', 'aggregation': 'sum'}], 'hazards': [], 'reason': 'nowcast', 'channels_sent': ['email'], 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', 'reason': 'channel_disabled'}, {'channel': 'premium_sms', 'reason': 'channel_disabled'}], 'lead_time_minutes': 10, 'event_at': '2026-08-18T10:10:00+00:00', 'event_end_at': '2026-08-18T10:40:00+00:00', 'measurement_point': {'segment_id': '1', 'km_from': 0.0, 'km_to': 23.996}, 'source': 'radar'}
+E       assert 'measurement_gaps' in {'changes_count': 1, 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', '...premium_sms', 'reason': 'channel_disabled'}], 'channels_sent': ['email'], 'entity_id': 'tdd-2050-s4b-trip-5b7ed3', ...}
+
+tests/tdd/test_radar_messluecken_protokoll.py:232: AssertionError
+_________ test_ausfall_am_ersten_punkt_erzeugt_keine_ausdehnungszeile __________
+
+    def test_ausfall_am_ersten_punkt_erzeugt_keine_ausdehnungszeile():
+        """AC-8 GIVEN der Ausfall trifft den ersten, ausloesenden Messpunkt /
+        WHEN der Pruflauf durchlaeuft / THEN entsteht dazu KEINE Protokollzeile
+        mit einer Ausdehnungsangabe — der Lauf steigt vorher aus.
+    
+        Positivkontrolle je Ausfallweg: DERSELBE Ausfall an Index 1 muss sehr wohl
+        eine Zeile mit `measurement_gaps` erzeugen. Ohne sie waere die
+        Abwesenheits-Pruefung oben trivial wahr — sie wuerde auch bestehen, wenn
+        das Feld ueberhaupt nie geschrieben wird, und damit gar nichts belegen.
+        """
+        for name, bau_erster, bau_zweiter in (
+            (
+                "Ausnahme",
+                lambda: _LueckenRadar(ausnahmen=(0,)),
+                lambda: _LueckenRadar(ausnahmen=(1,)),
+            ),
+            (
+                "data_unavailable",
+                lambda: _LueckenRadar(luecken={0: {"data_unavailable": True}}),
+                lambda: _LueckenRadar(luecken={1: {"data_unavailable": True}}),
+            ),
+        ):
+            lauf = _lauf(bau_erster(), tag="ac8-erster")
+            alle = lauf.entries + lauf.not_delivered
+            assert lauf.sent == 0, (
+                f"AC-8/{name}: der Ausfall am ersten Punkt darf keinen Alarm "
+                f"ausloesen, sent={lauf.sent}\nBody:\n{lauf.body}"
+            )
+            mit_ausdehnung = [e for e in alle if "measurement_gaps" in e]
+            assert not mit_ausdehnung, (
+                f"AC-8/{name}: kein Protokoll-Eintrag dieses Laufs darf eine "
+                f"Ausdehnungsangabe tragen — der Lauf hat die Mehrpunkt-Abfrage "
+                f"nie ausgewertet. Gefunden: {mit_ausdehnung!r}"
+            )
+    
+            radar_zweiter = bau_zweiter()
+            lauf_zweiter = _lauf(radar_zweiter, tag="ac8-zweiter")
+>           luecken = _pruefe_luecken(lauf_zweiter, radar_zweiter, punkte_erwartet=6)
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+tests/tdd/test_radar_messluecken_protokoll.py:491: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+tests/tdd/test_radar_messluecken_protokoll.py:274: in _pruefe_luecken
+    luecken = _messluecken(lauf)
+              ^^^^^^^^^^^^^^^^^^
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+
+lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-24 · ab 12:10 · letzter Regen gegen 12:40 · Na...5, 13.797641530778028, 15.79729972364441], uid='tdd-2050-s4b-ac8-zweiter-8f0f2b9d', trip_id='tdd-2050-s4b-trip-652ceb')
+
+    def _messluecken(lauf: _Lauf) -> dict:
+        eintrag = _versand_eintrag(lauf)
+>       assert "measurement_gaps" in eintrag, (
+            f"Der Protokoll-Eintrag muss `measurement_gaps` fuehren — sonst ist "
+            f"nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die "
+            f"Ausdehnung stammt. Eintrag: {eintrag!r}"
+        )
+E       AssertionError: Der Protokoll-Eintrag muss `measurement_gaps` fuehren — sonst ist nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die Ausdehnung stammt. Eintrag: {'entity_id': 'tdd-2050-s4b-trip-652ceb', 'entity_type': 'trip', 'sent_at': '2026-08-18T10:00:00+00:00', 'changes_count': 1, 'severity': 'MODERATE', 'metrics': [{'metric_id': 'precipitation', 'aggregation': 'sum'}], 'hazards': [], 'reason': 'nowcast', 'channels_sent': ['email'], 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', 'reason': 'channel_disabled'}, {'channel': 'premium_sms', 'reason': 'channel_disabled'}], 'lead_time_minutes': 10, 'event_at': '2026-08-18T10:10:00+00:00', 'event_end_at': '2026-08-18T10:40:00+00:00', 'measurement_point': {'segment_id': '1', 'km_from': 0.0, 'km_to': 23.996}, 'source': 'radar'}
+E       assert 'measurement_gaps' in {'changes_count': 1, 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', '...premium_sms', 'reason': 'channel_disabled'}], 'channels_sent': ['email'], 'entity_id': 'tdd-2050-s4b-trip-652ceb', ...}
+
+tests/tdd/test_radar_messluecken_protokoll.py:232: AssertionError
+------------------------------ Captured log call -------------------------------
+ERROR    trip_alert:trip_alert.py:1673 Radar nowcast failed for trip tdd-2050-s4b-trip-825ebc: Nowcast-Abruf fuer Zonenpunkt 0 absichtlich fehlgeschlagen
+WARNING  trip_alert:trip_alert.py:1714 Radar alert: Nowcast fuer Zonenpunkt (47.0701, 11.0000) des Trips tdd-2050-s4b-trip-652ceb fehlgeschlagen (Nowcast-Abruf fuer Zonenpunkt 1 absichtlich fehlgeschlagen) — der Punkt faellt aus der Ausdehnung heraus, der Alarm laeuft weiter.
+__________ test_scheiternde_luecken_ableitung_kostet_den_alarm_nicht ___________
+
+monkeypatch = <_pytest.monkeypatch.MonkeyPatch object at 0x72898e910c50>
+
+    def test_scheiternde_luecken_ableitung_kostet_den_alarm_nicht(monkeypatch):
+        """AC-9 GIVEN die Ableitung von `measurement_gaps` scheitert / WHEN der
+        Radar-Alarmpfad laeuft / THEN wird der Alarm trotzdem versendet und
+        protokolliert, nur ohne das Feld.
+    
+        Der Fehler wird an der ABLEITUNG selbst ausgeloest (`_messluecken_felder`),
+        nicht an `_radar_e1_fields` als Ganzem — sonst pruefte der Test die
+        bestehende Absicherung der fuenf E-1-Groessen aus #2050 S6 statt der neuen
+        Ableitung.
+    
+        Bewusst NICHT mitgeprueft: ob die uebrigen E-1-Groessen den Fehlschlag
+        ueberleben. Die Spec sagt an einer Stelle "nur ohne `measurement_gaps`"
+        (das verlangt einen eigenen Auffang) und an anderer "innerhalb des
+        bestehenden `try`-Blocks" (dann fielen alle fuenf mit weg). AC-9 im
+        Wortlaut fordert nur, dass Alarm und Eintrag entstehen — genau das steht
+        hier.
+        """
+        from services import trip_alert as trip_alert_mod
+    
+        def _explodiert(*args, **kwargs):
+            raise ValueError("absichtlich unerwartete Datenform")
+    
+>       monkeypatch.setattr(trip_alert_mod, "_messluecken_felder", _explodiert)
+E       AttributeError: <module 'services.trip_alert' from '/home/hem/gregor_zwanzig/.claude/worktrees/ws-2050-s4b/src/services/trip_alert.py'> has no attribute '_messluecken_felder'
+
+tests/tdd/test_radar_messluecken_protokoll.py:525: AttributeError
+_____________ test_zwei_nutzer_teilen_sich_keinen_luecken_eintrag ______________
+
+    def test_zwei_nutzer_teilen_sich_keinen_luecken_eintrag():
+        """AC-10 GIVEN zwei verschiedene Nutzer erleiden je eine Messluecke /
+        WHEN beide Alarmpfade laufen / THEN landet jeder `measurement_gaps`-
+        Eintrag ausschliesslich im Protokoll des betroffenen Nutzers.
+    
+        Die beiden Luecken liegen an VERSCHIEDENEN Punkten (Index 1 vs. 4): eine
+        Vermischung waere sonst nur an der Zahl der Eintraege erkennbar, nicht am
+        Inhalt — ein gemeinsamer Schreibort mit gleichem Wert kaeme durch.
+        """
+        radar_a = _LueckenRadar(luecken={1: {"data_unavailable": True}})
+        lauf_a = _lauf(radar_a, tag="ac10-a")
+        radar_b = _LueckenRadar(luecken={4: {"throttled": True}})
+        lauf_b = _lauf(radar_b, tag="ac10-b")
+    
+        assert lauf_a.uid != lauf_b.uid, "Testvoraussetzung: zwei VERSCHIEDENE Nutzer"
+    
+>       luecken_a = _pruefe_luecken(lauf_a, radar_a, punkte_erwartet=6)
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+tests/tdd/test_radar_messluecken_protokoll.py:560: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+tests/tdd/test_radar_messluecken_protokoll.py:274: in _pruefe_luecken
+    luecken = _messluecken(lauf)
+              ^^^^^^^^^^^^^^^^^^
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+
+lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-24 · ab 12:10 · letzter Regen gegen 12:40 · Na...791165, 13.797641530778028, 15.79729972364441], uid='tdd-2050-s4b-ac10-a-7849898d', trip_id='tdd-2050-s4b-trip-3d9b0b')
+
+    def _messluecken(lauf: _Lauf) -> dict:
+        eintrag = _versand_eintrag(lauf)
+>       assert "measurement_gaps" in eintrag, (
+            f"Der Protokoll-Eintrag muss `measurement_gaps` fuehren — sonst ist "
+            f"nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die "
+            f"Ausdehnung stammt. Eintrag: {eintrag!r}"
+        )
+E       AssertionError: Der Protokoll-Eintrag muss `measurement_gaps` fuehren — sonst ist nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die Ausdehnung stammt. Eintrag: {'entity_id': 'tdd-2050-s4b-trip-3d9b0b', 'entity_type': 'trip', 'sent_at': '2026-08-18T10:00:00+00:00', 'changes_count': 1, 'severity': 'MODERATE', 'metrics': [{'metric_id': 'precipitation', 'aggregation': 'sum'}], 'hazards': [], 'reason': 'nowcast', 'channels_sent': ['email'], 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', 'reason': 'channel_disabled'}, {'channel': 'premium_sms', 'reason': 'channel_disabled'}], 'lead_time_minutes': 10, 'event_at': '2026-08-18T10:10:00+00:00', 'event_end_at': '2026-08-18T10:40:00+00:00', 'measurement_point': {'segment_id': '1', 'km_from': 0.0, 'km_to': 23.996}, 'source': 'radar'}
+E       assert 'measurement_gaps' in {'changes_count': 1, 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', '...premium_sms', 'reason': 'channel_disabled'}], 'channels_sent': ['email'], 'entity_id': 'tdd-2050-s4b-trip-3d9b0b', ...}
+
+tests/tdd/test_radar_messluecken_protokoll.py:232: AssertionError
+__________ test_alteintrag_ohne_messluecken_feld_bleibt_unveraendert ___________
+
+    def test_alteintrag_ohne_messluecken_feld_bleibt_unveraendert():
+        """AC-11 GIVEN ein Alarmprotokoll mit einem Alt-Eintrag ohne
+        `measurement_gaps` / WHEN ein neuer Eintrag dazukommt / THEN bleibt der
+        Alt-Eintrag unveraendert lesbar und wird nicht umgeschrieben
+        (Read-Modify-Write)."""
+        uid = _uid("ac11")
+        alt = {
+            "entity_id": "trip-alt-2050-s4b", "entity_type": "trip",
+            "sent_at": "2026-01-05T06:00:00+00:00", "changes_count": 1,
+            "severity": "warn", "metrics": [], "hazards": [], "reason": "nowcast",
+            "channels_sent": ["email"], "channels_not_sent": [],
+        }
+        pfad = get_data_dir(uid) / "alert_log.json"
+        pfad.parent.mkdir(parents=True, exist_ok=True)
+        pfad.write_text(json.dumps({"entries": [dict(alt)]}))
+    
+        radar = _LueckenRadar(luecken={2: {"data_unavailable": True}})
+        lauf = _lauf(radar, tag="ac11", uid=uid)
+    
+        bestand = [e for e in lauf.entries if e.get("entity_id") == alt["entity_id"]]
+        assert bestand == [alt], (
+            f"AC-11: der Alt-Eintrag muss unveraendert erhalten bleiben (auch "
+            f"OHNE nachtraeglich angebautes `measurement_gaps`), war {bestand!r}"
+        )
+        assert lauf.entries[0] == alt, (
+            f"AC-11: der Alt-Eintrag muss an seiner Stelle stehen bleiben, "
+            f"entries={lauf.entries!r}"
+        )
+>       _pruefe_luecken(lauf, radar, punkte_erwartet=6)
+
+tests/tdd/test_radar_messluecken_protokoll.py:610: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+tests/tdd/test_radar_messluecken_protokoll.py:274: in _pruefe_luecken
+    luecken = _messluecken(lauf)
+              ^^^^^^^^^^^^^^^^^^
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+
+lauf = _Lauf(sent=1, body='Regen in 10 Min\n\nRadar-Nowcast\n\nWo & wann: km 0-24 · ab 12:10 · letzter Regen gegen 12:40 · Na...33791165, 13.797641530778028, 15.79729972364441], uid='tdd-2050-s4b-ac11-7b0e9619', trip_id='tdd-2050-s4b-trip-f6c919')
+
+    def _messluecken(lauf: _Lauf) -> dict:
+        eintrag = _versand_eintrag(lauf)
+>       assert "measurement_gaps" in eintrag, (
+            f"Der Protokoll-Eintrag muss `measurement_gaps` fuehren — sonst ist "
+            f"nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die "
+            f"Ausdehnung stammt. Eintrag: {eintrag!r}"
+        )
+E       AssertionError: Der Protokoll-Eintrag muss `measurement_gaps` fuehren — sonst ist nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die Ausdehnung stammt. Eintrag: {'entity_id': 'tdd-2050-s4b-trip-f6c919', 'entity_type': 'trip', 'sent_at': '2026-08-18T10:00:00+00:00', 'changes_count': 1, 'severity': 'MODERATE', 'metrics': [{'metric_id': 'precipitation', 'aggregation': 'sum'}], 'hazards': [], 'reason': 'nowcast', 'channels_sent': ['email'], 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', 'reason': 'channel_disabled'}, {'channel': 'premium_sms', 'reason': 'channel_disabled'}], 'lead_time_minutes': 10, 'event_at': '2026-08-18T10:10:00+00:00', 'event_end_at': '2026-08-18T10:40:00+00:00', 'measurement_point': {'segment_id': '1', 'km_from': 0.0, 'km_to': 23.996}, 'source': 'radar'}
+E       assert 'measurement_gaps' in {'changes_count': 1, 'channels_not_sent': [{'channel': 'telegram', 'reason': 'channel_disabled'}, {'channel': 'sms', '...premium_sms', 'reason': 'channel_disabled'}], 'channels_sent': ['email'], 'entity_id': 'tdd-2050-s4b-trip-f6c919', ...}
+
+tests/tdd/test_radar_messluecken_protokoll.py:232: AssertionError
+=========================== short test summary info ============================
+FAILED tests/tdd/test_radar_messluecken_protokoll.py::test_luecke_in_der_mitte_haelt_zahl_und_km_lage_fest
+FAILED tests/tdd/test_radar_messluecken_protokoll.py::test_alle_folgepunkte_ausgefallen_ist_der_extremfall
+FAILED tests/tdd/test_radar_messluecken_protokoll.py::test_echter_befund_ein_kilometer_ist_vom_extremfall_unterscheidbar
+FAILED tests/tdd/test_radar_messluecken_protokoll.py::test_luecken_feld_ist_auch_ohne_luecke_vorhanden
+FAILED tests/tdd/test_radar_messluecken_protokoll.py::test_geworfene_ausnahme_erscheint_als_luecke
+FAILED tests/tdd/test_radar_messluecken_protokoll.py::test_throttled_erscheint_als_luecke
+FAILED tests/tdd/test_radar_messluecken_protokoll.py::test_data_unavailable_erscheint_als_luecke
+FAILED tests/tdd/test_radar_messluecken_protokoll.py::test_ausfall_am_ersten_punkt_erzeugt_keine_ausdehnungszeile
+FAILED tests/tdd/test_radar_messluecken_protokoll.py::test_scheiternde_luecken_ableitung_kostet_den_alarm_nicht
+FAILED tests/tdd/test_radar_messluecken_protokoll.py::test_zwei_nutzer_teilen_sich_keinen_luecken_eintrag
+FAILED tests/tdd/test_radar_messluecken_protokoll.py::test_alteintrag_ohne_messluecken_feld_bleibt_unveraendert
+============================== 11 failed in 1.29s ==============================

--- a/docs/context/feat-2050-s4b-messluecken-protokoll.md
+++ b/docs/context/feat-2050-s4b-messluecken-protokoll.md
@@ -1,0 +1,295 @@
+# Context: #2050 S4b — Messlücken im Alarmprotokoll
+
+## Request Summary
+
+Ein Radar-Alarm nennt seit #2051 S2a die räumliche Ausdehnung des Regenereignisses („km 2–6").
+Fällt einer der bis zu sechs Messpunkte aus, verschwindet er in `derive_rain_zones` kommentarlos
+— aus dem Ergebnis ist nachträglich **nicht** erkennbar, dass die Ausdehnung nur aus vier von
+sechs Punkten stammt. Diese Scheibe baut die bereits geschriebenen, aber nie gebauten
+**AC-12/AC-13 der S4a-Spec**: Zahl und Lage der Lücken gehören ins Alarmprotokoll
+(Anforderung **E-1**, Nachvollziehbarkeit).
+
+**Die Textaussage selbst ist ausdrücklich NICHT Teil dieser Scheibe** — siehe „Zuschnitt-Entscheid".
+
+## Ausgangslage — am Code belegt
+
+### Wo eine Lücke entsteht (drei Wege)
+
+Alle in `trip_alert.py::check_radar_alerts`, in der Mehrpunkt-Abfrage (`:1698–1722`):
+
+| Weg | Stelle | Erkennungsmerkmal |
+|---|---|---|
+| Abruf wirft | `except Exception` `:1713`, hängt `None` an `:1720` | `logger.warning`, sonst stumm |
+| Abruf liefert, aber ohne verwertbare Frames | `_zonen_messwert()` `trip_alert.py:164-177` | `result.throttled` **oder** `result.data_unavailable` |
+| Ergebnis ist `None` | ebenda | `result is None` |
+
+`_zonen_messwert` gibt in allen drei Fällen `None` zurück — bewusst **kein** „trocken", weil ein
+als trocken gewerteter Ausfall eine Nass-Zone trennen und damit eine ungemessene trockene
+Strecke erfinden würde (#2051 S2a, E4).
+
+### Wo die Information verworfen wird
+
+`services/rain_extent.py::derive_rain_zones` (`:77-78`):
+
+```python
+for punkt, ergebnis in zip(points, results):
+    if ergebnis is None:
+        continue  # E4: echte Luecke — weder nass noch trocken
+```
+
+Das `continue` ist die einzige Stelle, an der die Lückeninformation existiert und verlorengeht.
+`RainZone` (`@dataclass(frozen=True)`, `:26-43`, vier Felder `km_from`/`km_to`/`onset_minutes`/
+`event_end_minutes`) trägt kein Kennzeichen.
+
+### Wo sie NICHT mehr abgreifbar ist
+
+`RadarAlertRequest` (`notification_service.py:176-267`) trägt `rain_zones` (bereits **verdichtet**)
+und `km_measured` (nur das Flag „km stammt aus echter GPX-Wegstrecke") — **weder Messpunkt- noch
+Lückenzahl**. Am Code bestätigt. Die Zahl muss also **vor** der Verdichtung aus `_punkte` /
+`_zonen_ergebnisse` abgegriffen werden.
+
+### Wie ein zugestellter Radar-Alarm heute protokolliert wird
+
+`alert_log.append_entry()` (`alert_log.py:384-507`), gerufen in `check_radar_alerts` (`:2193`),
+bekommt über `**_e1` die fünf E-1-Größen aus `_radar_e1_fields()` (`trip_alert.py:180-229`).
+Deren `measurement_point` ist die **Segment-Spanne der Etappe**:
+
+```python
+"measurement_point": {
+    "segment_id": ..., "km_from": active.start_point..., "km_to": active.end_point...,
+}
+```
+
+— nicht die einzelnen Messpunkte der Mehrpunkt-Abfrage. Nichts im Protokoll spricht heute über
+Messpunkte, Zonen oder Lücken. `_radar_e1_fields()` ist fail-soft (`{}` + Warnung bei Fehler,
+`:223-229`); der Alarm läuft dann trotzdem.
+
+### 🔴 `NameError`-Risiko: entwarnt
+
+Die S4a-Spec markierte als „vor dem Bauen zu prüfen", ob ein Verzweigungspfad die Lesestelle
+`:1722` ohne gesetztes `_zonen_ergebnisse` erreicht. **Er existiert nicht:** die Zuweisung
+`:1698` ist unbedingt, die Lesestelle `:1722` folgt auf derselben Einrückungsebene; dazwischen
+liegt nur die `for`-Schleife, deren `try/except` ausschließlich `append`t und nie neu bindet —
+kein `continue`, kein `return`, kein `if`. Die drei `continue`-Stellen davor (`:1589` Gate,
+`:1634-1652` Positionsbestimmung, `:1665-1686` erster Abruf) überspringen die Lesestelle
+zwangsläufig mit. Unabhängig von zwei Seiten belegt (eigene Lesung + Explore-Agent).
+
+## 🔴 Zuschnitt-Entscheid: warum die Zonenbildung UNVERÄNDERT bleibt
+
+Der naheliegende Vorschlag — „eine Lücke schließt die laufende Zone ab, dann stimmt der Text
+überall automatisch" — wurde geprüft und **verworfen**.
+
+**Grund 1: Er tauscht eine Unwahrheit gegen eine andere.** Beide Darstellungen behaupten
+Ungemessenes. Zusammenwachsen (`km 2–6` über die Lücke hinweg) behauptet durchgehende Nässe;
+Trennen (`km 2–3, km 5–6`) behauptet Trockenheit dazwischen. Ehrlich ist nur eine
+**Kennzeichnung** — und die ist Wortarbeit.
+
+**Grund 2: Er kippt eine freigegebene, gut gebaute Zusicherung.** Zwei Tests aus #2051 S2a
+schreiben das Nicht-Trennen ausdrücklich fest, beide mit Positivkontrolle:
+
+| Test | Zusicherung |
+|---|---|
+| `tests/tdd/test_regen_ausdehnung_zonenbildung.py::test_ac11_datenloser_punkt_faellt_aus_der_zonenbildung_heraus` (`:148-175`) | Ergebnis **mit** Lücke ist identisch zu „Punkt komplett entfernt"; Positivkontrolle erzwingt 2 Zonen |
+| `tests/tdd/test_regen_ausdehnung_textstellen.py::test_e4_punkt_ohne_frames_trennt_die_nasszone_nicht` (`:503`) | `throttled` **und** `data_unavailable` je einzeln: genau **eine** Zone; Positivkontrolle: ein *echt* trockener Punkt trennt sehr wohl |
+
+Die Begründung steht im Test selbst: ein als trennend gewerteter Ausfall „erfindet eine trockene
+Strecke, die niemand gemessen hat".
+
+**Folge:** Diese Scheibe **erhält** die Lückeninformation und protokolliert sie (E-1). Die
+Zonenbildung selbst bleibt byte-gleich, beide S2a-Tests bleiben grün. Die Textaussage beider
+Verzerrungsrichtungen wandert nach **S4b-2**, zusammen mit der Gewitter-Beschriftung — beides in
+`render.py`, beides nach dem #2051-S2b-Merge.
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `src/services/rain_extent.py` | `derive_rain_zones` verwirft die Lücke (`:77-78`); `RainZone` `frozen=True`, `:26-43` — neues Feld braucht **Default** (Zusage an die S2b-Session) |
+| `src/services/trip_alert.py` | `check_radar_alerts`: Abgriff zwischen `:1698` und `:1722`; `_zonen_messwert` `:164-177`; `_radar_e1_fields` `:180-229`; `append_entry`-Aufruf `:2193` |
+| `src/services/alert_log.py` | `append_entry()` `:384-507` — Zielort der neuen Protokollfelder |
+| `docs/specs/modules/feat_2050_s4a_radar_teilausfall.md` | AC-12/AC-13 bereits **geschrieben**, nie gebaut — Wortlaut übernehmen |
+| `docs/specs/modules/feat_2051_s2a_raeumliche_ausdehnung.md` | Known Limitation `:421ff` beschreibt beide Verzerrungsrichtungen; E4/AC-11 ist die Zusicherung, die nicht gekippt werden darf |
+| `tests/tdd/test_regen_ausdehnung_zonenbildung.py` | Muss grün bleiben (AC-11) |
+| `tests/tdd/test_regen_ausdehnung_textstellen.py` | Muss grün bleiben (E4) |
+
+## Existing Patterns
+
+- **Additives, optionales Feld mit Default** — das Muster der gesamten S4a-Scheibe
+  (`convective_checked: bool = True`, `UndeliveredIncident.convective_check_failed: bool = False`).
+  Altbestand bleibt lesbar, kein Schema-Bruch.
+- **Ausfall bekommt einen eigenen, ehrlichen Grund statt still unterzugehen** —
+  `REASON_DATA_UNAVAILABLE` / „Wetterdaten nicht verfügbar" (S4a), `get_official_alerts_with_status()`
+  (#1348, PO-Entscheid 2026-07-23 „streng": eine ausgefallene abdeckende Quelle genügt).
+- **Eine Ableitung für alle Protokollstellen eines Zweigs** — `_radar_e1_fields()` (#2050 S6),
+  damit derselbe Vorfall nicht je nach Ausgang verschieden im Protokoll steht.
+- **Fail-soft beim Protokollieren** — eine gescheiterte Protokollableitung darf den Alarm nie
+  kosten (`_radar_e1_fields` `:223-229`).
+
+## Dependencies
+
+- **Upstream:** `points_along_remaining_route()` (`trip_segments.py:683-716`, Deckel
+  `RADAR_ZONE_MAX_POINTS = 6`) erzeugt die Messpunkte; `radar_svc.get_nowcast()` liefert je Punkt.
+- **Downstream:** `derive_rain_zones` hat **genau einen** produktiven Aufrufer
+  (`trip_alert.py:1722`). `alert_log`-Einträge werden von `read_undelivered()` und der
+  Briefing-Leseseite konsumiert.
+
+## Parallele Sessions — abgestimmt, kollisionsfrei
+
+| Session | Scheibe | Dateien | Abstimmung |
+|---|---|---|---|
+| `2050 S4c` | #2050 S4c (ein Ereignis, ein Alarm) | `alert_gate.py`, `trip_alert.py` (`:310–657`, Löschung `:1835–1861`, `check_radar_alerts` `~:1990–2060`), `undelivered_hint.py` | Kein Überlapp; beidseitig gegengeprüft. Mein Hunk endet `:1722`, ~113 Zeilen Abstand zur Löschung. **Meine Änderung liegt VOR ihrer** und verschiebt deren Zeilen, nicht umgekehrt. |
+| `gregor-zwanzig-37` | #2051 S2b (Ausdehnung auf alle Kanäle) | `render.py` (`_render_subject_onset`, `_render_telegram_onset`, `_render_email_onset_multi`, `_render_sms_onset`), `validator_render_service.py` | Fasst `rain_extent.py` **nicht** an; konsumiert nur `OnsetEvent.rain_zones`. Ihre AC-Fixtures sind lückenfrei. Zusage von dort: brechende Wächter zieht sie selbst zurecht. |
+
+**Reihenfolge:** S2b merged zuerst, S4b-2 setzt danach auf ihrem Stand auf. Diese Scheibe (S4b)
+ist von der Reihenfolge unabhängig, weil sie `render.py` nicht berührt.
+
+## Risks & Considerations
+
+- **R1 — `RainZone` ist `frozen=True` und wird in Nachbarscheiben positional konstruiert.** Ein
+  neues Feld **muss** einen Default tragen, sonst brechen fremde Testaufbauten (S2b legt davon
+  „eine ganze Reihe" an). Ausdrückliche Zusage an die S2b-Session.
+- **R2 — Signaturänderung an `derive_rain_zones` ⇒ Referenzfeger.** Ändert sich Rückgabetyp oder
+  Signatur, `grep -rln "derive_rain_zones\|RainZone" tests/` — Signatur-Wächter liegen in
+  **fremden** Testdateien. Beide bekannten Dateien sind oben gelistet.
+- **R3 — Der erste Messpunkt ist ein Sonderfall.** `_zonen_ergebnisse[0]` stammt aus dem
+  auslösenden Abruf (`_zonen_messwert(result)`). Ein `data_unavailable` würde dort seit S4a schon
+  vorher aussteigen — `throttled` aber **nicht** zwingend. Zu prüfen: kann Index 0 eine Lücke sein,
+  und was heißt AC-13 („alle Folgepunkte fallen aus") dann genau?
+- **R4 — Protokollieren darf den Alarm nie kosten.** Neue Ableitung fail-soft halten, Muster
+  `_radar_e1_fields`.
+- **R5 — Bestandsdaten.** Alarmprotokoll-Einträge ohne die neuen Felder müssen lesbar bleiben und
+  dürfen nicht umgeschrieben werden (Read-Modify-Write, AC-19-Muster aus S3b).
+- **R6 — AC-12/AC-13 sind heute vollständig ungetestet.** Kein bestehender Test greift auf
+  `alert_log` / `measurement_point` / eine Lücken- oder Messpunktzahl zu. Die roten Tests entstehen
+  komplett neu — Positivkontrolle für jeden davon (Muster #2050 S2b).
+
+## Analysis
+
+### Type
+
+**Feature** — eine geschriebene, nie gebaute Zusicherung (AC-12/AC-13 der S4a-Spec) wird gebaut.
+Kein Bug: das heutige Verhalten ist spec-konform (#2051 S2a, E4), nur unvollständig
+nachvollziehbar.
+
+### 🔴 Technischer Ansatz: `derive_rain_zones` bleibt UNANGETASTET
+
+Drei Wege wurden gegeneinander bewertet; **Weg C** gewinnt mit Abstand:
+
+| Weg | Idee | Urteil |
+|---|---|---|
+| A | additives Feld an `RainZone` | ❌ **semantisch unmöglich** — eine Lücke liegt *zwischen* Zonen. Eine Lücke bei km 4 zwischen den Zonen km 0–2 und km 6–8 hat keine Zone, an die sie sich hängen ließe |
+| B | `derive_rain_zones` gibt Lücken zusätzlich zurück | ❌ Rückgabetyp-Änderung ⇒ Referenzfeger über fremde Testdateien; **und Doppelarbeit**, weil der Aufrufer die Rohinformation längst hat |
+| **C** | **Lücken im Aufrufer ableiten, `rain_extent.py` gar nicht anfassen** | ✅ **Empfohlen** |
+
+**Begründung für C:** In `trip_alert.py::check_radar_alerts` liegt zwischen der Zuweisung
+(`_zonen_ergebnisse: list = [_zonen_messwert(result)]`) und der Verdichtung
+(`derive_rain_zones(_punkte, _zonen_ergebnisse)`) bereits **index-genauer** Zugriff auf
+`_punkte[i].distance_from_start_km` **und** `_zonen_ergebnisse[i] is None` — also exakt die
+Rohinformation, die AC-12 („dass und an welcher Stelle") verlangt. `derive_rain_zones` bekäme
+nur den verdichteten Rest.
+
+**Folgen:** `rain_extent.py` wird nicht angefasst → R1 (frozen dataclass, Default-Pflicht) und
+R2 (Referenzfeger) entfallen **vollständig**. Die zwei S2a-Wächter können gar nicht rot werden.
+Die Zusage an die #2051-S2b-Session ist damit übererfüllt.
+
+### Datenform des Protokollfelds
+
+Neues optionales Feld `measurement_gaps`, abgeleitet in `_radar_e1_fields()` (Suchbegriff
+`def _radar_e1_fields(`, ~`:180`) — dem bestehenden Muster „**eine** Ableitung für alle
+Protokollstellen eines Zweigs" (#2050 S6) folgend. Die Funktion wird genau **einmal** gerufen
+(Suchbegriff `_e1 = _radar_e1_fields(`, ~`:1899`) und ihr Ergebnis per `**_e1` an alle
+Protokollstellen des Radarzweigs gespreadet — eine Änderung wirkt überall konsistent.
+
+```python
+"measurement_gaps": {
+    "points_total": <Zahl der Messpunkte>,
+    "points_measured": <Zahl mit verwertbarem Ergebnis>,
+    "gap_km": [<km-Lage jedes ausgefallenen Punkts>],
+}
+```
+
+**🔴 Verfeinerung gegenüber dem Agentenvorschlag:** Das Feld wird **immer** gesetzt, sobald die
+Mehrpunkt-Abfrage lief — auch bei leerer `gap_km`-Liste. Der Vorschlag „Feld weglassen, wenn
+keine Lücke" wäre schlanker, aber ein *fehlendes* Feld hätte dann **drei** Bedeutungen: „alles
+gemessen", „Alteintrag von vor dem Deploy" und „Ableitung fail-soft gescheitert". Genau diese
+Ununterscheidbarkeit ist der Mangel, den die Scheibe beheben soll — sie darf nicht auf einer
+Ebene höher neu entstehen.
+
+- **AC-12 erfüllt:** `gap_km` nennt Zahl *und* Lage.
+- **AC-13 erfüllt:** der Extremfall (`points_total=6, points_measured=1`) ist strukturell vom
+  echten Befund „Regen nur auf einem Kilometer" (`points_total == points_measured`)
+  unterscheidbar — an Zahlen, nicht am Text.
+
+### 🔴 Risiko R3 aufgelöst: Index 0 kann bei einem ausgelösten Alarm nie eine Lücke sein
+
+Unabhängig von zwei Seiten belegt. Drei Wege, wie der erste Punkt ausfällt — **keiner** erreicht
+eine Protokollzeile mit Ausdehnung:
+
+| Fall am ersten Punkt | Warum kein Alarm |
+|---|---|
+| Abruf wirft | `except` `continue`t, bevor `_zonen_ergebnisse` überhaupt existiert |
+| `data_unavailable=True` | Zonenbildung läuft zwar, aber `if result.data_unavailable:` `continue`t mit `REASON_DATA_UNAVAILABLE` (S4a) |
+| `throttled=True` | impliziert `not frames` ⇒ `onset_minutes=None`; `radar_alert_due()` verlangt `onset is not None` **oder** `already_running` — beides falsch ⇒ stiller `continue` |
+
+**Folge:** AC-13 („alle Folgepunkte fallen aus") ist wie geschrieben korrekt — gemeint sind
+zwangsläufig Index 1..N-1. **Keine Spec-Korrektur nötig.** Aber diese Tatsache braucht eine
+eigene Positivkontrolle: sonst prüft niemand, dass ein Ausfall an Index 0 gar nicht bis zur
+Protokollzeile kommt.
+
+### Affected Files
+
+| Datei | Änderung | Beschreibung |
+|---|---|---|
+| `src/services/trip_alert.py` | MODIFY | `_radar_e1_fields()` um die Lücken-Ableitung erweitern (fail-soft, **innerhalb** des bestehenden `try`), Aufrufstelle um die zwei Argumente ergänzen |
+| `src/services/alert_log.py` | MODIFY | `append_entry()` (`:384`) **und** `append_suppressed_entry()` (`:525`) je um `measurement_gaps: Optional[dict] = None` — **zwei** Stellen mit festen Signaturen, keine `**kwargs` |
+| `tests/tdd/test_radar_messluecken_protokoll.py` | CREATE | AC-12/AC-13 + Positivkontrollen |
+
+**`src/services/rain_extent.py`: NICHT betroffen.** Ausdrücklich.
+
+### Scope Assessment
+
+- Produktivdateien: **2** · Produktivcode ~30–40 LoC · Tests ~80–140 LoC
+- LoC-Limit 250: **eingehalten**
+- Risiko: **LOW** — additiv, fail-soft, keine Verhaltensänderung an einer bestehenden Zusicherung
+
+### Offene Punkte — beide geklärt
+
+- [x] **Test-Werkzeug: bereits vorhanden, keine Helfer-Erweiterung nötig.** `_ZonenRadar`
+      (`tests/tdd/test_regen_ausdehnung_textstellen.py:383`) ist eine echte
+      `RadarNowcastService`-Unterklasse am DI-Seam von `TripAlertService` — **kein Mock**, sie
+      liefert die Produktiv-Dataclass mit echten Feldern und steuert nur, *welches* Ergebnis ein
+      Punkt bekommt. Steuerbar per Index über `trocken_index`, `trocken_felder`
+      (z. B. `{"data_unavailable": True}`), `ausnahme_index`, `weitere_trockene` — deckt alle drei
+      Lückenwege ab. Muster wiederverwenden statt neu bauen.
+- [x] **Rundung `gap_km`: eine Nachkommastelle**, konsistent mit der gemessenen km-Spanne
+      (`segments.format_alert_location`) und dem Zonen-Rendering aus #2051 S2a. Entschieden, keine
+      PO-Frage.
+
+## Nebenbefunde (nicht in dieser Scheibe)
+
+- **Amtlicher Zweig:** `check_official_alert_triggers` ruft `get_official_alerts_for_location` —
+  den Alt-Wrapper **ohne** Ausfall-Status — und verschluckt den Fehlschlag mit `logger.warning`.
+  Derselbe B-4-Verstoß, andere Quelle. Aus dem S4a-Kontext übernommen, weiterhin offen.
+- **`convective_checked` erreicht den Renderer nicht.** Die Kette bricht beim Bau von
+  `RadarAlertRequest` (`trip_alert.py:2060ff`): `is_convective=result.is_convective` wird
+  mitgenommen, `result.convective_checked` nicht — das DTO hat kein solches Feld. Die fünf
+  Beschriftungsstellen (`render.py:480` `_render_subject_onset`, `:653` `_render_email_onset_multi`,
+  `:727` `_render_email_onset`, `:805` `_render_telegram_onset`, `:946` `_render_sms_onset`) lesen
+  daher nur `is_convective`. **Vorarbeit für S4b-2, hier bewusst liegengelassen.**
+- **Vorbild für S4b-2 (Kennzeichnung von Unsicherheit):** #2051 S3 hat das Paar bereits gebaut —
+  Langform `_onset_sharpness_suffix()` (`render.py:599`, no-op wenn leer) und Kurzform
+  `_sms_onset_sharpness_marker()` (`:907`), die ein `"?"` ans **fertige** Zeit-Token hängt.
+  Bewusst `?` statt `~`, weil `~` GSM-7-Extension ist und vom Transport zu `-` gefaltet würde.
+  Belegtes Kurzform-Inventar, mit dem ein neues Zeichen nicht kollidieren darf: `R`, `TH`, `now`,
+  `?`, `Rest{mm}`, `!{code}`, sowie app-weit reserviert `X` (UNAVAILABLE_SYMBOL,
+  `tokens/builder.py:84-86`).
+- **Platzzusage der #2051-S2b-Session für S4b-2** (von dort mitgeteilt): ihr neuer Kurzform-Helfer
+  heißt `_sms_onset_extent_marker()` und liegt **hinter** `_sms_onset_sharpness_marker()`. Die
+  Tokenreihenfolge wird `{Zeitgruppe}{Ende}{Güte-Marker ?} {Zonen-Kürzel km8-12}`. Empfehlung von
+  dort: eine Lücken-Kennzeichnung gehört **hinter** das Zonen-Kürzel, weil die Lücke eine Aussage
+  über die *Strecke* ist, nicht über die Zeit.
+- **⚠️ Kein Prioritäts-Kürzen im Alarm-SMS-Pfad.** Der harte Schnitt `body[:limit]` ist eine
+  Reißleine, die laut Bestandstest `tests/tdd/test_onset_ende_sms_budget.py:107-137` **nie**
+  greifen darf — das 140-Zeichen-Budget wird durch Konstruktion gehalten. S2b führt mit ihrer AC-8
+  die erste explizite Abwahl ein (Kürzel entfällt ganz statt abgeschnitten). Ein weiteres Zeichen
+  in S4b-2 braucht dieselbe Disziplin, sonst kippt der Bestandstest.

--- a/docs/specs/modules/feat_2050_s4b_messluecken_protokoll.md
+++ b/docs/specs/modules/feat_2050_s4b_messluecken_protokoll.md
@@ -173,9 +173,23 @@ Zwei-Dateien-Vorgabe.
 
 ### Fail-soft (AC-9)
 
-Die neue Ableitung liegt **innerhalb** des bestehenden `try`-Blocks von `_radar_e1_fields()`
-(Muster `_radar_e1_fields` `:207-229`): scheitert sie, entsteht der Alarm trotzdem, nur ohne
-`measurement_gaps` — dieselbe Absicherung wie bei den fünf bestehenden E-1-Größen.
+🔴 **Präzisiert 2026-08-23 nach einem Befund aus der RED-Phase.** Die frühere Fassung („liegt
+innerhalb des bestehenden `try`-Blocks von `_radar_e1_fields()`") war zu grob und hätte eine
+**Regression** eingebaut: der bestehende Auffang gibt bei einem Fehler `{}` zurück, es fielen
+also **alle fünf** bestehenden E-1-Größen mit weg (`measurement_point`, `event_at`,
+`lead_time_minutes`, `reference_at`, `source`). Ein Fehler in der neuen, **nachrangigen**
+Buchführung hätte damit die bestehende E-1-Protokollierung aus #2050 S6 zerstört — schlechter
+als der Zustand vor dieser Scheibe.
+
+**Verbindlich gilt die strenge Lesart:** Die neue Ableitung bekommt einen **eigenen** Auffang.
+Scheitert sie, fehlt **nur** `measurement_gaps`; die fünf bestehenden E-1-Größen stehen
+unverändert im Eintrag, und der Alarm geht raus. Das ist der Wortlaut von AC-9 („kein Ausbleiben
+des gesamten Eintrags") beim Wort genommen.
+
+**Ableitungsfunktion:** eigener Modul-Helfer `_messluecken_felder(punkte, ergebnisse)` in
+`src/services/trip_alert.py` — kein Inline-Block. Nur so ist der Fehlerfall aus AC-9 gezielt an
+der Ableitung selbst prüfbar (statt an `_radar_e1_fields()` als Ganzem), und nur so trägt der
+eigene Auffang.
 
 ### Risiko R3 aufgelöst: Index 0 kann bei einem ausgelösten Alarm nie eine Lücke sein
 
@@ -355,9 +369,11 @@ Steuerungsidee mit mehr Indizes.
 
 ## Risiken
 
-- **R4 — Protokollieren darf den Alarm nie kosten.** Die neue Ableitung liegt innerhalb des
-  bestehenden `try`-Blocks von `_radar_e1_fields()` — dasselbe Fail-soft-Muster wie die fünf
-  bestehenden E-1-Größen (AC-9).
+- **R4 — Protokollieren darf den Alarm nie kosten, und die neue Buchführung darf die alte nicht
+  mitreißen.** Die neue Ableitung `_messluecken_felder()` bekommt einen **eigenen** Auffang, nicht
+  den bestehenden von `_radar_e1_fields()`. Sonst risse ein Fehler in der nachrangigen
+  Lücken-Ableitung alle fünf bestehenden E-1-Größen mit (`{}`-Rückgabe) — eine Regression gegen
+  #2050 S6. Siehe „Fail-soft (AC-9)", dort 2026-08-23 präzisiert.
 - **R5 — Bestandsdaten.** Alarmprotokoll-Einträge ohne `measurement_gaps` müssen lesbar bleiben
   und dürfen nicht umgeschrieben werden — Read-Modify-Write, Muster AC-14 aus #2050 S3b (AC-11).
 - **R6 — AC-12/AC-13 der S4a-Spec waren bis zu dieser Scheibe vollständig ungetestet.** Kein

--- a/docs/specs/modules/feat_2050_s4b_messluecken_protokoll.md
+++ b/docs/specs/modules/feat_2050_s4b_messluecken_protokoll.md
@@ -1,0 +1,382 @@
+---
+entity_id: feat_2050_s4b_messluecken_protokoll
+type: feature
+created: 2026-08-23
+updated: 2026-08-23
+status: draft
+workflow: feat-2050-s4b-messluecken-protokoll
+version: "1.0"
+tags: [alarm, nowcast, radar, protokoll, messluecken]
+---
+
+# Messlücken der Radar-Ausdehnung landen im Alarmprotokoll (Issue #2050, Scheibe S4b)
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Ein Radar-Alarm nennt seit #2051 S2a die räumliche Ausdehnung des Regenereignisses
+(„km 2–6"). Fällt einer der bis zu sechs Messpunkte entlang der Reststrecke aus, verschwindet
+er in `derive_rain_zones` kommentarlos — eine Ausdehnung, die aus vier von sechs Punkten
+stammt, ist nachträglich nicht von einer vollständig vermessenen zu unterscheiden. Diese
+Scheibe erfüllt Anforderung **E-1** (Nachvollziehbarkeit: Messpunkt und Vergleichsbasis gehören
+ins Protokoll) für die Ausdehnungs-Messpunkte, indem sie die bereits geschriebenen, aber nie
+gebauten **AC-12/AC-13 der S4a-Spec** baut: Zahl und km-Lage ausgefallener Messpunkte werden im
+Alarmprotokoll festgehalten.
+
+## Herkunft
+
+Aus `docs/specs/modules/feat_2050_s4a_radar_teilausfall.md`, Abschnitt „Acceptance Criteria"
+(dort geschrieben, nie gebaut):
+
+> **AC-12:** Given ein ausgelöster Radar-Alarm, dessen räumliche Ausdehnung aus Messpunkten
+> bestimmt wurde, von denen mindestens einer ausgefallen ist (`derive_rain_zones` überspringt
+> ihn heute kommentarlos, `rain_extent.py:77-78`), When der Alarm protokolliert wird, Then hält
+> der Protokolleintrag fest, dass und an welcher Stelle Messpunkte fehlten — eine Ausdehnung,
+> die aus vier von sechs Punkten stammt, ist nachträglich als solche erkennbar und nicht von
+> einer vollständig vermessenen zu unterscheiden (Anforderung E-1: Messpunkt und
+> Vergleichsbasis gehören ins Protokoll).
+>
+> **AC-13:** Given der auslösende erste Messpunkt meldet Regen, während **alle** Folgepunkte
+> ausfallen, When der Alarm protokolliert wird, Then weist der Eintrag sämtliche Folgepunkte
+> als fehlend aus — die Ausdehnungsaussage schrumpft in diesem Fall still auf den einen
+> gemessenen Punkt zusammen (`km X-X`), und genau dieser Extremfall muss im Protokoll vom
+> echten Befund „Regen nur auf einem Kilometer" unterscheidbar sein.
+
+## Source
+
+- **File:** `src/services/trip_alert.py` — `_radar_e1_fields()` (Suchbegriff
+  `def _radar_e1_fields(`, ~`:180`), Aufrufstelle `_e1 = _radar_e1_fields(` (~`:1899`),
+  Mehrpunkt-Abfrage zwischen der Zuweisung `_zonen_ergebnisse: list = [_zonen_messwert(result)]`
+  (~`:1698`) und der Verdichtung `derive_rain_zones(_punkte, _zonen_ergebnisse)` (~`:1722`)
+- **File:** `src/services/alert_log.py` — `append_entry()` (Suchbegriff `def append_entry(`,
+  ~`:384`), `append_suppressed_entry()` (Suchbegriff `def append_suppressed_entry(`, ~`:525`),
+  geteilter Schreib-Helfer `_apply_e1_fields()` (Suchbegriff `def _apply_e1_fields(`, ~`:341`)
+  samt `_E1_FIELD_TYPES` (~`:331`)
+- **Identifier:** `_radar_e1_fields`, `append_entry`, `append_suppressed_entry`,
+  `_apply_e1_fields`
+
+Schicht: ausschließlich Python-Core (`src/services/`). Kein Go-, kein Frontend-Anteil —
+`internal/store/log.go` liest weiterhin nur die bestehenden Felder aus `entries`, das neue
+Feld bleibt dort unsichtbar, wie schon die bestehenden E-1-Größen aus #2050 S6.
+
+## Zuschnitt-Entscheid: `rain_extent.py` bleibt unangetastet
+
+Der naheliegende Vorschlag — „eine Lücke schließt die laufende Zone ab, dann stimmt der Text
+überall automatisch" — wurde geprüft und **verworfen**. Beide denkbaren Zonenbildungen
+(Zusammenwachsen über die Lücke hinweg *oder* Trennen an der Lücke) behaupten etwas
+Ungemessenes: Zusammenwachsen behauptet durchgehende Nässe, Trennen behauptet Trockenheit.
+Ehrlich ist nur eine **Kennzeichnung** der Lücke — und die ist Wortarbeit, kein Zonen-Umbau.
+
+Zwei Tests aus #2051 S2a schreiben das heutige Nicht-Trennen ausdrücklich fest, beide mit
+Positivkontrolle:
+
+- `tests/tdd/test_regen_ausdehnung_zonenbildung.py::test_ac11_datenloser_punkt_faellt_aus_der_zonenbildung_heraus`
+  (~`:148`) — Ergebnis **mit** Lücke ist identisch zu „Punkt komplett entfernt".
+- `tests/tdd/test_regen_ausdehnung_textstellen.py::test_e4_punkt_ohne_frames_trennt_die_nasszone_nicht`
+  (~`:503`) — `throttled` **und** `data_unavailable` je einzeln: genau **eine** Zone.
+
+Diese Scheibe **erhält** die Lückeninformation und protokolliert sie zusätzlich (E-1). Die
+Zonenbildung selbst bleibt byte-gleich, beide S2a-Wächter bleiben grün. Die Textaussage beider
+Verzerrungsrichtungen (Zonen wachsen zu groß bzw. zu klein zusammen) ist bewusst **nicht** Teil
+dieser Scheibe — siehe „Nicht Ziel".
+
+## Estimated Scope
+
+- **LoC:** ~30–40 Produktivcode (ohne Tests); mit den zwölf ACs zugehörigen Tests kommen
+  voraussichtlich weitere ~80–140 Zeilen dazu
+- **Files:** 3 — 2 Produktivdateien, 1 neue Testdatei
+- **Effort:** low
+- **Risiko:** LOW — additiv, fail-soft, keine Verhaltensänderung an einer bestehenden,
+  freigegebenen Zusicherung (Zonenbildung bleibt unangetastet)
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `src/services/trip_alert.py::_zonen_messwert` | function | Bestehender Filter (#2051 S2a, E4), liefert `None` für alle drei Lückenwege — unverändert, nur ausgewertet |
+| `src/services/trip_alert.py::_punkte` | local list | Positionsgleich zu `_zonen_ergebnisse`; `_punkte[i].distance_from_start_km` liefert die km-Lage einer Lücke |
+| `src/services/alert_log.py::_apply_e1_fields` | function | Geteilter Schreib-Helfer beider `append_*`-Funktionen — bekommt den neuen Parameter, EINE Stelle für beide Aufrufer |
+| `src/services/alert_log.py::_E1_FIELD_TYPES` | module data | Typtabelle für die additiv-defensive Serialisierung — bekommt einen neuen Eintrag (`dict`) |
+| `tests/tdd/test_regen_ausdehnung_textstellen.py::_ZonenRadar` | test helper | Echte `RadarNowcastService`-Unterklasse am DI-Seam von `TripAlertService` (~`:383`), steuerbar über `trocken_index`/`trocken_felder`/`ausnahme_index`/`weitere_trockene` — Muster für die neue Testdatei |
+| `tests/tdd/test_regen_ausdehnung_zonenbildung.py`, `tests/tdd/test_regen_ausdehnung_textstellen.py` | test | Regressions-Wächter, müssen unverändert grün bleiben (AC-12 dieser Spec) |
+
+## Betroffene Dateien
+
+| Datei | Änderungstyp | Beschreibung |
+|---|---|---|
+| `src/services/trip_alert.py` | MODIFY | `_radar_e1_fields()` um die Lücken-Ableitung erweitern (**innerhalb** des bestehenden `try`), Aufrufstelle `_e1 = _radar_e1_fields(...)` um die zwei nötigen Argumente ergänzen (`_punkte`, `_zonen_ergebnisse`) |
+| `src/services/alert_log.py` | MODIFY | `append_entry()` und `append_suppressed_entry()` je um `measurement_gaps: Optional[dict] = None`; geteilter Helfer `_apply_e1_fields()` und `_E1_FIELD_TYPES` um denselben Schlüssel erweitert (EINE Ableitung für beide Aufrufer, Muster #2050 S6) |
+| `tests/tdd/test_radar_messluecken_protokoll.py` | CREATE | AC-1 bis AC-12, benannt nach Verhalten, nicht nach Issue-Nummer |
+
+**`src/services/rain_extent.py`: NICHT betroffen.** Ausdrücklich — siehe „Zuschnitt-Entscheid".
+
+## Implementation Details
+
+### Technischer Ansatz: Ableitung im Aufrufer, nicht in `derive_rain_zones`
+
+Drei Wege wurden gegeneinander bewertet:
+
+| Weg | Idee | Urteil |
+|---|---|---|
+| A | additives Feld an `RainZone` | ❌ semantisch unmöglich — eine Lücke liegt *zwischen* Zonen, keine Zone könnte sie tragen |
+| B | `derive_rain_zones` gibt Lücken zusätzlich zurück | ❌ Rückgabetyp-Änderung ⇒ Referenzfeger über fremde Testdateien, und Doppelarbeit, weil der Aufrufer die Rohinformation längst hat |
+| **C** | **Lücken im Aufrufer ableiten, `rain_extent.py` gar nicht anfassen** | ✅ gewählt |
+
+In `check_radar_alerts` liegt zwischen der Zuweisung `_zonen_ergebnisse: list = [...]`
+(~`:1698`) und der Verdichtung `derive_rain_zones(_punkte, _zonen_ergebnisse)` (~`:1722`)
+bereits index-genauer Zugriff auf `_punkte[i].distance_from_start_km` **und**
+`_zonen_ergebnisse[i] is None` — exakt die Rohinformation, die AC-12 verlangt.
+`derive_rain_zones` bekommt nur den verdichteten Rest und bleibt unverändert.
+
+### Datenform
+
+Neues optionales Feld `measurement_gaps`, abgeleitet in `_radar_e1_fields()` (~`:180`) —
+Suchbegriff `def _radar_e1_fields(` — dem bestehenden Muster „**eine** Ableitung für alle
+Protokollstellen eines Zweigs" folgend (#2050 S6). Die Funktion wird genau einmal gerufen
+(Suchbegriff `_e1 = _radar_e1_fields(`, ~`:1899`) und ihr Ergebnis per `**_e1` an
+`append_entry()` gespreadet.
+
+```python
+"measurement_gaps": {
+    "points_total": <Zahl der Messpunkte>,
+    "points_measured": <Zahl mit verwertbarem Ergebnis>,
+    "gap_km": [<km-Lage jedes ausgefallenen Punkts, auf eine Nachkommastelle gerundet>],
+}
+```
+
+Das Feld wird **immer** gesetzt, sobald die Mehrpunkt-Abfrage lief — auch bei leerer
+`gap_km`-Liste. Ein *fehlendes* Feld hätte sonst drei Bedeutungen zugleich: „alles gemessen",
+„Alteintrag von vor dem Deploy" und „Ableitung fail-soft gescheitert". Genau diese
+Ununterscheidbarkeit ist der Mangel, den die Scheibe beheben soll — sie darf nicht auf einer
+Ebene höher neu entstehen (AC-4).
+
+- **AC-2 erfüllt:** `points_total`/`points_measured`/`gap_km` nennen Zahl *und* Lage.
+- **AC-3 erfüllt:** der Extremfall (`points_total=6, points_measured=1`) ist strukturell vom
+  echten Befund „Regen nur auf einem Kilometer" (`points_total == points_measured`)
+  unterscheidbar — an Zahlen, nicht am Text.
+
+Die km-Rundung folgt derselben Nachkommastelle wie die gemessene km-Spanne
+(`segments.format_alert_location`) und das Zonen-Rendering aus #2051 S2a.
+
+### Geteilter Schreib-Helfer: `_apply_e1_fields` und `_E1_FIELD_TYPES` mitziehen
+
+`append_entry()` und `append_suppressed_entry()` schreiben ihre E-1-Größen beide über
+`_apply_e1_fields()` (~`:341`), gesteuert durch die Typtabelle `_E1_FIELD_TYPES` (~`:331`).
+Ein neues Feld an nur einer der beiden `append_*`-Funktionen vorbeizuschreiben würde diese
+zentrale, additiv-defensive Serialisierung (Typprüfung, `None` → Absenz, fail-soft mit
+`logger.warning`) umgehen. Die Erweiterung um `measurement_gaps: dict` bleibt innerhalb von
+`src/services/alert_log.py` — kein zusätzliches Produktivfile, kein Bruch der
+Zwei-Dateien-Vorgabe.
+
+### Fail-soft (AC-9)
+
+Die neue Ableitung liegt **innerhalb** des bestehenden `try`-Blocks von `_radar_e1_fields()`
+(Muster `_radar_e1_fields` `:207-229`): scheitert sie, entsteht der Alarm trotzdem, nur ohne
+`measurement_gaps` — dieselbe Absicherung wie bei den fünf bestehenden E-1-Größen.
+
+### Risiko R3 aufgelöst: Index 0 kann bei einem ausgelösten Alarm nie eine Lücke sein
+
+Drei Wege, wie der erste Messpunkt ausfällt — keiner erreicht eine Protokollzeile mit
+Ausdehnung:
+
+| Fall am ersten Punkt | Warum kein Alarm |
+|---|---|
+| Abruf wirft | `except` `continue`t, bevor `_zonen_ergebnisse` überhaupt existiert |
+| `data_unavailable=True` | die Zonenbildung läuft zwar, aber der auslösende Zweig `continue`t vorher mit `REASON_DATA_UNAVAILABLE` (S4a) |
+| `throttled=True` | impliziert `not frames` ⇒ `onset_minutes=None`; `radar_alert_due()` verlangt `onset is not None` oder `already_running` — beides falsch ⇒ stiller `continue` |
+
+Folge: AC-13 der S4a-Spec („alle Folgepunkte fallen aus") ist wie geschrieben korrekt —
+gemeint sind zwangsläufig Index 1..N-1. Diese Tatsache braucht eine eigene Positivkontrolle
+(AC-8): sonst prüft niemand, dass ein Ausfall an Index 0 gar nicht bis zur Protokollzeile
+kommt und die Prüfung des Extremfalls (AC-2) damit überhaupt etwas misst.
+
+## Expected Behavior
+
+- **Input:** ein ausgelöster Radar-Alarm, dessen Mehrpunkt-Abfrage für mindestens einen der
+  Folgepunkte kein verwertbares Ergebnis liefert (geworfene Ausnahme, `throttled` oder
+  `data_unavailable`).
+- **Output:** der zugehörige `append_entry()`-Aufruf trägt ein `measurement_gaps`-Feld mit
+  `points_total`, `points_measured` und `gap_km` — unabhängig davon, welcher der drei Wege die
+  Lücke verursacht hat.
+- **Side effects:** keine — die Zonenbildung, die versendete Alarmnachricht und die
+  Auslöseentscheidung bleiben unverändert. Betroffen ist ausschließlich das Alarmprotokoll.
+
+## Acceptance Criteria
+
+- **AC-1:** Given ein Radar-Prüflauf mit drei Zonenpunkten nass–Lücke–nass (mittlerer Punkt
+  ausgefallen), When der Alarm protokolliert wird, Then hält der Eintrag `measurement_gaps`
+  mit der Zahl und der km-Lage genau des mittleren, ausgefallenen Punkts fest.
+
+- **AC-2:** Given der auslösende erste Messpunkt meldet Regen, während alle Folgepunkte
+  ausfallen (`points_total=6`), When der Alarm protokolliert wird, Then weist
+  `measurement_gaps` `points_measured=1` und alle fünf Folgepunkte als `gap_km` aus.
+
+- **AC-3:** Given ein echter Befund „Regen nur auf einem Kilometer" bei vollständig
+  vermessener Strecke (alle sechs Punkte liefern ein Ergebnis, nur einer davon ist nass), When
+  der Alarm protokolliert wird, Then zeigt `measurement_gaps` `points_total == points_measured`
+  und eine leere `gap_km`-Liste — strukturell unterscheidbar vom Extremfall aus AC-2, obwohl
+  beide dieselbe Ausdehnungsangabe „km X–X" im Text erzeugen könnten.
+
+- **AC-4:** Given ein Radar-Prüflauf, dessen Mehrpunkt-Abfrage lief und für alle Punkte ein
+  verwertbares Ergebnis lieferte, When der Alarm protokolliert wird, Then ist
+  `measurement_gaps` trotzdem im Eintrag vorhanden, mit leerer `gap_km`-Liste und
+  `points_total == points_measured` — ein fehlendes Feld darf nicht zugleich „alles gemessen"
+  und „Ableitung gescheitert" bedeuten können.
+
+- **AC-5:** Given der Abruf für einen Folgepunkt wirft eine Ausnahme, When der Alarm
+  protokolliert wird, Then erscheint dieser Punkt in `gap_km` des Protokolleintrags —
+  unabhängig und getrennt von den beiden anderen Lückenwegen geprüft.
+
+- **AC-6:** Given der Abruf für einen Folgepunkt liefert `throttled=True`, When der Alarm
+  protokolliert wird, Then erscheint dieser Punkt in `gap_km` des Protokolleintrags —
+  unabhängig und getrennt von AC-5 und AC-7 geprüft.
+
+- **AC-7:** Given der Abruf für einen Folgepunkt liefert `data_unavailable=True`, When der
+  Alarm protokolliert wird, Then erscheint dieser Punkt in `gap_km` des Protokolleintrags —
+  unabhängig und getrennt von AC-5 und AC-6 geprüft.
+
+- **AC-8:** Given der Ausfall trifft den ersten, auslösenden Messpunkt (Ausnahme oder
+  `data_unavailable=True`), When der Prüflauf durchläuft, Then entsteht dazu **keine**
+  Protokollzeile mit einer Ausdehnungsangabe — der Lauf steigt vorher aus (Positivkontrolle:
+  ohne diesen Nachweis würde niemand belegen, dass AC-2 tatsächlich einen Index-1..N-1-Fall
+  misst).
+
+- **AC-9:** Given die Ableitung von `measurement_gaps` scheitert (z. B. eine unerwartete
+  Datenform), When der Radar-Alarmpfad geprüft wird, Then wird der Alarm trotzdem versendet und
+  protokolliert — nur ohne das Feld `measurement_gaps`, kein Ausbleiben des gesamten Eintrags.
+
+- **AC-10:** Given zwei verschiedene Nutzer erleiden im selben Prüfzyklus je eine Messlücke bei
+  einem ausgelösten Radar-Alarm, When beide Alarmpfade geprüft werden, Then landet jeder
+  `measurement_gaps`-Eintrag ausschließlich im Alarmprotokoll des jeweils betroffenen Nutzers.
+
+- **AC-11:** Given ein Alarmprotokoll enthält Alteinträge ohne das Feld `measurement_gaps`
+  (vor dieser Scheibe geschrieben), When das Protokoll nach dieser Scheibe erneut gelesen oder
+  um einen neuen Eintrag ergänzt wird, Then bleiben die Alteinträge unverändert lesbar und
+  werden nicht umgeschrieben (Read-Modify-Write).
+
+- **AC-12:** Given die beiden bestehenden Regressions-Wächter aus #2051 S2a
+  (`test_ac11_datenloser_punkt_faellt_aus_der_zonenbildung_heraus`,
+  `test_e4_punkt_ohne_frames_trennt_die_nasszone_nicht`), When diese Scheibe implementiert ist,
+  Then bleiben beide Tests unverändert grün und die gerenderte Ausdehnungs-Aussage (Zonenbildung
+  und Text) ändert sich an keiner Stelle.
+
+## Nicht Ziel
+
+- **Die Zonenbildung selbst** (`rain_extent.py::derive_rain_zones`) wird nicht geändert — siehe
+  „Zuschnitt-Entscheid". Beide denkbaren Änderungen (Zusammenwachsen über die Lücke hinweg
+  verhindern oder an der Lücke trennen) behaupten etwas Ungemessenes; ehrlich ist nur eine
+  Kennzeichnung, und die ist Wortarbeit, nicht Zonen-Umbau.
+- **Die Textaussage der Alarmnachricht selbst** — die Kennzeichnung beider
+  Verzerrungsrichtungen (Zonen wachsen zu groß bzw. zu klein zusammen) in `render.py` über alle
+  vier Kanäle samt SMS-Kurzform. Das ist Wortarbeit über das Renderer-Commit-Gate und gehört in
+  die Folge-Scheibe **S4b-2**, nach dem Merge von #2051 S2b.
+- **Keine neue Alarmart und keine Änderung an der Auslöseentscheidung.** Diese Scheibe ist
+  reine Buchführung — ob und wann ein Alarm auslöst, bleibt unverändert.
+- **Kein neuer Alarm für den amtlichen Zweig.** `check_official_alert_triggers` kennt seinen
+  Ausfall-Status im Alarmpfad weiterhin nicht — eigenständiger Nebenbefund, nicht Gegenstand
+  dieser Scheibe.
+- **Regel-Budget:** Diese Scheibe führt **keine** neue Pflicht-Regel und **kein** neues Gate
+  ein — additive, fail-soft Erweiterung eines bestehenden Protokollierungs-Musters.
+
+## Test Plan
+
+### Automated Tests (TDD RED)
+
+Neue Testdatei `tests/tdd/test_radar_messluecken_protokoll.py`, benannt nach Verhalten. Jeder
+Test fährt über die **echte** Auslöseentscheidung (`check_radar_alerts`), nicht über einen Mock
+der geprüften Funktion — Vorbild `tests/tdd/test_regen_ausdehnung_textstellen.py`. Das
+Test-Werkzeug `_ZonenRadar` (~`:383` dort) ist eine echte `RadarNowcastService`-Unterklasse am
+DI-Seam von `TripAlertService` — kein Mock, liefert die Produktiv-Dataclass, steuerbar per
+Index über `trocken_index`, `trocken_felder` (z. B. `{"data_unavailable": True}`,
+`{"throttled": True}`), `ausnahme_index`, `weitere_trockene`. Für AC-2 (alle Folgepunkte
+ausgefallen) muss das Muster ggf. um mehrere gleichzeitige Lückenindizes erweitert werden
+(Implementierungsentscheidung der RED-Phase) — kein neuer Helfer, sondern dieselbe
+Steuerungsidee mit mehr Indizes.
+
+- **AC-1:** `_ZonenRadar` mit einem `trocken_felder`-Lauf (z. B. `data_unavailable`) auf dem
+  mittleren von drei Zonenpunkten; Nachweis über `alert_log.read_undelivered()` bzw. das
+  geschriebene `entries`-Feld `measurement_gaps` — Zahl 1, km-Lage exakt der mittlere Punkt.
+- **AC-2:** alle Folgepunkte auf einen Lückenweg gestellt; `measurement_gaps.points_total=6`,
+  `points_measured=1`, `gap_km` mit fünf Einträgen.
+- **AC-3 (Gegenprobe zu AC-2):** derselbe Aufbau, aber alle sechs Punkte liefern ein Ergebnis,
+  nur einer ist real trocken/nass unterschiedlich — `points_total == points_measured`, leere
+  `gap_km`.
+- **AC-4:** Kontroll-Lauf ganz ohne Ausfall — `measurement_gaps` ist trotzdem vorhanden, mit
+  leerer `gap_km`.
+- **AC-5/AC-6/AC-7:** drei getrennte Testfunktionen, je ein Lückenweg (Ausnahme via
+  `ausnahme_index`, `throttled` via `trocken_felder`, `data_unavailable` via `trocken_felder`)
+  an genau einem Folgepunkt.
+- **AC-8 (Positivkontrolle):** Ausfall am ersten Messpunkt (Ausnahme bzw.
+  `data_unavailable=True`) — Nachweis, dass **keine** Ausdehnungs-Protokollzeile entsteht
+  (kein `measurement_point`/`measurement_gaps`-Eintrag zu diesem Lauf).
+- **AC-9 (Fail-soft):** eine gezielt fehlerhafte Eingabe an die neue Ableitung (z. B. über
+  `monkeypatch` auf die Ableitungsfunktion selbst, nicht auf `_radar_e1_fields` als Ganzes) —
+  der Alarm wird trotzdem versendet und protokolliert, nur ohne `measurement_gaps`.
+- **AC-10:** zwei Nutzer, je ein Lückenlauf im selben Testprozess — `read_undelivered()`/
+  `entries` je Nutzer geprüft, keine Vermischung.
+- **AC-11:** ein vorbereiteter Alteintrag ohne `measurement_gaps` in `alert_log.json`, danach
+  ein neuer Lauf für denselben Nutzer — der Alteintrag bleibt byte-identisch erhalten.
+- **AC-12:** die beiden bestehenden Dateien `tests/tdd/test_regen_ausdehnung_zonenbildung.py`
+  und `tests/tdd/test_regen_ausdehnung_textstellen.py` werden im selben Testlauf mitgeführt und
+  bleiben grün — kein neuer Test nötig, reiner Regressionsnachweis über den vollen Testlauf der
+  Scheibe.
+
+### AC-Test-Mapping
+
+| AC | Testfunktion (geplant) |
+|---|---|
+| AC-1 | `test_luecke_in_der_mitte_haelt_zahl_und_km_lage_fest` |
+| AC-2 | `test_alle_folgepunkte_ausgefallen_ist_der_extremfall` |
+| AC-3 | `test_echter_befund_ein_kilometer_ist_vom_extremfall_unterscheidbar` |
+| AC-4 | `test_luecken_feld_ist_auch_ohne_luecke_vorhanden` |
+| AC-5 | `test_geworfene_ausnahme_erscheint_als_luecke` |
+| AC-6 | `test_throttled_erscheint_als_luecke` |
+| AC-7 | `test_data_unavailable_erscheint_als_luecke` |
+| AC-8 | `test_ausfall_am_ersten_punkt_erzeugt_keine_ausdehnungszeile` |
+| AC-9 | `test_scheiternde_luecken_ableitung_kostet_den_alarm_nicht` |
+| AC-10 | `test_zwei_nutzer_teilen_sich_keinen_luecken_eintrag` |
+| AC-11 | `test_alteintrag_ohne_messluecken_feld_bleibt_unveraendert` |
+| AC-12 | Regressionslauf der beiden #2051-S2a-Dateien im selben Testdurchgang |
+
+## Known Limitations
+
+- **Die Textaussage beider Verzerrungsrichtungen bleibt offen.** Weder das Zu-groß- noch das
+  Zu-klein-Zusammenwachsen der Zonen über eine Lücke hinweg wird durch diese Scheibe im
+  gerenderten Text kenntlich gemacht — Folge-Scheibe **S4b-2**, nach dem Merge von #2051 S2b.
+- **Nur der Trip-Radarzweig.** Der Ortsvergleich-Radarpfad (`compare_radar_alert.py`) hat keine
+  eigene Mehrpunkt-Ausdehnungsmessung und ist von dieser Scheibe nicht betroffen.
+- **Der amtliche Zweig kennt seinen Ausfall im Alarmpfad weiterhin nicht.**
+  `check_official_alert_triggers` verschluckt einen Fehlschlag von
+  `get_official_alerts_for_location` unverändert mit `logger.warning` — eigenständiger
+  Nebenbefund, nicht Gegenstand dieser Scheibe.
+
+## Risiken
+
+- **R4 — Protokollieren darf den Alarm nie kosten.** Die neue Ableitung liegt innerhalb des
+  bestehenden `try`-Blocks von `_radar_e1_fields()` — dasselbe Fail-soft-Muster wie die fünf
+  bestehenden E-1-Größen (AC-9).
+- **R5 — Bestandsdaten.** Alarmprotokoll-Einträge ohne `measurement_gaps` müssen lesbar bleiben
+  und dürfen nicht umgeschrieben werden — Read-Modify-Write, Muster AC-14 aus #2050 S3b (AC-11).
+- **R6 — AC-12/AC-13 der S4a-Spec waren bis zu dieser Scheibe vollständig ungetestet.** Kein
+  bestehender Test griff auf `measurement_gaps` oder eine Lücken-/Messpunktzahl im Protokoll
+  zu — alle roten Tests dieser Scheibe entstehen komplett neu, mit Positivkontrolle für jeden
+  einzelnen (Muster #2050 S2b).
+- **R1/R2 — entfallen.** Beide Risiken der S4a-Spec (frozen `RainZone` braucht Default,
+  Signaturänderung an `derive_rain_zones` erfordert einen Referenzfeger über fremde
+  Testdateien) betrafen ausschließlich Weg A/B. Mit dem gewählten Weg C bleibt
+  `rain_extent.py` unangetastet — beide Risiken sind gegenstandslos, nicht nur gemindert.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** additive Erweiterung eines bereits etablierten, dokumentierten
+  Protokollierungs-Musters (E-1-Größen, #2050 S6/S4a) um ein weiteres optionales Feld. Keine
+  neue Entscheidungsfläche (Kanäle, Provider, Datenmodell-Grundform, Auth, Editor-Paradigma,
+  Test-/Deploy-Strategie) berührt.
+
+## Changelog
+
+- 2026-08-23: Initial spec created (aus `docs/context/feat-2050-s4b-messluecken-protokoll.md`).

--- a/src/services/alert_log.py
+++ b/src/services/alert_log.py
@@ -335,6 +335,11 @@ _E1_FIELD_TYPES = {
     "measurement_point": dict,
     "reference_at": str,
     "source": str,
+    # Issue #2050 S4b (E-1): Zahl und km-Lage der ausgefallenen Messpunkte der
+    # Ausdehnungs-Messung. Ohne Eintrag HIER liefe das Feld an der
+    # additiv-defensiven Serialisierung vorbei (Typpruefung, Absenz bei
+    # `None`, fail-soft mit Meldung).
+    "measurement_gaps": dict,
 }
 
 
@@ -342,6 +347,7 @@ def _apply_e1_fields(
     entry: dict, *, entity_id: str,
     lead_time_minutes=None, event_at=None, event_end_at=None,
     measurement_point=None, reference_at=None, source=None,
+    measurement_gaps=None,
 ) -> None:
     """Additive E-1-Groessen additiv-defensiv in ``entry`` schreiben
     (Issue #2050 S6). ``None`` -> Absenz (kein Schluessel, kein ``null``).
@@ -361,6 +367,7 @@ def _apply_e1_fields(
         ("measurement_point", measurement_point),
         ("reference_at", reference_at),
         ("source", source),
+        ("measurement_gaps", measurement_gaps),
     ):
         if wert is None:
             continue
@@ -406,6 +413,7 @@ def append_entry(
     measurement_point: Optional[dict] = None,
     reference_at: Optional[str] = None,
     source: Optional[str] = None,
+    measurement_gaps: Optional[dict] = None,
 ) -> None:
     """Haengt GENAU EINEN Eintrag an das Alarm-Protokoll des Nutzers an.
 
@@ -497,11 +505,14 @@ def append_entry(
         entry["addendum_reported_at"] = addendum_reported_at
     # Issue #2050 S6 (E-1): gemeldete Vorwarnzeit, Ereigniszeit, Messpunkt,
     # Vergleichsbasis, Quelle -- additiv, defensiv, nie werfend (AC-15).
+    # Issue #2050 S4b: `measurement_gaps` derselbe Weg -- aus wie vielen
+    # Messpunkten die Ausdehnung stammt, gehoert zur Nachvollziehbarkeit.
     _apply_e1_fields(
         entry, entity_id=entity_id,
         lead_time_minutes=lead_time_minutes, event_at=event_at,
         event_end_at=event_end_at, measurement_point=measurement_point,
         reference_at=reference_at, source=source,
+        measurement_gaps=measurement_gaps,
     )
 
     _append(user_id, "entries" if reachable else "not_delivered", entry)
@@ -537,6 +548,7 @@ def append_suppressed_entry(
     measurement_point: Optional[dict] = None,
     reference_at: Optional[str] = None,
     source: Optional[str] = None,
+    measurement_gaps: Optional[dict] = None,
     convective_checked: Optional[bool] = None,
 ) -> None:
     """Haengt GENAU EINEN Eintrag fuer eine VOR dem Versand abgewiesene
@@ -623,6 +635,7 @@ def append_suppressed_entry(
         lead_time_minutes=lead_time_minutes, event_at=event_at,
         event_end_at=event_end_at, measurement_point=measurement_point,
         reference_at=reference_at, source=source,
+        measurement_gaps=measurement_gaps,
     )
     _append(user_id, "not_delivered", entry)
 

--- a/src/services/trip_alert.py
+++ b/src/services/trip_alert.py
@@ -177,9 +177,42 @@ def _zonen_messwert(result):
     return result
 
 
+def _messluecken_felder(punkte, ergebnisse) -> dict:
+    """Zahl und km-Lage der AUSGEFALLENEN Messpunkte der Ausdehnungs-Messung
+    (Issue #2050 S4b, Anforderung E-1).
+
+    Eine Luecke ist ein Punkt ohne verwertbares Ergebnis (`None`): geworfener
+    Abruf, `throttled` und `data_unavailable` sind derselbe Fall in
+    verschiedener Form (`_zonen_messwert`). `derive_rain_zones` uebergeht sie
+    kommentarlos — ohne diese Buchfuehrung waere eine Ausdehnung aus vier von
+    sechs Punkten nachtraeglich nicht von einer vollstaendig vermessenen zu
+    unterscheiden.
+
+    Das Feld entsteht IMMER, sobald die Mehrpunkt-Abfrage lief — auch mit
+    leerer `gap_km`-Liste. Eine Absenz hiesse sonst zugleich "alles gemessen",
+    "Alteintrag von vor dieser Scheibe" und "Ableitung gescheitert", also
+    genau die Ununterscheidbarkeit, die diese Ableitung beseitigen soll.
+
+    Die km-Lage stammt aus derselben Groesse, aus der auch die Zonen ihre
+    Spanne bilden (`distance_from_start_km`), auf eine Nachkommastelle
+    gerundet wie die gemessene Spanne im Text.
+    """
+    luecken = [
+        round(punkt.distance_from_start_km, 1)
+        for punkt, ergebnis in zip(punkte, ergebnisse) if ergebnis is None
+    ]
+    return {
+        "measurement_gaps": {
+            "points_total": len(ergebnisse),
+            "points_measured": len(ergebnisse) - len(luecken),
+            "gap_km": luecken,
+        }
+    }
+
+
 def _radar_e1_fields(
     *, entity_id: str, result, now_utc: datetime, onset_dt: datetime,
-    active, snapshot,
+    active, snapshot, punkte=None, zonen_ergebnisse=None,
 ) -> dict:
     """Die fuenf E-1-Groessen des Radar-Nowcast-Zweigs (Issue #2050 S6).
 
@@ -206,7 +239,7 @@ def _radar_e1_fields(
     """
     try:
         ende_dt = alert_log.nowcast_event_end_at(result, now_utc)
-        return {
+        felder = {
             "lead_time_minutes": result.onset_minutes,
             "event_at": onset_dt.isoformat(),
             "event_end_at": ende_dt.isoformat() if ende_dt else None,
@@ -227,6 +260,23 @@ def _radar_e1_fields(
             entity_id, e,
         )
         return {}
+    # Issue #2050 S4b: EIGENER Auffang, bewusst NICHT der gemeinsame oben.
+    # Der gibt bei einem Fehler `{}` zurueck — ein Fehler in dieser
+    # NACHRANGIGEN Buchfuehrung risse damit alle sechs bestehenden E-1-Groessen
+    # mit und loeschte Messpunkt, Ereigniszeit und Quelle aus dem Eintrag. Das
+    # waere eine Regression gegen #2050 S6, also schlechter als der Stand vor
+    # dieser Scheibe. Scheitert die Ableitung, fehlt genau EIN Feld (AC-9).
+    if punkte is not None and zonen_ergebnisse is not None:
+        try:
+            felder.update(_messluecken_felder(punkte, zonen_ergebnisse))
+        except Exception as e:
+            logger.warning(
+                "alert_log: Messluecken der Ausdehnung fuer entity_id=%s nicht "
+                "ableitbar (%s) — der Alarm laeuft weiter, der Eintrag entsteht "
+                "ohne dieses Feld, die uebrigen E-1-Groessen bleiben.",
+                entity_id, e,
+            )
+    return felder
 
 
 def _trip_telegram_style(trip: "Trip") -> str:
@@ -1896,9 +1946,15 @@ class TripAlertService:
             # Issue #2050 S6 (E-1): die an DIESEM Zweig bekannten Groessen --
             # EINMAL abgeleitet und an allen drei Protokollstellen dieses
             # Zweigs identisch (Briefing-Gate, Ereignis-Identitaet, Versand).
+            # Issue #2050 S4b: `_punkte`/`_zonen_ergebnisse` sind die ROHFORM
+            # der Ausdehnungs-Messung, positionsgleich — aus ihnen entsteht die
+            # Buchfuehrung ueber die ausgefallenen Messpunkte. Die verdichteten
+            # Zonen taugen dafuer nicht: `derive_rain_zones` uebergeht eine
+            # Luecke kommentarlos, danach ist sie nicht mehr rekonstruierbar.
             _e1 = _radar_e1_fields(
                 entity_id=trip.id, result=result, now_utc=now_utc,
                 onset_dt=_onset_dt, active=active, snapshot=_snapshot,
+                punkte=_punkte, zonen_ergebnisse=_zonen_ergebnisse,
             )
             # Sicherheits-Override (Slice 4, #883): konvektive Gefahr (Gewitter/Hagel)
             # durchbricht die Briefing-Unterdrückung. Normaler (nicht-konvektiver)

--- a/tests/tdd/test_radar_messluecken_protokoll.py
+++ b/tests/tdd/test_radar_messluecken_protokoll.py
@@ -61,6 +61,18 @@ _GRAD_PRO_KM = (_ZONEN_LAT1 - _ZONEN_LAT0) / haversine_km(
 # Testvoraussetzung geprueft.
 _DREI_PUNKTE_KM = 6.6
 
+# Die BESTEHENDEN E-1-Groessen des Radar-Zweigs (#2050 S6), die ein
+# Fehlschlag der neuen Luecken-Ableitung nicht mitreissen darf (AC-9).
+# Bewusst namentlich aufgezaehlt und NICHT aus `alert_log._E1_FIELD_TYPES`
+# abgeleitet: eine aus dem Pruefling gezogene Liste hoerte still auf, eine
+# Groesse zu bewachen, sobald sie dort verschwindet.
+# `reference_at` fehlt hier absichtlich — sie entsteht in diesem Aufbau nicht
+# (kein Briefing-Schnappschuss), s. Docstring von AC-9.
+_E1_GROESSEN = (
+    "lead_time_minutes", "event_at", "event_end_at", "measurement_point",
+    "source",
+)
+
 
 class _LueckenRadar(_ZonenRadar):
     """Dieselbe Steuerungsidee wie `_ZonenRadar` — echte
@@ -503,21 +515,44 @@ def test_ausfall_am_ersten_punkt_erzeugt_keine_ausdehnungszeile():
 def test_scheiternde_luecken_ableitung_kostet_den_alarm_nicht(monkeypatch):
     """AC-9 GIVEN die Ableitung von `measurement_gaps` scheitert / WHEN der
     Radar-Alarmpfad laeuft / THEN wird der Alarm trotzdem versendet und
-    protokolliert, nur ohne das Feld.
+    protokolliert — NUR ohne dieses eine Feld.
 
     Der Fehler wird an der ABLEITUNG selbst ausgeloest (`_messluecken_felder`),
     nicht an `_radar_e1_fields` als Ganzem — sonst pruefte der Test die
-    bestehende Absicherung der fuenf E-1-Groessen aus #2050 S6 statt der neuen
+    bestehende Absicherung der E-1-Groessen aus #2050 S6 statt der neuen
     Ableitung.
 
-    Bewusst NICHT mitgeprueft: ob die uebrigen E-1-Groessen den Fehlschlag
-    ueberleben. Die Spec sagt an einer Stelle "nur ohne `measurement_gaps`"
-    (das verlangt einen eigenen Auffang) und an anderer "innerhalb des
-    bestehenden `try`-Blocks" (dann fielen alle fuenf mit weg). AC-9 im
-    Wortlaut fordert nur, dass Alarm und Eintrag entstehen — genau das steht
-    hier.
+    Kern der Zusicherung ist die zweite Haelfte: die BESTEHENDEN E-1-Groessen
+    muessen den Fehlschlag ueberleben. Liegt die neue Ableitung im gemeinsamen
+    `try` von `_radar_e1_fields()`, gibt die Funktion `{}` zurueck und reisst
+    alle fuenf mit — ein Fehler in der nachrangigen Luecken-Buchfuehrung
+    loeschte dann Messpunkt, Ereigniszeit und Quelle aus dem Eintrag. Das waere
+    eine Regression gegen #2050 S6, also schlechter als der Stand vor dieser
+    Scheibe. Geprueft wird deshalb namentlich und am WERT (gegen einen
+    Referenzlauf mit identischem Aufbau), nicht als Sammelaussage: eine reine
+    Praesenz-Pruefung fiele auf einen Eintrag herein, der die Groessen zwar
+    fuehrt, aber mit anderen Zahlen.
+
+    `reference_at` ist die sechste E-1-Groesse und fehlt in DIESEM Aufbau
+    zurecht (kein Briefing-Schnappschuss -> `None` -> Absenz, `_apply_e1_fields`
+    schreibt sie dann gar nicht). Sie steht deshalb nicht in der Liste; die
+    Testvoraussetzung unten haelt fest, welche Groessen der Referenzlauf
+    wirklich fuehrt, damit die Pruefung nicht still leerlaeuft.
     """
     from services import trip_alert as trip_alert_mod
+
+    # Referenzlauf ZUERST, mit identischem Aufbau und noch UNBERUEHRTER
+    # Ableitung: er liefert die Sollwerte der bestehenden E-1-Groessen. Ein
+    # Literal waere hier wertlos — die Werte haengen an Geometrie und Uhr.
+    referenz = _versand_eintrag(
+        _lauf(_LueckenRadar(luecken={2: {"data_unavailable": True}}), tag="ac9-ref")
+    )
+    fehlend = [n for n in _E1_GROESSEN if n not in referenz]
+    assert not fehlend, (
+        f"Testvoraussetzung: der Referenzlauf muss alle gepruefen "
+        f"E-1-Groessen fuehren, es fehlen {fehlend} — sonst prueft der "
+        f"Vergleich unten nichts. Eintrag: {referenz!r}"
+    )
 
     def _explodiert(*args, **kwargs):
         raise ValueError("absichtlich unerwartete Datenform")
@@ -535,6 +570,18 @@ def test_scheiternde_luecken_ableitung_kostet_den_alarm_nicht(monkeypatch):
         f"AC-9: die gescheiterte Ableitung darf kein halbes/erfundenes Feld "
         f"hinterlassen, Eintrag: {eintrag!r}"
     )
+    for name in _E1_GROESSEN:
+        assert name in eintrag, (
+            f"AC-9: die gescheiterte Luecken-Ableitung darf die bestehende "
+            f"E-1-Groesse `{name}` nicht mitreissen (#2050 S6) — sie fehlt im "
+            f"Eintrag. Ein gemeinsamer `try`-Block mit `_radar_e1_fields()` "
+            f"tut genau das. Eintrag: {eintrag!r}"
+        )
+        assert eintrag[name] == referenz[name], (
+            f"AC-9: `{name}` muss den Fehlschlag UNVERAENDERT ueberstehen — "
+            f"erwartet {referenz[name]!r} (Referenzlauf mit identischem "
+            f"Aufbau), war {eintrag[name]!r}"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tdd/test_radar_messluecken_protokoll.py
+++ b/tests/tdd/test_radar_messluecken_protokoll.py
@@ -1,0 +1,610 @@
+"""TDD RED — Issue #2050 Scheibe S4b: Messluecken der Radar-Ausdehnung landen
+im Alarmprotokoll (Anforderung E-1).
+
+SPEC: docs/specs/modules/feat_2050_s4b_messluecken_protokoll.md — AC-1..AC-11
+(AC-12 ist ein reiner Regressionslauf der beiden #2051-S2a-Dateien und braucht
+keinen eigenen Test).
+
+RED-Grund: das Protokollfeld `measurement_gaps` existiert nicht. Faellt einer
+der bis zu sechs Messpunkte aus, verschwindet er in `derive_rain_zones`
+kommentarlos — eine Ausdehnung aus vier von sechs Punkten ist nachtraeglich
+nicht von einer vollstaendig vermessenen zu unterscheiden.
+
+Mock-frei: jeder Lauf geht ueber die ECHTE Ausloeseentscheidung
+(`TripAlertService.check_radar_alerts()`) mit einer echten
+`RadarNowcastService`-Unterklasse am DI-Seam (Muster `_ZonenRadar`,
+`test_regen_ausdehnung_textstellen.py`) und einer echten `alert_log.json`
+unter `get_data_dir(user_id)`. Gesteuert wird ausschliesslich, WELCHES
+`NowcastResult` ein Punkt bekommt.
+
+Die erwarteten km-Werte werden aus den TATSAECHLICH abgefragten Koordinaten
+abgeleitet (Geometrie, `haversine_km` ab WP0), nicht als Literal gesetzt —
+sonst bliebe die Bildungsstelle der km-Lage unbewacht.
+"""
+from __future__ import annotations
+
+import json
+import uuid
+from typing import NamedTuple
+
+from freezegun import freeze_time
+
+from app.config import Settings
+from app.loader import get_briefings_dir, get_data_dir
+from services.radar_service import NowcastResult
+from services.trip_alert import TripAlertService
+from utils.geo import haversine_km
+
+from tests.helpers.arrival_window_fixtures import stage_date
+from tests.tdd.test_regen_ausdehnung_textstellen import (
+    _UHR_TIROL,
+    _ZONEN_LAT0,
+    _ZONEN_LAT1,
+    _ZONEN_LON0,
+    _ZONEN_LON1,
+    _ZonenRadar,
+    _nass_spannen,
+)
+
+# Nord-Strecke wie in `test_regen_ausdehnung_textstellen.py`: bei Zeitanteil
+# 87/360 (`_at` = jetzt + RADAR_ONSET_THRESHOLD_MIN//2) bleiben von den ~24 km
+# gut 18 km Reststrecke und damit die vollen sechs Messpunkte (Deckel).
+# Der Umrechnungsfaktor wird aus DIESER Strecke abgeleitet, nicht geraten —
+# so laesst sich eine kuerzere Etappe (AC-1: drei Punkte) davon ableiten.
+_GRAD_PRO_KM = (_ZONEN_LAT1 - _ZONEN_LAT0) / haversine_km(
+    _ZONEN_LAT0, _ZONEN_LON0, _ZONEN_LAT1, _ZONEN_LON1,
+)
+
+# Etappenlaenge fuer den Drei-Punkte-Aufbau (AC-1): Reststrecke ist 0,7583 der
+# Laenge, drei Punkte entstehen bei Reststrecke in [4, 6) km — 6,6 km liegt
+# mittig in diesem Fenster. Die Punktzahl wird trotzdem in jedem Test als
+# Testvoraussetzung geprueft.
+_DREI_PUNKTE_KM = 6.6
+
+
+class _LueckenRadar(_ZonenRadar):
+    """Dieselbe Steuerungsidee wie `_ZonenRadar` — echte
+    `RadarNowcastService`-Unterklasse am DI-Seam von `TripAlertService`, echte
+    `NowcastResult`-Objekte, kein Mock —, nur mit MEHREREN gleichzeitigen
+    Luecken (AC-2 braucht alle fuenf Folgepunkte auf einmal).
+
+    `luecken` bildet Index -> Felder des Leerergebnisses
+    (`{"throttled": True}` / `{"data_unavailable": True}`), `ausnahmen` sind
+    die Indizes, deren Abruf wirft, `trockene` die ECHT trockenen Punkte
+    (Ergebnis vorhanden, nur kein Regen).
+    """
+
+    def __init__(
+        self,
+        *,
+        luecken: dict[int, dict] | None = None,
+        ausnahmen: tuple[int, ...] = (),
+        trockene: tuple[int, ...] = (),
+    ) -> None:
+        super().__init__()
+        self._luecken = dict(luecken or {})
+        self._ausnahmen = set(ausnahmen)
+        self._trockene = set(trockene)
+
+    @property
+    def ausgefallene_indizes(self) -> list[int]:
+        """Die Indizes, an denen dieser Aufbau eine LUECKE erzeugt — aus der
+        Konfiguration abgeleitet, damit kein Test dieselbe Zahl zweimal
+        hinschreibt."""
+        return sorted(set(self._luecken) | self._ausnahmen)
+
+    def get_nowcast(self, lat, lon, elevation_m=None, priority="user_briefing"):
+        i = len(self.aufrufe)
+        self.aufrufe.append((lat, lon))
+        if i in self._ausnahmen:
+            raise RuntimeError(
+                f"Nowcast-Abruf fuer Zonenpunkt {i} absichtlich fehlgeschlagen"
+            )
+        if i in self._luecken:
+            return NowcastResult(
+                onset_minutes=None, intensity_label="Kein Regen", source="radar",
+                **self._luecken[i],
+            )
+        if i in self._trockene:
+            return NowcastResult(
+                onset_minutes=None, intensity_label="Kein Regen", source="radar",
+            )
+        return NowcastResult(
+            onset_minutes=10, intensity_label="Mäßiger Regen", source="radar",
+            window_precip_mm=3.0, event_end_minutes=40,
+        )
+
+
+class _Lauf(NamedTuple):
+    sent: int
+    body: str
+    spannen: list[str]
+    entries: list[dict]
+    not_delivered: list[dict]
+    km: list[float]
+    uid: str
+    trip_id: str
+
+
+def _uid(tag: str) -> str:
+    return f"tdd-2050-s4b-{tag}-{uuid.uuid4().hex[:8]}"
+
+
+def _endpunkt(strecke_km: float | None) -> tuple[float, float]:
+    if strecke_km is None:
+        return _ZONEN_LAT1, _ZONEN_LON1
+    return _ZONEN_LAT0 + strecke_km * _GRAD_PRO_KM, _ZONEN_LON0
+
+
+def _protokoll(uid: str) -> dict:
+    pfad = get_data_dir(uid) / "alert_log.json"
+    return json.loads(pfad.read_text()) if pfad.exists() else {}
+
+
+def _lauf(
+    radar: _ZonenRadar, *, tag: str = "lauf", uid: str | None = None,
+    strecke_km: float | None = None,
+) -> _Lauf:
+    """Ein echter `check_radar_alerts()`-Lauf (Muster `_zonen_lauf`,
+    `test_regen_ausdehnung_textstellen.py`), zusaetzlich mit dem geschriebenen
+    Alarmprotokoll des Nutzers.
+
+    Der Trip wird als Datei geschrieben und vom Pruefling selbst geladen —
+    dieselbe Strecke wie in Produktion. `km` haelt die Kilometrierung der
+    TATSAECHLICH abgefragten Punkte, unabhaengig vom Pruefling ueber die
+    Geometrie gerechnet (gerade Nord-Strecke, `distance_from_start_km` 0 am
+    Startwegpunkt): ein Sollwert, den der Pruefling selbst liefert, prueft
+    nichts.
+    """
+    uid = uid or _uid(tag)
+    lat1, lon1 = _endpunkt(strecke_km)
+    with freeze_time(_UHR_TIROL):
+        luftlinie = haversine_km(_ZONEN_LAT0, _ZONEN_LON0, lat1, lon1)
+        trip_id = f"tdd-2050-s4b-trip-{uuid.uuid4().hex[:6]}"
+        trips_dir = get_briefings_dir(uid)
+        trips_dir.mkdir(parents=True, exist_ok=True)
+        (trips_dir / f"{trip_id}.json").write_text(json.dumps({
+            "id": trip_id, "name": "Messluecken Draht Trip",
+            "stages": [{
+                "id": "S1", "name": "Tag 1",
+                "date": stage_date(_ZONEN_LAT0, _ZONEN_LON0).isoformat(),
+                "waypoints": [
+                    {
+                        "id": "WP0", "name": "WP0",
+                        "lat": _ZONEN_LAT0, "lon": _ZONEN_LON0,
+                        "elevation_m": 1000.0, "arrival_calculated": "11:00",
+                        "distance_from_start_km": 0.0,
+                    },
+                    {
+                        "id": "WP1", "name": "WP1",
+                        "lat": lat1, "lon": lon1,
+                        "elevation_m": 1000.0, "arrival_calculated": "17:00",
+                        "distance_from_start_km": round(luftlinie, 3),
+                    },
+                ],
+            }],
+            "report_config": {
+                "trip_id": trip_id, "send_email": True, "send_telegram": False,
+            },
+        }))
+
+        captured: list[dict] = []
+        svc = TripAlertService(
+            throttle_hours=2, user_id=uid, radar_service=radar,
+            settings=Settings(
+                smtp_host="test.invalid", smtp_user="u", smtp_pass="p",
+                mail_to="x@example.com",
+            ),
+            mail_sink=lambda subject, body: captured.append(
+                {"subject": subject, "body": body}
+            ),
+        )
+        svc.clear_radar_throttle(trip_id)
+        sent = svc.check_radar_alerts()
+
+    body = captured[0]["body"] if captured else ""
+    protokoll = _protokoll(uid)
+    return _Lauf(
+        sent=sent, body=body, spannen=_nass_spannen(body),
+        entries=protokoll.get("entries", []),
+        not_delivered=protokoll.get("not_delivered", []),
+        km=[
+            haversine_km(_ZONEN_LAT0, _ZONEN_LON0, lat, lon)
+            for lat, lon in radar.aufrufe
+        ],
+        uid=uid, trip_id=trip_id,
+    )
+
+
+def _versand_eintrag(lauf: _Lauf) -> dict:
+    """Der Protokoll-Eintrag des ZUGESTELLTEN Alarms dieses Laufs."""
+    treffer = [e for e in lauf.entries if e.get("entity_id") == lauf.trip_id]
+    assert lauf.sent >= 1 and len(treffer) == 1, (
+        f"Testvoraussetzung: der Lauf muss GENAU EINEN zugestellten "
+        f"Protokoll-Eintrag erzeugt haben (sent={lauf.sent}, "
+        f"entries={lauf.entries!r}, not_delivered={lauf.not_delivered!r})"
+    )
+    return treffer[0]
+
+
+def _messluecken(lauf: _Lauf) -> dict:
+    eintrag = _versand_eintrag(lauf)
+    assert "measurement_gaps" in eintrag, (
+        f"Der Protokoll-Eintrag muss `measurement_gaps` fuehren — sonst ist "
+        f"nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die "
+        f"Ausdehnung stammt. Eintrag: {eintrag!r}"
+    )
+    return eintrag["measurement_gaps"]
+
+
+def _erwartete_gap_km(lauf: _Lauf, indizes: list[int]) -> list[float]:
+    """km-Lage der ausgefallenen Punkte, aus den Abruf-Koordinaten abgeleitet
+    und auf eine Nachkommastelle gerundet (Spec: dieselbe Nachkommastelle wie
+    die gemessene km-Spanne)."""
+    werte = []
+    for i in indizes:
+        roh = lauf.km[i]
+        # Die Rundung kippt bei einer halben Nachkommastelle (x,x5) — nur DORT
+        # waere der Sollwert mehrdeutig. Die Geometrie des Tests wird ueber
+        # diesen Abstand geprueft, nicht ueber die Naehe zum Zehntel selbst.
+        assert abs((roh * 10) % 1 - 0.5) > 0.02, (
+            f"Testvoraussetzung: {roh:.4f} km liegt zu dicht an der "
+            f"Rundungsgrenze (x,x5) — der Sollwert waere nicht eindeutig."
+        )
+        werte.append(round(roh, 1))
+    return werte
+
+
+def _pruefe_luecken(
+    lauf: _Lauf, radar: _LueckenRadar, *, punkte_erwartet: int,
+) -> dict:
+    """Die drei Zahlen gegen den Aufbau pruefen — alle drei ABGELEITET:
+    `points_total` aus der Zahl der tatsaechlichen Abrufe, `points_measured`
+    aus der Differenz zu den ausgefallenen Indizes, `gap_km` aus deren
+    Koordinaten."""
+    assert len(lauf.km) == punkte_erwartet, (
+        f"Testvoraussetzung: {punkte_erwartet} Messpunkte erwartet (der "
+        f"Aufbau haengt daran), gesehen {len(lauf.km)}"
+    )
+    # Sollwerte ZUERST (sie tragen eigene Testvoraussetzungen), erst danach
+    # der Blick ins Protokoll — sonst bliebe eine untaugliche Geometrie hinter
+    # dem fehlenden Feld verborgen.
+    ausgefallen = radar.ausgefallene_indizes
+    erwartete_km = _erwartete_gap_km(lauf, ausgefallen)
+    luecken = _messluecken(lauf)
+
+    assert luecken.get("points_total") == len(lauf.km), (
+        f"`points_total` muss die Zahl der Messpunkte nennen "
+        f"({len(lauf.km)}), war {luecken.get('points_total')!r}: {luecken!r}"
+    )
+    assert luecken.get("points_measured") == len(lauf.km) - len(ausgefallen), (
+        f"`points_measured` muss die Punkte MIT verwertbarem Ergebnis nennen "
+        f"({len(lauf.km)} - {len(ausgefallen)} = "
+        f"{len(lauf.km) - len(ausgefallen)}), war "
+        f"{luecken.get('points_measured')!r}: {luecken!r}"
+    )
+    assert luecken.get("gap_km") == erwartete_km, (
+        f"`gap_km` muss die km-Lage JEDES ausgefallenen Punkts nennen "
+        f"(Indizes {ausgefallen}, abgeleitet aus den Abruf-Koordinaten: "
+        f"{[round(k, 3) for k in lauf.km]}), war {luecken.get('gap_km')!r}"
+    )
+    return luecken
+
+
+# ---------------------------------------------------------------------------
+# AC-1: nass — Luecke — nass, drei Zonenpunkte.
+# ---------------------------------------------------------------------------
+
+def test_luecke_in_der_mitte_haelt_zahl_und_km_lage_fest():
+    """AC-1 GIVEN drei Zonenpunkte, der mittlere ausgefallen / WHEN der Alarm
+    protokolliert wird / THEN nennt `measurement_gaps` Zahl UND km-Lage genau
+    dieses Punkts.
+
+    Geprueft werden die WERTE, nicht die Form: ein `gap_km` mit der km-Lage
+    eines FALSCHEN Punkts (z.B. des ersten statt des mittleren) faellt hier
+    durch, weil der Sollwert aus den Abruf-Koordinaten abgeleitet wird.
+    """
+    radar = _LueckenRadar(luecken={1: {"data_unavailable": True}})
+    lauf = _lauf(radar, tag="ac1", strecke_km=_DREI_PUNKTE_KM)
+
+    luecken = _pruefe_luecken(lauf, radar, punkte_erwartet=3)
+
+    # Die Luecke liegt WEDER am ersten NOCH am letzten Punkt — sonst koennte
+    # ein Pruefling, der schlicht den Streckenanfang oder das Streckenende
+    # meldet, hier zufaellig richtig liegen.
+    assert lauf.km[0] < luecken["gap_km"][0] < lauf.km[-1], (
+        f"Testvoraussetzung: die gemeldete Luecke muss ZWISCHEN erstem und "
+        f"letztem Messpunkt liegen ({[round(k, 3) for k in lauf.km]}), war "
+        f"{luecken['gap_km']!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-2 / AC-3: der Extremfall und sein echter Zwilling — nebeneinander, sonst
+#              belegt AC-2 nichts.
+# ---------------------------------------------------------------------------
+
+def test_alle_folgepunkte_ausgefallen_ist_der_extremfall():
+    """AC-2 GIVEN der ausloesende erste Messpunkt meldet Regen, alle fuenf
+    Folgepunkte fallen aus / WHEN der Alarm protokolliert wird / THEN weist
+    `measurement_gaps` `points_measured=1` und alle fuenf Folgepunkte als
+    `gap_km` aus."""
+    radar = _LueckenRadar(luecken={i: {"data_unavailable": True} for i in range(1, 6)})
+    lauf = _lauf(radar, tag="ac2")
+
+    luecken = _pruefe_luecken(lauf, radar, punkte_erwartet=6)
+
+    assert luecken["points_measured"] == 1 and len(luecken["gap_km"]) == 5, (
+        f"AC-2: genau EIN gemessener Punkt und FUENF Luecken erwartet, war "
+        f"{luecken!r}"
+    )
+
+
+def test_echter_befund_ein_kilometer_ist_vom_extremfall_unterscheidbar():
+    """AC-3 (Gegenprobe zu AC-2) GIVEN dieselbe Strecke, aber alle sechs
+    Punkte liefern ein Ergebnis und nur der erste ist nass / WHEN der Alarm
+    protokolliert wird / THEN zeigt `measurement_gaps`
+    `points_total == points_measured` und eine LEERE `gap_km`-Liste.
+
+    Beide Laeufe stehen hier NEBENEINANDER: die Zusicherung ist nicht "leere
+    Liste", sondern "an den Zahlen unterscheidbar, obwohl der TEXT beide Male
+    dieselbe Ausdehnungsangabe traegt". Ohne den Extremfall im selben Test
+    waere die leere Liste ein Wert ohne Aussage.
+    """
+    echt = _LueckenRadar(trockene=(1, 2, 3, 4, 5))
+    lauf_echt = _lauf(echt, tag="ac3-echt")
+    extrem = _LueckenRadar(luecken={i: {"data_unavailable": True} for i in range(1, 6)})
+    lauf_extrem = _lauf(extrem, tag="ac3-extrem")
+
+    assert lauf_echt.spannen and lauf_echt.spannen == lauf_extrem.spannen, (
+        f"Testvoraussetzung: beide Laeufe muessen DIESELBE Ausdehnungsangabe "
+        f"im Text erzeugen — genau darum muss der Unterschied an den Zahlen "
+        f"haengen. Echt: {lauf_echt.spannen!r}, Extremfall: "
+        f"{lauf_extrem.spannen!r}"
+    )
+
+    luecken_echt = _pruefe_luecken(lauf_echt, echt, punkte_erwartet=6)
+    luecken_extrem = _messluecken(lauf_extrem)
+
+    assert luecken_echt["gap_km"] == [], (
+        f"AC-3: eine vollstaendig vermessene Strecke hat keine Luecken, war "
+        f"{luecken_echt!r}"
+    )
+    assert luecken_echt["points_total"] == luecken_echt["points_measured"], (
+        f"AC-3: vollstaendig vermessen heisst points_total == points_measured, "
+        f"war {luecken_echt!r}"
+    )
+    assert luecken_echt != luecken_extrem, (
+        f"AC-3: der echte Ein-Kilometer-Befund und der Extremfall aus AC-2 "
+        f"muessen sich im Protokoll UNTERSCHEIDEN — beide Male "
+        f"{luecken_echt!r} bei identischem Text {lauf_echt.spannen!r} waere "
+        f"genau die Ununterscheidbarkeit, die diese Scheibe beseitigt."
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-4: das Feld entsteht IMMER, sobald die Mehrpunkt-Abfrage lief.
+# ---------------------------------------------------------------------------
+
+def test_luecken_feld_ist_auch_ohne_luecke_vorhanden():
+    """AC-4 GIVEN ein Lauf ohne jeden Ausfall / WHEN der Alarm protokolliert
+    wird / THEN ist `measurement_gaps` trotzdem vorhanden, mit leerer
+    `gap_km`-Liste.
+
+    Positivkontrolle im zweiten Lauf: derselbe Aufbau MIT einer Luecke muss
+    eine gefuellte `gap_km`-Liste liefern — sonst waere die leere Liste oben
+    trivial wahr (ein Pruefling, der die Liste nie fuellt, kaeme durch).
+    """
+    ohne = _LueckenRadar()
+    lauf_ohne = _lauf(ohne, tag="ac4-ohne")
+    luecken_ohne = _pruefe_luecken(lauf_ohne, ohne, punkte_erwartet=6)
+
+    assert luecken_ohne["gap_km"] == [] and (
+        luecken_ohne["points_total"] == luecken_ohne["points_measured"] == len(lauf_ohne.km)
+    ), (
+        f"AC-4: ohne Ausfall muessen alle Punkte als gemessen gelten und "
+        f"`gap_km` leer sein, war {luecken_ohne!r}"
+    )
+
+    mit = _LueckenRadar(luecken={3: {"throttled": True}})
+    lauf_mit = _lauf(mit, tag="ac4-mit")
+    luecken_mit = _pruefe_luecken(lauf_mit, mit, punkte_erwartet=6)
+    assert luecken_mit["gap_km"], (
+        f"Positivkontrolle: derselbe Aufbau MIT Luecke muss eine gefuellte "
+        f"`gap_km`-Liste liefern — sonst prueft die leere Liste oben nichts. "
+        f"War {luecken_mit!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-5 / AC-6 / AC-7: die drei Lueckenwege, getrennt geprueft.
+# ---------------------------------------------------------------------------
+
+def test_geworfene_ausnahme_erscheint_als_luecke():
+    """AC-5 GIVEN der Abruf eines Folgepunkts wirft / WHEN der Alarm
+    protokolliert wird / THEN erscheint dieser Punkt in `gap_km`."""
+    radar = _LueckenRadar(ausnahmen=(2,))
+    lauf = _lauf(radar, tag="ac5")
+    _pruefe_luecken(lauf, radar, punkte_erwartet=6)
+
+
+def test_throttled_erscheint_als_luecke():
+    """AC-6 GIVEN der Abruf eines Folgepunkts liefert `throttled=True` /
+    WHEN der Alarm protokolliert wird / THEN erscheint dieser Punkt in
+    `gap_km` — die Budget-Drosselung ist kein belegtes "trocken"."""
+    radar = _LueckenRadar(luecken={2: {"throttled": True}})
+    lauf = _lauf(radar, tag="ac6")
+    _pruefe_luecken(lauf, radar, punkte_erwartet=6)
+
+
+def test_data_unavailable_erscheint_als_luecke():
+    """AC-7 GIVEN der Abruf eines Folgepunkts liefert `data_unavailable=True` /
+    WHEN der Alarm protokolliert wird / THEN erscheint dieser Punkt in
+    `gap_km` — der Quellenausfall ist kein belegtes "trocken"."""
+    radar = _LueckenRadar(luecken={2: {"data_unavailable": True}})
+    lauf = _lauf(radar, tag="ac7")
+    _pruefe_luecken(lauf, radar, punkte_erwartet=6)
+
+
+# ---------------------------------------------------------------------------
+# AC-8 (Positivkontrolle): am ERSTEN Punkt entsteht gar keine Zeile mit
+#       Ausdehnung — nur deshalb misst AC-2 einen Index-1..N-1-Fall.
+# ---------------------------------------------------------------------------
+
+def test_ausfall_am_ersten_punkt_erzeugt_keine_ausdehnungszeile():
+    """AC-8 GIVEN der Ausfall trifft den ersten, ausloesenden Messpunkt /
+    WHEN der Pruflauf durchlaeuft / THEN entsteht dazu KEINE Protokollzeile
+    mit einer Ausdehnungsangabe — der Lauf steigt vorher aus.
+
+    Positivkontrolle je Ausfallweg: DERSELBE Ausfall an Index 1 muss sehr wohl
+    eine Zeile mit `measurement_gaps` erzeugen. Ohne sie waere die
+    Abwesenheits-Pruefung oben trivial wahr — sie wuerde auch bestehen, wenn
+    das Feld ueberhaupt nie geschrieben wird, und damit gar nichts belegen.
+    """
+    for name, bau_erster, bau_zweiter in (
+        (
+            "Ausnahme",
+            lambda: _LueckenRadar(ausnahmen=(0,)),
+            lambda: _LueckenRadar(ausnahmen=(1,)),
+        ),
+        (
+            "data_unavailable",
+            lambda: _LueckenRadar(luecken={0: {"data_unavailable": True}}),
+            lambda: _LueckenRadar(luecken={1: {"data_unavailable": True}}),
+        ),
+    ):
+        lauf = _lauf(bau_erster(), tag="ac8-erster")
+        alle = lauf.entries + lauf.not_delivered
+        assert lauf.sent == 0, (
+            f"AC-8/{name}: der Ausfall am ersten Punkt darf keinen Alarm "
+            f"ausloesen, sent={lauf.sent}\nBody:\n{lauf.body}"
+        )
+        mit_ausdehnung = [e for e in alle if "measurement_gaps" in e]
+        assert not mit_ausdehnung, (
+            f"AC-8/{name}: kein Protokoll-Eintrag dieses Laufs darf eine "
+            f"Ausdehnungsangabe tragen — der Lauf hat die Mehrpunkt-Abfrage "
+            f"nie ausgewertet. Gefunden: {mit_ausdehnung!r}"
+        )
+
+        radar_zweiter = bau_zweiter()
+        lauf_zweiter = _lauf(radar_zweiter, tag="ac8-zweiter")
+        luecken = _pruefe_luecken(lauf_zweiter, radar_zweiter, punkte_erwartet=6)
+        assert luecken["gap_km"], (
+            f"Positivkontrolle/{name}: derselbe Ausfall an Index 1 MUSS eine "
+            f"Zeile mit gefuelltem `gap_km` erzeugen — sonst belegt die "
+            f"Abwesenheit oben nichts. War {luecken!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-9: Fail-soft — Protokollieren darf den Alarm nie kosten.
+# ---------------------------------------------------------------------------
+
+def test_scheiternde_luecken_ableitung_kostet_den_alarm_nicht(monkeypatch):
+    """AC-9 GIVEN die Ableitung von `measurement_gaps` scheitert / WHEN der
+    Radar-Alarmpfad laeuft / THEN wird der Alarm trotzdem versendet und
+    protokolliert, nur ohne das Feld.
+
+    Der Fehler wird an der ABLEITUNG selbst ausgeloest (`_messluecken_felder`),
+    nicht an `_radar_e1_fields` als Ganzem — sonst pruefte der Test die
+    bestehende Absicherung der fuenf E-1-Groessen aus #2050 S6 statt der neuen
+    Ableitung.
+
+    Bewusst NICHT mitgeprueft: ob die uebrigen E-1-Groessen den Fehlschlag
+    ueberleben. Die Spec sagt an einer Stelle "nur ohne `measurement_gaps`"
+    (das verlangt einen eigenen Auffang) und an anderer "innerhalb des
+    bestehenden `try`-Blocks" (dann fielen alle fuenf mit weg). AC-9 im
+    Wortlaut fordert nur, dass Alarm und Eintrag entstehen — genau das steht
+    hier.
+    """
+    from services import trip_alert as trip_alert_mod
+
+    def _explodiert(*args, **kwargs):
+        raise ValueError("absichtlich unerwartete Datenform")
+
+    monkeypatch.setattr(trip_alert_mod, "_messluecken_felder", _explodiert)
+
+    lauf = _lauf(_LueckenRadar(luecken={2: {"data_unavailable": True}}), tag="ac9")
+
+    assert lauf.sent >= 1 and lauf.body, (
+        f"AC-9: eine gescheiterte Protokoll-Ableitung darf den Alarm nicht "
+        f"kosten — sent={lauf.sent}\nBody:\n{lauf.body}"
+    )
+    eintrag = _versand_eintrag(lauf)
+    assert "measurement_gaps" not in eintrag, (
+        f"AC-9: die gescheiterte Ableitung darf kein halbes/erfundenes Feld "
+        f"hinterlassen, Eintrag: {eintrag!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-10: Mandantentrennung — zwei verschiedene Nutzer, echte user_id.
+# ---------------------------------------------------------------------------
+
+def test_zwei_nutzer_teilen_sich_keinen_luecken_eintrag():
+    """AC-10 GIVEN zwei verschiedene Nutzer erleiden je eine Messluecke /
+    WHEN beide Alarmpfade laufen / THEN landet jeder `measurement_gaps`-
+    Eintrag ausschliesslich im Protokoll des betroffenen Nutzers.
+
+    Die beiden Luecken liegen an VERSCHIEDENEN Punkten (Index 1 vs. 4): eine
+    Vermischung waere sonst nur an der Zahl der Eintraege erkennbar, nicht am
+    Inhalt — ein gemeinsamer Schreibort mit gleichem Wert kaeme durch.
+    """
+    radar_a = _LueckenRadar(luecken={1: {"data_unavailable": True}})
+    lauf_a = _lauf(radar_a, tag="ac10-a")
+    radar_b = _LueckenRadar(luecken={4: {"throttled": True}})
+    lauf_b = _lauf(radar_b, tag="ac10-b")
+
+    assert lauf_a.uid != lauf_b.uid, "Testvoraussetzung: zwei VERSCHIEDENE Nutzer"
+
+    luecken_a = _pruefe_luecken(lauf_a, radar_a, punkte_erwartet=6)
+    luecken_b = _pruefe_luecken(lauf_b, radar_b, punkte_erwartet=6)
+
+    assert luecken_a["gap_km"] != luecken_b["gap_km"], (
+        f"Testvoraussetzung: die beiden Laeufe muessen unterscheidbare "
+        f"Luecken erzeugen, waren {luecken_a!r} / {luecken_b!r}"
+    )
+    for lauf, fremd in ((lauf_a, lauf_b), (lauf_b, lauf_a)):
+        fremde = [
+            e for e in lauf.entries + lauf.not_delivered
+            if e.get("entity_id") == fremd.trip_id
+        ]
+        assert not fremde, (
+            f"AC-10: im Protokoll von {lauf.uid} darf kein Eintrag des "
+            f"anderen Nutzers stehen — gefunden {fremde!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-11: Bestandsdaten — Alteintraege ohne das Feld bleiben unveraendert.
+# ---------------------------------------------------------------------------
+
+def test_alteintrag_ohne_messluecken_feld_bleibt_unveraendert():
+    """AC-11 GIVEN ein Alarmprotokoll mit einem Alt-Eintrag ohne
+    `measurement_gaps` / WHEN ein neuer Eintrag dazukommt / THEN bleibt der
+    Alt-Eintrag unveraendert lesbar und wird nicht umgeschrieben
+    (Read-Modify-Write)."""
+    uid = _uid("ac11")
+    alt = {
+        "entity_id": "trip-alt-2050-s4b", "entity_type": "trip",
+        "sent_at": "2026-01-05T06:00:00+00:00", "changes_count": 1,
+        "severity": "warn", "metrics": [], "hazards": [], "reason": "nowcast",
+        "channels_sent": ["email"], "channels_not_sent": [],
+    }
+    pfad = get_data_dir(uid) / "alert_log.json"
+    pfad.parent.mkdir(parents=True, exist_ok=True)
+    pfad.write_text(json.dumps({"entries": [dict(alt)]}))
+
+    radar = _LueckenRadar(luecken={2: {"data_unavailable": True}})
+    lauf = _lauf(radar, tag="ac11", uid=uid)
+
+    bestand = [e for e in lauf.entries if e.get("entity_id") == alt["entity_id"]]
+    assert bestand == [alt], (
+        f"AC-11: der Alt-Eintrag muss unveraendert erhalten bleiben (auch "
+        f"OHNE nachtraeglich angebautes `measurement_gaps`), war {bestand!r}"
+    )
+    assert lauf.entries[0] == alt, (
+        f"AC-11: der Alt-Eintrag muss an seiner Stelle stehen bleiben, "
+        f"entries={lauf.entries!r}"
+    )
+    _pruefe_luecken(lauf, radar, punkte_erwartet=6)

--- a/tests/tdd/test_radar_messluecken_protokoll.py
+++ b/tests/tdd/test_radar_messluecken_protokoll.py
@@ -25,17 +25,23 @@ from __future__ import annotations
 
 import json
 import uuid
+from datetime import datetime, timedelta, timezone
 from typing import NamedTuple
 
 from freezegun import freeze_time
 
 from app.config import Settings
 from app.loader import get_briefings_dir, get_data_dir
+from app.models import (
+    ForecastMeta, NormalizedTimeseries, Provider, SegmentWeatherData,
+    SegmentWeatherSummary,
+)
 from services.radar_service import NowcastResult
 from services.trip_alert import TripAlertService
 from utils.geo import haversine_km
 
 from tests.helpers.arrival_window_fixtures import stage_date
+from tests.tdd.test_issue_1070_daily_alert_limit import _segment
 from tests.tdd.test_regen_ausdehnung_textstellen import (
     _UHR_TIROL,
     _ZONEN_LAT0,
@@ -66,12 +72,21 @@ _DREI_PUNKTE_KM = 6.6
 # Bewusst namentlich aufgezaehlt und NICHT aus `alert_log._E1_FIELD_TYPES`
 # abgeleitet: eine aus dem Pruefling gezogene Liste hoerte still auf, eine
 # Groesse zu bewachen, sobald sie dort verschwindet.
-# `reference_at` fehlt hier absichtlich — sie entsteht in diesem Aufbau nicht
-# (kein Briefing-Schnappschuss), s. Docstring von AC-9.
+# `reference_at` ist dabei: der AC-9-Aufbau legt eigens einen
+# Briefing-Schnappschuss an, damit die Groesse ueberhaupt entsteht (ohne ihn
+# bliebe sie `None` und die Zusicherung waere fuer sie leer).
 _E1_GROESSEN = (
     "lead_time_minutes", "event_at", "event_end_at", "measurement_point",
-    "source",
+    "reference_at", "source",
 )
+
+# Erhebungszeitpunkt der Vergleichsbasis im AC-9-Aufbau: eine Stunde vor der
+# gestellten Uhr. EINE Variable — sie speist den geschriebenen Schnappschuss
+# und (ueber den Referenzlauf) die Erwartung, damit `reference_at` am WERT
+# haengt und nicht nur an der Anwesenheit des Schluessels.
+_VERGLEICHSBASIS_AT = datetime.fromisoformat(_UHR_TIROL).astimezone(
+    timezone.utc
+) - timedelta(hours=1)
 
 
 class _LueckenRadar(_ZonenRadar):
@@ -153,9 +168,36 @@ def _protokoll(uid: str) -> dict:
     return json.loads(pfad.read_text()) if pfad.exists() else {}
 
 
+def _schreibe_vergleichsbasis(uid: str, trip_id: str, tag_datum, fetched_at) -> None:
+    """Einen Briefing-Schnappschuss fuer den Tag anlegen, damit
+    `reference_at` ueberhaupt entstehen kann (AC-9).
+
+    Die Zeitreihe bleibt LEER: `_briefing_precip_for_onset()` liefert dann
+    `None`, die Briefing-Unterdrueckung greift nicht und der Alarm laeuft
+    durch — `reference_at` haengt allein am Vorhandensein des Schnappschusses
+    (`snapshot[0].fetched_at`), nicht an einer angekuendigten Menge.
+    """
+    from services.weather_snapshot import WeatherSnapshotService
+
+    WeatherSnapshotService(uid).save_dated(trip_id, tag_datum, [
+        SegmentWeatherData(
+            segment=_segment(1),
+            timeseries=NormalizedTimeseries(
+                meta=ForecastMeta(
+                    provider=Provider.OPENMETEO, model="test", grid_res_km=1.0,
+                ),
+                data=[],
+            ),
+            aggregated=SegmentWeatherSummary(precip_sum_mm=0.0),
+            fetched_at=fetched_at,
+            provider="openmeteo",
+        ),
+    ])
+
+
 def _lauf(
     radar: _ZonenRadar, *, tag: str = "lauf", uid: str | None = None,
-    strecke_km: float | None = None,
+    strecke_km: float | None = None, vergleichsbasis_at=None,
 ) -> _Lauf:
     """Ein echter `check_radar_alerts()`-Lauf (Muster `_zonen_lauf`,
     `test_regen_ausdehnung_textstellen.py`), zusaetzlich mit dem geschriebenen
@@ -167,19 +209,24 @@ def _lauf(
     Geometrie gerechnet (gerade Nord-Strecke, `distance_from_start_km` 0 am
     Startwegpunkt): ein Sollwert, den der Pruefling selbst liefert, prueft
     nichts.
+
+    `vergleichsbasis_at` legt zusaetzlich einen Briefing-Schnappschuss mit
+    diesem Erhebungszeitpunkt an (nur AC-9 braucht ihn, s.
+    `_schreibe_vergleichsbasis`).
     """
     uid = uid or _uid(tag)
     lat1, lon1 = _endpunkt(strecke_km)
     with freeze_time(_UHR_TIROL):
         luftlinie = haversine_km(_ZONEN_LAT0, _ZONEN_LON0, lat1, lon1)
         trip_id = f"tdd-2050-s4b-trip-{uuid.uuid4().hex[:6]}"
+        tag_datum = stage_date(_ZONEN_LAT0, _ZONEN_LON0)
         trips_dir = get_briefings_dir(uid)
         trips_dir.mkdir(parents=True, exist_ok=True)
         (trips_dir / f"{trip_id}.json").write_text(json.dumps({
             "id": trip_id, "name": "Messluecken Draht Trip",
             "stages": [{
                 "id": "S1", "name": "Tag 1",
-                "date": stage_date(_ZONEN_LAT0, _ZONEN_LON0).isoformat(),
+                "date": tag_datum.isoformat(),
                 "waypoints": [
                     {
                         "id": "WP0", "name": "WP0",
@@ -199,6 +246,8 @@ def _lauf(
                 "trip_id": trip_id, "send_email": True, "send_telegram": False,
             },
         }))
+        if vergleichsbasis_at is not None:
+            _schreibe_vergleichsbasis(uid, trip_id, tag_datum, vergleichsbasis_at)
 
         captured: list[dict] = []
         svc = TripAlertService(
@@ -533,25 +582,34 @@ def test_scheiternde_luecken_ableitung_kostet_den_alarm_nicht(monkeypatch):
     Praesenz-Pruefung fiele auf einen Eintrag herein, der die Groessen zwar
     fuehrt, aber mit anderen Zahlen.
 
-    `reference_at` ist die sechste E-1-Groesse und fehlt in DIESEM Aufbau
-    zurecht (kein Briefing-Schnappschuss -> `None` -> Absenz, `_apply_e1_fields`
-    schreibt sie dann gar nicht). Sie steht deshalb nicht in der Liste; die
-    Testvoraussetzung unten haelt fest, welche Groessen der Referenzlauf
-    wirklich fuehrt, damit die Pruefung nicht still leerlaeuft.
+    Beide Laeufe legen eigens einen Briefing-Schnappschuss an: ohne ihn bliebe
+    `reference_at` unbestimmbar (`None` -> Absenz, `_apply_e1_fields` schreibt
+    sie dann gar nicht) und die Zusicherung waere fuer die sechste Groesse
+    leer. Die Zeitreihe des Schnappschusses bleibt leer, damit die
+    Briefing-Unterdrueckung nicht greift und der Alarm durchlaeuft. Die
+    Testvoraussetzung unten haelt fest, dass der Referenzlauf wirklich ALLE
+    gepruefen Groessen fuehrt — sonst liefe der Vergleich still leer.
     """
     from services import trip_alert as trip_alert_mod
 
     # Referenzlauf ZUERST, mit identischem Aufbau und noch UNBERUEHRTER
     # Ableitung: er liefert die Sollwerte der bestehenden E-1-Groessen. Ein
     # Literal waere hier wertlos — die Werte haengen an Geometrie und Uhr.
-    referenz = _versand_eintrag(
-        _lauf(_LueckenRadar(luecken={2: {"data_unavailable": True}}), tag="ac9-ref")
-    )
+    referenz = _versand_eintrag(_lauf(
+        _LueckenRadar(luecken={2: {"data_unavailable": True}}), tag="ac9-ref",
+        vergleichsbasis_at=_VERGLEICHSBASIS_AT,
+    ))
     fehlend = [n for n in _E1_GROESSEN if n not in referenz]
     assert not fehlend, (
         f"Testvoraussetzung: der Referenzlauf muss alle gepruefen "
         f"E-1-Groessen fuehren, es fehlen {fehlend} — sonst prueft der "
         f"Vergleich unten nichts. Eintrag: {referenz!r}"
+    )
+    assert datetime.fromisoformat(referenz["reference_at"]) == _VERGLEICHSBASIS_AT, (
+        f"Testvoraussetzung: `reference_at` muss der Erhebungszeitpunkt des "
+        f"geschriebenen Schnappschusses sein ({_VERGLEICHSBASIS_AT.isoformat()}), "
+        f"war {referenz['reference_at']!r} — sonst misst der Vergleich unten "
+        f"einen Wert, den dieser Test gar nicht gesetzt hat."
     )
 
     def _explodiert(*args, **kwargs):
@@ -559,7 +617,10 @@ def test_scheiternde_luecken_ableitung_kostet_den_alarm_nicht(monkeypatch):
 
     monkeypatch.setattr(trip_alert_mod, "_messluecken_felder", _explodiert)
 
-    lauf = _lauf(_LueckenRadar(luecken={2: {"data_unavailable": True}}), tag="ac9")
+    lauf = _lauf(
+        _LueckenRadar(luecken={2: {"data_unavailable": True}}), tag="ac9",
+        vergleichsbasis_at=_VERGLEICHSBASIS_AT,
+    )
 
     assert lauf.sent >= 1 and lauf.body, (
         f"AC-9: eine gescheiterte Protokoll-Ableitung darf den Alarm nicht "

--- a/tests/tdd/test_radar_messluecken_protokoll.py
+++ b/tests/tdd/test_radar_messluecken_protokoll.py
@@ -33,8 +33,8 @@ from freezegun import freeze_time
 from app.config import Settings
 from app.loader import get_briefings_dir, get_data_dir
 from app.models import (
-    ForecastMeta, NormalizedTimeseries, Provider, SegmentWeatherData,
-    SegmentWeatherSummary,
+    ForecastDataPoint, ForecastMeta, NormalizedTimeseries, Provider,
+    SegmentWeatherData, SegmentWeatherSummary,
 )
 from services.radar_service import NowcastResult
 from services.trip_alert import TripAlertService
@@ -87,6 +87,17 @@ _E1_GROESSEN = (
 _VERGLEICHSBASIS_AT = datetime.fromisoformat(_UHR_TIROL).astimezone(
     timezone.utc
 ) - timedelta(hours=1)
+
+# Angekuendigte Stundenmenge des Briefings fuer den UNTERDRUECKTEN Lauf.
+# Sie muss zwei Bedingungen zugleich erfuellen, damit die
+# Briefing-Unterdrueckung wirklich greift (`trip_alert.py`, Zweig
+# `_briefing_announced and ... and not _overtaking`):
+#   * >= 0,5 mm  -> das Briefing gilt als "hat Regen angekuendigt"
+#   * so gross, dass die gemessenen 3,0 mm des Nowcasts sie NICHT ueberholen
+#     (Ueberholung ab dem Doppelten der Ankuendigung)
+# 5,0 mm erfuellt beides mit Abstand. Der Testaufbau prueft die zweite
+# Bedingung unten selbst nach, statt sich auf diese Rechnung zu verlassen.
+_BRIEFING_MENGE_MM = 5.0
 
 
 class _LueckenRadar(_ZonenRadar):
@@ -168,14 +179,45 @@ def _protokoll(uid: str) -> dict:
     return json.loads(pfad.read_text()) if pfad.exists() else {}
 
 
-def _schreibe_vergleichsbasis(uid: str, trip_id: str, tag_datum, fetched_at) -> None:
+def _stundenreihe(stundenmenge_mm: float | None) -> list:
+    """Stuendliche Zeitreihe ueber zwei Tage mit ueberall derselben
+    angekuendigten Menge — oder LEER, wenn keine Menge gewuenscht ist.
+
+    Ueber zwei volle Tage statt nur der Ereignisstunde: welche Stunde der
+    Pruefling nachschlaegt, haengt an `onset_minutes` und der gestellten Uhr.
+    Eine einzelne, hier ausgerechnete Stunde waere genau die Sorte Literal,
+    die still danebenliegt, sobald sich der Aufbau verschiebt.
+    """
+    if stundenmenge_mm is None:
+        return []
+    tagesbeginn = datetime.now(timezone.utc).replace(
+        hour=0, minute=0, second=0, microsecond=0,
+    )
+    return [
+        ForecastDataPoint(
+            ts=tagesbeginn + timedelta(hours=stunde),
+            precip_1h_mm=stundenmenge_mm,
+        )
+        for stunde in range(48)
+    ]
+
+
+def _schreibe_vergleichsbasis(
+    uid: str, trip_id: str, tag_datum, fetched_at,
+    stundenmenge_mm: float | None = None,
+) -> None:
     """Einen Briefing-Schnappschuss fuer den Tag anlegen, damit
     `reference_at` ueberhaupt entstehen kann (AC-9).
 
-    Die Zeitreihe bleibt LEER: `_briefing_precip_for_onset()` liefert dann
-    `None`, die Briefing-Unterdrueckung greift nicht und der Alarm laeuft
-    durch — `reference_at` haengt allein am Vorhandensein des Schnappschusses
+    Ohne `stundenmenge_mm` bleibt die Zeitreihe LEER:
+    `_briefing_precip_for_onset()` liefert dann `None`, die
+    Briefing-Unterdrueckung greift nicht und der Alarm laeuft durch —
+    `reference_at` haengt allein am Vorhandensein des Schnappschusses
     (`snapshot[0].fetched_at`), nicht an einer angekuendigten Menge.
+
+    MIT `stundenmenge_mm` ist es umgekehrt: das Briefing hat Regen
+    angekuendigt, der Alarm wird unterdrueckt und landet in `not_delivered`
+    (zweiter Schreibpfad, `append_suppressed_entry`).
     """
     from services.weather_snapshot import WeatherSnapshotService
 
@@ -186,7 +228,7 @@ def _schreibe_vergleichsbasis(uid: str, trip_id: str, tag_datum, fetched_at) -> 
                 meta=ForecastMeta(
                     provider=Provider.OPENMETEO, model="test", grid_res_km=1.0,
                 ),
-                data=[],
+                data=_stundenreihe(stundenmenge_mm),
             ),
             aggregated=SegmentWeatherSummary(precip_sum_mm=0.0),
             fetched_at=fetched_at,
@@ -198,6 +240,7 @@ def _schreibe_vergleichsbasis(uid: str, trip_id: str, tag_datum, fetched_at) -> 
 def _lauf(
     radar: _ZonenRadar, *, tag: str = "lauf", uid: str | None = None,
     strecke_km: float | None = None, vergleichsbasis_at=None,
+    briefing_menge_mm: float | None = None,
 ) -> _Lauf:
     """Ein echter `check_radar_alerts()`-Lauf (Muster `_zonen_lauf`,
     `test_regen_ausdehnung_textstellen.py`), zusaetzlich mit dem geschriebenen
@@ -213,6 +256,11 @@ def _lauf(
     `vergleichsbasis_at` legt zusaetzlich einen Briefing-Schnappschuss mit
     diesem Erhebungszeitpunkt an (nur AC-9 braucht ihn, s.
     `_schreibe_vergleichsbasis`).
+
+    `briefing_menge_mm` fuellt dessen Zeitreihe mit einer angekuendigten
+    Stundenmenge — damit laeuft derselbe Aufbau in die
+    Briefing-Unterdrueckung und schreibt ueber den ZWEITEN Protokollpfad
+    (`append_suppressed_entry`) nach `not_delivered`.
     """
     uid = uid or _uid(tag)
     lat1, lon1 = _endpunkt(strecke_km)
@@ -246,8 +294,12 @@ def _lauf(
                 "trip_id": trip_id, "send_email": True, "send_telegram": False,
             },
         }))
-        if vergleichsbasis_at is not None:
-            _schreibe_vergleichsbasis(uid, trip_id, tag_datum, vergleichsbasis_at)
+        if vergleichsbasis_at is not None or briefing_menge_mm is not None:
+            _schreibe_vergleichsbasis(
+                uid, trip_id, tag_datum,
+                vergleichsbasis_at or datetime.now(timezone.utc),
+                stundenmenge_mm=briefing_menge_mm,
+            )
 
         captured: list[dict] = []
         svc = TripAlertService(
@@ -288,14 +340,37 @@ def _versand_eintrag(lauf: _Lauf) -> dict:
     return treffer[0]
 
 
-def _messluecken(lauf: _Lauf) -> dict:
-    eintrag = _versand_eintrag(lauf)
+def _unterdrueckungs_eintrag(lauf: _Lauf) -> dict:
+    """Der Protokoll-Eintrag eines UNTERDRUECKTEN Laufs — zweiter Schreibpfad
+    (`append_suppressed_entry` -> `not_delivered`).
+
+    Zugleich die Positivkontrolle des Aufbaus: nur wenn nichts versendet wurde
+    UND `entries` leer bleibt, misst der Test wirklich den
+    Unterdrueckungspfad. Sonst pruefte er versehentlich wieder
+    `append_entry()`, und die Regression an der zweiten Weiterreichung bliebe
+    unbemerkt.
+    """
+    treffer = [e for e in lauf.not_delivered if e.get("entity_id") == lauf.trip_id]
+    assert lauf.sent == 0 and not lauf.entries and len(treffer) == 1, (
+        f"Testvoraussetzung: der Lauf muss UNTERDRUECKT worden sein — nichts "
+        f"versendet (sent={lauf.sent}), nichts in `entries` "
+        f"({lauf.entries!r}) und GENAU EIN Eintrag in `not_delivered` "
+        f"({lauf.not_delivered!r})"
+    )
+    return treffer[0]
+
+
+def _luecken_feld(eintrag: dict) -> dict:
     assert "measurement_gaps" in eintrag, (
         f"Der Protokoll-Eintrag muss `measurement_gaps` fuehren — sonst ist "
         f"nachtraeglich nicht erkennbar, aus wie vielen Messpunkten die "
         f"Ausdehnung stammt. Eintrag: {eintrag!r}"
     )
     return eintrag["measurement_gaps"]
+
+
+def _messluecken(lauf: _Lauf) -> dict:
+    return _luecken_feld(_versand_eintrag(lauf))
 
 
 def _erwartete_gap_km(lauf: _Lauf, indizes: list[int]) -> list[float]:
@@ -318,11 +393,16 @@ def _erwartete_gap_km(lauf: _Lauf, indizes: list[int]) -> list[float]:
 
 def _pruefe_luecken(
     lauf: _Lauf, radar: _LueckenRadar, *, punkte_erwartet: int,
+    eintrag: dict | None = None,
 ) -> dict:
     """Die drei Zahlen gegen den Aufbau pruefen — alle drei ABGELEITET:
     `points_total` aus der Zahl der tatsaechlichen Abrufe, `points_measured`
     aus der Differenz zu den ausgefallenen Indizes, `gap_km` aus deren
-    Koordinaten."""
+    Koordinaten.
+
+    Ohne `eintrag` wird der zugestellte Eintrag geprueft (`entries`), mit
+    `eintrag` der uebergebene — so gilt fuer BEIDE Protokollpfade dieselbe
+    Wertpruefung, statt dass der zweite eine eigene, schwaechere bekommt."""
     assert len(lauf.km) == punkte_erwartet, (
         f"Testvoraussetzung: {punkte_erwartet} Messpunkte erwartet (der "
         f"Aufbau haengt daran), gesehen {len(lauf.km)}"
@@ -332,7 +412,7 @@ def _pruefe_luecken(
     # dem fehlenden Feld verborgen.
     ausgefallen = radar.ausgefallene_indizes
     erwartete_km = _erwartete_gap_km(lauf, ausgefallen)
-    luecken = _messluecken(lauf)
+    luecken = _messluecken(lauf) if eintrag is None else _luecken_feld(eintrag)
 
     assert luecken.get("points_total") == len(lauf.km), (
         f"`points_total` muss die Zahl der Messpunkte nennen "
@@ -716,3 +796,49 @@ def test_alteintrag_ohne_messluecken_feld_bleibt_unveraendert():
         f"entries={lauf.entries!r}"
     )
     _pruefe_luecken(lauf, radar, punkte_erwartet=6)
+
+
+# ---------------------------------------------------------------------------
+# AC-1 am ZWEITEN Schreibpfad: der unterdrueckte Alarm (`not_delivered`).
+# ---------------------------------------------------------------------------
+
+def test_unterdrueckter_alarm_haelt_die_luecke_genauso_fest():
+    """AC-1 GIVEN ein Lauf mit Messluecke, den das Briefing-Gate UNTERDRUECKT
+    / WHEN er protokolliert wird / THEN traegt sein Eintrag in
+    `not_delivered` dieselbe `measurement_gaps`-Angabe wie ein zugestellter.
+
+    Warum eigener Test: `measurement_gaps` nimmt zwei Wege ins Protokoll —
+    `append_entry()` fuer den zugestellten Alarm und `append_suppressed_entry()`
+    fuer den unterdrueckten. Alle uebrigen Tests dieser Datei laufen ueber den
+    ERSTEN. Die zweite Weiterreichung war damit unbewacht: sie ersatzlos zu
+    entfernen liess jeden anderen Test gruen (Adversary-Fund F001).
+
+    Fachlich ist das kein Randfall — gerade der unterdrueckte Alarm muss
+    nachtraeglich belegen koennen, auf welcher Datenlage die Entscheidung fiel.
+    Ein Eintrag, der die Unterdrueckung festhaelt, aber verschweigt, dass die
+    Ausdehnung aus fuenf von sechs Punkten stammt, ist genau die
+    Ununterscheidbarkeit, die diese Scheibe beseitigt.
+
+    Geprueft wird ueber DIESELBE Wertpruefung wie der zugestellte Pfad
+    (`_pruefe_luecken`), nicht ueber eine schwaechere Praesenz-Abfrage: km-Lage
+    aus der Geometrie abgeleitet, `points_total`/`points_measured` aus dem
+    Aufbau.
+    """
+    radar = _LueckenRadar(luecken={2: {"data_unavailable": True}})
+    lauf = _lauf(radar, tag="unterdrueckt", briefing_menge_mm=_BRIEFING_MENGE_MM)
+
+    eintrag = _unterdrueckungs_eintrag(lauf)
+
+    # Testvoraussetzung: es muss die BRIEFING-Unterdrueckung sein. Die frueher
+    # greifenden Gates (Sperrzeit, Quellenausfall) protokollieren ueber einen
+    # anderen Helfer, der die E-1-Groessen gar nicht entgegennimmt — liefe der
+    # Test dort hinein, pruefte er eine Stelle, an der das Feld konstruktiv
+    # nie ankommt, und der Fehlschlag benannte die falsche Ursache.
+    gruende = {g.get("reason") for g in eintrag.get("channels_not_sent", [])}
+    assert any(str(g).startswith("briefing_announced:") for g in gruende), (
+        f"Testvoraussetzung: der Lauf muss an der BRIEFING-Ankuendigung "
+        f"gescheitert sein (Grund `briefing_announced:…`), gesehen "
+        f"{gruende!r} — sonst misst dieser Test einen anderen Sperrgrund."
+    )
+
+    _pruefe_luecken(lauf, radar, punkte_erwartet=6, eintrag=eintrag)


### PR DESCRIPTION
Baut die in der S4a-Spec **geschriebenen, aber nie gebauten** AC-12/AC-13: Fällt einer der
bis zu sechs Radar-Messpunkte aus, hält der Alarm-Protokolleintrag jetzt Zahl und km-Lage der
Lücken fest (Anforderung **E-1**, Nachvollziehbarkeit).

Bisher war eine Ausdehnung aus vier von sechs Punkten nachträglich **nicht** von einer
vollständig vermessenen zu unterscheiden.

## Was drin ist

Neues additives Protokollfeld `measurement_gaps` (`points_total`, `points_measured`, `gap_km`),
abgeleitet vom neuen Modul-Helfer `_messluecken_felder()`, geschrieben über die zentrale
additiv-defensive Serialisierung (`_E1_FIELD_TYPES` / `_apply_e1_fields`) in **beiden**
Schreibpfaden (`append_entry` und `append_suppressed_entry`).

Das Feld wird **immer** gesetzt, sobald die Mehrpunkt-Abfrage lief — auch ohne Lücke. Sonst
hieße ein fehlendes Feld zugleich „alles gemessen", „Alteintrag" und „Ableitung gescheitert";
genau diese Ununterscheidbarkeit soll die Scheibe beheben.

## Zwei Zuschnitt-Entscheide, die den Umfang klein gehalten haben

**`rain_extent.py` bleibt unangetastet.** Der naheliegende Weg — eine Lücke schließt die
laufende Zone ab — wurde geprüft und verworfen: er tauscht eine Unwahrheit gegen eine andere
(Zusammenwachsen behauptet durchgehende Nässe, Trennen behauptet Trockenheit dazwischen) und
kippt zwei freigegebene Wächter aus #2051 S2a. Ehrlich ist nur eine Kennzeichnung im Text —
die kommt in S4b-2.

**Eigener Fail-soft-Auffang.** Läge die neue Ableitung im bestehenden `try` von
`_radar_e1_fields()`, risse ein Fehler in der *nachrangigen* Lücken-Buchführung alle
E-1-Größen aus #2050 S6 mit (`{}`-Rückgabe) — schlechter als vorher. Jetzt fehlt im
Fehlerfall **nur** `measurement_gaps`.

## Nachweise

| Nachweis | Ergebnis |
|---|---|
| Neue Tests | 12, alle grün |
| Regressions-Wächter #2051 S2a | 15 grün (AC-12: Zonenbildung und Text unverändert) |
| Referenzfeger über 25 fremde Testdateien | 249 Tests, Exit 0 |
| Adversary | Runde 1 **BROKEN** (F001), Runde 2 **VERIFIED** |
| Mutations-Gegenprobe | 10 Mutationen, alle gefangen |

**F001** (Runde 1): Das Forwarding in `append_suppressed_entry()` war durch **keinen** Test im
Repo abgesichert — die Implementierung war korrekt, eine spätere Regression wäre unsichtbar
geblieben. Geschlossen durch einen Test über den `briefing_announced`-Unterdrückungspfad, dessen
Rot-Nachweis der Adversary in Runde 2 selbst nachgestellt hat.

## Was bewusst offen bleibt

- **Die Textaussage** beider Verzerrungsrichtungen → **S4b-2**, nach dem #2051-S2b-Merge
  (dieselben Renderer-Funktionen).
- Nur der Trip-Radarzweig; der amtliche Zweig kennt seinen Ausfall im Alarmpfad weiterhin nicht.

Für Nutzer ändert sich **nichts** sichtbar: keine neue Nachricht, kein geänderter Text, kein
neuer Alarm. Reine Buchführung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KcjAWTQBAhtvGZH67HuYoM
