### PR TITLE
worktree intake 2109

### DIFF
--- a/docs/context/fix-2109-kilometrierung-verlust.md
+++ b/docs/context/fix-2109-kilometrierung-verlust.md
@@ -1,0 +1,98 @@
+# Context: fix-2109-kilometrierung-verlust
+
+## Request Summary
+Die Ausblick-Schleife (`_build_stage_trend`, `_collect_future_stage_weather`) ruft für bis zu 3 künftige Etappen `_convert_trip_to_segments(trip, stage.date)` auf. Diese Methode lässt intern `backfill_stage_distances()` den Trip nachträglich vermessen, persistiert das Ergebnis via `save_trip` — gibt das aktualisierte Trip-Objekt aber nur lokal zurück, nicht an den Aufrufer. Die Schleife arbeitet weiter mit dem alten (unvermessenen) `trip`-Objekt. Beim nächsten Schleifendurchlauf überschreibt `save_trip` (Read-Modify-Write mit Listen-als-Ganzes-Merge, #2058) die zuvor nachgetragene Kilometrierung der vorherigen Etappe wieder mit dem stale Stand. Nachgewiesen im Produktivbetrieb (Trip `5f534011`, Etappe `91bbc11b` dreimal nachgerüstet — Beweis für wiederholten Verlust).
+
+## Related Files
+| File | Relevance |
+|------|-----------|
+| `src/services/trip_report_scheduler.py:2324-2413` (`_build_stage_trend`) | Schleife über `future_stages[:3]`, Zeile 2396 ruft `_convert_trip_to_segments(trip, stage.date)` mit stale `trip` je Iteration |
+| `src/services/trip_report_scheduler.py:2791-2870` (`_collect_future_stage_weather`) | Gleiches Muster, Zeile 2854 — Schleife über `trip.get_future_stages(target_date)`, gefiltert auf `wanted_dates` (bis zu 2 Etappen) |
+| `src/services/trip_report_scheduler.py:1980-2028` (`_convert_trip_to_segments`) | Thin Delegator: ruft `backfill_stage_distances`, gibt NUR `List[TripSegment]` zurück, das aktualisierte `trip` bleibt lokal (Zeile 2025-2028). Wird direkt von **~20 Testdateien** aufgerufen (`segments = svc._convert_trip_to_segments(trip, date)`) — Signatur/Rückgabetyp ist eine breite, stabile Schnittstelle und darf NICHT geändert werden |
+| `src/services/trip_report_scheduler.py:1240-1262` (`_build_report`, primärer Versandpfad) | Ruft `_convert_trip_to_segments` einmal für `target_date`, ggf. ein zweites Mal für einen Test-Fallback-Tag — kein Mehrfach-Backfill DERSELBEN Etappe, daher vermutlich nicht vom selben Verlustmuster betroffen. In Analyse-Phase gegenprüfen, ob `trip` danach noch für die aktuelle Etappe weiterverwendet wird |
+| `src/services/track_resolution.py:264-345` (`backfill_stage_distances`) | Baut per `dataclasses.replace` ein NEUES Trip-Objekt, persistiert bei `persist=True` via `save_trip`, gibt das neue Objekt zurück. Fail-soft (jeder Fehler → unveränderter Trip). Idempotent: kehrt sofort um, wenn alle Wegpunkte bereits `distance_from_start_km` tragen (Zeile 298-304) |
+| `src/app/loader.py:1708-1769` (`save_trip`) + `:128` (`_deep_merge_preserve_unknown`) | Read-Modify-Write mit Merge gegen die Datei auf Platte. Ersetzt Wegpunktlisten pro Etappe ALS GANZES (dokumentiert in #2058) — das ist der Mechanismus, der den stale Stand der vorherigen Iteration über den bereits gespeicherten Fortschritt schreibt |
+| `tests/tdd/test_preview_does_not_mutate_trip_data.py` | Etabliertes Verhalten: `persist`-Parameter-Kontrakt von `_convert_trip_to_segments`/`backfill_stage_distances` ist bereits Gegenstand eines eigenen Bugfixes (#2036 CI-Nachschlag) — jeder Fix hier muss den `persist=False`-Preview-Pfad unangetastet lassen |
+| `docs/specs/modules/trip_report_scheduler.md` | Bestehende Modul-Spec — Ausblick-Feature-Bereich, wird ggf. um AC ergänzt |
+
+## Existing Patterns
+- **`persist`-Parameter-Threading** (#2036/#2058): `_convert_trip_to_segments(trip, date, *, persist=None)` — `None` heißt "folge `self.persist_backfill`". Nebenpfade (`_build_stage_trend`, `_collect_future_stage_weather`) rufen OHNE Keyword und werden über das Objekt-Attribut gesteuert, weil Test-Doubles diese beiden Methoden komplett überschreiben (siehe unten). Ein Fix darf dieses Steuerungsmuster nicht durchbrechen.
+- **Fail-soft**: `backfill_stage_distances` fängt jeden Fehler und gibt den unveränderten Trip zurück — eine fehlende Kilometerangabe ist laut Docstring "ein Schönheitsfehler, ein ausgefallener Alarm nicht". Der Fix muss diese Fail-soft-Eigenschaft erhalten.
+- **Read-Modify-Write mit Merge ist CLAUDE.md-Pflicht** bei jeder Schema-relevanten Änderung — hier bereits vorhanden in `save_trip`, aber der Merge schützt nicht vor einem stale In-Memory-Objekt, das VOR dem Schreiben bereits veraltet ist.
+- **Test-Doubles überschreiben `_build_stage_trend`/`_collect_future_stage_weather` komplett** (>15 Fundstellen, z.B. `test_thunder_origin_preview.py:316`, `test_outlook_scheduler_wires_hiking_window.py:47`) — ein Fix, der neue Pflichtparameter an diesen Methoden einführt, bricht diese Doubles lautlos (kein Fehler, aber die Overrides greifen dann nicht mehr wie erwartet). Signaturänderungen hier sind riskant; ein Fix, der NUR den internen Schleifenkörper ändert (ohne Methodensignatur zu berühren), ist vorzuziehen.
+
+## Dependencies
+- **Upstream:** `services.track_resolution.backfill_stage_distances`, `services.track_resolution.resolve_stage_track_km`, `app.loader.save_trip`/`get_data_dir`
+- **Downstream:** `internal/model/naismith.go:135-138` (Go, Gehzeit-Schätzung nutzt `DistanceFromStartKm` — fällt bei fehlendem Wert auf Ersatzweg zurück, betrifft künftige Etappen im Ausblick). Alarm-Pfad (`trip_alert.py:1385`) ist NICHT betroffen — rüstet die Etappe von `today` selbst und separat nach, vor der Segmentauflösung.
+
+## Existing Specs
+- `docs/specs/modules/trip_report_scheduler.md` — Ausblick-Feature (Abschnitt Implementation Details)
+- Kein dediziertes ADR zu Backfill-Semantik; #2036/#2058 sind die relevanten Vorgänger-Issues (nicht als ADR dokumentiert, nur als Issue-Historie)
+
+## Risks & Considerations
+- **Signaturbruch-Risiko:** `_convert_trip_to_segments` wird direkt von ~20 Testdateien mit der Erwartung `segments = svc._convert_trip_to_segments(...)` (reine Liste) aufgerufen. Rückgabetyp ändern (z.B. Tupel `(trip, segments)`) bricht diese breit. Fix sollte stattdessen den aktualisierten Trip NUR innerhalb der drei betroffenen Schleifen-Aufrufer (`_build_stage_trend`, `_collect_future_stage_weather`, ggf. `_build_report` Fallback) selbst nachführen — z.B. über einen neuen internen Helfer, der (trip, segments) liefert, während `_convert_trip_to_segments` selbst unverändert bleibt.
+- **Doppel-Backfill/Log-Rauschen:** Wird derselbe Trip innerhalb einer Schleife mehrfach an `backfill_stage_distances` übergeben, muss das Verhalten bei "bereits vermessen" (`_melde_unplausible_messung`) nicht neu ausgelöst werden — jede Iteration betrifft eine ANDERE Etappe, daher unkritisch, aber in Adversary-Runde gegenprüfen.
+- **Mutations-Wächter nötig:** Ein grüner Test allein beweist nichts. Wächter muss ZWEI Backfills nacheinander in derselben Schleife/demselben Prozess durchlaufen lassen und danach BEIDE Etappen als vermessen prüfen (Ticket-Vorgabe) — nicht nur die zuletzt bearbeitete.
+- **Datenschema-Änderung:** Kein neues Feld, keine Migration — reiner Kontrollfluss-Fix. `data_schema_backup.py`-Hook greift trotzdem, da `trip_report_scheduler.py` als schema-relevant gilt (import-seitig verknüpft) — prüfen, ob der Pre-Snapshot-Hook triggert.
+- **`_build_report`-Fallback (Zeile 1248/1258):** offene Frage für Analyse-Phase, ob dort ebenfalls ein Verlust entsteht, wenn `trip` nach dem ersten `_convert_trip_to_segments`-Aufruf noch für die (jetzt vermessene) Etappe weiterverwendet wird, bevor der zweite Aufruf (Fallback-Datum) läuft. Nicht Teil des Ticket-Nachweises, aber strukturell verwandt.
+
+## Nicht Ziel (aus Ticket übernommen)
+- Der schlüsselbasierte Listen-Merge aus #2058 — eigene Fallhöhe, eigene Entscheidung.
+- Änderungen an der Trip-Konfiguration des PO.
+
+## Analysis
+
+### Type
+Bug
+
+### Root Cause bestätigt + erweitert
+`_convert_trip_to_segments` (Zeile 2025-2028) reassigned `trip` nur lokal nach dem Backfill und gibt ausschließlich `List[TripSegment]` zurück. Jeder Aufrufer, der `trip` danach WEITERVERWENDET (statt es wegzuwerfen), arbeitet mit dem Stand von vor dem Backfill. Beim nächsten `save_trip` (Read-Modify-Write) wird die zuvor bereits persistierte Kilometrierung überschrieben, weil `_deep_merge_preserve_unknown` Listen — also auch `stages` — **wholesale ersetzt, nicht elementweise merged** (`loader.py:132`: *"Lists are replaced wholesale (not element-merged) — overlay wins."*). Das ist die exakte Stelle, die den in #2109 beschriebenen Verlust technisch erklärt.
+
+**Erweiterter Fund (über das Ticket hinaus, gleicher Mechanismus):** Der Verlust ist nicht auf die Ausblick-Schleife beschränkt. `_build_report` (Zeile 1248) ruft `_convert_trip_to_segments(trip, target_date)` für die HEUTIGE Etappe auf, verwirft die Aktualisierung genauso — und reicht dasselbe stale `trip` anschließend an `_build_stage_trend` (Zeile 1423) und `_collect_future_stage_weather` (Zeile 2602) weiter. Der erste Speichervorgang INNERHALB der Ausblick-Schleife überschreibt dadurch bereits die soeben persistierte Kilometrierung der HEUTIGEN Etappe — nicht nur die einer vorherigen Ausblicks-Iteration. Vier Stellen teilen denselben Fehler:
+1. `_build_report` Zeile 1248 (primärer Aufruf)
+2. `_build_report` Zeile 1258 (Test-Fallback — unkritisch, da anderes Zieldatum UND nur erreicht, wenn Zeile 1248 keine Etappe fand, also dort auch kein Backfill lief)
+3. `_build_stage_trend` Zeile 2396 (Schleife, bis zu 3 Iterationen)
+4. `_collect_future_stage_weather` Zeile 2854 (Schleife, bis zu 2 Iterationen)
+
+### Affected Files (with changes)
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `src/services/trip_report_scheduler.py` | MODIFY | `_convert_trip_to_segments` hinterlegt das aktualisierte Trip-Objekt zusätzlich in einem Instanz-Attribut (Sentinel-Pattern, s.u.); die drei Aufrufstellen (1248, 2396, 2854) lesen es nach dem Aufruf und führen ihr lokales `trip` nach |
+| `tests/tdd/test_stage_trend_backfill_survives_iterations.py` (o.ä. Name, TDD-Phase legt fest) | CREATE | Wächter: zwei/drei Backfills nacheinander in derselben Ausblick-Schleife, danach ALLE betroffenen Etappen als vermessen prüfen |
+
+### Scope Assessment
+- Files: 1 Produktivdatei (4 Stellen) + 1 neue Testdatei
+- Estimated LoC: ca. +25/-4 (klein, mechanischer Fix + Testdatei)
+- Risk Level: **MEDIUM** — Blast Radius ist hoch (Schreibpfad auf Nutzerdaten), aber der Fix selbst ändert keine öffentliche Signatur und keine bestehende Rückgabelogik
+
+### Technical Approach
+**Kein Signaturwechsel von `_convert_trip_to_segments`.** Begründung: ~20 Testdateien rufen `svc._convert_trip_to_segments(trip, date)` direkt auf und erwarten eine reine `List[TripSegment]`; mindestens ein Test (`test_outlook_scheduler_wires_hiking_window.py:47-51`) **überschreibt** `_convert_trip_to_segments` in einer Unterklasse mit fester 2-Positional-Argument-Signatur — ein neues Keyword-Argument an der Aufrufstelle würde diesen Override zur Laufzeit mit `TypeError` brechen. Sowohl Rückgabetyp als auch Aufrufsignatur bleiben deshalb unangetastet.
+
+**Gewählter Mechanismus: Instanz-Attribut als Seitenkanal**, passend zum bestehenden Muster (`self.persist_backfill` steuert bereits heute genau diese Methode auf dieselbe Art):
+
+```python
+# In _convert_trip_to_segments, nach dem Backfill (Ersatz für Zeile 2025-2028):
+if user_id:
+    trip = backfill_stage_distances(trip, user_id, target_date, persist=effective_persist)
+self._last_converted_trip = trip
+return convert_trip_to_segments(trip, target_date)
+```
+
+An jeder der drei betroffenen Aufrufstellen:
+```python
+self._last_converted_trip = None
+segments = self._convert_trip_to_segments(trip, stage.date)  # oder target_date
+if self._last_converted_trip is not None:
+    trip = self._last_converted_trip
+```
+
+**Warum das Sentinel-Reset vor jedem Aufruf zwingend ist:** Wird `_convert_trip_to_segments` in einer Unterklasse überschrieben (wie im genannten Test), läuft der Seitenkanal nie — `self._last_converted_trip` bliebe sonst auf dem Wert eines FRÜHEREN, nicht überschriebenen Aufrufs stehen und der Aufrufer würde fälschlich ein fremdes `trip`-Objekt übernehmen. Das Zurücksetzen auf `None` unmittelbar vor jedem Aufruf verhindert das und lässt bestehende Overrides unverändert funktionieren (sie liefern weiterhin nur Segmente, das Fallback-`trip` bleibt unangetastet — exakt heutiges Verhalten).
+
+Dieses Muster deckt alle vier identifizierten Stellen einheitlich ab, ohne dass irgendein bestehender Test seine Erwartung ändern muss.
+
+### Dependencies
+Keine neuen. Bestehende: `track_resolution.backfill_stage_distances`, `app.loader.save_trip`.
+
+### Open Questions
+- [x] Ist `_build_report` Zeile 1248/1258 vom selben Muster betroffen? → Ja (1248), Nein-praktisch (1258, da kein Backfill vor dem Fallback lief). Beide werden trotzdem einheitlich mitbehandelt (identischer Fix, kein Mehraufwand).
+- [ ] PO-Freigabe der erweiterten Spec (4 statt der im Ticket explizit genannten 2-3 Stellen) — wird in der Spec transparent begründet, keine separate Rückfrage nötig (Tech-Lead-Entscheidung, kein PO-Ermessen).

--- a/docs/specs/modules/fix_2109_kilometrierung_backfill_propagation.md
+++ b/docs/specs/modules/fix_2109_kilometrierung_backfill_propagation.md
@@ -1,0 +1,207 @@
+---
+entity_id: fix_2109_kilometrierung_backfill_propagation
+type: bugfix
+created: 2026-08-23
+updated: 2026-08-23
+status: draft
+version: "1.0"
+tags: [trip-report-scheduler, backfill, track-resolution, persistence]
+workflow: fix-2109-kilometrierung-verlust
+---
+
+# Nachgerüstete Kilometrierung geht in der Ausblick-Schleife wieder verloren
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+`_convert_trip_to_segments()` lässt intern `backfill_stage_distances()` den Trip nachträglich
+vermessen und persistiert das Ergebnis via `save_trip()` — gibt das aktualisierte Trip-Objekt aber
+ausschließlich als lokale Variable zurück, nicht an den Aufrufer. Vier Aufrufstellen arbeiten
+danach mit dem STALE `trip`-Objekt weiter. Da `save_trip()` Listen (u. a. `stages`) beim
+Read-Modify-Write-Merge wholesale ersetzt statt elementweise zu mergen, überschreibt jeder
+nachfolgende Save mit dem stale `trip` eine bereits persistierte Kilometrierung wieder mit dem
+alten Stand. Diese Spec führt das aktualisierte Trip-Objekt an allen betroffenen Aufrufstellen
+zurück in die lokale Variable, damit nachfolgende Saves nicht rückwirkend Daten verlieren.
+
+## Source
+
+- **File:** `src/services/trip_report_scheduler.py`
+- **Identifier:** `_convert_trip_to_segments()` (:1980-2028), `_build_report()` (:1248, :1258),
+  `_build_stage_trend()` (:2396), `_collect_future_stage_weather()` (:2854)
+
+> **Schicht-Hinweis:** Python-Core / Domain-Backend (`src/services/`). Kein Go- und kein
+> Frontend-Anteil — reiner Kontrollfluss-Fix innerhalb bestehender Methoden, kein neues Datenfeld,
+> keine Schema-Änderung.
+
+## Estimated Scope
+
+- **LoC:** ~25-35 Produktivcode
+- **Files:** 2 (`src/services/trip_report_scheduler.py`, 1 neue Testdatei unter `tests/tdd/`)
+- **Effort:** medium — mechanischer Fix an vier Stellen, aber der Wächter muss echte
+  Mehrfach-Iteration über den persistierten Zustand nachweisen, nicht nur den Rückgabewert einer
+  einzelnen Methode.
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `src/services/track_resolution.py` (`backfill_stage_distances`) | module | Baut per `dataclasses.replace` ein neues Trip-Objekt, persistiert bei `persist=True`, gibt das neue Objekt zurück. Fail-soft, idempotent — bleibt unverändert |
+| `src/app/loader.py` (`save_trip`, `_deep_merge_preserve_unknown`) | module | Read-Modify-Write mit Merge; ersetzt Listen (`stages`) wholesale, nicht elementweise (#2058) — der Mechanismus, der den stale Stand über bereits Persistiertes schreibt. Bleibt unverändert |
+| `src/services/trip_report_scheduler.py` (`self.persist_backfill`) | attribute | Bestehendes Instanz-Attribut-Steuerungsmuster für dieselbe Methode — Vorbild für den neuen Seitenkanal `self._last_converted_trip` |
+| `tests/tdd/test_outlook_scheduler_wires_hiking_window.py` (:47-51) | test | Überschreibt `_convert_trip_to_segments` in einer Unterklasse mit fester 2-Positional-Argument-Signatur — muss unverändert funktionieren (kein `TypeError`, kein Übernehmen eines fremden `trip`) |
+| `tests/tdd/test_preview_does_not_mutate_trip_data.py` | test | Etabliert den `persist=False`-Preview-Pfad (#2036 CI-Nachschlag) — darf durch diesen Fix nicht wieder brechen |
+
+## Implementation Details
+
+**Kein Signaturwechsel von `_convert_trip_to_segments`.** Begründung: ~20 Testdateien rufen
+`svc._convert_trip_to_segments(trip, date)` direkt auf und erwarten eine reine
+`List[TripSegment]`; mindestens ein Test (`test_outlook_scheduler_wires_hiking_window.py:47-51`)
+überschreibt die Methode in einer Unterklasse mit fester 2-Positional-Argument-Signatur — ein
+zusätzliches Argument an der Aufrufstelle würde diesen Override mit `TypeError` brechen. Sowohl
+Rückgabetyp als auch Aufrufsignatur bleiben deshalb unangetastet.
+
+**Mechanismus: Instanz-Attribut als Seitenkanal**, passend zum bestehenden Muster
+(`self.persist_backfill` steuert bereits heute dieselbe Methode auf identische Art):
+
+In `_convert_trip_to_segments`, Ersatz für Zeile 2025-2028:
+
+```python
+if user_id:
+    trip = backfill_stage_distances(trip, user_id, target_date, persist=effective_persist)
+self._last_converted_trip = trip
+return convert_trip_to_segments(trip, target_date)
+```
+
+An jeder der vier betroffenen Aufrufstellen (`_build_report` :1248, `_build_report` :1258 als
+Test-Fallback, `_build_stage_trend` :2396, `_collect_future_stage_weather` :2854) unmittelbar um
+den bestehenden Aufruf:
+
+```python
+self._last_converted_trip = None
+segments = self._convert_trip_to_segments(trip, stage.date)  # bzw. target_date
+if self._last_converted_trip is not None:
+    trip = self._last_converted_trip
+```
+
+**Warum das Reset auf `None` vor jedem Aufruf zwingend ist:** Wird `_convert_trip_to_segments` in
+einer Unterklasse überschrieben (wie im genannten Test), läuft der Seitenkanal nie —
+`self._last_converted_trip` bliebe sonst auf dem Wert eines FRÜHEREN, nicht überschriebenen
+Aufrufs stehen, und der Aufrufer würde fälschlich ein fremdes `trip`-Objekt aus einem anderen
+Kontext übernehmen. Das Zurücksetzen auf `None` unmittelbar vor jedem Aufruf verhindert das:
+läuft der Override, bleibt `self._last_converted_trip` `None`, der Aufrufer behält sein
+ursprüngliches `trip` — exakt heutiges (getestetes) Verhalten.
+
+**Warum vier statt der im Ticket genannten zwei/drei Stellen:** `_build_report` (:1248) ruft
+`_convert_trip_to_segments` für die HEUTIGE Etappe auf und reicht dasselbe stale `trip`
+anschließend an `_build_stage_trend` und `_collect_future_stage_weather` weiter — der erste
+Speichervorgang INNERHALB der Ausblick-Schleife überschreibt dadurch bereits die soeben
+persistierte Kilometrierung der heutigen Etappe, nicht nur die einer vorherigen
+Ausblicks-Iteration. Zeile 1258 (Test-Fallback, anderes Zieldatum) wird aus Konsistenzgründen
+identisch mitgepatcht, obwohl dort praktisch kein Verlust entsteht (kein Backfill lief vor
+Erreichen dieser Zeile, da sie nur greift, wenn Zeile 1248 keine Etappe fand).
+
+## Expected Behavior
+
+- **Input:** Ein Trip mit mindestens zwei Etappen (heutige + mindestens eine künftige), deren
+  Wegpunkte noch keine `distance_from_start_km`-Werte tragen, sowie ein GPX-Bestand, aus dem
+  `backfill_stage_distances()` diese Werte für beide Etappen ableiten kann.
+- **Output:** Nach einem vollständigen Report-Lauf (`_build_report` inkl. Ausblick) tragen ALLE
+  vom Lauf berührten Etappen (heutige UND künftige) ihre nachgerüstete Kilometrierung auf der
+  Platte — keine überschreibt die andere.
+- **Side effects:** `self._last_converted_trip` ist ein neues, rein internes Instanz-Attribut ohne
+  Persistenz und ohne API-Sichtbarkeit. Keine Änderung an `save_trip()`, `backfill_stage_distances()`
+  oder deren Signaturen.
+
+## Acceptance Criteria
+
+- **AC-1:** Given eine heutige Etappe hat noch keine nachgerüstete Kilometrierung, ein
+  Ausblicks-Etappe folgt / When `_build_report()` läuft (persist=True) und dabei zuerst die
+  heutige Etappe konvertiert, danach im Rahmen des Ausblicks die künftige Etappe konvertiert und
+  gespeichert wird / Then trägt nach dem Lauf sowohl die heutige als auch die künftige Etappe ihre
+  jeweils nachgerüstete Kilometrierung auf der Platte.
+  - Test: Trip mit zwei unvermessenen Etappen und passendem GPX-Bestand wird durch
+    `_build_report()` geschickt; anschließend wird der Trip neu von der Platte geladen und beide
+    Etappen tragen `distance_from_start_km`-Werte an ihren Wegpunkten — nicht nur die zuletzt
+    bearbeitete.
+
+- **AC-2:** Given eine Ausblick-Schleife (`_build_stage_trend()` oder
+  `_collect_future_stage_weather()`) durchläuft zwei oder drei künftige Etappen nacheinander, jede
+  davon zuvor unvermessen / When jede Iteration `_convert_trip_to_segments()` aufruft und dabei
+  ihre Etappe nachrüstet und speichert / Then trägt nach Abschluss der Schleife JEDE der
+  durchlaufenen Etappen ihre nachgerüstete Kilometrierung — nicht nur die zeitlich letzte
+  Iteration.
+  - Test: Trip mit drei künftigen, unvermessenen Etappen und vollständigem GPX-Bestand wird durch
+    `_build_stage_trend()` geschickt; nach dem Lauf wird der Trip neu von der Platte geladen und
+    prüft für alle drei Etappen (nicht nur die dritte) auf gesetzte
+    `distance_from_start_km`-Werte. Das ist der vom Ticket geforderte Wächter gegen den in Prod
+    (Trip `5f534011`, Etappe `91bbc11b`) beobachteten Mehrfach-Verlust.
+
+- **AC-3:** Given `_build_report()` rüstet die heutige Etappe nach (:1248) und übergibt den Trip
+  danach an `_build_stage_trend()`, wo eine künftige Etappe ebenfalls nachgerüstet und gespeichert
+  wird / When beide Schritte im selben Report-Lauf ablaufen / Then verliert die heutige Etappe ihre
+  Kilometrierung NICHT, obwohl der Speichervorgang der künftigen Etappe zeitlich später erfolgt.
+  - Test: Trip mit unvermessener heutiger und unvermessener künftiger Etappe wird durch den
+    kompletten `_build_report()`-Lauf (inkl. Ausblick) geschickt; nach dem Lauf trägt die HEUTIGE
+    Etappe ihre Kilometrierung, obwohl `_build_stage_trend()` danach nochmals gespeichert hat.
+    Deckt die Cross-Boundary-Kette `_build_report` → `_build_stage_trend` ab.
+
+- **AC-4:** Given eine Unterklasse überschreibt `_convert_trip_to_segments(self, trip,
+  target_date)` mit der alten 2-Positional-Argument-Signatur (wie
+  `test_outlook_scheduler_wires_hiking_window.py`) / When `_build_report()`,
+  `_build_stage_trend()` oder `_collect_future_stage_weather()` diese überschriebene Methode
+  aufrufen / Then läuft der Aufruf ohne `TypeError`, und der Aufrufer arbeitet weiterhin mit
+  seinem ursprünglichen `trip`-Objekt statt mit dem Ergebnis eines früheren, nicht überschriebenen
+  Aufrufs.
+  - Test: Eine Testklasse überschreibt `_convert_trip_to_segments` exakt wie im bestehenden
+    Override und ruft anschließend zweimal hintereinander eine der drei Aufrufer-Methoden mit
+    unterschiedlichen `trip`-Objekten auf; der zweite Aufruf zeigt keine Spur des `trip`-Objekts
+    aus dem ersten Aufruf (Identitätsprüfung `is`/`is not` auf das lokale `trip` nach dem Aufruf).
+
+- **AC-5:** Given `backfill_stage_distances()` wirft eine Exception während eines Aufrufs von
+  `_convert_trip_to_segments()` innerhalb der Ausblick-Schleife / When der Fehler auftritt / Then
+  bleibt das bisher verwendete `trip`-Objekt beim Aufrufer unverändert nutzbar, kein Absturz des
+  Report-Laufs, und die Fail-soft-Eigenschaft bleibt erhalten.
+  - Test: `backfill_stage_distances` wird für eine Etappe so präpariert, dass sie eine Exception
+    wirft; `_build_stage_trend()` bzw. `_collect_future_stage_weather()` läuft trotzdem bis zum
+    Ende durch (kein unbehandelter Fehler propagiert nach außen), das lokale `trip` bleibt danach
+    identisch zum Zustand vor dem fehlgeschlagenen Aufruf.
+
+- **AC-6:** Given `PreviewService` ruft `_convert_trip_to_segments(trip, date, persist=False)`
+  auf / When der Aufruf läuft / Then wird weiterhin NICHTS auf die Platte geschrieben — der neue
+  Seitenkanal (`self._last_converted_trip`) ändert nichts am Persistenz-Verhalten des
+  `persist=False`-Pfads.
+  - Test: Bestehender Test `test_preview_does_not_mutate_trip_data.py` läuft unverändert grün;
+    zusätzlich wird nach einem `persist=False`-Aufruf geprüft, dass die Trip-Datei auf der Platte
+    zeitlich unverändert bleibt (kein neuer `mtime`).
+
+## Known Limitations
+
+- **Der schlüsselbasierte Listen-Merge aus #2058 wird nicht angefasst.** `save_trip()` ersetzt
+  Listen weiterhin wholesale, nicht elementweise — diese Spec verhindert nur, dass ein STALE
+  `trip`-Objekt überhaupt an `save_trip()` übergeben wird. Eine grundsätzlich robustere
+  Merge-Strategie ist eine eigene, separate Entscheidung.
+- **Keine Änderung an der Trip-Konfiguration des PO.** Der Fix ändert ausschließlich
+  Kontrollfluss in `trip_report_scheduler.py`, keine Nutzerdaten.
+- **Zeile 1258 (Test-Fallback) ist praktisch unkritisch**, da an dieser Stelle bislang kein
+  Backfill lief, bevor sie erreicht wird (nur relevant, wenn Zeile 1248 keine Etappe fand). Wird
+  aus Konsistenzgründen mit demselben Muster gepatcht, um keine Sonderfall-Ausnahme im Code zu
+  hinterlassen, die bei künftigen Änderungen übersehen werden könnte.
+- **Der Seitenkanal `self._last_converted_trip` ist proze­ss-/instanzlokal.** Parallel laufende
+  Report-Läufe auf unterschiedlichen `TripReportSchedulerService`-Instanzen beeinflussen sich
+  nicht gegenseitig; innerhalb EINER Instanz ist die Reihenfolge Reset→Aufruf→Lesen zwingend
+  einzuhalten (siehe AC-4).
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Reiner Kontrollfluss-Fix innerhalb bestehender Methoden — kein neues Datenfeld,
+  keine Schema-Änderung, kein neuer Kanal, keine neue Persistenzentscheidung. Das Seitenkanal-Muster
+  greift ein bereits etabliertes Steuerungsmuster (`self.persist_backfill`) auf, führt kein neues
+  Architekturkonzept ein.
+
+## Changelog
+
+- 2026-08-23: Initial spec created

--- a/docs/specs/modules/fix_2109_kilometrierung_backfill_propagation.md
+++ b/docs/specs/modules/fix_2109_kilometrierung_backfill_propagation.md
@@ -31,6 +31,11 @@ zurück in die lokale Variable, damit nachfolgende Saves nicht rückwirkend Date
 - **File:** `src/services/trip_report_scheduler.py`
 - **Identifier:** `_convert_trip_to_segments()` (:1980-2028), `_build_report()` (:1248, :1258),
   `_build_stage_trend()` (:2396), `_collect_future_stage_weather()` (:2854)
+- **File (Nachtrag Adversary-Finding F001):** `src/services/trip_command_processor.py`
+- **Identifier:** `_fetch_and_save_snapshot()` (:359-360) — On-Demand-Query-Pfad (Telegram
+  „heute"/„morgen"-Abfrage), reproduziert denselben Mechanismus: zwei aufeinanderfolgende
+  `scheduler._convert_trip_to_segments()`-Aufrufe (heute, morgen) teilen dasselbe, nie
+  aktualisierte `trip`-Objekt
 
 > **Schicht-Hinweis:** Python-Core / Domain-Backend (`src/services/`). Kein Go- und kein
 > Frontend-Anteil — reiner Kontrollfluss-Fix innerhalb bestehender Methoden, kein neues Datenfeld,
@@ -38,9 +43,10 @@ zurück in die lokale Variable, damit nachfolgende Saves nicht rückwirkend Date
 
 ## Estimated Scope
 
-- **LoC:** ~25-35 Produktivcode
-- **Files:** 2 (`src/services/trip_report_scheduler.py`, 1 neue Testdatei unter `tests/tdd/`)
-- **Effort:** medium — mechanischer Fix an vier Stellen, aber der Wächter muss echte
+- **LoC:** ~25-35 Produktivcode + ~6-10 (Nachtrag F001)
+- **Files:** 3 (`src/services/trip_report_scheduler.py`, `src/services/trip_command_processor.py`,
+  1 neue Testdatei unter `tests/tdd/`)
+- **Effort:** medium — mechanischer Fix an vier (+1 Nachtrag) Stellen, aber der Wächter muss echte
   Mehrfach-Iteration über den persistierten Zustand nachweisen, nicht nur den Rückgabewert einer
   einzelnen Methode.
 
@@ -177,6 +183,21 @@ Erreichen dieser Zeile, da sie nur greift, wenn Zeile 1248 keine Etappe fand).
     zusätzlich wird nach einem `persist=False`-Aufruf geprüft, dass die Trip-Datei auf der Platte
     zeitlich unverändert bleibt (kein neuer `mtime`).
 
+- **AC-7 (Nachtrag, Adversary-Finding F001):** Given `_fetch_and_save_snapshot()`
+  (`trip_command_processor.py:359-360`, On-Demand-Query-Pfad z.B. Telegram „heute"/„morgen") ruft
+  `scheduler._convert_trip_to_segments(trip, today)` und danach
+  `scheduler._convert_trip_to_segments(trip, tomorrow)` auf, beide Etappen zuvor unvermessen /
+  When der erste Aufruf die heutige Etappe nachrüstet und speichert, der zweite Aufruf danach die
+  morgige Etappe nachrüstet und speichert / Then behält die heutige Etappe ihre Kilometrierung —
+  derselbe Seitenkanal-Mechanismus (`scheduler._last_converted_trip`, Reset vor jedem Aufruf, Lesen
+  danach) wird auch hier angewendet, da `scheduler` eine konkrete `TripReportSchedulerService`-
+  Instanz ist (kein Override-Risiko wie bei AC-4).
+  - Test: Trip mit zwei unvermessenen Etappen (heute, morgen) und passendem GPX-Bestand wird durch
+    `_fetch_and_save_snapshot()` geschickt; anschließend wird der Trip neu von der Platte geladen
+    und die heutige Etappe trägt weiterhin ihre `distance_from_start_km`-Werte, obwohl der zweite
+    (morgige) Save zeitlich später erfolgte. Von der Adversary-Verifikation empirisch als RED
+    nachgewiesen (Repro-Test im Scratchpad der Verifikations-Session).
+
 ## Known Limitations
 
 - **Der schlüsselbasierte Listen-Merge aus #2058 wird nicht angefasst.** `save_trip()` ersetzt
@@ -205,3 +226,7 @@ Erreichen dieser Zeile, da sie nur greift, wenn Zeile 1248 keine Etappe fand).
 ## Changelog
 
 - 2026-08-23: Initial spec created
+- 2026-08-23: AC-7 nachgetragen (Adversary-Finding F001) — fünfte Aufrufstelle
+  `trip_command_processor.py:_fetch_and_save_snapshot()` reproduziert denselben Mechanismus,
+  identischer Fix (Tech-Lead-Entscheidung, transparent begründet, kein separates PO-Gate — analog
+  zur bereits dokumentierten Erweiterung von 2-3 auf 4 Stellen im ursprünglichen Scope)

--- a/docs/specs/modules/trip_report_scheduler.md
+++ b/docs/specs/modules/trip_report_scheduler.md
@@ -111,6 +111,12 @@ def _convert_trip_to_segments(trip: Trip, target_date: date) -> list[TripSegment
     return segments
 ```
 
+> **Hinweis (2026-08-23, #2109):** Diese Skizze zeigt den ursprünglichen Story-3-Entwurf. Die
+> heutige Implementierung ruft in `_convert_trip_to_segments` zusätzlich
+> `backfill_stage_distances()` auf und persistiert das nachgerüstete Trip-Objekt via
+> `self._last_converted_trip` (Instanz-Attribut-Seitenkanal) an die Aufrufer zurück — Details in
+> `docs/specs/modules/fix_2109_kilometrierung_backfill_propagation.md`.
+
 ### 2. Active Trip Filter
 
 Nur Trips mit Stage fuer heute (Morning) oder morgen (Evening) werden verarbeitet:

--- a/src/services/trip_command_processor.py
+++ b/src/services/trip_command_processor.py
@@ -356,8 +356,14 @@ def _fetch_and_save_snapshot(trip, user_id: str, today, tomorrow) -> None:
 
     try:
         scheduler = TripReportSchedulerService(user_id=user_id)
+        scheduler._last_converted_trip = None
         segments = scheduler._convert_trip_to_segments(trip, today)
+        if scheduler._last_converted_trip is not None:
+            trip = scheduler._last_converted_trip
+        scheduler._last_converted_trip = None
         segments_tomorrow = scheduler._convert_trip_to_segments(trip, tomorrow)
+        if scheduler._last_converted_trip is not None:
+            trip = scheduler._last_converted_trip
         all_segments = segments + segments_tomorrow
         if not all_segments:
             return

--- a/src/services/trip_report_scheduler.py
+++ b/src/services/trip_report_scheduler.py
@@ -1245,7 +1245,10 @@ class TripReportSchedulerService:
         # ersetzt die interne Auflösung — kein zweiter Auflöser.
         if target_date is None:
             target_date = self._get_target_date(report_type, trip, now_utc)
+        self._last_converted_trip = None
         segments = self._convert_trip_to_segments(trip, target_date)
+        if self._last_converted_trip is not None:
+            trip = self._last_converted_trip
 
         # Issue #768: Test-Pfad-Fallback — wenn am regulären Zieldatum keine
         # Etappe liegt, weicht NUR der Test-Versand auf die nächste kommende
@@ -1255,7 +1258,10 @@ class TripReportSchedulerService:
             fb = self.select_test_stage(trip, report_type, now_utc)
             if fb is not None:
                 target_date = fb.date
+                self._last_converted_trip = None
                 segments = self._convert_trip_to_segments(trip, target_date)
+                if self._last_converted_trip is not None:
+                    trip = self._last_converted_trip
 
         if not segments:
             logger.warning(f"No segments for trip {trip.id} on {target_date}")
@@ -2025,6 +2031,7 @@ class TripReportSchedulerService:
             trip = backfill_stage_distances(
                 trip, user_id, target_date, persist=effective_persist,
             )
+        self._last_converted_trip = trip
         return convert_trip_to_segments(trip, target_date)
 
     def _clamp_segments_to_today(
@@ -2393,7 +2400,10 @@ class TripReportSchedulerService:
                 horizon_days = OPENMETEO_MAX_FORECAST_DAYS
                 continue
             try:
+                self._last_converted_trip = None
                 segments = self._convert_trip_to_segments(trip, stage.date)
+                if self._last_converted_trip is not None:
+                    trip = self._last_converted_trip
                 if not segments:
                     # Fix #1486: bisher voellig stumm.
                     logger.warning(
@@ -2851,7 +2861,10 @@ class TripReportSchedulerService:
             if not is_within_forecast_horizon(stage.date, today):
                 continue
             try:
+                self._last_converted_trip = None
                 segments = self._convert_trip_to_segments(trip, stage.date)
+                if self._last_converted_trip is not None:
+                    trip = self._last_converted_trip
                 if not segments:
                     continue
                 seg_weather = self._fetch_weather(segments)

--- a/tests/tdd/test_ausblick_schleife_bewahrt_alle_nachgeruesteten_kilometrierungen.py
+++ b/tests/tdd/test_ausblick_schleife_bewahrt_alle_nachgeruesteten_kilometrierungen.py
@@ -236,6 +236,38 @@ def test_ac3_heutige_etappe_verliert_kilometrierung_nicht_durch_spaeteren_ausbli
 
 
 # ---------------------------------------------------------------------------
+# AC-7 — On-Demand-Snapshot-Pfad (Adversary-Finding F001): fünfte Aufrufstelle
+# in trip_command_processor.py._fetch_and_save_snapshot() teilt denselben
+# Bug -- zwei Aufrufe (heute, morgen) auf demselben stale `trip`.
+# ---------------------------------------------------------------------------
+
+def test_ac7_on_demand_snapshot_pfad_bewahrt_heutige_etappe():
+    """AC-7 (Adversary-Finding F001): `_fetch_and_save_snapshot()` ruft
+    `scheduler._convert_trip_to_segments(trip, today)` und danach
+    `scheduler._convert_trip_to_segments(trip, tomorrow)` auf demselben
+    `scheduler` auf -- der erste Aufruf rüstet die heutige Etappe nach und
+    speichert, der zweite (morgige) Aufruf darf diese Kilometrierung nicht
+    wieder mit dem stale Stand überschreiben."""
+    from services.trip_command_processor import _fetch_and_save_snapshot
+
+    heute = date.today()
+    morgen = heute + timedelta(days=1)
+    user = _uid("ac7")
+    trip = _trip_mit_n_unvermessenen_etappen(user, [heute, morgen])
+
+    _fetch_and_save_snapshot(trip=trip, user_id=user, today=heute, tomorrow=morgen)
+
+    reloaded = _reload(trip.id, user)
+    heutige_etappe = reloaded.stages[0]
+    assert heutige_etappe.date == heute, "Testaufbau: Etappe 0 ist nicht die heutige"
+    assert _alle_distanzen_gesetzt(heutige_etappe), (
+        "Die HEUTIGE Etappe hat ihre Kilometrierung verloren, obwohl der "
+        f"spaetere Save (morgige Etappe) nicht ihr eigener war: "
+        f"{[wp.distance_from_start_km for wp in heutige_etappe.waypoints]}"
+    )
+
+
+# ---------------------------------------------------------------------------
 # AC-4 — Regressions-Wächter für den Reset-Mechanismus SELBST
 #
 # Strukturell bereits VOR dem Fix grün: der Seitenkanal (`self.

--- a/tests/tdd/test_ausblick_schleife_bewahrt_alle_nachgeruesteten_kilometrierungen.py
+++ b/tests/tdd/test_ausblick_schleife_bewahrt_alle_nachgeruesteten_kilometrierungen.py
@@ -1,0 +1,376 @@
+"""TDD RED — Issue #2109: nachgerüstete Kilometrierung geht in der
+Ausblick-Schleife wieder verloren.
+
+SPEC:    docs/specs/modules/fix_2109_kilometrierung_backfill_propagation.md
+KONTEXT: docs/context/fix-2109-kilometrierung-verlust.md
+
+Root Cause: ``_convert_trip_to_segments()`` (`trip_report_scheduler.py:1980-
+2028`) lässt intern ``backfill_stage_distances()`` den Trip nachträglich
+vermessen und via ``save_trip()`` persistieren, gibt das aktualisierte
+Trip-Objekt aber NUR als lokale Variable zurück. Vier Aufrufstellen arbeiten
+danach mit dem STALE ``trip`` weiter (``_send_trip_report_outcome`` :1248/
+:1258, ``_build_stage_trend`` :2396, ``_collect_future_stage_weather``
+:2854). Da ``save_trip()`` Listen (``stages``) beim Read-Modify-Write-Merge
+wholesale ersetzt statt elementweise zu mergen, überschreibt jeder
+nachfolgende Save mit dem stale ``trip`` eine bereits persistierte
+Kilometrierung wieder mit dem alten Stand.
+
+Testpolitik (CLAUDE.md "Test-Politik: Zwei Schichten"): kein Mock-Theater.
+Echte GR221-Mallorca-Fixtures (``tests/fixtures/data_root/users/default/``)
+mit echtem GPX-Bestand + echter ``backfill_stage_distances``/``save_trip``-
+Persistenz unter der isolierten Datenwurzel (``tests/conftest.py``
+``_isolate_data_root``, autouse). Wetterabruf läuft über den autouse
+Offline-``FixtureProvider`` (Issue #346, ``GZ_TEST_FIXTURE_DIR``) — NICHT
+gestubbt, sondern der echte Fetch-Pfad, damit die Ausblicks-Zeile
+(``build_outlook_row``) real durchläuft (ein leerer ``weather()``-Stub würde
+dort scheitern und den Wächter-Wert verfälschen).
+
+Jeder Test läuft unter einem eindeutigen ``user_id`` (uuid-Suffix), weil
+``backfill_stage_distances`` einen MODUL-GLOBALEN Fehl-Cache
+(``_failed_lookups`` in ``services/track_resolution.py``) über den
+Prozess hinweg teilt.
+"""
+from __future__ import annotations
+
+import dataclasses
+import json
+import shutil
+import uuid
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+
+from app.config import Settings
+from app.loader import get_data_dir, load_all_trips, load_trip_from_dict, save_trip
+from app.models import OutlookState, TripReportConfig
+from app.trip import Stage, Trip, Waypoint
+from services.trip_report_scheduler import TripReportSchedulerService
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_FIXTURE_ROOT = _REPO_ROOT / "tests" / "fixtures" / "data_root" / "users" / "default"
+_TRIP_JSON = _FIXTURE_ROOT / "trips" / "gr221-mallorca.json"
+_GPX_TAGE = [
+    _FIXTURE_ROOT / "gpx" / "2026-01-17_2753214331_Tag 1_ von Valldemossa nach Deià.gpx",
+    _FIXTURE_ROOT / "gpx" / "2026-01-17_2753216748_Tag 2_ von Deià nach Sóller.gpx",
+    _FIXTURE_ROOT / "gpx" / "2026-01-17_2753225520_Tag 3_ von Sóller nach Tossals Verds.gpx",
+    _FIXTURE_ROOT / "gpx" / "2026-01-17_2753228656_Tag 4_ von Tossals Verds nach Lluc.gpx",
+]
+assert _TRIP_JSON.exists(), f"Trip-Fixture fehlt: {_TRIP_JSON}"
+for _gpx in _GPX_TAGE:
+    assert _gpx.exists(), f"GPX-Fixture fehlt: {_gpx}"
+
+_NO_TRANSPORT_FIELDS: dict = {
+    "smtp_host": "", "smtp_user": "", "smtp_pass": "", "mail_to": "",
+    "telegram_bot_token": "", "telegram_chat_id": "",
+    "telegram_test_bot_token": "", "telegram_test_chat_id": "",
+    "sms_gateway_url": "", "seven_api_key": "", "sms_to": "",
+}
+
+
+def _uid(prefix: str) -> str:
+    return f"tdd-2109-{prefix}-{uuid.uuid4().hex[:6]}"
+
+
+def _settings_no_transport() -> Settings:
+    return Settings(**_NO_TRANSPORT_FIELDS)
+
+
+def _trip_mit_n_unvermessenen_etappen(user_id: str, dates: list) -> Trip:
+    """Baut den GR221-Bestandstrip mit ``len(dates)`` Etappen (Etappe i
+    erhält das i-te GPX-Tag als exakt passenden Track), jede Etappe
+    unvermessen, Etappen-Daten auf ``dates`` gezogen. GPX-Bestand + Trip
+    werden im isolierten Datenverzeichnis des Nutzers persistiert."""
+    gpx_dir = get_data_dir(user_id) / "gpx"
+    gpx_dir.mkdir(parents=True, exist_ok=True)
+    for gpx in _GPX_TAGE[: len(dates)]:
+        shutil.copyfile(gpx, gpx_dir / gpx.name)
+
+    data = json.loads(_TRIP_JSON.read_text(encoding="utf-8"))
+    trip = load_trip_from_dict(data)
+    stages = [
+        dataclasses.replace(trip.stages[i], date=dates[i])
+        for i in range(len(dates))
+    ]
+    trip = dataclasses.replace(trip, stages=stages)
+    assert all(
+        wp.distance_from_start_km is None
+        for stage in trip.stages for wp in stage.waypoints
+    ), "Testaufbau: alle Etappen muessen unvermessen starten"
+    save_trip(trip, user_id=user_id)
+    return trip
+
+
+def _minimal_trip(trip_id: str, stage_date: date) -> Trip:
+    """Synthetischer Trip ohne GPX-Bestand -- fuer AC-4/AC-5, wo es nur auf
+    die Identitaet des durchgereichten ``trip``-Objekts ankommt, nicht auf
+    eine echte Vermessung."""
+    return Trip(
+        id=trip_id, name="Minimal",
+        stages=[Stage(
+            id="S1", name="E1", date=stage_date,
+            waypoints=[Waypoint(id="W1", name="Ort", lat=42.0, lon=9.0, elevation_m=500)],
+        )],
+    )
+
+
+def _alle_distanzen_gesetzt(stage) -> bool:
+    return all(wp.distance_from_start_km is not None for wp in stage.waypoints)
+
+
+def _reload(trip_id: str, user_id: str) -> Trip:
+    return next(t for t in load_all_trips(user_id=user_id) if t.id == trip_id)
+
+
+# ---------------------------------------------------------------------------
+# AC-1 — heutige UND künftige Etappe behalten nach dem vollen Lauf beide ihre
+# Kilometrierung (primäre Bug-Reproduktion)
+# ---------------------------------------------------------------------------
+
+def test_ac1_heutige_und_kuenftige_etappe_behalten_beide_ihre_kilometrierung():
+    """AC-1: `_send_trip_report_outcome()` konvertiert zuerst die heutige
+    Etappe (:1248, Backfill+Save), dann im Ausblick (`_build_stage_trend`)
+    die künftige Etappe (Backfill+Save) -- danach müssen BEIDE Etappen ihre
+    nachgerüstete Kilometrierung auf der Platte tragen, nicht nur die
+    zuletzt gespeicherte.
+
+    RED heute: der zweite Save (Ausblick) überschreibt die `stages`-Liste
+    mit dem stale `trip` von VOR dem ersten Backfill -- die heutige Etappe
+    verliert ihre gerade erst geschriebene Kilometrierung wieder."""
+    heute = date.today()
+    user = _uid("ac1")
+    trip = _trip_mit_n_unvermessenen_etappen(user, [heute, heute + timedelta(days=1)])
+    trip.report_config = TripReportConfig(
+        trip_id=trip.id, send_email=False, send_telegram=False, send_sms=False,
+    )
+    trip.alert_cooldown_minutes = 0
+
+    service = TripReportSchedulerService(_settings_no_transport(), user_id=user)
+    outcome = service._send_trip_report_outcome(trip, "evening", target_date=heute)
+
+    assert outcome == "no_channels", f"Testaufbau: unerwarteter Ausgang {outcome!r}"
+
+    reloaded = _reload(trip.id, user)
+    for i, stage in enumerate(reloaded.stages):
+        assert _alle_distanzen_gesetzt(stage), (
+            f"Etappe {i} ({stage.id}, {stage.date}) verlor ihre Kilometrierung: "
+            f"{[wp.distance_from_start_km for wp in stage.waypoints]}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-2 — Ausblicks-Schleife über DREI künftige Etappen: JEDE behält ihre
+# Kilometrierung, nicht nur die zeitlich letzte (Prod-Fund Trip `5f534011`)
+# ---------------------------------------------------------------------------
+
+def test_ac2_ausblicksschleife_bewahrt_alle_drei_etappen_nicht_nur_die_letzte():
+    """AC-2: `_build_stage_trend()` durchläuft bis zu drei künftige Etappen
+    nacheinander; jede Iteration ruft `_convert_trip_to_segments()` auf und
+    rüstet dabei ihre eigene Etappe nach. Nach Abschluss der Schleife muss
+    JEDE der drei durchlaufenen Etappen ihre Kilometrierung tragen.
+
+    RED heute: nur die dritte (zuletzt gespeicherte) Etappe überlebt --
+    jeder Save überschreibt die Kilometrierung der vorherigen Iteration mit
+    dem Stand vor deren eigenem Backfill.
+
+    Datumswahl: der Offline-``FixtureProvider`` liefert genau 72 Stunden
+    (heute+heute+1+heute+2) Wetterdaten, verankert am ECHTEN UTC-Tag,
+    unabhängig vom ``target_date``-Argument -- die drei Etappen liegen
+    deshalb auf heute/heute+1/heute+2, `target_date` (für "künftig") auf
+    gestern."""
+    heute = date.today()
+    gestern = heute - timedelta(days=1)
+    user = _uid("ac2")
+    dates = [heute, heute + timedelta(days=1), heute + timedelta(days=2)]
+    trip = _trip_mit_n_unvermessenen_etappen(user, dates)
+
+    service = TripReportSchedulerService(_settings_no_transport(), user_id=user)
+    result = service._build_stage_trend(trip, gestern, now_utc=datetime.now(timezone.utc))
+
+    assert result.rows and len(result.rows) == 3, (
+        f"Testaufbau: Ausblick nicht vollstaendig gebaut (state={result.state}, "
+        f"rows={result.rows}) -- der Test misst sonst nichts"
+    )
+
+    reloaded = _reload(trip.id, user)
+    for i, stage in enumerate(reloaded.stages):
+        assert _alle_distanzen_gesetzt(stage), (
+            f"Etappe {i} ({stage.id}, {stage.date}) verlor ihre Kilometrierung: "
+            f"{[wp.distance_from_start_km for wp in stage.waypoints]}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-3 — dieselbe Kette wie AC-1, Assertion fokussiert gezielt auf die
+# HEUTIGE Etappe (Cross-Boundary `_send_trip_report_outcome` -> `_build_
+# stage_trend`)
+# ---------------------------------------------------------------------------
+
+def test_ac3_heutige_etappe_verliert_kilometrierung_nicht_durch_spaeteren_ausblick_save():
+    """AC-3: `_send_trip_report_outcome()` rüstet die heutige Etappe nach
+    (:1248) und übergibt den Trip danach an `_build_stage_trend()`, wo eine
+    künftige Etappe ebenfalls nachgerüstet UND gespeichert wird. Die heutige
+    Etappe darf ihre Kilometrierung NICHT verlieren, obwohl der Speichervorgang
+    der künftigen Etappe zeitlich SPÄTER erfolgt.
+
+    RED heute: exakt dieser zeitlich spätere Save der künftigen Etappe
+    überschreibt die `stages`-Liste mit dem stale (unvermessenen) Stand der
+    heutigen Etappe."""
+    heute = date.today()
+    user = _uid("ac3")
+    trip = _trip_mit_n_unvermessenen_etappen(user, [heute, heute + timedelta(days=1)])
+    trip.report_config = TripReportConfig(
+        trip_id=trip.id, send_email=False, send_telegram=False, send_sms=False,
+    )
+    trip.alert_cooldown_minutes = 0
+
+    service = TripReportSchedulerService(_settings_no_transport(), user_id=user)
+    service._send_trip_report_outcome(trip, "evening", target_date=heute)
+
+    reloaded = _reload(trip.id, user)
+    heutige_etappe = reloaded.stages[0]
+    assert heutige_etappe.date == heute, "Testaufbau: Etappe 0 ist nicht die heutige"
+    assert _alle_distanzen_gesetzt(heutige_etappe), (
+        "Die HEUTIGE Etappe hat ihre Kilometrierung verloren, obwohl der "
+        f"spaetere Ausblicks-Save (kuenftige Etappe) nicht ihr eigener war: "
+        f"{[wp.distance_from_start_km for wp in heutige_etappe.waypoints]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-4 — Regressions-Wächter für den Reset-Mechanismus SELBST
+#
+# Strukturell bereits VOR dem Fix grün: der Seitenkanal (`self.
+# _last_converted_trip`) existiert heute noch nicht, also kann er auch
+# nichts kontaminieren. Zweck des Tests: sobald der Fix den Seitenkanal
+# einführt, wacht dieser Test darüber, dass das Reset VOR jedem Aufruf steht
+# -- eine unvollständige Fix-Variante (Reset vergessen) würde einen fremden
+# `trip` aus einem FRÜHEREN, nicht überschriebenen Aufruf derselben Instanz
+# übernehmen.
+# ---------------------------------------------------------------------------
+
+def test_ac4_ueberschriebene_convert_methode_bleibt_frei_von_fremdem_trip():
+    """AC-4: Eine Unterklasse überschreibt `_convert_trip_to_segments(self,
+    trip, target_date)` mit der alten 2-Positional-Argument-Signatur (wie
+    `test_outlook_scheduler_wires_hiking_window.py:48`). VOR dem
+    überschriebenen Aufruf läuft auf DERSELBEN Instanz ein echter, NICHT
+    überschriebener Aufruf mit einem ANDEREN Trip (`trip_other`). Danach
+    muss `_build_stage_trend(trip_a, ...)` weiterhin mit `trip_a` arbeiten
+    -- nicht mit dem Ergebnis des früheren `trip_other`-Aufrufs."""
+    heute = date.today()
+    user = _uid("ac4")
+    trip_other = _minimal_trip(f"i2109-ac4-other-{uuid.uuid4().hex[:6]}", heute)
+    trip_a = _minimal_trip(f"i2109-ac4-a-{uuid.uuid4().hex[:6]}", heute + timedelta(days=1))
+
+    class _ToggleScheduler(TripReportSchedulerService):
+        def __init__(self, *a, **kw) -> None:
+            super().__init__(*a, **kw)
+            self.override_active = False
+            self.recorded_trips: list = []
+
+        def _convert_trip_to_segments(self, trip, target_date):
+            if self.override_active:
+                return ["ein-segment"]
+            return TripReportSchedulerService._convert_trip_to_segments(
+                self, trip, target_date,
+            )
+
+        def _fetch_weather(self, segments, provider=None):
+            from tests.helpers.alert_log_fixtures import weather
+            return [weather("1")]
+
+        def _enrich_ensemble_for_trip(self, trip, weather_data):
+            self.recorded_trips.append(trip)
+
+    service = _ToggleScheduler(_settings_no_transport(), user_id=user)
+
+    # Schritt 1: echter (nicht überschriebener) Aufruf mit trip_other.
+    service.override_active = False
+    service._convert_trip_to_segments(trip_other, heute)
+
+    # Schritt 2: überschriebener Aufruf über _build_stage_trend mit trip_a.
+    service.override_active = True
+    service._build_stage_trend(trip_a, heute, now_utc=datetime.now(timezone.utc))
+
+    assert service.recorded_trips, (
+        "_enrich_ensemble_for_trip wurde nicht erreicht -- der Test misst sonst nichts"
+    )
+    letztes = service.recorded_trips[-1]
+    assert letztes is trip_a, (
+        f"Der Aufrufer arbeitet nicht mehr mit seinem eigenen trip_a-Objekt "
+        f"(id={id(letztes)}), sondern mit einem fremden Objekt (trip_a-id={id(trip_a)})"
+    )
+    assert letztes is not trip_other, (
+        "Der Aufrufer hat faelschlich das trip-Objekt aus dem FRUEHEREN, "
+        "nicht ueberschriebenen Aufruf uebernommen"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-5 — Fail-soft bei Exception in backfill_stage_distances
+#
+# Strukturell bereits VOR dem Fix grün: `_build_stage_trend()` umschließt
+# JEDEN Schleifendurchlauf bereits heute mit einem eigenen `try/except`
+# (trip_report_scheduler.py:2395/2495) -- eine Exception aus dem Backfill
+# bricht schon jetzt nicht den ganzen Lauf ab. Zweck: der Fix darf diese
+# Eigenschaft NICHT versehentlich brechen (z.B. Reset NACH statt VOR dem
+# Aufruf, der bei einer Exception uebersprungen wuerde).
+# ---------------------------------------------------------------------------
+
+def test_ac5_backfill_exception_bleibt_fail_soft():
+    """AC-5: `backfill_stage_distances` wirft eine Exception während eines
+    Aufrufs von `_convert_trip_to_segments()` innerhalb der Ausblick-
+    Schleife -- der Report-Lauf darf nicht abstürzen, `_build_stage_trend()`
+    muss ein reguläres `TrendResult` (kein unbehandelter Fehler) liefern."""
+    import services.track_resolution as track_resolution
+
+    def _boom(*_a, **_kw):
+        raise RuntimeError("simulierter Absturz der Track-Aufloesung")
+
+    original = track_resolution.backfill_stage_distances
+    track_resolution.backfill_stage_distances = _boom
+    try:
+        heute = date.today()
+        user = _uid("ac5")
+        trip = _minimal_trip(f"i2109-ac5-{uuid.uuid4().hex[:6]}", heute + timedelta(days=1))
+        service = TripReportSchedulerService(_settings_no_transport(), user_id=user)
+
+        result = service._build_stage_trend(trip, heute, now_utc=datetime.now(timezone.utc))
+    finally:
+        track_resolution.backfill_stage_distances = original
+
+    assert result is not None, "Aufruf ist abgesturzt statt fail-soft ein TrendResult zu liefern"
+    assert result.state == OutlookState.UNAVAILABLE, (
+        f"Erwartet UNAVAILABLE (einzige Etappe scheiterte fail-soft), erhalten {result.state}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-6 — persist=False bleibt unverändert folgenlos (Preview-Pfad)
+# ---------------------------------------------------------------------------
+
+def test_ac6_persist_false_schreibt_weiterhin_nichts_auf_die_platte():
+    """AC-6: `_convert_trip_to_segments(trip, date, persist=False)` darf
+    weiterhin NICHTS auf die Platte schreiben -- der neue Seitenkanal
+    (`self._last_converted_trip`) ändert nichts am Persistenz-Verhalten des
+    `persist=False`-Pfads (`PreviewService`, #2036 CI-Nachschlag).
+
+    Bestehender Test `test_preview_does_not_mutate_trip_data.py` bleibt
+    unverändert und wird von dieser Änderung nicht berührt."""
+    heute = date.today()
+    user = _uid("ac6")
+    trip = _trip_mit_n_unvermessenen_etappen(user, [heute])
+
+    trip_datei = get_data_dir(user) / "briefings" / f"{trip.id}.json"
+    assert trip_datei.exists(), f"Trip-Datei fehlt: {trip_datei}"
+    inhalt_vorher = trip_datei.read_bytes()
+    mtime_vorher = trip_datei.stat().st_mtime_ns
+
+    service = TripReportSchedulerService(_settings_no_transport(), user_id=user)
+    segments = service._convert_trip_to_segments(trip, heute, persist=False)
+
+    assert segments, "Testaufbau: Segmente muessen entstehen, sonst prueft der Test nichts"
+    assert trip_datei.stat().st_mtime_ns == mtime_vorher, (
+        "persist=False hat die Trip-Datei dennoch neu geschrieben (mtime geaendert)"
+    )
+    assert trip_datei.read_bytes() == inhalt_vorher, (
+        "persist=False hat den Trip-Bestand inhaltlich veraendert"
+    )


### PR DESCRIPTION
- **test(#2109): TDD RED Fixtures fuer Kilometrierung-Verlust in Ausblick-Schleife**
- **fix(#2109): nachgerüstete Kilometrierung übersteht die Ausblick-Schleife**
- **docs(#2109): AC-7 nachtragen — Adversary-Finding F001 (5. Aufrufstelle in trip_command_processor.py)**
- **fix(#2109): AC-7 — On-Demand-Snapshot-Pfad bewahrt ebenfalls die Kilometrierung**
- **docs(#2109): Hinweis auf Seitenkanal-Fix in trip_report_scheduler-Spec ergaenzt**
