### PR TITLE
feat(#2051): S2b — Ausdehnung auf die uebrigen Kanaele

### DIFF
--- a/api/routers/validator.py
+++ b/api/routers/validator.py
@@ -223,6 +223,15 @@ class SegmentTimePayload(BaseModel):
     end: str    # "HH:MM"
 
 
+class RainZonePayload(BaseModel):
+    """Issue #2051 S2b: eine zusammenhaengend nasse Zone der Reststrecke --
+    Feldspiegel von ``RainZone`` (services/rain_extent.py:26)."""
+    km_from: float
+    km_to: float
+    onset_minutes: int
+    event_end_minutes: int | None = None
+
+
 class OnsetPayload(BaseModel):
     """Issue #1948 S5 (AC-15, Vorbedingung aus S4): `segment_id` additiv
     nachgezogen -- `OfficialAlertPayload` transportiert die Segment-Kennung
@@ -266,6 +275,12 @@ class OnsetPayload(BaseModel):
     source_reach_day_offset: int = 0
     location_sharpness_limit_time: str | None = None
     location_sharpness_limit_day_offset: int = 0
+    # Issue #2051 S2b: raeumliche Ausdehnung, additiv und optional -- Muster
+    # `event_end_time` o. Pydantic verwirft unbekannte Schluessel STILL
+    # (#2046 F002): ohne diese beiden Felder zeigte die Vorschau in keinem
+    # Kanal eine Zonenangabe, obwohl der Payload sie traegt.
+    km_measured: bool = False
+    rain_zones: list[RainZonePayload] = Field(default_factory=list)
 
 
 class OfficialAlertPayload(BaseModel):

--- a/docs/context/feat-2051-s2b-ausdehnung-kanaele.md
+++ b/docs/context/feat-2051-s2b-ausdehnung-kanaele.md
@@ -1,0 +1,163 @@
+# Context: #2051 S2b — Ausdehnung auf die übrigen Kanäle
+
+Erstellt 2026-08-23 · Workflow `feat-2051-s2b-ausdehnung-kanaele` · Standard-Track
+
+## Request Summary
+
+S2a hat die räumliche Ausdehnung eines Regenereignisses als km-Zonen eingeführt
+(`rain_extent.derive_rain_zones()`, `OnsetEvent.rain_zones`) und **eine** Textstelle
+bespielt. S2b soll die Angabe auf die übrigen Textstellen und Kanäle bringen, die
+Kanal-Kaskade festlegen, das SMS-Zeichenbudget klären und die Darstellung für
+unvermessene Etappen liefern.
+
+## Ausgangslage: der Baustein existiert bereits
+
+`_onset_extent_suffix()` (`src/output/renderers/alert/render.py:614-639`) ist der
+S2a-Baustein nach dem Muster von `_onset_end_suffix` (S1) und `_onset_reach_suffix`
+(S3): „anhängbares Stück oder LEER". Er hängt heute an **genau einer** Aufrufstelle,
+während die S1/S3-Bausteine an vier hängen.
+
+| Aufrufstelle | Datei:Zeile | S1/S3 | S2a extent |
+|---|---|---|---|
+| Betreff, Einzel-Event | `render.py:479-486` | ja | **nein** |
+| Betreff, Bündel >1 Event | `render.py:477-478` | nein (trägt gar keine Suffixe) | nein |
+| E-Mail Trip, Einzelort | `render.py:739-742` | ja | **ja — die einzige** |
+| E-Mail Mehr-Orte/Bündel | `render.py:658-660` | ja | nein |
+| Telegram rich | `render.py:810-813` | ja | **nein** |
+| SMS / Premium-SMS | `render.py:869-924`, zusammengesetzt `:945-964` | ja | **nein** (kein Token) |
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `src/output/renderers/alert/render.py` | Alle Langform-Suffixe, Betreff, Telegram rich, Kurzform-Bau (`_render_sms_onset`, `_sms_onset_ende`, `_sms_onset_sharpness_marker`) |
+| `src/output/renderers/alert/model.py:172-178` | `OnsetEvent.rain_zones`, `km_measured` |
+| `src/services/rain_extent.py` | `RainZone(km_from, km_to, onset_minutes, event_end_minutes)`, `derive_rain_zones()` |
+| `src/services/notification_service.py:267, :1395-1427` | `RadarAlertRequest.rain_zones`, Trip-Produktivpfad (führt alles) |
+| `src/services/validator_render_service.py:117-172` | Alert-Preview-Nachweisfläche — führt S1+S3, **nicht** `rain_zones`/`km_measured` |
+| `src/output/renderers/alert/project.py:621-663` | Ortsvergleich-Bündel — setzt `rain_zones` bewusst nicht (S2a AC-15) |
+| `src/services/trip_segments.py:119-157, :683-716` | `stage_measured_distances()`, `points_along_remaining_route()` |
+| `src/services/starkregen_hint.py:19-89` | Briefing-Kurzfristhinweis |
+| `src/services/trip_report_scheduler.py:1876-1913` | Quelle des Kurzfristhinweises — **Ein-Punkt-Abfrage** |
+| `src/services/radar_service.py:626-678` | `/jetzt`-Kommandotext |
+
+## Existing Patterns
+
+- **Suffix-Baustein-Muster:** jede Zusatzangabe ist eine Funktion `_onset_*_suffix(e) -> str`,
+  die entweder ein anhängbares ` · Text`-Stück oder `""` liefert. Die Schwellen-/
+  `None`-Entscheidung fällt vorher in `project.py`, im Renderer steht nur ein `None`-Check.
+- **Kurzform ist englisch** (`R`, `TH`, `now`), Trennzeichen `@` (Zeitpunkt), `>`
+  (Untergrenze), `?` (Unschärfe).
+- **Kanal-Kaskade als Code-Mechanismus existiert NICHT.** Jede Aufrufstelle verkettet
+  ihre Suffixe einzeln. „Grundauswahl = Maximum, Kanal wählt ab" ist heute eine
+  Konvention in den Specs, kein zentraler Schalter.
+
+## Risks & Considerations
+
+### R1 — Drei der „sechs Textstellen" sind nicht bespielbar wie gedacht
+
+- **E-Mail Mehr-Orte** (`render.py:658`) läuft ausschließlich über den
+  Ortsvergleich-Bündelpfad; der Trip-Radar-Pfad baut immer genau ein Event
+  (`notification_service.py:1433`). Da der Ortsvergleich kein Streckenkonzept hat
+  (S2a AC-15), bliebe die Angabe dort dauerhaft leer — ein Anhängen ist ein No-op,
+  das nur die Parität dokumentiert.
+- **Briefing-Kurzfristhinweis** speist sich aus einer **Ein-Punkt-Abfrage**
+  (Segmentmitte, `trip_report_scheduler.py:1876-1882`) und transportiert ein rohes
+  6er-Tupel, kein `OnsetEvent`. Zonen gibt es dort nicht — sie müssten erst durch
+  eine eigene Mehrpunkt-Verdrahtung entstehen (das ist S2a-Arbeit im Hinweis-Pfad,
+  nicht Textverteilung).
+- **`/jetzt`** ist laut Docstring (`trip_command_processor.py:1536`) eine Sofortabfrage
+  am Standort, ohne Reststrecken-Konzept; `NowcastResult` trägt kein Zonenfeld.
+
+### R2 — Wegpunktnamen: ERLEDIGT, die Prämisse war falsch (nachgemessen 2026-08-23)
+
+**Die S2a-Spec-Aussage „9 von 13 Etappen zeigen keine Ausdehnung" ist eine
+Momentaufnahme des Datenbestands, keine Aussage über die Laufzeit.** Nachgemessen:
+
+- `backfill_stage_distances()` (`src/services/track_resolution.py:264-344`) rüstet die
+  Kilometrierung aus dem GPX-Bestand nach. Der Alarmpfad ruft sie **selbst auf**, für
+  die Etappe von `today`, **vor** der Segmentauflösung (`trip_alert.py:1385`).
+- Zur Alarmzeit ist die aktive Etappe damit vermessen, unabhängig vom persistierten
+  Stand. Die Ausdehnung erscheint also auf **jeder** Etappe, wenn sie gebraucht wird.
+- ⇒ Eine Ersatzdarstellung für unvermessene Etappen wird nicht gebraucht. Der
+  Wegpunktnamen-Punkt aus der S2a-Spec entfällt in S2b **ersatzlos**.
+
+Nebenbefund aus derselben Messung: Der persistierte Nachtrag geht in der
+Ausblick-Schleife wieder verloren (verlorener Update, `trip_report_scheduler.py:2385-2396`)
+→ **#2109**, plus Gegenbeleg an #2058. Betrifft S2b nicht, weil der Alarmpfad ohnehin
+selbst nachrüstet.
+
+Die ursprüngliche Datenlage-Erhebung bleibt hier stehen, weil sie erklärt, warum
+„zwischen X und Y" auch bei künftigem Bedarf nicht ohne Weiteres baubar wäre:
+
+- `GPXPoint` (der Zonen-Abfragepunkt, `models.py:363-370`) trägt **kein Namensfeld**
+  und keine Rück-Identität zu einem Wegpunkt; `points_along_remaining_route()`
+  interpoliert rein geometrisch.
+- Die persistierten `Waypoint.name` tragen in den echten Prod-Daten generische Labels
+  (`Start`, `Seg 3 Start`, `GIPFEL`, `TAL`, `Ziel`) — auch auf den vermessenen Etappen.
+  Die echten Hütten-/Ortsnamen stehen nur als zusammengesetzter String im `Stage.name`
+  (z. B. `06: Almgasthof Valentinalm nach Zollnersee Hütte`).
+- Die einzige Koordinate→Name-Logik (`_match_gpx_waypoints`,
+  `src/core/elevation_analysis.py:114ff`) läuft einmalig beim GPX-Upload; die
+  Quell-GPX ist vom persistierten Trip aus nicht mehr referenzierbar (kein
+  `gpx_path`-Feld).
+
+Die einzige Abhilfe wäre Datenpflege an den Trip-Etappen — **im Ticket als Nicht-Ziel
+gesetzt** („Änderungen an der Trip-Konfiguration des PO"). Da der Punkt nach R2 oben
+entfällt, ist das keine offene Frage mehr, sondern nur noch dokumentierter Grund.
+
+## Zuschnitt-Entscheidung S2b (2026-08-23)
+
+**In S2b:**
+1. `_onset_extent_suffix` an den E-Mail-Betreff (`render.py:486`) und an Telegram rich
+   (`render.py:813`) — der Baustein existiert, es ist derselbe Handgriff wie S1/S3.
+2. Ein Zonen-Token in der Kurzform (`_render_sms_onset`) — wirkt zugleich auf SMS,
+   Premium-SMS und Telegram-Kurzstil, die denselben Text tragen. Muss durch
+   Konstruktion ins 140-Zeichen-Budget passen (R3), GSM-7 ist unkritisch.
+3. `validator_render_service.py` um `rain_zones`/`km_measured` erweitern — ohne das
+   ist kein AC dieser Scheibe auf Staging messbar (R4).
+4. Mehr-Orte-Zweig (`render.py:659`): Suffix anhängen als dokumentierter No-op, damit
+   die Parität der Aufrufstellen nicht schweigend auseinanderläuft.
+
+**Nicht in S2b, eigene Scheiben:**
+- Briefing-Kurzfristhinweis — braucht erst eine Mehrpunkt-Abfrage im Hinweis-Pfad (R1).
+- `/jetzt` — Sofortabfrage ohne Reststreckenbezug (R1).
+- Wegpunktnamen — entfällt ersatzlos (R2).
+
+### R3 — SMS-Budget wird durch Konstruktion gehalten, nicht durch Kappung
+
+Im Alarm-SMS-Pfad gibt es **keine** Prioritäts-Kürzung. `body[:140]`
+(`render.py:996`) ist eine Reißleine, die laut Bestandstest
+`tests/tdd/test_onset_ende_sms_budget.py:107-137` im Normalfall nie greifen darf
+(Nachweis: `render(limit=140) == render(limit=4000)` im Extremfall). Ein Zonen-Token
+muss also von vornherein ins Budget passen. Der Bindestrich ist GSM-7-Basisalphabet
+(`tests/tdd/_gsm7_charset.py:22`) — `km8-12` ist zeichensatzsicher, ein Septet je
+Zeichen.
+
+Telegram-Kurzstil und Premium-SMS haben **keinen eigenen Renderer** — sie senden
+denselben SMS-Text (`notification_service.py:1599-1615`, `:1680`, `:1694`). Eine
+Änderung am Kurzform-Token wirkt damit auf drei Kanäle gleichzeitig.
+
+### R4 — Ohne Ergänzung der Preview-Fläche ist kein Staging-Nachweis möglich
+
+`validator_render_service.py:117-172` baut sein `OnsetEvent` ohne `rain_zones` und
+ohne `km_measured`. Das ist genau die Lücke, die die S2a-Lieferung als „nicht
+gemessen" gebucht hat. Solange sie offen ist, kann kein AC dieser Scheibe über
+`POST /api/trips/{id}/alert-preview` auf Staging gemessen werden.
+
+### R5 — Vier unabhängige `OnsetEvent`-Konstruktionsstellen
+
+`radar_alert_service.py:60` (Legacy, führt nichts), `validator_render_service.py:117`,
+`notification_service.py:1395` (Produktivpfad, führt alles), `project.py:621`
+(Ortsvergleich). Jede Feldergänzung muss gegen alle vier geprüft werden, sonst
+entsteht wieder eine stille Lücke.
+
+## Existing Specs
+
+- `docs/specs/modules/feat_2051_s2a_raeumliche_ausdehnung.md` — Vorgänger, benennt
+  S2b-Scope in „Known Limitations" und „Nicht-Ziele"
+- `docs/specs/modules/feat_2051_s3_reichweite_und_guete.md` — Bauplan des
+  Textstellen-Fächers und der Kurzform-Abwahl
+- `docs/specs/modules/fix_2017_nowcast_messpunkt.md` — Ein-Punkt-Zusicherung, von S2a
+  für den Alarmpfad abgelöst
+- `docs/specs/modules/fix_2036_*` — Regel „km-Zahlen nur bei vermessener Etappe"

--- a/docs/features/architecture.md
+++ b/docs/features/architecture.md
@@ -422,7 +422,25 @@ Scheibe 3 (#1170). Scheduler: `POST /api/scheduler/compare-alert-checks`, Go-Cro
        statt `R2.5@0:23+1`, Beginn und Ende unabhängig bewertet (`TH@Do18:00@Fr3:00 R2.5`) —
        dieselbe Schreibweise, die derselbe Kanal für Abweichungsalarme (#2020 S2) und amtliche
        Warnungen (#1948 S5) bereits führt. Bei Tagesversatz 0 bleibt die Ausgabe byte-identisch.
-     - `OnsetEvent`-Datenklasse: `onset_minutes`, `onset_time`, `km_from`/`km_to`, `is_convective`, `intensity_label`, `source_label`, `onset_precip_mm` (additiv, #2046 — Menge ab Ereignisbeginn, getrennt von `NowcastResult.window_precip_mm`, das ab „jetzt" misst), `onset_day_offset`/`onset_weekday` (additiv, #2054 — Tagesbezug des Beginns und sein DE-Wochentagskürzel, `onset_day_offset` selbst existiert bereits seit #2009), `event_end_time`/`event_end_day_offset`/`event_end_weekday`/`event_ongoing_beyond_horizon` (additiv — `event_end_time`/`event_end_day_offset`/`event_ongoing_beyond_horizon` seit #2051 S1, `event_end_weekday` seit #2054 analog zu `onset_weekday`, aber eigenständig aus dem Ende-Zeitpunkt abgeleitet, da Beginn und Ende an verschiedenen Kalendertagen liegen können — Ende desselben Ereignisses aus `NowcastResult.event_end_minutes`/`.event_ongoing_beyond_horizon` abgeleitet)
+       **Seit #2051 S2a/S2b** trägt der Token zusätzlich die räumliche Ausdehnung des
+       Regenereignisses als km-Zonen der Reststrecke: `derive_rain_zones()`
+       (`src/services/rain_extent.py`) bildet aus den bereits abgerufenen Nowcast-Frames
+       zusammenhängend nasse km-Spannen; der Baustein `_onset_extent_suffix()` hängt sie in
+       der Langform an (`Nass km 8-12` bzw. bei mehreren getrennt gezählten Zonen
+       `Nass km 8-12, km 19-21` — die trockene Strecke dazwischen erscheint bewusst nicht
+       als zusammengefasste Spanne). S2a bespielte damit zunächst nur die E-Mail-Trip-
+       Langform; S2b (2026-08-23) hängt denselben Baustein zusätzlich an E-Mail-Betreff,
+       Telegram rich und den Mehr-Orte-Zweig (dort dokumentierter No-op — der Ortsvergleich
+       hat kein Streckenkonzept und setzt `rain_zones` nie) und ergänzt die Kurzform
+       (SMS/Premium-SMS/Telegram-Kurzstil) um ein eigenes, budget-bewusstes Zonen-Kürzel
+       `km8-12` bzw. `km8-12,19-21` — als **letztes** Element angehängt und, anders als der
+       Rest der Kurzform, budget-abhängig: passt es nicht vollständig ins verbleibende
+       140-Zeichen-Budget, entfällt es komplett statt angeschnitten zu werden. Sichtbar nur
+       bei vermessener Etappe (`km_measured=True`, echte GPX-Wegstrecke) und nicht-leeren
+       `rain_zones`; ohne beides bleibt jeder betroffene Text byte-identisch zum Stand vor
+       #2051. Spec: `docs/specs/modules/feat_2051_s2a_raeumliche_ausdehnung.md`,
+       `docs/specs/modules/feat_2051_s2b_ausdehnung_kanaele.md`.
+     - `OnsetEvent`-Datenklasse: `onset_minutes`, `onset_time`, `km_from`/`km_to`, `is_convective`, `intensity_label`, `source_label`, `onset_precip_mm` (additiv, #2046 — Menge ab Ereignisbeginn, getrennt von `NowcastResult.window_precip_mm`, das ab „jetzt" misst), `onset_day_offset`/`onset_weekday` (additiv, #2054 — Tagesbezug des Beginns und sein DE-Wochentagskürzel, `onset_day_offset` selbst existiert bereits seit #2009), `event_end_time`/`event_end_day_offset`/`event_end_weekday`/`event_ongoing_beyond_horizon` (additiv — `event_end_time`/`event_end_day_offset`/`event_ongoing_beyond_horizon` seit #2051 S1, `event_end_weekday` seit #2054 analog zu `onset_weekday`, aber eigenständig aus dem Ende-Zeitpunkt abgeleitet, da Beginn und Ende an verschiedenen Kalendertagen liegen können — Ende desselben Ereignisses aus `NowcastResult.event_end_minutes`/`.event_ongoing_beyond_horizon` abgeleitet), `km_measured`/`rain_zones` (additiv, #2051 S2a — `rain_zones: tuple[RainZone, ...]`, Feldspiegel `km_from`/`km_to`/`onset_minutes`/`event_end_minutes`; S2b konsumiert beide Felder zusätzlich in Betreff, Telegram rich, Mehr-Orte-Zweig und Kurzform, ändert sie selbst nicht)
      - `AlertMessage.cooldown_display` trägt den dynamischen Cooldown-Text (z.B. „2 Stunden")
      - `src/outputs/radar_alert.py` ist gelöscht — kein separater Inline-Body-Bau mehr
    - **Throttle-Semantik unverändert** (Issue #773): `radar_alert_throttle.json` + `alert_log` auch bei Best-Effort-Versandfehlern

--- a/docs/reference/api_contract.md
+++ b/docs/reference/api_contract.md
@@ -3426,7 +3426,7 @@ S1-Eingangsprotokoll (`src/services/alert_input_capture.py`, siehe
 |------|-----|------|
 | changes | `ChangePayload[]` | Zweig a (Δ-Alarm): rohe Änderungswerte je Etappe (`metric`, `old_value`, `new_value`, `delta`, `threshold`, `severity`, `direction`, `segment_id`) |
 | segment_times | `SegmentTimePayload[]` | Optional bei `changes` — fehlt es, synthetisiert der Endpoint die Etappen-Zeitfenster aus dem geladenen Trip über dieselbe Produktions-Segmentierung wie der Versandpfad (`convert_trip_to_segments`) |
-| onset | `OnsetPayload` \| null | Radar-Onset (Zweig c, Alt-Form vor S2): `onset_minutes`, `onset_time`, `km_from`, `km_to`, `is_convective`, `intensity_label`, `source_label`, `cooldown_display?`, `segment_id?` (additiv seit #1948 S5, AC-15 — ohne Segment-Kennung fiel der Zweig auf den km-Rückfall zurück), `onset_precip_mm?` (additiv seit #2046 — Menge in mm, akkumuliert über 60 Min ab Ereignisbeginn; `None`/fehlend ⇒ SMS-Onset-Token ohne Zahl), `onset_day_offset?: int = 0`, `onset_weekday?: string \| null` (additiv seit #2054 — Tagesbezug des Beginns und sein DE-Wochentagskürzel für die Kurzform-Darstellung; ohne die Felder zeigt die Vorschau einen Zeitpunkt von heute, wo der Versand einen von morgen meldet), `event_end_time?: string \| null`, `event_end_day_offset?: int = 0`, `event_end_weekday?: string \| null` (`event_end_weekday` additiv seit #2054, analog zu `onset_weekday`, aber eigenständig aus dem Ende-Zeitpunkt abgeleitet — Beginn und Ende können an verschiedenen Kalendertagen liegen), `event_ongoing_beyond_horizon?: bool = false` (additiv seit #2051 S1 — Ende des zusammenhängenden nassen Blocks mit eigenem Tagesbezug, analog zu `onset_time`/`onset_day_offset`/`onset_weekday`; ohne `event_end_time` rendert der Vorschauweg die Ausweichform ohne Ende; `event_ongoing_beyond_horizon=true` wählt die Untergrenzen-Form `Regen mindestens bis HH:MM` statt `letzter Regen gegen HH:MM`) |
+| onset | `OnsetPayload` \| null | Radar-Onset (Zweig c, Alt-Form vor S2): `onset_minutes`, `onset_time`, `km_from`, `km_to`, `is_convective`, `intensity_label`, `source_label`, `cooldown_display?`, `segment_id?` (additiv seit #1948 S5, AC-15 — ohne Segment-Kennung fiel der Zweig auf den km-Rückfall zurück), `onset_precip_mm?` (additiv seit #2046 — Menge in mm, akkumuliert über 60 Min ab Ereignisbeginn; `None`/fehlend ⇒ SMS-Onset-Token ohne Zahl), `onset_day_offset?: int = 0`, `onset_weekday?: string \| null` (additiv seit #2054 — Tagesbezug des Beginns und sein DE-Wochentagskürzel für die Kurzform-Darstellung; ohne die Felder zeigt die Vorschau einen Zeitpunkt von heute, wo der Versand einen von morgen meldet), `event_end_time?: string \| null`, `event_end_day_offset?: int = 0`, `event_end_weekday?: string \| null` (`event_end_weekday` additiv seit #2054, analog zu `onset_weekday`, aber eigenständig aus dem Ende-Zeitpunkt abgeleitet — Beginn und Ende können an verschiedenen Kalendertagen liegen), `event_ongoing_beyond_horizon?: bool = false` (additiv seit #2051 S1 — Ende des zusammenhängenden nassen Blocks mit eigenem Tagesbezug, analog zu `onset_time`/`onset_day_offset`/`onset_weekday`; ohne `event_end_time` rendert der Vorschauweg die Ausweichform ohne Ende; `event_ongoing_beyond_horizon=true` wählt die Untergrenzen-Form `Regen mindestens bis HH:MM` statt `letzter Regen gegen HH:MM`), `km_measured?: bool = false`, `rain_zones?: RainZonePayload[]` (additiv seit #2051 S2b — Feldspiegel von `RainZone`: `km_from: float`, `km_to: float`, `onset_minutes: int`, `event_end_minutes?: int`; speist die räumliche Ausdehnung, die S2a in `_onset_extent_suffix()` einführte, jetzt in allen vier betroffenen Vorschau-Texten `subject`/`email_plain`/`telegram`/`sms`; ohne die beiden Felder zeigt kein Kanal eine Ausdehnungsangabe, auch wenn der eigentliche Alarmpfad sie trägt) |
 | official | `OfficialAlertPayload[]` \| null | **NEU (#1948 S2), Zweig b:** amtliche Warnung(en), Feldspiegel von `OfficialAlert` — `source`, `hazard`, `level: int`, `label`, `valid_from?`, `valid_to?`, `url?`, `region_label?`, `dedup_id?`, `segment_ids: string[]` |
 | nowcast_frames | `NowcastFramesPayload` \| null | **NEU (#1948 S2), Zweig c:** Replay eines S1-Nowcast-Mitschnitts — `source`, `frames: [{timestamp, precip_mm_h, is_convective}]`, `km_from`, `km_to`, `segment_id?` (additiv seit #1948 S5, AC-15, analog zu `OnsetPayload`) |
 
@@ -3711,6 +3711,21 @@ function corridorInside(value, min, max) {
 
 ## Changelog
 
+- 2026-08-23: Issue #2051 Scheibe S2b — die räumliche Ausdehnung eines Regenereignisses
+  (km-Zonen der Reststrecke, S2a) erscheint jetzt in allen sieben Alarm-Textstellen statt
+  nur in der E-Mail-Trip-Langform: `_onset_extent_suffix()` (bereits seit S2a fertig) hängt
+  zusätzlich am E-Mail-Betreff, an Telegram rich und am Mehr-Orte-Zweig (dort dokumentierter
+  No-op — der Ortsvergleich setzt `rain_zones` nie, kein Streckenkonzept). Neu in der
+  Kurzform (SMS/Premium-SMS/Telegram-Kurzstil): ein Zonen-Kürzel `km8-12` bzw.
+  `km8-12,19-21`, budget-bewusst gebildet — passt es nicht vollständig ins Zeichenbudget,
+  entfällt es vollständig statt angeschnitten zu werden. `OnsetPayload` (Section 22.5,
+  `POST /api/trips/{trip_id}/alert-preview`) bekommt dafür additiv die Felder
+  `km_measured: bool = false` und `rain_zones: RainZonePayload[]` (neuer Feldspiegel von
+  `RainZone`) — ohne sie war kein AC dieser Scheibe über den Vorschau-Endpoint messbar (S2a
+  hatte die Prüffläche `validator_render_service.py` noch nicht erweitert). Reine additive
+  Feld-Ergänzung, kein Formatwechsel; ohne die Felder bleibt jeder Vorschau-Text
+  byte-identisch zum Stand vor dieser Spec. Spec:
+  `docs/specs/modules/feat_2051_s2b_ausdehnung_kanaele.md`.
 - 2026-08-22: Issue #2054 — die Alarm-Kurznachricht (SMS · Premium-SMS · Telegram-Kurzstil)
   schreibt eine Uhrzeit an einem anderen Kalendertag jetzt mit einem vorangestellten
   DE-Wochentagskürzel (`R2.5@Sa0:23`) statt des bisherigen Zahlensuffixes (`R2.5@0:23+1`) —

--- a/docs/specs/modules/feat_2051_s2b_ausdehnung_kanaele.md
+++ b/docs/specs/modules/feat_2051_s2b_ausdehnung_kanaele.md
@@ -1,0 +1,472 @@
+---
+entity_id: feat_2051_s2b_ausdehnung_kanaele
+type: feature
+created: 2026-08-23
+updated: 2026-08-23
+status: draft
+version: "1.0"
+tags: [alarm, nowcast, radar, ausdehnung, zone, sms, kanal-kaskade]
+---
+
+# Ausdehnung auf die übrigen Kanäle — #2051 Scheibe S2b
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+S2a hat die räumliche Ausdehnung eines Regenereignisses als km-Zonen
+eingeführt (`rain_extent.derive_rain_zones()`, `OnsetEvent.rain_zones`) und
+**eine** von sieben Textstellen bespielt (E-Mail-Trip-Langform). Der
+Baustein `_onset_extent_suffix()` existiert bereits — S2b hängt ihn an die
+übrigen Langform-Stellen und bringt die Ausdehnung zusätzlich in die
+Kurzform (SMS/Premium-SMS/Telegram-Kurzstil), wo sie bisher komplett fehlt.
+Ohne S2b bleibt die Ausdehnung auf einer einzigen Textstelle stehen — genau
+die Lücke, die die Hütte am Karnischen Höhenweg trifft: dort kommt nur die
+Premium-SMS an, und die trägt heute keine Ausdehnungsangabe.
+
+Grundprinzip aus dem Ticket (unverändert bindend): **nur Daten über das
+Wetter, keine Rechnung über den Nutzer.**
+
+## Source
+
+- **File:** `src/output/renderers/alert/render.py` (Textstellen-Verkettung,
+  neuer Kurzform-Helfer), `src/services/validator_render_service.py`
+  (Prüffläche), `api/routers/validator.py` (`OnsetPayload`)
+- **Identifier:** `_onset_extent_suffix()` (bereits vorhanden,
+  `render.py:614-639`), `_render_sms_onset()` (`render.py:927-996`), neuer
+  Helfer `_sms_onset_extent_suffix()` (neu, `render.py`), `RainZone`
+  (`src/services/rain_extent.py:26-43`, unverändert), `render_alert_preview()`
+  (`validator_render_service.py:93`)
+
+> **Schicht-Hinweis:** Alle Änderungen liegen ausschließlich im Python-Core
+> (`src/output/renderers/alert/`, `src/services/`, `api/routers/`) — kein
+> Go-API-, kein Frontend-Anteil.
+
+## Estimated Scope
+
+- **LoC:** ~70-100 produktiv (drei Ein-Zeilen-Anhängungen, ein neuer
+  Kurzform-Helfer, Prüffläche + Payload-Erweiterung), ~180-220 Tests — in
+  Summe **über dem 250-LoC-Workflow-Limit**,
+  `workflow.py set-field loc_limit_override 500` ist vor `/40-tdd-red`
+  einzuplanen (Muster wie S2a/S3).
+- **Files:** `render.py`, `validator_render_service.py`,
+  `api/routers/validator.py` + 4-5 neue Testdateien.
+- **Effort:** medium — kein neuer Rechenkern, ausschließlich additive
+  Verkettung eines bestehenden Bausteins plus ein neuer, budget-bewusster
+  Kurzform-Helfer.
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `_onset_extent_suffix()` | function (`render.py:614-639`, S2a) | Bereits fertiger Baustein für die drei zusätzlichen Langform-Stellen — nur zusätzlich verkettet, keine Änderung an der Funktion selbst. |
+| `_onset_end_suffix` / `_onset_reach_suffix` / `_onset_sharpness_suffix` | functions (`render.py:546,585,599`) | Bestimmen die Verkettungs-Reihenfolge — `_onset_extent_suffix` hängt sich unverändert ans Ende an (Muster S1/S3). |
+| `_sms_onset_sharpness_marker` / `_sms_onset_ende` | functions (`render.py:869,907`) | Musterfassung für den neuen Kurzform-Helfer — anhängbares Zeichen/Token oder leer, Aufrufer bindet es an die bereits gebildete Zeitgruppe. |
+| `RainZone` | dataclass (`src/services/rain_extent.py:26-43`) | Datenquelle der Kurzform-Zonenwerte (`km_from`, `km_to`) — unverändert, keine neuen Felder nötig. |
+| `OnsetEvent.rain_zones` / `.km_measured` | fields (`model.py:120,178`, S2a) | Beide Felder existieren bereits auf `OnsetEvent` — S2b befüllt sie zusätzlich in der Prüffläche, ändert das Modell selbst nicht. |
+| `render_sms(msg, limit=140)` | function (`render.py:1482-1501`) | Öffentliche Kurzform-Fassade mit explizitem `limit`-Parameter — Testwerkzeug für die budget-genaue Drop-Prüfung (AC-8), keine Signaturänderung. |
+| `render_alert_preview()` | function (`validator_render_service.py:93-172`) | Prüffläche — muss `rain_zones`/`km_measured` aus `OnsetPayload` lesen und ins `OnsetEvent` durchreichen (R4). |
+| `OnsetPayload` | Pydantic-Model (`api/routers/validator.py:226-268`) | Vorschau-Payload-Schema — bekommt die neuen Felder gespiegelt (Vorwarnung analog #2046 F002 / S1/S3-Vorlage). |
+| `_ASCII_EXTENSION_REPLACEMENTS` / `tests/tdd/_gsm7_charset.py` | mechanism/fixture | Der ASCII-Bindestrich (`-`) im Zonen-Kürzel ist GSM-7-Basiszeichensatz und wird von der Faltung nicht angefasst — dieselbe Prüfung wie beim `?`-Zeichen (S3 E6). |
+
+## Getroffene Entscheidungen (aus dem PO-Briefing, nicht erneut vorlegen)
+
+**Kurzform-Format:** `km8-12`, angehängt hinter der gesamten Zeitgruppe
+inklusive des S3-Güte-Markers `?` — Beispiel: `R2.5@15:00@16:30 km8-12`.
+Ganzzahlig gerundet wie die Langform (`int(round(...))`), ASCII-Bindestrich.
+
+**Mehrere Zonen:** komma-getrennt ohne Leerzeichen, `km8-12,19-21` — EIN
+`km`-Präfix vor der ersten Spanne, danach nur noch `X-Y`-Paare. Getrennt
+aufgezählt, nie zu einer Hülle zusammengefasst (dieselbe Begründung wie S2a
+E2: die trockene Strecke dazwischen darf nicht als nass erscheinen).
+
+**Sichtbarkeit:** identisch zur Langform-Regel aus S2a — nur bei vermessener
+Etappe (`km_measured`) und nur bei nicht-leeren `rain_zones`. Sonst entfällt
+das Kürzel vollständig, die Zeile bleibt byte-identisch zum heutigen Stand.
+
+**Budget-Regel:** Das Zonen-Kürzel ist das **zuletzt** angefügte Element der
+Kurzform. Passt es nicht vollständig ins Zeichenbudget, entfällt es —
+**niemals abgeschnitten, niemals eine halbe Spanne**. Bei mehreren Zonen
+werden so viele genannt, wie vollständig passen, von vorn; passt nicht
+einmal die erste, entfällt die Angabe ganz. Der harte Schnitt `body[:limit]`
+(`render.py:996`) bleibt eine Reißleine, die auch mit Zonen nie greifen darf
+(Bestandsinvariante `tests/tdd/test_onset_ende_sms_budget.py:107-137`).
+
+**Sprache:** Die Kurzform ist ENGLISCH kodiert (`R`=Rain, `TH`=Thunder,
+`now`). `km` ist international und bleibt unverändert.
+
+**Mehr-Orte-Zweig:** `_onset_extent_suffix` wird auch dort angehängt — als
+**dokumentierter No-op**. Dieser Zweig läuft ausschließlich über den
+Ortsvergleich-Bündelpfad (`project.py:621`,
+`to_multi_location_onset_alert_message`), der `rain_zones` bewusst nie
+setzt (S2a AC-15, kein Streckenkonzept im Ortsvergleich). Zweck der
+Anhängung: die sieben Aufrufstellen laufen nicht schweigend auseinander —
+wer den Code liest, sieht an jeder Stelle denselben Baustein, nicht sechs
+von sieben. Es ist **kein** neues Verhalten für den Ortsvergleich.
+
+**Wegpunktnamen für unvermessene Etappen — entfällt ersatzlos** (Revision
+gegenüber der S2a-Spec, die diesen Punkt noch als S2b-Scope benannte). Die
+Analyse hat nachgemessen: `backfill_stage_distances()`
+(`src/services/track_resolution.py:264-344`) rüstet die Kilometrierung aus
+dem GPX-Bestand nach, und der Alarmpfad ruft sie **selbst auf**, für die
+Etappe von `today`, **vor** der Segmentauflösung (`trip_alert.py:1385`).
+Zur Alarmzeit ist die aktive Etappe damit vermessen, unabhängig vom
+persistierten Stand — die Aussage „9 von 13 KHW-Etappen zeigen keine
+Ausdehnung" aus der S2a-Spec beschreibt den gespeicherten Bestand, nicht die
+Laufzeit. Eine Ersatzdarstellung für unvermessene Etappen wird deshalb nicht
+gebraucht.
+
+## Implementation Details
+
+**Drei zusätzliche Langform-Aufrufstellen** (additive Verkettung des
+bestehenden Bausteins, keine Änderung an `_onset_extent_suffix` selbst,
+Reihenfolge wie bei S1/S3: Ende → Reichweite → Güte → Ausdehnung):
+
+```python
+# render.py:486 (_render_subject_onset)
+f"{_onset_end_suffix(e)}{_onset_reach_suffix(e)}{_onset_sharpness_suffix(e)}"
+f"{_onset_extent_suffix(e)}"
+
+# render.py:813 (_render_telegram_onset, Variable `second`)
+f"{_onset_wann_zeile(e)}{_onset_end_suffix(e)}"
+f"{_onset_reach_suffix(e)}{_onset_sharpness_suffix(e)}{_onset_extent_suffix(e)} · "
+f"{e.intensity_label} · {e.source_label}"
+
+# render.py:658-660 (_render_email_onset_multi, dokumentierter No-op)
+f"{_onset_wann_zeile(e, praefix='ab ')}{_onset_end_suffix(e)}"
+f"{_onset_reach_suffix(e)}{_onset_sharpness_suffix(e)}{_onset_extent_suffix(e)} · "
+f"{e.intensity_label}"
+```
+
+**Neuer Kurzform-Helfer** (`render.py`, Muster
+`_sms_onset_sharpness_marker`/`_sms_onset_ende`, aber mit einem zweiten
+Parameter für das verbleibende Budget — die einzige Kurzform-Anhängung
+dieser Scheiben-Familie, die budget-abhängig ganz entfällt statt
+unbedingt angehängt zu werden):
+
+```python
+def _sms_onset_extent_suffix(zonen: tuple[RainZone, ...], budget: int) -> str:
+    """Issue #2051 S2b: Zonen-Kuerzel der Kurzform (` km8-12,19-21`) oder
+    leer. `budget` ist die Anzahl noch verfuegbarer Zeichen NACH dem Rest
+    des Textes (limit - len(bisheriger_body)) -- das Kuerzel haengt sich nur
+    an, wenn es VOLLSTAENDIG hineinpasst; passt nicht einmal die erste Zone,
+    entfaellt die Angabe komplett. Bei mehreren Zonen werden von vorn so
+    viele genommen, wie vollstaendig passen -- nie eine angeschnittene
+    Spanne, nie ein haengendes Komma."""
+    if not zonen:
+        return ""
+    teile = [f"{int(round(z.km_from))}-{int(round(z.km_to))}" for z in zonen]
+    genommen: list[str] = []
+    for teil in teile:
+        kandidat = " km" + ",".join(genommen + [teil]) if not genommen else (
+            " km" + ",".join(genommen) + "," + teil
+        )
+        if len(kandidat) > budget:
+            break
+        genommen.append(teil)
+    if not genommen:
+        return ""
+    return " km" + ",".join(genommen)
+```
+
+**Aufruf in `_render_sms_onset`** (`render.py:927-996`): NACH dem Bau von
+`body = f"{head}: {token}"` (Zeile ~995), vor dem harten Schnitt:
+
+```python
+if getattr(e, "km_measured", False) and getattr(e, "rain_zones", ()):
+    body += _sms_onset_extent_suffix(e.rain_zones, limit - len(body))
+return body if len(body) <= limit else body[:limit]
+```
+
+Die `km_measured`/`rain_zones`-Prüfung steht bewusst VOR dem Helfer-Aufruf
+(dieselbe Sichtbarkeitsregel wie `_onset_extent_suffix` in der Langform) —
+der Helfer selbst kennt diese Regel nicht, er kennt nur das Budget.
+
+**Prüffläche** (`validator_render_service.py:93-172`,
+`render_alert_preview` → `OnsetEvent(...)`-Konstruktion): neue Felder
+zusätzlich zu den bestehenden `getattr(...)`-Zeilen (Muster
+`source_reach_time` o.), plus Import `from services.rain_extent import
+RainZone`:
+
+```python
+km_measured=getattr(body.onset, "km_measured", False),
+rain_zones=tuple(
+    RainZone(
+        km_from=z.km_from, km_to=z.km_to,
+        onset_minutes=z.onset_minutes, event_end_minutes=z.event_end_minutes,
+    )
+    for z in getattr(body.onset, "rain_zones", [])
+),
+```
+
+**`OnsetPayload`-Erweiterung** (`api/routers/validator.py:226-268`, additiv,
+Muster `event_end_time` o.):
+
+```python
+class RainZonePayload(BaseModel):
+    km_from: float
+    km_to: float
+    onset_minutes: int
+    event_end_minutes: int | None = None
+
+# in OnsetPayload:
+km_measured: bool = False
+rain_zones: list[RainZonePayload] = Field(default_factory=list)
+```
+
+## Expected Behavior
+
+- **Input:** `OnsetEvent` mit optional gesetzten `rain_zones` (aus S2a) und
+  `km_measured`; Kurzform-Renderer mit dem bestehenden `limit`-Parameter.
+- **Output:**
+  - Betreff, Telegram rich, E-Mail-Trip-Langform (unverändert seit S2a) und
+    der Mehr-Orte-Zweig (No-op) rufen `_onset_extent_suffix` einheitlich als
+    letztes Element auf.
+  - SMS, Premium-SMS und Telegram-Kurzstil tragen zusätzlich das
+    Zonen-Kürzel, wenn `km_measured` gesetzt UND `rain_zones` nicht leer
+    ist — als letztes Element der Kurzform, budget-bewusst gekürzt bis hin
+    zum vollständigen Entfallen, nie mitten in einer Spanne abgeschnitten.
+  - `POST /api/trips/{id}/alert-preview` zeigt die Ausdehnung in allen
+    betroffenen Kanälen, wenn der Payload `rain_zones`/`km_measured` trägt.
+  - Ohne Zonen oder auf unvermessener Etappe bleibt jeder betroffene Text
+    byte-identisch zum Stand vor dieser Spec.
+- **Side effects:** keine — additive Feld-Nutzung und Textverkettung. Keine
+  Persistenz betroffen, keine Änderung an der Auslöseregel.
+
+## Acceptance Criteria
+
+- **AC-1:** Given ZWEI `OnsetEvent` mit `km_measured=True`, die sich
+  ausschliesslich in ihrer Zone unterscheiden (Fall A: km 8-12, Fall B:
+  km 3-5) / When der E-Mail-Betreff (`_render_subject_onset`) fuer beide
+  gerendert wird / Then traegt Fall A `Nass km 8-12` und **nicht**
+  `Nass km 3-5`, Fall B `Nass km 3-5` und **nicht** `Nass km 8-12` — der
+  Betreff bildet die Angabe also aus den Zonendaten des jeweiligen Events
+  und traegt keinen konstanten Text.
+  - Test: EIN Unit-Test mit beiden Faellen. Die Sollstrings werden im Test
+    aus den Zonenwerten der jeweiligen Fixture **abgeleitet**
+    (`f"Nass km {int(round(z.km_from))}-{int(round(z.km_to))}"`), nicht als
+    Literal getippt — ein hart verdrahtetes Ergebnis im Produktivcode faellt
+    dadurch auf. Je Fall zusaetzlich die Negativpruefung gegen den Sollstring
+    des anderen Falls.
+
+- **AC-2:** Given denselben Zwei-Faelle-Aufbau wie AC-1 / When Telegram rich
+  (`_render_telegram_onset`) fuer beide gerendert wird / Then traegt die
+  zweite Zeile in Fall A `Nass km 8-12` und **nicht** `Nass km 3-5`, in
+  Fall B umgekehrt.
+  - Test: EIN Unit-Test mit beiden Faellen, Sollstrings wie in AC-1 aus den
+    Zonenwerten abgeleitet, je Fall die Negativpruefung gegen den anderen
+    Sollstring.
+
+- **AC-3:** Given ein Bündel-`AlertMessage` mit zwei Events aus dem
+  Ortsvergleich-Pfad (Muster `_render_email_onset_multi`, `rain_zones`
+  jeweils leer `()` — die einzige Konstellation, die dieser Pfad in
+  Produktion je erhält) / When der Mehr-Orte-Zweig gerendert wird / Then
+  bleibt der Text byte-identisch zum Stand vor dieser Spec, obwohl
+  `_onset_extent_suffix` jetzt auch dort aufgerufen wird — die Anhängung ist
+  ein dokumentierter No-op, kein neues Verhalten für den Ortsvergleich.
+  - Test: Regressionslauf des bestehenden Mehr-Orte-Tests mit unverändertem
+    Fixture (`rain_zones` nicht gesetzt), Volltextvergleich gegen den Stand
+    vor dieser Spec.
+
+- **AC-4:** Given ein `OnsetEvent` mit `km_measured=True`, einer Zone
+  km 8-12 und Beginn/Ende, die die Zeitgruppe `R2.5@15:00@16:30` erzeugen /
+  When `_render_sms_onset` (Standardlimit 140) rendert / Then lautet der
+  Token-Teil exakt `R2.5@15:00@16:30 km8-12` — das Zonen-Kürzel hängt
+  unmittelbar hinter der vollständigen Zeitgruppe, mit genau einem
+  Leerzeichen als Fuge.
+  - Test: Unit-Test gegen `_render_sms_onset`/`render_sms`, exakter
+    Substring-Vergleich auf `R2.5@15:00@16:30 km8-12`.
+
+- **AC-5:** Given denselben Aufbau wie AC-4, aber mit zwei Zonen km 8-12
+  und km 19-21 / When die Kurzform gerendert wird / Then lautet das Kürzel
+  exakt `km8-12,19-21` — komma-getrennt, ohne Leerzeichen, ohne
+  wiederholtes `km`-Präfix, und NIEMALS als zusammengefasste Spanne
+  `km8-21`.
+  - Test: Unit-Test mit zwei Zonen, Substring-Prüfung auf `km8-12,19-21`
+    UND Negativ-Prüfung, dass `km8-21` nicht vorkommt.
+
+- **AC-6:** Given zweimal denselben Aufbau wie AC-4, einmal mit
+  `km_measured=False` (unvermessene Etappe) und einmal — bei sonst
+  identischer Konstruktion — mit `km_measured=True` / When beide Texte
+  gerendert werden / Then fehlt das Zonen-Kürzel im ersten Fall vollständig
+  (Text byte-identisch zum Stand vor dieser Spec) UND erscheint im zweiten
+  Fall (Positivkontrolle — derselbe Aufbau, ein verschobener Wert,
+  gegensätzliches Ergebnis, Muster S3-AC-6).
+  - Test: Ein Testpaar mit identischem Aufbau bis auf `km_measured`, beide
+    Ausgänge (Abwesenheit und Anwesenheit des Kürzels) im selben Test
+    geprüft.
+
+- **AC-7:** Given eine Zone mit `km_from=7.6`, `km_to=11.4` / When das
+  Zonen-Kürzel gebildet wird / Then lautet es exakt `km8-11` — ganzzahlig
+  gerundet (`int(round(...))`) wie die Langform-Rundung in
+  `_onset_extent_suffix`, nicht abgeschnitten (`km7-11` wäre falsch).
+  - Test: Unit-Test mit den exakten Nachkommawerten 7.6/11.4, Substring-
+    Prüfung auf `km8-11` UND Negativ-Prüfung, dass `km7-11` nicht vorkommt.
+
+- **AC-8:** Given den Basistext ohne Zonen aus AC-4
+  (`"Obertilliacher Bergwiese: TH@18:00 >@23:59? R99.9"`, 49 Zeichen — 24
+  Zeichen Ortsname-Kopf gekappt + `": "` + Gewitter-Token mit
+  Untergrenzen-Ende und Güte-Marker) und zwei Zonen km 8-12/km 19-21
+  (Kürzel-Kandidat ` km8-12,19-21`, 13 Zeichen; erste Zone allein
+  ` km8-12`, 7 Zeichen) / When `render_sms` mit drei verschiedenen `limit`-
+  Werten rendert: (a) `limit=56` (49+7, exakt Platz für die erste Zone),
+  (b) `limit=55` (49+6, ein Zeichen zu wenig für die erste Zone),
+  (c) `limit=62` (49+13, Platz für beide Zonen) / Then zeigt (a) NUR die
+  erste Zone (`...R99.9 km8-12`, exakt 56 Zeichen), (b) GAR KEIN Kürzel
+  (Text bleibt bei 49 Zeichen, byte-identisch zum zonenlosen Stand), und
+  (c) BEIDE Zonen (`...R99.9 km8-12,19-21`, exakt 62 Zeichen) — nie eine
+  angeschnittene Spanne, nie ein hängendes Komma.
+  - Test: Drei Unit-Tests (oder ein parametrisierter Test) mit denselben
+    Event-Daten und den drei `limit`-Werten, je eine exakte
+    Zeichenlängen-Prüfung und ein exakter Substring-Vergleich.
+
+- **AC-9:** Given denselben kombinierten Extremfall wie AC-8 (30-Zeichen-
+  Ortsname → 24-Zeichen-Kopf, `onset_precip_mm=99.9`, Untergrenzen-Ende,
+  Güte-Marker) mit zwei realistischen Zonen (max. erreichbar bei
+  `RADAR_ZONE_MAX_POINTS=6`) UND dem Standardlimit `limit=140` / When
+  derselbe Aufruf einmal mit `limit=140` und einmal ungedeckelt
+  (`limit=4000`) rendert / Then sind beide Texte IDENTISCH (62 Zeichen,
+  Muster S1-AC-16) — der harte Schnitt `body[:limit]` greift im
+  Extremfall mit Zonen genauso wenig wie ohne.
+  - Test: Testpaar mit `limit=140` und `limit=4000`, Gleichheitsprüfung
+    beider Ergebnisse plus exakte Längenprüfung `== 62`.
+
+- **AC-10:** Given ein `OnsetEvent` mit zwei Zonen km 8-12 und km 19-21,
+  einmal über die E-Mail-Langform (`_render_email_onset`) und einmal über
+  die Kurzform (`_render_sms_onset`) gerendert (dieselben Rohdaten,
+  Kanalparität-Muster `test_onset_menge_kanalparitaet.py`) / When beide
+  Texte auf ihre Zonenwerte geprüft werden / Then tragen beide dieselben
+  km-Grenzen (8, 12, 19, 21) in derselben Reihenfolge — die Langform als
+  `Nass km 8-12, km 19-21`, die Kurzform als `km8-12,19-21` — unterschied-
+  liche Wortform, identischer Zahleninhalt.
+  - Test: Paritätstest, extrahiert die Zahlenpaare aus beiden gerenderten
+    Texten (Regex) und vergleicht sie auf Gleichheit.
+
+- **AC-11:** Given den Extremfall aus AC-9 mit gesetztem Zonen-Kürzel /
+  When der resultierende Text auf seinen Zeichenvorrat geprüft wird / Then
+  ist er vollständig ASCII-rein (`text.isascii()`) — der Bindestrich im
+  Zonen-Kürzel ist GSM-7-Basiszeichensatz und ändert daran nichts, anders
+  als `~` (S3 E6).
+  - Test: Unit-Test mit demselben Extremfall wie AC-9, `sms.isascii()`
+    geprüft.
+
+- **AC-12:** Given einen `OnsetPayload` mit gesetzten `rain_zones`
+  (mindestens einer Zone) und `km_measured=True` / When
+  `render_alert_preview(trip_obj, body)` läuft / Then trägt JEDER der vier
+  betroffenen Preview-Texte (`subject`, `email_plain`, `telegram`, `sms`)
+  die Ausdehnungsangabe — die Prüffläche muss die Lücke schließen, die die
+  S2a-Lieferung als „nicht gemessen" gebucht hat (R4), sonst ist kein AC
+  dieser Scheibe über HTTP nachweisbar.
+  - Test: Unit-Test gegen `render_alert_preview` mit einem `OnsetPayload`
+    (echtes Pydantic-Objekt, kein Mock), Substring-Prüfung auf die
+    Zonenangabe in allen vier zurückgegebenen Textfeldern.
+
+- **AC-13:** Given einen `OnsetPayload` OHNE die neuen Felder (Alt-Client,
+  Muster #2046 F002) / When `render_alert_preview` läuft / Then bleibt
+  jeder der vier Preview-Texte byte-identisch zum Stand vor dieser Spec —
+  die neuen Felder sind additiv und defaulten auf „keine Ausdehnung",
+  pydantic verwirft sie nicht still (Regressions-Absicherung des
+  Rückwärtskompatibilitäts-Vertrags).
+  - Test: Unit-Test mit einem `OnsetPayload`, der die neuen Felder
+    weglässt, Volltextvergleich der vier Preview-Texte gegen den
+    Stand vor dieser Spec.
+
+- **AC-14:** Given einen beliebigen der vier neu betroffenen Texte
+  (Betreff, Telegram rich, Mehr-Orte-Zweig, Kurzform) mit gesetzter
+  Ausdehnungsangabe / When der Text auf Formulierungen geprüft wird, die
+  eine Handlungsempfehlung oder eine Ankunftszeit-Rechnung über den Nutzer
+  enthalten (Muster S2a-AC-16/S3-AC-15) / Then enthält KEINER der vier
+  Texte eine solche Formulierung — ausschließlich km-Spannen und Zeiten.
+  - Test: Unit-Test über alle vier Renderer-Ausgaben mit gesetzten Zonen,
+    Negativ-Prüfung auf dieselbe Liste verbotener Muster wie S2a-AC-16.
+
+## Known Limitations
+
+- **Der Mehr-Orte-Zweig bleibt strukturell stumm.** Der No-op aus AC-3 ist
+  keine Verbesserung für den Ortsvergleich — er bleibt ohne
+  Streckenkonzept, `rain_zones` wird dort nie gesetzt. Eine echte
+  Ausdehnungsangabe im Ortsvergleich bräuchte ein eigenes Streckenkonzept,
+  das außerhalb dieser Scheiben-Familie liegt.
+- **Briefing-Kurzfristhinweis und `/jetzt`-Kommando bleiben ohne
+  Ausdehnung** — beide brauchen eine eigene Mehrpunkt-Verdrahtung
+  (Ein-Punkt-Abfrage bzw. kein Reststreckenbezug), außerhalb dieses
+  Zuschnitts.
+- **Die Budget-Drop-Regel wird im realistischen Betrieb kaum sichtbar.**
+  Bei `RADAR_ZONE_MAX_POINTS=6` und 2-km-Abstand entstehen höchstens drei
+  Zonen mit ein- bis zweistelligen km-Werten — die AC-9-Rechnung zeigt 62
+  von 140 möglichen Zeichen, deutlicher Puffer. AC-8 erzwingt die
+  Drop-Situation deshalb über den expliziten `limit`-Parameter statt über
+  eine im Betrieb erreichbare Zonenzahl — die Mechanik ist eine Reißleine
+  für lange Ortsnamen und künftig größere Zonendeckel, kein heute aktiv
+  durchlaufener Pfad.
+- **Messlücken bleiben unmarkiert** (S2a Known Limitation, unverändert) —
+  ein Punkt ohne Daten fällt still aus der Zonenbildung, ohne Kennzeichen
+  im Text. Betrifft S2b nicht zusätzlich, S2b bespielt nur weitere
+  Kanäle mit demselben, bereits bekannten Verhalten.
+
+## Nicht-Ziele
+
+- **Briefing-Kurzfristhinweis** (`starkregen_hint.py`) — braucht eine
+  eigene Mehrpunkt-Abfrage im Hinweis-Pfad, eigene Scheibe.
+- **`/jetzt`-Kommando** — Sofortabfrage ohne Reststreckenbezug,
+  `NowcastResult` trägt kein Zonenfeld.
+- **Wegpunktnamen für unvermessene Etappen — entfällt ersatzlos** (siehe
+  Entscheidungs-Abschnitt oben; die S2a-Spec-Aussage war eine
+  Momentaufnahme des Datenbestands, nicht der Laufzeit).
+- **Änderungen an der Zonenbildung** (`src/services/rain_extent.py`,
+  `derive_rain_zones`, `RainZone`) — S2b **konsumiert** die Zonen
+  ausschließlich. Wie eine **Messlücke** behandelt wird (heute: der Punkt
+  fällt still heraus, `rain_extent.py:77-78`, und zwei nasse Abschnitte
+  verschmelzen zu EINER Zone), gehört **#2050 S4b/S4b-2** (abgestimmt
+  2026-08-23 mit der dortigen Sitzung).
+
+  **Stand nach der Abstimmung:** Die Zonenbildung bleibt **byte-gleich**.
+  S4b hatte zunächst geplant, eine Lücke die Zone abschließen zu lassen,
+  und hat das zurückgezogen — zwei S2a-Wächter sichern das Nicht-Trennen
+  ausdrücklich zu (`test_regen_ausdehnung_zonenbildung.py:148`,
+  `test_regen_ausdehnung_textstellen.py:503`, beide mit Positivkontrolle),
+  und die dortige Begründung trägt: Ein als trennend gewerteter Ausfall
+  erfindet eine trockene Strecke, die niemand gemessen hat. Beide
+  Darstellungen behaupten Ungemessenes; ehrlich ist allein eine
+  **Kennzeichnung**, und die ist Wortarbeit (S4b-2). S4b liefert deshalb
+  nur die Nachvollziehbarkeit (additives `RainZone`-Feld mit Default,
+  Abgriff ins Alarmprotokoll).
+
+  **Kein AC dieser Spec schreibt das heutige Lückenverhalten fest.** Alle
+  AC-Fixtures verwenden **lückenfreie** Punktreihen (jeder Abfragepunkt
+  trägt ein Ergebnis). Die Zusicherung „mehrere Zonen bleiben getrennt
+  aufgezählt" (AC-5, AC-10) wird deshalb mit zwei **bereits getrennten**
+  Zonen in der Fixture geprüft, nie über eine Lücke hinweg — sonst wäre der
+  Test ein Wächter, der die Korrektur aus #2050 S4b fälschlich rot färbt.
+
+  Die Zonenzahl bewegt sich durch S4b also **nicht**. Sollte eine spätere
+  Scheibe sie doch verändern (etwa indem eine gekennzeichnete Lücke zu zwei
+  Zonen führt), wird das Kurzform-Kürzel länger und kann nach der
+  Budget-Regel (AC-8) entfallen — das wäre **gewolltes Verhalten, keine
+  Regression**.
+
+- **Änderungen am Ortsvergleich** (`compare_radar_alert.py`,
+  `project.py:621`) — kein Streckenkonzept, `rain_zones` bleibt dort leer.
+- **Signaturänderung an `get_nowcast()`** — bleibt Ein-Punkt-API.
+- **Keine neue Zentral-Kaskaden-Mechanik** — jede Aufrufstelle verkettet
+  ihre Suffixe weiterhin einzeln (Bestandsmuster, unverändert seit S1).
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Additive Verkettung eines in S2a bereits fertigen
+  Bausteins an drei weitere Aufrufstellen plus ein neuer, budget-bewusster
+  Kurzform-Helfer nach demselben Suffix-Muster. Berührt keine der vier
+  Entscheidungsflächen, die ein neues ADR verlangen würden: ADR-0011 (ein
+  Backend-Renderer) bleibt gültig; ADR-0021 (geteilter Code Trip/Compare)
+  wird angewendet, nicht verändert (Mehr-Orte-Zweig bleibt dokumentierter
+  No-op, AC-3); kein neuer Kanal, kein neuer Provider, keine
+  Persistenz-Änderung, keine Änderung an der Auslöseregel.
+
+## Changelog
+
+- 2026-08-23: Initial spec created (#2051 Scheibe S2b, Ausdehnung auf die
+  übrigen Kanäle — drei zusätzliche Langform-Stellen, Kurzform-Zonenkürzel
+  mit Budget-Drop-Mechanik, Prüffläche `validator_render_service.py`).

--- a/src/output/renderers/alert/render.py
+++ b/src/output/renderers/alert/render.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import unicodedata
 from datetime import datetime, timezone
+from typing import TYPE_CHECKING
 
 from app.metric_catalog import (
     format_metric_value, get_alert_label, get_decimals, get_label_for_field,
@@ -25,6 +26,11 @@ from .model import (
 )
 from .project import COMPARE_RADAR_SOURCE
 from .segments import _renderable_segment_ids, format_alert_location
+
+if TYPE_CHECKING:  # pragma: no cover — nur fuer Typpruefung
+    # Muster `model.py`: der Renderer haengt sich zur LAUFZEIT nicht an die
+    # Service-Schicht, nur die Typpruefung kennt die Zonen-Datenklasse.
+    from services.rain_extent import RainZone
 
 
 def _sorted(msg: AlertMessage) -> list[AlertEvent]:
@@ -481,9 +487,13 @@ def _render_subject_onset(msg: AlertMessage) -> str:
     km = _km_str_onset(e)
     # Issue #2051 S1: das Ende additiv HINTER der Beginn-Angabe -- ohne
     # behauptbares Ende bleibt der Betreff byte-identisch (AC-19).
+    # Issue #2051 S2b: die Ausdehnung als LETZTES Element derselben Kette --
+    # ohne Zonen bzw. auf unvermessener Etappe bleibt der Betreff
+    # byte-identisch (AC-1).
     return (
         f"[{msg.trip_short}] {km} · {label} {_onset_wann_kopf(e)}"
         f"{_onset_end_suffix(e)}{_onset_reach_suffix(e)}{_onset_sharpness_suffix(e)}"
+        f"{_onset_extent_suffix(e)}"
     )
 
 
@@ -655,8 +665,13 @@ def _render_email_onset_multi(msg: AlertMessage) -> tuple[str, str]:
             # Issue #2051 S1: das Ende JE ORT aus dessen eigenem Event -- ein
             # Buendel kann Orte mit verschiedenen Ende-Zeiten tragen. Ohne
             # behauptbares Ende bleibt die Zeile byte-identisch (AC-19).
+            # Issue #2051 S2b: dokumentierter No-op -- dieser Zweig laeuft nur
+            # ueber den Ortsvergleich-Buendelpfad, der `rain_zones` nie setzt
+            # (S2a AC-15). Angehaengt, damit die sieben Aufrufstellen nicht
+            # schweigend auseinanderlaufen (AC-3).
             f"{_onset_wann_zeile(e, praefix='ab ')}{_onset_end_suffix(e)}"
-            f"{_onset_reach_suffix(e)}{_onset_sharpness_suffix(e)} · "
+            f"{_onset_reach_suffix(e)}{_onset_sharpness_suffix(e)}"
+            f"{_onset_extent_suffix(e)} · "
             f"{e.intensity_label}",
         )
         for e in msg.events
@@ -807,9 +822,12 @@ def _render_telegram_onset(msg: AlertMessage) -> str:
     first = f"<b>{_esc(f'{msg.trip_short} · {km} · {label} {_onset_wann_kopf(e)}')}</b>"
     # Issue #2051 S1: das Ende additiv HINTER der Beginn-Zeit, vor Intensitaet
     # und Quelle -- ohne behauptbares Ende byte-identisch wie bisher (AC-19).
+    # Issue #2051 S2b: die Ausdehnung als LETZTES Suffix der Detailzeile, vor
+    # Intensitaet und Quelle -- ohne Zonen byte-identisch wie bisher (AC-2).
     second = (
         f"{_onset_wann_zeile(e)}{_onset_end_suffix(e)}"
-        f"{_onset_reach_suffix(e)}{_onset_sharpness_suffix(e)} · "
+        f"{_onset_reach_suffix(e)}{_onset_sharpness_suffix(e)}"
+        f"{_onset_extent_suffix(e)} · "
         f"{e.intensity_label} · {e.source_label}"
     )
     # Issue #2018 (AC-B3): die Bezugszeile steht als EIGENE Zeile zwischen Kopf
@@ -924,6 +942,40 @@ def _sms_onset_sharpness_marker(e: OnsetEvent) -> str:
     return "?" if getattr(e, "location_sharpness_limit_time", None) else ""
 
 
+def _sms_onset_extent_suffix(zonen: tuple[RainZone, ...], budget: int) -> str:
+    """Issue #2051 S2b: Zonen-Kuerzel der Kurzform (` km8-12,19-21`) oder leer.
+
+    `budget` ist die Anzahl noch verfuegbarer Zeichen NACH dem Rest des Textes
+    (`limit - len(bisheriger_body)`) -- das Kuerzel haengt sich nur an, wenn es
+    VOLLSTAENDIG hineinpasst; passt nicht einmal die erste Zone, entfaellt die
+    Angabe komplett. Bei mehreren Zonen werden von vorn so viele genommen, wie
+    vollstaendig passen -- nie eine angeschnittene Spanne, nie ein haengendes
+    Komma.
+
+    Der Grund ist fachlich, nicht kosmetisch: `km8-1` waere im Satellitenkanal
+    eine FALSCHE Angabe, keine fehlende -- und auf der Huette am Karnischen
+    Hoehenweg kommt nur die Premium-SMS an, es gibt dort keinen zweiten Kanal,
+    der sie richtigstellt.
+
+    EIN `km`-Praefix vor der ersten Spanne, danach nur noch `X-Y`-Paare
+    (Zeichenbudget). Ganzzahlig gerundet und mit ASCII-Bindestrich wie die
+    Langform (`_onset_extent_suffix`) -- unterschiedliche Wortform, identischer
+    Zahleninhalt (AC-10). Die Sichtbarkeitsregel (`km_measured`, leere Zonen)
+    kennt diese Funktion bewusst NICHT, sie kennt nur das Budget; entschieden
+    wird sie an der Aufrufstelle, wie in der Langform."""
+    if not zonen:
+        return ""
+    genommen: list[str] = []
+    for z in zonen:
+        kandidat = genommen + [f"{int(round(z.km_from))}-{int(round(z.km_to))}"]
+        if len(" km" + ",".join(kandidat)) > budget:
+            break
+        genommen = kandidat
+    if not genommen:
+        return ""
+    return " km" + ",".join(genommen)
+
+
 def _render_sms_onset(msg: AlertMessage, limit: int = 140) -> str:
     """Issue #1948 S4: die Nowcast-/Onset-Kurznachricht nennt einen ZEITPUNKT
     (`TH@15:40`) statt eines Countdowns (`TH!8`) und spricht im Kopf dieselbe
@@ -993,6 +1045,12 @@ def _render_sms_onset(msg: AlertMessage, limit: int = 140) -> str:
     else:
         head = _ascii_alert_location(_location_of((e,), None))[:24]
     body = f"{head}: {token}"
+    # Issue #2051 S2b: das Zonen-Kuerzel ist das ZULETZT angefuegte Element --
+    # dieselbe Sichtbarkeitsregel wie `_onset_extent_suffix` in der Langform
+    # (nur vermessene Etappe, nur nicht-leere Zonen), und nur so viel, wie
+    # vollstaendig ins Budget passt (AC-4/AC-6/AC-8).
+    if getattr(e, "km_measured", False) and getattr(e, "rain_zones", ()):
+        body += _sms_onset_extent_suffix(e.rain_zones, limit - len(body))
     return body if len(body) <= limit else body[:limit]
 
 

--- a/src/services/validator_render_service.py
+++ b/src/services/validator_render_service.py
@@ -41,6 +41,7 @@ from output.renderers.sms_trip import SMS_MULTI_SYMBOLS_BY_METRIC, SMS_SYMBOL_BY
 from output.tokens.builder import build_token_line
 from output.tokens.dto import DailyForecast, HourlyValue, MetricSpec, NormalizedForecast
 from output.tokens.render import render_line_with_survivors
+from services.rain_extent import RainZone  # Issue #2051 S2b
 from utils.timezone import local_fmt, tz_for_coords
 
 
@@ -168,6 +169,19 @@ def render_alert_preview(
             ),
             location_sharpness_limit_day_offset=getattr(
                 body.onset, "location_sharpness_limit_day_offset", 0,
+            ),
+            # Issue #2051 S2b: Ausdehnung des Payloads. Ohne diese beiden
+            # Felder zeigte die Vorschau in KEINEM Kanal eine Zonenangabe --
+            # genau die Luecke, die die S2a-Lieferung als "nicht gemessen"
+            # gebucht hat (R4).
+            km_measured=getattr(body.onset, "km_measured", False),
+            rain_zones=tuple(
+                RainZone(
+                    km_from=z.km_from, km_to=z.km_to,
+                    onset_minutes=z.onset_minutes,
+                    event_end_minutes=z.event_end_minutes,
+                )
+                for z in getattr(body.onset, "rain_zones", [])
             ),
         )
         msg = AlertMessage(

--- a/tests/tdd/test_regen_ausdehnung_kanalparitaet.py
+++ b/tests/tdd/test_regen_ausdehnung_kanalparitaet.py
@@ -1,0 +1,102 @@
+"""TDD RED — Issue #2051 Scheibe S2b: Langform und Kurzform nennen DIESELBEN
+km-Grenzen in derselben Reihenfolge.
+
+SPEC: docs/specs/modules/feat_2051_s2b_ausdehnung_kanaele.md — AC-10.
+
+Fachlicher Kern: die beiden Textformen unterscheiden sich in der WORTFORM
+(`Nass km 8-12, km 19-21` gegen `km8-12,19-21`), niemals im ZAHLENINHALT.
+Auf dem Pass liest der Nutzer E-Mail/Telegram, auf der Huette nur die
+Premium-SMS — zwei verschiedene Zahlenaussagen ueber dieselbe Strecke waeren
+ein Widerspruch, den niemand aufloesen kann.
+
+Muster: `test_onset_menge_kanalparitaet.py` (#2046), hier auf der
+Renderer-Ebene, weil beide Formen aus demselben `OnsetEvent` entstehen.
+
+RED-Ursache: die Kurzform traegt heute ueberhaupt keine Zonenangabe.
+
+Mock-frei: echte `OnsetEvent`/`RainZone`/`AlertMessage`-Objekte durch die
+echten Renderer.
+"""
+from __future__ import annotations
+
+import re
+
+from output.renderers.alert.model import AlertMessage, OnsetEvent
+from output.renderers.alert.render import render_email, render_sms
+from services.rain_extent import RainZone
+
+_ZONE_A = RainZone(km_from=8.0, km_to=12.0, onset_minutes=20, event_end_minutes=40)
+_ZONE_B = RainZone(km_from=19.0, km_to=21.0, onset_minutes=50, event_end_minutes=70)
+
+_PAAR_RE = re.compile(r"(\d+)-(\d+)")
+
+
+def _msg() -> AlertMessage:
+    event = OnsetEvent(
+        onset_minutes=25, onset_time="15:00", km_from=0.0, km_to=6.0,
+        is_convective=False, intensity_label="Mäßiger Regen",
+        source_label="Radar (DWD)", location_label="Sillian",
+        onset_precip_mm=2.5, event_end_time="16:30",
+        km_measured=True, rain_zones=(_ZONE_A, _ZONE_B),
+    )
+    return AlertMessage(
+        trip_short="KHW 403", stand_at="14:35", events=(event,),
+        source="Radar (DWD)",
+    )
+
+
+def _paare_langform(plain: str) -> list[tuple[int, int]]:
+    """Die Zahlenpaare der LANGFORM-Ausdehnung (`· Nass km 8-12, km 19-21`).
+
+    Bewusst erst ab dem `Nass`-Abschnitt gelesen: die uebrige Zeile traegt
+    ihre eigene km-Spanne (Segment-Lage), die hier nichts zu suchen hat."""
+    treffer = re.search(r"· Nass (km [^·\n]*)", plain)
+    if not treffer:
+        return []
+    return [(int(a), int(b)) for a, b in _PAAR_RE.findall(treffer.group(1))]
+
+
+def _paare_kurzform(sms: str) -> list[tuple[int, int]]:
+    """Die Zahlenpaare der KURZFORM-Ausdehnung (` km8-12,19-21`)."""
+    treffer = re.search(r" km([\d,-]+)", sms)
+    if not treffer:
+        return []
+    return [(int(a), int(b)) for a, b in _PAAR_RE.findall(treffer.group(1))]
+
+
+def test_ac10_langform_und_kurzform_nennen_dieselben_km_grenzen():
+    """AC-10 GIVEN ein `OnsetEvent` mit zwei Zonen km 8-12 und km 19-21,
+    einmal ueber die E-Mail-Langform und einmal ueber die Kurzform gerendert
+    (DIESELBEN Rohdaten)
+    WHEN beide Texte auf ihre Zonenwerte geprueft werden
+    THEN tragen beide dieselben km-Grenzen in derselben Reihenfolge —
+    unterschiedliche Wortform, identischer Zahleninhalt.
+
+    Der Sollwert wird aus den Zonen der Fixture abgeleitet, nicht getippt;
+    zusaetzlich werden die beiden EXTRAHIERTEN Listen direkt gegeneinander
+    geprueft — eine Verschiebung nur in einem der beiden Renderer faellt so
+    auf, auch wenn beide dieselbe Form behalten.
+
+    RED heute: die Kurzform traegt keine Zonenangabe, ihre Paarliste ist
+    leer."""
+    erwartet = [
+        (int(round(z.km_from)), int(round(z.km_to))) for z in (_ZONE_A, _ZONE_B)
+    ]
+    msg = _msg()
+
+    _html, plain = render_email(msg)
+    sms = render_sms(msg)
+
+    lang = _paare_langform(plain)
+    kurz = _paare_kurzform(sms)
+
+    assert lang == erwartet, (
+        f"AC-10: die Langform muss {erwartet} nennen, extrahiert {lang}:\n{plain}"
+    )
+    assert kurz == erwartet, (
+        f"AC-10: die Kurzform muss {erwartet} nennen, extrahiert {kurz}: {sms!r}"
+    )
+    assert lang == kurz, (
+        f"AC-10: Langform {lang} und Kurzform {kurz} nennen verschiedene "
+        f"km-Grenzen.\nLangform:\n{plain}\nKurzform: {sms!r}"
+    )

--- a/tests/tdd/test_regen_ausdehnung_kurzform.py
+++ b/tests/tdd/test_regen_ausdehnung_kurzform.py
@@ -1,0 +1,277 @@
+"""TDD RED — Issue #2051 Scheibe S2b: die Kurzform (SMS, Premium-SMS,
+Telegram-Kurzstil) traegt das Zonen-Kuerzel `km8-12`.
+
+SPEC: docs/specs/modules/feat_2051_s2b_ausdehnung_kanaele.md — AC-4, AC-5,
+AC-6, AC-7, AC-11.
+
+Warum das zaehlt: auf der Huette am Karnischen Hoehenweg kommt NUR die
+Premium-SMS an, und die traegt heute keinerlei Ausdehnungsangabe. Alle drei
+Kurzkanaele senden denselben `sms_body` — ein Kuerzel hier wirkt auf alle
+drei zugleich.
+
+RED-Ursache: `_render_sms_onset` (`render.py:927-996`) kennt kein
+Zonen-Token; der Helfer `_sms_onset_extent_suffix` existiert nicht.
+
+Mock-frei: echte `OnsetEvent`/`RainZone`/`AlertMessage`-Objekte durch den
+echten Renderer, feste Zeitangaben, keine Wanduhr.
+"""
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+from output.renderers.alert.model import AlertMessage, OnsetEvent
+from output.renderers.alert.render import render_sms
+from services.rain_extent import RainZone
+
+# Zeitgruppe `R2.5@15:00@16:30` (Spec AC-4): Beginn 15:00, bekanntes Ende
+# 16:30 (kein Untergrenzen-Waechter), Menge 2.5 mm, kein Guete-Marker.
+_MINIMAL_FIELDS = dict(
+    onset_minutes=25, onset_time="15:00", km_from=0.0, km_to=6.0,
+    is_convective=False, intensity_label="Mäßiger Regen",
+    source_label="Radar (DWD)", location_label="Sillian",
+    onset_precip_mm=2.5, event_end_time="16:30",
+)
+
+_ZEITGRUPPE = "R2.5@15:00@16:30"
+
+_ZONE_A = RainZone(km_from=8.0, km_to=12.0, onset_minutes=20, event_end_minutes=40)
+_ZONE_B = RainZone(km_from=19.0, km_to=21.0, onset_minutes=50, event_end_minutes=70)
+
+
+def _onset_event(**overrides) -> OnsetEvent:
+    fields = dict(_MINIMAL_FIELDS)
+    fields.update(overrides)
+    return OnsetEvent(**fields)
+
+
+def _onset_msg(*events: OnsetEvent) -> AlertMessage:
+    return AlertMessage(
+        trip_short="KHW 403", stand_at="14:35", events=tuple(events),
+        source="Radar (DWD)",
+    )
+
+
+def _kurzform_soll(*zonen: RainZone) -> str:
+    """Das Zonen-Kuerzel der KURZFORM, ABGELEITET aus den Zonenwerten der
+    Fixture (` km8-12,19-21`) — nie als Literal getippt.
+
+    EIN `km`-Praefix vor der ersten Spanne, danach nur noch `X-Y`-Paare,
+    komma-getrennt ohne Leerzeichen; ganzzahlig gerundet wie die Langform."""
+    return " km" + ",".join(
+        f"{int(round(z.km_from))}-{int(round(z.km_to))}" for z in zonen
+    )
+
+
+def test_prueling_stammt_aus_diesem_arbeitsbaum():
+    """Vorbedingung (kein AC): der geprueften Renderer wird RELATIV ZU DIESER
+    Testdatei aufgeloest — sonst pruefte ein Worktree-Lauf still die Datei des
+    Hauptrepos und lieferte falsches Gruen."""
+    from output.renderers.alert import render as render_module
+
+    modul_pfad = Path(inspect.getfile(render_module)).resolve()
+    arbeitsbaum = Path(__file__).resolve().parents[2]
+    assert modul_pfad.is_relative_to(arbeitsbaum), (
+        f"Prueling stammt nicht aus diesem Arbeitsbaum: {modul_pfad}"
+    )
+
+
+# --------------------------------------------------------------------------
+# AC-4 — das Kuerzel haengt unmittelbar hinter der VOLLSTAENDIGEN Zeitgruppe,
+#        mit genau EINEM Leerzeichen als Fuge.
+# --------------------------------------------------------------------------
+
+def test_ac4_zonen_kuerzel_haengt_hinter_der_zeitgruppe():
+    """AC-4 GIVEN ein `OnsetEvent` mit `km_measured=True`, einer Zone km 8-12
+    und Beginn/Ende, die die Zeitgruppe `R2.5@15:00@16:30` erzeugen
+    WHEN `render_sms` mit dem Standardlimit 140 rendert
+    THEN lautet der Token-Teil exakt `R2.5@15:00@16:30 km8-12`.
+
+    Der Sollwert wird aus den Zonenwerten der Fixture abgeleitet
+    (`_kurzform_soll`); die Vorbedingung darunter haelt fest, dass die
+    Fixture wirklich das Beispiel der Spec erzeugt — sonst koennte die
+    Ableitung mit dem Pruefling gemeinsam abdriften.
+
+    RED heute: die Kurzform kennt kein Zonen-Token."""
+    kuerzel = _kurzform_soll(_ZONE_A)
+    assert kuerzel == " km8-12", (
+        f"Testvoraussetzung: die Fixture muss das Spec-Beispiel ' km8-12' "
+        f"erzeugen, abgeleitet wurde {kuerzel!r}"
+    )
+
+    sms = render_sms(
+        _onset_msg(_onset_event(km_measured=True, rain_zones=(_ZONE_A,)))
+    )
+
+    assert f"{_ZEITGRUPPE}{kuerzel}" in sms, (
+        f"AC-4: erwartet {_ZEITGRUPPE + kuerzel!r} als Token-Teil, "
+        f"erhalten: {sms!r}"
+    )
+    assert sms == f"Sillian: {_ZEITGRUPPE}{kuerzel}", (
+        f"AC-4: die Kurzform muss aus Kopf, Zeitgruppe und Kuerzel bestehen, "
+        f"ohne weitere Zusaetze: {sms!r}"
+    )
+
+
+# --------------------------------------------------------------------------
+# AC-5 — zwei Zonen: komma-getrennt, EIN `km`-Praefix, NIE zusammengefasst.
+# --------------------------------------------------------------------------
+
+def test_ac5_zwei_zonen_komma_getrennt_ohne_huelle():
+    """AC-5 GIVEN denselben Aufbau wie AC-4, aber mit zwei Zonen km 8-12 und
+    km 19-21
+    WHEN die Kurzform gerendert wird
+    THEN lautet das Kuerzel exakt `km8-12,19-21` — ohne Leerzeichen, ohne
+    wiederholtes `km`-Praefix — und NIEMALS die zusammengefasste Spanne
+    `km8-21`.
+
+    Die Huelle waere eine Aussage ueber das Wetter, die niemand gemessen hat:
+    die trockene Strecke zwischen den Zonen erschiene als nass (S2a E2).
+
+    RED heute: die Kurzform kennt kein Zonen-Token."""
+    kuerzel = _kurzform_soll(_ZONE_A, _ZONE_B)
+    huelle = f"km{int(round(_ZONE_A.km_from))}-{int(round(_ZONE_B.km_to))}"
+    assert kuerzel == " km8-12,19-21" and huelle == "km8-21", (
+        f"Testvoraussetzung: Fixture muss ' km8-12,19-21' (Huelle 'km8-21') "
+        f"erzeugen, abgeleitet wurde {kuerzel!r} / {huelle!r}"
+    )
+
+    sms = render_sms(
+        _onset_msg(_onset_event(km_measured=True, rain_zones=(_ZONE_A, _ZONE_B)))
+    )
+
+    assert kuerzel in sms, (
+        f"AC-5: erwartet {kuerzel!r} in der Kurzform: {sms!r}"
+    )
+    assert huelle not in sms, (
+        f"AC-5: die zusammengefasste Huelle {huelle!r} ist verboten: {sms!r}"
+    )
+    wiederholtes_praefix = " " + ",".join(
+        f"km{int(round(z.km_from))}-{int(round(z.km_to))}"
+        for z in (_ZONE_A, _ZONE_B)
+    )
+    assert wiederholtes_praefix not in sms, (
+        f"AC-5: das `km`-Praefix darf sich nicht je Spanne wiederholen "
+        f"({wiederholtes_praefix!r}): {sms!r}"
+    )
+
+
+# --------------------------------------------------------------------------
+# AC-6 — unvermessene Etappe: kein Kuerzel, Text byte-identisch. Mit
+#        Positivkontrolle im selben Test (Muster S3-AC-6).
+# --------------------------------------------------------------------------
+
+def test_ac6_unvermessene_etappe_ohne_kuerzel_vermessene_mit():
+    """AC-6 GIVEN zweimal denselben Aufbau wie AC-4, einmal mit
+    `km_measured=False` (unvermessene Etappe) und einmal — bei sonst
+    identischer Konstruktion — mit `km_measured=True`
+    WHEN beide Texte gerendert werden
+    THEN fehlt das Zonen-Kuerzel im ersten Fall vollstaendig (Text
+    byte-identisch zum zonenlosen Stand) UND erscheint im zweiten.
+
+    Ein verschobener Wert, gegensaetzliches Ergebnis: ohne den zweiten Fall
+    waere die Abwesenheitspruefung trivial wahr (heute traegt die Kurzform
+    ueberhaupt kein Kuerzel).
+
+    RED heute: der zweite Fall (Positivkontrolle) faellt aus."""
+    kuerzel = _kurzform_soll(_ZONE_A)
+
+    ohne_zonen = render_sms(
+        _onset_msg(_onset_event(km_measured=False, rain_zones=()))
+    )
+    unvermessen = render_sms(
+        _onset_msg(_onset_event(km_measured=False, rain_zones=(_ZONE_A,)))
+    )
+    vermessen = render_sms(
+        _onset_msg(_onset_event(km_measured=True, rain_zones=(_ZONE_A,)))
+    )
+
+    assert unvermessen == ohne_zonen, (
+        "AC-6: auf unvermessener Etappe muss der Text byte-identisch zum "
+        f"zonenlosen Stand bleiben.\n  mit Zonen: {unvermessen!r}\n"
+        f"  ohne Zonen: {ohne_zonen!r}"
+    )
+    assert "km" not in unvermessen.removeprefix("Sillian: "), (
+        f"AC-6: kein km-Kuerzel auf unvermessener Etappe: {unvermessen!r}"
+    )
+    assert kuerzel in vermessen, (
+        f"AC-6 (Positivkontrolle): bei `km_measured=True` MUSS {kuerzel!r} "
+        f"erscheinen — sonst prueft die Abwesenheit oben nichts: {vermessen!r}"
+    )
+
+
+# --------------------------------------------------------------------------
+# AC-7 — Rundung, nicht Abschneiden.
+# --------------------------------------------------------------------------
+
+def test_ac7_fraktionale_zonengrenzen_werden_gerundet():
+    """AC-7 GIVEN eine Zone mit `km_from=7.6`, `km_to=11.4`
+    WHEN das Zonen-Kuerzel gebildet wird
+    THEN lautet es exakt `km8-11` — ganzzahlig gerundet wie die Langform,
+    NICHT abgeschnitten (`km7-11` waere falsch).
+
+    Die Werte sind so gewaehlt, dass Runden und Abschneiden AUSEINANDER-
+    LAUFEN — sonst pruefte der Test die Form statt des Werts. Beide Sollwerte
+    stehen hier bewusst als Literal: geprueft wird die RUNDUNGSREGEL selbst,
+    eine Ableitung ueber `int(round(...))` wuerde den Pruefling spiegeln.
+
+    RED heute: die Kurzform kennt kein Zonen-Token."""
+    zone = RainZone(km_from=7.6, km_to=11.4, onset_minutes=20, event_end_minutes=40)
+
+    sms = render_sms(
+        _onset_msg(_onset_event(km_measured=True, rain_zones=(zone,)))
+    )
+
+    assert "km8-11" in sms, (
+        f"AC-7: 7.6/11.4 muessen gerundet als 'km8-11' erscheinen: {sms!r}"
+    )
+    assert "km7-11" not in sms, (
+        f"AC-7: abgeschnitten statt gerundet ('km7-11') ist falsch: {sms!r}"
+    )
+
+
+# --------------------------------------------------------------------------
+# AC-11 — Zeichenvorrat: der ASCII-Bindestrich ist GSM-7-Basiszeichensatz.
+# --------------------------------------------------------------------------
+
+def _extremfall_msg(*zonen: RainZone) -> AlertMessage:
+    """Der kombinierte Extremfall aus AC-9: 30-Zeichen-Ortsname (auf 24
+    gekappt), `onset_precip_mm=99.9`, Untergrenzen-Ende und Guete-Marker."""
+    ortsname = "Obertilliacher Bergwiesenalm".ljust(30, "x")
+    assert len(ortsname) == 30, "Voraussetzung: 30-Zeichen-Ortsname"
+    event = OnsetEvent(
+        onset_minutes=40, onset_time="18:00", km_from=0.0, km_to=0.0,
+        is_convective=True, intensity_label="Starker Regen",
+        source_label="Radar (DWD)", location_label=ortsname,
+        onset_precip_mm=99.9, event_end_time="23:59",
+        event_ongoing_beyond_horizon=True,
+        location_sharpness_limit_time="20:00",
+        km_measured=True, rain_zones=tuple(zonen),
+    )
+    return AlertMessage(
+        trip_short="Alpen", stand_at="17:20", events=(event,),
+        source="Radar (DWD)",
+    )
+
+
+def test_ac11_extremfall_mit_zonen_bleibt_ascii_rein():
+    """AC-11 GIVEN den Extremfall aus AC-9 mit gesetztem Zonen-Kuerzel
+    WHEN der resultierende Text auf seinen Zeichenvorrat geprueft wird
+    THEN ist er vollstaendig ASCII-rein.
+
+    Ein einziges Zeichen ausserhalb von GSM-7 stellte die Nachricht auf UCS-2
+    um und halbierte die Kapazitaet von 160 auf 70 Zeichen — die
+    Zeichenzahl allein bewiese das Budget dann nicht. Der Bindestrich des
+    Zonen-Kuerzels ist GSM-7-BASISzeichen und aendert daran nichts, anders
+    als `~` (S3 E6); genau das wird hier nachgewiesen statt angenommen.
+
+    RED heute: das Kuerzel steht gar nicht im Text — die Vorbedingung faellt
+    aus."""
+    kuerzel = _kurzform_soll(_ZONE_A, _ZONE_B)
+    sms = render_sms(_extremfall_msg(_ZONE_A, _ZONE_B), limit=140)
+
+    assert kuerzel in sms, (
+        f"Vorbedingung: das Zonen-Kuerzel {kuerzel!r} muss im Text stehen, "
+        f"sonst prueft die ASCII-Zusicherung den falschen Text: {sms!r}"
+    )
+    assert sms.isascii(), f"AC-11: Kurznachricht ist nicht ASCII-rein: {sms!r}"

--- a/tests/tdd/test_regen_ausdehnung_kurzform_budget.py
+++ b/tests/tdd/test_regen_ausdehnung_kurzform_budget.py
@@ -1,0 +1,182 @@
+"""TDD RED — Issue #2051 Scheibe S2b: das Zonen-Kuerzel der Kurzform ist
+budget-bewusst — es entfaellt ganz, statt angeschnitten zu werden.
+
+SPEC: docs/specs/modules/feat_2051_s2b_ausdehnung_kanaele.md — AC-8, AC-9.
+
+Fachlicher Kern: das Kuerzel ist das ZULETZT angefuegte Element der Kurzform.
+Passt es nicht vollstaendig ins Zeichenbudget, entfaellt es — niemals eine
+halbe Spanne, niemals ein haengendes Komma. Bei mehreren Zonen werden von
+vorn so viele genannt, wie vollstaendig passen.
+
+Warum das zaehlt: `km8-1` (angeschnitten) waere im Satellitenkanal eine
+FALSCHE Angabe, keine fehlende — und auf der Huette am Karnischen Hoehenweg
+gibt es keinen zweiten Kanal, der sie richtigstellt.
+
+RED-Ursache: die Kurzform (`render.py:927-996`) kennt kein Zonen-Token und
+damit auch keine Budget-Regel dafuer.
+
+Mock-frei: echte `OnsetEvent`/`RainZone`/`AlertMessage`-Objekte durch den
+echten Renderer mit seinem oeffentlichen `limit`-Parameter.
+"""
+from __future__ import annotations
+
+import pytest
+
+from output.renderers.alert.model import AlertMessage, OnsetEvent
+from output.renderers.alert.render import render_sms
+from services.rain_extent import RainZone
+
+SMS_LIMIT = 140
+# Deutlich ueber dem Limit: rendert derselbe Aufruf mit grosszuegigem Limit
+# denselben Text, hat der harte Schnitt `body[:limit]` NICHT gegriffen.
+UNGEDECKELT = 4000
+
+_ZONE_A = RainZone(km_from=8.0, km_to=12.0, onset_minutes=20, event_end_minutes=40)
+_ZONE_B = RainZone(km_from=19.0, km_to=21.0, onset_minutes=50, event_end_minutes=70)
+
+
+def _extremfall_msg(*zonen: RainZone, km_measured: bool = True) -> AlertMessage:
+    """Der kombinierte Extremfall (Spec AC-8/AC-9): 30-Zeichen-Ortsname (auf
+    24 gekappt), `onset_precip_mm=99.9`, Untergrenzen-Ende ` >@23:59` und
+    Guete-Marker `?` — die teuerste Zeitgruppe, die die Kurzform bauen kann.
+    """
+    ortsname = "Obertilliacher Bergwiesenalm".ljust(30, "x")
+    assert len(ortsname) == 30, "Voraussetzung: 30-Zeichen-Ortsname"
+    event = OnsetEvent(
+        onset_minutes=40, onset_time="18:00", km_from=0.0, km_to=0.0,
+        is_convective=True, intensity_label="Starker Regen",
+        source_label="Radar (DWD)", location_label=ortsname,
+        onset_precip_mm=99.9, event_end_time="23:59",
+        event_ongoing_beyond_horizon=True,
+        location_sharpness_limit_time="20:00",
+        km_measured=km_measured, rain_zones=tuple(zonen),
+    )
+    return AlertMessage(
+        trip_short="Alpen", stand_at="17:20", events=(event,),
+        source="Radar (DWD)",
+    )
+
+
+def _kuerzel(*zonen: RainZone) -> str:
+    """Das Zonen-Kuerzel, ABGELEITET aus den Zonenwerten der Fixture."""
+    return " km" + ",".join(
+        f"{int(round(z.km_from))}-{int(round(z.km_to))}" for z in zonen
+    )
+
+
+def _basistext() -> str:
+    """Der zonenlose Extremfall-Text, vom Renderer selbst gebildet.
+
+    Bewusst NICHT als Literal: die Spec-Rechnung (49 Zeichen) wird hier
+    nachgemessen statt abgeschrieben — aendert eine andere Scheibe die
+    Zeitgruppe, faellt das hier auf und nicht erst in einer Budget-Zusage,
+    die dann eine andere Grenze meint als gemeint war."""
+    return render_sms(_extremfall_msg(), limit=UNGEDECKELT)
+
+
+def test_vorbedingung_die_budget_rechnung_der_spec_stimmt():
+    """Vorbedingung (kein AC): die drei `limit`-Werte aus AC-8 haengen an
+    zwei gemessenen Groessen — Basistext 49 Zeichen, erstes Kuerzel 7,
+    volles Kuerzel 13 Zeichen. Stimmt eine davon nicht, pruefen die
+    AC-8-Faelle unten andere Grenzen als die Spec meint."""
+    basis = _basistext()
+
+    assert basis == "Obertilliacher Bergwiese: TH@18:00 >@23:59? R99.9", (
+        f"Der zonenlose Extremfall-Text hat sich veraendert: {basis!r}"
+    )
+    assert len(basis) == 49, f"Basistext: {len(basis)} statt 49 Zeichen: {basis!r}"
+    assert len(_kuerzel(_ZONE_A)) == 7, (
+        f"Erstes Kuerzel: {_kuerzel(_ZONE_A)!r} ist nicht 7 Zeichen lang"
+    )
+    assert len(_kuerzel(_ZONE_A, _ZONE_B)) == 13, (
+        f"Volles Kuerzel: {_kuerzel(_ZONE_A, _ZONE_B)!r} ist nicht 13 Zeichen lang"
+    )
+
+
+# --------------------------------------------------------------------------
+# AC-8 — drei Budget-Faelle: erste Zone passt / nichts passt / beide passen.
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "fall, limit, zonen_im_text",
+    [
+        ("a", 56, (_ZONE_A,)),           # 49 + 7 -> exakt Platz fuer Zone 1
+        ("b", 55, ()),                   # 49 + 6 -> ein Zeichen zu wenig
+        ("c", 62, (_ZONE_A, _ZONE_B)),   # 49 + 13 -> Platz fuer beide
+    ],
+)
+def test_ac8_zonen_kuerzel_entfaellt_statt_angeschnitten_zu_werden(
+    fall, limit, zonen_im_text,
+):
+    """AC-8 GIVEN den zonenlosen Basistext (49 Zeichen) und zwei Zonen
+    km 8-12 / km 19-21 (Kuerzel-Kandidat ` km8-12,19-21`, 13 Zeichen; erste
+    Zone allein ` km8-12`, 7 Zeichen)
+    WHEN `render_sms` mit `limit=56` / `limit=55` / `limit=62` rendert
+    THEN zeigt (a) NUR die erste Zone (exakt 56 Zeichen), (b) GAR KEIN
+    Kuerzel (49 Zeichen, byte-identisch zum zonenlosen Stand) und (c) BEIDE
+    Zonen (exakt 62 Zeichen) — nie eine angeschnittene Spanne, nie ein
+    haengendes Komma.
+
+    Fall (b) ist die Abwesenheits-Zusicherung, (a) und (c) sind ihre
+    Positivkontrolle: derselbe Aufbau, ein verschobener `limit`-Wert,
+    gegensaetzliches Ergebnis.
+
+    Der Sollwert wird aus Basistext und Zonenwerten ZUSAMMENGESETZT, nicht
+    getippt — ein hart verdrahteter Text im Produktivcode faellt dadurch auf.
+
+    RED heute: die Kurzform kennt kein Zonen-Token, Fall (a) und (c)
+    schlagen fehl."""
+    erwartet = _basistext() + (_kuerzel(*zonen_im_text) if zonen_im_text else "")
+
+    sms = render_sms(_extremfall_msg(_ZONE_A, _ZONE_B), limit=limit)
+
+    assert sms == erwartet, (
+        f"AC-8 Fall ({fall}, limit={limit}): erwartet {erwartet!r}, "
+        f"erhalten {sms!r}"
+    )
+    assert len(sms) == len(erwartet) <= limit, (
+        f"AC-8 Fall ({fall}): {len(sms)} Zeichen, erwartet {len(erwartet)} "
+        f"und hoechstens {limit}: {sms!r}"
+    )
+    # Kein angeschnittenes Kuerzel, kein haengendes Komma — auch dann nicht,
+    # wenn die Laenge zufaellig stimmte.
+    assert not sms.endswith(","), f"AC-8 Fall ({fall}): haengendes Komma: {sms!r}"
+    assert not sms.endswith("-"), (
+        f"AC-8 Fall ({fall}): angeschnittene Spanne: {sms!r}"
+    )
+    if not zonen_im_text:
+        assert " km" not in sms, (
+            f"AC-8 Fall ({fall}): das Kuerzel passt nicht und muss deshalb "
+            f"VOLLSTAENDIG entfallen: {sms!r}"
+        )
+
+
+# --------------------------------------------------------------------------
+# AC-9 — der harte Schnitt `body[:limit]` greift auch mit Zonen nicht.
+# --------------------------------------------------------------------------
+
+def test_ac9_der_harte_schnitt_greift_im_extremfall_mit_zonen_nicht():
+    """AC-9 GIVEN denselben kombinierten Extremfall mit zwei realistischen
+    Zonen (max. erreichbar bei `RADAR_ZONE_MAX_POINTS=6`)
+    WHEN derselbe Aufruf einmal mit `limit=140` und einmal ungedeckelt
+    (`limit=4000`) rendert
+    THEN sind beide Texte IDENTISCH und 62 Zeichen lang — der harte Schnitt
+    `body[:limit]` (`render.py:996`) greift im Extremfall MIT Zonen genauso
+    wenig wie ohne (Bestandsinvariante aus S1-AC-16).
+
+    Ohne diese Pruefung waere jede Laengenzusage trivial erfuellbar: ein
+    abgeschnittener Text ist immer kurz genug.
+
+    RED heute: beide Texte sind 49 Zeichen lang (kein Zonen-Token)."""
+    gedeckelt = render_sms(_extremfall_msg(_ZONE_A, _ZONE_B), limit=SMS_LIMIT)
+    ungedeckelt = render_sms(_extremfall_msg(_ZONE_A, _ZONE_B), limit=UNGEDECKELT)
+
+    assert gedeckelt == ungedeckelt, (
+        "AC-9: der harte Schnitt greift im Extremfall mit Zonen.\n"
+        f"  gedeckelt   ({len(gedeckelt)}) = {gedeckelt!r}\n"
+        f"  ungedeckelt ({len(ungedeckelt)}) = {ungedeckelt!r}"
+    )
+    assert len(gedeckelt) == 62, (
+        f"AC-9: erwartet 62 Zeichen (49 Basistext + 13 Kuerzel), erhalten "
+        f"{len(gedeckelt)}: {gedeckelt!r}"
+    )

--- a/tests/tdd/test_regen_ausdehnung_langform_kanaele.py
+++ b/tests/tdd/test_regen_ausdehnung_langform_kanaele.py
@@ -1,0 +1,364 @@
+"""TDD RED — Issue #2051 Scheibe S2b: die raeumliche Ausdehnung erreicht die
+uebrigen LANGFORM-Stellen (Betreff, Telegram rich) und bleibt im
+Mehr-Orte-Zweig ein dokumentierter No-op.
+
+SPEC: docs/specs/modules/feat_2051_s2b_ausdehnung_kanaele.md — AC-1, AC-2,
+AC-3, AC-14.
+
+RED-Ursache: `_onset_extent_suffix()` (S2a, `render.py:614`) haengt heute an
+GENAU EINER Aufrufstelle (E-Mail-Trip-Langform, `render.py:742`). Betreff
+(`render.py:486`) und Telegram rich (`render.py:813`) verketten den Baustein
+nicht — die Ausdehnungsangabe fehlt dort vollstaendig.
+
+Mock-frei: echte `OnsetEvent`/`RainZone`/`AlertMessage`-Objekte durch die
+echten Renderer (Muster `test_regen_ausdehnung_textstellen.py` aus S2a),
+feste Zeitangaben, keine Wanduhr.
+"""
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+from output.renderers.alert.model import AlertMessage, OnsetEvent
+from output.renderers.alert.render import (
+    render_email, render_sms, render_subject, render_telegram,
+)
+from services.rain_extent import RainZone
+
+_MINIMAL_FIELDS = dict(
+    onset_minutes=25, onset_time="15:00", km_from=0.0, km_to=6.0,
+    is_convective=False, intensity_label="Mäßiger Regen",
+    source_label="Radar (DWD)", event_end_time="16:30",
+)
+
+
+def _onset_event(**overrides) -> OnsetEvent:
+    fields = dict(_MINIMAL_FIELDS)
+    fields.update(overrides)
+    return OnsetEvent(**fields)
+
+
+def _onset_msg(*events: OnsetEvent) -> AlertMessage:
+    return AlertMessage(
+        trip_short="KHW 403", stand_at="14:35", events=tuple(events),
+        source="Radar (DWD)",
+    )
+
+
+def _langform_soll(*zonen: RainZone) -> str:
+    """Der Sollstring der LANGFORM, ABGELEITET aus den Zonenwerten der
+    Fixture (`Nass km 8-12`) — nie als Literal getippt.
+
+    Ein im Produktivcode hart verdrahtetes Ergebnis faellt dadurch auf: die
+    beiden Faelle unten unterscheiden sich ausschliesslich in ihren
+    Zonenwerten, und genau die muessen im Text ankommen."""
+    spannen = ", ".join(
+        f"km {int(round(z.km_from))}-{int(round(z.km_to))}" for z in zonen
+    )
+    return f"Nass {spannen}"
+
+
+_ZONE_A = RainZone(km_from=8.0, km_to=12.0, onset_minutes=20, event_end_minutes=40)
+_ZONE_B = RainZone(km_from=3.0, km_to=5.0, onset_minutes=20, event_end_minutes=40)
+
+
+def test_prueling_stammt_aus_diesem_arbeitsbaum():
+    """Vorbedingung (kein AC): der geprueften Renderer wird RELATIV ZU DIESER
+    Testdatei aufgeloest — sonst pruefte ein Worktree-Lauf still die Datei des
+    Hauptrepos und lieferte falsches Gruen."""
+    from output.renderers.alert import render as render_module
+
+    modul_pfad = Path(inspect.getfile(render_module)).resolve()
+    arbeitsbaum = Path(__file__).resolve().parents[2]
+    assert modul_pfad.is_relative_to(arbeitsbaum), (
+        f"Prueling stammt nicht aus diesem Arbeitsbaum: {modul_pfad}"
+    )
+
+
+# --------------------------------------------------------------------------
+# AC-1 — der E-Mail-Betreff traegt die Ausdehnung aus den Zonendaten DES
+#        JEWEILIGEN Events, nicht einen konstanten Text.
+# --------------------------------------------------------------------------
+
+def test_ac1_betreff_traegt_die_zone_des_jeweiligen_events():
+    """AC-1 GIVEN zwei `OnsetEvent` mit `km_measured=True`, die sich
+    AUSSCHLIESSLICH in ihrer Zone unterscheiden (Fall A: km 8-12, Fall B:
+    km 3-5)
+    WHEN `render_subject` beide rendert
+    THEN traegt Fall A `Nass km 8-12` und NICHT `Nass km 3-5`, Fall B
+    umgekehrt.
+
+    Die Sollstrings werden aus den Zonenwerten der Fixture ABGELEITET
+    (`_langform_soll`) — ein hart verdrahtetes Ergebnis im Produktivcode
+    faellt dadurch auf. Die Kreuz-Negativpruefung schliesst aus, dass der
+    Betreff einen konstanten Text traegt, der zufaellig zu einem der beiden
+    Faelle passt.
+
+    RED heute: der Betreff (`render.py:486`) verkettet
+    `_onset_extent_suffix` nicht."""
+    soll_a = _langform_soll(_ZONE_A)
+    soll_b = _langform_soll(_ZONE_B)
+    assert soll_a != soll_b, (
+        f"Testvoraussetzung: die beiden Sollstrings muessen sich "
+        f"unterscheiden, waren beide {soll_a!r}"
+    )
+
+    betreff_a = render_subject(
+        _onset_msg(_onset_event(km_measured=True, rain_zones=(_ZONE_A,)))
+    )
+    betreff_b = render_subject(
+        _onset_msg(_onset_event(km_measured=True, rain_zones=(_ZONE_B,)))
+    )
+
+    assert soll_a in betreff_a, (
+        f"AC-1: Fall A muss {soll_a!r} tragen:\n{betreff_a}"
+    )
+    assert soll_b not in betreff_a, (
+        f"AC-1: Fall A darf {soll_b!r} (Zone des anderen Falls) NICHT "
+        f"tragen:\n{betreff_a}"
+    )
+    assert soll_b in betreff_b, (
+        f"AC-1: Fall B muss {soll_b!r} tragen:\n{betreff_b}"
+    )
+    assert soll_a not in betreff_b, (
+        f"AC-1: Fall B darf {soll_a!r} (Zone des anderen Falls) NICHT "
+        f"tragen:\n{betreff_b}"
+    )
+
+
+# --------------------------------------------------------------------------
+# AC-2 — Telegram rich: dieselbe Zusicherung in der ZWEITEN Zeile.
+# --------------------------------------------------------------------------
+
+def test_ac2_telegram_rich_zweite_zeile_traegt_die_zone_des_events():
+    """AC-2 GIVEN denselben Zwei-Faelle-Aufbau wie AC-1
+    WHEN `render_telegram` beide rendert
+    THEN traegt die ZWEITE Zeile in Fall A `Nass km 8-12` und nicht
+    `Nass km 3-5`, in Fall B umgekehrt.
+
+    Sollstrings wie in AC-1 aus den Zonenwerten abgeleitet. Geprueft wird
+    ausdruecklich die zweite Zeile (die Detailzeile mit Zeit, Intensitaet und
+    Quelle) — die Kopfzeile traegt keine Suffixe.
+
+    RED heute: `_render_telegram_onset` (`render.py:810-814`) verkettet
+    `_onset_extent_suffix` nicht."""
+    soll_a = _langform_soll(_ZONE_A)
+    soll_b = _langform_soll(_ZONE_B)
+
+    text_a = render_telegram(
+        _onset_msg(_onset_event(km_measured=True, rain_zones=(_ZONE_A,)))
+    )
+    text_b = render_telegram(
+        _onset_msg(_onset_event(km_measured=True, rain_zones=(_ZONE_B,)))
+    )
+    zeilen_a = text_a.split("\n")
+    zeilen_b = text_b.split("\n")
+
+    assert len(zeilen_a) >= 2 and len(zeilen_b) >= 2, (
+        f"Testvoraussetzung: Telegram rich hat mindestens zwei Zeilen — "
+        f"A={zeilen_a!r}, B={zeilen_b!r}"
+    )
+
+    assert soll_a in zeilen_a[1], (
+        f"AC-2: Fall A muss {soll_a!r} in der zweiten Zeile tragen:\n{zeilen_a[1]}"
+    )
+    assert soll_b not in zeilen_a[1], (
+        f"AC-2: Fall A darf {soll_b!r} NICHT tragen:\n{zeilen_a[1]}"
+    )
+    assert soll_b in zeilen_b[1], (
+        f"AC-2: Fall B muss {soll_b!r} in der zweiten Zeile tragen:\n{zeilen_b[1]}"
+    )
+    assert soll_a not in zeilen_b[1], (
+        f"AC-2: Fall B darf {soll_a!r} NICHT tragen:\n{zeilen_b[1]}"
+    )
+
+
+# --------------------------------------------------------------------------
+# AC-3 — Mehr-Orte-Zweig: die zusaetzliche Anhaengung ist ein dokumentierter
+#        No-op. Der Ortsvergleich-Buendelpfad setzt `rain_zones` nie
+#        (S2a AC-15), also bleibt der Text byte-identisch.
+# --------------------------------------------------------------------------
+
+def _buendel_msg(**overrides) -> AlertMessage:
+    """Zwei Events aus dem Ortsvergleich-Muster (`_render_email_onset_multi`).
+
+    `rain_zones` bleibt per Default LEER — die einzige Konstellation, die
+    dieser Pfad in Produktion je erhaelt (S2a AC-15)."""
+    gemeinsam = dict(
+        km_from=0.0, km_to=6.0, source_label="Radar (DWD)",
+    )
+    gemeinsam.update(overrides)
+    erster = OnsetEvent(
+        onset_minutes=25, onset_time="18:00", is_convective=False,
+        intensity_label="Mäßiger Regen", location_label="Sillian",
+        event_end_time="19:30", **gemeinsam,
+    )
+    zweiter_felder = dict(gemeinsam)
+    zweiter_felder["source_label"] = "AROME-FR"
+    zweiter = OnsetEvent(
+        onset_minutes=40, onset_time="18:15", is_convective=True,
+        intensity_label="Starker Regen", location_label="Zermatt",
+        **zweiter_felder,
+    )
+    return AlertMessage(
+        trip_short="KHW 403", stand_at="17:30", events=(erster, zweiter),
+        source="Radar (DWD)",
+    )
+
+
+# Aufgenommener Ist-Text des Mehr-Orte-Zweigs VOR dieser Spec (Stand
+# `c8334159`, aufgenommen 2026-08-23 durch Rendern derselben Fixture).
+# Wanduhrfrei: `stand_at` und alle Zeiten stammen aus der Fixture.
+_AC3_GOLD_PLAIN = (
+    "Regen-Alarm: 2 Orte\n"
+    "\n"
+    "Radar-Nowcast\n"
+    "\n"
+    "Sillian · Regen in 25 Min: ab 18:00 · letzter Regen gegen 19:30 · "
+    "Mäßiger Regen\n"
+    "Zermatt · Gewitter/Hagel in 40 Min: ab 18:15 · Starker Regen\n"
+    "\n"
+    "Stand: heute 17:30 · Quelle: Radar (DWD), AROME-FR\n"
+    "\n"
+    "Regen-/Gewitter-Alarm · Radar (DWD)"
+)
+
+
+def test_ac3_mehr_orte_zweig_bleibt_byte_identisch():
+    """AC-3 GIVEN ein Buendel-`AlertMessage` mit zwei Events aus dem
+    Ortsvergleich-Pfad (`rain_zones` jeweils leer — die einzige
+    Konstellation, die dieser Pfad in Produktion je erhaelt)
+    WHEN der Mehr-Orte-Zweig gerendert wird
+    THEN bleibt der Text byte-identisch zum Stand VOR dieser Spec, obwohl
+    `_onset_extent_suffix` dort kuenftig ebenfalls aufgerufen wird.
+
+    Regressionstest: laeuft heute (RED-Zustand) GRUEN und muss nach der
+    Implementierung gruen BLEIBEN — die Anhaengung ist ein dokumentierter
+    No-op, kein neues Verhalten fuer den Ortsvergleich.
+
+    Positivkontrolle in `test_ac3_positivkontrolle_...` unten: derselbe Zweig
+    zeigt die Angabe sehr wohl, sobald Zonen gesetzt sind. Ohne sie waere
+    diese Byte-Gleichheit trivial erfuellbar (ein Baustein, der nirgends
+    wirkt, ist immer identisch)."""
+    _html, plain = render_email(_buendel_msg())
+
+    assert plain == _AC3_GOLD_PLAIN, (
+        "AC-3: der Mehr-Orte-Zweig hat sich gegenueber dem Stand vor dieser "
+        f"Spec veraendert.\nErhalten:\n{plain!r}\nErwartet:\n{_AC3_GOLD_PLAIN!r}"
+    )
+    assert "Nass km" not in plain, (
+        f"AC-3: ohne Zonen darf keine Ausdehnungs-Angabe erscheinen:\n{plain}"
+    )
+
+
+def test_ac3_positivkontrolle_mehr_orte_zweig_zeigt_gesetzte_zonen():
+    """AC-3 (Positivkontrolle) GIVEN denselben Buendel-Aufbau, aber MIT
+    gesetzten Zonen und `km_measured=True` an beiden Events
+    WHEN derselbe Mehr-Orte-Zweig rendert
+    THEN traegt der Text die Ausdehnungsangabe.
+
+    Zweck: nachweisen, dass die Byte-Gleichheit oben aus den LEEREN Zonen
+    folgt und nicht daraus, dass der Baustein an dieser Stelle ueberhaupt
+    nicht verkettet ist. Genau dieser Unterschied macht AC-3 zu einer
+    Zusicherung statt zu einer Selbstverstaendlichkeit.
+
+    RED heute: `_render_email_onset_multi` (`render.py:658-660`) verkettet
+    `_onset_extent_suffix` nicht."""
+    soll = _langform_soll(_ZONE_A)
+    msg = _buendel_msg(km_measured=True, rain_zones=(_ZONE_A,))
+
+    _html, plain = render_email(msg)
+
+    assert soll in plain, (
+        f"AC-3 (Positivkontrolle): mit gesetzten Zonen muss {soll!r} im "
+        f"Mehr-Orte-Zweig erscheinen — sonst prueft die Byte-Gleichheit "
+        f"oben nichts:\n{plain}"
+    )
+
+
+# --------------------------------------------------------------------------
+# AC-14 — keine Handlungsempfehlung, keine Ankunftszeit-Rechnung in den vier
+#         neu betroffenen Texten.
+# --------------------------------------------------------------------------
+
+# Identische Musterliste wie S2a-AC-16
+# (`test_regen_ausdehnung_textstellen.py:294-308`).
+_VERBOTENE_MUSTER = [
+    "verlass dich nicht",
+    "solltest du",
+    "bis dahin solltest",
+    "rechne damit, dass du",
+    "sei vorsichtig",
+    "achte darauf, dass du",
+    "plane damit",
+    "du erreichst",
+    "wirst du dort",
+    "wirst du diese zone",
+    "bist du dort",
+    "kommst du dort an",
+    "wenn du ankommst",
+]
+
+
+def _pruefe(kandidaten: dict[str, str]) -> dict[str, list[str]]:
+    gefunden: dict[str, list[str]] = {}
+    for name, text in kandidaten.items():
+        text_klein = text.lower()
+        treffer = [m for m in _VERBOTENE_MUSTER if m in text_klein]
+        if treffer:
+            gefunden[name] = treffer
+    return gefunden
+
+
+def test_ac14_keine_bevormundung_in_den_vier_neu_betroffenen_texten():
+    """AC-14 GIVEN die vier neu betroffenen Texte (Betreff, Telegram rich,
+    Mehr-Orte-Zweig, Kurzform) MIT gesetzter Ausdehnungsangabe
+    WHEN sie auf Handlungsempfehlungen und Ankunftszeit-Rechnungen ueber den
+    Nutzer geprueft werden
+    THEN enthaelt KEINER eine solche Formulierung — ausschliesslich
+    km-Spannen und Zeiten.
+
+    Zwei Kontrollen, ohne die die Negativpruefung trivial waere:
+      * DETEKTOR-Positivkontrolle (Lehre aus #2054): ein synthetischer,
+        absichtlich verbotener Satz muss von derselben Pruefschleife
+        gefunden werden;
+      * INHALTS-Vorbedingung: in jedem der vier Texte muss die
+        Ausdehnungsangabe ueberhaupt stehen — sonst prueft der Test einen
+        Text ohne den Gegenstand des ACs.
+
+    RED heute: die Vorbedingung faellt fuer Betreff, Telegram rich,
+    Mehr-Orte-Zweig und Kurzform aus (die Angabe fehlt dort)."""
+    langform_soll = _langform_soll(_ZONE_A)
+    kurzform_soll = f"km{int(round(_ZONE_A.km_from))}-{int(round(_ZONE_A.km_to))}"
+
+    einzel = _onset_msg(_onset_event(km_measured=True, rain_zones=(_ZONE_A,)))
+    buendel = _buendel_msg(km_measured=True, rain_zones=(_ZONE_A,))
+    _html, multi_plain = render_email(buendel)
+
+    texte = {
+        "betreff": render_subject(einzel),
+        "telegram_rich": render_telegram(einzel),
+        "mehr_orte": multi_plain,
+        "kurzform": render_sms(einzel),
+    }
+
+    synthetisch = _pruefe({
+        "synthetisch": f"{langform_soll}. Du erreichst diese Zone in 45 Minuten.",
+    })
+    assert synthetisch, (
+        "Vorbedingung: der Detektor muss einen ABSICHTLICH eingebauten "
+        "Verstoss erkennen — sonst waere die Negativpruefung unten trivial "
+        "wahr."
+    )
+
+    for name, text in texte.items():
+        erwartet = kurzform_soll if name == "kurzform" else langform_soll
+        assert erwartet in text, (
+            f"Vorbedingung ({name}): die Ausdehnungsangabe {erwartet!r} muss "
+            f"ueberhaupt im Text stehen, sonst prueft AC-14 hier nichts:\n{text}"
+        )
+
+    treffer = _pruefe(texte)
+    assert not treffer, (
+        f"AC-14: verbotene Formulierung gefunden: {treffer}\nTexte: {texte}"
+    )

--- a/tests/tdd/test_regen_ausdehnung_vorschau.py
+++ b/tests/tdd/test_regen_ausdehnung_vorschau.py
@@ -1,0 +1,197 @@
+"""TDD RED — Issue #2051 Scheibe S2b: die Alarm-Vorschau zeigt die
+raeumliche Ausdehnung in allen vier Kanaltexten.
+
+SPEC: docs/specs/modules/feat_2051_s2b_ausdehnung_kanaele.md — AC-12, AC-13.
+
+Warum das zaehlt (R4): `render_alert_preview` baut sein `OnsetEvent` heute
+OHNE `rain_zones`/`km_measured` (`validator_render_service.py:117-172`) und
+`OnsetPayload` kennt die Felder nicht (`api/routers/validator.py:226-268`).
+Solange diese Luecke offen ist, ist KEIN AC dieser Scheibe ueber
+`POST /api/trips/{id}/alert-preview` auf Staging messbar — genau das hat die
+S2a-Lieferung als „nicht gemessen" gebucht.
+
+Pydantic verwirft unbekannte Felder STILL (Muster #2046 Finding F002): ohne
+diesen Test liesse sich die Payload-Erweiterung ersatzlos streichen, und die
+Ausdehnung verschwaende lautlos aus der Vorschau.
+
+Mock-frei: echte Pydantic-Payloads (`AlertPreviewBody`/`OnsetPayload`),
+echter `Trip`, echte Renderer. Gestellte Uhr (`freeze_time`) statt Wanduhr —
+die Vorschau setzt ihre Stand-Zeile aus `datetime.now()`.
+"""
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+from freezegun import freeze_time
+
+from api.routers.validator import AlertPreviewBody
+from app.trip import Trip
+from services.rain_extent import RainZone
+from services.validator_render_service import render_alert_preview
+
+# Feste Uhr: die Stand-Zeile der Vorschau ("Stand: heute 12:00") entsteht aus
+# `datetime.now()`. Ohne gestellte Uhr waere der Volltextvergleich in AC-13
+# wanduhrabhaengig.
+_UHR = "2026-08-23T12:00:00+00:00"
+
+_ZONE = RainZone(km_from=8.0, km_to=12.0, onset_minutes=20, event_end_minutes=40)
+
+_KANAL_FELDER = ("subject", "email_plain", "telegram", "sms")
+
+
+def _trip() -> Trip:
+    return Trip(id="trip-2051-s2b", name="Vorschau-Trip", stages=[])
+
+
+def _payload(**onset_overrides) -> AlertPreviewBody:
+    """Der Vorschau-Payload als ECHTES Pydantic-Objekt (kein Mock, kein
+    `SimpleNamespace`) — nur so laeuft der Test durch denselben
+    Validierungsweg wie der HTTP-Endpunkt."""
+    onset = {
+        "onset_minutes": 25,
+        "onset_time": "15:00",
+        "km_from": 0.0,
+        "km_to": 6.0,
+        "is_convective": False,
+        "intensity_label": "Mäßiger Regen",
+        "source_label": "Radar (DWD)",
+        "segment_id": "Ziel",
+        "onset_precip_mm": 2.5,
+        "event_end_time": "16:30",
+    }
+    onset.update(onset_overrides)
+    return AlertPreviewBody(onset=onset)
+
+
+def test_prueling_stammt_aus_diesem_arbeitsbaum():
+    """Vorbedingung (kein AC): Prueffläche und Payload-Schema werden RELATIV
+    ZU DIESER Testdatei aufgeloest — sonst pruefte ein Worktree-Lauf still
+    die Dateien des Hauptrepos und lieferte falsches Gruen."""
+    from api.routers import validator as validator_modul
+    from services import validator_render_service as service_modul
+
+    arbeitsbaum = Path(__file__).resolve().parents[2]
+    for modul in (validator_modul, service_modul):
+        pfad = Path(inspect.getfile(modul)).resolve()
+        assert pfad.is_relative_to(arbeitsbaum), (
+            f"Prueling stammt nicht aus diesem Arbeitsbaum: {pfad}"
+        )
+
+
+# --------------------------------------------------------------------------
+# AC-12 — mit gesetzten Feldern traegt JEDER der vier Vorschau-Texte die
+#         Ausdehnungsangabe.
+# --------------------------------------------------------------------------
+
+def test_ac12_vorschau_zeigt_die_ausdehnung_in_allen_vier_kanaelen():
+    """AC-12 GIVEN einen `OnsetPayload` mit gesetzten `rain_zones` und
+    `km_measured=True`
+    WHEN `render_alert_preview(trip_obj, body)` laeuft
+    THEN traegt JEDER der vier betroffenen Preview-Texte (`subject`,
+    `email_plain`, `telegram`, `sms`) die Ausdehnungsangabe.
+
+    Die Vorbedingung prueft zuerst das PAYLOAD-SCHEMA selbst: verwirft
+    pydantic die neuen Schluessel still, waere der Rest des Tests eine
+    Aussage ueber einen Payload, der die Angabe gar nicht enthaelt.
+
+    Zugleich die Positivkontrolle zu AC-13 unten: dort wird Byte-Gleichheit
+    OHNE die Felder zugesichert — ohne diesen Test waere sie trivial wahr.
+
+    RED heute: `OnsetPayload` kennt `rain_zones`/`km_measured` nicht
+    (`AttributeError` an der Vorbedingung)."""
+    body = _payload(
+        km_measured=True,
+        rain_zones=[{
+            "km_from": _ZONE.km_from, "km_to": _ZONE.km_to,
+            "onset_minutes": _ZONE.onset_minutes,
+            "event_end_minutes": _ZONE.event_end_minutes,
+        }],
+    )
+
+    assert body.onset.km_measured is True, (
+        "Vorbedingung: `OnsetPayload` muss `km_measured` fuehren — pydantic "
+        "verwirft ein unbekanntes Feld sonst still."
+    )
+    assert len(body.onset.rain_zones) == 1, (
+        f"Vorbedingung: `OnsetPayload.rain_zones` muss die Zone fuehren, "
+        f"erhalten {body.onset.rain_zones!r}"
+    )
+    assert (
+        body.onset.rain_zones[0].km_from == _ZONE.km_from
+        and body.onset.rain_zones[0].km_to == _ZONE.km_to
+    ), (
+        f"Vorbedingung: die Zonenwerte muessen unveraendert ankommen, "
+        f"erhalten {body.onset.rain_zones[0]!r}"
+    )
+
+    with freeze_time(_UHR):
+        out = render_alert_preview(_trip(), body)
+
+    langform = f"Nass km {int(round(_ZONE.km_from))}-{int(round(_ZONE.km_to))}"
+    kurzform = f"km{int(round(_ZONE.km_from))}-{int(round(_ZONE.km_to))}"
+
+    for feld in _KANAL_FELDER:
+        erwartet = kurzform if feld == "sms" else langform
+        assert erwartet in (out[feld] or ""), (
+            f"AC-12: das Vorschau-Feld {feld!r} traegt die Ausdehnungsangabe "
+            f"{erwartet!r} nicht: {out[feld]!r}"
+        )
+
+
+# --------------------------------------------------------------------------
+# AC-13 — ohne die neuen Felder bleibt jeder Vorschau-Text byte-identisch
+#         (Rueckwaertskompatibilitaets-Vertrag, Muster #2046 F002).
+# --------------------------------------------------------------------------
+
+# Aufgenommener Ist-Stand der vier Vorschau-Texte VOR dieser Spec (Stand
+# `c8334159`, aufgenommen 2026-08-23 bei gestellter Uhr `_UHR`).
+_AC13_GOLD = {
+    "subject": "[Vorschau-Trip] 🏁 Ziel · Regen in 25 Min · letzter Regen gegen 16:30",
+    "email_plain": (
+        "Regen in 25 Min\n"
+        "\n"
+        "Radar-Nowcast\n"
+        "\n"
+        "Wo & wann: 🏁 Ziel · ab 15:00 · letzter Regen gegen 16:30\n"
+        "Intensität: Mäßiger Regen\n"
+        "Quelle: Radar (DWD)\n"
+        "\n"
+        "Stand: heute 12:00\n"
+        "\n"
+        "Regen-/Gewitter-Alarm · Radar (DWD)"
+    ),
+    "telegram": (
+        "<b>Vorschau-Trip · 🏁 Ziel · Regen in 25 Min</b>\n"
+        "15:00 · letzter Regen gegen 16:30 · Mäßiger Regen · Radar (DWD)"
+    ),
+    "sms": "Ziel: R2.5@15:00@16:30",
+}
+
+
+def test_ac13_alt_client_payload_bleibt_byte_identisch():
+    """AC-13 GIVEN einen `OnsetPayload` OHNE die neuen Felder (Alt-Client)
+    WHEN `render_alert_preview` laeuft
+    THEN bleibt jeder der vier Preview-Texte byte-identisch zum Stand vor
+    dieser Spec — die neuen Felder sind additiv und defaulten auf „keine
+    Ausdehnung".
+
+    Regressionstest: laeuft heute (RED-Zustand) GRUEN und muss nach der
+    Implementierung gruen BLEIBEN. Seine Positivkontrolle ist AC-12 oben —
+    derselbe Aufbau MIT den Feldern erzeugt einen anderen Text; ohne sie
+    waere diese Byte-Gleichheit trivial erfuellbar.
+
+    RED heute: gruen (Regressions-Absicherung)."""
+    with freeze_time(_UHR):
+        out = render_alert_preview(_trip(), _payload())
+
+    for feld in _KANAL_FELDER:
+        assert out[feld] == _AC13_GOLD[feld], (
+            f"AC-13: das Vorschau-Feld {feld!r} hat sich gegenueber dem Stand "
+            f"vor dieser Spec veraendert.\n"
+            f"Erhalten:\n{out[feld]!r}\nErwartet:\n{_AC13_GOLD[feld]!r}"
+        )
+        assert "Nass km" not in (out[feld] or ""), (
+            f"AC-13: ohne die neuen Felder darf keine Ausdehnungsangabe "
+            f"erscheinen ({feld}): {out[feld]!r}"
+        )


### PR DESCRIPTION
## Was

Die räumliche Ausdehnung eines Regenereignisses (km-Zonen der Reststrecke, aus S2a) erschien bisher nur in **einer** von sieben Textstellen: der E-Mail-Trip-Langform. S2b bringt sie überall hin — vor allem in die **Kurzform**, wo sie komplett fehlte.

Das ist der Punkt, der die Hütte am Karnischen Höhenweg trifft: dort kommt nur die Premium-SMS an, und die trug bisher keine Ausdehnungsangabe.

## Langform — drei zusätzliche Stellen

Additive Verkettung des seit S2a fertigen `_onset_extent_suffix()`, keine Änderung an der Funktion selbst:

- E-Mail-Betreff (`_render_subject_onset`)
- Telegram rich (`_render_telegram_onset`)
- Mehr-Orte-Zweig (`_render_email_onset_multi`) — **dokumentierter No-op**: dieser Zweig läuft nur über den Ortsvergleich-Bündelpfad, der `rain_zones` nie setzt (kein Streckenkonzept, S2a AC-15). Angehängt, damit die sieben Aufrufstellen nicht schweigend auseinanderlaufen.

## Kurzform — neu

`_sms_onset_extent_suffix(zonen, budget)` bildet `km8-12` bzw. `km8-12,19-21`:

- EIN `km`-Präfix, komma-getrennt, **nie** zu einer Hülle `km8-21` zusammengefasst — die trockene Strecke dazwischen darf nicht als nass erscheinen
- **Budget-Regel:** Passt das Kürzel nicht vollständig ins Zeichenbudget, entfällt es ganz. `km8-1` wäre im Satellitenkanal eine *falsche* Angabe, keine fehlende — und dort gibt es keinen zweiten Kanal, der sie richtigstellt
- Sichtbarkeitsregel (`km_measured` + nicht-leere Zonen) steht an der **Aufrufstelle**, nicht im Helfer — wie in der Langform

## Prüffläche

`render_alert_preview` reicht `km_measured`/`rain_zones` durch; `OnsetPayload` bekommt beide Felder additiv, dazu `RainZonePayload`. Ohne das war kein Kriterium dieser Scheibe über HTTP messbar (Lücke R4 aus S2a).

## Nachweise

| | |
|---|---|
| Neue Tests | 21 grün |
| Regressionsfeger | 1.722 grün, 0 rot (alle 130 Testdateien, die den Alarm-Renderer berühren) |
| Adversary | **VERIFIED** — 9 Mutationen, 8 gefangen |
| Renderer-Mail-Gate | `radar_alert_mail_validator.py` Exit 0 gegen echt zugestellte Mail |
| Umfang | 3 Produktivdateien, +89/−2 Zeilen |

**Offener Nebenbefund F001** (kein Blocker, → #1199): Der harte Schnitt `body[:limit]` in `_render_sms_onset` ist von keinem Test bewacht. Unveränderter Bestandscode und strukturell unerreichbar, weil der neue Helfer sein Budget selbst rechnet.

## Nicht in diesem Zuschnitt

Briefing-Kurzfristhinweis und `/jetzt` (eigene Mehrpunkt-Verdrahtung nötig), Änderungen an der Zonenbildung (gehört zu #2050 S4b), Ortsvergleich (kein Streckenkonzept).

Spec: `docs/specs/modules/feat_2051_s2b_ausdehnung_kanaele.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)