### PR TITLE
fix(#2110): Trip-GUI nutzt echte GPX-Distanz statt Haversine-Luftlinie

### DIFF
--- a/docs/context/fix-2110-gui-gpx-km.md
+++ b/docs/context/fix-2110-gui-gpx-km.md
@@ -1,0 +1,81 @@
+# Context: fix-2110-gui-gpx-km
+
+## Request Summary
+GUI zeigt Etappen-Distanz als reine Haversine-Summe (Luftlinie zwischen Wegpunkten) statt der
+echten, aus GPX-Tracks vermessenen Distanz (`distance_from_start_km`, Backend). PO-Beispiel: Etappe
+„03: Porzehütte → Hochweißsteinhaus" zeigt 12,8 km, real 17,7 km.
+
+## Related Files
+
+| File | Relevance |
+|------|-----------|
+| `frontend/src/lib/components/email-preview/headerStats.ts` | **Kanonische Quelle des vom PO gemeldeten Werts.** `computeHeaderStats()` + `haversineKm()` — reine Haversine-Summe über `stage.waypoints`. Wird direkt von `StageDetailRow.svelte` importiert (das die „Distanz"-Kachel rendert, die der PO sah). |
+| `frontend/src/lib/components/trip-detail/StageDetailRow.svelte` | Zeile 104: `{stats.distanceKm.toFixed(1)} km` — der exakte Anzeigepunkt des PO-Befunds. `stats = computeHeaderStats(stage)`. |
+| `frontend/src/lib/utils/tripStats.ts` | `computeTripStats()` summiert `computeHeaderStats(stage).distanceKm` über alle Etappen für den Trip-Gesamtwert. Nutzt dieselbe Quelle — profitiert automatisch von einem Fix in `headerStats.ts`. |
+| `frontend/src/routes/_home/cockpitHelpers.ts` | Cockpit-Dashboard nutzt ebenfalls `computeHeaderStats()` für die km-Anzeige der aktiven Etappe. Gleiche Quelle. |
+| `frontend/src/lib/components/email-preview/EmailPreviewHeader.svelte` + `index.ts` | E-Mail-Vorschau im Editor nutzt ebenfalls `computeHeaderStats()`. |
+| `frontend/src/lib/utils/naismith.ts` | **Bereits DRY:** importiert `haversineKm` explizit aus `headerStats.ts` statt einer eigenen Kopie (Kommentar: „gemeinsame haversineKm aus headerStats.ts (DRY, kein eigener Haversine)"). Berechnet aber **selbst** Distanz pro Segment für die live Editor-Ankunftszeiten-Vorschau (`computeArrivalTimes`), nicht über `computeHeaderStats`. |
+| `frontend/src/lib/utils/fullProfile.ts` | **Zweite, unabhängige Haversine-Implementierung** (eigene Kopie von `haversineKm`, nicht DRY zu `headerStats.ts`). Nutzt sie in `buildProfilePoints()` (Profil-Chart x-Achse) und `computeStageBoundaries()` (xStart/xEnd je Etappe). `computeStageBoundaries` wird in `StageList.svelte` aufgerufen, aber **nur `.code` wird angezeigt** (Etappen-Kürzel wie „T03"), xStart/xEnd fließen nicht in eine sichtbare km-Zahl — nur in die Profil-Chart-Skalierung (`FullProfile.svelte`). |
+| `frontend/src/lib/types.ts` | `Waypoint`-Interface (Zeile 32-48) kennt `distance_from_start_km` **nicht** — muss ergänzt werden, um das Feld überhaupt nutzen zu können. |
+| `docs/reference/api_contract.md` (Zeile 1022, 1026-1028) | Backend-DTO (Go **und** Python) führt `distance_from_start_km` bereits, `omitempty`/`Optional`. `nil`/`None` heißt „nicht gemessen" — der Fallback-Fall ist im Contract bereits als regulärer Zustand vorgesehen. |
+
+## Existing Patterns
+
+- **DRY-Präzedenzfall vorhanden:** `naismith.ts` importiert `haversineKm` statt eigener Kopie zu
+  pflegen — genau das Muster, das für `fullProfile.ts` fehlt (dort existiert eine eigene Kopie).
+- **Optional-Feld-Fallback ist Backend-Konvention:** `distance_from_start_km: nil` bedeutet
+  „nicht gemessen", kein Fehlerzustand — das Backend-Contract sieht Konsumenten explizit vor, die
+  bei fehlendem Wert selbst zurückfallen müssen.
+- **Bereits gelöst auf Backend-Seite:** #2042 (Ankunftszeiten) und #2082 (Go-Gehzeit) haben exakt
+  dasselbe Muster (Luftlinie statt Wegstrecke) im Backend bereits behoben — dort ist die Präferenz-
+  Regel „echter Wert wenn vorhanden, sonst Haversine-Fallback" der etablierte Ansatz.
+
+## Dependencies
+
+- **Upstream:** Backend liefert `distance_from_start_km` je Wegpunkt über die Trip-API, sobald
+  `resolve_stage_track_km()`/`backfill_stage_distances()` gelaufen sind (Python) bzw. äquivalent
+  in Go. **Zuverlässigkeit dieser Datenquelle hängt an #2109** (offen, in Arbeit bei einer
+  Parallel-Sitzung — Datenverlust-Bug, der genau dieses Feld bei manchen Etappen leert). Ohne
+  #2109-Fix fällt die GUI bei betroffenen Etappen weiterhin auf Haversine zurück — technisch
+  korrektes Verhalten, aber der PO-Fall selbst bleibt bis zum #2109-Merge unverändert 12,8 km
+  zeigen (die Etappe hat aktuell 0/7 Wegpunkte mit `distance_from_start_km`, siehe #2109-Kommentar
+  von heute 13:28 Uhr).
+- **Downstream:** `tripStats.ts` (Trip-Summe), `cockpitHelpers.ts` (Dashboard), E-Mail-Vorschau —
+  alle drei hängen an `headerStats.ts` und werden durch einen Fix dort automatisch mitkorrigiert,
+  ohne eigene Änderung.
+
+## Existing Specs
+
+- Keine Spec zu `headerStats.ts` selbst gefunden (Issue #183 referenziert, keine Datei unter
+  `docs/specs/modules/` mit diesem Namen — vermutlich vor der Spec-Pflicht entstanden).
+- `docs/specs/modules/issue_296_fe_profile_editor.md` — betrifft `naismith.ts`, nicht direkt
+  Ziel dieses Fixes.
+
+## Risks & Considerations
+
+- **Teilweise vermessene Etappen (Kernfrage):** Eine Etappe kann Wegpunkte mit UND ohne
+  `distance_from_start_km` gemischt enthalten (z.B. nach nur teilweise gelungenem GPX-Match).
+  Entscheidung nötig: pro Segment (Wegpunkt-Paar) mischen — echten Wert nehmen, wenn BEIDE
+  Endpunkte ihn tragen, sonst Haversine für dieses Segment — oder pro Etappe ganz auf Haversine
+  zurückfallen, sobald auch nur ein Wegpunkt den Wert nicht trägt. Segmentweises Mischen ist näher
+  an der Wahrheit, aber ein Etappen-km-Wert, der teils gemessen/teils geschätzt ist, könnte
+  Nutzer verwirren, wenn sie das nicht erkennen können.
+- **Kein Anzeige-Hinweis heute:** Weder Backend noch Frontend markieren aktuell sichtbar, ob eine
+  km-Zahl gemessen oder geschätzt ist (vgl. #2073 — „Fehlschlag ist STILL"). Für diesen Fix stellt
+  sich dieselbe Frage nur risikoärmer, weil hier nicht komplett verworfen wird, sondern zwischen
+  zwei Werten gewählt wird.
+- **#2109-Abhängigkeit ist eine Holschuld, kein Blocker:** Der Fix hier ist unabhängig von #2109
+  entwickelbar und testbar (Fixture mit/ohne `distance_from_start_km`), liefert dem PO aber erst
+  sichtbaren Nutzen für seinen konkreten Fall, sobald #2109 gemergt ist.
+
+## PO-Entscheide (2026-08-23, vor Spec-Erstellung)
+
+- **Scope: alle drei Stellen.** `headerStats.ts` (km-Anzeige/Trip-Summe/Cockpit/E-Mail-Vorschau),
+  `fullProfile.ts` (Profil-Chart-Skalierung) UND `naismith.ts` (Editor-Live-Vorschau der
+  Ankunftszeiten) werden in diesem Ticket umgestellt — kein Nebenbefund, kein Folge-Ticket.
+- **Fallback-Regel: Etappen-weise, nicht segmentweise.** Trägt auch nur EIN Wegpunkt der Etappe
+  kein `distance_from_start_km`, fällt die GESAMTE Etappe auf die bisherige Haversine-Berechnung
+  zurück — kein Mischen aus echten und geschätzten Segmenten innerhalb derselben Etappe. Das
+  betrifft `computeHeaderStats()`, `buildProfilePoints()`/`computeStageBoundaries()` und
+  `computeArrivalTimes()` gleichermaßen: pro Etappe prüfen, ob ALLE Wegpunkte den echten Wert
+  tragen, sonst komplett Haversine für diese Etappe.

--- a/docs/specs/modules/fix_2110_gui_gpx_km.md
+++ b/docs/specs/modules/fix_2110_gui_gpx_km.md
@@ -1,0 +1,220 @@
+---
+entity_id: fix_2110_gui_gpx_km
+type: bugfix
+created: 2026-08-23
+updated: 2026-08-23
+status: implemented
+workflow: fix-2110-gui-gpx-km
+---
+
+# Fix #2110: Trip-GUI zeigt echte GPX-Distanz statt Haversine-Luftlinie
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Die Trip-GUI berechnet Etappen-Distanzen aktuell ausschließlich als Haversine-Luftlinien-Summe
+zwischen Wegpunkten, obwohl das Backend die real aus dem GPX-Track vermessene Distanz je
+Wegpunkt (`distance_from_start_km`) bereits über die API liefert. Dieser Fix stellt alle drei
+Frontend-Berechnungsstellen (Etappen-Kachel/Trip-Summe/Cockpit/E-Mail-Vorschau, Profil-Chart,
+Ankunftszeiten-Vorschau) so um, dass sie die echte GPX-Distanz nutzen, wenn eine Etappe
+vollständig vermessen ist, und andernfalls unverändert auf die bisherige Haversine-Berechnung
+zurückfallen — ohne Anzeige-Kennzeichnung, welcher Fall gerade greift.
+
+## Source
+
+- **File:** `frontend/src/lib/components/email-preview/headerStats.ts`
+- **Identifier:** `function computeHeaderStats`
+- **File:** `frontend/src/lib/utils/fullProfile.ts`
+- **Identifier:** `function buildProfilePoints`, `function computeStageBoundaries`
+- **File:** `frontend/src/lib/utils/naismith.ts`
+- **Identifier:** `function computeArrivalTimes`
+- **File:** `frontend/src/lib/types.ts`
+- **Identifier:** `interface Waypoint`
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `frontend/src/lib/types.ts` (`Waypoint`) | type | Neues optionales Feld `distance_from_start_km?: number` — Grundlage für alle drei Berechnungsstellen |
+| `frontend/src/lib/utils/tripStats.ts` (`computeTripStats`) | module | Summiert `computeHeaderStats(stage).distanceKm` über alle Etappen — profitiert ohne Codeänderung |
+| `frontend/src/routes/_home/cockpitHelpers.ts` | module | Cockpit-Dashboard nutzt `computeHeaderStats()` — profitiert ohne Codeänderung |
+| `frontend/src/lib/components/email-preview/EmailPreviewHeader.svelte` + `index.ts` | module | E-Mail-Vorschau nutzt `computeHeaderStats()` — profitiert ohne Codeänderung |
+| `frontend/src/lib/components/trip-detail/StageDetailRow.svelte` | module | Rendert `computeHeaderStats(stage).distanceKm` direkt — der vom PO gemeldete Anzeigepunkt |
+| Backend `distance_from_start_km` (Go/Python DTO, `docs/reference/api_contract.md` Zeile ~1022) | api | Liefert das Feld bereits optional (`omitempty`/`Optional`); `null`/fehlend heißt „nicht gemessen" |
+| Issue #2109 (Datenverlust bei `distance_from_start_km`, separat in Arbeit) | upstream | Ohne #2109-Fix bleibt der konkrete PO-Fall (Etappe „03: Porzehütte → Hochweißsteinhaus") bis zum Merge dort auf Haversine — technisch korrektes Fallback-Verhalten, aber der sichtbare Nutzen für den PO tritt erst nach #2109 ein. Wird in diesem Fix NICHT angefasst. |
+
+## Scope
+
+### Affected Files
+| File | Change Type | Description |
+|------|-------------|--------------|
+| `frontend/src/lib/types.ts` | MODIFY | `Waypoint`-Interface um `distance_from_start_km?: number` ergänzen |
+| `frontend/src/lib/components/email-preview/headerStats.ts` | MODIFY | `computeHeaderStats()`: pro Etappe prüfen, ob ALLE Wegpunkte `distance_from_start_km` tragen; wenn ja, `distanceKm` aus Differenzen dieses Felds statt Haversine-Summe berechnen, sonst unverändert Haversine |
+| `frontend/src/lib/utils/fullProfile.ts` | MODIFY | `buildProfilePoints()` und `computeStageBoundaries()`: dieselbe Etappen-weise Prüfung; kumulativer x-Cursor nutzt bei vollständig vermessener Etappe die echten Differenzwerte für die Segmente dieser Etappe, sonst Haversine |
+| `frontend/src/lib/utils/naismith.ts` | MODIFY | `computeArrivalTimes()`: dieselbe Etappen-weise Prüfung vor der Segment-Schleife; Distanz je Segment aus `distance_from_start_km`-Differenz statt `haversineKm()`, wenn die gesamte Stage vermessen ist |
+| `frontend/src/lib/components/email-preview/__tests__/headerStats.test.ts` | MODIFY | Neue Testfälle: vollständig vermessen, unvermessen (Regression), teilweise vermessen (Fallback) |
+| `frontend/src/lib/utils/fullProfile.test.ts` | MODIFY | Neue Testfälle für dieselben drei Fälle, inkl. trip-übergreifendem cumKm-Verhalten |
+| `frontend/src/lib/utils/naismith.test.ts` | MODIFY | Neue Testfälle für dieselben drei Fälle in `computeArrivalTimes()` |
+
+### Estimated Changes
+- Files: 7
+- LoC: +140/-20
+
+## Implementation Details
+
+Jede der drei Berechnungsstellen bekommt dieselbe Vorprüfung pro Etappe:
+
+```
+function stageHasFullTrackDistance(wps: Waypoint[]): boolean {
+  return wps.length > 0 && wps.every(
+    (wp) => wp.distance_from_start_km !== undefined
+         && wp.distance_from_start_km !== null
+         && Number.isFinite(wp.distance_from_start_km)
+  );
+}
+```
+
+- **`computeHeaderStats()`:** `stageHasFullTrackDistance(wps)` einmal vor der Segment-Schleife
+  prüfen. Ist die Etappe vollständig vermessen, wird `distanceKm` als
+  `wps[wps.length-1].distance_from_start_km - wps[0].distance_from_start_km` berechnet
+  (äquivalent zur Summe der Differenzen aufeinanderfolgender Werte, da monoton). Sonst
+  unverändert die bestehende Haversine-Summierung.
+- **`fullProfile.ts` (`buildProfilePoints`, `computeStageBoundaries`):** Die Prüfung erfolgt pro
+  Etappe VOR dem Betreten der inneren Wegpunkt-Schleife. Der `cumKm`-Cursor läuft
+  trip-übergreifend; die Owner-Etappe eines Wegpunkt-Paar-Segments ist die Etappe, in deren
+  Schleifen-Iteration das zweite (jüngere) Wegpunkt der beiden liegt — das entspricht dem
+  bestehenden Schleifenaufbau unverändert. Innerhalb einer als „vollständig vermessen"
+  erkannten Etappe wird für jedes interne Segment die Differenz der `distance_from_start_km`-
+  Werte addiert statt `haversineKm()`. Segmente, die eine Etappengrenze überschreiten (letzter
+  Wegpunkt Etappe N-1 → erster Wegpunkt Etappe N), bleiben unverändert Haversine-basiert (keine
+  trackbasierte Distanz über Etappengrenzen hinweg — das Backend liefert `distance_from_start_km`
+  je Etappe relativ zum Etappenstart, ein Vergleich über Etappen hinweg wäre nicht sinnvoll).
+- **`computeArrivalTimes()`:** Gleiche Vorprüfung vor der Segment-Schleife (`for i=1..wps.length`).
+  Ist die Stage vollständig vermessen, wird `dist` je Segment aus der Differenz der
+  `distance_from_start_km`-Werte von `wps[i]` und `wps[i-1]` berechnet statt `haversineKm(prev, wp)`.
+  Höhen-basierte Anteile der Naismith-Formel (`ascent`/`descent`) bleiben unverändert.
+
+Kein neuer Haversine-Code entsteht; `fullProfile.ts` behält seine eigene `haversineKm()`-Kopie
+(bestehende Nicht-DRY-Situation, außerhalb dieses Fixes) und `naismith.ts` seinen bestehenden
+Import aus `headerStats.ts`.
+
+## Test Plan
+
+### Automated Tests (TDD RED)
+- [ ] Test 1 (`headerStats.test.ts`): GIVEN eine Etappe mit 3 Wegpunkten, alle mit
+      `distance_from_start_km` (z.B. 0, 8.5, 17.7) WHEN `computeHeaderStats(stage)` aufgerufen
+      wird THEN ist `distanceKm === 17.7`, nicht die (kleinere) Haversine-Summe der
+      Koordinaten.
+- [ ] Test 2 (`headerStats.test.ts`): GIVEN eine Etappe, bei der KEIN Wegpunkt
+      `distance_from_start_km` trägt (heutiger Normalfall) WHEN `computeHeaderStats(stage)`
+      aufgerufen wird THEN ist `distanceKm` exakt der bisherige Haversine-Wert (Regressionsschutz,
+      byte-/wertgleich zum Bestandstest).
+- [ ] Test 3 (`headerStats.test.ts`): GIVEN eine Etappe mit 3 Wegpunkten, bei der NUR der mittlere
+      Wegpunkt `distance_from_start_km` NICHT trägt WHEN `computeHeaderStats(stage)` aufgerufen
+      wird THEN fällt die GESAMTE Etappe auf Haversine zurück (kein Mischen), Ergebnis identisch
+      zu Test 2 mit denselben Koordinaten.
+- [ ] Test 4 (`fullProfile.test.ts`): GIVEN ein Trip mit zwei Etappen, Etappe 1 vollständig
+      vermessen, Etappe 2 unvermessen WHEN `buildProfilePoints(trip)` und
+      `computeStageBoundaries(trip)` aufgerufen werden THEN nutzen die x-Werte innerhalb Etappe 1
+      die Track-Differenzen, die x-Werte innerhalb Etappe 2 bleiben Haversine-basiert, und der
+      kumulative Cursor ist an der Etappengrenze konsistent (kein Sprung/keine Lücke).
+- [ ] Test 5 (`naismith.test.ts`): GIVEN eine Stage mit 2 Wegpunkten, beide mit
+      `distance_from_start_km` (Differenz z.B. 5.0 km, abweichend von der Haversine-Distanz der
+      Koordinaten) WHEN `computeArrivalTimes(stage, '08:00')` aufgerufen wird THEN basiert die
+      berechnete Ankunftszeit des zweiten Wegpunkts auf der Track-Distanz (5.0 km), nicht auf der
+      Haversine-Distanz.
+- [ ] Test 6 (`naismith.test.ts`): GIVEN eine Stage ohne `distance_from_start_km` an irgendeinem
+      Wegpunkt (heutiger Normalfall) WHEN `computeArrivalTimes(stage, '08:00')` aufgerufen wird
+      THEN ist das Ergebnis-Array wertgleich zum Bestandsverhalten vor diesem Fix
+      (Regressionsschutz).
+
+## Acceptance Criteria
+
+- **AC-1:** Given eine Etappe, bei der ALLE Wegpunkte `distance_from_start_km` tragen / When
+  `computeHeaderStats(stage)` aufgerufen wird / Then entspricht `distanceKm` der Differenz aus
+  letztem und erstem `distance_from_start_km`-Wert der Etappe, nicht der Haversine-Summe der
+  Koordinaten.
+  - Test: `headerStats.test.ts` mit Fixture, deren Track-Distanz (17.7 km) sich klar von der
+    Haversine-Distanz derselben Koordinaten (12.8 km) unterscheidet — Assertion auf 17.7, nicht
+    auf einen String im Dateiinhalt.
+
+- **AC-2:** Given eine Etappe, bei der KEIN Wegpunkt `distance_from_start_km` trägt / When
+  `computeHeaderStats(stage)` aufgerufen wird / Then bleibt `distanceKm` exakt der bisherige
+  Haversine-Wert — bestehende Trips ohne GPX-Zuordnung zeigen unverändert dieselbe Zahl wie vor
+  diesem Fix.
+  - Test: Bestandsfixtures aus `headerStats.test.ts` laufen unverändert grün; zusätzlicher Test
+    vergleicht den Rückgabewert explizit mit dem manuell berechneten Haversine-Referenzwert.
+
+- **AC-3:** Given eine Etappe mit mindestens einem Wegpunkt OHNE `distance_from_start_km`, aber
+  mindestens einem MIT / When `computeHeaderStats(stage)` aufgerufen wird / Then fällt die
+  GESAMTE Etappe auf Haversine zurück (kein segmentweises Mischen aus echten und geschätzten
+  Teilstrecken innerhalb derselben Etappe).
+  - Test: Fixture mit genau einem fehlenden Wert in der Mitte einer 3-Wegpunkte-Etappe;
+    Assertion, dass das Ergebnis exakt dem reinen-Haversine-Fall (Test 2-Fixture mit denselben
+    Koordinaten) entspricht.
+
+- **AC-4:** Given ein Trip mit mehreren Etappen unterschiedlichen Vermessungsstands / When
+  `buildProfilePoints(trip)` bzw. `computeStageBoundaries(trip)` aufgerufen werden / Then nutzt
+  die x-Achsen-Skalierung des Profil-Charts pro Etappe dieselbe Etappen-weise Fallback-Regel wie
+  `computeHeaderStats()` (vollständig vermessene Etappe → Track-Distanz, sonst Haversine), und der
+  trip-übergreifende kumulative Distanz-Cursor bleibt an Etappengrenzen konsistent ohne Sprung
+  oder Lücke.
+  - Test: `fullProfile.test.ts` mit zwei Etappen unterschiedlichen Vermessungsstands; Assertion
+    auf konkrete x-Werte je Punkt, nicht nur auf Monotonie.
+
+- **AC-5:** Given eine Stage, bei der ALLE Wegpunkte `distance_from_start_km` tragen / When
+  `computeArrivalTimes(stage, startTime)` aufgerufen wird / Then wird die Distanz je Segment aus
+  der Differenz der `distance_from_start_km`-Werte berechnet statt aus `haversineKm()`, sodass
+  sich die berechnete Ankunftszeit bei abweichender Track- vs. Haversine-Distanz entsprechend
+  unterscheidet.
+  - Test: `naismith.test.ts` mit Fixture, deren Track-Distanz und Haversine-Distanz für dasselbe
+    Segment unterschiedliche Naismith-Minuten ergeben; Assertion auf den konkreten "HH:MM"-String.
+
+- **AC-6:** Given eine Stage ohne vollständige `distance_from_start_km`-Abdeckung (unvermessen
+  oder teilweise vermessen) / When `computeArrivalTimes(stage, startTime)` aufgerufen wird /
+  Then ist das Ergebnis-Array wertgleich zum Bestandsverhalten vor diesem Fix (Haversine je
+  Segment) — keine Regression für Trips ohne GPX-Zuordnung.
+  - Test: Bestandsfixtures aus `naismith.test.ts`/`naismith_674.test.ts` laufen unverändert grün.
+
+- **AC-7:** Given ein Fix in `computeHeaderStats()` gemäß AC-1/AC-2/AC-3 / When
+  `computeTripStats()` (Trip-Summe), `cockpitHelpers.ts` (Cockpit-Dashboard) oder die
+  E-Mail-Vorschau (`EmailPreviewHeader.svelte`/`index.ts`) aufgerufen werden / Then zeigen sie die
+  korrigierte Distanz automatisch, ohne dass diese drei Dateien selbst geändert werden — sie
+  rufen ausschließlich `computeHeaderStats()` auf und erben dessen Verhalten.
+  - Test: Bestehender Test für `tripStats.ts` (falls vorhanden) bzw. manueller Nachweis, dass
+    diese drei Dateien im Diff dieses Fixes NICHT verändert wurden, während ihr Verhalten sich
+    über den `headerStats.ts`-Fix ändert.
+
+## Known Limitations
+
+- Kein sichtbarer UI-Hinweis, ob eine angezeigte km-Zahl gemessen (Track) oder geschätzt
+  (Haversine) ist — explizit kein Ziel dieses Fixes (PO-Entscheid).
+- Segmente, die eine Etappengrenze überschreiten (`fullProfile.ts`), bleiben grundsätzlich
+  Haversine-basiert, auch wenn beide angrenzenden Etappen vollständig vermessen sind — das
+  Backend liefert `distance_from_start_km` je Etappe relativ zum jeweiligen Etappenstart, ein
+  direkter Vergleich der Rohwerte über Etappengrenzen hinweg wäre nicht korrekt.
+- Der PO-Beispielfall (Etappe „03: Porzehütte → Hochweißsteinhaus") zeigt weiterhin 12,8 km statt
+  17,7 km, bis Issue #2109 (Datenverlust bei `distance_from_start_km` im Backend) separat gemergt
+  ist — dieser Fix ist unabhängig entwickel- und testbar (Fixtures mit/ohne das Feld), liefert dem
+  PO aber erst nach #2109 sichtbaren Nutzen für diesen konkreten Fall.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Reiner Bugfix nach etabliertem, bereits im Backend zweimal angewendetem Muster
+  („echter Wert wenn vorhanden, sonst Haversine-Fallback", siehe #2042/#2082). Keine neue
+  Architekturentscheidung — die Fallback-Regel (etappen-weise statt segmentweise) ist ein
+  PO-Entscheid zur Implementierungsdetail-Ebene, keine Grundsatzentscheidung im Sinne der
+  ADR-Kategorien (Kanäle, Provider, Datenmodell/Persistenz, Auth, Editor-Paradigma,
+  Test-/Deploy-Strategie).
+
+## Changelog
+
+- 2026-08-23: Initial spec created
+- 2026-08-23: Implementiert (TDD GREEN, 45/45 Tests grün, voller Regressionslauf
+  2760/2765 grün). Adversary-Finding F001 (Etappengrenzen-Guard in `fullProfile.ts`
+  ungetestet) durch Nachtrag-Test geschlossen, eigene Mutations-Gegenprobe bestätigt
+  den Fang. Adversary-Verdict: VERIFIED (7/7 ACs).

--- a/frontend/src/lib/components/email-preview/__tests__/headerStats.test.ts
+++ b/frontend/src/lib/components/email-preview/__tests__/headerStats.test.ts
@@ -86,6 +86,61 @@ test('Single waypoint: no segments, no distance, but elevation visible', () => {
 	assert.equal(stats.descentM, 0);
 });
 
+// =============================================================================
+// TDD RED: Issue #2110 — Track-Distanz statt Haversine, wenn Etappe vollständig
+// vermessen ist (distance_from_start_km je Wegpunkt).
+// Spec: docs/specs/modules/fix_2110_gui_gpx_km.md (AC-1, AC-2, AC-3)
+// `distance_from_start_km` existiert im `Waypoint`-Type noch NICHT (kommt in
+// Phase 6) — hier bewusst als lockeres Objekt-Literal gesetzt, `wp()` deckt
+// den Rest ab. `--experimental-strip-types` prüft zur Laufzeit keine Typen.
+// =============================================================================
+
+test('AC-1: vollstaendig vermessene Etappe nutzt Track-Distanz statt Haversine-Summe', () => {
+	// Haversine (47.0,11.0)→(47.009,11.0) ≈ 1.0 km (s.o.), Track-Distanz wird
+	// hier bewusst auf 5.0 km gesetzt — deutlich verschieden, damit die
+	// Assertion nur bei echter Track-Nutzung erfüllt ist.
+	const stage: Stage = {
+		id: 's1', name: 'demo', date: '2026-05-11',
+		waypoints: [
+			{ ...wp('A', 47.0, 11.0, 800), distance_from_start_km: 0 },
+			{ ...wp('B', 47.009, 11.0, 800), distance_from_start_km: 5.0 }
+		]
+	};
+	const stats = computeHeaderStats(stage);
+	assert.equal(
+		stats.distanceKm,
+		5.0,
+		`erwartet Track-Distanz 5.0 km (Haversine wäre ~1.0 km), erhalten ${stats.distanceKm}`
+	);
+});
+
+test('AC-3: teilweise vermessene Etappe (ein Wegpunkt ohne distance_from_start_km) faellt komplett auf Haversine zurueck — kein Mischen', () => {
+	const coordsOnly: Stage = {
+		id: 's1', name: 'demo', date: '2026-05-11',
+		waypoints: [
+			wp('A', 47.0, 11.0, 800),
+			wp('B', 47.003, 11.0, 900),
+			wp('C', 47.009, 11.0, 800)
+		]
+	};
+	const expectedHaversine = computeHeaderStats(coordsOnly).distanceKm;
+
+	const partiallyMeasured: Stage = {
+		id: 's1', name: 'demo', date: '2026-05-11',
+		waypoints: [
+			{ ...wp('A', 47.0, 11.0, 800), distance_from_start_km: 0 },
+			wp('B', 47.003, 11.0, 900), // fehlt: distance_from_start_km
+			{ ...wp('C', 47.009, 11.0, 800), distance_from_start_km: 5.0 }
+		]
+	};
+	const stats = computeHeaderStats(partiallyMeasured);
+	assert.equal(
+		stats.distanceKm,
+		expectedHaversine,
+		`teilweise vermessene Etappe muss exakt dem reinen Haversine-Fall entsprechen (kein Segment-Mischen), erwartet ${expectedHaversine}, erhalten ${stats.distanceKm}`
+	);
+});
+
 test('Multiple stages with various profiles', () => {
 	// Flacher Trail
 	const flat: Stage = {

--- a/frontend/src/lib/components/email-preview/headerStats.ts
+++ b/frontend/src/lib/components/email-preview/headerStats.ts
@@ -26,9 +26,25 @@ export function haversineKm(a: Waypoint, b: Waypoint): number {
 }
 
 /**
+ * Issue #2110 — true, wenn ALLE Wegpunkte der Etappe eine echte, aus dem GPX-Track
+ * vermessene Distanz (`distance_from_start_km`) tragen. Nur dann darf die Track-Distanz
+ * statt der Haversine-Luftlinie genutzt werden; ein einziger fehlender Wert lässt die
+ * GESAMTE Etappe auf Haversine zurückfallen (kein segmentweises Mischen).
+ */
+export function stageHasFullTrackDistance(wps: Waypoint[] | null | undefined): boolean {
+	if (!wps || wps.length === 0) return false;
+	return wps.every((wp) => {
+		const d = wp?.distance_from_start_km;
+		return d !== undefined && d !== null && Number.isFinite(d);
+	});
+}
+
+/**
  * Berechnet Header-Statistiken für eine Etappe aus ihren Waypoints.
  *
- * - distanceKm: Summe der Haversine-Distanzen zwischen aufeinanderfolgenden Waypoints
+ * - distanceKm: Track-Distanz (letzter minus erster `distance_from_start_km`), wenn die
+ *   Etappe vollständig vermessen ist (#2110), sonst Summe der Haversine-Distanzen
+ *   zwischen aufeinanderfolgenden Waypoints
  * - ascentM: Summe positiver Höhendifferenzen
  * - descentM: Summe negativer Höhendifferenzen (als positiver Wert)
  * - maxElevationM: Max über alle Waypoints
@@ -48,6 +64,7 @@ export function computeHeaderStats(stage: Stage | null | undefined): HeaderStats
 		return empty;
 	}
 	const wps = stage.waypoints;
+	const useTrack = stageHasFullTrackDistance(wps);
 	let distanceKm = 0;
 	let ascentM = 0;
 	let descentM = 0;
@@ -58,11 +75,17 @@ export function computeHeaderStats(stage: Stage | null | undefined): HeaderStats
 			maxElevationM = wps[i].elevation_m;
 		}
 		if (i > 0) {
-			distanceKm += haversineKm(wps[i - 1], wps[i]);
+			if (!useTrack) distanceKm += haversineKm(wps[i - 1], wps[i]);
 			const delta = wps[i].elevation_m - wps[i - 1].elevation_m;
 			if (delta > 0) ascentM += delta;
 			else descentM += -delta;
 		}
+	}
+
+	if (useTrack) {
+		distanceKm =
+			(wps[wps.length - 1].distance_from_start_km as number) -
+			(wps[0].distance_from_start_km as number);
 	}
 
 	return {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -45,6 +45,9 @@ export interface Waypoint {
 	arrival_override?: string;    // User-Override "HH:MM"
 	// Issue #585 — Wegpunkt-Typ (Gipfel, Pass, Hütte, etc.)
 	type?: string;                // 'start' | 'end' | 'summit' | 'pass' | 'valley' | 'hut'
+	// Issue #2110 — real aus dem GPX-Track vermessene Distanz ab Etappenstart (km).
+	// Optional: fehlt/null heißt "nicht gemessen" → Haversine-Fallback.
+	distance_from_start_km?: number | null;
 }
 
 export interface Stage {

--- a/frontend/src/lib/utils/fullProfile.test.ts
+++ b/frontend/src/lib/utils/fullProfile.test.ts
@@ -236,6 +236,141 @@ test('buildProfilePoints > alle Punkte haben definierte numerische x und y', () 
 });
 
 // =============================================================================
+// TDD RED: Issue #2110 — Track-Distanz statt Haversine, wenn eine Etappe
+// vollstaendig vermessen ist (distance_from_start_km je Wegpunkt).
+// Spec: docs/specs/modules/fix_2110_gui_gpx_km.md (AC-4)
+// `distance_from_start_km` existiert im `Waypoint`-Type noch NICHT (kommt in
+// Phase 6) — hier als lockeres Objekt-Literal gesetzt, `wp()` liefert den Rest.
+// =============================================================================
+
+test('AC-4: vollstaendig vermessene Etappe nutzt Track-Distanz fuer x-Werte + Boundaries, unvermessene Nachbaretappe bleibt Haversine, Cursor an der Grenze konsistent', () => {
+	const s1w1 = { ...wp('w1', 47.0, 11.0, 800), distance_from_start_km: 0 };
+	const s1w2 = { ...wp('w2', 47.001, 11.0, 900), distance_from_start_km: 3.0 };
+	const s1w3 = { ...wp('w3', 47.002, 11.0, 850), distance_from_start_km: 8.0 };
+	// Haversine (47.0,11.0)→(47.001,11.0)→(47.002,11.0) ≈ 0.22 km gesamt —
+	// deutlich kleiner als die gesetzte Track-Distanz 8.0 km.
+
+	// Etappe 2: unvermessen (kein distance_from_start_km) → bleibt Haversine.
+	const s2w1 = wp('w4', 47.1, 11.1, 700);
+	const s2w2 = wp('w5', 47.11, 11.11, 650);
+
+	const trip = tripWith({
+		stages: [
+			stage('s1', '2026-05-11', [s1w1, s1w2, s1w3]),
+			stage('s2', '2026-05-12', [s2w1, s2w2])
+		]
+	});
+
+	const points = buildProfilePoints(trip);
+	assert.equal(points.length, 5);
+
+	// Innerhalb s1: Track-Differenzen statt Haversine.
+	assert.ok(Math.abs(points[0].x - 0) < 1e-6, `w1 x sollte 0 sein, war ${points[0].x}`);
+	assert.ok(
+		Math.abs(points[1].x - 3.0) < 1e-6,
+		`w2 x sollte Track-Distanz 3.0 km sein (Haversine wäre ~0.11 km), war ${points[1].x}`
+	);
+	assert.ok(
+		Math.abs(points[2].x - 8.0) < 1e-6,
+		`w3 x sollte Track-Distanz 8.0 km sein (Haversine wäre ~0.22 km), war ${points[2].x}`
+	);
+
+	// Etappengrenze s1→s2 (w3→w4): bleibt Haversine-basiert, Cursor läuft
+	// aber konsistent weiter (kein Sprung, kein Reset auf 0).
+	assert.ok(points[3].x > points[2].x, 'x-Cursor muss an der Etappengrenze monoton weiterlaufen');
+
+	// Innerhalb s2 (unvermessen): Differenz bleibt Haversine-basiert.
+	const s2SegmentHaversine = points[4].x - points[3].x;
+	assert.ok(s2SegmentHaversine > 0 && s2SegmentHaversine < 5, 'Segment innerhalb s2 muss Haversine-Größenordnung haben (~1-2 km), nicht Track-Distanz');
+
+	const boundaries = computeStageBoundaries(trip);
+	const s1Boundary = boundaries.find((b) => b.stageId === 's1');
+	assert.notEqual(s1Boundary, undefined);
+	assert.ok(
+		Math.abs(s1Boundary!.xStart - 0) < 1e-6 && Math.abs(s1Boundary!.xEnd - 8.0) < 1e-6,
+		`s1-Boundary sollte xStart=0, xEnd=8.0 sein (Track-Distanz), war xStart=${s1Boundary!.xStart}, xEnd=${s1Boundary!.xEnd}`
+	);
+});
+
+test('AC-4: Grenzsegment zwischen ZWEI vollstaendig vermessenen Etappen bleibt Haversine (distance_from_start_km ist etappen-relativ)', () => {
+	// Etappe 1: vollstaendig vermessen, Track-Distanz 0 → 3.0 → 8.0 km.
+	// Koordinaten eng beieinander (~0.11 km je Segment) → Track ≠ Haversine.
+	const s1w1 = { ...wp('w1', 47.0, 11.0, 800), distance_from_start_km: 0 };
+	const s1w2 = { ...wp('w2', 47.001, 11.0, 900), distance_from_start_km: 3.0 };
+	const s1w3 = { ...wp('w3', 47.002, 11.0, 850), distance_from_start_km: 8.0 };
+
+	// Etappe 2: EBENFALLS vollstaendig vermessen — und ihr Zaehler startet wieder
+	// bei 0. Eine Differenz ueber die Etappengrenze hinweg (0 − 8.0 = −8.0) waere
+	// unsinnig; ohne den `i > 0`-Guard griffe der Code zudem auf wps[-1] zu (NaN).
+	const s2w1 = { ...wp('w4', 47.5, 11.0, 700), distance_from_start_km: 0 };
+	const s2w2 = { ...wp('w5', 47.501, 11.0, 650), distance_from_start_km: 4.0 };
+	const s2w3 = { ...wp('w6', 47.502, 11.0, 600), distance_from_start_km: 9.0 };
+
+	const trip = tripWith({
+		stages: [
+			stage('s1', '2026-05-11', [s1w1, s1w2, s1w3]),
+			stage('s2', '2026-05-12', [s2w1, s2w2, s2w3])
+		]
+	});
+
+	const points = buildProfilePoints(trip);
+	assert.equal(points.length, 6);
+
+	// Innerhalb s1: Track-Distanz (Abgrenzung — nur das Grenzsegment ist betroffen).
+	assert.ok(Math.abs(points[0].x - 0) < 1e-6, `w1 x sollte 0 sein, war ${points[0].x}`);
+	assert.ok(Math.abs(points[1].x - 3.0) < 1e-6, `w2 x sollte 3.0 sein, war ${points[1].x}`);
+	assert.ok(Math.abs(points[2].x - 8.0) < 1e-6, `w3 x sollte 8.0 sein, war ${points[2].x}`);
+
+	// Grenzsegment w3 (47.002, 11.0) → w4 (47.5, 11.0): gleiche Laenge, dLat = 0.498°
+	// → Haversine = 6371.0088 km × 0.498 × π/180 ≈ 55.375 km.
+	const boundarySegment = points[3].x - points[2].x;
+	assert.equal(
+		Number.isFinite(boundarySegment),
+		true,
+		`Grenzsegment muss endlich sein (NaN = Zugriff auf wps[-1]), war ${boundarySegment}`
+	);
+	assert.ok(
+		Math.abs(boundarySegment - 55.375) < 0.02,
+		`Grenzsegment muss Haversine ≈ 55.375 km sein, war ${boundarySegment}`
+	);
+	// Explizit NICHT aus distance_from_start_km abgeleitet: weder −8.0 (0 − 8.0)
+	// noch 0 (gleicher Zaehlerstand) noch 8.0 (Betrag davon).
+	assert.ok(
+		Math.abs(boundarySegment - -8.0) > 1e-6 &&
+			Math.abs(boundarySegment - 0) > 1e-6 &&
+			Math.abs(boundarySegment - 8.0) > 1e-6,
+		`Grenzsegment darf keine distance_from_start_km-Differenz sein, war ${boundarySegment}`
+	);
+	// Cursor laeuft monoton weiter (eine dfs-Differenz waere negativ gewesen).
+	assert.ok(points[3].x > points[2].x, 'x-Cursor muss an der Etappengrenze monoton steigen');
+
+	// Innerhalb s2: wieder Track-Distanz, relativ zum Etappenstart (0 → 4.0 → 9.0).
+	assert.ok(
+		Math.abs(points[4].x - points[3].x - 4.0) < 1e-6,
+		`Segment w4→w5 sollte Track-Distanz 4.0 km sein (Haversine wäre ~0.11 km), war ${points[4].x - points[3].x}`
+	);
+	assert.ok(
+		Math.abs(points[5].x - points[3].x - 9.0) < 1e-6,
+		`Segment w4→w6 sollte Track-Distanz 9.0 km sein (Haversine wäre ~0.22 km), war ${points[5].x - points[3].x}`
+	);
+
+	// Gleiche Regel in computeStageBoundaries. Dort wird `xStart` VOR der inneren
+	// Schleife gesetzt, das Grenzsegment faellt also in die Spanne von s2:
+	//   s2.xStart = 8.0 (s1-Track-Ende), s2.xEnd = 8.0 + 55.375 + 9.0.
+	const boundaries = computeStageBoundaries(trip);
+	const s2Boundary = boundaries.find((b) => b.stageId === 's2');
+	assert.notEqual(s2Boundary, undefined);
+	assert.ok(
+		Math.abs(s2Boundary!.xStart - 8.0) < 1e-6,
+		`s2.xStart sollte das s1-Track-Ende 8.0 km sein, war ${s2Boundary!.xStart}`
+	);
+	assert.ok(
+		Math.abs(s2Boundary!.xEnd - s2Boundary!.xStart - (55.375 + 9.0)) < 0.02,
+		`s2-Spanne sollte 55.375 km (Grenz-Haversine) + 9.0 km (s2-Track) sein, war ${s2Boundary!.xEnd - s2Boundary!.xStart}`
+	);
+});
+
+// =============================================================================
 // computeStageBoundaries
 // =============================================================================
 

--- a/frontend/src/lib/utils/fullProfile.ts
+++ b/frontend/src/lib/utils/fullProfile.ts
@@ -11,6 +11,8 @@
 
 import type { Trip, Stage, Waypoint } from '$lib/types';
 import { deriveTripStatus } from './tripStatus.ts';
+// #2110: geteilte Etappen-Vorpruefung (identische Regel wie computeHeaderStats).
+import { stageHasFullTrackDistance } from '../components/email-preview/headerStats.ts';
 
 export interface ProfilePoint {
 	x: number; // kumulative Distanz in km
@@ -57,9 +59,17 @@ export function buildProfilePoints(trip: Trip): ProfilePoint[] {
 
 	for (const stage of stages) {
 		const wps = stage?.waypoints ?? [];
-		for (const wp of wps) {
+		// #2110: Track-Distanz nur innerhalb einer vollstaendig vermessenen Etappe.
+		const useTrack = stageHasFullTrackDistance(wps);
+		for (let i = 0; i < wps.length; i++) {
+			const wp = wps[i];
 			if (prevWp !== null) {
-				cumKm += haversineKm(prevWp, wp);
+				// i === 0 ist das etappenuebergreifende Segment → immer Haversine.
+				cumKm +=
+					useTrack && i > 0
+						? (wp.distance_from_start_km as number) -
+							(wps[i - 1].distance_from_start_km as number)
+						: haversineKm(prevWp, wp);
 			}
 			if (hasElevation(wp)) {
 				points.push({ x: cumKm, y: wp.elevation_m, stageId: stage.id });
@@ -93,10 +103,18 @@ export function computeStageBoundaries(trip: Trip): StageBoundary[] {
 		const code = formatStageCode(nonPauseIndex, isPause);
 
 		const xStart = cumKm;
+		// #2110: Track-Distanz nur innerhalb einer vollstaendig vermessenen Etappe.
+		const useTrack = stageHasFullTrackDistance(wps);
 		// Distanzen innerhalb der Stage durchlaufen.
-		for (const wp of wps) {
+		for (let i = 0; i < wps.length; i++) {
+			const wp = wps[i];
 			if (prevWp !== null) {
-				cumKm += haversineKm(prevWp, wp);
+				// i === 0 ist das etappenuebergreifende Segment → immer Haversine.
+				cumKm +=
+					useTrack && i > 0
+						? (wp.distance_from_start_km as number) -
+							(wps[i - 1].distance_from_start_km as number)
+						: haversineKm(prevWp, wp);
 			}
 			prevWp = wp;
 		}

--- a/frontend/src/lib/utils/naismith.test.ts
+++ b/frontend/src/lib/utils/naismith.test.ts
@@ -87,6 +87,36 @@ test('AC-5: Pausentag (0 Wegpunkte) → []', () => {
 	assert.deepEqual(computeArrivalTimes(s, s.start_time), []);
 });
 
+// =============================================================================
+// TDD RED: Issue #2110 — Track-Distanz statt Haversine, wenn die Stage
+// vollstaendig vermessen ist (distance_from_start_km je Wegpunkt).
+// Spec: docs/specs/modules/fix_2110_gui_gpx_km.md (AC-5)
+// `distance_from_start_km` existiert im `Waypoint`-Type noch NICHT (kommt in
+// Phase 6) — hier als lockeres Objekt-Literal gesetzt, `wp()` liefert den Rest.
+// =============================================================================
+
+test('AC-5: vollstaendig vermessene Stage nutzt Track-Distanz statt Haversine fuer die Ankunftszeit', () => {
+	// Haversine (42.0,9.0)→(42.009,9.0) ≈ 1.0 km → +15 min bei 4 km/h flach.
+	// Track-Distanz wird bewusst auf 4.0 km gesetzt → +60 min. Nur bei echter
+	// Track-Nutzung landet die Ankunft auf "09:00", nicht "08:15".
+	const s = stage(
+		's1',
+		[
+			{ ...wp('w1', 'Start', 42.0, 9.0, 1000), distance_from_start_km: 0 },
+			{ ...wp('w2', 'Ziel', 42.009, 9.0, 1000), distance_from_start_km: 4.0 }
+		],
+		'08:00'
+	);
+	const arrivals = computeArrivalTimes(s, s.start_time);
+	assert.equal(arrivals.length, 2);
+	assert.equal(arrivals[0], '08:00');
+	assert.equal(
+		arrivals[1],
+		'09:00',
+		`erwartet Track-Distanz 4 km → +1h Ankunft "09:00" (Haversine wäre nur ~1 km → "08:15"), erhalten ${arrivals[1]}`
+	);
+});
+
 test('AC-5: Default-Startzeit 08:00 wenn startTime fehlt', () => {
 	const s = stage('s1', [wp('w1', 'Start', 42.0, 9.0, 1000)]);
 	const arrivals = computeArrivalTimes(s);

--- a/frontend/src/lib/utils/naismith.ts
+++ b/frontend/src/lib/utils/naismith.ts
@@ -11,7 +11,7 @@
 //
 // Distanz: gemeinsame haversineKm aus headerStats.ts (DRY, kein eigener Haversine).
 
-import { haversineKm } from '../components/email-preview/headerStats.ts';
+import { haversineKm, stageHasFullTrackDistance } from '../components/email-preview/headerStats.ts';
 import type { ActivityType, Stage } from '../types';
 
 const SPEED_FLAT_KMH = 4.0;
@@ -98,13 +98,17 @@ export function computeArrivalTimes(stage: Stage, startTime?: string, speedFlatK
 	if (!wps || wps.length === 0) return [];
 
 	const speed = speedFlatKmh ?? SPEED_FLAT_KMH;
+	// #2110: Track-Distanz nur bei vollstaendig vermessener Stage, sonst Haversine.
+	const useTrack = stageHasFullTrackDistance(wps);
 	let cur = parseStartMinutes(startTime);
 	const arrivals: string[] = [formatHHMM(Math.round(cur))];
 
 	for (let i = 1; i < wps.length; i++) {
 		const prev = wps[i - 1];
 		const wp = wps[i];
-		const dist = haversineKm(prev, wp);
+		const dist = useTrack
+			? (wp.distance_from_start_km as number) - (prev.distance_from_start_km as number)
+			: haversineKm(prev, wp);
 		const dElev = wp.elevation_m - prev.elevation_m;
 		const ascent = Math.max(0, dElev);
 		const descent = Math.max(0, -dElev);

--- a/openspec.yaml
+++ b/openspec.yaml
@@ -92,6 +92,25 @@ strict_code_gate:
     - "scripts/"
     - "tools/"
     - "e2e/"
+  # Ueberschreibt den Hook-Default vollstaendig (kein Merge, siehe edit_gate.py
+  # _get_config_list) — deshalb Default-Liste hier vollstaendig repliziert,
+  # PLUS ".test.ts$": Frontend-Konvention legt Testdateien oft direkt neben den
+  # Quellcode (z.B. fullProfile.test.ts, naismith.test.ts), nicht in einem
+  # test/tests/__tests__-Ordner. Ohne dieses Muster blockierte edit_gate.py
+  # solche Testdateien faelschlich als Produktivcode in Phase 5 (TDD RED) —
+  # gefunden bei #2110, PO-bestaetigt 2026-08-23.
+  always_allowed_patterns:
+    - "\\.md$"
+    - "\\.txt$"
+    - "\\.json$"
+    - "\\.yaml$"
+    - "\\.yml$"
+    - "\\.toml$"
+    - "\\.gitignore$"
+    - "README"
+    - "CHANGELOG"
+    - "LICENSE"
+    - "\\.test\\.ts$"
 
 # Specs Configuration
 specs:


### PR DESCRIPTION
## Summary
- GUI (Etappen-Kachel, Trip-Summe, Cockpit, E-Mail-Vorschau, Profil-Chart, Ankunftszeiten-Vorschau) nutzt jetzt die vom Backend gemessene GPX-Track-Distanz statt einer reinen Haversine-Luftlinie zwischen Wegpunkten, wenn eine Etappe vollständig vermessen ist.
- Etappen-weiser Fallback (PO-Entscheid): fehlt auch nur ein Wegpunkt-Wert, bleibt die gesamte Etappe bei Haversine — kein segmentweises Mischen.
- Etappengrenzen-Segmente bleiben grundsätzlich Haversine-basiert (Track-Distanz ist etappen-relativ, über Etappengrenzen nicht vergleichbar).
- Nebenbei: `openspec.yaml` Gate-Korrektur (`.test.ts$` zu `always_allowed_patterns`), da kolozierte Testdateien ohne `test/`-Ordner vom `edit_gate` fälschlich blockiert wurden.

## Test plan
- [x] TDD RED: 3 Tests initial rot (AC-1, AC-4, AC-5)
- [x] TDD GREEN: 45/45 Ziel-Tests grün, voller Frontend-Regressionslauf 2760/2765 grün (0 rot)
- [x] Adversary-Dialog: VERIFIED, 7/7 ACs bewiesen (Code + Test + Mutations-Gegenprobe je AC)
- [x] Finding F001 (Etappengrenzen-Guard ungetestet) durch Nachtrag-Test geschlossen, unabhängig vom Adversary gegengeprüft
- [ ] Staging-Verifikation (folgt via `/e2e-verify`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017RCHrPjiHmnrVweHHTPJNg