### PR TITLE
feat(#2051): S4 — /strecke-Kommando fuer die Lage entlang der Reststrecke

### DIFF
--- a/docs/context/feat-2051-s4-strecke-kommando.md
+++ b/docs/context/feat-2051-s4-strecke-kommando.md
@@ -1,0 +1,82 @@
+# Context: feat-2051-s4-strecke-kommando
+
+## Request Summary
+
+Issue #2051 Scheibe S4: Ein neues Inbound-Kommando (Arbeitstitel `/strecke`), das die
+Regen-Ereignisflaechen **entlang der Reststrecke der aktiven Etappe** ausgibt. Bestand:
+alle Kommandos (`/jetzt`, `/heute`, `/morgen`, `/gewitter`, `/timeline_heute`, `/glance`)
+liefern **Ortswetter an einem Punkt** — keins die Lage entlang der Strecke.
+
+Die Datenbausteine liegen seit S2a/S2b live vor; S4 verdrahtet sie erstmals in einen
+**abrufbaren** Pfad statt in den Alarm-Pfad.
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `src/services/trip_command_processor.py` | Channel-agnostischer Kommando-Kern. `_VALID_COMMANDS:83`, `_BARE_KEYWORD_MAP:87-102`, Dispatch `:512-546`, Hilfe `_show_help:1371-1391`, Vorbild-Handler `_show_now:1507-1582` |
+| `src/services/inbound_telegram_reader.py` | Telegram-Eingang. `_VALID_COMMANDS:33-35`, `_SHORTCUT_MAP:37-57`, Parser `_parse_command:205`, Aufruf `process():245,274`, Antwort-Formatierung `:257-263` |
+| `src/services/inbound_email_reader.py` | Zweiter Eingang, ruft `process()` auf `:153`, Antwort `:156` |
+| `src/services/trip_segments.py` | `points_along_remaining_route():683-715`, Konstanten `RADAR_ZONE_POINT_SPACING_KM=2.0`, `RADAR_ZONE_MAX_POINTS=6` `:36-37`; `position_at_time`, `resolve_current_segment` |
+| `src/services/rain_extent.py` | `RainZone:27-43` (km_from, km_to, onset_minutes, event_end_minutes), `derive_rain_zones():46-91` |
+| `src/services/radar_service.py` | `RadarNowcastService.get_nowcast()`, `format_now_text():563-662` (Textvorlage der Kommando-Antwort mit S1-Ende und S3-Reichweite) |
+| `src/services/trip_alert.py` | Referenz-Kette Punkte→Nowcasts→Zonen: `:1637-1639`, `:1720`, `:1738-1770` |
+| `src/services/forecast_budget.py` | `ForecastBudgetGate:36`, `DAILY_BUDGET=9000`, `POLLING_THRESHOLD=0.80`, `BRIEFING_ONLY_THRESHOLD=0.95` `:40-42`, `allow():54-73` |
+| `src/services/radar_cache.py` | Nowcast-Cache, Schluessel lat/lon/Region/Hoehe `:72-84`, TTL 300 s `:123`, prozessweites Singleton |
+| `src/output/renderers/alert/render.py` | `_onset_extent_suffix():624-649` (Langform `· Nass km 8-12, km 19-21`), `_sms_onset_extent_suffix():945-976` (Kurzform ` km8-12,19-21`) |
+
+## Existing Patterns
+
+- **Kommando-Handler:** `_show_now` holt Etappe (`get_stage_for_date`), loest die Position
+  ueber `resolve_current_segment` + `position_at_time` auf, ruft **einen** Nowcast mit
+  `priority="user_briefing"` und gibt `CommandResult(confirmation_body=...)` zurueck.
+- **Kommando-Registrierung ist zweistufig:** Telegram-Reader validiert Slash-Kommandos gegen
+  seine eigene Liste, der Prozessor gegen `_BARE_KEYWORD_MAP` (Freitext). Beide muessen
+  gepflegt werden, sonst ist das Kommando nur ueber einen Weg erreichbar.
+- **Argument-Muster:** `/ruhetag N`, `/pause 2d`, `/startdatum YYYY-MM-DD` — Parser liefert
+  `(key, value)`, der Handler interpretiert `value` selbst.
+- **Zonen-Text ist heute ausschliesslich inline** (ein Suffix im Satz), es gibt **keinen**
+  Renderer, der Zonen als mehrzeilige Liste oder Tabelle ausgibt.
+- **Fail-soft bei Folgepunkten** (S2a, `trip_alert.py:1763-1770`): faellt ein Zonenpunkt aus,
+  laeuft der Hauptpfad weiter, nur `logger.warning`.
+
+## Dependencies
+
+- **Upstream:** `points_along_remaining_route()`, `derive_rain_zones()`,
+  `RadarNowcastService.get_nowcast()`, `ForecastBudgetGate`, `RadarNowcastCacheService`
+- **Downstream:** `CommandResult` → `send_command_reply_telegram()` /
+  `send_command_reply_email()`; die Hilfe-Ausgabe `_show_help`
+
+## Existing Specs
+
+- `docs/specs/modules/feat_2051_s1_dauer_und_ende.md` (approved v1.1) — Ende/Dauer, sieben
+  Textstellen inkl. **Kommando-Antwort**
+- `docs/specs/modules/feat_2051_s2a_raeumliche_ausdehnung.md` (approved v1.0) — `RainZone`,
+  `derive_rain_zones`, Mehrpunkt-Abruf im Alarm-Pfad; benennt `/strecke` als S4-Nicht-Ziel
+- `docs/specs/modules/feat_2051_s2b_ausdehnung_kanaele.md` — Kanal-Kaskade der Zonen-Angabe;
+  haelt fest: getrennte Zonen bleiben getrennt, Budget-Drop statt Anschnitt
+- `docs/specs/modules/feat_2051_s3_reichweite_und_guete.md` (approved v1.1) —
+  `source_reach_minutes`, `location_sharpness_limit_minutes`, Wortwahl `unscharf`
+
+## Risks & Considerations
+
+1. **Budget-Kollision mit dem Alarm-Pfad (hoch).** Kommando und Alarm zaehlen gegen dasselbe
+   Tageskontingent (9000). `/jetzt` faehrt `user_briefing` = **nie** gedrosselt, der
+   Alarm-Pfad `polling` = ab 80 % abgewiesen. Ein `/strecke` mit 6 ungedrosselten Abrufen
+   koennte also genau das Kontingent verbrauchen, das die Alarme brauchen — auf der Tour die
+   sicherheitsrelevantere Flaeche.
+2. **`RainZone` traegt heute weder Intensitaet noch Quelle.** Das Ticket verlangt fuer die
+   E-Mail-Fassung km-Spanne, **Zeitspanne, Intensitaet, Quelle**. Zwei der vier Groessen
+   muessten additiv an der Zone entstehen.
+3. **Kein Zonen-Listen-Renderer im Bestand** — Neubau, und er muss die Kanal-Kaskade des
+   Tickets tragen (E-Mail-Tabelle / Telegram eine Zeile je Flaeche / Kurzform eine Zeile).
+4. **Zwei Eingangskanaele, ein Kern.** Wer das Kommando im Prozessor registriert, macht es
+   automatisch auch per E-Mail-Inbound erreichbar. Das ist erwuenscht (Kanalgleichrangigkeit),
+   muss aber bewusst gebaut und geprueft werden, nicht als Nebenwirkung.
+5. **Unvermessene Etappe.** Ohne GPX-Kilometrierung gibt es keine km-Zahlen (S2b-Regel
+   `km_measured`). Die Antwort braucht einen ehrlichen Zweig dafuer.
+6. **Keine Rechnung ueber den Nutzer** (PO-Grundprinzip des Tickets): keine Ankunftszeit,
+   kein "bei Planzeit bist du um ... bei km ...". Die Planposition darf die *Reststrecke*
+   bestimmen, nicht eine Aussage ueber den Nutzer erzeugen.
+7. **Wiederholtes Abrufen** ist nicht begrenzt — der Telegram-Rate-Limit (18/60 s) bremst nur
+   den Versand, nicht den Kommando-Eingang. Der 300-s-Nowcast-Cache daempft das teilweise.

--- a/docs/features/f6-trip-commands.md
+++ b/docs/features/f6-trip-commands.md
@@ -1,6 +1,8 @@
 # Trip-Befehle — Email-Reply & Telegram (F6)
 
-**Updated:** 2026-06-13 (Briefing-Mail lesbar: D/W/G-Kürzel aus E-Mail-Betreff entfernt — neu `[GZ#GRANK] Tag 3 — Morgen — Gewitter` ohne Zahlenkürzel); 2026-06-12 (Bug #775 — Trip-Shortcode-Routing: E-Mail-Betreff trägt neuen `[GZ#XXXX]`-Shortcode als primären Routing-Key, RFC-2047-Dekodierung, toleranter Whitespace-Lookup als Fallback); 2026-06-11 (Issue #731 — Befehlssatz vereinheitlicht: abruf-zentriert (HEUTE/MORGEN/JETZT/GEWITTER/RUHETAG/STATUS/STOP/WEITER/HILFE), PAUSE/SKIP/CONFIG entfernt); 2026-06-08 (Issues #672/#671 — E2E-Pipeline-Tests + vollständiges Bot-Menü; #651/#653/#654/#655 — Telegram Tier-1/2/3 + Zoom-Navigation)
+**Updated:** 2026-08-23 (Issue #2051 Scheibe S4 — neues Abfrage-Kommando `STRECKE`/`/strecke`:
+Regen-Ereignisflächen entlang der Reststrecke des aktuell aktiven Wegabschnitts, erreichbar über
+Email und Telegram); 2026-06-13 (Briefing-Mail lesbar: D/W/G-Kürzel aus E-Mail-Betreff entfernt — neu `[GZ#GRANK] Tag 3 — Morgen — Gewitter` ohne Zahlenkürzel); 2026-06-12 (Bug #775 — Trip-Shortcode-Routing: E-Mail-Betreff trägt neuen `[GZ#XXXX]`-Shortcode als primären Routing-Key, RFC-2047-Dekodierung, toleranter Whitespace-Lookup als Fallback); 2026-06-11 (Issue #731 — Befehlssatz vereinheitlicht: abruf-zentriert (HEUTE/MORGEN/JETZT/GEWITTER/RUHETAG/STATUS/STOP/WEITER/HILFE), PAUSE/SKIP/CONFIG entfernt); 2026-06-08 (Issues #672/#671 — E2E-Pipeline-Tests + vollständiges Bot-Menü; #651/#653/#654/#655 — Telegram Tier-1/2/3 + Zoom-Navigation)
 
 Gregor Zwanzig empfaengt Trip-Befehle ueber zwei Kanäle:
 - **Email:** Du antwortest auf einen bestehenden Report (alle 5 Minuten abgerufen)
@@ -56,6 +58,7 @@ Diese Befehle zeigen Wetter-Informationen **ohne** Trip-State zu veraendern.
 | `JETZT` / `NOW` | Nowcast (Regen/Gewitter naechste ~2h) |
 | `GEWITTER` | Gewittergefahr heutige Etappe (stuendlich) |
 | `STATUS` | Heute + kommende Etappen (ohne vergangene) |
+| `STRECKE` / `STRECKE <km>` | Regen-Ereignisflächen entlang der Reststrecke des aktuell aktiven Wegabschnitts (Issue #2051 S4) |
 | `HILFE` / `HELP` | Verfuegbare Befehle anzeigen |
 
 **Beispiel:**
@@ -64,6 +67,56 @@ HEUTE
 ```
 
 Gregor antwortet mit dem Wetter fuer die heutige Etappe.
+
+---
+
+### `STRECKE` — Regen-Ereignisflächen entlang der Reststrecke (Issue #2051 S4)
+
+Zeigt die Regen-Ereignisflächen entlang der Reststrecke des **aktuell aktiven
+Wegabschnitts** (nicht der ganzen Tagesetappe — siehe Grenze unten). Erreichbar über
+Email (Freitext `STRECKE` in der ersten Zeile) und Telegram (Freitext `strecke` oder
+Slash `/strecke`). Anders als die Kurzbefehle im Bot-Menü (Abschnitt „Telegram —
+Abfrage-Befehle" unten) taucht `/strecke` **nicht** im Telegram-Bot-Menü auf — es muss
+getippt werden.
+
+**Ohne Argument:** Ausgangspunkt ist die aktuelle Planposition.
+
+**Mit Argument** (`STRECKE 5` bzw. `/strecke 5`): Ausgangspunkt ist der selbst genannte
+km-Stand, bezogen auf die stage-kumulative Kilometrierung des aktiven Segments.
+Gültiger Bereich: `[Segment-Start-km, Segment-Ende-km]` (beide Ränder eingeschlossen),
+Dezimalwerte erlaubt. Werte außerhalb des Bereichs oder nicht-numerische Eingaben werden
+abgelehnt — kein Wetterabruf.
+
+**Antwort:**
+- Email: je Regen-Ereignisfläche eine Zeile mit km-Spanne, Zeitspanne, Intensität und
+  Quelle im Klartext (`Radar (DWD)`, `INCA (GeoSphere AT)`).
+- Telegram: dieselben Zeilen ohne Quelle-Spalte (Platzgrund).
+- Jede Antwort mit Messung schließt mit `Geprüft: km {von}-{bis}.` — der tatsächlich
+  geprüften Spanne (aus den erfolgreich abgefragten Punkten, nicht den geplanten).
+
+**Drei ehrliche Sonderfälle:**
+- Keine aktive Etappe/kein auflösbarer Standort — derselbe Text wie `JETZT` in derselben
+  Situation.
+- Kilometrierung für die Etappe nicht verfügbar (auch nach Nachrüst-Versuch) — keine
+  Streckenangabe möglich, kein Wetterabruf.
+- Kein Regen im geprüften Abschnitt erkannt — eigener Hinweistext samt geprüfter Spanne.
+
+**Bekannte Grenze:** Die Antwort deckt nur das aktuell aktive Wegpunkt-Segment ab, nicht
+die volle Resttagesetappe (Bestandsgrenze aus S2a/S2b im Alarm-Pfad — dieselben Bausteine
+`derive_rain_zones()`/`points_along_remaining_route()` — hier nur über die
+`Geprüft:`-Zeile sichtbar gemacht, nicht behoben). Kein SMS-/Premium-SMS-Kanal (dort gibt
+es keinen Inbound-Kommando-Pfad).
+
+**Beispiel:**
+```
+STRECKE
+```
+oder mit eigenem km-Stand:
+```
+STRECKE 5
+```
+
+Spec: `docs/specs/modules/feat_2051_s4_strecke_kommando.md`
 
 ---
 
@@ -257,6 +310,7 @@ MORGEN
 JETZT (oder NOW)
 GEWITTER
 STATUS
+STRECKE (auch STRECKE <km>, oder /strecke)
 HILFE
 ```
 

--- a/docs/specs/modules/feat_2051_s4_strecke_kommando.md
+++ b/docs/specs/modules/feat_2051_s4_strecke_kommando.md
@@ -1,0 +1,785 @@
+---
+entity_id: feat_2051_s4_strecke_kommando
+type: feature
+created: 2026-08-23
+updated: 2026-08-23
+status: draft
+version: "1.3"
+tags: [alarm, nowcast, radar, ausdehnung, zone, kommando, inbound]
+---
+
+# Inbound-Kommando `/strecke` — #2051 Scheibe S4
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Alle bestehenden Kommandos (`/jetzt`, `/heute`, `/morgen`, `/gewitter`,
+`/timeline_heute`, `/glance`) liefern **Ortswetter an einem Punkt**. S4 fuegt
+ein neues, abrufbares Kommando `/strecke` hinzu, das die **Regen-
+Ereignisflaechen entlang der Reststrecke der aktiven Etappe** ausgibt — die
+Datenbausteine dafuer (`RainZone`, `derive_rain_zones()`,
+`points_along_remaining_route()`) liegen seit S2a/S2b live im Alarm-Pfad,
+S4 verdrahtet sie erstmals in einen **vom Nutzer selbst ausloesbaren** Pfad.
+
+Grundprinzip aus dem Ticket (unveraendert bindend): **nur Daten ueber das
+Wetter, keine Handlungsempfehlung und keine Rechnung ueber den Nutzer.**
+Verboten sind Ankunftszeiten, Begegnungspunkte, "bei Planzeit bist du um
+15:40 bei km 9". Erlaubt ist "Nass km 8-12, 15:00-16:30, mäßig, INCA".
+
+## Source
+
+- **File:** `src/services/trip_command_processor.py` (neuer Handler
+  `_show_strecke` + zwei neue Renderer-Helfer), `src/services/trip_segments.py`
+  (neue Punktbildung ab genanntem km), `src/services/rain_extent.py`
+  (additive Felder auf `RainZone`), `src/services/inbound_telegram_reader.py`
+  (Slash-Kurzform)
+- **Identifier:** `_show_strecke()` (neu, `trip_command_processor.py`),
+  `points_from_km()` (neu, `trip_segments.py`), `RainZone.intensity_label` /
+  `RainZone.source` (neu, additiv, `rain_extent.py`)
+
+> **Schicht-Hinweis:** Alle Aenderungen liegen ausschliesslich im
+> Python-Core (`src/services/`) — kein Go-API-, kein Frontend-Anteil.
+
+## Estimated Scope
+
+- **LoC:** ~210-270 produktiv (neue Punktbildung ~40, additive Felder +
+  Aggregation in `rain_extent.py` ~30, `_show_strecke` inkl. Argument-
+  Validierung und Spannenbildung (E7) ~100, zwei Renderer-Helfer ~60,
+  Wiring an drei Registrierungsstellen ~15), ~270-340 Tests — **über dem
+  250-LoC-Workflow-Limit**, `workflow.py set-field loc_limit_override 500`
+  vor `/40-tdd-red` einplanen (Muster wie S2a/S2b/S3).
+- **Files:** `trip_command_processor.py`, `trip_segments.py`,
+  `rain_extent.py`, `inbound_telegram_reader.py` + 3-4 neue Testdateien.
+- **Effort:** medium-high — kein neuer Rechenkern (Punktbildung/Zonenbildung
+  liegen seit S2a fertig vor), aber zwei neue Renderer, eine neue
+  Argument-Validierung mit mehreren Randfällen, und Verdrahtung an zwei
+  unabhängigen Eingangskanälen.
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `points_along_remaining_route()` | function (`trip_segments.py:683-715`, S2a) | Muster für die neue `points_from_km()` — dieselbe Deckelung (`RADAR_ZONE_MAX_POINTS`, `RADAR_ZONE_POINT_SPACING_KM`), nur mit anderem Startpunkt. |
+| `derive_rain_zones()` / `RainZone` | function/dataclass (`rain_extent.py:26-91`, S2a) | Zonenbildung unverändert — S4 erweitert nur die Datenklasse additiv und liest die neuen Felder. |
+| `ForecastBudgetGate` | class (`forecast_budget.py:36-74`) | `allow("user_briefing")` immer `True`, `allow("polling")` ab 80% `False` — trägt E1 ohne eigenes neues Gate. |
+| `backfill_stage_distances()` | function (`track_resolution.py:264-344`) | Fail-soft-Nachrüstung der Kilometrierung — S4 ruft sie **selbst** auf, nach dem Muster des Alarm-Pfads (`trip_alert.py:1432-1436`), bevor das Segment aufgelöst wird. |
+| `resolve_current_segment()` / `position_at_time()` | functions (`trip_segments.py:455,561`) | Unverändert — Planpositions-Einstieg ohne km-Argument (Muster `_show_now`). |
+| `RadarNowcastService.source_label()` | method (`radar_service.py:555-561`) | Roh-Quellenschlüssel → Klartext, von den neuen Renderern zur Render-Zeit aufgerufen — `rain_extent.py` bleibt dadurch eine reine Auswertung ohne Kopplung an `radar_service.py`. |
+| `_BARE_KEYWORD_MAP` / `_VALID_COMMANDS` | dict/set (`trip_command_processor.py:83,87-102`) | Zweistufige Registrierung — bare Keyword macht das Kommando automatisch auch über E-Mail-Inbound erreichbar (E4). |
+| `_SHORTCUT_MAP` | dict (`inbound_telegram_reader.py:37-57`) | Slash-Variante `/strecke` für den Telegram-Bot-Menü-Tap — eigener Eintrag nötig, `_BARE_KEYWORD_MAP` allein deckt nur die Freitext-Eingabe ohne führenden Slash ab (siehe Korrektur unten). |
+| `_show_now` | method (`trip_command_processor.py:1513-1588`) | Vorbild-Handler: Segmentauflösung, `elevation_m`-Normalisierung, Fehlerbranch bei fehlender heutiger Etappe — dessen Wortlaut wird für denselben Fall **wiederverwendet** (AC-18). |
+
+## Korrektur gegenüber dem Kontextdokument
+
+Das Kontextdokument benennt `inbound_telegram_reader._VALID_COMMANDS:33-35`
+als zweite Slash-Registrierungsstelle. Nachgemessen (`inbound_telegram_
+reader.py:449-484`) hat dieses Set dort **keine** Wirkung auf die Slash-Form:
+`_parse_command()` prüft zuerst `_SHORTCUT_MAP` (explizite `/xyz`-Einträge,
+z. B. `/heute`, `/now`, `/jetzt`), danach das geteilte `_BARE_KEYWORD_MAP`
+(Freitext ohne Slash), und `_VALID_COMMANDS` greift nur als **Fallback für
+Kommandos, die nicht in `_BARE_KEYWORD_MAP` stehen** (aktuell nur
+`startdatum`/`report`). Da `strecke` in `_BARE_KEYWORD_MAP` landet (Schritt
+2 löst es bereits auf), ist eine Ergänzung von `_VALID_COMMANDS` an dieser
+Stelle **nicht** funktional notwendig — die tatsächliche Registrierungsstelle
+für die Slash-Form ist `_SHORTCUT_MAP` (neuer Eintrag `"/strecke": "strecke"`,
+Muster der bestehenden `/heute`/`/morgen`/`/now`-Einträge). Kein AC prüft
+daher die Mitgliedschaft in `_VALID_COMMANDS` — das wäre eine Formprüfung
+ohne beobachtbare Wirkung; AC-1 prüft stattdessen das tatsächliche
+Dispatch-Ergebnis beider Eingabeformen.
+
+## Getroffene Entscheidungen (E1–E7 aus dem Briefing + eigene Festlegungen)
+
+**E1 — Abrufpriorität.** Der erste Messpunkt fährt `priority="user_briefing"`
+(nie gedrosselt — eine Antwort kommt immer). Die Folgepunkte (bis zu 5
+weitere) fahren `priority="polling"` und entfallen bei knapper Budgetlage.
+Fällt ein einzelner Folgepunkt aus (Budget oder Fehler), läuft das Kommando
+fail-soft mit den übrigen Punkten weiter (Muster `trip_alert.py:1748-1770`,
+E4 aus S2a). Fallen **alle** Folgepunkte aus, während mehr als ein Punkt
+geplant war, gibt die Antwort **keine** km-Zonen-Angabe aus — sie sagt
+ehrlich, dass die Ausdehnung nicht ermittelt werden konnte (AC-7). Ist genau
+1 Punkt geplant (Reststrecke unter der 2-km-Spacing-Schwelle, S2a-Regime),
+ist dieser Punkt der volle, gültige Messumfang — sein Ergebnis ist eine
+normale Antwort, kein Ausfall (AC-6, Positivkontrolle zu AC-7).
+
+**E2 — `RainZone` additiv um `intensity_label`/`source` erweitert.**
+Beide Felder tragen einen Default (`""`), bestehende S2a/S2b-Konstruktionen
+(alle mit Keyword-Argumenten) bleiben unverändert lauffähig. Aggregation je
+Zone:
+- `intensity_label` = der **stärkste** Wert unter den Punkten der Zone,
+  Rangfolge `INTENSITY_CONVECTIVE > INTENSITY_HEAVY > INTENSITY_MODERATE >
+  INTENSITY_LIGHT` (Konstanten aus `radar_service.py:137-140`; `DRY` kommt
+  in einer Zone strukturell nicht vor, da nur nasse Punkte — `onset_minutes
+  is not None` — überhaupt in die Zonenbildung eingehen).
+- `source` = der **rohe** Quellenschlüssel (z. B. `"INCA"`, `"radar"`) des
+  Punkts, der die Zone trägt. Bei uneinheitlichen Quellen gewinnt der
+  **erste** Punkt der Zone (kleinster km-Wert) — kein Mehrheitsentscheid,
+  keine Kombination mehrerer Quellen in einem String. Die Klartext-
+  Übersetzung (`RadarNowcastService.source_label()`) passiert **erst beim
+  Rendern**, nicht in `rain_extent.py` — das Modul bleibt dadurch, wie im
+  eigenen Docstring festgehalten, eine reine Auswertung ohne Kopplung an
+  `radar_service.py`.
+
+**E3 — Zwei neue Renderer, kein Antasten der bestehenden Suffix-Helfer.**
+`_onset_extent_suffix()`/`_sms_onset_extent_suffix()` (`render.py`, S2a/S2b,
+live) bleiben unverändert — sie hängen eine Ausdehnungs-**Angabe** an einen
+Alarm-Satz. `/strecke` braucht etwas anderes: eine **mehrzeilige** Auflistung
+aller Zonen als eigenständige Antwort. Die beiden neuen Helfer leben in
+`trip_command_processor.py` (Muster der dortigen privaten Formatierer
+`_fmt_glance`/`_fmt_timeline`/`_fmt_gewitter`), nicht in `render.py` — sie
+teilen sich keinen Code mit den Alarm-Renderern, weil die Darstellungsform
+(Tabelle/Liste vs. angehängter Halbsatz) grundverschieden ist. Beide
+Renderer bekommen den **Abrufzeitpunkt als expliziten Parameter**
+durchgereicht (Nachtrag, s. Implementation Details) — kein `datetime.now()`
+im Renderer selbst.
+
+**E4 — Zwei Eingangskanäle, eine Registrierungsstelle mit Wirkung auf beide,
+plus eine kanalspezifische Ergänzung.** `strecke` kommt in
+`_BARE_KEYWORD_MAP` (`trip_command_processor.py`) — das macht es automatisch
+sowohl über Telegram-Freitext als auch über E-Mail-Inbound erreichbar (beide
+rufen `TripCommandProcessor().process()` auf dieselbe Weise). Zusätzlich
+nötig: der Slash-Eintrag in `_SHORTCUT_MAP` (`inbound_telegram_reader.py`,
+siehe Korrektur oben) für den Telegram-Bot-Menü-Tap, sowie ein Eintrag in
+`_show_help()`. SMS/Premium-SMS sind **keine** Registrierungsstelle — dort
+gibt es keinen Inbound-Kommando-Pfad (Premium-SMS ist reiner Sendekanal,
+siehe CLAUDE.md).
+
+**E5 — Optionales km-Argument, bezogen auf die STAGE-kumulative
+Kilometrierung des AKTUELL AKTIVEN Segments (eigene Festlegung).**
+`points_along_remaining_route()` operiert auf `active: TripSegment` — dem
+aktuell laufenden ~2h-Wegabschnitt, nicht der ganzen Tagesetappe. Die
+ausgegebenen Zonen-km-Werte (`RainZone.km_from/km_to`, aus
+`GPXPoint.distance_from_start_km`) sind aber **tageskumulativ** (S2a-Docstring:
+"NICHT die Segment-Grenzen"). Damit das km-Argument dieselbe Einheit trägt
+wie die Ausgabe, ist sein gültiger Bereich `[active.start_point.
+distance_from_start_km, active.end_point.distance_from_start_km]` — die
+kumulative Spanne des aktuell aktiven Segments, nicht `[0, aktive
+Segmentlänge]` und nicht die ganze Tagesetappe. Eine Anfrage über mehrere
+Segmente hinweg (z. B. "zeig mir ab km 2, obwohl ich gerade bei km 9 bin")
+ist damit bewusst **außerhalb des Scopes** dieser Scheibe (Known Limitation)
+— sie würde eine mehrsegmentige Traversierung erfordern, die
+`points_along_remaining_route()` heute nicht kann.
+
+Voraussetzung für ein gültiges Argument: `active.distance_measured is True`
+(nach dem Backfill-Versuch, s. E6) — auf einem unvermessenen Segment hat
+"km 5" keine verlässliche Bedeutung, egal ob der Nutzer sie selbst nennt.
+
+**Ungültige Eingaben** (nicht-numerisch, negativ *relativ zum Segmentstart*
+— konkret: unterhalb `active.start_point`-km oder oberhalb `active.
+end_point`-km, oder syntaktisch kein Zahl): alle drei Fälle werden
+**abgelehnt**, nicht stillschweigend geklemmt — ein geklemmter Wert würde
+eine andere Frage beantworten als die gestellte (AC-15). **Dezimalwerte sind
+erlaubt** (`float()`-Parsing, Punkt als Dezimaltrennzeichen) — die
+Zonen-km-Werte selbst sind bereits `float`, eine künstliche Beschränkung auf
+Ganzzahlen hätte keinen Gegenwert (AC-16). Der obere Rand des gültigen
+Bereichs ist **eingeschlossen** — km gleich `end_point`-km ergibt eine
+gültige, wenn auch entartete Anfrage mit Reststrecke 0 (AC-14, Konsistenz
+mit dem bestehenden "Reststrecke < Spacing → 1 Punkt"-Verhalten aus S2a).
+
+**E6 — Drei ehrliche Zweige, geprüft VOR jedem Nowcast-Aufruf.** `/strecke`
+ruft zuerst `backfill_stage_distances(trip, user_id, today, persist=True)`
+auf (Muster `trip_alert.py:1432-1436`) und löst danach das aktive Segment
+auf.
+1. **Keine aktive Etappe/kein auflösbares Segment** — derselbe Text wie
+   `_show_now` in derselben Situation (AC-18), keine neue Formulierung für
+   denselben Fall.
+2. **Segment bleibt unvermessen** (auch nach dem Backfill-Versuch) — die
+   Antwort kann keine einzige km-Zahl nennen, also auch keine Zonen-Liste;
+   das ist kein Suffix-Wegfall wie in S2a/S2b (dort trägt der Restsatz noch
+   Information), sondern der gesamte Kern der Antwort entfällt. Geprüft
+   **vor** jedem `get_nowcast`-Aufruf — kein Budget wird für eine Antwort
+   verbraucht, die ohnehin nicht kommen kann (AC-17).
+3. **Kein Regen erkannt** (alle geplanten Punkte liefern Daten, alle
+   trocken) — eigener, von den beiden anderen Zweigen wortlich
+   unterscheidbarer Hinweis (AC-19).
+
+**E7 — Die geprüfte Streckenspanne ist selbst ein Datum (Nachtrag,
+Adversary-Befund team-lead).** `_remaining_km()`
+(`trip_segments.py:665-681`) und die neue `points_from_km()` rechnen
+ausschließlich innerhalb von `active` — dem aktuell laufenden ~2h-Segment,
+nicht der vollen Resttagesetappe. Segmente entstehen wegpunktweise
+(`convert_trip_to_segments`) und sind oft deutlich kürzer als die
+theoretische 6×2-km-Reichweite der Punktbildung. Eine Antwort, die nur
+"Kein Regen entlang der Reststrecke erkannt" sagt, behauptet damit mehr, als
+gemessen wurde — der Nutzer liest daraus Trockenheit bis zum Etappenziel,
+geprüft wurde aber nur ein Ausschnitt. Das ist keine Handlungsempfehlung,
+sondern eine unbelegte Datenaussage — und widerspricht damit demselben
+Grundprinzip, das Handlungsempfehlungen verbietet: nur sagen, was gemessen
+wurde.
+
+Direkte Analogie zu S3 (`· Radar reicht bis HH:MM` macht sichtbar, wo eine
+Aussage endet, ohne sie zu bewerten): **jede Antwort, die überhaupt
+gemessen hat, nennt zusätzlich die tatsächlich geprüfte km-Spanne** — vom
+kleinsten bis zum größten km-Wert unter den **erfolgreich** abgefragten
+Punkten (nicht den geplanten). Format, angehängt als eigene Zeile am Ende
+der Antwort, in beiden Kanälen gleich: `Geprüft: km {von}-{bis}.`
+(ganzzahlig gerundet wie die Zonen-km-Werte, ASCII-Bindestrich wie
+`_sms_onset_extent_suffix`). Bei nur einem erfolgreichen Punkt entartet die
+Spanne zu `von == bis` (z. B. `Geprüft: km 8-8.`) — genau dieselbe
+Schreibweise wie ein einzelner degenerierter `RainZone`-Eintrag (S2a-AC-5).
+
+Gilt in allen Zweigen **mit** Messung: Zonen vorhanden (E-Mail- und
+Telegram-Fassung), kein Regen erkannt (AC-19), alle Folgepunkte ausgefallen
+(AC-7 — dort ist die Spanne der Beleg für den Hinweistext selbst: "nur der
+Startpunkt lieferte Daten" wird durch `Geprüft: km X-X` konkret). Gilt
+**nicht** in den Zweigen ohne jede Messung: keine aktive Etappe (AC-18),
+Kilometrierung fehlt (AC-17), ungültiges km-Argument (AC-15) — dort wurde
+nichts abgefragt, eine Spanne wäre erfunden.
+
+E7 behebt **nicht** die zugrundeliegende Segment-Grenze selbst (die
+Antwort reicht weiterhin nur bis zum Ende des aktuell aktiven Segments,
+nicht bis zum Etappenziel) — das würde `points_along_remaining_route()`/
+`_remaining_km()` grundlegend ändern und damit den seit S2a **live**
+laufenden Alarm-Pfad kurz vor Tourstart anfassen. E7 macht die bestehende
+Grenze für den Nutzer **sichtbar** statt sie zu verschweigen; ihre
+Aufhebung ist eine eigene, spätere Arbeit.
+
+**Zeitanker der Renderer (Nachtrag aus der RED-Phase, team-lead-Befund).**
+`RainZone.onset_minutes`/`event_end_minutes` sind **relative** Minuten
+gegenüber dem Abrufzeitpunkt, AC-11/AC-12 verlangen aber **absolute**
+Uhrzeiten. Ein Renderer, der die Uhrzeit selbst aus `datetime.now()`
+bildet, liest damit eine ZWEITE, spätere Uhr als die, gegen die
+`onset_minutes` gemessen wurde — jede Uhrzeit verschiebt sich systematisch
+um die Dauer der bis zu sechs HTTP-Abrufe. Er wäre außerdem ohne
+Zeitmanipulation nicht deterministisch prüfbar, die Bildungsstelle der
+Uhrzeit bliebe unbewacht. Beide Renderer bekommen daher **denselben
+`now_utc`, gegen den `_show_strecke` die Nowcasts abgerufen hat, als
+expliziten dritten Parameter** — kein `datetime.now()` im Renderer (AC-23).
+
+## Implementation Details
+
+**Neue Punktbildung** (`trip_segments.py`, additiv, Muster
+`points_along_remaining_route`):
+
+```python
+def points_from_km(
+    trip: "Trip", active: TripSegment, segment_date: date, start_km: float,
+) -> List[GPXPoint]:
+    """Wie points_along_remaining_route(), aber der Startpunkt ist die vom
+    Nutzer genannte, STAGE-kumulative Kilometrierung (Issue #2051 S4, E5) --
+    nicht die Planposition. Aufrufer prueft VORHER active.distance_measured
+    und die Bereichsgrenzen [active.start_point.distance_from_start_km,
+    active.end_point.distance_from_start_km] (E5); diese Funktion nimmt
+    start_km innerhalb dieses Bereichs als gegeben an."""
+    frac = (
+        (start_km - active.start_point.distance_from_start_km)
+        / (active.end_point.distance_from_start_km
+           - active.start_point.distance_from_start_km)
+    ) if active.end_point.distance_from_start_km > active.start_point.distance_from_start_km else 0.0
+    start = _lerp_point(active.start_point, active.end_point, frac)
+    rest_km = active.end_point.distance_from_start_km - start_km
+    if rest_km < RADAR_ZONE_POINT_SPACING_KM:
+        return [start]
+    anzahl = min(RADAR_ZONE_MAX_POINTS, int(rest_km // RADAR_ZONE_POINT_SPACING_KM) + 1)
+    return [start] + [
+        _lerp_point(start, active.end_point, (i * RADAR_ZONE_POINT_SPACING_KM) / rest_km)
+        for i in range(1, anzahl)
+    ]
+```
+
+**Additive Felder auf `RainZone`** (`rain_extent.py`):
+
+```python
+@dataclass(frozen=True)
+class RainZone:
+    km_from: float
+    km_to: float
+    onset_minutes: int
+    event_end_minutes: int | None
+    intensity_label: str = ""  # Issue #2051 S4 (E2): staerkster Wert der Zone
+    source: str = ""           # Issue #2051 S4 (E2): Roh-Quelle des ersten
+                                # Punkts bei Uneinheitlichkeit -- Klartext-
+                                # Uebersetzung bleibt Sache der Renderer.
+```
+
+`_abschliessen()` in `derive_rain_zones()` sammelt zusätzlich Intensität und
+Rohquelle je Punkt in `laufend` und berechnet beim Zonenabschluss den
+stärksten Intensitätswert (Rang-Lookup, s. E2) sowie die Quelle des ersten
+Eintrags.
+
+**Geprüfte Spanne** (`trip_command_processor.py`, E7 — reine Hilfsfunktion,
+unabhängig von Zonen/Regen-Zustand):
+
+```python
+def _geprueft_spanne(
+    punkte: list, ergebnisse: list,
+) -> tuple[float, float] | None:
+    """km-Spanne der ERFOLGREICH abgefragten Punkte (nicht der geplanten,
+    Issue #2051 S4, E7). None, wenn kein einziger Punkt ein Ergebnis lieferte
+    (defensiv -- bei priority=user_briefing fuer den ersten Punkt in der
+    Praxis nicht erreichbar, s. E1)."""
+    kms = [
+        p.distance_from_start_km
+        for p, e in zip(punkte, ergebnisse) if e is not None
+    ]
+    if not kms:
+        return None
+    return (min(kms), max(kms))
+```
+
+Aufruf und Anhängung passieren NACH der Fail-soft-Schleife aus E1, in JEDEM
+Zweig mit Messung (Zonen vorhanden, kein Regen, alle Folgepunkte aus) —
+nicht in den drei Zweigen ohne jede Messung (E6).
+
+**Neuer Kommando-Handler** (`trip_command_processor.py`, Muster `_show_now`):
+
+```python
+def _show_strecke(
+    self, trip: Trip, value: Optional[str], now_utc: datetime,
+    user_id: str, channel: str,
+) -> CommandResult:
+    """Regen-Ereignisflaechen entlang der Reststrecke (Issue #2051 S4)."""
+    from services.track_resolution import backfill_stage_distances
+    from services.trip_segments import (
+        points_along_remaining_route, points_from_km, resolve_current_segment,
+    )
+    today = trip_local_today(trip, now_utc)
+    trip = backfill_stage_distances(trip, user_id, today, persist=True)
+    resolved = resolve_current_segment(trip, now_utc, today)
+    if resolved is None:
+        return CommandResult(  # AC-18: wortgleich zu _show_now
+            success=False, command="strecke",
+            confirmation_subject=f"[{trip.name}] Kein heutiger Standort",
+            confirmation_body=(
+                "Keine heutige Etappe gefunden. "
+                "Aktueller Position/Standort unbekannt — "
+                "bitte Etappenplan prüfen."
+            ),
+            trip_name=trip.name,
+        )
+    active, segment_date = resolved
+    if not active.distance_measured:
+        # AC-17: vor jedem Nowcast-Aufruf, kein Budget verbraucht
+        ...
+    if value is not None:
+        # E5: Argument parsen und gegen [start_km, end_km] pruefen (AC-15/16)
+        ...
+        points = points_from_km(trip, active, segment_date, start_km)
+    else:
+        points = points_along_remaining_route(trip, active, segment_date, now_utc)
+    # E1: erster Punkt user_briefing, Folgepunkte polling + fail-soft
+    # ...ergebnisse sammeln...
+    # E7: spanne = _geprueft_spanne(points, ergebnisse), an jede der drei
+    # Messungs-Zweig-Antworten (Zonen/kein Regen/alle Folgepunkte aus) anhaengen
+    tz = tz_for_coords(points[0].lat, points[0].lon)
+    if channel == "email":
+        body = _fmt_strecke_email(zonen, tz, now_utc)  # now_utc = derselbe Anker
+    else:
+        body = _fmt_strecke_telegram(zonen, tz, now_utc)  # wie die Nowcast-Abrufe
+    ...
+```
+
+**Zwei neue Renderer** (`trip_command_processor.py`, je ein privater
+Formatierer, `now_utc` als expliziter Zeitanker — s. Abschnitt "Zeitanker
+der Renderer" oben, AC-23):
+
+```python
+def _fmt_strecke_email(
+    zonen: tuple["RainZone", ...], tz, now_utc: datetime,
+) -> str:
+    """Tabellarische Zeile je Zone: km-Spanne, Zeitspanne, Intensitaet,
+    Quelle (Issue #2051 S4, E3). `now_utc` ist der Abrufzeitpunkt, gegen den
+    die relativen `onset_minutes`/`event_end_minutes` in absolute HH:MM
+    umgerechnet werden -- IMMER derselbe Wert, den `_show_strecke` fuer die
+    Nowcast-Abrufe verwendet hat, NIE `datetime.now()`."""
+
+def _fmt_strecke_telegram(
+    zonen: tuple["RainZone", ...], tz, now_utc: datetime,
+) -> str:
+    """Verdichtete Fassung: eine Zeile je Zone, km-Spanne, Zeitspanne,
+    Intensitaet -- ohne Quelle-Spalte (Platzgrund, Issue #2051 S4). Derselbe
+    Zeitanker-Vertrag wie `_fmt_strecke_email`."""
+```
+
+**Registrierung** (drei Stellen, E4):
+
+```python
+# trip_command_processor.py:83
+_VALID_COMMANDS = {..., "strecke"}
+# trip_command_processor.py:87-102
+_BARE_KEYWORD_MAP = {..., "strecke": "strecke"}
+# trip_command_processor.py Dispatch (~line 525)
+elif key == "strecke":
+    return self._show_strecke(trip, value, msg.received_at, msg.user_id, msg.channel)
+# inbound_telegram_reader.py:37-57
+_SHORTCUT_MAP = {..., "/strecke": "strecke"}
+# trip_command_processor.py:_show_help (~line 1391)
+"  STRECKE [km]           – Regen-Ereignisflächen entlang der Reststrecke\n"
+```
+
+## Expected Behavior
+
+- **Input:** Trip, aktueller Zeitpunkt (`msg.received_at`, zugleich der
+  Abrufzeitpunkt `now_utc` für die Nowcast-Abrufe UND der Zeitanker, den
+  beide Renderer explizit als Parameter bekommen — E1/E3), Kanal
+  (`msg.channel` — `"email"`/`"telegram"`), optionales km-Argument (String
+  oder `None`), `user_id`.
+- **Output:**
+  - E-Mail-Antwort: eine Zeile je Regen-Ereignisfläche mit km-Spanne,
+    Zeitspanne (absolut, gegen den durchgereichten Anker berechnet),
+    Intensität und Quelle, plus abschließender
+    `Geprüft: km {von}-{bis}.`-Zeile (E7).
+  - Telegram-Antwort: eine verdichtete Zeile je Fläche (km-Spanne,
+    Zeitspanne, Intensität), plus dieselbe abschließende Geprüft-Zeile.
+  - Drei ehrliche Sonderfälle (E6): keine aktive Etappe, Segment unvermessen,
+    kein Regen erkannt — jeweils eigener, unterscheidbarer Text; im
+    Kein-Regen-Fall zusätzlich die geprüfte Spanne (E7).
+  - Ungültiges km-Argument: Ablehnung mit dem gültigen Bereich im Text, kein
+    Nowcast-Abruf, keine Spannen-Angabe (nichts wurde gemessen).
+  - Fallen alle Folgepunkte aus (E1): ehrlicher Hinweis, belegt durch die
+    (degenerierte) geprüfte Spanne `km X-X` (E7).
+- **Side effects:** bis zu `RADAR_ZONE_MAX_POINTS` `get_nowcast`-Aufrufe je
+  Kommando (gedeckelt, wie S2a), ein `backfill_stage_distances`-Schreibvorgang
+  (fail-soft, additiv, unabhängig vom Kommando-Ergebnis). Keine
+  Trip-Konfiguration wird verändert.
+
+## Acceptance Criteria
+
+- **AC-1:** Given zwei Telegram-Nachrichten mit identischem Kommando in
+  unterschiedlicher Schreibweise — (a) `strecke` (Freitext, kein Slash) und
+  (b) `/strecke` (Slash, Bot-Menü-Tap) / When beide durch
+  `InboundTelegramReader._parse_command` laufen / Then lösen BEIDE denselben
+  internen Schlüssel `("strecke", None)` auf — kein Unterschied zwischen
+  Freitext- und Slash-Eingabe.
+  - Test: Unit-Test gegen `_parse_command` mit beiden Eingaben, Assert auf
+    identisches Ergebnis. Bewacht: `inbound_telegram_reader.py:_SHORTCUT_MAP`
+    + `trip_command_processor.py:_BARE_KEYWORD_MAP`.
+
+- **AC-2:** Given eine E-Mail mit Body `STRECKE` als erste Zeile / When
+  `TripCommandProcessor().process()` mit `channel="email"` läuft / Then wird
+  `_show_strecke` aufgerufen (`result.command == "strecke"`, kein
+  "Unbekannter Befehl").
+  - Test: Unit-Test gegen `process()` mit `InboundMessage(channel="email",
+    body="STRECKE", ...)`, Assert auf `result.command`. Bewacht:
+    `trip_command_processor.py:_VALID_COMMANDS`, Dispatch-Zweig.
+
+- **AC-3:** Given den Befehl HILFE / When `_show_help()` läuft / Then
+  enthält der Text eine Zeile, die mit `"  STRECKE"` beginnt, mit einer
+  Kurzbeschreibung der Regen-Ereignisflächen entlang der Reststrecke.
+  - Test: Unit-Test gegen `_show_help`, Substring-Prüfung. Bewacht:
+    `trip_command_processor.py:_show_help`.
+
+- **AC-4:** Given ein aktives Segment mit Reststrecke 10 km (mehrere
+  geplante Punkte) UND einem simulierten Budgetstand von 85% (`allow
+  ("polling")` würde `False` liefern) / When `/strecke` verarbeitet wird /
+  Then liefert der ERSTE Abfragepunkt trotzdem ein Ergebnis, UND dessen
+  `get_nowcast`-Aufruf trägt `priority="user_briefing"`.
+  - Test: Unit-Test mit Budget-Fixture bei 85% Auslastung, Assert auf den
+    Prioritätsparameter des ersten Aufrufs. Bewacht:
+    `trip_command_processor.py:_show_strecke`.
+
+- **AC-5:** Given 4 geplante Punkte, wobei Punkt 3 (nicht Punkt 1) eine
+  Exception wirft / When `/strecke` verarbeitet wird / Then werden Punkt 2
+  und Punkt 4 dennoch mit `priority="polling"` abgefragt, UND die Antwort
+  enthält die aus den Punkten 1/2/4 gebildeten Zonen — das Kommando bricht
+  wegen des Einzelausfalls NICHT ab.
+  - Test: Unit-Test mit Fake-Service, der bei Index 3 wirft, Assert auf
+    Aufrufzahl UND enthaltene Zonen. Bewacht:
+    `trip_command_processor.py:_show_strecke` (Fail-soft-Schleife).
+
+- **AC-6:** Given eine Reststrecke von 1,5 km (unter der 2-km-Schwelle,
+  genau 1 geplanter Punkt), dieser liefert eine Nass-Zone / When `/strecke`
+  verarbeitet wird / Then meldet die Antwort diese eine Zone als normale
+  Streckenangabe, OHNE den Hinweis auf eine nicht ermittelbare Ausdehnung.
+  - Test: Unit-Test mit 1-Punkt-Fixture, Assert dass die Zonen-Zeile
+    erscheint UND der AC-7-Hinweistext fehlt. Bewacht:
+    `trip_command_processor.py:_show_strecke`.
+
+- **AC-7:** Given 6 geplante Punkte bei den km-Werten 0, 2, 4, 6, 8, 10
+  (Reststrecke 12 km), von denen NUR der erste (km 0) ein Ergebnis liefert
+  (Punkte 2-6 alle `throttled`/Exception) / When `/strecke` verarbeitet
+  wird / Then enthält die Antwort exakt `"Ausdehnung entlang der
+  Reststrecke konnte nicht ermittelt werden — nur der Startpunkt lieferte
+  Daten. Geprüft: km 0-0."` — die degenerierte Spanne (E7) belegt den
+  Hinweistext mit einem konkreten Wert — und KEINE km-Zonen-Angabe.
+  - Test: Unit-Test mit 6-Punkte-Fixture (Punkte 2-6 liefern `None`),
+    Volltextvergleich (inkl. der Geprüft-Zeile) UND Negativ-Prüfung, dass
+    kein `RainZone`-Muster (`"Nass km"`) vorkommt. Bewacht:
+    `trip_command_processor.py:_show_strecke`.
+
+- **AC-8:** Given 3 zusammenhängende nasse Punkte einer Zone mit den
+  Intensitäten "Leichter Regen", "Starker Regen", "Mäßiger Regen" (in
+  dieser Reihenfolge entlang der Strecke) / When die Zone gebildet wird /
+  Then trägt `RainZone.intensity_label == "Starker Regen"` — der stärkste
+  Wert, unabhängig von seiner Position.
+  - Test: Unit-Test gegen `derive_rain_zones` mit den drei Intensitäten als
+    Fixture-Ergebnisse. Bewacht: `rain_extent.py:derive_rain_zones`.
+
+- **AC-9:** Given zwei Fälle: (a) zwei nasse Punkte einer Zone mit
+  identischer Quelle `"radar"`, (b) zwei nasse Punkte einer Zone mit den
+  Quellen `"INCA"` (erster/km-kleinster Punkt) und `"radar"` (zweiter
+  Punkt) / When beide Zonen gebildet werden / Then trägt Zone (a)
+  `RainZone.source == "radar"`, Zone (b) `RainZone.source == "INCA"` — NICHT
+  `"radar"`.
+  - Test: Unit-Test gegen `derive_rain_zones` mit beiden Fixtures, je
+    Fall Assert auf `zone.source`, Negativ-Prüfung für Fall (b). Bewacht:
+    `rain_extent.py:derive_rain_zones`.
+
+- **AC-10:** Given die bestehenden S2a/S2b-Testfixtures für
+  `derive_rain_zones()` und die sieben gerenderten Alarm-Textstellen
+  (`render.py`) / When der Alarm-Pfad mit diesen Fixtures unverändert
+  läuft / Then bleiben `RainZone.km_from/km_to/onset_minutes/
+  event_end_minutes` UND alle sieben gerenderten Texte byte-identisch zum
+  Stand vor dieser Spec — die neuen Felder `intensity_label`/`source`
+  werden dort nicht gelesen.
+  - Test: Regressionslauf von `test_regen_ausdehnung_zonenbildung.py` und
+    `test_regen_ausdehnung_textstellen.py` ohne Fixture-Änderung — müssen
+    unverändert grün bleiben. Bewacht: `rain_extent.py`, `render.py`
+    (Nicht-Berührung).
+
+- **AC-11:** Given zwei Zonen (km 8-12, "Mäßiger Regen", Quelle "INCA",
+  Zeitspanne 15:00-16:30; km 19-21, "Starker Regen", Quelle "radar",
+  Zeitspanne 17:10-17:40) / When die E-Mail-Antwort gerendert wird / Then
+  enthält der Text für JEDE Zone eine eigene Zeile mit allen vier Werten —
+  konkret Zeile 1 mit `km 8-12`, `15:00-16:30`, `Mäßiger Regen`, `INCA`,
+  Zeile 2 entsprechend mit den Werten der zweiten Zone.
+  - Test: Unit-Test gegen `_fmt_strecke_email` mit der Zwei-Zonen-Fixture,
+    Substring-Prüfung beider vollständigen Zeilen, Sollstrings aus den
+    Fixture-Werten abgeleitet. Bewacht: `trip_command_processor.py`.
+
+- **AC-12:** Given denselben Zwei-Zonen-Aufbau wie AC-11 / When die
+  Telegram-Antwort gerendert wird / Then enthält der Text GENAU zwei
+  Zeilen (eine je Fläche), UND alle aus beiden Texten extrahierten km-Zahlen
+  UND Uhrzeiten (Regex) stimmen zwischen E-Mail- und Telegram-Fassung exakt
+  überein.
+  - Test: Paritätstest (Muster `test_onset_menge_kanalparitaet.py`):
+    Regex-Extraktion der Zahlenpaare aus beiden Texten, Gleichheitsprüfung.
+    Bewacht: `trip_command_processor.py` (beide Renderer gemeinsam).
+
+- **AC-13:** Given ein aktives Segment mit `start_point.distance_from_
+  start_km=3.0`, `end_point.distance_from_start_km=8.0`,
+  `distance_measured=True` UND dem Kommando `/strecke 5` / When die
+  Abfragepunkte gebildet werden / Then liegt der ERSTE Punkt bei
+  `distance_from_start_km == 5.0` — NICHT an der über `position_at_time`
+  bestimmten Planposition.
+  - Test: Unit-Test gegen `points_from_km`, Assert auf den exakten km-Wert
+    des ersten erzeugten Punkts. Bewacht: `trip_segments.py:points_from_km`.
+
+- **AC-14:** Given dasselbe Segment wie AC-13, Kommando `/strecke 8`
+  (exakt `end_point`-km, oberer Rand des gültigen Bereichs eingeschlossen) /
+  When verarbeitet wird / Then entsteht GENAU EIN Punkt bei km 8.0
+  (Reststrecke=0 innerhalb des Segments) — gültige, wenn auch entartete
+  Anfrage, KEINE Fehlermeldung.
+  - Test: Unit-Test mit km=8.0, Assert auf genau 1 erzeugten Punkt UND
+    `result.success is True`. Bewacht: `trip_segments.py:points_from_km`,
+    `trip_command_processor.py:_show_strecke`.
+
+- **AC-15:** Given dasselbe Segment (gültiger Bereich 3–8 km) mit drei
+  Kommandos: `/strecke 8.1` (über der oberen Grenze), `/strecke 2.9` (unter
+  der unteren Grenze), `/strecke abc` (nicht-numerisch) / When jedes
+  verarbeitet wird / Then liefert JEDES exakt den Text `"Ungültige
+  km-Angabe. Gültiger Bereich für die aktuelle Etappe: 3–8 km."` UND in
+  KEINEM der drei Fälle erfolgt ein `get_nowcast`-Aufruf.
+  - Test: Drei Unit-Tests (oder parametrisiert) gegen `_show_strecke`, je
+    Volltextvergleich UND Assert `nowcast_spy.call_count == 0`. Bewacht:
+    `trip_command_processor.py:_show_strecke` (Argument-Validierung).
+
+- **AC-16:** Given dasselbe Segment, Kommando `/strecke 5.5` / When
+  verarbeitet wird / Then liegt der erste erzeugte Punkt exakt bei km 5.5 —
+  Dezimalwerte werden akzeptiert und nicht auf ganze km gerundet.
+  - Test: Unit-Test mit km=5.5, Assert auf den exakten Fließkommawert.
+    Bewacht: `trip_segments.py:points_from_km`.
+
+- **AC-17:** Given ein aktives Segment, das auch nach dem Backfill-Versuch
+  `distance_measured=False` bleibt, in zwei Varianten: (a) `/strecke` ohne
+  Argument, (b) `/strecke 5` mit Argument / When beide verarbeitet werden /
+  Then liefert (a) exakt `"Kilometrierung für die heutige Etappe nicht
+  verfügbar — keine Streckenangabe möglich."`, (b) exakt `"Kilometrierung
+  für die heutige Etappe nicht verfügbar — die km-Angabe kann nicht
+  ausgewertet werden."` — UND in BEIDEN Fällen erfolgt KEIN
+  `get_nowcast`-Aufruf UND KEINE `Geprüft:`-Zeile (nichts wurde gemessen).
+  - Test: Zwei Unit-Tests mit `distance_measured=False`-Fixture (simulierter
+    Backfill-Fehlschlag), Volltextvergleich je Variante, Assert
+    `nowcast_spy.call_count == 0` UND Negativ-Prüfung auf `"Geprüft:"`.
+    Bewacht: `trip_command_processor.py:_show_strecke` (Gate vor jedem
+    Aufruf).
+
+- **AC-18:** Given keinen auflösbaren Standort für heute
+  (`resolve_current_segment` liefert `None`, analog zur `/jetzt`-Situation) /
+  When `/strecke` verarbeitet wird / Then ist `result.confirmation_body`
+  TEXTIDENTISCH zu dem Text, den `_show_now` in derselben Situation liefert
+  (`"Keine heutige Etappe gefunden. Aktueller Position/Standort unbekannt —
+  bitte Etappenplan prüfen."`) — insbesondere ohne jede `Geprüft:`-Zeile.
+  - Test: Unit-Test mit fehlgeschlagener Segmentauflösung, String-Gleichheit
+    gegen den bekannten `_show_now`-Text. Bewacht:
+    `trip_command_processor.py:_show_strecke`.
+
+- **AC-19:** Given ein vermessenes aktives Segment mit 4 geplanten Punkten
+  bei km 0, 2, 4, 6 (illustrativ — entscheidend ist nicht die konkrete
+  km-Lage, sondern dass die Werte aus den ERFOLGREICH abgefragten Punkten
+  abgeleitet werden, s. AC-21; km 0 als Startwert gewählt, da der
+  argumentlose Pfad den ersten Punkt nur im ERSTEN Segment einer Etappe
+  driftfrei exakt am Segmentanfang liefert — spätere Segmente sind über die
+  reale Zeit-Segmentwahl nicht mit p=0 erreichbar), bei denen ALLE ein
+  Ergebnis liefern und ALLE trocken sind (`onset_minutes is None`, kein
+  `data_unavailable`) / When `/strecke` verarbeitet wird / Then enthält die
+  Antwort exakt `"Kein Regen entlang des geprüften Abschnitts erkannt.
+  Geprüft: km 0-6."` — die Aussage bezieht sich ausdrücklich auf den
+  GEPRÜFTEN Abschnitt (E7), nicht pauschal auf "die Reststrecke" bis zum
+  Etappenziel, und der Wortlaut unterscheidet sich klar von AC-7
+  (Ausdehnung nicht ermittelbar) und AC-17 (Kilometrierung fehlt).
+  - Test: Unit-Test mit vollständig trockener 4-Punkte-Fixture (km 0-6),
+    Volltextvergleich inkl. der Geprüft-Zeile mit den aus der Fixture
+    abgeleiteten Grenzwerten. Bewacht: `trip_command_processor.py:
+    _show_strecke`.
+
+- **AC-20:** Given eine beliebige Zonen-Antwort in E-Mail- ODER
+  Telegram-Fassung mit gesetzten Zonen / When der Text auf eine Liste
+  verbotener Muster geprüft wird (Ankunftszeit-Rechnung,
+  Handlungsempfehlung, Begegnungspunkt-Aussage — dieselbe Musterliste wie
+  S2a-AC-16/S2b-AC-14) / Then enthält der Text KEINES dieser Muster —
+  ausschließlich km-Spannen, Uhrzeiten, Intensität, Quelle und die
+  geprüfte Spanne.
+  - Test: Unit-Test über beide Renderer-Ausgaben mit gesetzten Zonen,
+    Negativ-Prüfung gegen die bestehende Musterliste. Bewacht:
+    `trip_command_processor.py` (beide neuen Renderer).
+
+- **AC-21 (E7):** Given 4 geplante Punkte bei km 0, 2, 4, 6 (dieselbe
+  illustrative Fixture-Wahl wie AC-19 — km 0 als erster Punkt des ersten
+  Segments), von denen der LETZTE (km 6) eine Exception wirft, die übrigen
+  drei (km 0, 2, 4) liefern Daten (mindestens einer nass, damit eine
+  Zonen-Antwort entsteht) / When `/strecke` verarbeitet wird / Then nennt
+  die Antwort exakt `"Geprüft: km 0-4."` — abgeleitet aus dem kleinsten und
+  größten km-Wert der ERFOLGREICH abgefragten Punkte (0 und 4), NICHT aus
+  dem geplanten Maximum (6).
+  - Test: Unit-Test mit 4-Punkte-Fixture, Punkt bei km 6 wirft, Substring-
+    Prüfung auf exakt `"Geprüft: km 0-4."` UND Negativ-Prüfung, dass
+    `"km 0-6"` nicht vorkommt (die Bildungsstelle wird aus den
+    tatsächlichen Ergebnissen gespeist, nicht aus der Planung). Bewacht:
+    `trip_command_processor.py:_geprueft_spanne`.
+
+- **AC-22 (E7, Positivkontrolle):** Given zwei Fälle mit identischem
+  Trip-/Zeit-Aufbau bis auf einen Unterschied: (a) `distance_measured=False`
+  bleibt nach dem Backfill-Versuch (AC-17-Konstellation, kein
+  Nowcast-Abruf), (b) derselbe Aufbau, aber `distance_measured=True`
+  (mindestens 1 Punkt liefert Daten) / When beide Antworten erzeugt werden
+  / Then enthält Antwort (a) KEINE `"Geprüft:"`-Zeile, während Antwort (b)
+  — bei sonst identischem Aufbau — eine `"Geprüft: km"`-Zeile mit dem
+  erwarteten Wert trägt.
+  - Test: Testpaar mit identischem Aufbau bis auf `distance_measured`,
+    Negativ-Prüfung für (a), Positiv-Prüfung mit exaktem Wert für (b) im
+    selben Test (Muster S2b-AC-6) — belegt, dass das Fehlen in (a) eine
+    echte Weiche ist und nicht schlicht ein nirgends implementierter Text.
+    Bewacht: `trip_command_processor.py:_show_strecke`.
+
+- **AC-23 (Zeitanker der Renderer, Nachtrag):** Given eine identische
+  Zonen-Fixture (eine Zone mit `onset_minutes=30`, `event_end_minutes=90`)
+  UND zwei verschiedene Ankerzeitpunkte `now_utc`: (a)
+  `2026-08-23T12:00:00Z`, (b) `2026-08-23T12:47:00Z` (47 Minuten später) /
+  When derselbe Renderer (`_fmt_strecke_email` bzw. `_fmt_strecke_telegram`)
+  einmal mit Anker (a) und einmal mit Anker (b) auf DIESELBE Zonen-Fixture
+  angewendet wird / Then unterscheiden sich sowohl die gerenderte
+  BEGINN-Uhrzeit ALS AUCH die gerenderte ENDE-Uhrzeit zwischen beiden
+  Läufen um EXAKT 47 Minuten — konkret Fall (a) Beginn `12:30`/Ende `13:30`,
+  Fall (b) Beginn `13:17`/Ende `14:17` — die Uhrzeit wird aus dem
+  ÜBERGEBENEN Anker abgeleitet, nicht aus der Systemuhr; ein Rückfall auf
+  `datetime.now()` würde bei zwei im selben Testlauf ausgeführten Aufrufen
+  eine Differenz nahe 0 statt exakt 47 Minuten ergeben und beide Prüfungen
+  (Beginn UND Ende) rot färben.
+  - Test: Zwei Unit-Tests (oder ein Testpaar) gegen `_fmt_strecke_email`
+    UND `_fmt_strecke_telegram` mit identischer Zonen-Fixture und den zwei
+    Ankerwerten, JE ZWEI Asserts (Beginn-Differenz UND Ende-Differenz
+    exakt 47 Minuten) statt eines pauschalen Textvergleichs — eine
+    Implementierung, die nur eine der beiden Zeitangaben korrekt aus dem
+    Anker ableitet, die andere aber aus einer zweiten Quelle bezieht, wird
+    dadurch separat gefangen. Bewacht:
+    `trip_command_processor.py:_fmt_strecke_email`/`_fmt_strecke_telegram`
+    (Zeitanker-Parameter, s. E3-Nachtrag).
+
+## Known Limitations
+
+- **Die Antwort deckt nur das aktuell aktive Wegpunkt-Segment ab, nicht die
+  volle Resttagesetappe** (Bestandseigenschaft aus S2a — der Alarm-Pfad hat
+  dieselbe Grenze, `_remaining_km()`/`points_along_remaining_route()`
+  rechnen ausschließlich innerhalb von `active`). Diese Scheibe behebt die
+  Grenze **nicht** — der live laufende Alarm-Pfad wird kurz vor Tourstart
+  bewusst nicht angefasst —, macht sie aber über E7 (`Geprüft: km ...`)
+  für den Nutzer **sichtbar** statt sie zu verschweigen. Die Aufhebung
+  dieser Grenze (mehrsegmentige Traversierung bis zum Etappenziel) ist
+  eine eigene, spätere Arbeit.
+- **km-Argument nur innerhalb des aktuell aktiven Segments adressierbar**
+  (eigene Festlegung E5), aus demselben Grund — siehe oben.
+- **Kein SMS-/Premium-SMS-Kanal für `/strecke`.** Beide sind keine
+  Inbound-Kommando-Kanäle in diesem System (Premium-SMS ist reiner
+  Sendekanal) — das ist keine Lücke dieser Scheibe, sondern eine
+  bestehende Systemgrenze.
+- **Messlücken bleiben unmarkiert** (S2a Known Limitation, unverändert) —
+  ein Punkt ohne Daten fällt still aus der Zonenbildung heraus. E7 macht
+  nur die AUSSENGRENZE der Messung sichtbar (welcher km-Bereich überhaupt
+  geprüft wurde), nicht einzelne Lücken innerhalb dieses Bereichs.
+- **Kein Wiederholungs-Rate-Limit für das Kommando selbst.** Der
+  300-Sekunden-Nowcast-Cache dämpft wiederholte Abfragen teilweise, der
+  Telegram-Rate-Limit (18/60s) bremst nur den Versand. Ein Nutzer kann
+  `/strecke` beliebig oft hintereinander senden — jedes Mal zählt gegen das
+  Tagesbudget (mit `polling`-Priorität für die Folgepunkte, gedeckelt).
+- **Ortsvergleich bleibt ohne `/strecke`** — kein Streckenkonzept
+  (unverändert seit S2a/S2b).
+
+## Nicht-Ziele
+
+- Handlungsempfehlungen jeder Art.
+- Rechnungen über den Nutzer: Ankunftszeiten, Begegnungspunkte,
+  Ausweichfenster.
+- GPS-Ortung oder Check-in-Pflicht.
+- Änderungen an bestehenden Alarm-Textstellen oder an
+  `_onset_extent_suffix()`/`_sms_onset_extent_suffix()` (S2a/S2b sind live).
+- Änderungen am `/jetzt`-Pfad (`_show_now`) und am Briefing-
+  Kurzfristhinweis (`starkregen_hint.py`).
+- Änderungen an der Trip-Konfiguration des Product Owners.
+- Ortsvergleich: kein Streckenkonzept, `/strecke` gilt nur für Trips.
+- SMS/Premium-SMS als Antwortkanal für `/strecke` (kein Inbound-Kanal für
+  diese beiden).
+- Mehrsegmentige Traversierung über das aktuell aktive Segment hinaus beim
+  km-Argument, bzw. eine Erweiterung der Reststrecken-Reichweite auf die
+  volle Resttagesetappe (s. Known Limitations) — insbesondere keine
+  Änderung an `_remaining_km()`/`points_along_remaining_route()` selbst,
+  die den live laufenden Alarm-Pfad beträfe.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Ein neues **Kommando** über zwei bereits bestehende
+  Inbound-Kanäle (Telegram, E-Mail) — keine der vier Output-Kanäle
+  (ADR-0049) wird verändert oder erweitert, es kommt kein neuer Kanal
+  hinzu. Die Datenbausteine (`RainZone`, `derive_rain_zones`,
+  `points_along_remaining_route`) sind additiv erweitert, keine bestehende
+  Signatur ändert sich. Kein neuer Provider, keine Persistenz-Änderung
+  außer der bereits etablierten, fail-soften `backfill_stage_distances`-
+  Nachrüstung. Berührt keine der vier Entscheidungsflächen, die ein neues
+  ADR verlangen würden.
+
+## Changelog
+
+- 2026-08-23: Initial spec created (#2051 Scheibe S4, Inbound-Kommando
+  `/strecke` — zwei Eingangskanäle, Prioritäts-/Budget-Regel E1, additive
+  `RainZone`-Felder E2, zwei neue Renderer E3, km-Argument E5, drei ehrliche
+  Sonderfälle E6).
+- 2026-08-23 (v1.1): E7 nachgetragen (Adversary-Befund team-lead) — die
+  geprüfte Streckenspanne wird als eigenes Datum ausgegeben, weil die
+  Antwort strukturell nur bis zum Ende des aktuell aktiven Segments reicht,
+  nicht bis zum Etappenziel. AC-19 umformuliert (nennt jetzt die geprüfte
+  Spanne statt pauschal "die Reststrecke" zu behaupten), AC-7
+  entsprechend ergänzt, zwei neue ACs (AC-21 Bildung aus erfolgreich statt
+  geplant abgefragten Punkten, AC-22 Positivkontrolle Messung vs. keine
+  Messung). AC-Zahl 20 → 22. Known Limitations/Nicht-Ziele um die
+  Segment-Grenze ergänzt.
+- 2026-08-23 (v1.2): Zeitanker-Korrektur aus der RED-Phase (team-lead-
+  Befund) — beide Renderer bekommen `now_utc` als expliziten dritten
+  Parameter statt selbst die Systemuhr zu lesen (relative
+  `onset_minutes`/`event_end_minutes` müssen gegen denselben Zeitpunkt
+  umgerechnet werden, gegen den die Nowcasts abgerufen wurden). Neues
+  AC-23 (Zeitanker, zwei verschiedene `now_utc`-Werte ergeben exakt
+  verschobene Uhrzeiten). AC-Zahl 22 → 23. Illustrative km-Werte in AC-19/
+  AC-21 auf 0/2/4/6 nachgezogen (Testkonstruktion: der argumentlose Pfad
+  erreicht den Segmentanfang driftfrei nur im ersten Segment einer
+  Etappe) — die geprüfte Zusicherung selbst (Ableitung aus erfolgreich
+  abgefragten statt geplanten Punkten) ist davon unberührt.
+- 2026-08-23 (v1.3): AC-23 an die tatsächlich in der RED-Phase gebauten
+  Tests angeglichen (team-lead-Rückfrage) — Ankerdifferenz von 10 auf 47
+  Minuten korrigiert, UND die Zusicherung explizit auf BEIDE Zeitwerte
+  (Beginn UND Ende der Zone) statt eines pauschalen Textvergleichs
+  ausgeweitet, damit eine Implementierung, die nur einen der beiden Werte
+  korrekt aus dem Anker ableitet, ebenfalls auffällt. Keine Änderung an
+  Renderer-Signaturen oder sonstigen ACs.

--- a/src/services/inbound_telegram_reader.py
+++ b/src/services/inbound_telegram_reader.py
@@ -54,6 +54,7 @@ _SHORTCUT_MAP = {
     "/timeline_heute": "timeline_heute",
     "/timeline_morgen": "timeline_morgen",
     "/hilfe": "hilfe",
+    "/strecke": "strecke",  # Issue #2051 S4
 }
 
 

--- a/src/services/rain_extent.py
+++ b/src/services/rain_extent.py
@@ -18,9 +18,27 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Sequence
 
+from services.radar_service import (
+    INTENSITY_CONVECTIVE,
+    INTENSITY_HEAVY,
+    INTENSITY_LIGHT,
+    INTENSITY_MODERATE,
+)
+
 if TYPE_CHECKING:  # pragma: no cover — nur fuer Typpruefung
     from app.models import GPXPoint
     from services.radar_service import NowcastResult
+
+# Issue #2051 S4 (E2): Rangfolge fuer den staerksten Intensitaetswert einer
+# Zone. `INTENSITY_DRY` kommt in einer Zone strukturell nicht vor -- nur
+# nasse Punkte (`onset_minutes is not None`) gehen ueberhaupt in die
+# Zonenbildung ein.
+_INTENSITY_RANK = {
+    INTENSITY_LIGHT: 0,
+    INTENSITY_MODERATE: 1,
+    INTENSITY_HEAVY: 2,
+    INTENSITY_CONVECTIVE: 3,
+}
 
 
 @dataclass(frozen=True)
@@ -36,11 +54,18 @@ class RainZone:
     Beginn und spaetestes Ende unter ihren eigenen Punkten, nie eine globale
     Spanne ueber mehrere Zonen (AC-6). `event_end_minutes` ist `None`, wenn
     kein Punkt der Zone ein Ende kennt.
+
+    `intensity_label`/`source` sind additiv (Issue #2051 S4, E2): der
+    staerkste Intensitaetswert bzw. die rohe Quelle des km-kleinsten Punkts
+    der Zone. Beide tragen den Default `""`, bestehende S2a/S2b-Konstruktionen
+    (alle mit Keyword-Argumenten) bleiben unveraendert lauffaehig.
     """
     km_from: float
     km_to: float
     onset_minutes: int
     event_end_minutes: int | None
+    intensity_label: str = ""
+    source: str = ""
 
 
 def derive_rain_zones(
@@ -54,21 +79,31 @@ def derive_rain_zones(
     uebersprungen, jeder uebrige trockene Punkt schliesst die laufende Zone.
     """
     zonen: list[RainZone] = []
-    laufend: list[tuple[float, int, int | None]] = []
+    laufend: list[tuple[float, int, int | None, str, str]] = []
 
     def _abschliessen() -> None:
         if not laufend:
             return
         zonen.append(
             RainZone(
-                km_from=min(k for k, _o, _e in laufend),
-                km_to=max(k for k, _o, _e in laufend),
-                onset_minutes=min(o for _k, o, _e in laufend),
+                km_from=min(k for k, _o, _e, _i, _s in laufend),
+                km_to=max(k for k, _o, _e, _i, _s in laufend),
+                onset_minutes=min(o for _k, o, _e, _i, _s in laufend),
                 event_end_minutes=(
-                    max(e for _k, _o, e in laufend if e is not None)
-                    if any(e is not None for _k, _o, e in laufend)
+                    max(e for _k, _o, e, _i, _s in laufend if e is not None)
+                    if any(e is not None for _k, _o, e, _i, _s in laufend)
                     else None
                 ),
+                # Issue #2051 S4 (E2): staerkster Wert unter den Punkten der
+                # Zone, unabhaengig von seiner Position.
+                intensity_label=max(
+                    (i for _k, _o, _e, i, _s in laufend),
+                    key=lambda label: _INTENSITY_RANK.get(label, -1),
+                ),
+                # Issue #2051 S4 (E2): rohe Quelle des ERSTEN (km-kleinsten)
+                # Punkts -- `laufend` wird in Punkt-Reihenfolge (aufsteigende
+                # km) befuellt, kein Mehrheitsentscheid.
+                source=laufend[0][4],
             )
         )
         laufend.clear()
@@ -85,6 +120,8 @@ def derive_rain_zones(
                 punkt.distance_from_start_km,
                 onset,
                 getattr(ergebnis, "event_end_minutes", None),
+                getattr(ergebnis, "intensity_label", ""),
+                getattr(ergebnis, "source", ""),
             )
         )
     _abschliessen()

--- a/src/services/trip_command_processor.py
+++ b/src/services/trip_command_processor.py
@@ -80,7 +80,7 @@ class CommandResult:
 
 _COMMAND_PATTERN = re.compile(r"^###\s+(\S+?)(?:[:\s]\s*(.+))?$")
 
-_VALID_COMMANDS = {"ruhetag", "report", "startdatum", "abbruch", "status", "hilfe", "now", "weiter", "pause", "skip"}
+_VALID_COMMANDS = {"ruhetag", "report", "startdatum", "abbruch", "status", "hilfe", "now", "weiter", "pause", "skip", "strecke"}
 
 # Bare-keyword mapping (case-insensitive): keyword → internal key
 # Kanalübergreifender Grundbefehlssatz (Issue #731): HEUTE/MORGEN/JETZT/GEWITTER/RUHETAG/STATUS/STOP/WEITER/HILFE/PAUSE/SKIP
@@ -99,6 +99,7 @@ _BARE_KEYWORD_MAP = {
     "glance":   "glance",
     "pause":    "pause",
     "skip":     "skip",
+    "strecke":  "strecke",
 }
 
 _PAUSE_DURATION_RE = re.compile(r"^(\d+)\s*([dh]?)$")
@@ -523,6 +524,8 @@ class TripCommandProcessor:
             return self._apply_pause(trip, value, msg.user_id)
         elif key == "skip":
             return self._apply_skip(trip, msg.user_id)
+        elif key == "strecke":
+            return self._show_strecke(trip, value, msg.received_at, msg.user_id, msg.channel)
 
         # Should not reach here due to whitelist check above
         return CommandResult(
@@ -1382,6 +1385,7 @@ class TripCommandProcessor:
             "  MORGEN                – Wetter der morgigen Etappe\n"
             "  JETZT                 – Nowcast Regen/Gewitter nächste ~2h\n"
             "  GEWITTER              – Gewittergefahr heutige Etappe\n"
+            "  STRECKE [km]           – Regen-Ereignisflächen entlang der Reststrecke\n"
             "  RUHETAG [N]           – Etappen um N Tage verschieben (Standard: 1)\n"
             "  STATUS                – Heute und kommende Etappen\n"
             "  PAUSE [2d / 12h]      – Briefings für Dauer unterbrechen\n"
@@ -1587,6 +1591,161 @@ class TripCommandProcessor:
             reply_markup={"inline_keyboard": [[{"text": "🔄 Aktualisieren", "callback_data": "now"}]]},
         )
 
+    def _show_strecke(
+        self, trip: Trip, value: Optional[str], now_utc: datetime,
+        user_id: str, channel: str,
+    ) -> CommandResult:
+        """Regen-Ereignisflaechen entlang der Reststrecke (Issue #2051 S4).
+
+        Drei ehrliche Sonderfaelle VOR jedem Nowcast-Aufruf (E6): keine
+        aktive Etappe (wortgleich zu `_show_now`, AC-18), unvermessene
+        Kilometrierung (AC-17), ungueltiges km-Argument (AC-15/16). Der
+        erste Abfragepunkt faehrt `priority="user_briefing"` (nie
+        gedrosselt), die Folgepunkte `priority="polling"` und fallen
+        fail-soft aus (E1). Jede Antwort MIT Messung traegt zusaetzlich die
+        tatsaechlich geprueften km-Grenzen (E7).
+        """
+        from services.radar_service import RadarNowcastService
+        from services.rain_extent import derive_rain_zones
+        from services.track_resolution import backfill_stage_distances
+        from services.trip_alert import _zonen_messwert
+        from services.trip_segments import (
+            points_along_remaining_route, points_from_km, resolve_current_segment,
+        )
+        from utils.timezone import tz_for_coords
+
+        today = trip_local_today(trip, now_utc)
+        trip = backfill_stage_distances(trip, user_id, today, persist=True)
+        resolved = resolve_current_segment(trip, now_utc, today)
+        if resolved is None:
+            return CommandResult(  # AC-18: wortgleich zu _show_now
+                success=False, command="strecke",
+                confirmation_subject=f"[{trip.name}] Kein heutiger Standort",
+                confirmation_body=(
+                    "Keine heutige Etappe gefunden. "
+                    "Aktueller Position/Standort unbekannt — "
+                    "bitte Etappenplan prüfen."
+                ),
+                trip_name=trip.name,
+            )
+        active, segment_date = resolved
+
+        if not active.distance_measured:
+            # AC-17: geprueft VOR jedem Nowcast-Aufruf -- kein Budget wird
+            # fuer eine Antwort verbraucht, die ohnehin nicht kommen kann.
+            body = (
+                "Kilometrierung für die heutige Etappe nicht verfügbar — "
+                "keine Streckenangabe möglich."
+                if value is None else
+                "Kilometrierung für die heutige Etappe nicht verfügbar — "
+                "die km-Angabe kann nicht ausgewertet werden."
+            )
+            return CommandResult(
+                success=False, command="strecke",
+                confirmation_subject=f"[{trip.name}] Kilometrierung fehlt",
+                confirmation_body=body,
+                trip_name=trip.name,
+            )
+
+        if value is not None:
+            # E5: Bereich [start_point-km, end_point-km] des aktiven
+            # Segments, oberer Rand eingeschlossen (AC-14). Ungueltige
+            # Eingaben werden abgelehnt, nicht geklemmt (AC-15/16).
+            seg_start_km = active.start_point.distance_from_start_km
+            seg_end_km = active.end_point.distance_from_start_km
+            try:
+                start_km = float(value)
+            except ValueError:
+                start_km = None
+            if start_km is None or not (seg_start_km <= start_km <= seg_end_km):
+                return CommandResult(
+                    success=False, command="strecke",
+                    confirmation_subject=f"[{trip.name}] Ungültige km-Angabe",
+                    confirmation_body=(
+                        "Ungültige km-Angabe. Gültiger Bereich für die "
+                        f"aktuelle Etappe: {int(round(seg_start_km))}"
+                        f"–{int(round(seg_end_km))} km."
+                    ),
+                    trip_name=trip.name,
+                )
+            points = points_from_km(trip, active, segment_date, start_km)
+        else:
+            points = points_along_remaining_route(trip, active, segment_date, now_utc)
+
+        # E1: erster Punkt user_briefing (nie gedrosselt), Folgepunkte
+        # polling + fail-soft (Muster trip_alert.py:1748-1770).
+        svc = RadarNowcastService()
+        ergebnisse: list = []
+        for i, p in enumerate(points):
+            prio = "user_briefing" if i == 0 else "polling"
+            elevation_m = (
+                int(round(p.elevation_m)) if p.elevation_m is not None else None
+            )
+            try:
+                result = svc.get_nowcast(
+                    p.lat, p.lon, elevation_m=elevation_m, priority=prio,
+                )
+            except Exception as e:
+                logger.warning(
+                    "Strecke-Kommando: Nowcast fuer Punkt %d (km %.1f) des "
+                    "Trips %s fehlgeschlagen (%s) -- der Punkt faellt aus "
+                    "der Ausdehnung heraus, das Kommando laeuft weiter.",
+                    i, p.distance_from_start_km, trip.id, e,
+                )
+                ergebnisse.append(None)
+                continue
+            ergebnisse.append(_zonen_messwert(result))
+
+        spanne = _geprueft_spanne(points, ergebnisse)
+        geprueft_zeile = (
+            f"Geprüft: km {int(round(spanne[0]))}-{int(round(spanne[1]))}."
+            if spanne is not None else ""
+        )
+
+        # E1: fallen ALLE Folgepunkte aus, obwohl mehr als einer geplant
+        # war, gibt es keine km-Zonen-Angabe (AC-7) -- genau 1 geplanter
+        # Punkt ist dagegen der volle Messumfang, kein Ausfall (AC-6).
+        folgepunkte = ergebnisse[1:]
+        if len(points) > 1 and folgepunkte and all(e is None for e in folgepunkte):
+            text = (
+                "Ausdehnung entlang der Reststrecke konnte nicht ermittelt "
+                "werden — nur der Startpunkt lieferte Daten."
+            )
+            if geprueft_zeile:
+                text = f"{text} {geprueft_zeile}"
+            return CommandResult(
+                success=True, command="strecke",
+                confirmation_subject=f"[{trip.name}] Strecke",
+                confirmation_body=text,
+                trip_name=trip.name,
+            )
+
+        zonen = tuple(derive_rain_zones(points, ergebnisse))
+        if not zonen:
+            text = "Kein Regen entlang des geprüften Abschnitts erkannt."
+            if geprueft_zeile:
+                text = f"{text} {geprueft_zeile}"
+            return CommandResult(
+                success=True, command="strecke",
+                confirmation_subject=f"[{trip.name}] Strecke",
+                confirmation_body=text,
+                trip_name=trip.name,
+            )
+
+        tz = tz_for_coords(points[0].lat, points[0].lon)
+        body = (
+            _fmt_strecke_email(zonen, tz, now_utc) if channel == "email"
+            else _fmt_strecke_telegram(zonen, tz, now_utc)
+        )
+        if geprueft_zeile:
+            body = f"{body}\n{geprueft_zeile}"
+        return CommandResult(
+            success=True, command="strecke",
+            confirmation_subject=f"[{trip.name}] Strecke",
+            confirmation_body=body,
+            trip_name=trip.name,
+        )
+
     def _cancel_trip(self, trip: Trip, user_id: str = "default") -> CommandResult:
         """Disable report scheduling for the trip."""
         if trip.report_config:
@@ -1674,3 +1833,70 @@ class TripCommandProcessor:
             ):
                 return True
         return False
+
+
+# ---------------------------------------------------------------------------
+# /strecke: Streckenspanne + Renderer (Issue #2051 S4, E3/E7)
+# ---------------------------------------------------------------------------
+
+def _geprueft_spanne(
+    punkte: list, ergebnisse: list,
+) -> Optional[tuple[float, float]]:
+    """km-Spanne der ERFOLGREICH abgefragten Punkte (nicht der geplanten,
+    Issue #2051 S4, E7). None, wenn kein einziger Punkt ein Ergebnis lieferte
+    (defensiv -- bei priority=user_briefing fuer den ersten Punkt in der
+    Praxis nicht erreichbar, s. E1)."""
+    kms = [
+        p.distance_from_start_km
+        for p, e in zip(punkte, ergebnisse) if e is not None
+    ]
+    if not kms:
+        return None
+    return (min(kms), max(kms))
+
+
+def _fmt_strecke_email(zonen: tuple, tz, now_utc: datetime) -> str:
+    """Tabellarische Zeile je Zone: km-Spanne, Zeitspanne, Intensitaet,
+    Quelle (Issue #2051 S4, E3). `now_utc` ist der Abrufzeitpunkt, gegen den
+    die relativen `onset_minutes`/`event_end_minutes` in absolute HH:MM
+    umgerechnet werden -- IMMER derselbe Wert, den `_show_strecke` fuer die
+    Nowcast-Abrufe verwendet hat, NIE `datetime.now()` (AC-23).
+
+    Quelle wird als Klartext ausgegeben (`RadarNowcastService.source_label()`,
+    Muster `trip_alert.py:2210/2316`) -- die rohe Quelle (`"radar"`, `"INCA"`)
+    ist ein interner Schluessel, kein Nutzertext (team-lead-Entscheidung: die
+    Klartext-Uebersetzung ist Teil von E2, keine Testanpassung darf sie
+    umgehen)."""
+    from services.radar_service import RadarNowcastService
+
+    svc = RadarNowcastService()
+    zeilen = []
+    for z in zonen:
+        beginn = local_fmt(now_utc + timedelta(minutes=z.onset_minutes), tz)
+        ende = (
+            local_fmt(now_utc + timedelta(minutes=z.event_end_minutes), tz)
+            if z.event_end_minutes is not None else "?"
+        )
+        zeilen.append(
+            f"km {int(round(z.km_from))}-{int(round(z.km_to))}: "
+            f"{beginn}-{ende}, {z.intensity_label}, {svc.source_label(z.source)}"
+        )
+    return "\n".join(zeilen)
+
+
+def _fmt_strecke_telegram(zonen: tuple, tz, now_utc: datetime) -> str:
+    """Verdichtete Fassung: eine Zeile je Zone, km-Spanne, Zeitspanne,
+    Intensitaet -- ohne Quelle-Spalte (Platzgrund, Issue #2051 S4). Derselbe
+    Zeitanker-Vertrag wie `_fmt_strecke_email` (AC-23)."""
+    zeilen = []
+    for z in zonen:
+        beginn = local_fmt(now_utc + timedelta(minutes=z.onset_minutes), tz)
+        ende = (
+            local_fmt(now_utc + timedelta(minutes=z.event_end_minutes), tz)
+            if z.event_end_minutes is not None else "?"
+        )
+        zeilen.append(
+            f"km {int(round(z.km_from))}-{int(round(z.km_to))}: "
+            f"{beginn}-{ende}, {z.intensity_label}"
+        )
+    return "\n".join(zeilen)

--- a/src/services/trip_segments.py
+++ b/src/services/trip_segments.py
@@ -713,3 +713,29 @@ def points_along_remaining_route(
         )
         for i in range(1, anzahl)
     ]
+
+
+def points_from_km(
+    trip: "Trip", active: TripSegment, segment_date: date, start_km: float,
+) -> List[GPXPoint]:
+    """Wie ``points_along_remaining_route()``, aber der Startpunkt ist die vom
+    Nutzer genannte, STAGE-kumulative Kilometrierung (Issue #2051 S4, E5) --
+    nicht die Planposition. Aufrufer prueft VORHER ``active.distance_measured``
+    und die Bereichsgrenzen ``[active.start_point.distance_from_start_km,
+    active.end_point.distance_from_start_km]`` (E5); diese Funktion nimmt
+    ``start_km`` innerhalb dieses Bereichs als gegeben an."""
+    seg_start_km = active.start_point.distance_from_start_km
+    seg_end_km = active.end_point.distance_from_start_km
+    frac = (
+        (start_km - seg_start_km) / (seg_end_km - seg_start_km)
+        if seg_end_km > seg_start_km else 0.0
+    )
+    start = _lerp_point(active.start_point, active.end_point, frac)
+    rest_km = seg_end_km - start_km
+    if rest_km < RADAR_ZONE_POINT_SPACING_KM:
+        return [start]
+    anzahl = min(RADAR_ZONE_MAX_POINTS, int(rest_km // RADAR_ZONE_POINT_SPACING_KM) + 1)
+    return [start] + [
+        _lerp_point(start, active.end_point, (i * RADAR_ZONE_POINT_SPACING_KM) / rest_km)
+        for i in range(1, anzahl)
+    ]

--- a/tests/helpers/strecke_fixtures.py
+++ b/tests/helpers/strecke_fixtures.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 
 import math
 import uuid
-from datetime import date, timedelta
+from datetime import timedelta
 
 from app.models import TripReportConfig
 from app.trip import Stage, Trip, Waypoint

--- a/tests/helpers/strecke_fixtures.py
+++ b/tests/helpers/strecke_fixtures.py
@@ -1,0 +1,233 @@
+"""Gemeinsame Bausteine der `/strecke`-Kommando-Tests (Issue #2051 S4).
+
+SPEC: docs/specs/modules/feat_2051_s4_strecke_kommando.md
+
+Mock-frei: echte `Trip`/`Stage`/`Waypoint`-Objekte, echte
+`convert_trip_to_segments()`/`resolve_current_segment()` (kein Nachbau von
+`TripSegment` von Hand fuer die Kommando-Ebene — die Tests durchlaufen die
+echte Segment-Aufloesung). Die Aequator-Geometrie (Muster
+`test_regen_ausdehnung_messpunkte.py::_aequator_segment`) macht km-Werte
+analytisch nachrechenbar (`haversine_km` == lineare Laengengrad-Distanz).
+
+Zwei Fixture-Familien:
+
+* `future_two_point_trip()` — EIN zukuenftiges Segment (Preview-Zweig von
+  `resolve_current_segment`, `position_at_time()` liefert dadurch GARANTIERT
+  `active.start_point` exakt, `p=0`) fuer die `points_along_remaining_route`-
+  Familie (AC-4/5/6/7/19/21/22).
+* `active_three_point_trip()` — ein ECHT zeitaktives ZWEITES Segment einer
+  Drei-Wegpunkt-Etappe fuer die `points_from_km`-Familie (AC-13/14/15/16):
+  `active.start_point`/`end_point` tragen dort ungleich-null km-Werte, was
+  eine Stage mit >= 3 Wegpunkten UND echter Zeit-Aktivitaet braucht (der
+  Preview-Zweig liefert immer nur das ERSTE Segment des Tages).
+
+Beide Familien setzen `distance_from_start_km` auf jedem Wegpunkt exakt auf
+den geometrisch konstruierten Wert -- das erfuellt
+`trip_segments.stage_measured_distances()` (`span >= luftlinie`) und macht
+die Etappe `distance_measured=True`.
+"""
+from __future__ import annotations
+
+import math
+import uuid
+from datetime import date, timedelta
+
+from app.models import TripReportConfig
+from app.trip import Stage, Trip, Waypoint
+from utils.geo import haversine_km
+
+from tests.helpers.arrival_window_fixtures import active_window_offsets, stage_date
+
+# Muss zu `utils.geo._EARTH_KM` passen (Muster S2a-Messpunkte-Test) — nur zur
+# Konstruktion, die tatsaechliche Distanz wird unten per `haversine_km()`
+# gegengeprueft, nicht als zweite Quelle der Wahrheit angenommen.
+_EARTH_KM = 6371.0088
+
+LAT, LON = 0.0, 0.0  # Aequator -- Grosskreis-Distanz == lineare Laengengrad-Interpolation
+
+
+def _lon_at(km: float, lon0: float = LON) -> float:
+    return lon0 + math.degrees(km / _EARTH_KM)
+
+
+def _waypoint(idx: int, km: float, arrival: str, *, lat: float = LAT, lon0: float = LON) -> Waypoint:
+    return Waypoint(
+        id=f"WP{idx}", name=f"WP{idx}", lat=lat, lon=_lon_at(km, lon0),
+        elevation_m=1000.0, arrival_calculated=arrival,
+        distance_from_start_km=km,
+    )
+
+
+def _report_config(trip_id: str) -> TripReportConfig:
+    return TripReportConfig(trip_id=trip_id, send_email=True, send_telegram=False)
+
+
+def fresh_trip_id(tag: str) -> str:
+    return f"tdd-2051-s4-{tag}-{uuid.uuid4().hex[:6]}"
+
+
+def future_two_point_trip(
+    trip_id: str, distance_km: float, *, lat: float = LAT, lon: float = LON,
+) -> Trip:
+    """Ein-Segment-Etappe, VOLLSTAENDIG in der Zukunft (Preview-Zweig).
+
+    `resolve_current_segment()` liefert damit garantiert
+    `(segment, heute)` mit `position_at_time() == active.start_point`
+    (p=0 exakt, kein Zeit-Rundungsrisiko) und `_remaining_km() ==
+    distance_km` exakt -- dieselbe Eigenschaft, die
+    `test_regen_ausdehnung_messpunkte.py::_aequator_segment` fuer die
+    rohe `TripSegment`-Ebene nutzt, hier ueber den vollen Trip-Pfad.
+    """
+    tag = stage_date(lat, lon)
+    ankunft0, ankunft1 = active_window_offsets(lat, lon, 60, 180)
+    wp0 = _waypoint(0, 0.0, ankunft0, lat=lat, lon0=lon)
+    wp1 = _waypoint(1, distance_km, ankunft1, lat=lat, lon0=lon)
+    gemessen = haversine_km(wp0.lat, wp0.lon, wp1.lat, wp1.lon)
+    assert abs(gemessen - distance_km) < 1e-6, (
+        f"Testvoraussetzung: die konstruierte Strecke muss {distance_km} km "
+        f"messen, misst tatsaechlich {gemessen} km"
+    )
+    stage = Stage(id="S1", name="Tag 1", date=tag, waypoints=[wp0, wp1])
+    trip = Trip(id=trip_id, name="Strecke-Testtrip", stages=[stage])
+    trip.report_config = _report_config(trip_id)
+    return trip
+
+
+def active_three_point_trip(
+    trip_id: str, km_mid: float, km_end: float, *, lat: float = LAT, lon: float = LON,
+) -> Trip:
+    """Drei-Wegpunkt-Etappe, deren ZWEITES Segment (WP1->WP2) ECHT
+    zeitaktiv ist ("jetzt" liegt innerhalb seines Zeitfensters, nicht nur
+    im Preview-Zweig -- der liefert immer nur das erste Segment des Tages).
+
+    `active.start_point.distance_from_start_km == km_mid`,
+    `active.end_point.distance_from_start_km == km_end`.
+    """
+    tag = stage_date(lat, lon)
+    # Segment 0 (WP0->WP1) liegt VOLLSTAENDIG in der Vergangenheit, Segment 1
+    # (WP1->WP2) umschliesst "jetzt".
+    a0, a1, a2 = active_window_offsets(lat, lon, -120, -30, 60)
+    wp0 = _waypoint(0, 0.0, a0, lat=lat, lon0=lon)
+    wp1 = _waypoint(1, km_mid, a1, lat=lat, lon0=lon)
+    wp2 = _waypoint(2, km_end, a2, lat=lat, lon0=lon)
+    stage = Stage(id="S1", name="Tag 1", date=tag, waypoints=[wp0, wp1, wp2])
+    trip = Trip(id=trip_id, name="Strecke-Testtrip-Argument", stages=[stage])
+    trip.report_config = _report_config(trip_id)
+    return trip
+
+
+def unmeasured_future_trip(trip_id: str, *, lat: float = LAT, lon: float = LON) -> Trip:
+    """Wie `future_two_point_trip()`, aber OHNE `distance_from_start_km` auf
+    den Wegpunkten -- die Etappe bleibt `distance_measured=False`, auch nach
+    einem (hier wirkungslosen, weil GPX-losen) Backfill-Versuch."""
+    tag = stage_date(lat, lon)
+    ankunft0, ankunft1 = active_window_offsets(lat, lon, 60, 180)
+    wp0 = Waypoint(
+        id="WP0", name="WP0", lat=lat, lon=lon, elevation_m=1000.0,
+        arrival_calculated=ankunft0,
+    )
+    wp1 = Waypoint(
+        id="WP1", name="WP1", lat=lat, lon=_lon_at(5.0, lon), elevation_m=1000.0,
+        arrival_calculated=ankunft1,
+    )
+    stage = Stage(id="S1", name="Tag 1", date=tag, waypoints=[wp0, wp1])
+    trip = Trip(id=trip_id, name="Strecke-Testtrip-Unvermessen", stages=[stage])
+    trip.report_config = _report_config(trip_id)
+    return trip
+
+
+def no_active_segment_trip(trip_id: str, *, lat: float = LAT, lon: float = LON) -> Trip:
+    """Etappe an einem Tag, der weder "heute" noch "gestern" trifft --
+    `resolve_current_segment()` liefert `None` (analog zur `/jetzt`-
+    Situation `test_ac18`)."""
+    tag = stage_date(lat, lon) + timedelta(days=5)
+    wp0 = Waypoint(id="WP0", name="WP0", lat=lat, lon=lon, elevation_m=1000.0, arrival_calculated="08:00")
+    wp1 = Waypoint(id="WP1", name="WP1", lat=lat, lon=_lon_at(5.0, lon), elevation_m=1000.0, arrival_calculated="10:00")
+    stage = Stage(id="S1", name="Tag X", date=tag, waypoints=[wp0, wp1])
+    trip = Trip(id=trip_id, name="Strecke-Testtrip-Ohne-Segment", stages=[stage])
+    trip.report_config = _report_config(trip_id)
+    return trip
+
+
+# ---------------------------------------------------------------------------
+# Aufzeichnender Radar-Dienst (Muster test_jetzt_misst_am_aufenthaltsort.py)
+# ---------------------------------------------------------------------------
+
+def recording_radar_service_type(calls: list, *, script) -> type:
+    """Echte `RadarNowcastService`-Unterklasse (kein `Mock()`/`patch()`), die
+    jeden `get_nowcast()`-Aufruf mitschreibt (`lat`/`lon`/`elevation_m`/
+    `priority`) und danach `script(index)` befragt: liefert das ein
+    `NowcastResult`, wird es zurueckgegeben (ohne Netz, ohne echten Cache-
+    Unterbau -- reine Fake-Antwort); liefert es eine `Exception`-Instanz,
+    wird sie GEWORFEN (Fail-soft-Pruefung der Aufrufer).
+
+    Injektion via `monkeypatch.setattr("services.radar_service.
+    RadarNowcastService", ...)` -- `_show_strecke` importiert die Klasse
+    lokal an ihrem Wohnort, hat keinen Konstruktor-DI-Seam (wie `_show_now`,
+    s. `tests/unit/test_radar_budget_and_priority.py:243-248`).
+    """
+    from services.radar_service import RadarNowcastService
+
+    class _Aufzeichnend(RadarNowcastService):
+        def __init__(self, *_a, **_kw) -> None:
+            pass  # kein echter Unterbau noetig -- get_nowcast() ist ueberschrieben
+
+        def get_nowcast(self, lat, lon, elevation_m=None, priority="user_briefing"):
+            idx = len(calls)
+            calls.append({
+                "lat": lat, "lon": lon,
+                "elevation_m": elevation_m, "priority": priority,
+            })
+            ergebnis = script(idx)
+            if isinstance(ergebnis, Exception):
+                raise ergebnis
+            return ergebnis
+
+    return _Aufzeichnend
+
+
+def wrapping_radar_service_type(calls: list, frame_source) -> type:
+    """Wie `recording_radar_service_type()`, aber mit ECHTER
+    `RadarNowcastService`-Ableitungslogik dahinter (Muster
+    `test_jetzt_misst_am_aufenthaltsort.py::_aufzeichnender_typ`) --
+    fuer Faelle, die das ECHTE Budget-/Drosselungsverhalten von
+    `get_nowcast()` brauchen (AC-4), nicht nur eine kontrollierte
+    Fake-Antwort. Speichert zusaetzlich das ERGEBNIS jedes Aufrufs unter
+    `calls[i]['result']`."""
+    from services.radar_cache import RadarNowcastCacheService
+    from services.radar_service import RadarNowcastService
+
+    class _Aufzeichnend(RadarNowcastService):
+        def __init__(self, *_a, **_kw) -> None:
+            super().__init__(
+                frame_source=frame_source, cache=RadarNowcastCacheService(),
+            )
+
+        def get_nowcast(self, lat, lon, elevation_m=None, priority="user_briefing"):
+            eintrag = {
+                "lat": lat, "lon": lon,
+                "elevation_m": elevation_m, "priority": priority,
+            }
+            calls.append(eintrag)
+            ergebnis = super().get_nowcast(
+                lat, lon, elevation_m=elevation_m, priority=priority,
+            )
+            eintrag["result"] = ergebnis
+            return ergebnis
+
+    return _Aufzeichnend
+
+
+def nass(onset_minutes: int, event_end_minutes: int | None = None, *, source: str = "radar") -> object:
+    from services.radar_service import INTENSITY_MODERATE, NowcastResult
+
+    return NowcastResult(
+        onset_minutes=onset_minutes, intensity_label=INTENSITY_MODERATE,
+        source=source, event_end_minutes=event_end_minutes,
+    )
+
+
+def trocken() -> object:
+    from services.radar_service import INTENSITY_DRY, NowcastResult
+
+    return NowcastResult(onset_minutes=None, intensity_label=INTENSITY_DRY, source="radar")

--- a/tests/tdd/test_strecke_abrufpriorisierung.py
+++ b/tests/tdd/test_strecke_abrufpriorisierung.py
@@ -1,0 +1,346 @@
+"""TDD RED — Issue #2051 Scheibe S4: Abruf-Priorisierung (E1) des neuen
+`/strecke`-Kommandos -- erster Punkt nie gedrosselt, Folgepunkte fail-soft.
+
+SPEC: docs/specs/modules/feat_2051_s4_strecke_kommando.md — AC-4, AC-5, AC-6,
+AC-7.
+
+RED-Ursache: `TripCommandProcessor._show_strecke` existiert noch nicht ->
+AttributeError.
+
+Mock-frei: echte `Trip`/`TripSegment`-Aufloesung (Aequator-Geometrie,
+`tests/helpers/strecke_fixtures.py`), echte `RadarNowcastService`-
+Unterklassen (Aufzeichnung/Skript, kein `Mock()`/`patch()`), echte
+`ForecastBudgetGate`-Datei fuer AC-4.
+"""
+from __future__ import annotations
+
+import json
+from datetime import date, datetime, timedelta, timezone
+
+from services.trip_command_processor import TripCommandProcessor
+from tests.helpers.strecke_fixtures import (
+    fresh_trip_id,
+    future_two_point_trip,
+    nass,
+    recording_radar_service_type,
+    trocken,
+    wrapping_radar_service_type,
+)
+
+_KANAL = "telegram"
+
+
+def _write_budget(calls_openmeteo: int) -> None:
+    """Echte forecast_budget.json unter der isolierten Datenwurzel (Muster
+    `test_radar_nowcast_health_journal.py::_write_budget`)."""
+    from app.loader import get_data_root
+
+    pfad = get_data_root() / "diagnostics" / "forecast_budget.json"
+    pfad.parent.mkdir(parents=True, exist_ok=True)
+    pfad.write_text(json.dumps({
+        "date": date.today().isoformat(),
+        "calls": {"openmeteo": calls_openmeteo},
+        "cache_hits": 0,
+        "cache_misses": 0,
+    }))
+
+
+def _wet_frames(lat: float, lon: float) -> list:
+    from providers.brightsky import RadarFrame
+
+    now = datetime.now(timezone.utc)
+    return [RadarFrame(timestamp=now + timedelta(minutes=5), precip_mm_h=1.0)]
+
+
+# --------------------------------------------------------------------------
+# AC-4: 85% Budget -- der ERSTE Punkt faehrt user_briefing (nie gedrosselt)
+#       und liefert trotzdem ein Ergebnis.
+# --------------------------------------------------------------------------
+
+def test_ac4_erster_punkt_faehrt_user_briefing_trotz_budget_druck(monkeypatch):
+    """AC-4 GIVEN ein aktives Segment mit Reststrecke 10 km (mehrere
+    geplante Punkte) UND einem simulierten Budgetstand von 85%
+    (`allow('polling')` waere `False`) WHEN `/strecke` verarbeitet wird THEN
+    liefert der ERSTE Abfragepunkt trotzdem ein Ergebnis, UND dessen
+    `get_nowcast()`-Aufruf traegt `priority='user_briefing'`."""
+    trip_id = fresh_trip_id("ac4")
+    trip = future_two_point_trip(trip_id, 10.0)
+    now_utc = datetime.now(timezone.utc)
+
+    _write_budget(7650)  # 7650 / 9000 = 0.85 >= POLLING_THRESHOLD (0.80)
+
+    calls: list = []
+    monkeypatch.setattr(
+        "services.radar_service.RadarNowcastService",
+        wrapping_radar_service_type(calls, _wet_frames),
+    )
+
+    result = TripCommandProcessor()._show_strecke(
+        trip, None, now_utc, trip_id, _KANAL,
+    )
+
+    assert len(calls) >= 1, (
+        f"Testvoraussetzung: mindestens ein get_nowcast()-Aufruf erwartet, "
+        f"erhalten {len(calls)} -- Antwort: {result.confirmation_body!r}"
+    )
+    assert calls[0]["priority"] == "user_briefing", (
+        f"AC-4: der ERSTE Abfragepunkt muss priority='user_briefing' "
+        f"tragen (nie gedrosselt), erhalten {calls[0]['priority']!r}"
+    )
+    # Positivkontrolle: das Ergebnis des ersten Punkts ist tatsaechlich
+    # durchgekommen (nicht durch die 85%-Budgetlage gedrosselt) -- ein
+    # faelschlich mit priority="polling" gefahrener erster Aufruf waere bei
+    # 85% Budgetlast throttled=True und traege onset_minutes=None.
+    erstes_ergebnis = calls[0]["result"]
+    assert erstes_ergebnis.throttled is False, (
+        f"AC-4: der erste Punkt darf bei 85% Budgetlast NICHT gedrosselt "
+        f"sein (belegt priority='user_briefing' wirkt wirklich), throttled="
+        f"{erstes_ergebnis.throttled}"
+    )
+    assert erstes_ergebnis.onset_minutes is not None, (
+        f"AC-4: der erste (nasse) Punkt muss einen Onset liefern, erhalten "
+        f"onset_minutes={erstes_ergebnis.onset_minutes}"
+    )
+
+
+# --------------------------------------------------------------------------
+# AC-5: Fail-soft -- Punkt 3 wirft, Punkt 2 und 4 werden TROTZDEM
+#       (priority=polling) abgefragt, das Kommando bricht nicht ab.
+# --------------------------------------------------------------------------
+
+def test_ac5_einzelausfall_eines_folgepunkts_bricht_das_kommando_nicht_ab(monkeypatch):
+    """AC-5 GIVEN 5 geplante Punkte (km 0/2/4/6/8), wobei Punkt 3 (km 4,
+    nicht Punkt 1) eine Exception wirft und Punkt 5 (km 8) GENUIN TROCKEN
+    ist (trennt die Zone) WHEN `/strecke` verarbeitet wird THEN werden
+    Punkt 2/4/5 dennoch mit `priority='polling'` abgefragt, UND die Antwort
+    enthaelt die aus den Punkten 1/2/4 gebildete Zone (km 0-6) -- das
+    Kommando bricht wegen des Einzelausfalls NICHT ab.
+
+    F001/F002-Korrektur (Adversary-Befund team-lead): der fuenfte,
+    genuin trockene Punkt (km 8, gemessen, aber trocken) sorgt dafuer, dass
+    die Geprueft-Spanne (0-8, alle ERFOLGREICHEN Punkte inkl. des trockenen)
+    und die Zonen-Spanne (0-6, nur die NASSEN Punkte) STRUKTURELL
+    auseinanderfallen -- vorher fiel bei Reststrecke 6 km beides zufaellig
+    zusammen, wodurch die Geprueft-Zeile allein die 'km 0-6'-Pruefung
+    haette tragen koennen, ohne dass der Zonentext ueberhaupt gerendert
+    wurde. Zusaetzlich eine vom Zonentext exklusive Positivpruefung
+    (Intensitaetswort, kann in der Geprueft-Zeile strukturell nicht
+    auftreten) sowie die Negativ-Pruefung, dass NICHT der AC-7-Ausfalltext
+    erscheint (F002)."""
+    trip_id = fresh_trip_id("ac5")
+    trip = future_two_point_trip(trip_id, 9.0)  # -> 5 Punkte bei km 0/2/4/6/8
+    now_utc = datetime.now(timezone.utc)
+
+    def _skript(idx: int):
+        if idx == 2:  # Punkt 3 (0-basiert Index 2, km 4) -- Ausfall (Luecke)
+            return RuntimeError("Nowcast fuer Punkt 3 fehlgeschlagen")
+        if idx == 4:  # Punkt 5 (km 8) -- genuin trocken, trennt die Zone
+            return trocken()
+        return nass(10 + idx, 20 + idx)
+
+    calls: list = []
+    monkeypatch.setattr(
+        "services.radar_service.RadarNowcastService",
+        recording_radar_service_type(calls, script=_skript),
+    )
+
+    result = TripCommandProcessor()._show_strecke(
+        trip, None, now_utc, trip_id, _KANAL,
+    )
+
+    assert len(calls) == 5, (
+        f"AC-5: alle 5 geplanten Punkte muessen abgefragt werden (Fail-soft "
+        f"bei Punkt 3), erhalten {len(calls)} Aufrufe: {calls!r}"
+    )
+    assert calls[0]["priority"] == "user_briefing", (
+        f"AC-5: Punkt 1 muss user_briefing tragen, erhalten "
+        f"{calls[0]['priority']!r}"
+    )
+    for idx in (1, 2, 3, 4):
+        assert calls[idx]["priority"] == "polling", (
+            f"AC-5: Folgepunkt {idx + 1} muss priority='polling' tragen, "
+            f"erhalten {calls[idx]['priority']!r}"
+        )
+    assert "km 0-6" in result.confirmation_body, (
+        f"AC-5: die Antwort muss die aus Punkt 1/2/4 gebildete Zone 'km "
+        f"0-6' enthalten (der Ausfall von Punkt 3 trennt NICHT, s. S2a "
+        f"AC-11) -- Antwort:\n{result.confirmation_body}"
+    )
+    assert "Mäßiger Regen" in result.confirmation_body, (
+        f"AC-5: der Zonentext selbst (Intensitaetswort, in der "
+        f"Geprueft-Zeile strukturell unmoeglich) muss tatsaechlich "
+        f"gerendert sein -- Antwort:\n{result.confirmation_body}"
+    )
+    assert "Geprüft: km 0-8." in result.confirmation_body, (
+        f"AC-5: die Geprueft-Spanne (alle ERFOLGREICHEN Punkte, auch der "
+        f"trockene bei km 8) muss von der Zonen-Spanne (nur die nassen "
+        f"Punkte, km 0-6) UNTERSCHEIDBAR sein -- Antwort:\n"
+        f"{result.confirmation_body}"
+    )
+    assert "konnte nicht ermittelt werden" not in result.confirmation_body, (
+        f"AC-5 (F002): mit mehreren erfolgreichen Punkten darf NICHT der "
+        f"AC-7-Ausfalltext erscheinen -- Antwort:\n{result.confirmation_body}"
+    )
+
+
+# --------------------------------------------------------------------------
+# AC-6: Reststrecke 1,5 km (genau 1 Punkt) -> normale Streckenangabe, KEIN
+#       Hinweis auf nicht ermittelbare Ausdehnung.
+# --------------------------------------------------------------------------
+
+def test_ac6_ein_einzelner_punkt_unter_der_schwelle_ist_eine_normale_antwort(monkeypatch):
+    """AC-6 (Positivkontrolle zu AC-7) GIVEN eine Reststrecke von 1,5 km
+    (unter der 2-km-Schwelle, genau 1 geplanter Punkt), dieser liefert eine
+    Nass-Zone WHEN `/strecke` verarbeitet wird THEN meldet die Antwort diese
+    eine Zone als normale Streckenangabe, OHNE den Hinweis auf eine nicht
+    ermittelbare Ausdehnung (AC-7-Text)."""
+    trip_id = fresh_trip_id("ac6")
+    trip = future_two_point_trip(trip_id, 1.5)
+    now_utc = datetime.now(timezone.utc)
+
+    calls: list = []
+    monkeypatch.setattr(
+        "services.radar_service.RadarNowcastService",
+        recording_radar_service_type(calls, script=lambda idx: nass(15, 30)),
+    )
+
+    result = TripCommandProcessor()._show_strecke(
+        trip, None, now_utc, trip_id, _KANAL,
+    )
+
+    assert len(calls) == 1, (
+        f"Testvoraussetzung: bei Reststrecke 1,5 km darf es nur EINEN "
+        f"geplanten Punkt geben (S2a-Regime), erhalten {len(calls)}"
+    )
+    assert calls[0]["priority"] == "user_briefing"
+    assert "km 0-0" in result.confirmation_body, (
+        f"AC-6: die eine Zone (degenerierter Einzelpunkt km 0-0) muss "
+        f"erscheinen -- Antwort:\n{result.confirmation_body}"
+    )
+    # F001-Gegenprobe (Adversary-Befund team-lead): bei genau 1 Punkt sind
+    # Zonen- und Geprueft-Spanne IMMER identisch (km 0-0) -- "km 0-0" allein
+    # koennte also von der Geprueft-Zeile getragen werden, selbst wenn der
+    # Zonentext gar nicht gerendert wurde. Das Intensitaetswort kann in der
+    # Geprueft-Zeile strukturell nicht auftreten und belegt damit, dass der
+    # Zonentext SELBST vorhanden ist.
+    assert "Mäßiger Regen" in result.confirmation_body, (
+        f"AC-6: der Zonentext selbst (Intensitaetswort) muss tatsaechlich "
+        f"gerendert sein, nicht nur die Geprueft-Zeile -- Antwort:\n"
+        f"{result.confirmation_body}"
+    )
+    assert "konnte nicht ermittelt werden" not in result.confirmation_body, (
+        f"AC-6: der AC-7-Hinweistext ('Ausdehnung ... konnte nicht "
+        f"ermittelt werden') darf hier NICHT erscheinen -- Antwort:\n"
+        f"{result.confirmation_body}"
+    )
+
+
+# --------------------------------------------------------------------------
+# AC-7: alle Folgepunkte fallen aus -> ehrlicher Hinweis mit degenerierter
+#       Geprueft-Spanne, KEINE km-Zonen-Angabe.
+# --------------------------------------------------------------------------
+
+def test_ac7_alle_folgepunkte_fallen_aus_kein_zonenwert(monkeypatch):
+    """AC-7 GIVEN 6 geplante Punkte bei km 0/2/4/6/8/10 (Reststrecke 12 km),
+    von denen NUR der erste (km 0) ein Ergebnis liefert (Punkte 2-6 alle
+    Exception) WHEN `/strecke` verarbeitet wird THEN enthaelt die Antwort
+    EXAKT den Hinweistext mit der degenerierten Geprueft-Spanne km 0-0 UND
+    KEINE km-Zonen-Angabe."""
+    trip_id = fresh_trip_id("ac7")
+    trip = future_two_point_trip(trip_id, 12.0)
+    now_utc = datetime.now(timezone.utc)
+
+    def _skript(idx: int):
+        if idx == 0:
+            return nass(10, 20)
+        return RuntimeError(f"Nowcast fuer Folgepunkt {idx + 1} fehlgeschlagen")
+
+    calls: list = []
+    monkeypatch.setattr(
+        "services.radar_service.RadarNowcastService",
+        recording_radar_service_type(calls, script=_skript),
+    )
+
+    result = TripCommandProcessor()._show_strecke(
+        trip, None, now_utc, trip_id, _KANAL,
+    )
+
+    assert len(calls) == 6, (
+        f"Testvoraussetzung: bei Reststrecke 12 km muessen 6 Punkte geplant "
+        f"sein (S2a-Deckel), erhalten {len(calls)}"
+    )
+    erwartet = (
+        "Ausdehnung entlang der Reststrecke konnte nicht ermittelt werden "
+        "— nur der Startpunkt lieferte Daten. Geprüft: km 0-0."
+    )
+    assert result.confirmation_body == erwartet, (
+        f"AC-7: erwartet exakt {erwartet!r}, erhalten "
+        f"{result.confirmation_body!r}"
+    )
+    assert "Nass km" not in result.confirmation_body, (
+        f"AC-7: keine km-Zonen-Angabe erlaubt, wenn nur der Startpunkt "
+        f"Daten liefert -- Antwort:\n{result.confirmation_body}"
+    )
+
+
+# --------------------------------------------------------------------------
+# F004 (Adversary-Befund team-lead, CLAUDE.md-Mandantenpflicht): der
+# SCHREIBENDE Seitenaufruf `backfill_stage_distances(trip, user_id, ...)`
+# war mit KEINEM Nutzer belegt -- ein Regressionsfehler, der dort das
+# Literal "default" statt der echten user_id einsetzt, faende kein Test
+# (Cross-User-Datenleck-Regel, CLAUDE.md).
+# --------------------------------------------------------------------------
+
+def test_f004_backfill_erhaelt_die_echte_user_id_nicht_default(monkeypatch):
+    """F004 GIVEN zwei VERSCHIEDENE, echte user_id-Werte (keiner davon
+    'default') WHEN `/strecke` fuer beide Nutzer nacheinander verarbeitet
+    wird THEN erhaelt `backfill_stage_distances()` in BEIDEN Aufrufen genau
+    die user_id des jeweils aufrufenden Nutzers -- nie 'default', und die
+    beiden Aufrufe duerfen nicht vertauscht sein (belegt im SELBEN Test,
+    damit eine Verwechslung zwischen den Nutzern auffiele, nicht nur eine
+    pauschale 'default' vs. 'nicht default'-Unterscheidung)."""
+    import services.track_resolution as track_resolution_mod
+
+    calls: list = []
+
+    def _fake_backfill(trip, user_id, target_date, *, persist=True):
+        calls.append((user_id, trip.id))
+        return trip
+
+    monkeypatch.setattr(track_resolution_mod, "backfill_stage_distances", _fake_backfill)
+    monkeypatch.setattr(
+        "services.radar_service.RadarNowcastService",
+        recording_radar_service_type([], script=lambda idx: nass(10, 20)),
+    )
+
+    now_utc = datetime.now(timezone.utc)
+    trip_a_id = fresh_trip_id("f004a")
+    trip_a = future_two_point_trip(trip_a_id, 3.0)
+    user_a = f"tdd-2051-s4-f004-nutzer-a-{trip_a_id[-6:]}"
+
+    trip_b_id = fresh_trip_id("f004b")
+    trip_b = future_two_point_trip(trip_b_id, 3.0)
+    user_b = f"tdd-2051-s4-f004-nutzer-b-{trip_b_id[-6:]}"
+
+    TripCommandProcessor()._show_strecke(trip_a, None, now_utc, user_a, _KANAL)
+    TripCommandProcessor()._show_strecke(trip_b, None, now_utc, user_b, _KANAL)
+
+    assert len(calls) == 2, (
+        f"Testvoraussetzung: beide Aufrufe muessen backfill_stage_distances "
+        f"erreichen, erhalten {len(calls)} Aufrufe: {calls!r}"
+    )
+    assert calls[0] == (user_a, trip_a.id), (
+        f"F004: Nutzer A's Aufruf muss dessen eigene user_id tragen "
+        f"({user_a!r}), erhalten {calls[0]!r}"
+    )
+    assert calls[1] == (user_b, trip_b.id), (
+        f"F004: Nutzer B's Aufruf muss dessen eigene user_id tragen "
+        f"({user_b!r}), erhalten {calls[1]!r}"
+    )
+    assert calls[0][0] != "default" and calls[1][0] != "default", (
+        f"F004: kein Aufruf darf auf 'default' zurueckfallen -- {calls!r}"
+    )
+    assert calls[0][0] != calls[1][0], (
+        f"F004: die beiden Nutzer-Aufrufe duerfen nicht dieselbe user_id "
+        f"tragen (Verwechslungs-Gegenprobe) -- {calls!r}"
+    )

--- a/tests/tdd/test_strecke_km_argument.py
+++ b/tests/tdd/test_strecke_km_argument.py
@@ -1,0 +1,378 @@
+"""TDD RED — Issue #2051 Scheibe S4: optionales km-Argument von `/strecke`
+(E5) -- neue Punktbildung `points_from_km()`, Bereichspruefung, Dezimalwerte.
+
+SPEC: docs/specs/modules/feat_2051_s4_strecke_kommando.md — AC-13, AC-14,
+AC-15, AC-16.
+
+RED-Ursache: `services.trip_segments.points_from_km` existiert noch nicht ->
+ImportError; `TripCommandProcessor._show_strecke` existiert noch nicht ->
+AttributeError.
+
+Mock-frei: echte `Trip`/`TripSegment`-Aufloesung
+(`tests/helpers/strecke_fixtures.py::active_three_point_trip`, echte
+`resolve_current_segment()`), echte aufzeichnende `RadarNowcastService`-
+Unterklasse fuer den Nowcast-Spion (kein `Mock()`/`patch()`).
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from services.trip_command_processor import TripCommandProcessor
+from services.trip_segments import resolve_current_segment
+from tests.helpers.strecke_fixtures import (
+    active_three_point_trip,
+    fresh_trip_id,
+    nass,
+    recording_radar_service_type,
+)
+
+_KANAL = "telegram"
+
+
+def _aktives_segment(trip):
+    """`(active, segment_date)` fuer den 'jetzt' der Fixture --
+    `active_three_point_trip()` legt Segment 2 (WP1->WP2) als echt
+    zeitaktiv an."""
+    now_utc = datetime.now(timezone.utc)
+    resolved = resolve_current_segment(trip, now_utc, trip.stages[0].date)
+    assert resolved is not None, (
+        "Testvoraussetzung: die Fixture muss ein aktives Segment liefern"
+    )
+    return resolved
+
+
+# --------------------------------------------------------------------------
+# AC-13: der erste Punkt liegt bei der GENANNTEN km-Zahl, nicht an der
+#        Planposition.
+# --------------------------------------------------------------------------
+
+def test_ac13_erster_punkt_liegt_bei_der_genannten_km_zahl():
+    """AC-13 GIVEN ein aktives Segment mit start_point.km=3.0,
+    end_point.km=8.0, distance_measured=True UND dem Kommando '/strecke 5'
+    WHEN die Abfragepunkte gebildet werden THEN liegt der ERSTE Punkt bei
+    distance_from_start_km == 5.0 -- NICHT an der ueber position_at_time
+    bestimmten Planposition."""
+    from services.trip_segments import points_from_km
+
+    trip_id = fresh_trip_id("ac13")
+    trip = active_three_point_trip(trip_id, 3.0, 8.0)
+    active, segment_date = _aktives_segment(trip)
+    assert active.start_point.distance_from_start_km == 3.0, (
+        f"Testvoraussetzung: start_point muss km 3.0 tragen, erhalten "
+        f"{active.start_point.distance_from_start_km}"
+    )
+    assert active.end_point.distance_from_start_km == 8.0, (
+        f"Testvoraussetzung: end_point muss km 8.0 tragen, erhalten "
+        f"{active.end_point.distance_from_start_km}"
+    )
+    assert active.distance_measured is True, "Testvoraussetzung: distance_measured muss True sein"
+
+    punkte = points_from_km(trip, active, segment_date, 5.0)
+
+    assert punkte[0].distance_from_start_km == 5.0, (
+        f"AC-13: der erste Punkt muss bei km 5.0 liegen (dem genannten "
+        f"Argument), erhalten km {punkte[0].distance_from_start_km}"
+    )
+    # Gegenprobe "Form statt Wert": die Planposition (Segmentmitte/-anfang,
+    # NICHT km 5) darf hier nicht durchscheinen.
+    assert punkte[0].distance_from_start_km != active.start_point.distance_from_start_km, (
+        "AC-13: der erste Punkt darf NICHT am Segmentanfang (km 3.0) liegen"
+    )
+
+
+# --------------------------------------------------------------------------
+# AC-14: km == end_point-km (oberer Rand eingeschlossen) -> genau 1 Punkt,
+#        gueltige, entartete Anfrage, KEINE Fehlermeldung.
+# --------------------------------------------------------------------------
+
+def test_ac14_oberer_rand_ist_eingeschlossen_und_ergibt_einen_punkt(monkeypatch):
+    """AC-14 GIVEN dasselbe Segment wie AC-13, Kommando '/strecke 8' (exakt
+    end_point-km) WHEN verarbeitet wird THEN entsteht GENAU EIN Punkt bei km
+    8.0 (Reststrecke=0 innerhalb des Segments) -- gueltige, wenn auch
+    entartete Anfrage, KEINE Fehlermeldung."""
+    from services.trip_segments import points_from_km
+
+    trip_id = fresh_trip_id("ac14")
+    trip = active_three_point_trip(trip_id, 3.0, 8.0)
+    active, segment_date = _aktives_segment(trip)
+
+    punkte = points_from_km(trip, active, segment_date, 8.0)
+    assert len(punkte) == 1, (
+        f"AC-14: erwartet genau 1 Punkt bei km==end_point, erhalten "
+        f"{len(punkte)}: {punkte!r}"
+    )
+    assert punkte[0].distance_from_start_km == 8.0, (
+        f"AC-14: der eine Punkt muss bei km 8.0 liegen, erhalten "
+        f"{punkte[0].distance_from_start_km}"
+    )
+
+    # Draht-Test: `_show_strecke` selbst darf hier KEINE Fehlermeldung
+    # liefern -- der obere Rand ist eine gueltige, entartete Anfrage.
+    now_utc = datetime.now(timezone.utc)
+    calls: list = []
+    monkeypatch.setattr(
+        "services.radar_service.RadarNowcastService",
+        recording_radar_service_type(calls, script=lambda idx: nass(10, 20)),
+    )
+    result = TripCommandProcessor()._show_strecke(trip, "8", now_utc, trip_id, _KANAL)
+    assert result.success is True, (
+        f"AC-14: der obere Rand ist eine gueltige Anfrage, "
+        f"result.success muss True sein, war {result.success} -- "
+        f"Antwort: {result.confirmation_body!r}"
+    )
+    assert "Ungültige km-Angabe" not in result.confirmation_body, (
+        f"AC-14: keine Fehlermeldung erwartet -- Antwort:\n"
+        f"{result.confirmation_body}"
+    )
+
+
+# --------------------------------------------------------------------------
+# F005 (Adversary-Befund team-lead): AC-14 deckt nur den OBEREN Rand des
+# gueltigen Bereichs -- kein Test nutzt den unteren Rand
+# (start_point-km) als GUELTIGES Argument. Kippunkt UND je ein Wert knapp
+# innerhalb/ausserhalb, damit eine verschobene Grenze (nicht nur ein
+# vertauschtes >=/>) auffiele.
+# --------------------------------------------------------------------------
+
+def test_f005_unterer_rand_ist_eingeschlossen_und_ergibt_reguläre_punkte(monkeypatch):
+    """F005 GIVEN dasselbe Segment wie AC-13/AC-14 (gueltiger Bereich 3-8 km)
+    WHEN '/strecke 3' (exakt start_point-km, Kippunkt) UND '/strecke 3.01'
+    (knapp innerhalb) verarbeitet werden THEN sind BEIDE gueltige Anfragen
+    (kein 'Ungültige km-Angabe'), waehrend '/strecke 2.99' (knapp
+    ausserhalb) weiterhin abgelehnt wird."""
+    from services.trip_segments import points_from_km
+
+    trip_id = fresh_trip_id("f005")
+    trip = active_three_point_trip(trip_id, 3.0, 8.0)
+    active, segment_date = _aktives_segment(trip)
+
+    # Kippunkt exakt am unteren Rand: regulaerer (nicht entarteter) Fall,
+    # da die Reststrecke im Segment (5 km) ueber der Punktabstand-Schwelle
+    # liegt -- anders als AC-14, das entartet auf 1 Punkt zurueckfaellt.
+    punkte = points_from_km(trip, active, segment_date, 3.0)
+    assert punkte[0].distance_from_start_km == 3.0, (
+        f"F005: der erste Punkt muss exakt bei km 3.0 liegen (unterer "
+        f"Rand), erhalten {punkte[0].distance_from_start_km}"
+    )
+    assert len(punkte) > 1, (
+        f"Testvoraussetzung: am unteren Rand mit 5 km Restsegment muessen "
+        f"mehrere Punkte entstehen (kein entarteter Einzelfall wie AC-14), "
+        f"erhalten {len(punkte)}"
+    )
+
+    now_utc = datetime.now(timezone.utc)
+    monkeypatch.setattr(
+        "services.radar_service.RadarNowcastService",
+        recording_radar_service_type([], script=lambda idx: nass(10, 20)),
+    )
+
+    kippunkt = TripCommandProcessor()._show_strecke(trip, "3", now_utc, trip_id, _KANAL)
+    assert kippunkt.success is True and "Ungültige km-Angabe" not in kippunkt.confirmation_body, (
+        f"F005: der Kippunkt (km 3, exakt der untere Rand) ist eine "
+        f"gueltige Anfrage -- Antwort: {kippunkt.confirmation_body!r}"
+    )
+
+    knapp_innerhalb = TripCommandProcessor()._show_strecke(trip, "3.01", now_utc, trip_id, _KANAL)
+    assert knapp_innerhalb.success is True and "Ungültige km-Angabe" not in knapp_innerhalb.confirmation_body, (
+        f"F005: '3.01' (knapp innerhalb) ist eine gueltige Anfrage -- "
+        f"Antwort: {knapp_innerhalb.confirmation_body!r}"
+    )
+
+    knapp_ausserhalb = TripCommandProcessor()._show_strecke(trip, "2.99", now_utc, trip_id, _KANAL)
+    assert "Ungültige km-Angabe" in knapp_ausserhalb.confirmation_body, (
+        f"F005: '2.99' (knapp ausserhalb) muss weiterhin abgelehnt werden "
+        f"-- Antwort: {knapp_ausserhalb.confirmation_body!r}"
+    )
+
+
+# --------------------------------------------------------------------------
+# AC-15: ungueltige Eingaben -- ausserhalb des Bereichs, nicht-numerisch.
+#        Immer dieselbe Ablehnung, NIE ein Nowcast-Abruf.
+# --------------------------------------------------------------------------
+
+def _unerwarteter_aufruf(idx: int) -> Exception:
+    return AssertionError(
+        "get_nowcast() haette bei ungueltigem km-Argument nicht gerufen "
+        "werden duerfen"
+    )
+
+
+def _spion(monkeypatch) -> list:
+    calls: list = []
+    monkeypatch.setattr(
+        "services.radar_service.RadarNowcastService",
+        recording_radar_service_type(calls, script=_unerwarteter_aufruf),
+    )
+    return calls
+
+
+_ERWARTETE_ABLEHNUNG = "Ungültige km-Angabe. Gültiger Bereich für die aktuelle Etappe: 3–8 km."
+
+
+def test_ac15_ueber_der_oberen_grenze_wird_abgelehnt(monkeypatch):
+    """AC-15 Fall 1: '/strecke 8.1' liegt ueber der oberen Grenze (8 km)."""
+    trip_id = fresh_trip_id("ac15a")
+    trip = active_three_point_trip(trip_id, 3.0, 8.0)
+    now_utc = datetime.now(timezone.utc)
+    nowcast_spy = _spion(monkeypatch)
+
+    result = TripCommandProcessor()._show_strecke(trip, "8.1", now_utc, trip_id, _KANAL)
+
+    assert result.confirmation_body == _ERWARTETE_ABLEHNUNG, (
+        f"AC-15 (8.1): erwartet {_ERWARTETE_ABLEHNUNG!r}, erhalten "
+        f"{result.confirmation_body!r}"
+    )
+    assert len(nowcast_spy) == 0, (
+        f"AC-15 (8.1): KEIN get_nowcast()-Aufruf erwartet, erhalten "
+        f"{len(nowcast_spy)}"
+    )
+
+
+def test_ac15_unter_der_unteren_grenze_wird_abgelehnt(monkeypatch):
+    """AC-15 Fall 2: '/strecke 2.9' liegt unter der unteren Grenze (3 km)."""
+    trip_id = fresh_trip_id("ac15b")
+    trip = active_three_point_trip(trip_id, 3.0, 8.0)
+    now_utc = datetime.now(timezone.utc)
+    nowcast_spy = _spion(monkeypatch)
+
+    result = TripCommandProcessor()._show_strecke(trip, "2.9", now_utc, trip_id, _KANAL)
+
+    assert result.confirmation_body == _ERWARTETE_ABLEHNUNG, (
+        f"AC-15 (2.9): erwartet {_ERWARTETE_ABLEHNUNG!r}, erhalten "
+        f"{result.confirmation_body!r}"
+    )
+    assert len(nowcast_spy) == 0, (
+        f"AC-15 (2.9): KEIN get_nowcast()-Aufruf erwartet, erhalten "
+        f"{len(nowcast_spy)}"
+    )
+
+
+def test_ac15_nicht_numerisch_wird_abgelehnt(monkeypatch):
+    """AC-15 Fall 3: '/strecke abc' ist nicht-numerisch."""
+    trip_id = fresh_trip_id("ac15c")
+    trip = active_three_point_trip(trip_id, 3.0, 8.0)
+    now_utc = datetime.now(timezone.utc)
+    nowcast_spy = _spion(monkeypatch)
+
+    result = TripCommandProcessor()._show_strecke(trip, "abc", now_utc, trip_id, _KANAL)
+
+    assert result.confirmation_body == _ERWARTETE_ABLEHNUNG, (
+        f"AC-15 (abc): erwartet {_ERWARTETE_ABLEHNUNG!r}, erhalten "
+        f"{result.confirmation_body!r}"
+    )
+    assert len(nowcast_spy) == 0, (
+        f"AC-15 (abc): KEIN get_nowcast()-Aufruf erwartet, erhalten "
+        f"{len(nowcast_spy)}"
+    )
+
+
+def test_ac15_positivkontrolle_gueltiges_argument_ruft_den_nowcast(monkeypatch):
+    """AC-15 Positivkontrolle (Abwesenheits-Zusicherung braucht ihr
+    Gegenstueck): dasselbe Segment, ein GUELTIGES Argument ('5') MUSS
+    tatsaechlich einen get_nowcast()-Aufruf ausloesen -- sonst waere der
+    'kein Aufruf'-Nachweis der drei Ablehnungsfaelle oben trivial wahr
+    (Spy wuerde nie zaehlen, egal was passiert)."""
+    from tests.helpers.strecke_fixtures import nass
+
+    trip_id = fresh_trip_id("ac15d")
+    trip = active_three_point_trip(trip_id, 3.0, 8.0)
+    now_utc = datetime.now(timezone.utc)
+
+    calls: list = []
+    monkeypatch.setattr(
+        "services.radar_service.RadarNowcastService",
+        recording_radar_service_type(calls, script=lambda idx: nass(10, 20)),
+    )
+
+    result = TripCommandProcessor()._show_strecke(trip, "5", now_utc, trip_id, _KANAL)
+
+    assert len(calls) >= 1, (
+        f"AC-15 Positivkontrolle: ein gueltiges Argument muss mindestens "
+        f"einen get_nowcast()-Aufruf ausloesen, erhalten {len(calls)} -- "
+        f"Antwort: {result.confirmation_body!r}"
+    )
+    assert result.confirmation_body != _ERWARTETE_ABLEHNUNG
+
+
+# --------------------------------------------------------------------------
+# AC-16: Dezimalwerte werden akzeptiert, nicht auf ganze km gerundet.
+# --------------------------------------------------------------------------
+
+def test_ac16_dezimalwert_wird_nicht_gerundet():
+    """AC-16 GIVEN dasselbe Segment, Kommando '/strecke 5.5' WHEN
+    verarbeitet wird THEN liegt der erste erzeugte Punkt exakt bei km 5.5 --
+    Dezimalwerte werden akzeptiert und NICHT auf ganze km gerundet."""
+    from services.trip_segments import points_from_km
+
+    trip_id = fresh_trip_id("ac16")
+    trip = active_three_point_trip(trip_id, 3.0, 8.0)
+    active, segment_date = _aktives_segment(trip)
+
+    punkte = points_from_km(trip, active, segment_date, 5.5)
+
+    assert punkte[0].distance_from_start_km == 5.5, (
+        f"AC-16: der erste Punkt muss exakt bei km 5.5 liegen (kein "
+        f"Runden auf ganze km), erhalten {punkte[0].distance_from_start_km}"
+    )
+
+
+# --------------------------------------------------------------------------
+# F006 (Adversary-Befund team-lead, MEDIUM -- inhaltlich wichtigster der
+# drei Nachtraege): AC-16 belegt nur, dass die INTERNE `GPXPoint`-
+# Kilometrierung fraktional bleibt -- kein Test prueft, wie diese Zahl in
+# einer TEXTAUSGABE gerundet wird ("aus km 5,5 wird eine 5 oder eine 6").
+# Beide Text-Bildungsstellen benutzen `int(round(...))`: die Zonen-Zeile
+# (Renderer) UND die Geprueft-Zeile (`_show_strecke`) -- dieser End-to-End-
+# Test deckt BEIDE gleichzeitig ab, mit der Erwartung aus `round()`
+# ABGELEITET statt hingeschrieben.
+# --------------------------------------------------------------------------
+
+def test_f006_fraktionale_km_werden_in_der_textausgabe_gerundet_nicht_abgeschnitten(monkeypatch):
+    """F006 GIVEN dasselbe Segment (3-8 km), Kommando '/strecke 5.5' -- die
+    beiden erzeugten Punkte liegen bei km 5.5 UND 7.5 (fraktional, s.
+    AC-16), beide liefern eine Nass-Zone WHEN '/strecke' verarbeitet wird
+    THEN erscheinen sowohl die Zonen-Zeile ALS AUCH die Geprueft-Zeile mit
+    den GERUNDETEN (nicht abgeschnittenen) km-Werten -- `round(5.5) == 6`,
+    `round(7.5) == 8`, waehrend Abschneiden `5` bzw. `7` ergaebe."""
+    from services.trip_segments import points_from_km
+
+    trip_id = fresh_trip_id("f006")
+    trip = active_three_point_trip(trip_id, 3.0, 8.0)
+    active, segment_date = _aktives_segment(trip)
+    punkte = points_from_km(trip, active, segment_date, 5.5)
+    assert [p.distance_from_start_km for p in punkte] == [5.5, 7.5], (
+        f"Testvoraussetzung: die zwei Punkte muessen fraktional bei km "
+        f"5.5/7.5 liegen, erhalten {[p.distance_from_start_km for p in punkte]}"
+    )
+    von_gerundet, bis_gerundet = round(5.5), round(7.5)
+    von_abgeschnitten, bis_abgeschnitten = int(5.5), int(7.5)
+    assert (von_gerundet, bis_gerundet) != (von_abgeschnitten, bis_abgeschnitten), (
+        "Testvoraussetzung: Runden und Abschneiden muessen bei dieser "
+        "Fixture unterschiedliche Werte ergeben, sonst waere die Pruefung "
+        "unten wirkungslos"
+    )
+
+    now_utc = datetime.now(timezone.utc)
+    monkeypatch.setattr(
+        "services.radar_service.RadarNowcastService",
+        recording_radar_service_type([], script=lambda idx: nass(10, 20)),
+    )
+
+    result = TripCommandProcessor()._show_strecke(trip, "5.5", now_utc, trip_id, _KANAL)
+
+    zonen_zeile_erwartet = f"km {von_gerundet}-{bis_gerundet}"
+    assert zonen_zeile_erwartet in result.confirmation_body, (
+        f"F006: die Zonen-Zeile muss die GERUNDETEN km-Werte "
+        f"{zonen_zeile_erwartet!r} tragen, Antwort:\n"
+        f"{result.confirmation_body}"
+    )
+    geprueft_erwartet = f"Geprüft: km {von_gerundet}-{bis_gerundet}."
+    assert geprueft_erwartet in result.confirmation_body, (
+        f"F006: die Geprueft-Zeile muss ebenfalls die GERUNDETEN km-Werte "
+        f"{geprueft_erwartet!r} tragen, Antwort:\n{result.confirmation_body}"
+    )
+    zonen_zeile_abgeschnitten = f"km {von_abgeschnitten}-{bis_abgeschnitten}"
+    assert zonen_zeile_abgeschnitten not in result.confirmation_body, (
+        f"F006: die ABGESCHNITTENE Schreibweise {zonen_zeile_abgeschnitten!r} "
+        f"darf NICHT erscheinen -- Antwort:\n{result.confirmation_body}"
+    )

--- a/tests/tdd/test_strecke_kommando_eingang.py
+++ b/tests/tdd/test_strecke_kommando_eingang.py
@@ -1,0 +1,220 @@
+"""TDD RED — Issue #2051 Scheibe S4: Eingang des neuen Kommandos `/strecke`
+ueber beide Inbound-Kanaele (Telegram-Freitext/-Slash, E-Mail) plus Hilfe.
+
+SPEC: docs/specs/modules/feat_2051_s4_strecke_kommando.md — AC-1, AC-2, AC-3.
+
+RED-Ursache: `"strecke"` steht weder in
+`inbound_telegram_reader._SHORTCUT_MAP` noch in
+`trip_command_processor._BARE_KEYWORD_MAP`/`_VALID_COMMANDS`, und
+`_show_help()` kennt keine STRECKE-Zeile.
+
+Mock-frei: echte `InboundTelegramReader`/`TripCommandProcessor`/
+`InboundMessage`-Objekte, kein `Mock()`/`patch()`.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from services.inbound_telegram_reader import InboundTelegramReader
+from services.trip_command_processor import InboundMessage, TripCommandProcessor
+from tests.helpers.strecke_fixtures import fresh_trip_id, future_two_point_trip
+
+
+# --------------------------------------------------------------------------
+# AC-1: Freitext "strecke" und Slash "/strecke" loesen denselben Schluessel.
+# --------------------------------------------------------------------------
+
+def test_ac1_freitext_und_slash_liefern_denselben_schluessel():
+    """AC-1 GIVEN zwei Telegram-Nachrichten -- (a) 'strecke' (Freitext), (b)
+    '/strecke' (Slash) -- WHEN beide durch `_parse_command` laufen THEN
+    lösen BEIDE denselben internen Schlüssel `('strecke', None)` auf."""
+    reader = InboundTelegramReader()
+
+    schluessel_freitext = reader._parse_command("strecke")
+    schluessel_slash = reader._parse_command("/strecke")
+
+    assert schluessel_freitext == ("strecke", None), (
+        f"AC-1: Freitext 'strecke' muss ('strecke', None) liefern, erhalten "
+        f"{schluessel_freitext!r}"
+    )
+    assert schluessel_slash == ("strecke", None), (
+        f"AC-1: Slash '/strecke' muss ('strecke', None) liefern, erhalten "
+        f"{schluessel_slash!r}"
+    )
+    assert schluessel_freitext == schluessel_slash, (
+        f"AC-1: Freitext- und Slash-Eingabe muessen IDENTISCH aufgeloest "
+        f"werden, erhalten {schluessel_freitext!r} vs. {schluessel_slash!r}"
+    )
+    # Gegenprobe "Form statt Wert": ein Schluessel, der zwar wahr, aber ein
+    # ANDERER String ist (z.B. 'Strecke' mit Grossschreibung oder ein Tippfehler),
+    # faellt hier durch die Gleichheitspruefung, nicht nur durch Wahrheitswert.
+    assert schluessel_freitext[0] == "strecke" and schluessel_slash[0] == "strecke"
+
+
+def test_ac1_grossschreibung_und_restliche_zeile_bleiben_unveraendert():
+    """AC-1 (Formvarianten): case-insensitive wie alle Bare-Keywords, und
+    eine fuehrende Grossschreibung darf das Ergebnis nicht veraendern --
+    dasselbe Muster wie 'HEUTE'/'heute'."""
+    reader = InboundTelegramReader()
+
+    assert reader._parse_command("STRECKE") == ("strecke", None), (
+        "AC-1: Grossschreibung 'STRECKE' muss wie 'strecke' aufgeloest werden"
+    )
+    assert reader._parse_command("Strecke") == ("strecke", None)
+
+
+# --------------------------------------------------------------------------
+# AC-2: E-Mail-Inbound (channel="email") loest ueber denselben Prozessor-
+#       Kern denselben Handler aus -- kein "Unbekannter Befehl".
+# --------------------------------------------------------------------------
+
+def test_ac2_email_body_strecke_loest_den_handler_aus():
+    """AC-2 GIVEN eine E-Mail mit Body 'STRECKE' als erste Zeile WHEN
+    `TripCommandProcessor().process()` mit channel='email' laeuft THEN wird
+    `_show_strecke` aufgerufen (`result.command == 'strecke'`, kein
+    'Unbekannter Befehl')."""
+    trip_id = fresh_trip_id("ac2")
+    trip = future_two_point_trip(trip_id, 8.0)
+
+    # Trip muss ueber den Prozessor-Lookup ("Trip nicht gefunden" sonst)
+    # auffindbar sein -- dafuer persistiert der Test ihn ueber die echte
+    # save_trip()-Schreibkette (Muster S2a AC-9-Draht-Test).
+    import json
+
+    from app.loader import get_briefings_dir
+
+    uid = f"tdd-2051-s4-ac2-{uuid.uuid4().hex[:6]}"
+    trips_dir = get_briefings_dir(uid)
+    trips_dir.mkdir(parents=True, exist_ok=True)
+    data = {
+        "id": trip.id, "name": trip.name,
+        "stages": [{
+            "id": trip.stages[0].id, "name": trip.stages[0].name,
+            "date": trip.stages[0].date.isoformat(),
+            "waypoints": [
+                {
+                    "id": w.id, "name": w.name, "lat": w.lat, "lon": w.lon,
+                    "elevation_m": w.elevation_m,
+                    "arrival_calculated": w.arrival_calculated,
+                    "distance_from_start_km": w.distance_from_start_km,
+                }
+                for w in trip.stages[0].waypoints
+            ],
+        }],
+        "report_config": {
+            "trip_id": trip.report_config.trip_id,
+            "send_email": True, "send_telegram": False,
+        },
+    }
+    (trips_dir / f"{trip.id}.json").write_text(json.dumps(data))
+
+    msg = InboundMessage(
+        trip_name=trip.name, body="STRECKE", sender="tester@example.invalid",
+        channel="email", received_at=datetime.now(timezone.utc), user_id=uid,
+    )
+
+    result = TripCommandProcessor().process(msg)
+
+    assert result.command == "strecke", (
+        f"AC-2: erwartet result.command == 'strecke', erhalten "
+        f"{result.command!r} (subject={result.confirmation_subject!r}, "
+        f"body={result.confirmation_body!r})"
+    )
+    assert "Unbekannter Befehl" not in result.confirmation_subject, (
+        f"AC-2: 'STRECKE' darf nicht als unbekannter Befehl gelten -- "
+        f"subject={result.confirmation_subject!r}"
+    )
+
+
+# --------------------------------------------------------------------------
+# F003 (Adversary-Befund team-lead): der Telegram-Eingangsdraht war end-to-
+# end unverifiziert -- AC-1 prueft nur `_parse_command()` isoliert, AC-2 nur
+# `channel="email"` durch `process()`. Diese Luecke faengt die Mutation
+# 'elif key == "strecke" and msg.channel == "email":' im Dispatch, die
+# Telegram-Nachrichten in "Interner Fehler." laufen liesse -- Telegram ist
+# der haeufiger genutzte Eingangskanal (E4).
+# --------------------------------------------------------------------------
+
+def test_f003_telegram_body_strecke_loest_den_handler_aus_end_to_end():
+    """F003 GIVEN eine Telegram-Nachricht mit Body 'STRECKE' als erste Zeile
+    WHEN `TripCommandProcessor().process()` mit channel='telegram' laeuft
+    THEN wird `_show_strecke` real aufgerufen (`result.command == 'strecke'`,
+    kein 'Interner Fehler.') -- derselbe Draht-Nachweis wie AC-2, nur ueber
+    den anderen Eingangskanal."""
+    import json
+
+    from app.loader import get_briefings_dir
+
+    trip_id = fresh_trip_id("f003")
+    trip = future_two_point_trip(trip_id, 8.0)
+
+    uid = f"tdd-2051-s4-f003-{uuid.uuid4().hex[:6]}"
+    trips_dir = get_briefings_dir(uid)
+    trips_dir.mkdir(parents=True, exist_ok=True)
+    data = {
+        "id": trip.id, "name": trip.name,
+        "stages": [{
+            "id": trip.stages[0].id, "name": trip.stages[0].name,
+            "date": trip.stages[0].date.isoformat(),
+            "waypoints": [
+                {
+                    "id": w.id, "name": w.name, "lat": w.lat, "lon": w.lon,
+                    "elevation_m": w.elevation_m,
+                    "arrival_calculated": w.arrival_calculated,
+                    "distance_from_start_km": w.distance_from_start_km,
+                }
+                for w in trip.stages[0].waypoints
+            ],
+        }],
+        "report_config": {
+            "trip_id": trip.report_config.trip_id,
+            "send_email": True, "send_telegram": False,
+        },
+    }
+    (trips_dir / f"{trip.id}.json").write_text(json.dumps(data))
+
+    msg = InboundMessage(
+        trip_name=trip.name, body="STRECKE", sender="123456789",
+        channel="telegram", received_at=datetime.now(timezone.utc), user_id=uid,
+    )
+
+    result = TripCommandProcessor().process(msg)
+
+    assert result.command == "strecke", (
+        f"F003: erwartet result.command == 'strecke' ueber channel="
+        f"'telegram', erhalten {result.command!r} (subject="
+        f"{result.confirmation_subject!r}, body={result.confirmation_body!r})"
+    )
+    assert "Interner Fehler" not in result.confirmation_body, (
+        f"F003: der Telegram-Draht darf nicht im 'Should not reach here'-"
+        f"Zweig landen -- body={result.confirmation_body!r}"
+    )
+
+
+# --------------------------------------------------------------------------
+# AC-3: die Hilfe kennt eine STRECKE-Zeile.
+# --------------------------------------------------------------------------
+
+def test_ac3_hilfe_nennt_strecke_kommando():
+    """AC-3 GIVEN den Befehl HILFE WHEN `_show_help()` laeuft THEN enthaelt
+    der Text eine Zeile, die mit '  STRECKE' beginnt, mit einer
+    Kurzbeschreibung der Regen-Ereignisflaechen entlang der Reststrecke."""
+    result = TripCommandProcessor()._show_help()
+
+    zeilen = result.confirmation_body.splitlines()
+    strecke_zeilen = [z for z in zeilen if z.startswith("  STRECKE")]
+
+    assert strecke_zeilen, (
+        f"AC-3: keine Zeile beginnt mit '  STRECKE' im Hilfe-Text:\n"
+        f"{result.confirmation_body}"
+    )
+    # Positivkontrolle: die Zeile muss auch inhaltlich etwas ueber die
+    # Reststrecke/Ereignisflaechen sagen, nicht nur das Wort STRECKE tragen
+    # (Formpruefung waere sonst schon mit einer leeren Ueberschrift wahr).
+    assert any(
+        "Reststrecke" in z or "Regen" in z for z in strecke_zeilen
+    ), (
+        f"AC-3: die STRECKE-Zeile muss die Reststrecke/Regen-Ereignisflaechen "
+        f"benennen, erhalten: {strecke_zeilen!r}"
+    )

--- a/tests/tdd/test_strecke_leerzweige.py
+++ b/tests/tdd/test_strecke_leerzweige.py
@@ -1,0 +1,299 @@
+"""TDD RED — Issue #2051 Scheibe S4: die drei ehrlichen Sonderfaelle (E6) und
+die geprueften Streckenspanne (E7) des `/strecke`-Kommandos.
+
+SPEC: docs/specs/modules/feat_2051_s4_strecke_kommando.md — AC-17, AC-18,
+AC-19, AC-21, AC-22.
+
+RED-Ursache: `TripCommandProcessor._show_strecke` existiert noch nicht ->
+AttributeError.
+
+Mock-frei: echte `Trip`/`TripSegment`-Aufloesung
+(`tests/helpers/strecke_fixtures.py`), echte aufzeichnende
+`RadarNowcastService`-Unterklasse (kein `Mock()`/`patch()`).
+
+Hinweis zur Fixture-Wahl AC-19/AC-21: die Spec illustriert beide Szenarien
+mit Punkten bei km 2/4/6/8. Strukturell liefert `resolve_current_segment()`
+fuer den ARGUMENTLOSEN Pfad (`points_along_remaining_route`) den ERSTEN
+Punkt nur dann EXAKT am Segmentanfang (p=0, keine Zeitanteils-Drift), wenn
+dieses Segment das ERSTE der Etappe ist -- dessen Kilometrierung ist nach
+`stage_measured_distances()` IMMER auf 0 normiert (Etappenstart). Die Tests
+nutzen deshalb dieselbe Vier-Punkte-Kardinalitaet (km 0/2/4/6, Reststrecke
+6 km) wie die Spec-Skizze, aber bei 0 beginnend -- der Sollwert der
+'Geprueft:'-Zeile wird in JEDEM Test aus den tatsaechlichen Fixture-Punkten
+ABGELEITET, nicht abgeschrieben.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from services.trip_command_processor import TripCommandProcessor
+from tests.helpers.strecke_fixtures import (
+    fresh_trip_id,
+    future_two_point_trip,
+    nass,
+    no_active_segment_trip,
+    recording_radar_service_type,
+    trocken,
+    unmeasured_future_trip,
+)
+
+_KANAL = "telegram"
+
+
+# --------------------------------------------------------------------------
+# AC-17: Kilometrierung bleibt unvermessen (auch nach Backfill-Versuch) --
+#        zwei Varianten, IMMER vor jedem Nowcast-Aufruf geprueft.
+# --------------------------------------------------------------------------
+
+def test_ac17a_unvermessen_ohne_argument(monkeypatch):
+    """AC-17 (a) GIVEN ein aktives Segment, das auch nach dem
+    Backfill-Versuch `distance_measured=False` bleibt, '/strecke' OHNE
+    Argument WHEN verarbeitet wird THEN liefert die Antwort exakt
+    'Kilometrierung für die heutige Etappe nicht verfügbar — keine
+    Streckenangabe möglich.' UND es erfolgt KEIN get_nowcast()-Aufruf UND
+    KEINE 'Geprüft:'-Zeile."""
+    trip_id = fresh_trip_id("ac17a")
+    trip = unmeasured_future_trip(trip_id)
+    now_utc = datetime.now(timezone.utc)
+
+    calls: list = []
+    monkeypatch.setattr(
+        "services.radar_service.RadarNowcastService",
+        recording_radar_service_type(calls, script=lambda idx: nass(10, 20)),
+    )
+
+    result = TripCommandProcessor()._show_strecke(trip, None, now_utc, trip_id, _KANAL)
+
+    erwartet = (
+        "Kilometrierung für die heutige Etappe nicht verfügbar — keine "
+        "Streckenangabe möglich."
+    )
+    assert result.confirmation_body == erwartet, (
+        f"AC-17 (a): erwartet {erwartet!r}, erhalten "
+        f"{result.confirmation_body!r}"
+    )
+    assert len(calls) == 0, f"AC-17 (a): KEIN get_nowcast()-Aufruf erwartet, erhalten {len(calls)}"
+    assert "Geprüft:" not in result.confirmation_body, (
+        f"AC-17 (a): keine Geprueft-Zeile erlaubt -- nichts wurde "
+        f"gemessen: {result.confirmation_body!r}"
+    )
+
+
+def test_ac17b_unvermessen_mit_argument(monkeypatch):
+    """AC-17 (b) dieselbe Etappe, '/strecke 5' MIT Argument WHEN verarbeitet
+    wird THEN liefert die Antwort exakt 'Kilometrierung für die heutige
+    Etappe nicht verfügbar — die km-Angabe kann nicht ausgewertet werden.'
+    UND es erfolgt KEIN get_nowcast()-Aufruf UND KEINE 'Geprüft:'-Zeile."""
+    trip_id = fresh_trip_id("ac17b")
+    trip = unmeasured_future_trip(trip_id)
+    now_utc = datetime.now(timezone.utc)
+
+    calls: list = []
+    monkeypatch.setattr(
+        "services.radar_service.RadarNowcastService",
+        recording_radar_service_type(calls, script=lambda idx: nass(10, 20)),
+    )
+
+    result = TripCommandProcessor()._show_strecke(trip, "5", now_utc, trip_id, _KANAL)
+
+    erwartet = (
+        "Kilometrierung für die heutige Etappe nicht verfügbar — die "
+        "km-Angabe kann nicht ausgewertet werden."
+    )
+    assert result.confirmation_body == erwartet, (
+        f"AC-17 (b): erwartet {erwartet!r}, erhalten "
+        f"{result.confirmation_body!r}"
+    )
+    assert len(calls) == 0, f"AC-17 (b): KEIN get_nowcast()-Aufruf erwartet, erhalten {len(calls)}"
+    assert "Geprüft:" not in result.confirmation_body, (
+        f"AC-17 (b): keine Geprueft-Zeile erlaubt: {result.confirmation_body!r}"
+    )
+
+
+# --------------------------------------------------------------------------
+# AC-18: kein aufloesbarer Standort -- wortidentisch zu _show_now.
+# --------------------------------------------------------------------------
+
+def test_ac18_kein_standort_ist_wortidentisch_zu_show_now():
+    """AC-18 GIVEN keinen aufloesbaren Standort fuer heute
+    (`resolve_current_segment` liefert `None`) WHEN '/strecke' verarbeitet
+    wird THEN ist `result.confirmation_body` TEXTIDENTISCH zu dem Text, den
+    `_show_now` in derselben Situation liefert -- insbesondere ohne jede
+    'Geprüft:'-Zeile."""
+    trip_id = fresh_trip_id("ac18")
+    trip = no_active_segment_trip(trip_id)
+    now_utc = datetime.now(timezone.utc)
+
+    prozessor = TripCommandProcessor()
+    strecke_ergebnis = prozessor._show_strecke(trip, None, now_utc, trip_id, _KANAL)
+    now_ergebnis = prozessor._show_now(trip, now_utc)
+
+    assert now_ergebnis.success is False, (
+        "Testvoraussetzung: _show_now muss in dieser Situation ebenfalls "
+        f"scheitern (kein heutiger Standort), war success={now_ergebnis.success}"
+    )
+    assert strecke_ergebnis.confirmation_body == now_ergebnis.confirmation_body, (
+        f"AC-18: /strecke muss denselben Text wie /jetzt liefern.\n"
+        f"/strecke: {strecke_ergebnis.confirmation_body!r}\n"
+        f"/jetzt:   {now_ergebnis.confirmation_body!r}"
+    )
+    # Wortlaut auch gegen die bekannte, feste Textstelle abgesichert (die
+    # `_show_now` heute schon traegt) -- kein zufaelliger Gleichklang zweier
+    # unabhaengig gewachsener Texte.
+    erwartet = (
+        "Keine heutige Etappe gefunden. Aktueller Position/Standort "
+        "unbekannt — bitte Etappenplan prüfen."
+    )
+    assert strecke_ergebnis.confirmation_body == erwartet, (
+        f"AC-18: erwartet {erwartet!r}, erhalten "
+        f"{strecke_ergebnis.confirmation_body!r}"
+    )
+    assert "Geprüft:" not in strecke_ergebnis.confirmation_body
+
+
+# --------------------------------------------------------------------------
+# AC-19: alle geplanten Punkte liefern Daten, alle trocken -- eigener,
+#        vom geprueften Abschnitt sprechender Hinweis.
+# --------------------------------------------------------------------------
+
+def test_ac19_alle_punkte_trocken_nennt_den_geprueften_abschnitt(monkeypatch):
+    """AC-19 GIVEN ein vermessenes aktives Segment mit 4 geplanten Punkten,
+    bei denen ALLE ein Ergebnis liefern und ALLE trocken sind WHEN
+    '/strecke' verarbeitet wird THEN enthaelt die Antwort exakt 'Kein Regen
+    entlang des geprüften Abschnitts erkannt. Geprüft: km {von}-{bis}.' --
+    mit dem AUS DEN FIXTURE-PUNKTEN abgeleiteten von/bis, nicht pauschal
+    'die Reststrecke'."""
+    trip_id = fresh_trip_id("ac19")
+    trip = future_two_point_trip(trip_id, 6.0)  # -> 4 Punkte bei km 0/2/4/6
+    now_utc = datetime.now(timezone.utc)
+
+    calls: list = []
+    monkeypatch.setattr(
+        "services.radar_service.RadarNowcastService",
+        recording_radar_service_type(calls, script=lambda idx: trocken()),
+    )
+
+    result = TripCommandProcessor()._show_strecke(trip, None, now_utc, trip_id, _KANAL)
+
+    assert len(calls) == 4, f"Testvoraussetzung: 4 Punkte erwartet, erhalten {len(calls)}"
+    # Die km-Werte selbst stehen nicht in `calls` (nur lat/lon) -- die
+    # Fixture ist Aequator-linear konstruiert, die geplanten km sind daher
+    # exakt 0/2/4/6 (S2a-Deckelformel bei Reststrecke 6 km).
+    erwartet = "Kein Regen entlang des geprüften Abschnitts erkannt. Geprüft: km 0-6."
+    assert result.confirmation_body == erwartet, (
+        f"AC-19: erwartet {erwartet!r}, erhalten {result.confirmation_body!r}"
+    )
+    assert "konnte nicht ermittelt werden" not in result.confirmation_body, (
+        "AC-19: der Wortlaut muss sich klar von AC-7 (Ausdehnung nicht "
+        f"ermittelbar) unterscheiden: {result.confirmation_body!r}"
+    )
+    assert "Kilometrierung" not in result.confirmation_body, (
+        "AC-19: der Wortlaut muss sich klar von AC-17 (Kilometrierung "
+        f"fehlt) unterscheiden: {result.confirmation_body!r}"
+    )
+
+
+# --------------------------------------------------------------------------
+# AC-21 (E7): die Geprueft-Spanne stammt aus den ERFOLGREICH abgefragten
+#            Punkten, NICHT aus dem geplanten Maximum.
+# --------------------------------------------------------------------------
+
+def test_ac21_geprueft_spanne_aus_erfolgreichen_nicht_geplanten_punkten(monkeypatch):
+    """AC-21 GIVEN 4 geplante Punkte (km 0/2/4/6), von denen der LETZTE (km
+    6) eine Exception wirft, die uebrigen drei (km 0/2/4) liefern Daten
+    (mindestens einer nass) WHEN '/strecke' verarbeitet wird THEN nennt die
+    Antwort exakt 'Geprüft: km 0-4.' -- abgeleitet aus dem kleinsten und
+    groessten km-Wert der ERFOLGREICH abgefragten Punkte (0 und 4), NICHT
+    aus dem geplanten Maximum (6)."""
+    trip_id = fresh_trip_id("ac21")
+    trip = future_two_point_trip(trip_id, 6.0)  # -> 4 Punkte bei km 0/2/4/6
+    now_utc = datetime.now(timezone.utc)
+
+    def _skript(idx: int):
+        if idx == 3:  # letzter Punkt (km 6)
+            return RuntimeError("Nowcast fuer den letzten Punkt fehlgeschlagen")
+        return nass(10 + idx, 25 + idx)
+
+    calls: list = []
+    monkeypatch.setattr(
+        "services.radar_service.RadarNowcastService",
+        recording_radar_service_type(calls, script=_skript),
+    )
+
+    result = TripCommandProcessor()._show_strecke(trip, None, now_utc, trip_id, _KANAL)
+
+    assert len(calls) == 4, f"Testvoraussetzung: 4 geplante Punkte, erhalten {len(calls)}"
+    assert "Geprüft: km 0-4." in result.confirmation_body, (
+        f"AC-21: erwartet die Teilzeile 'Geprüft: km 0-4.' (abgeleitet aus "
+        f"den erfolgreichen Punkten 0/2/4, nicht dem geplanten Maximum 6), "
+        f"Antwort:\n{result.confirmation_body}"
+    )
+    assert "km 0-6" not in result.confirmation_body, (
+        f"AC-21: die Bildungsstelle darf NICHT aus dem geplanten Maximum "
+        f"(km 6, das fehlgeschlagen ist) gespeist werden: "
+        f"{result.confirmation_body!r}"
+    )
+    # F002-Gegenprobe (Adversary-Befund team-lead): die Geprueft-Spanne
+    # dieses Falls ist bei korrektem UND bei vertauschtem Zweig identisch
+    # (0-4) -- die obige Substring-Pruefung allein wuerde eine faelschlich
+    # in den AC-7-Zweig ("Ausdehnung ... konnte nicht ermittelt werden")
+    # gerutschte Weiche NICHT bemerken. Diese Negativ-Pruefung trennt die
+    # beiden Zweige zusaetzlich ueber den Wortlaut.
+    assert "konnte nicht ermittelt werden" not in result.confirmation_body, (
+        f"AC-21: mit >1 erfolgreichem Punkt darf NICHT der AC-7-Ausfalltext "
+        f"erscheinen -- Antwort:\n{result.confirmation_body}"
+    )
+
+
+# --------------------------------------------------------------------------
+# AC-22 (E7, Positivkontrolle): Geprueft-Zeile erscheint NUR, wenn
+#        tatsaechlich gemessen wurde -- echte Weiche, kein Zufall.
+# --------------------------------------------------------------------------
+
+def test_ac22_geprueft_zeile_nur_bei_tatsaechlicher_messung(monkeypatch):
+    """AC-22 GIVEN zwei Faelle mit identischem Aufbau bis auf einen
+    Unterschied: (a) `distance_measured=False` (kein Nowcast-Abruf), (b)
+    `distance_measured=True` (mindestens 1 Punkt liefert Daten) WHEN beide
+    Antworten erzeugt werden THEN enthaelt Antwort (a) KEINE 'Geprüft:'-
+    Zeile, waehrend Antwort (b) eine 'Geprüft: km'-Zeile mit dem erwarteten
+    Wert traegt -- belegt im SELBEN Test, dass das Fehlen in (a) eine echte
+    Weiche ist."""
+    now_utc = datetime.now(timezone.utc)
+
+    # (a) unvermessen
+    trip_a_id = fresh_trip_id("ac22a")
+    trip_a = unmeasured_future_trip(trip_a_id)
+    calls_a: list = []
+    monkeypatch.setattr(
+        "services.radar_service.RadarNowcastService",
+        recording_radar_service_type(calls_a, script=lambda idx: nass(10, 20)),
+    )
+    ergebnis_a = TripCommandProcessor()._show_strecke(trip_a, None, now_utc, trip_a_id, _KANAL)
+
+    assert len(calls_a) == 0, (
+        f"Testvoraussetzung (a): kein Nowcast-Abruf bei unvermessener "
+        f"Etappe, erhalten {len(calls_a)}"
+    )
+    assert "Geprüft:" not in ergebnis_a.confirmation_body, (
+        f"AC-22 (a): keine Geprueft-Zeile bei unvermessener Etappe: "
+        f"{ergebnis_a.confirmation_body!r}"
+    )
+
+    # (b) vermessen, identischer Aufbau bis auf die Kilometrierung
+    trip_b_id = fresh_trip_id("ac22b")
+    trip_b = future_two_point_trip(trip_b_id, 1.5)  # -> genau 1 Punkt (S2a-Regime)
+    calls_b: list = []
+    monkeypatch.setattr(
+        "services.radar_service.RadarNowcastService",
+        recording_radar_service_type(calls_b, script=lambda idx: nass(10, 20)),
+    )
+    ergebnis_b = TripCommandProcessor()._show_strecke(trip_b, None, now_utc, trip_b_id, _KANAL)
+
+    assert len(calls_b) >= 1, (
+        f"Testvoraussetzung (b): mindestens ein Punkt muss Daten liefern, "
+        f"erhalten {len(calls_b)}"
+    )
+    assert "Geprüft: km 0-0." in ergebnis_b.confirmation_body, (
+        f"AC-22 (b): erwartet die Teilzeile 'Geprüft: km 0-0.' (degenerierte "
+        f"Spanne bei genau 1 Punkt), Antwort:\n{ergebnis_b.confirmation_body}"
+    )

--- a/tests/tdd/test_strecke_renderer.py
+++ b/tests/tdd/test_strecke_renderer.py
@@ -1,0 +1,279 @@
+"""TDD RED — Issue #2051 Scheibe S4: die zwei neuen Zonen-Renderer (E3) der
+`/strecke`-Antwort -- E-Mail-Tabellenzeile, Telegram-Kurzzeile, Kanalparitaet,
+verbotene Muster (E7-unabhaengige Grundregel, dieselbe Musterliste wie
+S2a-AC-16/S2b-AC-14) und der explizite Zeitanker (AC-23).
+
+SPEC: docs/specs/modules/feat_2051_s4_strecke_kommando.md — AC-11, AC-12,
+AC-20, AC-23.
+
+RED-Ursache: `trip_command_processor._fmt_strecke_email`/
+`_fmt_strecke_telegram` existieren noch nicht -> ImportError.
+
+Mock-frei: echte `RainZone`-Objekte, echte Renderer-Funktionen.
+
+Zeitanker (PO/Team-Lead-Entscheidung nach Rueckfrage): die Umrechnung
+`onset_minutes`/`event_end_minutes` -> Uhrzeit haengt NICHT an der
+Systemuhr, sondern an einem EXPLIZIT durchgereichten dritten Argument
+(`now_utc`, derselbe Abrufzeitpunkt, gegen den `_show_strecke` die Nowcasts
+geholt hat) -- sonst waere die Bildungsstelle der Uhrzeit unbewacht (beide
+Seiten eines Tests laesen sonst dieselbe Systemuhr und ein Rueckfall auf sie
+im Produktivcode faenge kein Test). Kein `freeze_time` mehr noetig: der
+Anker ist eine normale Testeingabe.
+"""
+from __future__ import annotations
+
+import re
+from datetime import datetime, timedelta, timezone
+
+from services.rain_extent import RainZone
+
+_ANKER = datetime(2026, 8, 23, 15, 0, tzinfo=timezone.utc)  # -> 15:00 UTC
+
+# Zone A: onset 0 Min (-> 15:00 am Anker), Ende 90 Min (-> 16:30).
+_ZONE_A = RainZone(
+    km_from=8.0, km_to=12.0, onset_minutes=0, event_end_minutes=90,
+    intensity_label="Mäßiger Regen", source="INCA",
+)
+# Zone B: onset 130 Min (-> 17:10 am Anker), Ende 160 Min (-> 17:40).
+_ZONE_B = RainZone(
+    km_from=19.0, km_to=21.0, onset_minutes=130, event_end_minutes=160,
+    intensity_label="Starker Regen", source="radar",
+)
+
+# Praezisierung (team-lead, nach Adversary-Rueckfrage): ohne das "km"-Praefix
+# matcht `(\d+)-(\d+)` JEDE Ziffer-Bindestrich-Ziffer-Folge im Text -- die von
+# AC-11 selbst geforderte Zeitschreibweise "HH:MM-HH:MM" erzeugt dadurch
+# STRUKTURELL einen Scheintreffer (z. B. "00-16" aus "15:00-16:30", die
+# Minuten direkt vor und die Stunde direkt nach dem Bindestrich). `\s*`
+# deckt beide Renderer-Schreibweisen ab, falls sie das Leerzeichen nach
+# "km" unterschiedlich setzen.
+_PAAR_RE = re.compile(r"km\s*(\d+)-(\d+)")
+_ZEIT_RE = re.compile(r"(\d{2}:\d{2})-(\d{2}:\d{2})")
+
+
+def _zeile_mit(text: str, teilstring: str) -> str:
+    treffer = [z for z in text.splitlines() if teilstring in z]
+    assert len(treffer) == 1, (
+        f"Testvoraussetzung: genau eine Zeile mit {teilstring!r} erwartet, "
+        f"gefunden {len(treffer)}: {treffer!r}\nVoller Text:\n{text}"
+    )
+    return treffer[0]
+
+
+# --------------------------------------------------------------------------
+# AC-11: E-Mail -- je Zone eine EIGENE Zeile mit allen vier Werten.
+# --------------------------------------------------------------------------
+
+def test_ac11_email_zeigt_je_zone_eine_zeile_mit_allen_vier_werten():
+    """AC-11 GIVEN zwei Zonen (km 8-12, 'Mäßiger Regen', Quelle 'INCA',
+    15:00-16:30; km 19-21, 'Starker Regen', Quelle 'radar', 17:10-17:40),
+    gerechnet gegen den Anker 15:00 UTC WHEN die E-Mail-Antwort gerendert
+    wird THEN enthaelt der Text fuer JEDE Zone eine eigene Zeile mit allen
+    vier Werten.
+
+    Quelle wird als KLARTEXT erwartet (team-lead-Entscheidung, E2): die
+    Erwartung wird aus `RadarNowcastService.source_label()` ABGELEITET,
+    nicht als Roh-Quellen-Literal ins Testfile geschrieben -- sonst bliebe
+    die Uebersetzungsstelle im Renderer unbewacht und der Test friere nur
+    zufaellig die heutige Roh-Schreibweise ein."""
+    from services.radar_service import RadarNowcastService
+    from services.trip_command_processor import _fmt_strecke_email
+
+    text = _fmt_strecke_email((_ZONE_A, _ZONE_B), timezone.utc, _ANKER)
+    svc = RadarNowcastService()
+    label_inca = svc.source_label("INCA")
+    label_radar = svc.source_label("radar")
+
+    zeile_a = _zeile_mit(text, "km 8-12")
+    for erwartet in ("km 8-12", "15:00-16:30", "Mäßiger Regen", label_inca):
+        assert erwartet in zeile_a, (
+            f"AC-11: Zeile 1 muss {erwartet!r} enthalten:\n{zeile_a!r}"
+        )
+
+    zeile_b = _zeile_mit(text, "km 19-21")
+    for erwartet in ("km 19-21", "17:10-17:40", "Starker Regen", label_radar):
+        assert erwartet in zeile_b, (
+            f"AC-11: Zeile 2 muss {erwartet!r} enthalten:\n{zeile_b!r}"
+        )
+    assert zeile_a != zeile_b, "AC-11: die beiden Zonen muessen VERSCHIEDENE Zeilen sein"
+
+
+# --------------------------------------------------------------------------
+# AC-12: Telegram -- GENAU zwei Zeilen, km/Uhrzeit-Paritaet zur E-Mail.
+# --------------------------------------------------------------------------
+
+def test_ac12_telegram_hat_genau_zwei_zeilen_und_zahlen_stimmen_mit_email_ueberein():
+    """AC-12 GIVEN denselben Zwei-Zonen-Aufbau wie AC-11 (derselbe Anker)
+    WHEN die Telegram-Antwort gerendert wird THEN enthaelt der Text GENAU
+    zwei Zeilen (eine je Flaeche), UND alle aus beiden Texten extrahierten
+    km-Zahlen UND Uhrzeiten (Regex) stimmen zwischen E-Mail- und
+    Telegram-Fassung exakt ueberein."""
+    from services.trip_command_processor import (
+        _fmt_strecke_email,
+        _fmt_strecke_telegram,
+    )
+
+    email_text = _fmt_strecke_email((_ZONE_A, _ZONE_B), timezone.utc, _ANKER)
+    telegram_text = _fmt_strecke_telegram((_ZONE_A, _ZONE_B), timezone.utc, _ANKER)
+
+    telegram_zeilen = [z for z in telegram_text.splitlines() if z.strip()]
+    assert len(telegram_zeilen) == 2, (
+        f"AC-12: Telegram-Antwort muss GENAU 2 Zeilen haben (eine je "
+        f"Flaeche), erhalten {len(telegram_zeilen)}:\n{telegram_text!r}"
+    )
+
+    km_email = _PAAR_RE.findall(email_text)
+    km_telegram = _PAAR_RE.findall(telegram_text)
+    zeit_email = _ZEIT_RE.findall(email_text)
+    zeit_telegram = _ZEIT_RE.findall(telegram_text)
+
+    erwartete_km = [("8", "12"), ("19", "21")]
+    erwartete_zeit = [("15:00", "16:30"), ("17:10", "17:40")]
+
+    assert km_email == erwartete_km, f"AC-12: E-Mail-km-Paare {km_email} != {erwartete_km}"
+    assert km_telegram == erwartete_km, f"AC-12: Telegram-km-Paare {km_telegram} != {erwartete_km}"
+    assert zeit_email == erwartete_zeit, f"AC-12: E-Mail-Zeiten {zeit_email} != {erwartete_zeit}"
+    assert zeit_telegram == erwartete_zeit, f"AC-12: Telegram-Zeiten {zeit_telegram} != {erwartete_zeit}"
+
+    # F008 (Adversary-Befund team-lead): E3 sagt Telegram OHNE Quelle-Spalte
+    # (Platzgrund) -- bisher pruefte kein Test das. Positivkontrolle im
+    # SELBEN Test (Quelle steht in der E-Mail-Fassung sehr wohl), damit die
+    # Negativ-Pruefung unten nicht nur das Fehlen von etwas prueft, das es
+    # vielleicht nirgends gibt.
+    from services.radar_service import RadarNowcastService
+
+    svc = RadarNowcastService()
+    label_inca = svc.source_label("INCA")
+    label_radar = svc.source_label("radar")
+    assert label_inca in email_text and label_radar in email_text, (
+        f"Testvoraussetzung (Positivkontrolle): die E-Mail-Fassung muss "
+        f"beide Quellen-Label enthalten -- email_text={email_text!r}"
+    )
+    assert label_inca not in telegram_text and label_radar not in telegram_text, (
+        f"F008: die Telegram-Fassung darf KEIN Quellen-Label enthalten "
+        f"(E3: ohne Quelle-Spalte) -- telegram_text={telegram_text!r}"
+    )
+
+
+# --------------------------------------------------------------------------
+# AC-20: verbotene Muster (Ankunftszeit-Rechnung, Handlungsempfehlung,
+#        Begegnungspunkt-Aussage) -- keines darf erscheinen.
+# --------------------------------------------------------------------------
+
+# Dieselbe Musterliste wie S2a-AC-16/S2b-AC-14
+# (test_regen_ausdehnung_textstellen.py::_VERBOTENE_MUSTER).
+_VERBOTENE_MUSTER = [
+    "verlass dich nicht",
+    "solltest du",
+    "bis dahin solltest",
+    "rechne damit, dass du",
+    "sei vorsichtig",
+    "achte darauf, dass du",
+    "plane damit",
+    "du erreichst",
+    "wirst du dort",
+    "wirst du diese zone",
+    "bist du dort",
+    "kommst du dort an",
+    "wenn du ankommst",
+]
+
+
+def _pruefe(kandidaten: dict[str, str]) -> dict[str, list[str]]:
+    treffer: dict[str, list[str]] = {}
+    for name, text in kandidaten.items():
+        text_klein = text.lower()
+        gefunden = [m for m in _VERBOTENE_MUSTER if m in text_klein]
+        if gefunden:
+            treffer[name] = gefunden
+    return treffer
+
+
+def test_ac20_beide_renderer_enthalten_keine_verbotenen_muster():
+    """AC-20 GIVEN eine Zonen-Antwort in E-Mail- ODER Telegram-Fassung mit
+    gesetzten Zonen WHEN der Text auf eine Liste verbotener Muster geprueft
+    wird THEN enthaelt der Text KEINES dieser Muster.
+
+    Positivkontrolle des Detektors (Lehre aus #2054, Muster S2a-AC-16): ein
+    synthetischer, ABSICHTLICH verbotener Satz muss von DERSELBEN
+    Pruefschleife erkannt werden."""
+    from services.trip_command_processor import (
+        _fmt_strecke_email,
+        _fmt_strecke_telegram,
+    )
+
+    email_text = _fmt_strecke_email((_ZONE_A, _ZONE_B), timezone.utc, _ANKER)
+    telegram_text = _fmt_strecke_telegram((_ZONE_A, _ZONE_B), timezone.utc, _ANKER)
+
+    synthetischer_verstoss = _pruefe({
+        "synthetisch": "km 8-12. Du erreichst diese Zone in 45 Minuten.",
+    })
+    assert synthetischer_verstoss, (
+        "Vorbedingung: der Detektor muss einen ABSICHTLICH eingebauten "
+        "Verstoss erkennen -- sonst waere die Negativpruefung unten trivial "
+        "wahr."
+    )
+
+    treffer = _pruefe({"email": email_text, "telegram": telegram_text})
+    assert not treffer, f"AC-20: verbotene Formulierung gefunden: {treffer}"
+
+
+# --------------------------------------------------------------------------
+# AC-23: der Zeitanker ist eine ECHTE Eingabe -- zwei verschiedene Anker
+#        verschieben die gebildeten Uhrzeiten um GENAU ihre Differenz.
+# --------------------------------------------------------------------------
+
+def test_ac23_zwei_anker_verschieben_die_uhrzeiten_um_genau_ihre_differenz():
+    """AC-23 GIVEN dieselbe Zonen-Fixture, EINMAL gegen Anker A (15:00 UTC)
+    und EINMAL gegen Anker B (15:00 UTC + 47 Minuten) gerendert WHEN die
+    gebildeten Uhrzeiten beider Laeufe verglichen werden THEN unterscheiden
+    sie sich um EXAKT die Anker-Differenz (47 Minuten) -- nicht nur
+    "irgendeine" Uhrzeit erscheint, sondern die Verschiebung ist die
+    Anker-Differenz selbst.
+
+    Faengt einen Rueckfall auf die Systemuhr im Renderer: wuerde
+    `datetime.now()` statt des uebergebenen Ankers gelesen, waeren die
+    Uhrzeiten beider Laeufe IDENTISCH (dieselbe reale Uhrzeit beim
+    Testlauf) statt um 47 Minuten verschoben -- die Differenz-Pruefung
+    unten wuerde durchfallen."""
+    from services.trip_command_processor import _fmt_strecke_email
+
+    versatz = timedelta(minutes=47)
+    anker_a = _ANKER
+    anker_b = _ANKER + versatz
+
+    text_a = _fmt_strecke_email((_ZONE_A,), timezone.utc, anker_a)
+    text_b = _fmt_strecke_email((_ZONE_A,), timezone.utc, anker_b)
+
+    zeiten_a = _ZEIT_RE.findall(text_a)
+    zeiten_b = _ZEIT_RE.findall(text_b)
+
+    assert zeiten_a and zeiten_b, (
+        f"Testvoraussetzung: beide Texte muessen eine Zeitspanne enthalten -- "
+        f"a={text_a!r}, b={text_b!r}"
+    )
+    assert zeiten_a != zeiten_b, (
+        f"AC-23: unterschiedliche Anker muessen unterschiedliche Uhrzeiten "
+        f"ergeben (sonst liest der Renderer die Systemuhr statt des Ankers): "
+        f"a={zeiten_a}, b={zeiten_b}"
+    )
+
+    def _als_datetime(hhmm: str, bezug: datetime) -> datetime:
+        stunde, minute = (int(x) for x in hhmm.split(":"))
+        return bezug.replace(hour=stunde, minute=minute, second=0, microsecond=0)
+
+    beginn_a = _als_datetime(zeiten_a[0][0], anker_a)
+    beginn_b = _als_datetime(zeiten_b[0][0], anker_b)
+    ende_a = _als_datetime(zeiten_a[0][1], anker_a)
+    ende_b = _als_datetime(zeiten_b[0][1], anker_b)
+
+    assert (beginn_b - beginn_a) == versatz, (
+        f"AC-23: die Beginn-Uhrzeit muss sich um EXAKT die Anker-Differenz "
+        f"({versatz}) verschieben, tatsaechlich {beginn_b - beginn_a} "
+        f"({zeiten_a[0][0]!r} -> {zeiten_b[0][0]!r})"
+    )
+    assert (ende_b - ende_a) == versatz, (
+        f"AC-23: die Ende-Uhrzeit muss sich um EXAKT die Anker-Differenz "
+        f"({versatz}) verschieben, tatsaechlich {ende_b - ende_a} "
+        f"({zeiten_a[0][1]!r} -> {zeiten_b[0][1]!r})"
+    )

--- a/tests/tdd/test_strecke_zonen_intensitaet_quelle.py
+++ b/tests/tdd/test_strecke_zonen_intensitaet_quelle.py
@@ -1,0 +1,197 @@
+"""TDD RED — Issue #2051 Scheibe S4: additive `RainZone`-Felder
+`intensity_label`/`source` (E2) plus Regressionsschutz der Bestandsfelder.
+
+SPEC: docs/specs/modules/feat_2051_s4_strecke_kommando.md — AC-8, AC-9,
+AC-10.
+
+RED-Ursache: `RainZone` (rain_extent.py) kennt weder `intensity_label` noch
+`source` -> `TypeError: unexpected keyword argument` bei der Konstruktion
+bzw. bei der Aggregation in `derive_rain_zones()`.
+
+Mock-frei: echte `GPXPoint`-/`NowcastResult`-Objekte (Muster
+`test_regen_ausdehnung_zonenbildung.py`).
+"""
+from __future__ import annotations
+
+from app.models import GPXPoint
+from services.radar_service import (
+    INTENSITY_CONVECTIVE,
+    INTENSITY_DRY,
+    INTENSITY_HEAVY,
+    INTENSITY_LIGHT,
+    INTENSITY_MODERATE,
+    NowcastResult,
+)
+
+
+def _punkt(km: float) -> GPXPoint:
+    return GPXPoint(lat=0.0, lon=km / 111.0, elevation_m=1000.0, distance_from_start_km=km)
+
+
+def _nass(onset_minutes: int, intensity: str, *, source: str = "radar", event_end_minutes=None) -> NowcastResult:
+    return NowcastResult(
+        onset_minutes=onset_minutes, intensity_label=intensity, source=source,
+        event_end_minutes=event_end_minutes,
+    )
+
+
+def _trocken() -> NowcastResult:
+    return NowcastResult(onset_minutes=None, intensity_label=INTENSITY_DRY, source="radar")
+
+
+# --------------------------------------------------------------------------
+# AC-8: die Zone traegt den STAERKSTEN Intensitaetswert ihrer Punkte,
+#       unabhaengig von seiner Position innerhalb der Zone.
+# --------------------------------------------------------------------------
+
+def test_ac8_zone_traegt_den_staerksten_intensitaetswert():
+    """AC-8 GIVEN 3 zusammenhaengende nasse Punkte einer Zone mit den
+    Intensitaeten 'Leichter Regen', 'Starker Regen', 'Maessiger Regen' (in
+    dieser Reihenfolge entlang der Strecke) WHEN die Zone gebildet wird THEN
+    traegt `RainZone.intensity_label == 'Starker Regen'` -- der staerkste
+    Wert, unabhaengig von seiner Position."""
+    from services.rain_extent import derive_rain_zones
+
+    points = [_punkt(km) for km in (0, 2, 4)]
+    results = [
+        _nass(10, INTENSITY_LIGHT),
+        _nass(20, INTENSITY_HEAVY),
+        _nass(15, INTENSITY_MODERATE),
+    ]
+
+    zones = derive_rain_zones(points, results)
+
+    assert len(zones) == 1, f"Testvoraussetzung: eine zusammenhaengende Zone, erhalten {zones!r}"
+    assert zones[0].intensity_label == INTENSITY_HEAVY, (
+        f"AC-8: erwartet den staerksten Wert '{INTENSITY_HEAVY}' (Punkt in "
+        f"der Mitte der Zone), erhalten {zones[0].intensity_label!r}"
+    )
+    # Gegenprobe: der Wert des ERSTEN oder LETZTEN Punkts (Positions-
+    # Verwechslung statt Rang) darf hier NICHT herauskommen.
+    assert zones[0].intensity_label not in (INTENSITY_LIGHT, INTENSITY_MODERATE), (
+        f"AC-8: der Rang muss ueber die Position gewinnen, erhalten "
+        f"{zones[0].intensity_label!r}"
+    )
+
+
+def test_ac8_rangfolge_konvektiv_schlaegt_starken_regen():
+    """AC-8 (Rangfolge-Ergaenzung): `INTENSITY_CONVECTIVE` schlaegt
+    `INTENSITY_HEAVY`, auch wenn der konvektive Punkt NICHT der staerkste
+    (letzte) Onset-Wert ist -- reine Rang-, keine Reihenfolgefrage."""
+    from services.rain_extent import derive_rain_zones
+
+    points = [_punkt(km) for km in (0, 2)]
+    results = [_nass(30, INTENSITY_HEAVY), _nass(10, INTENSITY_CONVECTIVE)]
+
+    zones = derive_rain_zones(points, results)
+
+    assert zones[0].intensity_label == INTENSITY_CONVECTIVE, (
+        f"AC-8: 'Starker Hagel/Gewitter' muss 'Starker Regen' schlagen, "
+        f"erhalten {zones[0].intensity_label!r}"
+    )
+
+
+# --------------------------------------------------------------------------
+# AC-9: die Zone traegt die ROHE Quelle des ERSTEN (km-kleinsten) Punkts bei
+#       Uneinheitlichkeit -- kein Mehrheitsentscheid, keine Kombination.
+# --------------------------------------------------------------------------
+
+def test_ac9a_einheitliche_quelle_bleibt_erhalten():
+    """AC-9 Fall (a) GIVEN zwei nasse Punkte einer Zone mit identischer
+    Quelle 'radar' WHEN die Zone gebildet wird THEN traegt sie
+    `source == 'radar'`."""
+    from services.rain_extent import derive_rain_zones
+
+    points = [_punkt(km) for km in (0, 2)]
+    results = [_nass(10, INTENSITY_MODERATE, source="radar"), _nass(15, INTENSITY_MODERATE, source="radar")]
+
+    zones = derive_rain_zones(points, results)
+
+    assert zones[0].source == "radar", (
+        f"AC-9 (a): erwartet source='radar', erhalten {zones[0].source!r}"
+    )
+
+
+def test_ac9b_uneinheitliche_quelle_gewinnt_der_km_kleinste_punkt():
+    """AC-9 Fall (b) GIVEN zwei nasse Punkte einer Zone mit den Quellen
+    'INCA' (erster/km-kleinster Punkt) und 'radar' (zweiter Punkt) WHEN die
+    Zone gebildet wird THEN traegt sie `source == 'INCA'` -- NICHT
+    'radar'."""
+    from services.rain_extent import derive_rain_zones
+
+    points = [_punkt(km) for km in (0, 2)]
+    results = [_nass(10, INTENSITY_MODERATE, source="INCA"), _nass(15, INTENSITY_MODERATE, source="radar")]
+
+    zones = derive_rain_zones(points, results)
+
+    assert zones[0].source == "INCA", (
+        f"AC-9 (b): der km-kleinste Punkt gewinnt bei Uneinheitlichkeit, "
+        f"erwartet 'INCA', erhalten {zones[0].source!r}"
+    )
+    assert zones[0].source != "radar", (
+        "AC-9 (b): keine Kombination/Mehrheitsentscheid -- 'radar' darf "
+        "hier nicht gewinnen"
+    )
+
+
+# --------------------------------------------------------------------------
+# AC-10: Bestandsfelder + Alarm-Textstellen bleiben unangetastet -- die
+#        neuen Felder werden dort nicht gelesen.
+# --------------------------------------------------------------------------
+
+def test_ac10_bestandsfelder_bleiben_unveraendert_bei_neuen_defaultfeldern():
+    """AC-10 GIVEN dieselbe S2a-AC-4-Fixture (zwei getrennte Nasszonen aus
+    sechs Punkten) WHEN die Zonen gebildet werden THEN bleiben `km_from`/
+    `km_to`/`onset_minutes`/`event_end_minutes` byte-identisch zum S2a-Stand.
+
+    Korrektur (team-lead, nach Adversary-Rueckfrage des Developer-Agenten):
+    die urspruengliche Fassung verglich das ECHTE `derive_rain_zones()`-
+    Ergebnis per Objektgleichheit gegen eine Referenz mit `intensity_label=
+    ''`/`source=''` -- das misst ueber den Stellvertreter "vollstaendige
+    Objektgleichheit" eine FALSCHE Aussage, denn E2 aggregiert diese Felder
+    IMMER aus den Punkten (s. AC-8/AC-9 im selben File), sie bleiben nur bei
+    einer Konstruktion OHNE diese Keyword-Argumente leer. AC-10 sichert
+    zwei unabhaengige Dinge zu: (1) die Bestandsfelder bleiben unveraendert
+    -- geprueft durch die Tupel-Vergleiche unten; (2) die Erweiterung ist
+    ADDITIV -- ein Aufrufer, der `RainZone` weiterhin ohne die beiden neuen
+    Felder konstruiert (wie jeder S2a/S2b-Aufrufer), muss dieselben
+    Default-Werte bekommen und darf keinen `TypeError` erhalten."""
+    from services.rain_extent import RainZone, derive_rain_zones
+
+    points = [_punkt(km) for km in (0, 2, 4, 6, 8, 10)]
+    results = [
+        _nass(10, INTENSITY_MODERATE, event_end_minutes=12),
+        _nass(11, INTENSITY_MODERATE, event_end_minutes=9),
+        _trocken(),
+        _nass(20, INTENSITY_MODERATE, event_end_minutes=22),
+        _nass(21, INTENSITY_MODERATE, event_end_minutes=19),
+        _trocken(),
+    ]
+
+    zones = derive_rain_zones(points, results)
+
+    assert len(zones) == 2, f"Testvoraussetzung: 2 Zonen erwartet, erhalten {zones!r}"
+    a, b = zones
+    assert (a.km_from, a.km_to, a.onset_minutes, a.event_end_minutes) == (0.0, 2.0, 10, 12), (
+        f"AC-10: Zone A darf sich in den Bestandsfeldern nicht veraendert "
+        f"haben, erhalten {(a.km_from, a.km_to, a.onset_minutes, a.event_end_minutes)}"
+    )
+    assert (b.km_from, b.km_to, b.onset_minutes, b.event_end_minutes) == (6.0, 8.0, 20, 22), (
+        f"AC-10: Zone B darf sich in den Bestandsfeldern nicht veraendert "
+        f"haben, erhalten {(b.km_from, b.km_to, b.onset_minutes, b.event_end_minutes)}"
+    )
+    # Additivitaet: Konstruktion OHNE die neuen Felder (Muster jedes
+    # bestehenden S2a/S2b-Aufrufers) darf keinen TypeError werfen, und die
+    # Defaults muessen greifen -- NICHT geprueft wird, ob `derive_rain_zones()`
+    # diese Felder befuellt (das tut sie, s. AC-8/AC-9).
+    ohne_neue_felder = RainZone(
+        km_from=0.0, km_to=2.0, onset_minutes=10, event_end_minutes=12,
+    )
+    assert ohne_neue_felder.intensity_label == "", (
+        f"AC-10: RainZone ohne intensity_label-Argument muss den Default "
+        f"'' tragen, erhalten {ohne_neue_felder.intensity_label!r}"
+    )
+    assert ohne_neue_felder.source == "", (
+        f"AC-10: RainZone ohne source-Argument muss den Default '' tragen, "
+        f"erhalten {ohne_neue_felder.source!r}"
+    )

--- a/tests/test_success_status_guard.py
+++ b/tests/test_success_status_guard.py
@@ -1672,6 +1672,33 @@ KNOWN_VIOLATIONS: dict[str, str] = {
     "src/services/trip_command_processor.py::_resume_trip::0": (
         "B18 (#1405) — _resume_trip: dito."
     ),
+    # --- Issue #2051 S4 (/strecke-Kommando, Adversary-Runde 3): dieselbe
+    # B18-Signatur wie _show_now/_show_status/_handle_query oben -- nach
+    # einem Aufruf (get_nowcast(...)/derive_rain_zones(...)/den beiden
+    # Renderern) folgt ein unbedingtes `success=True`, das nicht auf den
+    # Aufruf Bezug nimmt. Fachlich geprueft (team-lead-Auftrag): `success`
+    # wird von KEINEM Aufrufer gelesen (inbound_telegram_reader.py,
+    # inbound_email_reader.py senden confirmation_subject/-body IMMER
+    # gleich zurueck, unabhaengig vom Wert) -- die Unterscheidung hat heute
+    # keine Verhaltensauswirkung. Fachlich ist `success=True` in allen drei
+    # Zweigen zudem korrekt: das Kommando hat eine gueltige, ehrliche
+    # Antwort verfasst (auch der Ausfall-Zweig AC-7 ist per Spec E1 eine
+    # normale, keine fehlgeschlagene Antwort -- Analogie zu AC-6). Dieselbe
+    # Bestandsentscheidung wie bei den bereits gelisteten Query-Kommandos:
+    # Reparatur-Vorrat (B18), keine Ausnahme in INTENTIONAL_CONSTANT_SUCCESS
+    # (die bleibt strukturell auf den einen Webhook-Fall beschraenkt, AC-14).
+    "src/services/trip_command_processor.py::_show_strecke::0": (
+        "B18 (#1405, Analogie) — _show_strecke: alle Folgepunkte ausgefallen "
+        "(AC-7), nach der Fail-soft-Nowcast-Schleife."
+    ),
+    "src/services/trip_command_processor.py::_show_strecke::1": (
+        "B18 (#1405, Analogie) — _show_strecke: kein Regen erkannt (AC-19), "
+        "nach derive_rain_zones(...)."
+    ),
+    "src/services/trip_command_processor.py::_show_strecke::2": (
+        "B18 (#1405, Analogie) — _show_strecke: Zonen gebildet (Normalfall), "
+        "nach _fmt_strecke_email(...)/_fmt_strecke_telegram(...)."
+    ),
     # --- B17 + der eine neue Fundort: beide zählen ohne Gegenzähler.
     "src/services/trip_report_scheduler.py::send_reports::0": (
         "B17 (#1405) — send_reports: sent_count ohne Gegenzähler, return int."


### PR DESCRIPTION
Schliesst die letzte offene Scheibe von #2051.

## Was neu ist

Alle bisherigen Kommandos liefern Wetter an **einem Punkt**. `/strecke` liefert die **Regen-Ereignisflaechen entlang der Reststrecke** des aktiven Wegabschnitts — je Flaeche km-Spanne, Zeitspanne, Intensitaet, in der E-Mail-Fassung zusaetzlich die Quelle im Klartext (`Radar (DWD)`, `INCA (GeoSphere AT)`).

Beispielzeile: `km 8-12: 15:00-16:30, Mäßiger Regen, INCA (GeoSphere AT)`

Erreichbar ueber **beide** Inbound-Kanaele (Telegram und E-Mail), Antwort auf demselben Weg zurueck. Steht in der HILFE-Liste. `/strecke` erscheint bewusst **nicht** im Telegram-Bot-Menue (`BOT_COMMANDS` unveraendert, nicht Teil dieser Scheibe) — es wird getippt.

## Entscheidungen

- **`/strecke 5`** setzt den selbst genannten km-Stand als Ausgangspunkt statt der Planposition. Gueltiger Bereich ist die kumulative km-Spanne des aktiven Segments, **beide Raender eingeschlossen**, Dezimalwerte erlaubt. Ungueltige Eingaben werden **abgelehnt** statt geklemmt — ein geklemmter Wert beantwortet eine andere Frage als die gestellte. Kein Datenabruf dabei.
- **Der Alarm-Pfad ist geschuetzt.** Kommando und Alarm zaehlen gegen dasselbe Tagesbudget. Der erste Messpunkt faehrt `user_briefing` (nie gedrosselt — eine Antwort kommt immer), die bis zu fuenf Folgepunkte `polling` (entfallen bei knappem Budget). Einzelausfaelle fail-soft.
- **`Geprüft: km {von}-{bis}.`** in jeder Antwort mit Messung — gebildet aus den **erfolgreich** abgefragten Punkten, nicht aus den geplanten. Analog zu S3 (`Radar reicht bis HH:MM`) macht die Zeile sichtbar, wo die Aussage endet. Ohne sie wuerde "kein Regen" Trockenheit bis zum Etappenziel suggerieren.
- **Drei ehrliche Sonderfaelle** mit unterscheidbarem Wortlaut: keine aktive Etappe · fehlende Kilometrierung · kein Regen im geprueften Abschnitt. Fallen **alle** Folgepunkte aus, erscheint bewusst **keine** km-Angabe statt einer Punktmessung im Gewand einer Streckenangabe.

## Bekannte Grenze

Die Antwort deckt nur das **aktive Wegpunkt-Segment** ab, nicht die volle Resttagesetappe. Das ist eine Bestandseigenschaft aus S2a — der live laufende Alarm-Pfad hat dieselbe Grenze. Sie wird hier bewusst **nicht** verschoben (Tourstart), sondern durch die `Geprüft:`-Zeile sichtbar gemacht. Aufhebung ist eigene, spaetere Arbeit.

## Nachweis

**105/105 gruen** — 34 neue Tests zu 23 ACs, 51 S2a/S2b-Regressionstests unveraendert, 20 Waechter-Tests. Zusaetzlich 869 Tests ueber 58 Dateien im Regressionslauf ohne Funktionsregression.

**Adversary: VERIFIED** nach drei Runden, 31 Punkte bewiesen. Acht Findings, alle geschlossen:

| | Befund | Art |
|---|---|---|
| F001 | Der gesamte Zonentext konnte entfallen, ohne dass ein Test rot wurde — die `Geprüft:`-Zeile trug dieselbe km-Zahl wie die Zone und erfuellte die Pruefung allein | CRITICAL |
| F004 | `user_id` im Schreibpfad (`backfill_stage_distances`) ungeprueft — ein Rueckfall auf `"default"` blieb unbemerkt | CRITICAL |
| F002 | `all()`/`any()`-Vertauschung in der Ausfall-Weiche unbewacht | HIGH |
| F003 | Telegram-Eingang nie end-to-end durch `process()` geprueft | HIGH |
| F005/F006/F008 | unterer km-Rand · Rundung fraktionaler km in der Textausgabe · fehlende Quelle in der Telegram-Fassung | MEDIUM |

Jede Behebung wurde per **Mutations-Gegenprobe** abgenommen: die urspruenglich durchgerutschte Verfaelschung muss danach rot werden, unabhaengig nachgemessen. F001 wurde strukturell aufgeloest (die beiden km-Spannen fallen in der Fixture jetzt bewusst auseinander), nicht nur zugepflastert.

Drei waehrend der Arbeit gefundene **Testdefekte** wurden als Praezisierung der Messung korrigiert, nicht als Absenkung der Erwartung — jeweils mit Beleg, dass der korrigierte Test einen plausibel falschen Wert weiterhin faengt.

**Offen als Backlog-Eintrag** (LOW, kein Blocker): Reihenfolge zweier getrennter Zonen im vollen Kommando-Fluss; die zugrundeliegende Sortierung ist durch die S2a-Regression geschuetzt. Dazu ein Nebenbefund am **bestehenden** Fehlerprotokoll-Pfad (`record_track_resolution_failure`), der schon vor dieser Scheibe ungeprueft war und auch den Alarm-Pfad betrifft.

Spec: `docs/specs/modules/feat_2051_s4_strecke_kommando.md` (v1.3, 23 ACs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FGmX5zSP2E2Hbz4TUSEg6T
