### PR TITLE
feat(#2129): Anmeldung haelt bis zum Abmelden, Widerruf ueberlebt Neustart

### DIFF
--- a/docs/adr/0030-session-auth-hmac-cookie.md
+++ b/docs/adr/0030-session-auth-hmac-cookie.md
@@ -1,6 +1,12 @@
 # ADR-0030: Session-Auth über HMAC-signiertes Cookie (kein JWT, keine Server-Session-Tabelle)
 
-- **Status:** Akzeptiert (rückwirkend dokumentiert 2026-07-22 — gelebte Praxis seit der Auth-Einführung, Issue #1343)
+- **Status:** Abgelöst durch [ADR-0060](0060-dauerhafte-anmeldung-mit-widerrufsliste.md) (2026-09-05, Issue #2129) — ursprünglich akzeptiert, rückwirkend dokumentiert 2026-07-22 (gelebte Praxis seit der Auth-Einführung, Issue #1343)
+
+> **Nachtrag 2026-09-05:** Die unten unter „Verworfene Alternativen" genannte
+> Begründung, eine serverseitige Sitzungsverwaltung sei „bei 24h-TTL und
+> Passwortwechsel als Notweg" verzichtbar, traf nicht zu: Der Passwortwechsel
+> hat bestehende Sitzungen nie invalidiert. Es gab also keinen Notweg.
+> ADR-0060 ersetzt die TTL durch eine dateibasierte Liste gültiger Sitzungen.
 - **Datum:** 2026-07-22
 - **Bezug:** `internal/middleware/auth.go`, `docs/reference/api_contract.md` (Session-Cookie-Format)
 

--- a/docs/adr/0060-dauerhafte-anmeldung-mit-widerrufsliste.md
+++ b/docs/adr/0060-dauerhafte-anmeldung-mit-widerrufsliste.md
@@ -36,7 +36,14 @@ steht — nicht mehr, solange eine Frist läuft.
 
 - **Format:** `{userId}.{sessionId}.{ts}.{sig}`, HMAC-SHA256 über
   `{userId}:{sessionId}:{ts}`. `sessionId` sind 16 Zufallsbytes hex. Keine
-  Ablaufprüfung. Die Cookie-Lebensdauer im Browser beträgt mindestens ein Jahr.
+  Ablaufprüfung. Die Cookie-Lebensdauer im Browser beträgt 400 Tage — Browser
+  deckeln persistente Cookies dort, ein höherer Wert wäre eine Zusage, die der
+  Browser nicht einlöst.
+- **Alt und neu werden über die Signatur unterschieden, nicht über die
+  Segmentzahl.** Eine Nutzerkennung mit Punkt erzeugt auch im alten Format vier
+  Segmente; die Teilezahl trennt die Formate also nicht. Geprüft wird zuerst das
+  neue Format, bei Fehlschlag das alte — zwei HMAC-Vergleiche, die Reihenfolge
+  kostet nichts.
 - **Ablage:** `data/users/<user_id>/sessions.json`, bewusst **getrennt** vom
   Nutzer-Datensatz. Die 15 bestehenden `SaveUser`-Aufrufer schreiben stets das
   ganze Nutzerobjekt zurück; läge die Liste dort, könnte ein gleichzeitiger
@@ -57,7 +64,19 @@ steht — nicht mehr, solange eine Frist läuft.
   haben. Nachrüstbar, sobald eine Lastmessung ihn begründet.
 - **Zwei Abmelde-Wege:** „Abmelden" entfernt einen Eintrag, „Auf allen Geräten
   abmelden" (`POST /api/auth/logout-all`) leert die Liste. Passwortwechsel,
-  Passwort-Zurücksetzen und Kontolöschung leeren sie ebenfalls.
+  Passwort-Zurücksetzen und Kontolöschung leeren sie ebenfalls. Der
+  **Passwortwechsel** stellt dem Gerät, an dem er ausgelöst wird, sofort ein
+  neues Merkmal aus: alle anderen Geräte fliegen hinaus, der Wechselnde sperrt
+  sich nicht selbst aus. Beim **Zurücksetzen** eines vergessenen Passworts
+  geschieht das bewusst nicht — dort ist Aussperren im Kompromittierungsfall
+  die richtige Antwort.
+- **Auch Alt-Merkmale sind widerrufbar.** Ein Zeitstempel `legacy_revoked_at`
+  in derselben Datei wird bei jedem Widerruf gesetzt; der Legacy-Zweig weist
+  danach jedes ältere Alt-Merkmal ab. Ohne ihn bliebe ein Nutzer, der sich
+  anmeldet, nichts tut und sich sofort abmeldet, bis zu 24 Stunden angemeldet —
+  sein Merkmal steht auf keiner Liste, es gäbe also nichts zu entfernen. Ein
+  einzelner Wert je Nutzer, kein Verzeichnis einzelner Merkmale; er entfällt
+  mit dem Legacy-Zweig.
 - **Beide Prüfstellen zerlegen von rechts.** Der Go-Dienst zerlegte bisher mit
   `SplitN(".", 3)`, der Frontend-Server war unter #425 AC-7 bereits auf ein
   rechts-verankertes Verfahren umgestellt worden, ohne dass Go nachgezogen

--- a/docs/adr/0060-dauerhafte-anmeldung-mit-widerrufsliste.md
+++ b/docs/adr/0060-dauerhafte-anmeldung-mit-widerrufsliste.md
@@ -1,0 +1,113 @@
+# ADR-0060: Dauerhafte Anmeldung mit dateibasierter Liste gültiger Sitzungen (löst ADR-0030 ab)
+
+- **Status:** Akzeptiert
+- **Datum:** 2026-09-05
+- **Bezug:** löst [ADR-0030](0030-session-auth-hmac-cookie.md) ab · `internal/middleware/auth.go`, `internal/store/sessions.go`, `frontend/src/lib/auth.ts`, `docs/reference/api_contract.md`, Issue #2129 (Scheibe 2 von #2127)
+
+## Kontext
+
+Die Anmeldung lief nach exakt 24 Stunden ab, hart ab dem Login und ohne
+Verlängerung bei Nutzung (`MaxAge: 86400` an sechs Ausstellungsstellen,
+Prüfung `time.Now().Unix()-ts > 86400`). Auf einer mehrtägigen Tour heißt das:
+jeden Tag neu anmelden, bei schlechtem Netz. Der PO hat am 2026-09-05
+entschieden, dass die Anmeldung dauerhaft bis zum Abmelden gilt — unter der
+Bedingung einer Fern-Abmeldung, die tatsächlich wirkt.
+
+Diese Bedingung war nicht erfüllt. Zwei Befunde aus der Analyse:
+
+1. **Das Abmelden überlebte keinen Neustart.** Die Sperrliste war eine
+   prozesslokale `sync.Map`. Nach jedem Deploy — und Deploys sind hier häufig —
+   war ein bereits abgemeldetes Cookie wieder gültig. Bei 24 Stunden Laufzeit
+   war der Schaden gedeckelt; bei unbefristeter Anmeldung wäre ein einmal
+   abgegriffenes Cookie unbegrenzt gültig gewesen.
+2. **Der in ADR-0030 genannte Notweg existierte nicht.** ADR-0030 verwarf die
+   serverseitige Sitzungsverwaltung mit der Begründung, bei „24h-TTL und
+   Passwortwechsel als Notweg" sei sie verzichtbar. Tatsächlich ändert
+   `ChangePasswordHandler` nur den Passwort-Hash, ohne jede
+   Sitzungs-Invalidierung; für `ResetPasswordHandler` gilt dasselbe. Der Preis,
+   den ADR-0030 bewusst zu zahlen glaubte, war also höher als dort angenommen:
+   es gab überhaupt keinen wirksamen Widerruf.
+
+## Entscheidung
+
+**Jeder Nutzer führt eine dateibasierte Liste seiner gültigen Anmeldungen.**
+Ein Anmelde-Merkmal ist gültig, solange seine Anmelde-Kennung auf dieser Liste
+steht — nicht mehr, solange eine Frist läuft.
+
+- **Format:** `{userId}.{sessionId}.{ts}.{sig}`, HMAC-SHA256 über
+  `{userId}:{sessionId}:{ts}`. `sessionId` sind 16 Zufallsbytes hex. Keine
+  Ablaufprüfung. Die Cookie-Lebensdauer im Browser beträgt mindestens ein Jahr.
+- **Ablage:** `data/users/<user_id>/sessions.json`, bewusst **getrennt** vom
+  Nutzer-Datensatz. Die 15 bestehenden `SaveUser`-Aufrufer schreiben stets das
+  ganze Nutzerobjekt zurück; läge die Liste dort, könnte ein gleichzeitiger
+  Profil-Schreiber einen Widerruf überschreiben — und ausgerechnet der Widerruf
+  verträgt diesen Verlust nicht. Die Trennung hält die Liste zudem aus dem
+  `model.User`-Schema heraus, sodass nicht jede Anmeldung den
+  Schema-Backup-Hook auslöst. Konform zu ADR-0031.
+- **Nebenläufigkeit:** Pro-Nutzer-Sperre nach dem Vorbild
+  `internal/store/briefing_lock.go` (Mutex-Pool auf Paketebene mit
+  Referenzzählung). Ein Prozess je Umgebung, daher genügt eine Prozess-Sperre.
+- **Kein Zwischenspeicher.** Jede authentifizierte Anfrage liest die Liste
+  direkt. Real existierende Nutzerdateien sind 193–433 Byte groß, der Bestand
+  umfasst eine Handvoll Nutzer, und es existieren keine Request-Metriken, die
+  einen Zwischenspeicher rechtfertigen würden. Vor allem aber: Ein
+  Zwischenspeicher wäre ein zweiter Zustandsbehälter, der genau die
+  Widerrufs-Zusicherung tragen müsste, auf der die unbefristete Anmeldung
+  beruht. Der billigste Weg, ihn nie falsch werden zu lassen, ist, ihn nicht zu
+  haben. Nachrüstbar, sobald eine Lastmessung ihn begründet.
+- **Zwei Abmelde-Wege:** „Abmelden" entfernt einen Eintrag, „Auf allen Geräten
+  abmelden" (`POST /api/auth/logout-all`) leert die Liste. Passwortwechsel,
+  Passwort-Zurücksetzen und Kontolöschung leeren sie ebenfalls.
+- **Beide Prüfstellen zerlegen von rechts.** Der Go-Dienst zerlegte bisher mit
+  `SplitN(".", 3)`, der Frontend-Server war unter #425 AC-7 bereits auf ein
+  rechts-verankertes Verfahren umgestellt worden, ohne dass Go nachgezogen
+  wurde. Heute nicht ausnutzbar (alle Kennungs-Erzeuger sind punktfrei), aber
+  eine strukturelle Divergenz zwischen zwei Stellen, die dasselbe prüfen
+  sollen. Wird mit dieser Entscheidung beseitigt.
+
+### Migrationspfad (Folgepflicht aus ADR-0030)
+
+Merkmale im alten dreiteiligen Format bleiben gültig und **behalten ihre
+24-Stunden-Grenze**. Bei einem gültigen Alt-Merkmal legt die Middleware
+synchron eine Anmelde-Kennung an, trägt sie ein und setzt das neue Cookie über
+den `ResponseWriter` nach. Niemand wird durch das Deploy hinausgeworfen. Da
+keine neuen Alt-Merkmale mehr ausgestellt werden, verschwindet der Altbestand
+binnen 24 Stunden von selbst; der Legacy-Zweig kann danach ersatzlos entfallen.
+Nutzer ohne `sessions.json` haben eine leere Liste — kein Migrationsskript.
+
+## Verworfene Alternativen
+
+- **Generationszähler** (eine Zahl je Nutzer, die das Merkmal mitträgt; erhöhen
+  = alle abmelden). Billiger zu prüfen und zu speichern, kann aber „nur dieses
+  Gerät abmelden" prinzipiell nicht abbilden. Um beide geforderten Abmelde-Arten
+  zu erfüllen, bräuchte er zusätzlich eine dauerhafte Sperrliste einzelner
+  Merkmale, die bei unbefristeten Merkmalen nie schrumpft — also zwei
+  Mechanismen nebeneinander, doppelter Code, doppelte Migration, doppelte Tests
+  ohne Gegenwert.
+- **Alles beim Alten lassen und nur die Frist verlängern.** Verlagert das
+  Problem, statt es zu lösen: ohne wirksamen Widerruf wächst mit jeder
+  Fristverlängerung das Zeitfenster eines abgegriffenen Cookies.
+- **Widerrufsprüfung auch im Frontend-Server.** Er hat keinen Zugriff auf den
+  Nutzer-Datenbestand; eine Rückfrage zum Go-Dienst kostete Wartezeit bei jedem
+  Seitenaufbau und bräche die bewusste Trennung, ohne einen echten Schaden
+  abzuwenden (siehe Negativ-Konsequenz unten).
+
+## Konsequenzen
+
+- **Positiv:** Anmeldung hält, bis der Nutzer sie beendet — das eigentliche
+  Produktziel auf Tour. Abmelden wirkt dauerhaft, auch über Deploys hinweg.
+  Ein verlorenes Handy lässt sich fern-abmelden. Passwortwechsel und
+  -Zurücksetzen wirken erstmals überhaupt auf bestehende Anmeldungen. Die
+  Zerlegungs-Divergenz zwischen den beiden Prüfstellen ist beseitigt.
+- **Negativ / Preis:** Ein Dateizugriff je authentifizierter Anfrage, wo bisher
+  keiner nötig war. Der Frontend-Server prüft weiterhin nur Signatur und
+  Format, nicht die Liste — nach einem Widerruf entsteht dort ein kurzes
+  Fenster „Seite lädt, Daten fehlen", bis der nächste Klick auf die
+  Anmelde-Seite führt; das entsprach schon dem Verhalten der alten Sperrliste.
+  Die Liste wächst je Gerät und wird durch keine Frist mehr geräumt — bei
+  unbefristeter Anmeldung ist genau das gewollt.
+- **Folgepflichten:** Das Cookie-Format bleibt API-Vertrag — Änderungen nur mit
+  neuem ADR und Migrationspfad. Der Legacy-Zweig für dreiteilige Merkmale ist
+  nach dem Deploy verzichtbar und soll dann entfernt werden. Beide Prüfstellen
+  (Go und Frontend-Server) müssen bei jeder Formatänderung gemeinsam
+  ausgeliefert werden; getrennte Deploys sperren Nutzer aus.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -92,7 +92,7 @@ bzw. in den Specs unter `docs/specs/`.
 | [0027](0027-adr-commit-guard-entfernt.md) | Lokales ADR-Commit-Gate (`adr_guard.py`) entfernt — tot seit Plugin-Migration, ADR-Praxis bleibt bestehen | Akzeptiert |
 | [0028](0028-e2e-prod-network-unreachable-admin-loses-never-delete.md) | Prod-Datenbaum wird für E2E netzwerkseitig unerreichbar; `admin` verliert den NEVER_DELETE-Schutz aus #1265 | Akzeptiert |
 | [0029](0029-openmeteo-standard-provider.md) | Open-Meteo als Standard-Wetterdaten-Provider (löst 0002 ab) | Akzeptiert |
-| [0030](0030-session-auth-hmac-cookie.md) | Session-Auth über HMAC-signiertes Cookie (kein JWT, keine Session-Tabelle) | Akzeptiert |
+| [0030](0030-session-auth-hmac-cookie.md) | Session-Auth über HMAC-signiertes Cookie (kein JWT, keine Session-Tabelle) | Abgelöst durch 0060 |
 | [0031](0031-persistenz-dateibasiert-data-users.md) | Dateibasierte JSON-Persistenz unter `data/users/{user_id}/` (keine Datenbank) | Akzeptiert |
 | [0032](0032-wizard-abschaffung-progressive-editoren.md) | Multi-Step-Wizards abgeschafft — progressive Tab-Editoren mit Auto-Save | Akzeptiert |
 | [0033](0033-warn-karte-nur-betroffene-segmente.md) | Amtliche Warn-Karte zeigt nur betroffene Segmente, kein Vollrouten-Gitter (löst #1233/#1216 ab) | Akzeptiert |
@@ -122,3 +122,4 @@ bzw. in den Specs unter `docs/specs/`.
 | [0057](0057-mehrere-gewitter-signalquellen-je-gebiet.md) | Mehrere Gewitter-Signalquellen je Gebiet sind additiv erlaubt — GeoSphere (cape/cin) ergänzt für Österreich den DWD, ohne ihn zu verdrängen (ergänzt 0025/0047, Issue #1758) | Akzeptiert |
 | [0058](0058-wegpunkt-hoehe-an-provider-api.md) | Wegpunkt-Höhe wird an die Provider-Schnittstelle durchgereicht — keine eigene Höhenphysik, kein Transparenzhinweis im Briefing (schreibt 0018 fort, Issue #1991) | Akzeptiert |
 | [0059](0059-compare-ausblick-erbt-grundauswahl.md) | Der 3-Tages-Ausblick verhält sich wie ein Kanal — Grundauswahl statt eigener Liste, für Trip UND Ortsvergleich (löst 0053 Punkt 1 ab, schreibt 0050/0055 fort, Issue #1848 Scheibe A3) | Akzeptiert |
+| [0060](0060-dauerhafte-anmeldung-mit-widerrufsliste.md) | Dauerhafte Anmeldung mit dateibasierter Liste gültiger Sitzungen — Widerruf überlebt den Neustart, „auf allen Geräten abmelden" (löst 0030 ab, Issue #2129 Scheibe S2 von #2127) | Akzeptiert |

--- a/docs/context/feat-2129-dauerhafte-anmeldung.md
+++ b/docs/context/feat-2129-dauerhafte-anmeldung.md
@@ -225,8 +225,16 @@ entscheide dagegen und lese bei jeder Anfrage direkt:
 | alt (3 Teile) | `{userId}.{ts}.{sig}` | `{userId}:{ts}` |
 | **neu (4 Teile)** | `{userId}.{sessionId}.{ts}.{sig}` | `{userId}:{sessionId}:{ts}` |
 
-`sessionId` = 16 Zufallsbytes hex. Die Teilezahl unterscheidet alt und neu eindeutig — deshalb
-bleibt `ts` erhalten, obwohl es für die Gültigkeit nicht mehr gebraucht wird.
+`sessionId` = 16 Zufallsbytes hex. `ts` bleibt erhalten, obwohl es für die Gültigkeit nicht mehr
+gebraucht wird — der Legacy-Zweig braucht es weiter.
+
+**Korrektur 2026-09-06 (bei der Umsetzung gefunden):** Die ursprüngliche Annahme, die *Teilezahl*
+unterscheide alt und neu eindeutig, ist falsch. Eine Nutzerkennung mit Punkt erzeugt auch im alten
+Format vier Segmente — `alice.smith.{ts}.{sig}` ist von `{userId}.{sessionId}.{ts}.{sig}` nicht an
+der Segmentzahl zu trennen. Unterschieden wird stattdessen über die **Signatur**: zuerst wird das
+neue Format geprüft (HMAC über `{userId}:{sessionId}:{ts}`), bei Fehlschlag das alte
+(`{userId}:{ts}`). Beides sind HMAC-Vergleiche, die Reihenfolge kostet nichts. Ohne diese
+Korrektur wäre entweder AC-14 oder der Legacy-Zweig gebrochen.
 
 **Beide Seiten parsen von rechts** (die letzten drei Segmente sind `sessionId`/`ts`/`sig`, alles
 davor ist die userId). Das behebt zugleich Befund 13 (siehe unten).

--- a/docs/context/feat-2129-dauerhafte-anmeldung.md
+++ b/docs/context/feat-2129-dauerhafte-anmeldung.md
@@ -1,0 +1,354 @@
+# Context: feat-2129-dauerhafte-anmeldung
+
+Issue: [#2129](https://github.com/henemm/gregor_zwanzig/issues/2129) · Elternscheibe: #2127 (S2 von 5)
+Track: Full Process · Erstellt: 2026-09-05
+
+## Request Summary
+
+Die Anmeldung soll unbefristet gelten (bis zum aktiven Abmelden) statt nach 24 Stunden hart
+abzulaufen. Bedingung des PO: ein Widerruf, der einen Server-Neustart überlebt — inklusive
+„auf allen Geräten abmelden". Ohne diesen Widerruf wäre ein einmal abgegriffenes Cookie
+unbegrenzt gültig.
+
+## Ist-Stand (recherchiert 2026-09-05)
+
+### Cookie-Format
+
+`gz_session` = `{userId}.{unixTimestamp}.{hmacSigHex}`, HMAC-SHA256 über `{userId}:{ts}`.
+
+| Rolle | Ort |
+|---|---|
+| Bau | `internal/middleware/auth.go:77-83` (`SignSession`) |
+| Prüfung Go | `internal/middleware/auth.go:91-120` (`validateSession`) — `SplitN(".", 3)`, Ablauf Z107, `hmac.Equal` Z111-116 |
+| Prüfung Frontend (eigenständig!) | `frontend/src/lib/auth.ts:9-29` (`verifySession`) — `parts.pop()`-Strategie, Ablauf Z23, Vergleich Z26 **ohne** `timingSafeEqual` |
+
+### Ausstellungsstellen (6× Go, 2× Frontend)
+
+Alle identisch: `gz_session`, Path `/`, HttpOnly, SameSite Lax, **MaxAge 86400**, Secure abhängig
+von `X-Forwarded-Proto`/`r.TLS`.
+
+| Datei:Zeile | Login-Weg |
+|---|---|
+| `internal/handler/auth.go:154-164` | Passwort |
+| `internal/handler/auth_magic.go:187-197` | Magic-Link |
+| `internal/handler/auth_oauth.go:182-192` | Google OAuth |
+| `internal/handler/passkey.go:256-266` | Passkey-Login |
+| `internal/handler/passkey.go:365-375` | Passkey discoverable |
+| `internal/handler/passkey.go:575-585` | Passkey-Registrierung |
+| `frontend/src/routes/login/+page.server.ts:43-49` | setzt das vom Go-Dienst erhaltene Cookie **erneut** |
+| `frontend/src/routes/magic-link/verify/+page.server.ts:42-48` | dito |
+
+### Widerruf heute
+
+- `var sessionBlacklist sync.Map` — `internal/middleware/auth.go:16`, Modul-global, reiner
+  Prozessspeicher. Key = **kompletter Token-String**.
+- `LogoutHandler` — `internal/handler/auth.go:431-449`: blacklistet genau diesen einen Token,
+  löscht das Cookie (`MaxAge -1`).
+- `DeleteAccountHandler` — `auth.go:189-196`: dasselbe.
+- **Kein Muster für „alle Sessions eines Nutzers"** — die Blacklist kann nur Token sperren, die man
+  kennt.
+
+### Prüfung und Kontext
+
+`AuthMiddleware` — `internal/middleware/auth.go:31-68`: Whitelist öffentlicher Pfade (Z34-47),
+Cookie lesen (Z52), `validateSession` (Z58), `IsBlacklisted` (Z59), bei Erfolg
+`context.WithValue(userIDContextKey, userId)` (Z64). Abruf via `UserIDFromContext` (Z70-73).
+Frontend-Gegenstück: `frontend/src/hooks.server.ts:1-31`, `publicPaths` Z6, bei ungültig
+`redirect(302, '/login')` Z21 (ohne `?redirect=`), bei gültig `event.locals.userId` Z24.
+
+### Persistenz-Muster
+
+- `LoadUser` / `SaveUser` — `internal/store/user.go:48-79`. `SaveUser` schreibt das **ganze**
+  `model.User`-Struct; das Read-Modify-Write-Merge entsteht ausschließlich beim Aufrufer.
+- Atomar via `writeFileAtomic` — `internal/store/write.go:35-59` (Temp + Rename).
+- **Kein Mutex** um Load→Modify→Save auf `user.json` (anders als `internal/store/briefing_lock.go:17`).
+- `model.User` — `internal/model/user.go:10-39`: kein Feld für Widerrufs-/Versionsstand vorhanden.
+  Nächstliegendes Bestandsmuster: `*time.Time` mit `omitempty` (wie `EmailVerifiedAt`, `RequestedAt`).
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `internal/middleware/auth.go` | Bau, Prüfung, Blacklist — **das Herzstück**, alles Format-Bruchrisiko konzentriert sich hier |
+| `internal/handler/auth.go` | Login, Logout, Passwortwechsel, Account-Löschung |
+| `internal/handler/auth_magic.go` / `auth_oauth.go` / `passkey.go` | vier weitere Ausstellungsstellen |
+| `internal/handler/auth.go:744-793` | `ChangePasswordHandler` — Ort für „Passwortwechsel meldet überall ab" |
+| `internal/handler/auth.go:308-375` | `ResetPasswordHandler` — dito |
+| `internal/store/user.go`, `internal/model/user.go` | Ablageort des Widerrufs-Stands (**löst `data_schema_backup.py` aus**) |
+| `internal/router/router.go:49` | Routen-Registrierung, Ort für einen neuen Endpunkt |
+| `frontend/src/lib/auth.ts`, `frontend/src/hooks.server.ts` | zweite, eigenständige Prüfung |
+| `frontend/src/routes/login/+page.server.ts`, `.../magic-link/verify/+page.server.ts` | Frontend-Cookie-Ausstellung |
+| `frontend/src/lib/api.ts:61-69` | 401 → harter Sprung auf `/login?expired=1&redirect=…` |
+| `frontend/src/routes/logout/+page.server.ts:6-17` | Formular-POST-Logout |
+| `frontend/src/lib/components/ui/sidebar/Sidebar.svelte:194-199, 259-264` | „Abmelden"-Knopf (2×: Desktop + Mobile) |
+| `frontend/src/routes/account/+page.svelte:761-779, 800-816` | „Gefahrenzone" + Dialog-Bestätigung — **Vorbild** für „Auf allen Geräten abmelden" |
+| `docs/adr/0030-session-auth-hmac-cookie.md` | wird durch diese Scheibe abgelöst |
+| `docs/reference/api_contract.md` Z2250, 2295, 2585, 2659, 2814 | Vertragstext zum Cookie |
+
+## Existing Patterns
+
+- **Destruktive Aktion im UI:** Card „Gefahrenzone" (rot) → Klick setzt `show…Dialog = true` →
+  `Dialog.Root` mit `Btn variant="outline"` (Abbrechen) + `Btn variant="destructive"` → `api.del/post`
+  → bei Fehler **inline** `{#if errorMsg}`-Box (kein Toast-System im Projekt). Vorbild:
+  „Account löschen", `account/+page.svelte:282-295`.
+- **Nutzerdaten-Änderung:** `LoadUser` → Feld setzen → `SaveUser(*user)` (Read-Modify-Write beim
+  Aufrufer, ADR-0031).
+- **Optionales Zeitfeld:** `*time.Time` mit `json:"…,omitempty"` — Nil bedeutet „nie geschehen",
+  das trägt die Abwärtskompatibilität für Bestandsnutzer ohne Migrationsskript.
+- **ADR-Ablösung:** altes ADR bleibt stehen, Status → „Abgelöst durch ADR-XXXX"; neues ADR nach
+  `docs/adr/_template.md`; Index-Zeile in `docs/adr/README.md`. **Nächste freie Nummer: 0060.**
+  `tests/test_adr_index_drift.py` erzwingt beides sofort: jede ADR-Datei muss im Index verlinkt
+  sein **und** die Status-Klasse muss zwischen Datei und Index übereinstimmen — der Statuswechsel
+  von ADR-0030 auf „abgelöst" muss also im selben Zug in den Index, sonst wird die Ampel rot.
+
+## Dependencies
+
+- **Upstream:** `GZ_SESSION_SECRET` (Go + Frontend), `store.Store`, `model.User`, `bcrypt`.
+- **Downstream:** jeder authentifizierte API-Aufruf (`UserIDFromContext`), jede geschützte
+  SvelteKit-Route (`event.locals.userId`), 17 Playwright-Setups, die `gz_session` aus einem echten
+  Login in `frontend/e2e/playwright/.auth/*.json` ablegen.
+
+## Existing Specs
+
+| Spec | Zustand |
+|---|---|
+| `docs/specs/modules/logout_session_blacklist.md` | beschreibt die heutige In-Memory-Blacklist — **muss aktualisiert werden** |
+| `docs/specs/modules/user_auth_endpoints.md` | Endpunkt-Liste, neuer Widerrufs-Endpunkt gehört hinein |
+| `docs/specs/modules/sveltekit_login_refactor.md` | Frontend-Anmeldeweg |
+| `docs/specs/modules/passkey_webauthn.md` (created 2026-05-30) | bei Änderung **AC-Pflicht** (created ≥ 2026-05-11) |
+| `docs/specs/modules/google_oauth_login.md` | Cookie-Ausstellung im OAuth-Weg |
+
+## Risks & Considerations
+
+### Befunde, die vom Ticket abweichen — vor der Spec zu klären
+
+1. **Punkt 4 des Tickets stimmt nicht.** „Passwortwechsel meldet überall ab — bislang der einzige
+   Notweg": `ChangePasswordHandler` (`auth.go:744-793`) ändert **nur** den Passwort-Hash, ohne jede
+   Session-Invalidierung; ebenso `ResetPasswordHandler` (`auth.go:308-375`). Es gibt heute also
+   **gar keinen** wirksamen Notweg. Sicherheitlich ist der Reset-Fall der schwerere: wer sein
+   Passwort zurücksetzt, weil es kompromittiert war, wirft den Angreifer heute nicht hinaus.
+2. **Vertragstext widerspricht sich selbst.** `api_contract.md:2250` behauptet „7-day expiry",
+   Z2585/2659/2814 sagen 24 h — der Code sagt 24 h. Bestehende Doku-Drift, im Zuge der
+   Vertragsänderung mitzuräumen.
+3. **Frontend-Fallback-Secret.** `hooks.server.ts:16` fällt auf `'dev-secret-change-me'` zurück,
+   wenn `GZ_SESSION_SECRET` fehlt. Bei unbefristeten Anmeldungen wiegt ein still greifender
+   Fallback schwerer als heute. → Nebenbefund-Triage.
+4. **Kein `timingSafeEqual` im Frontend** (`auth.ts:26`) — Go macht es korrekt (`hmac.Equal`).
+   → Nebenbefund-Triage.
+
+### Technische Risiken
+
+5. **Zwei Prüfstellen müssen synchron bleiben.** Lässt die eine durch, was die andere abweist,
+   entsteht ein Zustand, in dem die Seite lädt, aber jeder Datenabruf 401 gibt (oder umgekehrt eine
+   Umleitungsschleife). Beide Seiten gehören in **einen** Testlauf.
+6. **Race auf `user.json`.** Load→Modify→Save ist ungelockt. „Auf allen Geräten abmelden" schreibt
+   in dieselbe Datei wie jede andere Nutzeränderung; ein gleichzeitiger Schreiber kann den Widerruf
+   überschreiben — dann bliebe ein verlorenes Handy angemeldet. Der Widerruf ist genau die
+   Operation, die diesen Verlust nicht verträgt.
+7. **Ein Lesezugriff pro Anfrage.** Der Widerrufs-Stand muss bei **jeder** authentifizierten
+   Anfrage geprüft werden. Naiv ist das ein `user.json`-Lesevorgang pro Request. Frage für die
+   Analyse: Zwischenspeicher — und wenn ja, wie wird er beim Widerruf sofort ungültig (ein
+   Zwischenspeicher, der den Widerruf verzögert, hebt die Zusicherung auf)?
+8. **Bestandstests, die MaxAge 86400 festschreiben** — `auth_test.go:479-480`,
+   `auth_magic_test.go:259-260`, `passkey_test.go:419-420`, `passkey_public_test.go:239-240`, und
+   vor allem `middleware/auth_test.go:70-87` (`TestExpiredCookie_Returns401`, Cookie 25 h alt →
+   erwartet 401). Diese Erwartungen werden durch die Änderung **fachlich falsch** und sind bewusst
+   umzuschreiben, nicht wegzulöschen.
+9. **Frontend-Cookie-Attribute sind test-unbewacht.** Kein Test prüft `maxAge`/`httpOnly`/
+   `sameSite` in `login/+page.server.ts` — eine Änderung dort fällt heute niemandem auf.
+10. **Übergang ohne Ausloggen.** Bestandscookies im Altformat müssen weiterlaufen und still auf
+    das neue Format gehoben werden. Ein Nutzer mit einem 20 h alten Cookie darf durch das Deploy
+    nicht hinausfliegen.
+11. **Mandantentrennung.** Der Widerrufs-Stand ist pro Nutzer; die Nutzerkennung kommt weiterhin
+    ausschließlich aus dem geprüften Merkmal, nie aus einem Standardwert (ADR-0003). Nachweis
+    zwingend mit **zwei verschiedenen Nutzern**.
+12. **Schema-Änderung an `internal/model/user.go`** löst den Pre-Snapshot-Hook
+    `data_schema_backup.py` aus und verlangt Migrations-/Roundtrip-Nachweis (ADR-0031).
+
+### Erfreulich unkritisch
+
+- Keine Service-Worker-/Offline-Schicht vorhanden (nur `static/site.webmanifest`) — kein
+  Client-Cache, der eine unbefristete Session umgehen könnte. Das kommt erst mit S1 (#2128).
+- Kein Prüfwerkzeug und kein E2E-Setup baut ein `gz_session` synthetisch nach; alle lesen es aus
+  einem echten Login. Das Bruchrisiko der Formatänderung liegt praktisch vollständig in
+  `internal/middleware/auth.go` und `frontend/src/lib/auth.ts`.
+
+## Analysis
+
+### Type
+
+Feature (mit eingebetteter Sicherheitsbehebung).
+
+### Entwurfsentscheidung: Allowlist gültiger Sitzungen
+
+Zwei Entwürfe standen gegeneinander:
+
+| | **A — Generationszähler** | **B — Allowlist gültiger Sitzungen** |
+|---|---|---|
+| Prinzip | Zahl im Nutzerdatensatz, Cookie trägt sie mit; passt sie nicht, ist es ungültig | Jede Anmeldung erhält eine Zufalls-Kennung im Cookie; gültig ist, was in der Liste steht |
+| „alle Geräte abmelden" | Zähler erhöhen | Liste leeren |
+| **„nur dieses Gerät abmelden"** | **nicht möglich** — bräuchte zusätzlich eine dauerhafte Sperrliste, die bei unbefristeten Cookies nie schrumpft | einen Eintrag entfernen |
+| Wachstum | keines | ~100 Byte je Gerät, schrumpft beim Abmelden |
+
+**Gewählt: B.** A scheitert an einer der beiden geforderten Abmelde-Arten und bräuchte, um sie zu
+erfüllen, ohnehin genau die Struktur von B — zwei Mechanismen nebeneinander wären doppelter Code,
+doppelte Migration, doppelte Tests ohne Gegenwert.
+
+### Ablage und Nebenläufigkeit
+
+- **Eigene Datei `data/users/<user_id>/sessions.json`**, nicht in `user.json`. Zwei Gründe: (1) die
+  15 bestehenden `SaveUser`-Aufrufer schreiben das *ganze* Nutzerobjekt zurück — ein gleichzeitiger
+  Profil-Schreiber könnte einen Widerruf schlicht überschreiben, und ausgerechnet der Widerruf
+  verträgt diesen Verlust nicht; (2) es bleibt aus dem `model.User`-Schema heraus, löst also nicht
+  bei jeder Anmeldung den Schema-Backup-Hook aus.
+- **Pro-Nutzer-Sperre** nach dem Vorbild `internal/store/briefing_lock.go:17-58` (Mutex-Pool auf
+  Paketebene mit Referenzzählung). Ein Prozess je Umgebung, daher genügt eine Prozess-Sperre.
+
+### Kein Zwischenspeicher — bewusst gegen die Agenten-Empfehlung
+
+Der Strategie-Agent empfahl einen In-Memory-Zwischenspeicher mit synchroner Ungültigmachung. Ich
+entscheide dagegen und lese bei jeder Anfrage direkt:
+
+- Gemessen: `AuthMiddleware` liest heute **keine** Datei; real existierende `user.json` sind
+  193–433 Byte; der Bestand umfasst eine Handvoll Nutzer. Ein 400-Byte-Lesevorgang aus dem
+  Betriebssystem-Cache ist gegenüber allem anderen in der Anfrage nicht messbar.
+- Ein Zwischenspeicher ist ein zweiter Zustandsbehälter, der genau die Zusicherung tragen müsste,
+  auf der die unbefristete Anmeldung beruht. Der billigste Weg, ihn nie falsch werden zu lassen,
+  ist, ihn nicht zu haben.
+- Nachrüstbar, sobald es je eine Lastmessung gibt, die ihn rechtfertigt. Heute gibt es überhaupt
+  keine Request-Metriken (nachgesehen: keine).
+
+### Cookie-Format
+
+| | Format | Signatur über |
+|---|---|---|
+| alt (3 Teile) | `{userId}.{ts}.{sig}` | `{userId}:{ts}` |
+| **neu (4 Teile)** | `{userId}.{sessionId}.{ts}.{sig}` | `{userId}:{sessionId}:{ts}` |
+
+`sessionId` = 16 Zufallsbytes hex. Die Teilezahl unterscheidet alt und neu eindeutig — deshalb
+bleibt `ts` erhalten, obwohl es für die Gültigkeit nicht mehr gebraucht wird.
+
+**Beide Seiten parsen von rechts** (die letzten drei Segmente sind `sessionId`/`ts`/`sig`, alles
+davor ist die userId). Das behebt zugleich Befund 13 (siehe unten).
+
+### Befund 13 — Parsing-Divergenz zwischen den beiden Prüfstellen
+
+Nachgerechnet für `alice.smith`: Go (`SplitN(".", 3)`, `auth.go:92`) zerlegt
+`alice.smith.1757000000.abcdef` zu `["alice", "smith", "1757000000.abcdef"]`, scheitert dann beim
+Timestamp-Parsen und weist ab. Das Frontend (`auth.ts:14-18`, `pop()`) rekonstruiert `alice.smith`
+korrekt — es wurde im Zuge von #425 AC-7 vorsorglich gefixt, **Go wurde nie nachgezogen**.
+
+**Heute nicht ausnutzbar:** alle drei Kennungs-Erzeuger sind punktfrei
+(`^[a-zA-Z0-9_-]+$` bei Registrierung/Passkey, `m-{8hex}`, `g-{8hex}`), und kein einziger
+Nutzerordner im echten Bestand enthält einen Punkt. Es ist also kein Bug, sondern eine strukturelle
+Divergenz zwischen zwei Stellen, die dasselbe prüfen sollen — in genau der Datei, die wir ohnehin
+anfassen. Wird mitbehoben (~5 Zeilen), nicht als Nebenbefund vertagt.
+
+### Migrationspfad
+
+- Alt-Cookies (3 Teile) bleiben gültig — **behalten dabei ihre 24-Stunden-Grenze**. Neue Cookies
+  (4 Teile) haben keine. Damit verschwindet der Altbestand binnen 24 Stunden nach dem Deploy von
+  selbst, und der Legacy-Zweig kann später ersatzlos entfallen.
+- Bei einem gültigen Alt-Cookie legt die Middleware synchron eine Sitzungs-Kennung an, trägt sie in
+  die Allowlist ein und setzt das neue Cookie über den `ResponseWriter` nach. Niemand fliegt durch
+  das Deploy hinaus.
+- Nutzer ohne `sessions.json`: Datei fehlt = leere Liste, wird beim ersten Eintrag angelegt. Kein
+  Migrationsskript nötig.
+- Bekannte Grenze: Bei server-zu-server-Aufrufen aus SvelteKit-Ladefunktionen erreicht ein
+  `Set-Cookie` des Go-Dienstes den Browser nicht. Ein Nutzer, der 24 Stunden lang ausschließlich
+  Seiten betrachtet und nie eine Aktion auslöst, behält bis dahin sein Alt-Cookie — das ist exakt
+  das heutige Verhalten, also keine Verschlechterung.
+
+### Die zwei Prüfstellen
+
+Der Frontend-Server hat keinen Zugriff auf den Nutzer-Datenbestand und prüft weiterhin **nur**
+Signatur und Format, nicht die Allowlist. Das ist kein neues Zugeständnis: die heutige Sperrliste
+ist dem Frontend genauso unbekannt. Nachvollzogen, was ein Nutzer bei einer widerrufenen Sitzung
+sieht: die Ladefunktion bekommt 401, fängt es ab und liefert leere Daten — die Seite lädt, wirkt
+leer; der nächste Klick löst den harten Sprung auf `/login?expired=1` aus. **Keine
+Umleitungsschleife.** Bewusst wird **keine** Rückfrage vom Frontend-Server zum Go-Dienst
+eingeführt: das kostete Wartezeit bei jedem Seitenaufbau und bräche die Trennung, ohne einen
+echten Schaden abzuwenden.
+
+### Affected Files
+
+| Datei | Änderung | Beschreibung |
+|---|---|---|
+| `internal/store/sessions.go` | CREATE | Allowlist lesen/hinzufügen/entfernen/leeren, atomar |
+| `internal/store/sessions_lock.go` | CREATE | Pro-Nutzer-Sperre nach `briefing_lock.go`-Vorbild |
+| `internal/middleware/auth.go` | MODIFY | Format 4-teilig, rechts-verankertes Parsen, Allowlist-Prüfung, Legacy-Zweig + Nachsetzen, Sperrliste entfällt |
+| `internal/handler/auth.go` | MODIFY | Login mintet Kennung; Logout entfernt Eintrag; neuer Endpunkt „alle abmelden"; Passwortwechsel **und** -Zurücksetzen leeren die Liste; Account-Löschung |
+| `internal/handler/auth_magic.go` | MODIFY | Ausstellungsstelle |
+| `internal/handler/auth_oauth.go` | MODIFY | Ausstellungsstelle |
+| `internal/handler/passkey.go` | MODIFY | drei Ausstellungsstellen |
+| `internal/router/router.go` | MODIFY | Route für „alle abmelden" |
+| `frontend/src/lib/auth.ts` | MODIFY | Format spiegeln, Ablaufprüfung nur noch für Altformat |
+| `frontend/src/routes/login/+page.server.ts` | MODIFY | Cookie-Lebensdauer |
+| `frontend/src/routes/magic-link/verify/+page.server.ts` | MODIFY | Cookie-Lebensdauer |
+| `frontend/src/routes/account/+page.svelte` | MODIFY | „Auf allen Geräten abmelden" nach Vorbild „Gefahrenzone" + Bestätigungsdialog |
+| `docs/adr/0060-*.md` | CREATE | löst ADR-0030 ab |
+| `docs/adr/0030-session-auth-hmac-cookie.md` | MODIFY | Status → abgelöst |
+| `docs/adr/README.md` | MODIFY | Index-Zeile + Statuswechsel (sonst Ampel rot) |
+| `docs/reference/api_contract.md` | MODIFY | Format + vier Set-Cookie-Stellen, inkl. der falschen „7-day"-Zeile |
+| `docs/specs/modules/logout_session_blacklist.md` | MODIFY | beschreibt heute die abgelöste Mechanik |
+| Tests Go + Frontend | MODIFY/CREATE | fünf MaxAge-/Ablauf-Erwartungen werden fachlich falsch; neu: Neustart-Nachweis, zwei Nutzer, Wettlauf |
+
+### Scope Assessment
+
+- Dateien: ~18 (davon 2 neu im Code, 1 neues ADR)
+- Geschätzte LoC: **+450 bis +600** — das 250er-Limit wird gerissen, ein Override ist nötig und
+  wird gesetzt, sobald `workflow.py status` es anzeigt.
+- Risiko: **HIGH** (Anmeldung, Mandantentrennung, API-Vertrag)
+
+### Warum das trotz Größe *eine* Scheibe bleibt
+
+Der Strategie-Agent schlug vor, Backend und Frontend zu trennen. Das geht nicht: seine eigene
+Reihenfolge verlangt, dass die Frontend-Spiegelung **vor oder gleichzeitig mit** der
+Backend-Formatänderung live ist, sonst weist der Frontend-Server jede frische Anmeldung ab und
+sperrt alle Nutzer aus. Getrennte Scheiben heißen getrennte Deploys — der Schnitt widerspricht sich
+selbst.
+
+Auch der naheliegendere Schnitt „erst der Widerruf, später die Entfristung" wird nicht gezogen: Der
+PO hat die unbefristete Anmeldung ausdrücklich an die Bedingung einer wirksamen Fern-Abmeldung
+geknüpft. Beide Hälften gehören in **einen** Auslieferungsstand — die Reihenfolge wird stattdessen
+*innerhalb* der Scheibe erzwungen (siehe unten).
+
+### Reihenfolge — das Netz vor dem Sprung
+
+1. Allowlist-Ablage + Sperre, additiv und unbenutzt, mit eigenem Roundtrip-Test.
+2. Alle acht Ausstellungsstellen minten die Sitzungs-Kennung und tragen sie ein. **Die
+   24-Stunden-Grenze bleibt in diesem Schritt scharf** — nichts wird dadurch unsicherer.
+3. Frontend-Spiegelung des Formats (muss mit Schritt 2 zusammen ausgeliefert werden).
+4. Abmelden (ein Gerät) auf Allowlist umstellen — **hier wird der Neustart-Nachweis geführt**.
+5. „Auf allen Geräten abmelden" samt Bedienelement; Passwortwechsel und -Zurücksetzen verdrahten.
+6. **Zuletzt** die Ablaufprüfung für das neue Format entfernen und die Cookie-Lebensdauer
+   hochsetzen. Dieser Schritt nimmt das Sicherheitsnetz weg und darf erst laufen, wenn 1–5 grün
+   nachgewiesen sind.
+
+### Über den Ticket-Wortlaut hinaus
+
+- **Passwort-Zurücksetzen** wird mit verdrahtet, obwohl das Ticket nur den Passwortwechsel nennt.
+  Sicherheitlich ist es der wichtigere Fall: Wer zurücksetzt, *weil* das Passwort abgegriffen
+  wurde, wirft den Angreifer sonst nicht hinaus.
+- **Nicht gebaut:** eine Geräteliste („angemeldet auf 3 Geräten seit …"). Das Ticket fordert sie
+  nicht. Die Allowlist macht sie später ohne Umbau möglich.
+
+### Nebenbefunde → Triage (nicht in dieser Scheibe)
+
+- Frontend-Server fällt ohne gesetztes Geheimnis still auf `'dev-secret-change-me'` zurück
+  (`hooks.server.ts:16`).
+- Frontend vergleicht die Signatur ohne laufzeitkonstanten Vergleich (`auth.ts:26`); Go macht es
+  korrekt.
+- `SaveUser` ist generell ungelockt (15 Aufrufer) — diese Scheibe umgeht das Problem, statt es
+  allgemein zu lösen.
+
+### Open Questions
+
+Keine. Alle offenen Punkte waren technischer Natur und sind oben entschieden.
+
+## Nachweis-Anforderung (aus dem Ticket)
+
+Zwei verschiedene Nutzer. Anmeldung überlebt einen echten Dienst-Neustart und ist jenseits von
+24 Stunden noch gültig (mit vorgestellter Uhr geprüft). „Auf allen Geräten abmelden" macht ein
+zuvor gültiges Merkmal ungültig **und es bleibt auch nach einem Neustart ungültig** — das ist die
+Gegenprobe, die heute fehlschlagen würde.

--- a/docs/features/architecture.md
+++ b/docs/features/architecture.md
@@ -755,7 +755,7 @@ HTML + Client-Side Interactivity
   - User-ID format for OAuth users: `g-{8hex}` to prevent session parsing errors
 - **Magic Link (Issue #449):** `/api/auth/magic-link` + `/api/auth/magic-link/verify` (6-digit OTP per E-Mail)
 
-**Session Format:** Server-side-signed cookie `gz_session = <userId>.<timestamp>.<hmacSig>` (24h TTL, HttpOnly, SameSite=Lax, Secure on HTTPS) — identisch über alle Auth-Methoden hinweg.
+**Session Format (ADR-0060, löst ADR-0030 ab):** Server-side-signed cookie `gz_session = <userId>.<sessionId>.<timestamp>.<hmacSig>` (HttpOnly, SameSite=Lax, Secure on HTTPS, Cookie-Lebensdauer 400 Tage) — identisch über alle Auth-Methoden hinweg. Gültig, solange `sessionId` in `data/users/<user_id>/sessions.json` steht, keine Ablaufprüfung. Abmelden entfernt den Eintrag; `POST /api/auth/logout-all` leert die Liste. Alte dreiteilige Merkmale (`<userId>.<timestamp>.<hmacSig>`) bleiben mit ihrer 24h-TTL gültig und werden bei Gebrauch still auf das neue Format gehoben.
 
 **User Model Extensions (Issues #425, #450):**
 - `PasswordHash` field optional (`omitempty` JSON tag) — leerer Hash für reine OAuth/Passkey-User
@@ -864,7 +864,7 @@ Feld-Definitionen: `internal/model/` und `docs/reference/api_contract.md` Sektio
 
 **Format:** JSON, standard HTTP methods (GET, POST, PUT, DELETE)
 
-**Auth:** Session cookies (format: `<userId>.<timestamp>.<hmacSig>`, set by Login or Passkey endpoints, 24h TTL)
+**Auth:** Session cookies (format: `<userId>.<sessionId>.<timestamp>.<hmacSig>`, set by Login or Passkey endpoints, gültig bis Abmeldung — Details ADR-0060)
 
 ### Frontend → Channels
 

--- a/docs/reference/api_contract.md
+++ b/docs/reference/api_contract.md
@@ -140,6 +140,7 @@ Wortquelle für Trip, Vergleich und Alarme). Spec:
 | `/api/auth/google/init` | GET |
 | `/api/auth/login` | POST |
 | `/api/auth/logout` | POST |
+| `/api/auth/logout-all` | POST |
 | `/api/auth/magic-link` | POST |
 | `/api/auth/magic-link/verify` | POST |
 | `/api/auth/passkey/credentials/{id}` | DELETE |
@@ -2247,7 +2248,7 @@ Handles the OAuth callback from Google. Exchanges authorization code for ID toke
 **Side Effects:**
 
 - New `data/users/g-{8hex}/user.json` created for first-time Google users
-- Session cookie `gz_session` set with 7-day expiry
+- Session cookie `gz_session` set, unbefristet gueltig bis zum Widerruf (MaxAge 34560000 = 400 Tage, Issue #2129)
 - Existing users with matching `oauth_sub` skip creation and reuse their account
 
 ### User Data Model (Modified)
@@ -2289,12 +2290,55 @@ type User struct {
 - `frontend/src/routes/register/+page.server.ts` — exposes `data.googleEnabled` flag
 - Conditional button: `{#if data.googleEnabled} <a href="/api/auth/google/init">Mit Google anmelden</a> {/if}`
 
+### POST /api/auth/logout-all — auf allen Geraeten abmelden (Issue #2129)
+
+Authentifiziert (Cookie erforderlich, **nicht** in der Public-Allowlist der
+AuthMiddleware — die Nutzerkennung kommt aus dem geprueften Merkmal).
+
+**Request:** kein Body.
+
+**Response 200:** `{"status":"ok"}`
+
+**Side Effects:**
+- Leert `data/users/<user_id>/sessions.json` — **alle** Anmeldungen dieses Nutzers werden ungueltig, auch die auf anderen Geraeten, und bleiben es nach einem Dienst-Neustart.
+- Loescht das Cookie des aufrufenden Geraets (`MaxAge=-1`).
+- Nur der eigene Nutzer ist betroffen; andere Konten bleiben unberuehrt.
+
+**Error Responses:**
+
+| Status | Body | Scenario |
+|--------|------|----------|
+| 401 | `{"error":"unauthorized"}` | kein oder ungueltiges Anmelde-Merkmal |
+| 500 | `{"error":"store_error"}` | Gaesteliste nicht schreibbar |
+
+Dieselbe Wirkung loesen **Passwortwechsel** (`PUT /api/auth/password`) und
+**Passwort-Zuruecksetzen** (`POST /api/auth/reset-password`) aus. Die
+**Kontoloeschung** (`DELETE /api/auth/account`) entfernt die Gaesteliste mit dem
+Nutzerordner. `POST /api/auth/logout` entfernt dagegen nur den Eintrag des
+aufrufenden Geraets.
+
+**Ausnahme beim Passwortwechsel:** Er meldet alle **anderen** Geraete ab, stellt
+dem wechselnden Geraet aber sofort ein frisches Merkmal aus (`Set-Cookie` in
+derselben Antwort). Sonst saehe der Nutzer unmittelbar nach dem Wechsel eine
+Seite, deren Datenabrufe alle 401 geben. Zuruecksetzen, Kontoloeschung und
+`logout-all` stellen **kein** neues Merkmal aus — wer zuruecksetzt, weil das
+Passwort abgegriffen wurde, soll ausgesperrt bleiben.
+
+**Uebergangsformat:** Ein Alt-Merkmal steht auf keiner Gaesteliste, ein Widerruf
+haette dort also nichts zu entfernen. Dafuer traegt `sessions.json` zusaetzlich
+`legacy_revoked_at`: Abmelden mit einem Alt-Merkmal setzt den Zeitstempel, und
+danach gilt kein Alt-Merkmal mehr, dessen Ausstellungszeit nicht juenger ist.
+Der Wert wird bei jedem Leeren der Liste mitgesetzt und faellt mit dem
+Legacy-Zweig ersatzlos weg. Ein Alt-Merkmal eines **geloeschten** Kontos wird
+abgewiesen, weil die Pruefstelle die Existenz des Kontos verlangt.
+
 ### Session Handling
 
 Google OAuth users receive the same session mechanism as password-auth users:
-- Cookie: `gz_session` (format: `{userId}.{timestamp}.{sig}`)
+- Cookie: `gz_session` (format: `{userId}.{sessionId}.{timestamp}.{sig}`, signiert ueber `{userId}:{sessionId}:{timestamp}`)
 - User-ID format for OAuth users: `g-{8hex}` (no dots to prevent session parsing errors)
-- Session verification: `frontend/src/lib/auth.ts` → `verifySession()` handles split defensively
+- Session verification: `frontend/src/lib/auth.ts` → `verifySession()` zerlegt von rechts (identisch zum Go-Dienst)
+- Gueltigkeit: das Merkmal gilt unbefristet, solange seine `sessionId` in `data/users/<user_id>/sessions.json` steht (Issue #2129, ADR-0060). Das alte dreiteilige Format `{userId}.{timestamp}.{sig}` bleibt uebergangsweise gueltig, behaelt dabei aber seine 24-Stunden-Grenze und wird beim naechsten authentifizierten Aufruf still durch ein vierteiliges ersetzt.
 
 ---
 
@@ -2582,7 +2626,7 @@ User login with username + password, returns session cookie.
 ```
 
 **Side Effects:**
-- Sets `Set-Cookie: gz_session=<userId>.<timestamp>.<hmacSig>; HttpOnly; SameSite=Lax; MaxAge=86400; Secure` (Secure flag active on HTTPS)
+- Sets `Set-Cookie: gz_session=<userId>.<sessionId>.<timestamp>.<hmacSig>; HttpOnly; SameSite=Lax; MaxAge=34560000; Secure` (Secure flag active on HTTPS)
 
 **Error Responses:**
 
@@ -2656,7 +2700,7 @@ Complete discoverable passkey login. Browser provides `userHandle` from stored c
 ```
 
 **Side Effects:**
-- Sets `Set-Cookie: gz_session=<userId>.<timestamp>.<hmacSig>; HttpOnly; SameSite=Lax; MaxAge=86400; Secure`
+- Sets `Set-Cookie: gz_session=<userId>.<sessionId>.<timestamp>.<hmacSig>; HttpOnly; SameSite=Lax; MaxAge=34560000; Secure`
 - Updates `last_used_at` timestamp on the used credential
 - Increments `sign_count` on the credential (cloning detection)
 - ChallengeStore entry is destroyed after successful `Take()` (replay protection)
@@ -2811,7 +2855,7 @@ Complete passkey login (public, no auth required).
 ```
 
 **Side Effects:**
-- Sets `Set-Cookie: gz_session=<userId>.<timestamp>.<hmacSig>; HttpOnly; SameSite=Lax; MaxAge=86400; Secure`
+- Sets `Set-Cookie: gz_session=<userId>.<sessionId>.<timestamp>.<hmacSig>; HttpOnly; SameSite=Lax; MaxAge=34560000; Secure`
 - Updates `last_used_at` timestamp on the used credential
 - Increments `sign_count` on the credential (cloning detection)
 

--- a/docs/specs/modules/account_deletion.md
+++ b/docs/specs/modules/account_deletion.md
@@ -16,7 +16,7 @@ tags: [go, auth, account-deletion, f15]
 
 ## Purpose
 
-Eingeloggte User koennen ihren Account loeschen. Alle User-Daten werden kaskadierend entfernt (locations, trips, subscriptions, gpx, snapshots, user.json). Session wird blacklisted und Cookie geloescht.
+Eingeloggte User koennen ihren Account loeschen. Alle User-Daten werden kaskadierend entfernt (locations, trips, subscriptions, gpx, snapshots, user.json). **Seit #2129/ADR-0060:** Da `data/users/{id}/sessions.json` Teil des geloeschten Verzeichnisses ist, werden damit alle Anmeldungen des Nutzers auf allen Geraeten ungueltig, nicht nur die des loeschenden Geraets — davor blacklistete der Logout-Pfad nur die eine aktuelle Session.
 
 ## Scope
 
@@ -55,7 +55,7 @@ func DeleteAccountHandler(s *store.Store) http.HandlerFunc
 1. `userId := middleware.UserIDFromContext(r.Context())`
 2. `s.LoadUser(userId)` → 404 falls nicht gefunden
 3. `s.DeleteUser(userId)` → 500 bei Fehler
-4. Session blacklisten + Cookie loeschen (wie Logout)
+4. Cookie des anfragenden Geraets loeschen — die Sitzungsliste selbst ist mit dem Verzeichnis aus Schritt 3 bereits weg (seit #2129/ADR-0060; zuvor: Session blacklisten wie Logout, nur das eine Geraet)
 5. HTTP 200 `{"status":"deleted"}`
 
 ### Step 3: Route (`cmd/server/main.go`, +1 LoC)
@@ -68,7 +68,7 @@ NICHT exempt von AuthMiddleware — nur eingeloggte User koennen ihren Account l
 
 ## Expected Behavior
 
-- **Eingeloggt + DELETE /api/auth/account:** Account + alle Daten geloescht, Session invalidiert, Cookie geloescht
+- **Eingeloggt + DELETE /api/auth/account:** Account + alle Daten geloescht, alle Sessions auf allen Geraeten invalidiert (seit #2129/ADR-0060), Cookie des anfragenden Geraets geloescht
 - **Nicht eingeloggt:** 401 Unauthorized (durch Middleware)
 - **Nach Loeschung:** Login mit alten Credentials schlaegt fehl (User existiert nicht mehr)
 
@@ -81,3 +81,4 @@ NICHT exempt von AuthMiddleware — nur eingeloggte User koennen ihren Account l
 ## Changelog
 
 - 2026-04-16: Initial spec (F15 Phase 3 — Account Deletion, GitHub Issue #53)
+- 2026-09-06: Session-Invalidierung durch #2129 (ADR-0060) auf alle Geraete ausgeweitet — Details dort, nicht hier nachpflegen.

--- a/docs/specs/modules/change_password.md
+++ b/docs/specs/modules/change_password.md
@@ -153,7 +153,7 @@ async function changePassword() {
 - **Input:** Authentifizierter Nutzer gibt aktuelles Passwort, neues Passwort und Bestaetigung ein und klickt "Passwort aendern".
 - **Output (Erfolg):** Gruener Banner "Passwort geaendert", alle drei Felder werden geleert. Backend gibt `200 {"status":"ok"}` zurueck und persistiert den neuen bcrypt-Hash.
 - **Output (Fehler):** Roter Banner mit spezifischer Fehlermeldung; Felder bleiben befuellt.
-- **Side effects:** Der neue bcrypt-Hash wird in der Nutzerdatenbank gespeichert. Bestehende Sessions anderer Geraete bleiben aktiv (kein erzwungenes Logout aller Sessions — ausserhalb des Scopes).
+- **Side effects:** Der neue bcrypt-Hash wird in der Nutzerdatenbank gespeichert. **Überholt seit #2129/ADR-0060:** Ein Passwortwechsel widerruft jetzt alle Anmeldungen des Nutzers auf anderen Geraeten und stellt dem aendernden Geraet sofort ein neues Anmelde-Merkmal aus (siehe `docs/adr/0060-dauerhafte-anmeldung-mit-widerrufsliste.md`).
 
 ### Fehlerszenarien
 
@@ -168,10 +168,11 @@ async function changePassword() {
 
 ## Known Limitations
 
-- Bestehende Sessions anderer Geraete werden nach Passwortaenderung nicht invalidiert. Ein vollstaendiges Session-Revoke waere sicherer, ist aber nicht Teil dieses Scopes.
+- ~~Bestehende Sessions anderer Geraete werden nach Passwortaenderung nicht invalidiert.~~ Behoben durch #2129 (ADR-0060): Passwortwechsel leert die Sitzungsliste des Nutzers bis auf ein frisches Merkmal fuer das aendernde Geraet.
 - Kein Passwort-Staerke-Indikator im Frontend — nur Mindestlaenge 8 Zeichen wird geprueft.
 - Client-seitiger Check (Passwoerter stimmen ueberein) verhindert vermeidbare API-Calls, ersetzt aber nicht die Server-seitige Validierung.
 
 ## Changelog
 
 - 2026-04-16: Initial spec (F71 Passwort aendern, GitHub Issue #71)
+- 2026-09-06: Session-Verhalten bei Passwortaenderung durch #2129 (ADR-0060) ueberholt — Details dort, nicht hier nachpflegen.

--- a/docs/specs/modules/logout_session_blacklist.md
+++ b/docs/specs/modules/logout_session_blacklist.md
@@ -2,13 +2,31 @@
 entity_id: logout_session_blacklist
 type: module
 created: 2026-04-16
-updated: 2026-04-16
-status: draft
+updated: 2026-09-06
+status: superseded
 version: "1.0"
 tags: [go, sveltekit, auth, logout, session, f15]
 ---
 
 # F15 Phase 1 — Logout + Session-Blacklist
+
+> **ABGELOEST durch `session_allowlist.md` (Issue #2129, ADR-0060), 2026-09-06.**
+>
+> Die hier beschriebene Mechanik existiert nicht mehr. Die prozesslokale
+> In-Memory-Blacklist (`sessionBlacklist sync.Map`) ist ersatzlos entfallen:
+> sie ueberlebte keinen Dienst-Neustart und konnte nur Merkmale sperren, die
+> man kennt — "auf allen Geraeten abmelden" war damit gar nicht moeglich.
+>
+> An ihre Stelle tritt eine dateibasierte **Gaesteliste je Nutzer**
+> (`data/users/<user_id>/sessions.json`). Ein Anmelde-Merkmal ist gueltig,
+> solange seine Anmelde-Kennung dort steht; Abmelden entfernt den Eintrag,
+> "alle Geraete" leert die Liste. Beides wirkt ueber einen Neustart hinweg.
+> Die unten stehende Annahme "In-Memory reicht, Sessions laufen nach 24h ab"
+> traegt seit #2129 nicht mehr — die Anmeldung gilt unbefristet bis zum
+> Widerruf.
+>
+> Was unveraendert gilt: der Endpunkt `POST /api/auth/logout`, das Loeschen des
+> Cookies im Browser und der Abmelde-Knopf im Frontend.
 
 ## Approval
 

--- a/docs/specs/modules/session_allowlist.md
+++ b/docs/specs/modules/session_allowlist.md
@@ -1,0 +1,132 @@
+---
+entity_id: session_allowlist
+type: module
+created: 2026-09-05
+updated: 2026-09-05
+status: draft
+version: "1.0"
+tags: [auth, session, security]
+---
+
+# Session-Allowlist — dauerhafte Anmeldung mit widerrufbarem Anmelde-Merkmal
+
+## Approval
+
+- [x] Approved — PO (Henning), 2026-09-05
+
+## Purpose
+
+Löst die heutige 24-Stunden-Ablauffrist der Anmeldung ab: Anmeldungen gelten fortan unbefristet, bis sie aktiv widerrufen werden. Dafür führt jeder Nutzer eine eigene Gästeliste gültiger Anmeldungen; ein Anmelde-Merkmal ist nur gültig, solange seine Anmelde-Kennung auf dieser Liste steht — Widerruf (einzelnes Gerät oder „alle Geräte") entfernt den Eintrag und wirkt dauerhaft, auch über einen Dienst-Neustart hinweg.
+
+## Source
+
+- **File:** `internal/store/sessions.go` **(CREATE)**
+- **Identifier:** Gästeliste lesen/hinzufügen/entfernen/leeren (atomare Persistenz je Nutzer)
+- **File:** `internal/store/sessions_lock.go` **(CREATE)**
+- **Identifier:** Pro-Nutzer-Sperre nach Vorbild `internal/store/briefing_lock.go`
+- **File (Prüfstelle):** `internal/middleware/auth.go` **(MODIFY)**
+- **Identifier:** Anmelde-Merkmal zerlegen, Format-Weiche altes/neues Anmelde-Merkmal, Gästelisten-Abgleich
+
+> **Schicht-Hinweis:** Diese Scheibe betrifft ausschließlich die Go-API (`internal/`) und das SvelteKit-Frontend (`frontend/src/lib/auth.ts`, `frontend/src/hooks.server.ts`, `frontend/src/routes/...`). Kein Python-Core-Code betroffen.
+
+## Estimated Scope
+
+- **LoC:** +450 bis +600 (reißt das 250er-Limit, Override gesetzt)
+- **Files:** ~18 (davon 2 neue Code-Dateien, 1 neues ADR)
+- **Effort:** high
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `logout_session_blacklist` | module (Spec) | Wird durch diese Scheibe abgelöst: die heutige prozesslokale Sperrliste für einzelne Anmelde-Merkmale entfällt zugunsten der dateibasierten Gästeliste; die Spec wird auf den neuen Stand aktualisiert. |
+| `user_auth_endpoints` | module (Spec) | Bekommt einen neuen Endpunkt „auf allen Geräten abmelden" in die Endpunkt-Liste aufgenommen. |
+| `change_password` | module (Spec) | Der Passwortwechsel-Endpunkt meldet den Nutzer ab dieser Scheibe zusätzlich auf allen Geräten ab (bislang keine Session-Wirkung). |
+| `passkey_webauthn` | module (Spec) | Alle drei Passkey-Anmeldewege (Login, Login ohne Kennungseingabe, Registrierung) stellen künftig das vierteilige Anmelde-Merkmal aus und tragen die Anmeldung in die Gästeliste ein. |
+| `google_oauth_login` | module (Spec) | Die Google-Anmeldung stellt künftig das vierteilige Anmelde-Merkmal aus und trägt die Anmeldung in die Gästeliste ein. |
+| `sveltekit_login_refactor` | module (Spec) | Die Frontend-eigene Anmelde-Merkmal-Prüfung (`auth.ts`, `hooks.server.ts`) muss das neue Format identisch zum Go-Dienst zerlegen; Cookie-Lebensdauer wird unbefristet gesetzt. |
+
+## Implementation Details
+
+Zwei Anmelde-Merkmal-Formate laufen befristet nebeneinander: das alte dreiteilige (Nutzerkennung, Zeitstempel, Signatur — bleibt mit seiner bestehenden 24-Stunden-Grenze gültig) und das neue vierteilige (Nutzerkennung, Anmelde-Kennung, Zeitstempel, Signatur — unbefristet, solange die Anmelde-Kennung auf der Gästeliste steht). Beide Prüfstellen (Go-Dienst und Frontend-Server) zerlegen von rechts, damit eine Nutzerkennung mit Punkt nicht zu unterschiedlichen Ergebnissen führt. Ein gültiges altes Merkmal wird beim nächsten Aufruf still durch ein neues ersetzt (neuer Eintrag in der Gästeliste, neues Cookie im Antwort-Header) — ohne dass sich der Nutzer erneut anmelden muss.
+
+Die Gästeliste liegt in einer eigenen Datei `data/users/<user_id>/sessions.json`, getrennt vom Nutzer-Datensatz: ein gleichzeitiger Schreibvorgang auf den Nutzer-Datensatz (der stets das ganze Objekt zurückschreibt) kann so einen Widerruf nicht überschreiben, und das Anlegen einer Anmeldung löst nicht bei jedem Login den Schema-Backup-Hook für `model.User` aus. Eine Pro-Nutzer-Sperre (Mutex-Pool mit Referenzzählung, Vorbild `briefing_lock.go`) serialisiert Lesen-Ändern-Schreiben auf dieser Datei je Nutzer.
+
+Kein Zwischenspeicher: jede authentifizierte Anfrage liest die Gästeliste direkt von der Platte. Begründung: real existierende Nutzer-Datensätze sind wenige hundert Byte groß, der Lesevorgang aus dem Betriebssystem-Cache fällt gegenüber allem anderen in der Anfrage nicht ins Gewicht — ein Zwischenspeicher wäre ein zweiter Zustandsbehälter, der genau die Widerrufs-Zusicherung tragen müsste, auf der die unbefristete Anmeldung beruht, und der billigste Weg, ihn nie falsch werden zu lassen, ist, ihn nicht zu haben.
+
+## Expected Behavior
+
+- **Input:** Anmeldung über einen der sechs Anmeldewege (Passwort, Magic-Link, Google, Passkey-Login, Passkey-Login ohne Kennungseingabe, Passkey-Registrierung); Abmelde-Aufruf (ein Gerät oder alle Geräte); Passwortwechsel oder Passwort-Zurücksetzen; jede authentifizierte Anfrage mit einem Anmelde-Merkmal im Cookie.
+- **Output:** Erfolgreiche Anmeldung liefert ein vierteiliges Anmelde-Merkmal im `Set-Cookie`-Header. Eine authentifizierte Anfrage mit gültigem, gelistetem Merkmal liefert den regulären Antwortcode; mit widerrufenem, manipuliertem oder abgelaufenem Alt-Merkmal liefert sie 401.
+- **Side effects:** Jede Anmeldung schreibt einen neuen Eintrag in `data/users/<user_id>/sessions.json`. Abmelden (ein Gerät) entfernt genau diesen Eintrag. „Auf allen Geräten abmelden", Passwortwechsel und Passwort-Zurücksetzen leeren die gesamte Liste des Nutzers. Diese Effekte überstehen einen Dienst-Neustart, weil sie dateibasiert sind, nicht prozesslokal.
+
+## Acceptance Criteria
+
+- **AC-1:** Given ein Nutzer meldet sich frisch an / When die Anmeldung erfolgreich ist / Then enthält seine Gästeliste einen neuen Eintrag und das ausgestellte Anmelde-Merkmal besteht aus vier durch Punkt getrennten Teilen.
+  - Test: Login-Request gegen den echten Anmelde-Endpunkt, anschließend das ausgestellte Cookie am `.`-Zeichen aufsplitten (4 Segmente) und mit demselben Cookie einen geschützten Endpunkt aufrufen → 200.
+
+- **AC-2:** Given eine Anmeldung wurde soeben ausgestellt / When der Dienst einen echten Neustart durchläuft / Then bleibt das Anmelde-Merkmal gültig.
+  - Test: Login, Dienst-Prozess real beenden und neu starten, danach mit demselben Cookie einen geschützten Endpunkt aufrufen → weiterhin 200.
+
+- **AC-3:** Given eine Anmeldung wurde ausgestellt / When seither mehr als 24 Stunden vergangen sind (mit vorgestellter Systemuhr geprüft) / Then bleibt das neue Anmelde-Merkmal gültig, obwohl es nach der alten Regel bereits abgelaufen wäre.
+  - Test: Login, Testuhr um mehr als 25 Stunden vorstellen, Request mit demselben Cookie an geschützten Endpunkt → 200.
+
+- **AC-4:** Given ein Nutzer ist auf einem Gerät angemeldet / When er sich auf diesem Gerät abmeldet / Then wird sein Anmelde-Merkmal sofort ungültig und bleibt es auch nach einem echten Dienst-Neustart.
+  - Test: Login (Cookie A), Abmelde-Aufruf mit Cookie A, Request mit Cookie A → 401; Dienst real neu starten; Request mit demselben Cookie A erneut → 401.
+
+- **AC-5:** Given ein Nutzer ist auf zwei Geräten angemeldet / When er sich nur auf einem der beiden abmeldet / Then bleibt die Anmeldung des anderen Geräts gültig.
+  - Test: Zwei Logins desselben Kontos (Cookie A, Cookie B), Abmelden mit Cookie A. Request mit Cookie B → 200, Request mit Cookie A → 401.
+
+- **AC-6:** Given ein Nutzer ist auf mehreren Geräten angemeldet / When er „auf allen Geräten abmelden" auslöst / Then werden alle seine Anmeldungen ungültig, auch nach einem echten Dienst-Neustart.
+  - Test: Zwei Logins desselben Kontos (Cookie A, B), Aufruf des Endpunkts „alle abmelden" mit einem der beiden Cookies. Requests mit A und B → beide 401; Dienst neu starten; beide Requests erneut → weiterhin 401.
+
+- **AC-7:** Given zwei verschiedene, echte Nutzerkonten sind angemeldet / When „auf allen Geräten abmelden" bei Nutzer 1 ausgelöst wird / Then bleiben die Anmeldungen von Nutzer 2 unberührt.
+  - Test: Login Nutzer 1 und Nutzer 2 (getrennte Konten), „alle abmelden" bei Nutzer 1. Request mit Nutzer 1s Cookie → 401, Request mit Nutzer 2s Cookie → weiterhin 200.
+
+- **AC-8:** Given ein Nutzer ist angemeldet / When er sein Passwort über den Passwortwechsel-Endpunkt ändert / Then wird sein zuvor gültiges Anmelde-Merkmal ungültig.
+  - Test: Login (Cookie A), Passwortwechsel-Endpunkt aufrufen. Request mit Cookie A an geschützten Endpunkt → 401.
+
+- **AC-9:** Given ein Nutzer ist angemeldet / When er sein Passwort über den „Passwort vergessen"-Ablauf zurücksetzt / Then wird sein zuvor gültiges Anmelde-Merkmal ungültig.
+  - Test: Login (Cookie A), Passwort-Zurücksetzen-Ablauf bis zum Einlösen des Reset-Tokens durchlaufen. Request mit dem alten Cookie A → 401.
+
+- **AC-10:** Given ein Nutzer besitzt noch ein gültiges Anmelde-Merkmal im alten dreiteiligen Format / When er damit einen Request stellt / Then wird der Request angenommen und er erhält im selben Zug ein neues vierteiliges Anmelde-Merkmal, ohne sich neu anmelden zu müssen.
+  - Test: Request mit einem gültigen dreiteiligen Alt-Cookie an einen geschützten Endpunkt → 200 und Antwort enthält einen neuen `Set-Cookie`-Header mit vierteiligem Anmelde-Merkmal; kein Sprung auf die Anmelde-Seite.
+
+- **AC-11:** Given ein Anmelde-Merkmal im alten Format ist älter als 24 Stunden / When damit ein Request gestellt wird / Then wird er abgewiesen.
+  - Test: Request mit einem dreiteiligen Alt-Cookie, dessen Zeitstempel mehr als 24 Stunden zurückliegt, an geschützten Endpunkt → 401.
+
+- **AC-12:** Given ein Anmelde-Merkmal wurde verändert oder trägt eine Anmelde-Kennung, die nicht auf der Gästeliste steht / When damit ein Request gestellt wird / Then wird er in beiden Fällen abgewiesen.
+  - Test: (a) Request mit einem Cookie, dessen Signatur-Segment einzeln verändert wurde → 401. (b) Request mit einem korrekt signierten Cookie, dessen Anmelde-Kennung nicht in der Gästeliste des Nutzers enthalten ist → 401.
+
+- **AC-13:** Given ein Nutzer meldet sich über einen der sechs Anmeldewege an (Passwort, Magic-Link, Google, Passkey-Login, Passkey-Login ohne Kennungseingabe, Passkey-Registrierung) / When die Anmeldung abgeschlossen ist / Then besteht das jeweils ausgestellte Anmelde-Merkmal die eigene Prüfung.
+  - Test: Für jeden der sechs Wege einzeln: Anmeldung über den jeweiligen Endpunkt auslösen, danach mit dem ausgestellten Cookie einen geschützten Endpunkt aufrufen → 200 in allen sechs Fällen.
+
+- **AC-14:** Given ein Anmelde-Merkmal, dessen Nutzerkennung einen Punkt enthält / When der Go-Dienst und der Frontend-Server dasselbe Merkmal zerlegen / Then lesen beide dieselbe Nutzerkennung heraus und weisen es beide nicht ab.
+  - Test: Ein Konto mit einer Kennung wie `alice.smith` direkt im Datenbestand anlegen (die Registrierung lässt Punkte nicht zu, die Zerlegungsregel muss trotzdem auf beiden Seiten gleich sein), dafür ein Merkmal ausstellen und dasselbe Merkmal beiden Prüfstellen vorlegen → beide liefern `alice.smith`, keine weist ab. Heute liefert die Go-Seite hier eine Ablehnung.
+
+- **AC-15:** Given mehrere Änderungen an den Anmeldungen desselben Nutzers laufen gleichzeitig / When sie parallel abgesetzt werden / Then geht keine davon verloren.
+  - Test: (a) Zwei Anmeldungen desselben Kontos parallel auslösen → danach sind **beide** Merkmale gültig (keins hat das andere aus der Gästeliste verdrängt). (b) „Alle abmelden" parallel zu einer Profiländerung desselben Nutzers → danach ist das vorher gültige Merkmal abgewiesen **und** die Profiländerung ist gespeichert.
+
+- **AC-16:** Given ein Nutzer ist angemeldet / When sein Konto gelöscht wird / Then wird sein Anmelde-Merkmal ungültig und bleibt es auch nach einem echten Dienst-Neustart.
+  - Test: Login (Cookie A), Konto-Löschung auslösen, Request mit Cookie A → 401; Dienst real neu starten; Request mit Cookie A erneut → weiterhin 401.
+
+- **AC-17:** Given ein angemeldeter Nutzer ist auf der Konto-Seite / When er „Auf allen Geräten abmelden" anklickt und den Bestätigungsschritt bestätigt / Then wird er auf die Anmelde-Seite geleitet.
+  - Test: Browser-Test — Klick auf den Button öffnet einen Bestätigungsdialog; nach Bestätigen landet die Seite auf der Anmelde-Route.
+
+- **AC-18:** Given ein Nutzer meldet sich an / When das Cookie im Browser gesetzt wird / Then bleibt es über das Schließen des Browsers hinaus gespeichert und trägt eine Lebensdauer, die die alte 24-Stunden-Grenze deutlich übersteigt.
+  - Test: Der `Set-Cookie`-Header **jeder** der sechs Anmeldewege trägt eine Lebensdauer von mindestens einem Jahr. Der bisherige Wert (24 Stunden) darf diesen Nachweis nicht bestehen — ein Test, der jede beliebige Lebensdauer durchgehen lässt, prüft nichts.
+
+## Known Limitations
+
+- Der Frontend-Server prüft weiterhin nur Signatur und Format des Anmelde-Merkmals, nicht die Gästeliste (er hat keinen Zugriff auf den Nutzer-Datenbestand). Nach einem Widerruf entsteht dadurch ein kurzes Fenster: die Seite lädt, die Daten fehlen (die Ladefunktion bekommt vom Go-Dienst 401 und liefert leere Daten), bis der nächste Klick den harten Sprung auf die Anmelde-Seite auslöst. Keine Umleitungsschleife — entspricht dem heutigen Verhalten der bestehenden Sperrliste.
+- Ein Nutzer, der 24 Stunden lang ausschließlich Seiten betrachtet und nie eine Aktion auslöst, behält bis dahin sein altes dreiteiliges Anmelde-Merkmal: das neue Cookie erreicht den Browser nur bei Antworten, die er direkt erhält, nicht bei Ladefunktionen, die der Frontend-Server im Hintergrund stellt. Danach muss er sich einmalig neu anmelden — genau wie heute auch.
+- Keine Geräteliste in dieser Scheibe (kein „angemeldet auf 3 Geräten seit …" in der Oberfläche). Die Gästeliste macht das später ohne Umbau möglich.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** ADR-0060
+- **Rationale:** Löst ADR-0030 ab, weil eine unbefristete Anmeldung ohne wirksamen, neustart-festen Widerruf ein unbegrenzt gültiges, einmal abgegriffenes Cookie bedeuten würde. Eine dateibasierte Gästeliste je Nutzer (statt eines reinen Generationszählers) ist die einzige der zwei geprüften Varianten, die sowohl „ein Gerät abmelden" als auch „alle Geräte abmelden" ohne zwei parallele Mechanismen abdeckt.
+
+## Changelog
+
+- 2026-09-05: Initial spec created (#2129)

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -1,29 +1,76 @@
 import { createHmac } from 'crypto';
 
+/**
+ * Lebensdauer des Anmelde-Cookies in Sekunden (Issue #2129). Muss mit
+ * `SessionMaxAgeSeconds` in internal/middleware/auth.go übereinstimmen — 400
+ * Tage, weil Browser persistente Cookies dort deckeln.
+ */
+export const SESSION_MAX_AGE_SECONDS = 400 * 24 * 60 * 60;
+
+/**
+ * Ablauffrist des ALTEN dreiteiligen Merkmals. Bleibt scharf, damit der
+ * Altbestand binnen 24 Stunden nach dem Deploy von selbst verschwindet.
+ */
+const LEGACY_MAX_AGE_SECONDS = 86400;
+
 export function signSession(userId: string, secret: string): string {
 	const ts = Math.floor(Date.now() / 1000);
 	const sig = createHmac('sha256', secret).update(`${userId}:${ts}`).digest('hex');
 	return `${userId}.${ts}.${sig}`;
 }
 
+/**
+ * Zweite Prüfstelle: der Frontend-Server prüft Format und Signatur des
+ * Anmelde-Merkmals. Die Gästeliste kennt er NICHT — er hat keinen Zugriff auf
+ * den Nutzer-Datenbestand. Nach einem Widerruf lädt die Seite deshalb noch
+ * einmal und wirkt leer (jeder Datenabruf bekommt vom Go-Dienst 401), bis der
+ * nächste Klick den harten Sprung auf die Anmelde-Seite auslöst. Das ist
+ * dasselbe Verhalten wie mit der abgelösten Sperrliste, keine Umleitungsschleife.
+ *
+ * Beide Formate werden VON RECHTS zerlegt, damit eine Nutzerkennung mit Punkt
+ * hier und im Go-Dienst dieselbe Kennung ergibt. Die Segmentzahl allein
+ * unterscheidet die Formate nicht eindeutig — ein Alt-Merkmal für
+ * `alice.smith` hat ebenfalls vier Segmente —, deshalb entscheidet die
+ * Signatur: erst das neue Format versuchen, dann das alte.
+ */
 export function verifySession(
 	cookie: string,
 	secret: string,
-	maxAge = 86400
+	maxAge = LEGACY_MAX_AGE_SECONDS
 ): { userId: string } | null {
 	const parts = cookie.split('.');
-	if (parts.length < 3) return null;
-	const sig = parts.pop()!;
-	const tsStr = parts.pop()!;
-	const userId = parts.join('.');
-	if (!userId || !tsStr || !sig) return null;
 
-	const ts = parseInt(tsStr, 10);
-	if (isNaN(ts)) return null;
-	if (Date.now() / 1000 - ts > maxAge) return null;
+	if (parts.length >= 4) {
+		const sig = parts[parts.length - 1];
+		const tsStr = parts[parts.length - 2];
+		const sessionId = parts[parts.length - 3];
+		const userId = parts.slice(0, parts.length - 3).join('.');
+		if (userId && sessionId && tsStr && sig) {
+			const ts = parseInt(tsStr, 10);
+			if (!isNaN(ts)) {
+				const expected = createHmac('sha256', secret)
+					.update(`${userId}:${sessionId}:${ts}`)
+					.digest('hex');
+				// Kein Ablauf: beim neuen Format trägt die Gästeliste des
+				// Go-Dienstes die Gültigkeit, nicht der Zeitstempel.
+				if (sig === expected) return { userId };
+			}
+		}
+	}
 
-	const expected = createHmac('sha256', secret).update(`${userId}:${ts}`).digest('hex');
-	if (sig !== expected) return null;
+	if (parts.length >= 3) {
+		const sig = parts[parts.length - 1];
+		const tsStr = parts[parts.length - 2];
+		const userId = parts.slice(0, parts.length - 2).join('.');
+		if (!userId || !tsStr || !sig) return null;
 
-	return { userId };
+		const ts = parseInt(tsStr, 10);
+		if (isNaN(ts)) return null;
+		if (Date.now() / 1000 - ts > maxAge) return null;
+
+		const expected = createHmac('sha256', secret).update(`${userId}:${ts}`).digest('hex');
+		if (sig === expected) return { userId };
+	}
+
+	return null;
 }

--- a/frontend/src/lib/auth_oauth.test.ts
+++ b/frontend/src/lib/auth_oauth.test.ts
@@ -95,18 +95,15 @@ test('Defensiver Fix: verifySession mit userId "alice.smith" (enthält Punkt)', 
 
 // Sicherstellen: auth.ts exportiert die fixte verifySession (Source-Inspection-Test)
 // RED: Schlägt fehl weil der Fix noch nicht in auth.ts eingebaut ist.
-test('AC-7: auth.ts verifySession nutzt Pop-basierten Split (Source-Inspection)', async () => {
-	const { readFileSync } = await import('node:fs');
-	const { fileURLToPath } = await import('node:url');
-	const { join } = await import('node:path');
+test('AC-7: auth.ts verifySession zerlegt von rechts (Verhalten, echte Funktion)', async () => {
+	// Vormals eine Dateiinhalt-Prüfung auf den String "parts.pop()". Die maß die
+	// Schreibweise, nicht die Zusicherung, und wurde rot, als #2129 dieselbe
+	// Rechts-Verankerung über Index-Zugriff schrieb. Geprüft wird jetzt das
+	// Verhalten am echten Prüfling: eine Nutzerkennung mit Punkt muss
+	// unversehrt herauskommen.
+	const { verifySession } = await import('./auth.ts');
+	const secret = 'test-secret-32-chars-minimum-ok!';
+	const uid = 'user.with.dots';
 
-	const srcDir = fileURLToPath(new URL('..', import.meta.url));
-	const authTs = readFileSync(join(srcDir, 'lib', 'auth.ts'), 'utf-8');
-
-	// Nach dem Fix muss auth.ts parts.pop() verwenden, nicht parts.length !== 3
-	const hasPopBasedSplit = authTs.includes('parts.pop()');
-	assert.ok(
-		hasPopBasedSplit,
-		'auth.ts muss parts.pop() für defensiven Split verwenden (AC-7 Fix noch nicht implementiert)'
-	);
+	assert.deepEqual(verifySession(signSession(uid, secret), secret), { userId: uid });
 });

--- a/frontend/src/lib/session_format.test.ts
+++ b/frontend/src/lib/session_format.test.ts
@@ -1,0 +1,118 @@
+// TDD RED — Issue #2129: dauerhafte Anmeldung mit widerrufbarem Anmelde-Merkmal.
+// Spec: docs/specs/modules/session_allowlist.md
+//
+// Zerlegung des Anmelde-Merkmals auf der ZWEITEN Prüfstelle (Frontend-Server).
+// Geprüft wird die echte verifySession aus ./auth.ts — NICHT eine im Test
+// nachgebaute Kopie. Eine nachgebaute Kopie prüft nur sich selbst; die
+// Zusicherung lautet aber, dass Go-Dienst und Frontend-Server dasselbe Merkmal
+// gleich lesen, und dafür muss der echte Prüfling laufen.
+//
+// Ausführung:
+//   cd frontend && npm test -- src/lib/session_format.test.ts
+//
+// AC-17 (Bedienelement "Auf allen Geräten abmelden" → Bestätigungsdialog →
+// Sprung auf die Anmelde-Route) ist bewusst NICHT hier abgebildet: das ist ein
+// Browser-Nachweis. Er gehört als Playwright-Spec nach
+// frontend/e2e/playwright/ (Vorbild: die bestehenden Konto-Seiten-Specs) und
+// wird in der Staging-Phase geführt, nicht im Kern.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createHmac } from 'node:crypto';
+import { verifySession } from './auth.ts';
+
+const SECRET = 'test-secret-32-chars-minimum-ok!';
+
+// Altes dreiteiliges Merkmal: {userId}.{ts}.{sig}, Signatur über "{userId}:{ts}".
+function legacyCookie(userId: string, ts: number, secret = SECRET): string {
+	const sig = createHmac('sha256', secret).update(`${userId}:${ts}`).digest('hex');
+	return `${userId}.${ts}.${sig}`;
+}
+
+// Neues vierteiliges Merkmal: {userId}.{sessionId}.{ts}.{sig},
+// Signatur über "{userId}:{sessionId}:{ts}".
+function newCookie(userId: string, sessionId: string, ts: number, secret = SECRET): string {
+	const sig = createHmac('sha256', secret)
+		.update(`${userId}:${sessionId}:${ts}`)
+		.digest('hex');
+	return `${userId}.${sessionId}.${ts}.${sig}`;
+}
+
+const now = () => Math.floor(Date.now() / 1000);
+
+// AC-1 (Frontend-Prüfseite): Das vierteilige Merkmal wird angenommen und
+// liefert die Nutzerkennung.
+test('AC-1: vierteiliges Merkmal wird angenommen und liefert die Nutzerkennung', () => {
+	const cookie = newCookie('alice', 'sess-aaaa1111', now());
+	assert.equal(cookie.split('.').length, 4, 'Testaufbau: 4 Segmente erwartet');
+
+	const result = verifySession(cookie, SECRET);
+	assert.deepEqual(result, { userId: 'alice' });
+});
+
+// AC-3: Das neue Merkmal läuft nicht nach 24 Stunden ab.
+test('AC-3: vierteiliges Merkmal bleibt jenseits von 24 Stunden gültig', () => {
+	const ts = now() - 25 * 3600;
+	const result = verifySession(newCookie('alice', 'sess-old00001', ts), SECRET);
+	assert.deepEqual(result, { userId: 'alice' }, '25 h altes neues Merkmal muss gültig bleiben');
+});
+
+// AC-10: Ein gültiges Alt-Merkmal wird weiterhin angenommen — niemand fliegt
+// durch das Deploy hinaus. (Die Hebung auf das neue Format leistet der
+// Go-Dienst; der Frontend-Server muss das Alt-Merkmal nur weiter lesen.)
+test('AC-10: gültiges dreiteiliges Alt-Merkmal wird weiterhin angenommen', () => {
+	const result = verifySession(legacyCookie('alice', now()), SECRET);
+	assert.deepEqual(result, { userId: 'alice' });
+});
+
+// AC-11: Ein Alt-Merkmal jenseits von 24 Stunden wird abgewiesen — die alte
+// Grenze bleibt für das alte Format scharf.
+// Positivkontrolle voran: ein 23 h altes Alt-Merkmal MUSS durchkommen. Ohne sie
+// bestünde der Test auch dann, wenn jedes Alt-Merkmal pauschal abgewiesen würde.
+test('AC-11: dreiteiliges Alt-Merkmal älter als 24 h wird abgewiesen', () => {
+	assert.deepEqual(
+		verifySession(legacyCookie('alice', now() - 23 * 3600), SECRET),
+		{ userId: 'alice' },
+		'Positivkontrolle: 23 h altes Alt-Merkmal muss gültig sein'
+	);
+
+	assert.equal(
+		verifySession(legacyCookie('alice', now() - 25 * 3600), SECRET),
+		null,
+		'25 h altes Alt-Merkmal muss abgewiesen werden'
+	);
+});
+
+// AC-12 (a): Manipulierte Signatur wird abgewiesen — mit Positivkontrolle,
+// damit der Test nicht nur bestätigt, dass das ganze Format abgewiesen wird.
+test('AC-12a: manipulierte Signatur im vierteiligen Merkmal wird abgewiesen', () => {
+	const intact = newCookie('alice', 'sess-tamper01', now());
+	assert.deepEqual(
+		verifySession(intact, SECRET),
+		{ userId: 'alice' },
+		'Positivkontrolle: unverändertes Merkmal muss gültig sein'
+	);
+
+	const parts = intact.split('.');
+	parts[3] = (parts[3][0] === 'a' ? 'b' : 'a') + parts[3].slice(1);
+	assert.equal(verifySession(parts.join('.'), SECRET), null);
+});
+
+// AC-14: Nutzerkennung mit Punkt — von rechts zerlegen. Beide Prüfstellen
+// müssen dieselbe Kennung herauslesen; das Go-Gegenstück steht in
+// internal/middleware/session_allowlist_test.go (TestDottedUserID_SplitFromTheRight).
+test('AC-14: Nutzerkennung mit Punkt wird in beiden Formaten von rechts zerlegt', () => {
+	const uid = 'alice.smith';
+
+	assert.deepEqual(
+		verifySession(newCookie(uid, 'sess-dot00001', now()), SECRET),
+		{ userId: uid },
+		'neues Format: erwartet alice.smith'
+	);
+
+	assert.deepEqual(
+		verifySession(legacyCookie(uid, now()), SECRET),
+		{ userId: uid },
+		'Altformat: erwartet alice.smith'
+	);
+});

--- a/frontend/src/routes/account/+page.svelte
+++ b/frontend/src/routes/account/+page.svelte
@@ -41,6 +41,8 @@
 	let presetError = $state<string | null>(null);
 	let deletePresetTarget: MetricPreset | null = $state(null);
 	let showDeleteAccountDialog = $state(false);
+	let showLogoutAllDialog = $state(false);
+	let logoutAllErrorMsg = $state<string | null>(null);
 
 	// Issue #1068 — Nutzerlevel-Badge (immer sichtbar). Der Wert kommt aus
 	// data.profile.tier (Response-Feld ist serverseitig immer gesetzt, Default "free").
@@ -291,6 +293,23 @@
 		} catch (e: unknown) {
 			const body = e as { detail?: string; error?: string };
 			deleteErrorMsg = body?.detail ?? body?.error ?? 'Löschen fehlgeschlagen';
+		}
+	}
+
+	// Issue #2129 AC-17: auf allen Geräten abmelden — mit Bestätigungsschritt,
+	// weil die Wirkung jedes andere Gerät des Nutzers trifft.
+	function logoutAllDevices() {
+		showLogoutAllDialog = true;
+	}
+
+	async function confirmLogoutAllDevices() {
+		showLogoutAllDialog = false;
+		try {
+			await api.post('/api/auth/logout-all', {});
+			window.location.href = '/login';
+		} catch (e: unknown) {
+			const body = e as { detail?: string; error?: string };
+			logoutAllErrorMsg = body?.detail ?? body?.error ?? 'Abmelden fehlgeschlagen';
 		}
 	}
 </script>
@@ -758,6 +777,23 @@
 		</Card.Content>
 	</Card.Root>
 
+	<Card.Root>
+		<Card.Header>
+			<Card.Title>Anmeldungen</Card.Title>
+		</Card.Header>
+		<Card.Content>
+			<p class="mb-4 text-sm text-muted-foreground">
+				Deine Anmeldung bleibt bestehen, bis du dich abmeldest. Hast du ein Gerät verloren,
+				kannst du hier alle Anmeldungen auf einmal beenden — auch die auf Geräten, die du
+				gerade nicht zur Hand hast.
+			</p>
+			<Btn variant="outline" onclick={logoutAllDevices}>Auf allen Geräten abmelden</Btn>
+			{#if logoutAllErrorMsg}
+				<p class="mt-2 text-sm text-red-600">{logoutAllErrorMsg}</p>
+			{/if}
+		</Card.Content>
+	</Card.Root>
+
 	<Card.Root class="border-red-200">
 		<Card.Header>
 			<Card.Title class="text-red-700">Gefahrenzone</Card.Title>
@@ -793,6 +829,26 @@
 			<Dialog.Footer>
 				<Btn variant="outline" onclick={() => (deletePresetTarget = null)}>Abbrechen</Btn>
 				<Btn variant="destructive" onclick={confirmDeletePreset}>Löschen</Btn>
+			</Dialog.Footer>
+		</Dialog.Content>
+	</Dialog.Root>
+
+	<!-- Auf allen Geräten abmelden Dialog -->
+	<Dialog.Root
+		open={showLogoutAllDialog}
+		onOpenChange={(open) => { if (!open) showLogoutAllDialog = false; }}
+	>
+		<Dialog.Content>
+			<Dialog.Header>
+				<Dialog.Title>Auf allen Geräten abmelden</Dialog.Title>
+				<Dialog.Description>
+					Alle Anmeldungen werden beendet, auch die auf diesem Gerät. Zum Weiterarbeiten
+					musst du dich neu anmelden.
+				</Dialog.Description>
+			</Dialog.Header>
+			<Dialog.Footer>
+				<Btn variant="outline" onclick={() => (showLogoutAllDialog = false)}>Abbrechen</Btn>
+				<Btn variant="destructive" onclick={confirmLogoutAllDevices}>Abmelden</Btn>
 			</Dialog.Footer>
 		</Dialog.Content>
 	</Dialog.Root>

--- a/frontend/src/routes/login/+page.server.ts
+++ b/frontend/src/routes/login/+page.server.ts
@@ -1,6 +1,7 @@
 import { fail, redirect } from '@sveltejs/kit';
 import { env } from '$env/dynamic/private';
 import { safeRedirectPath } from '$lib/utils/safeRedirect.js';
+import { SESSION_MAX_AGE_SECONDS } from '$lib/auth.js';
 import type { Actions, PageServerLoad } from './$types.js';
 import { apiBase as API } from '$lib/server/apiBase.js';
 
@@ -45,7 +46,7 @@ export const actions = {
 					httpOnly: true,
 					sameSite: 'lax',
 					secure: env.NODE_ENV === 'production',
-					maxAge: 86400,
+					maxAge: SESSION_MAX_AGE_SECONDS,
 				});
 			}
 		}

--- a/frontend/src/routes/magic-link/verify/+page.server.ts
+++ b/frontend/src/routes/magic-link/verify/+page.server.ts
@@ -2,6 +2,7 @@ import { fail, redirect } from '@sveltejs/kit';
 import { env } from '$env/dynamic/private';
 import type { Actions, PageServerLoad } from './$types.js';
 import { apiBase as API } from '$lib/server/apiBase.js';
+import { SESSION_MAX_AGE_SECONDS } from '$lib/auth.js';
 
 
 export const load: PageServerLoad = async ({ url }) => {
@@ -44,7 +45,7 @@ export const actions = {
 					httpOnly: true,
 					sameSite: 'lax',
 					secure: env.NODE_ENV === 'production',
-					maxAge: 86400
+					maxAge: SESSION_MAX_AGE_SECONDS
 				});
 			}
 		}

--- a/internal/handler/auth.go
+++ b/internal/handler/auth.go
@@ -119,6 +119,32 @@ func RegisterHandler(s *store.Store, bcryptCost int, cfg config.Config) http.Han
 	}
 }
 
+// issueSession mintet eine Anmelde-Kennung, traegt sie in die Gaesteliste des
+// Nutzers ein und setzt das Anmelde-Cookie (Issue #2129). EINE Stelle fuer alle
+// sechs Anmeldewege: wird eine davon vergessen, sperrt dieser Weg alle seine
+// Nutzer aus, weil ihr Merkmal zwar wohlgeformt, aber nicht gelistet waere.
+//
+// Liefert false, wenn bereits geantwortet wurde (Fehlerfall).
+func issueSession(w http.ResponseWriter, r *http.Request, s *store.Store, userId, secret string) bool {
+	sessionId, err := middleware.NewSessionID()
+	if err != nil {
+		log.Printf("session issue: id generation failed for %s: %v", userId, err)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(500)
+		w.Write([]byte(`{"error":"internal error"}`))
+		return false
+	}
+	if err := s.AddSession(userId, sessionId); err != nil {
+		log.Printf("session issue: allowlist write failed for %s: %v", userId, err)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(500)
+		w.Write([]byte(`{"error":"store_error"}`))
+		return false
+	}
+	middleware.SetSessionCookie(w, r, middleware.SignSessionWithID(userId, sessionId, secret))
+	return true
+}
+
 func LoginHandler(s *store.Store, secret string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var req authRequest
@@ -151,17 +177,9 @@ func LoginHandler(s *store.Store, secret string) http.HandlerFunc {
 			return
 		}
 
-		token := middleware.SignSession(req.Username, secret)
-		secure := r.Header.Get("X-Forwarded-Proto") == "https" || r.TLS != nil
-		http.SetCookie(w, &http.Cookie{
-			Name:     "gz_session",
-			Value:    token,
-			Path:     "/",
-			HttpOnly: true,
-			SameSite: http.SameSiteLaxMode,
-			MaxAge:   86400,
-			Secure:   secure,
-		})
+		if !issueSession(w, r, s, req.Username, secret) {
+			return
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]string{"id": req.Username})
@@ -186,14 +204,10 @@ func DeleteAccountHandler(s *store.Store) http.HandlerFunc {
 			return
 		}
 
-		// Blacklist session + clear cookie (like logout)
-		cookie, err := r.Cookie("gz_session")
-		if err == nil && cookie.Value != "" {
-			middleware.BlacklistSession(cookie.Value)
-		}
-		http.SetCookie(w, &http.Cookie{
-			Name: "gz_session", Value: "", Path: "/", HttpOnly: true, MaxAge: -1,
-		})
+		// Die Gaesteliste liegt IM Nutzerordner und ist mit DeleteUser bereits
+		// verschwunden — jedes Merkmal dieses Kontos ist damit dauerhaft
+		// ungueltig, auch nach einem Dienst-Neustart (Issue #2129 AC-16).
+		middleware.ClearSessionCookie(w)
 
 		w.Header().Set("Content-Type", "application/json")
 		w.Write([]byte(`{"status":"deleted"}`))
@@ -368,6 +382,13 @@ func ResetPasswordHandler(s *store.Store, bcryptCost int) http.HandlerFunc {
 			return
 		}
 
+		// Issue #2129 AC-9: Wer sein Passwort zuruecksetzt, WEIL es abgegriffen
+		// wurde, muss den Angreifer damit hinauswerfen — also alle Anmeldungen
+		// widerrufen, nicht nur das Passwort tauschen.
+		if err := s.ClearSessions(req.Username); err != nil {
+			log.Printf("password reset: allowlist clear failed for %s: %v", req.Username, err)
+		}
+
 		s.DeleteResetToken(req.Username)
 
 		w.Write([]byte(`{"status":"ok"}`))
@@ -428,22 +449,62 @@ func VerifyEmailHandler(s *store.Store) http.HandlerFunc {
 	}
 }
 
-func LogoutHandler() http.HandlerFunc {
+// LogoutHandler meldet GENAU DIESES Geraet ab: der Eintrag der Anmelde-Kennung
+// verlaesst die Gaesteliste des Nutzers. Weil das dateibasiert geschieht, wirkt
+// der Widerruf auch nach einem Dienst-Neustart (Issue #2129 AC-4); die
+// bisherige prozesslokale Sperrliste ist damit abgeloest.
+//
+// Der Endpunkt ist oeffentlich (kein Auth-Kontext), die Nutzerkennung kommt
+// deshalb aus dem geprueften Merkmal selbst — nie aus einem Standardwert.
+func LogoutHandler(s *store.Store, secret string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		cookie, err := r.Cookie("gz_session")
 		if err == nil && cookie.Value != "" {
-			middleware.BlacklistSession(cookie.Value)
+			if userId, sessionId, ok := middleware.SessionFromCookie(cookie.Value, secret); ok {
+				if sessionId != "" {
+					if err := s.RemoveSession(userId, sessionId); err != nil {
+						log.Printf("logout: allowlist removal failed for %s: %v", userId, err)
+					}
+				} else if err := s.RevokeLegacySessions(userId); err != nil {
+					// Alt-Merkmal: es steht auf keiner Gaesteliste, es gaebe
+					// also nichts zu entfernen. Ohne den Widerrufs-Vermerk
+					// bliebe es bis zu 24 Stunden weiter gueltig — die Zusage
+					// "Abmelden wirkt" bekommt auch im Uebergangsfenster
+					// keine Ausnahme.
+					log.Printf("logout: legacy revocation failed for %s: %v", userId, err)
+				}
+			}
 		}
 
-		http.SetCookie(w, &http.Cookie{
-			Name:     "gz_session",
-			Value:    "",
-			Path:     "/",
-			HttpOnly: true,
-			MaxAge:   -1,
-		})
+		middleware.ClearSessionCookie(w)
 
 		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"status":"ok"}`))
+	}
+}
+
+// LogoutAllHandler meldet den Nutzer auf ALLEN Geraeten ab: die Gaesteliste
+// wird geleert (Issue #2129 AC-6). Authentifiziert — die Nutzerkennung kommt
+// aus dem geprueften Merkmal, nie aus einem Standardwert, sonst waere es ein
+// Widerruf auf fremden Konten.
+func LogoutAllHandler(s *store.Store) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userId := middleware.UserIDFromContext(r.Context())
+		w.Header().Set("Content-Type", "application/json")
+		if userId == "" {
+			w.WriteHeader(401)
+			w.Write([]byte(`{"error":"unauthorized"}`))
+			return
+		}
+
+		if err := s.ClearSessions(userId); err != nil {
+			log.Printf("logout-all: allowlist clear failed for %s: %v", userId, err)
+			w.WriteHeader(500)
+			w.Write([]byte(`{"error":"store_error"}`))
+			return
+		}
+
+		middleware.ClearSessionCookie(w)
 		w.Write([]byte(`{"status":"ok"}`))
 	}
 }
@@ -741,7 +802,7 @@ func hasControlChars(s string) bool {
 	return false
 }
 
-func ChangePasswordHandler(s *store.Store, bcryptCost int) http.HandlerFunc {
+func ChangePasswordHandler(s *store.Store, bcryptCost int, secret string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		userId := middleware.UserIDFromContext(r.Context())
 		w.Header().Set("Content-Type", "application/json")
@@ -786,6 +847,30 @@ func ChangePasswordHandler(s *store.Store, bcryptCost int) http.HandlerFunc {
 		if err := s.SaveUser(*user); err != nil {
 			w.WriteHeader(500)
 			w.Write([]byte(`{"error":"internal error"}`))
+			return
+		}
+
+		// Issue #2129 AC-8: Der Passwortwechsel meldet auf allen ANDEREN
+		// Geraeten ab. Bislang hatte er ueberhaupt keine Session-Wirkung — es
+		// gab damit keinen wirksamen Notweg, ein verlorenes Geraet
+		// auszusperren.
+		//
+		// Das Geraet, an dem gewechselt wird, bekommt sofort einen frischen
+		// Nachweis: Liste leeren, neue Anmelde-Kennung eintragen, neues Cookie
+		// in dieser Antwort. Sonst saehe der Nutzer unmittelbar nach dem
+		// Wechsel eine Seite, deren Datenabrufe alle 401 geben.
+		//
+		// Bewusst NUR hier: Passwort-Zuruecksetzen, Kontoloeschung und "auf
+		// allen Geraeten abmelden" stellen KEIN neues Merkmal aus. Wer
+		// zuruecksetzt, weil das Passwort abgegriffen wurde, soll ausgesperrt
+		// bleiben.
+		if err := s.ClearSessions(userId); err != nil {
+			log.Printf("password change: allowlist clear failed for %s: %v", userId, err)
+			w.WriteHeader(500)
+			w.Write([]byte(`{"error":"internal error"}`))
+			return
+		}
+		if !issueSession(w, r, s, userId, secret) {
 			return
 		}
 

--- a/internal/handler/auth_magic.go
+++ b/internal/handler/auth_magic.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/henemm/gregor-api/internal/config"
 	"github.com/henemm/gregor-api/internal/mail"
-	"github.com/henemm/gregor-api/internal/middleware"
 	"github.com/henemm/gregor-api/internal/model"
 	"github.com/henemm/gregor-api/internal/store"
 )
@@ -184,17 +183,9 @@ func MagicLinkVerifyHandler(s *store.Store, cfg *config.Config) http.HandlerFunc
 
 		// Success: single-use → delete entry, sign session, set cookie.
 		otpStore.Delete(normalizedEmail)
-		token := middleware.SignSession(entry.userID, cfg.SessionSecret)
-		secure := r.Header.Get("X-Forwarded-Proto") == "https" || r.TLS != nil
-		http.SetCookie(w, &http.Cookie{
-			Name:     "gz_session",
-			Value:    token,
-			Path:     "/",
-			HttpOnly: true,
-			SameSite: http.SameSiteLaxMode,
-			MaxAge:   86400,
-			Secure:   secure,
-		})
+		if !issueSession(w, r, s, entry.userID, cfg.SessionSecret) {
+			return
+		}
 		json.NewEncoder(w).Encode(map[string]string{"id": entry.userID})
 	}
 }

--- a/internal/handler/auth_magic_test.go
+++ b/internal/handler/auth_magic_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/henemm/gregor-api/internal/config"
+	"github.com/henemm/gregor-api/internal/middleware"
 	"github.com/henemm/gregor-api/internal/model"
 )
 
@@ -256,8 +257,9 @@ func TestMagicLinkVerifyHandler_ValidCode_SetsSessionCookie(t *testing.T) {
 	if !sessionCookie.HttpOnly {
 		t.Error("gz_session cookie must be HttpOnly")
 	}
-	if sessionCookie.MaxAge != 86400 {
-		t.Errorf("expected MaxAge 86400, got %d", sessionCookie.MaxAge)
+	// Issue #2129: die Anmeldung gilt unbefristet, bis sie widerrufen wird.
+	if sessionCookie.MaxAge != middleware.SessionMaxAgeSeconds {
+		t.Errorf("expected MaxAge %d, got %d", middleware.SessionMaxAgeSeconds, sessionCookie.MaxAge)
 	}
 	if sessionCookie.SameSite != http.SameSiteLaxMode {
 		t.Errorf("expected SameSite=Lax, got %v", sessionCookie.SameSite)

--- a/internal/handler/auth_oauth.go
+++ b/internal/handler/auth_oauth.go
@@ -16,7 +16,6 @@ import (
 	"golang.org/x/oauth2/google"
 
 	"github.com/henemm/gregor-api/internal/config"
-	"github.com/henemm/gregor-api/internal/middleware"
 	"github.com/henemm/gregor-api/internal/model"
 	"github.com/henemm/gregor-api/internal/store"
 )
@@ -179,17 +178,9 @@ func googleOAuthCallbackHandlerInternal(cfg *config.Config, s *store.Store, user
 			dispatchVerificationMail(s, *cfg, newUser.ID, newUser)
 		}
 
-		sessionToken := middleware.SignSession(userId, cfg.SessionSecret)
-		secure := r.Header.Get("X-Forwarded-Proto") == "https" || r.TLS != nil
-		http.SetCookie(w, &http.Cookie{
-			Name:     "gz_session",
-			Value:    sessionToken,
-			Path:     "/",
-			HttpOnly: true,
-			SameSite: http.SameSiteLaxMode,
-			MaxAge:   86400,
-			Secure:   secure,
-		})
+		if !issueSession(w, r, s, userId, cfg.SessionSecret) {
+			return
+		}
 
 		http.Redirect(w, r, "/", http.StatusFound)
 	}

--- a/internal/handler/auth_test.go
+++ b/internal/handler/auth_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/henemm/gregor-api/internal/config"
 	"github.com/henemm/gregor-api/internal/mail"
+	"github.com/henemm/gregor-api/internal/middleware"
 )
 
 // testRegisterCfg liefert eine Config, deren SMTPHost gesetzt ist, damit der
@@ -476,8 +477,9 @@ func TestLoginHandlerSuccess(t *testing.T) {
 	if !sessionCookie.HttpOnly {
 		t.Error("cookie should be HttpOnly")
 	}
-	if sessionCookie.MaxAge != 86400 {
-		t.Errorf("expected MaxAge 86400, got %d", sessionCookie.MaxAge)
+	// Issue #2129: die Anmeldung gilt unbefristet, bis sie widerrufen wird.
+	if sessionCookie.MaxAge != middleware.SessionMaxAgeSeconds {
+		t.Errorf("expected MaxAge %d, got %d", middleware.SessionMaxAgeSeconds, sessionCookie.MaxAge)
 	}
 
 	// Check cookie starts with username

--- a/internal/handler/change_password_test.go
+++ b/internal/handler/change_password_test.go
@@ -14,6 +14,10 @@ import (
 
 // TDD RED: Tests for ChangePasswordHandler — must FAIL until implemented.
 
+// Issue #2129: der Passwortwechsel stellt dem wechselnden Geraet ein frisches
+// Anmelde-Merkmal aus und braucht dafuer das Signatur-Geheimnis.
+const changePwTestSecret = "test-secret-32-chars-minimum-ok!"
+
 func setupUserWithPassword(t *testing.T, s *store.Store, userID, password string) {
 	t.Helper()
 	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.MinCost)
@@ -37,7 +41,7 @@ func TestChangePasswordHandler_Success(t *testing.T) {
 	req = addUserToContext(req, "alice")
 	w := httptest.NewRecorder()
 
-	ChangePasswordHandler(s, bcrypt.MinCost)(w, req)
+	ChangePasswordHandler(s, bcrypt.MinCost, changePwTestSecret)(w, req)
 
 	if w.Code != 200 {
 		t.Fatalf("Expected 200, got %d: %s", w.Code, w.Body.String())
@@ -63,7 +67,7 @@ func TestChangePasswordHandler_WrongOldPassword(t *testing.T) {
 	req = addUserToContext(req, "alice")
 	w := httptest.NewRecorder()
 
-	ChangePasswordHandler(s, bcrypt.MinCost)(w, req)
+	ChangePasswordHandler(s, bcrypt.MinCost, changePwTestSecret)(w, req)
 
 	if w.Code != 403 {
 		t.Fatalf("Expected 403, got %d: %s", w.Code, w.Body.String())
@@ -83,7 +87,7 @@ func TestChangePasswordHandler_NewPasswordTooShort(t *testing.T) {
 	req = addUserToContext(req, "alice")
 	w := httptest.NewRecorder()
 
-	ChangePasswordHandler(s, bcrypt.MinCost)(w, req)
+	ChangePasswordHandler(s, bcrypt.MinCost, changePwTestSecret)(w, req)
 
 	if w.Code != 400 {
 		t.Fatalf("Expected 400, got %d: %s", w.Code, w.Body.String())

--- a/internal/handler/delete_account_test.go
+++ b/internal/handler/delete_account_test.go
@@ -70,9 +70,12 @@ func TestDeleteAccountClearsCookie(t *testing.T) {
 		t.Error("gz_session cookie should be cleared")
 	}
 
-	// Session should be blacklisted
-	if !middleware.IsBlacklisted("bob.123.sig") {
-		t.Error("session should be blacklisted after account deletion")
+	// Issue #2129: die Gaesteliste liegt IM Nutzerordner und ist mit dem Konto
+	// verschwunden. Das ersetzt die abgeloeste prozesslokale Sperrliste und
+	// wirkt anders als diese auch nach einem Dienst-Neustart.
+	if sessions, err := s.LoadSessions("bob"); err != nil || len(sessions) != 0 {
+		t.Errorf("Gaesteliste muss nach der Kontoloeschung leer sein, sind %d (err=%v)",
+			len(sessions), err)
 	}
 }
 

--- a/internal/handler/logout_revocation_test.go
+++ b/internal/handler/logout_revocation_test.go
@@ -1,0 +1,803 @@
+package handler_test
+
+// TDD RED — Issue #2129: dauerhafte Anmeldung mit widerrufbarem Anmelde-Merkmal.
+// Spec: docs/specs/modules/session_allowlist.md — AC-2, 4, 5, 6, 7, 8, 9, 15, 16.
+//
+// Externes Testpaket (handler_test) mit Absicht: der Endpunkt "auf allen
+// Geräten abmelden" existiert noch nicht. Über den echten router.New
+// adressiert bricht kein Symbolaufruf die Kompilierung — der Request läuft
+// heute in ein 404, und in der GREEN-Phase greift die Route automatisch, ohne
+// dass dieser Test angefasst werden muss. Ein Go-Test, der eine noch nicht
+// existierende Funktion aufruft, nähme das ganze Paket mit in den
+// Kompilierfehler; dann fielen auch alle Bestandstests aus, und das wäre kein
+// brauchbares RED.
+//
+// Kein Mock: echte HTTP-Anfragen gegen den vollständig verdrahteten Router mit
+// echtem Dateispeicher in einem Temp-Verzeichnis. Kein Netz, kein Versand —
+// der "Passwort vergessen"-Mailweg wird umgangen, indem das Reset-Token direkt
+// über den Store gesetzt wird.
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-webauthn/webauthn/webauthn"
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/henemm/gregor-api/internal/config"
+	"github.com/henemm/gregor-api/internal/handler"
+	authmw "github.com/henemm/gregor-api/internal/middleware"
+	"github.com/henemm/gregor-api/internal/model"
+	"github.com/henemm/gregor-api/internal/router"
+	"github.com/henemm/gregor-api/internal/scheduler"
+	"github.com/henemm/gregor-api/internal/store"
+)
+
+// --- Umgebung --------------------------------------------------------------
+
+type authEnv struct {
+	router  http.Handler
+	store   *store.Store
+	dataDir string
+	secret  string
+}
+
+func newAuthEnv(t *testing.T) *authEnv {
+	t.Helper()
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("config.Load: %v", err)
+	}
+	cfg.DataDir = t.TempDir()
+
+	s := store.New(cfg.DataDir, cfg.UserID)
+
+	wa, err := webauthn.New(&webauthn.Config{
+		RPID:          cfg.WebAuthnRPID,
+		RPDisplayName: cfg.WebAuthnRPDisplayName,
+		RPOrigins:     []string{"http://localhost:5173"},
+	})
+	if err != nil {
+		t.Fatalf("webauthn.New: %v", err)
+	}
+
+	sched, err := scheduler.New(cfg, s)
+	if err != nil {
+		t.Fatalf("scheduler.New: %v", err)
+	}
+	t.Cleanup(sched.Stop)
+
+	r := router.New(router.Deps{
+		Config:             cfg,
+		Store:              s,
+		WeatherProvider:    nil,
+		WebAuthn:           wa,
+		ChallengeStore:     handler.NewChallengeStore(),
+		Scheduler:          sched,
+		TelegramTokenStore: handler.NewTelegramTokenStore(cfg.DataDir),
+		GitCommit:          "test",
+	})
+
+	return &authEnv{router: r, store: s, dataDir: cfg.DataDir, secret: cfg.SessionSecret}
+}
+
+// seedUser legt ein Konto direkt im Datenbestand an.
+//
+// JEDER TEST DIESER DATEI BENUTZT EINE EIGENE KONTO-KENNUNG. Das ist keine
+// Kosmetik: `SignSession` (internal/middleware/auth.go:77-83) kennt nur
+// Sekundenauflösung und keine Anmelde-Kennung, liefert für dieselbe
+// Nutzerkennung innerhalb derselben Sekunde also ein IDENTISCHES Merkmal — und
+// die heutige Sperrliste ist eine paketglobale sync.Map, die alle Tests
+// desselben Prozesses teilen. Mit einer gemeinsamen Kennung würde ein
+// Abmelde-Test jeden nachfolgenden Test vergiften: dessen frisch ausgestelltes
+// Merkmal wäre buchstabengleich mit dem gesperrten und käme als 401 zurück.
+// Gemessen im ersten RED-Lauf, sechs Tests scheiterten daran am falschen Grund.
+func (e *authEnv) seedUser(t *testing.T, id, password string) {
+	t.Helper()
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.MinCost)
+	if err != nil {
+		t.Fatalf("bcrypt: %v", err)
+	}
+	if err := e.store.SaveUser(model.User{
+		ID: id, PasswordHash: string(hash), Email: id + "@example.com", CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("SaveUser %s: %v", id, err)
+	}
+}
+
+// login meldet ein Gerät an und liefert den Wert des ausgestellten Merkmals.
+func (e *authEnv) login(t *testing.T, id, password string) string {
+	t.Helper()
+	cookie, err := e.loginNoFatal(id, password)
+	if err != nil {
+		t.Fatalf("Anmeldung %s: %v", id, err)
+	}
+	return cookie
+}
+
+// loginNoFatal ist die aus Nebenläufigkeit aufrufbare Fassung: t.Fatalf aus
+// einer fremden Goroutine heraus ist unzulässig, deshalb wird der Fehler
+// zurückgegeben und erst in der Test-Goroutine ausgewertet.
+func (e *authEnv) loginNoFatal(id, password string) (string, error) {
+	req := httptest.NewRequest("POST", "/api/auth/login",
+		strings.NewReader(fmt.Sprintf(`{"username":%q,"password":%q}`, id, password)))
+	w := httptest.NewRecorder()
+	e.router.ServeHTTP(w, req)
+	if w.Code != 200 {
+		return "", fmt.Errorf("erwartet 200, bekommen %d: %s", w.Code, w.Body.String())
+	}
+	for _, c := range w.Result().Cookies() {
+		if c.Name == "gz_session" {
+			return c.Value, nil
+		}
+	}
+	return "", fmt.Errorf("kein gz_session-Cookie in der Antwort")
+}
+
+// probe legt das Merkmal einem geschützten Endpunkt vor (gleicher Prozess).
+func (e *authEnv) probe(t *testing.T, cookieValue string) int {
+	t.Helper()
+	req := httptest.NewRequest("GET", "/api/auth/profile", nil)
+	req.AddCookie(&http.Cookie{Name: "gz_session", Value: cookieValue})
+	w := httptest.NewRecorder()
+	e.router.ServeHTTP(w, req)
+	return w.Code
+}
+
+func (e *authEnv) post(t *testing.T, path, cookieValue, body string) int {
+	t.Helper()
+	return e.do(t, "POST", path, cookieValue, body)
+}
+
+func (e *authEnv) do(t *testing.T, method, path, cookieValue, body string) int {
+	t.Helper()
+	return e.doResp(t, method, path, cookieValue, body).Code
+}
+
+func (e *authEnv) doResp(t *testing.T, method, path, cookieValue, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	var req *http.Request
+	if body == "" {
+		req = httptest.NewRequest(method, path, nil)
+	} else {
+		req = httptest.NewRequest(method, path, strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if cookieValue != "" {
+		req.AddCookie(&http.Cookie{Name: "gz_session", Value: cookieValue})
+	}
+	w := httptest.NewRecorder()
+	e.router.ServeHTTP(w, req)
+	return w
+}
+
+// sessionCookieOf liefert das in einer Antwort gesetzte Anmelde-Merkmal
+// (leer, wenn keines oder ein geloeschtes gesetzt wurde).
+func sessionCookieOf(w *httptest.ResponseRecorder) string {
+	for _, c := range w.Result().Cookies() {
+		if c.Name == "gz_session" && c.MaxAge > 0 {
+			return c.Value
+		}
+	}
+	return ""
+}
+
+func fourSegments(t *testing.T, ac, label, cookieValue string) {
+	t.Helper()
+	if n := len(strings.Split(cookieValue, ".")); n != 4 {
+		t.Errorf("%s: %s muss 4 Punkt-Segmente haben, hat %d (%q)", ac, label, n, cookieValue)
+	}
+}
+
+// --- Neustart-Sonde --------------------------------------------------------
+
+const (
+	probeEnvFlag   = "GZ_RESTART_PROBE"
+	probeEnvDir    = "GZ_RESTART_DATADIR"
+	probeEnvSecret = "GZ_RESTART_SECRET"
+	probeEnvCookie = "GZ_RESTART_COOKIE"
+	probeMarker    = "PROBE_STATUS="
+)
+
+// probeAfterRestart startet eine ECHTE zweite Prozess-Instanz des
+// Testbinaries und legt ihr dasselbe Anmelde-Merkmal vor.
+//
+// WAS ZWISCHEN DEN DURCHGÄNGEN VERWORFEN WIRD: der komplette Adressraum des
+// ersten Durchgangs. Namentlich die paketglobale middleware.sessionBlacklist
+// (sync.Map, internal/middleware/auth.go:16), jede store.Store-Instanz, der
+// ChallengeStore, der otpStore, sämtliche Ratenbegrenzer und jeder
+// Zwischenspeicher, den die GREEN-Phase noch einbauen könnte. Die EINZIGE
+// Brücke zwischen den beiden Durchgängen sind vier Zeichenketten in
+// Umgebungsvariablen: Datenverzeichnis, Geheimnis, Cookie-Wert und das
+// Sonden-Flag. Keine Pipe, die Objekte trägt, kein gemeinsamer Speicher, kein
+// Socket. Das Dateisystem wird ABSICHTLICH geteilt — ein echter Dienst-Neustart
+// behält die Platte ja auch; genau das ist die Zusicherung.
+//
+// WARUM NICHT EINFACH sessionBlacklist ZURÜCKSETZEN: das setzte genau den
+// Zustand zurück, den man heute KENNT. Käme in GREEN ein Allowlist-
+// Zwischenspeicher hinzu, bliebe er stehen und der Test bewiese still nichts
+// mehr. Der Kindprozess ist gleichgültig dagegen, welcher Zustand existiert.
+//
+// GRENZE DER AUSSAGE: bewiesen wird "kein Zustand INNERHALB dieses Prozesses".
+// Läge der Widerrufsstand jemals in einem zweiten, langlebigen Dienst, sähe das
+// Kind ihn weiter und die Sonde wäre blind. Nach dem gewählten Entwurf (nur
+// Dateien, ausdrücklich kein Zwischenspeicher) trifft das nicht zu — aber das
+// ist die Bedingung, unter der der Nachweis trägt. Einen echten
+// systemd-Neustart in Produktion beweist er ohnehin nicht; das bleibt Sache
+// der Staging-Prüfung.
+func probeAfterRestart(t *testing.T, dataDir, secret, cookieValue string) int {
+	t.Helper()
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestRestartProbeChild$", "-test.count=1")
+	cmd.Env = append(os.Environ(),
+		probeEnvFlag+"=1",
+		probeEnvDir+"="+dataDir,
+		probeEnvSecret+"="+secret,
+		probeEnvCookie+"="+cookieValue,
+	)
+	out, err := cmd.CombinedOutput()
+
+	// HARTE ABBRUCHREGEL: ohne Marker gibt es kein Ergebnis. Eine stumme Sonde
+	// — Kind überspringt sich, Elternprozess bucht das als Erfolg — wäre
+	// schlimmer als gar keine Sonde. Es gibt hier keinen Pfad, auf dem "keine
+	// Antwort" zu "bestanden" wird.
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, probeMarker) {
+			continue
+		}
+		code, convErr := strconv.Atoi(strings.TrimPrefix(line, probeMarker))
+		if convErr != nil {
+			t.Fatalf("Neustart-Sonde: unlesbarer Statuscode %q (%v)\nAusgabe:\n%s", line, convErr, out)
+		}
+		return code
+	}
+	t.Fatalf("Neustart-Sonde lieferte keinen %s-Marker (exec-Fehler: %v).\n"+
+		"Ohne Marker gibt es kein Messergebnis — der Test besteht NICHT still.\nAusgabe:\n%s",
+		probeMarker, err, out)
+	return 0
+}
+
+// TestRestartProbeChild ist die Sonde selbst und läuft nur im Kindprozess.
+// Im regulären Testlauf überspringt sie sich; die Rekursionssperre über
+// probeEnvFlag verhindert, dass das Kind seinerseits Kinder startet.
+func TestRestartProbeChild(t *testing.T) {
+	if os.Getenv(probeEnvFlag) != "1" {
+		t.Skip("Neustart-Sonde: läuft nur als Kindprozess von probeAfterRestart")
+	}
+
+	dataDir := os.Getenv(probeEnvDir)
+	secret := os.Getenv(probeEnvSecret)
+	cookieValue := os.Getenv(probeEnvCookie)
+	if dataDir == "" || secret == "" || cookieValue == "" {
+		t.Fatalf("Neustart-Sonde: unvollständige Übergabe (dir=%q secret gesetzt=%v cookie gesetzt=%v)",
+			dataDir, secret != "", cookieValue != "")
+	}
+
+	// Frischer Store aus dem Datenverzeichnis — nichts aus dem Elternprozess.
+	// Die Gästeliste wird ausschließlich von der Platte gelesen; das ist die
+	// einzige Brücke zwischen den beiden Durchgängen.
+	fresh := store.New(dataDir, "")
+
+	req := httptest.NewRequest("GET", "/api/auth/profile", nil)
+	req.AddCookie(&http.Cookie{Name: "gz_session", Value: cookieValue})
+	rr := httptest.NewRecorder()
+	authmw.AuthMiddleware(secret, fresh)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if authmw.UserIDFromContext(r.Context()) == "" {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})).ServeHTTP(rr, req)
+
+	fmt.Printf("%s%d\n", probeMarker, rr.Code)
+}
+
+// --- AC-2 ------------------------------------------------------------------
+
+// AC-2: Eine frisch ausgestellte Anmeldung übersteht einen echten Neustart.
+//
+// Die Vierteiligkeit wird mitgeprüft, weil der Test sonst HEUTE SCHON grün
+// wäre: das dreiteilige Merkmal übersteht einen Neustart ebenfalls — es gibt
+// ja überhaupt keinen Zustand. Erst mit der Segmentzahl misst der Test die
+// dateibasierte Gästeliste statt der bloßen Abwesenheit von Zustand.
+func TestSessionSurvivesServiceRestart(t *testing.T) {
+	e := newAuthEnv(t)
+	const uid = "u-ac2"
+	e.seedUser(t, uid, "geheim123")
+	cookie := e.login(t, uid, "geheim123")
+
+	fourSegments(t, "AC-2", "ausgestelltes Merkmal", cookie)
+
+	if code := e.probe(t, cookie); code != http.StatusOK {
+		t.Fatalf("AC-2: Merkmal muss vor dem Neustart gültig sein, bekommen %d", code)
+	}
+	if code := probeAfterRestart(t, e.dataDir, e.secret, cookie); code != http.StatusOK {
+		t.Errorf("AC-2: Merkmal muss den Neustart überleben, bekommen %d", code)
+	}
+}
+
+// --- AC-4 ------------------------------------------------------------------
+
+// AC-4: Abmelden auf einem Gerät wirkt sofort UND über einen echten Neustart
+// hinweg. Der zweite Teil ist die Gegenprobe, die heute fehlschlägt: die
+// Sperrliste ist reiner Prozessspeicher.
+func TestLogoutRevokesSessionAcrossRestart(t *testing.T) {
+	e := newAuthEnv(t)
+	const uid = "u-ac4"
+	e.seedUser(t, uid, "geheim123")
+	cookie := e.login(t, uid, "geheim123")
+
+	if code := e.probe(t, cookie); code != http.StatusOK {
+		t.Fatalf("AC-4 Positivkontrolle: Merkmal muss vor dem Abmelden gültig sein, bekommen %d", code)
+	}
+	if code := e.post(t, "/api/auth/logout", cookie, ""); code != http.StatusOK {
+		t.Fatalf("AC-4: Abmelden erwartet 200, bekommen %d", code)
+	}
+
+	if code := e.probe(t, cookie); code != http.StatusUnauthorized {
+		t.Errorf("AC-4: Merkmal muss sofort ungültig sein, bekommen %d", code)
+	}
+	if code := probeAfterRestart(t, e.dataDir, e.secret, cookie); code != http.StatusUnauthorized {
+		t.Errorf("AC-4: Merkmal muss auch nach dem Neustart ungültig bleiben, bekommen %d", code)
+	}
+}
+
+// --- AC-5 ------------------------------------------------------------------
+
+// AC-5: Abmelden auf einem Gerät lässt das andere Gerät angemeldet.
+//
+// Die Zusicherungen "A != B" und "beide vierteilig" stehen voran, weil der
+// Test sonst sekundengenau flatterig wäre: SignSession kennt nur
+// Sekundenauflösung und keine Anmelde-Kennung, zwei Anmeldungen innerhalb
+// derselben Sekunde liefern also ein IDENTISCHES Merkmal — dann sperrt das
+// Abmelden von A zwangsläufig auch B aus, aber nur, wenn die Sekunde nicht
+// zufällig übergesprungen ist.
+func TestLogoutOneDeviceKeepsOtherDevice(t *testing.T) {
+	e := newAuthEnv(t)
+	const uid = "u-ac5"
+	e.seedUser(t, uid, "geheim123")
+
+	deviceA := e.login(t, uid, "geheim123")
+	deviceB := e.login(t, uid, "geheim123")
+
+	fourSegments(t, "AC-5", "Merkmal Gerät A", deviceA)
+	fourSegments(t, "AC-5", "Merkmal Gerät B", deviceB)
+	if deviceA == deviceB {
+		t.Errorf("AC-5: zwei Anmeldungen desselben Kontos müssen verschiedene Merkmale liefern, "+
+			"beide sind %q", deviceA)
+	}
+
+	if code := e.post(t, "/api/auth/logout", deviceA, ""); code != http.StatusOK {
+		t.Fatalf("AC-5: Abmelden erwartet 200, bekommen %d", code)
+	}
+
+	if code := e.probe(t, deviceA); code != http.StatusUnauthorized {
+		t.Errorf("AC-5: Gerät A muss abgemeldet sein, bekommen %d", code)
+	}
+	if code := e.probe(t, deviceB); code != http.StatusOK {
+		t.Errorf("AC-5: Gerät B muss angemeldet bleiben, bekommen %d", code)
+	}
+}
+
+// --- AC-6 ------------------------------------------------------------------
+
+// AC-6: "Auf allen Geräten abmelden" macht alle Anmeldungen ungültig, auch
+// über einen echten Neustart hinweg.
+func TestLogoutAllDevicesRevokesAcrossRestart(t *testing.T) {
+	e := newAuthEnv(t)
+	const uid = "u-ac6"
+	e.seedUser(t, uid, "geheim123")
+
+	deviceA := e.login(t, uid, "geheim123")
+	deviceB := e.login(t, uid, "geheim123")
+
+	if code := e.post(t, "/api/auth/logout-all", deviceA, ""); code != http.StatusOK {
+		t.Fatalf("AC-6: 'alle abmelden' erwartet 200, bekommen %d "+
+			"(404 heißt: Route nicht registriert)", code)
+	}
+
+	if code := e.probe(t, deviceA); code != http.StatusUnauthorized {
+		t.Errorf("AC-6: Gerät A muss abgemeldet sein, bekommen %d", code)
+	}
+	if code := e.probe(t, deviceB); code != http.StatusUnauthorized {
+		t.Errorf("AC-6: Gerät B muss abgemeldet sein, bekommen %d", code)
+	}
+	if code := probeAfterRestart(t, e.dataDir, e.secret, deviceA); code != http.StatusUnauthorized {
+		t.Errorf("AC-6: Gerät A muss nach dem Neustart abgemeldet bleiben, bekommen %d", code)
+	}
+	if code := probeAfterRestart(t, e.dataDir, e.secret, deviceB); code != http.StatusUnauthorized {
+		t.Errorf("AC-6: Gerät B muss nach dem Neustart abgemeldet bleiben, bekommen %d", code)
+	}
+}
+
+// --- AC-7 ------------------------------------------------------------------
+
+// AC-7: Mandantentrennung — der Widerruf bei Nutzer 1 lässt Nutzer 2 unberührt.
+// Zwei echte, getrennte Konten im selben Datenbestand.
+func TestLogoutAllDevicesLeavesSecondUserUntouched(t *testing.T) {
+	e := newAuthEnv(t)
+	e.seedUser(t, "u-ac7-alice", "geheim123")
+	e.seedUser(t, "u-ac7-bob", "geheim456")
+
+	alice := e.login(t, "u-ac7-alice", "geheim123")
+	bob := e.login(t, "u-ac7-bob", "geheim456")
+
+	if code := e.post(t, "/api/auth/logout-all", alice, ""); code != http.StatusOK {
+		t.Fatalf("AC-7: 'alle abmelden' erwartet 200, bekommen %d "+
+			"(404 heißt: Route nicht registriert)", code)
+	}
+
+	if code := e.probe(t, alice); code != http.StatusUnauthorized {
+		t.Errorf("AC-7: Nutzer 1 muss abgemeldet sein, bekommen %d", code)
+	}
+	if code := e.probe(t, bob); code != http.StatusOK {
+		t.Errorf("AC-7: Nutzer 2 muss unberührt angemeldet bleiben, bekommen %d", code)
+	}
+}
+
+// --- AC-8 ------------------------------------------------------------------
+
+// AC-8: Der Passwortwechsel macht das zuvor gültige Merkmal ungültig.
+func TestPasswordChangeRevokesSessions(t *testing.T) {
+	e := newAuthEnv(t)
+	const uid = "u-ac8"
+	e.seedUser(t, uid, "geheim123")
+	cookie := e.login(t, uid, "geheim123")
+
+	if code := e.probe(t, cookie); code != http.StatusOK {
+		t.Fatalf("AC-8 Positivkontrolle: Merkmal muss vorher gültig sein, bekommen %d", code)
+	}
+
+	// Zweites Gerät: es muss den Passwortwechsel NICHT überleben.
+	other := e.login(t, uid, "geheim123")
+
+	resp := e.doResp(t, "PUT", "/api/auth/password", cookie,
+		`{"old_password":"geheim123","new_password":"nochgeheimer1"}`)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("AC-8: Passwortwechsel erwartet 200, bekommen %d: %s", resp.Code, resp.Body.String())
+	}
+
+	if code := e.probe(t, cookie); code != http.StatusUnauthorized {
+		t.Errorf("AC-8: das zuvor gültige Merkmal muss ungültig sein, bekommen %d", code)
+	}
+	if code := e.probe(t, other); code != http.StatusUnauthorized {
+		t.Errorf("AC-8: das andere Gerät muss abgemeldet sein, bekommen %d", code)
+	}
+
+	// Zweite Hälfte: das wechselnde Gerät darf NICHT ausgesperrt werden. Ohne
+	// diese Zusicherung bewacht nichts, dass der Nutzer nach dem
+	// Passwortwechsel weiterarbeiten kann — er säße vor einer Seite, deren
+	// Datenabrufe alle 401 geben.
+	fresh := sessionCookieOf(resp)
+	if fresh == "" {
+		t.Fatalf("AC-8: die Antwort des Passwortwechsels muss ein neues Anmelde-Merkmal tragen")
+	}
+	if fresh == cookie {
+		t.Errorf("AC-8: das neue Merkmal muss sich vom widerrufenen unterscheiden")
+	}
+	fourSegments(t, "AC-8", "neu ausgestelltes Merkmal", fresh)
+	if code := e.probe(t, fresh); code != http.StatusOK {
+		t.Errorf("AC-8: das neu ausgestellte Merkmal muss sofort funktionieren, bekommen %d", code)
+	}
+}
+
+// Abgrenzung zu AC-8: Passwort-Zurücksetzen, "auf allen Geräten abmelden" und
+// Kontolöschung stellen KEIN neues Merkmal aus. Wer zurücksetzt, weil das
+// Passwort abgegriffen wurde, soll ausgesperrt bleiben — ein frischer Nachweis
+// in der Antwort würde genau den Angreifer wieder hereinlassen, der den
+// Zurücksetzen-Ablauf ausgelöst hat.
+func TestOnlyPasswordChangeIssuesAFreshSession(t *testing.T) {
+	t.Run("Zurücksetzen", func(t *testing.T) {
+		e := newAuthEnv(t)
+		const uid = "u-nofresh-reset"
+		e.seedUser(t, uid, "geheim123")
+		e.login(t, uid, "geheim123")
+
+		const resetToken = "reset-token-nofresh"
+		hash, err := bcrypt.GenerateFromPassword([]byte(resetToken), bcrypt.MinCost)
+		if err != nil {
+			t.Fatalf("bcrypt: %v", err)
+		}
+		if err := e.store.SaveResetToken(uid, model.PasswordResetToken{
+			TokenHash: string(hash), ExpiresAt: time.Now().Add(time.Hour),
+		}); err != nil {
+			t.Fatalf("SaveResetToken: %v", err)
+		}
+
+		resp := e.doResp(t, "POST", "/api/auth/reset-password", "",
+			fmt.Sprintf(`{"username":%q,"token":%q,"new_password":"nochgeheimer1"}`, uid, resetToken))
+		if resp.Code != http.StatusOK {
+			t.Fatalf("Zurücksetzen erwartet 200, bekommen %d", resp.Code)
+		}
+		if fresh := sessionCookieOf(resp); fresh != "" {
+			t.Errorf("Zurücksetzen darf kein neues Merkmal ausstellen, bekommen %q", fresh)
+		}
+	})
+
+	t.Run("alle Geräte abmelden", func(t *testing.T) {
+		e := newAuthEnv(t)
+		const uid = "u-nofresh-all"
+		e.seedUser(t, uid, "geheim123")
+		cookie := e.login(t, uid, "geheim123")
+
+		resp := e.doResp(t, "POST", "/api/auth/logout-all", cookie, "")
+		if resp.Code != http.StatusOK {
+			t.Fatalf("'alle abmelden' erwartet 200, bekommen %d", resp.Code)
+		}
+		if fresh := sessionCookieOf(resp); fresh != "" {
+			t.Errorf("'alle abmelden' darf kein neues Merkmal ausstellen, bekommen %q", fresh)
+		}
+	})
+
+	t.Run("Kontolöschung", func(t *testing.T) {
+		e := newAuthEnv(t)
+		const uid = "u-nofresh-delete"
+		e.seedUser(t, uid, "geheim123")
+		cookie := e.login(t, uid, "geheim123")
+
+		resp := e.doResp(t, "DELETE", "/api/auth/account", cookie, "")
+		if resp.Code != http.StatusOK {
+			t.Fatalf("Kontolöschung erwartet 200, bekommen %d", resp.Code)
+		}
+		if fresh := sessionCookieOf(resp); fresh != "" {
+			t.Errorf("Kontolöschung darf kein neues Merkmal ausstellen, bekommen %q", fresh)
+		}
+	})
+}
+
+// Abmelden mit einem ALT-Merkmal wirkt ebenfalls — die Zusage "Abmelden wirkt"
+// bekommt auch im 24-Stunden-Übergangsfenster keine Ausnahme.
+//
+// Der gefährliche Fall ist der ohne jede authentifizierte Anfrage dazwischen:
+// nur dann bleibt das Alt-Merkmal ungehoben, steht auf keiner Gästeliste und
+// hätte ohne Widerrufs-Vermerk nichts, woran ein Abmelden greifen könnte.
+func TestLogoutWithLegacyCookieRevokesIt(t *testing.T) {
+	e := newAuthEnv(t)
+	const uid = "u-legacy-logout"
+	e.seedUser(t, uid, "geheim123")
+
+	legacy := authmw.SignSession(uid, e.secret)
+	if n := len(strings.Split(legacy, ".")); n != 3 {
+		t.Fatalf("Testaufbau: Alt-Merkmal muss 3 Segmente haben, hat %d", n)
+	}
+
+	// KEINE authentifizierte Anfrage vor dem Abmelden — sonst höbe die
+	// Middleware das Merkmal aufs neue Format und der Fall verschwände.
+	if code := e.post(t, "/api/auth/logout", legacy, ""); code != http.StatusOK {
+		t.Fatalf("Abmelden erwartet 200, bekommen %d", code)
+	}
+
+	if code := e.probe(t, legacy); code != http.StatusUnauthorized {
+		t.Errorf("Alt-Merkmal muss nach dem Abmelden ungültig sein, bekommen %d", code)
+	}
+}
+
+// AC-16 im Altformat: ein Alt-Merkmal überlebt die Kontolöschung nicht.
+//
+// `e.login()` liefert immer das NEUE vierteilige Merkmal, der Legacy-Zweig
+// wird vom regulären AC-16-Test also nie erreicht. Fiele die Konto-Prüfung
+// dort weg, bliebe ein vor der Löschung ausgestelltes und nie gehobenes
+// Alt-Merkmal bis zu 24 Stunden gültig — und die stille Hebung würde den
+// gelöschten Nutzerordner sogar neu anlegen.
+//
+// Dass der Legacy-Zweig grundsätzlich durchlässt, belegt
+// TestLegacyCookieWithoutLogoutStillWorks; deshalb misst dieser Test hier die
+// Löschung und nicht die Grundfunktion.
+func TestLegacyCookieDoesNotSurviveAccountDeletion(t *testing.T) {
+	e := newAuthEnv(t)
+	const uid = "u-legacy-delete"
+	e.seedUser(t, uid, "geheim123")
+
+	// Alt-Merkmal VOR der Löschung ausstellen und bewusst NICHT benutzen —
+	// jede authentifizierte Anfrage damit würde es aufs neue Format heben und
+	// den zu prüfenden Fall wegnehmen.
+	legacy := authmw.SignSession(uid, e.secret)
+	if n := len(strings.Split(legacy, ".")); n != 3 {
+		t.Fatalf("Testaufbau: Alt-Merkmal muss 3 Segmente haben, hat %d", n)
+	}
+
+	// Löschung über den echten Endpunkt, mit einem regulären neuen Merkmal.
+	current := e.login(t, uid, "geheim123")
+	if code := e.do(t, "DELETE", "/api/auth/account", current, ""); code != http.StatusOK {
+		t.Fatalf("Kontolöschung erwartet 200, bekommen %d", code)
+	}
+
+	if code := e.probe(t, legacy); code != http.StatusUnauthorized {
+		t.Errorf("Alt-Merkmal muss nach der Kontolöschung ungültig sein, bekommen %d", code)
+	}
+	// Gegenprobe zur Nebenwirkung: die stille Hebung ruft AddSession, und das
+	// legt das Nutzerverzeichnis per MkdirAll an. Geprüft wird deshalb das
+	// VERZEICHNIS, nicht UserExists — das schaut auf die user.json, die die
+	// Hebung gar nicht schreibt, und sähe die Wiederauferstehung nicht.
+	if _, err := os.Stat(e.store.UserDir(uid)); err == nil {
+		t.Errorf("der Ordner des gelöschten Kontos %q darf durch das Alt-Merkmal nicht wieder entstehen", uid)
+	}
+}
+
+// Positivkontrolle zum vorigen Test, in EIGENER Umgebung: ohne das Abmelden
+// wäre dieselbe Anfrage 200. Ohne sie misst der Test nur, dass Alt-Merkmale
+// generell abgewiesen werden — und wäre auch dann grün, wenn der
+// Legacy-Zweig ganz kaputt wäre.
+func TestLegacyCookieWithoutLogoutStillWorks(t *testing.T) {
+	e := newAuthEnv(t)
+	const uid = "u-legacy-ok"
+	e.seedUser(t, uid, "geheim123")
+
+	legacy := authmw.SignSession(uid, e.secret)
+	if code := e.probe(t, legacy); code != http.StatusOK {
+		t.Errorf("Positivkontrolle: gültiges Alt-Merkmal ohne Abmelden muss 200 liefern, bekommen %d", code)
+	}
+}
+
+// --- AC-9 ------------------------------------------------------------------
+
+// AC-9: Das Zurücksetzen des Passworts macht das zuvor gültige Merkmal
+// ungültig. Sicherheitlich der schwerere Fall: wer zurücksetzt, WEIL das
+// Passwort abgegriffen wurde, muss den Angreifer damit hinauswerfen.
+//
+// Das Reset-Token wird direkt über den Store gesetzt — der "Passwort
+// vergessen"-Mailweg wird bewusst nicht angefasst, der Test versendet nichts.
+func TestPasswordResetRevokesSessions(t *testing.T) {
+	e := newAuthEnv(t)
+	const uid = "u-ac9"
+	e.seedUser(t, uid, "geheim123")
+	cookie := e.login(t, uid, "geheim123")
+
+	if code := e.probe(t, cookie); code != http.StatusOK {
+		t.Fatalf("AC-9 Positivkontrolle: Merkmal muss vorher gültig sein, bekommen %d", code)
+	}
+
+	const resetToken = "reset-token-2129"
+	hash, err := bcrypt.GenerateFromPassword([]byte(resetToken), bcrypt.MinCost)
+	if err != nil {
+		t.Fatalf("bcrypt: %v", err)
+	}
+	if err := e.store.SaveResetToken(uid, model.PasswordResetToken{
+		TokenHash: string(hash), ExpiresAt: time.Now().Add(time.Hour),
+	}); err != nil {
+		t.Fatalf("SaveResetToken: %v", err)
+	}
+
+	code := e.post(t, "/api/auth/reset-password", "",
+		fmt.Sprintf(`{"username":%q,"token":%q,"new_password":"nochgeheimer1"}`, uid, resetToken))
+	if code != http.StatusOK {
+		t.Fatalf("AC-9: Zurücksetzen erwartet 200, bekommen %d", code)
+	}
+
+	if code := e.probe(t, cookie); code != http.StatusUnauthorized {
+		t.Errorf("AC-9: altes Merkmal muss nach dem Zurücksetzen ungültig sein, bekommen %d", code)
+	}
+}
+
+// --- AC-15 -----------------------------------------------------------------
+
+// AC-15 (a): Zwei gleichzeitige Anmeldungen desselben Kontos verdrängen
+// einander nicht.
+func TestTwoParallelLoginsDoNotEvictEachOther(t *testing.T) {
+	e := newAuthEnv(t)
+	const uid = "u-ac15a"
+	e.seedUser(t, uid, "geheim123")
+
+	var wg sync.WaitGroup
+	cookies := make([]string, 2)
+	errs := make([]error, 2)
+	for i := range cookies {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			cookies[idx], errs[idx] = e.loginNoFatal(uid, "geheim123")
+		}(i)
+	}
+	wg.Wait()
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("AC-15a: parallele Anmeldung %d fehlgeschlagen: %v", i+1, err)
+		}
+	}
+
+	fourSegments(t, "AC-15a", "erstes Merkmal", cookies[0])
+	fourSegments(t, "AC-15a", "zweites Merkmal", cookies[1])
+	if cookies[0] == cookies[1] {
+		t.Errorf("AC-15a: parallele Anmeldungen müssen verschiedene Merkmale liefern, beide sind %q",
+			cookies[0])
+	}
+	for i, c := range cookies {
+		if code := e.probe(t, c); code != http.StatusOK {
+			t.Errorf("AC-15a: Merkmal %d muss nach beiden Anmeldungen gültig sein, bekommen %d", i+1, code)
+		}
+	}
+}
+
+// AC-15 (b): Ein Widerruf parallel zu einer Profiländerung desselben Nutzers
+// geht nicht verloren.
+//
+// Unbedingt geprüft wird "der Widerruf hält" — das ist die Zusicherung, die
+// der Wettlauf gefährdet, und sie FIELE, läge die Gästeliste in der user.json:
+// ein gleichzeitiger Profil-Schreiber schreibt dort das ganze Nutzerobjekt
+// zurück und würfe den Widerruf damit weg. Die Dateitrennung
+// (sessions.json getrennt von user.json) ist deshalb kein Zierrat, sondern
+// genau das, was dieser Test bewacht.
+//
+// Die Profiländerung wird nur dann auf Persistenz geprüft, wenn sie 200 bekam:
+// gewinnt der Widerruf das Rennen, bekommt sie 401 und darf gar nichts
+// gespeichert haben. Eine Erwartung "beides immer" wäre reihenfolgeabhängig
+// und damit flatterig.
+func TestLogoutAllConcurrentWithProfileUpdate(t *testing.T) {
+	e := newAuthEnv(t)
+	const uid = "u-ac15b"
+	e.seedUser(t, uid, "geheim123")
+
+	const rounds = 5
+	for round := 0; round < rounds; round++ {
+		cookie := e.login(t, uid, "geheim123")
+		wantName := fmt.Sprintf("Runde %d", round)
+
+		var wg sync.WaitGroup
+		var profileCode, revokeCode int
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			profileCode = e.do(t, "PUT", "/api/auth/profile", cookie,
+				fmt.Sprintf(`{"display_name":%q}`, wantName))
+		}()
+		go func() {
+			defer wg.Done()
+			revokeCode = e.post(t, "/api/auth/logout-all", cookie, "")
+		}()
+		wg.Wait()
+
+		if revokeCode != http.StatusOK {
+			t.Fatalf("AC-15b Runde %d: 'alle abmelden' erwartet 200, bekommen %d "+
+				"(404 heißt: Route nicht registriert)", round, revokeCode)
+		}
+		if code := e.probe(t, cookie); code != http.StatusUnauthorized {
+			t.Fatalf("AC-15b Runde %d: der Widerruf darf durch den gleichzeitigen Profil-Schreiber "+
+				"nicht verloren gehen, bekommen %d", round, code)
+		}
+		if profileCode == http.StatusOK {
+			user, err := e.store.LoadUser(uid)
+			if err != nil || user == nil {
+				t.Fatalf("AC-15b Runde %d: LoadUser: %v", round, err)
+			}
+			if user.DisplayName != wantName {
+				t.Errorf("AC-15b Runde %d: angenommene Profiländerung muss gespeichert sein, "+
+					"erwartet %q, gespeichert %q", round, wantName, user.DisplayName)
+			}
+		}
+	}
+}
+
+// --- AC-16 -----------------------------------------------------------------
+
+// AC-16: Die Kontolöschung macht das Merkmal ungültig — auch über einen echten
+// Neustart hinweg.
+func TestAccountDeletionRevokesSessionAcrossRestart(t *testing.T) {
+	e := newAuthEnv(t)
+	const uid = "u-ac16"
+	e.seedUser(t, uid, "geheim123")
+	cookie := e.login(t, uid, "geheim123")
+
+	if code := e.probe(t, cookie); code != http.StatusOK {
+		t.Fatalf("AC-16 Positivkontrolle: Merkmal muss vorher gültig sein, bekommen %d", code)
+	}
+	if code := e.do(t, "DELETE", "/api/auth/account", cookie, ""); code != http.StatusOK {
+		t.Fatalf("AC-16: Kontolöschung erwartet 200, bekommen %d", code)
+	}
+
+	if code := e.probe(t, cookie); code != http.StatusUnauthorized {
+		t.Errorf("AC-16: Merkmal muss sofort ungültig sein, bekommen %d", code)
+	}
+	if code := probeAfterRestart(t, e.dataDir, e.secret, cookie); code != http.StatusUnauthorized {
+		t.Errorf("AC-16: Merkmal muss auch nach dem Neustart ungültig bleiben, bekommen %d", code)
+	}
+}

--- a/internal/handler/logout_test.go
+++ b/internal/handler/logout_test.go
@@ -8,10 +8,11 @@ import (
 	"github.com/henemm/gregor-api/internal/middleware"
 )
 
-// TDD RED: Tests for logout — must FAIL until implemented.
+const logoutTestSecret = "test-secret-32-chars-minimum-ok!"
 
 func TestLogoutHandlerClearsCookie(t *testing.T) {
-	h := LogoutHandler()
+	s := newTestStore(t)
+	h := LogoutHandler(s, logoutTestSecret)
 
 	req := httptest.NewRequest("POST", "/api/auth/logout", nil)
 	req.AddCookie(&http.Cookie{Name: "gz_session", Value: "alice.123.sig"})
@@ -39,28 +40,69 @@ func TestLogoutHandlerClearsCookie(t *testing.T) {
 	}
 }
 
-func TestLogoutBlacklistsSession(t *testing.T) {
-	token := "alice.123.fakesig"
-
-	// Before logout: not blacklisted
-	if middleware.IsBlacklisted(token) {
-		t.Fatal("token should not be blacklisted before logout")
+// Issue #2129: Abmelden entfernt den Eintrag aus der Gaesteliste des Nutzers,
+// statt den Token in einer prozesslokalen Sperrliste zu vermerken. Das ist der
+// Unterschied, auf dem die unbefristete Anmeldung beruht: der Widerruf liegt
+// auf der Platte und ueberlebt damit einen Dienst-Neustart.
+func TestLogoutRemovesSessionFromAllowlist(t *testing.T) {
+	s := newTestStore(t)
+	sessionId, err := middleware.NewSessionID()
+	if err != nil {
+		t.Fatalf("NewSessionID: %v", err)
+	}
+	if err := s.AddSession("alice", sessionId); err != nil {
+		t.Fatalf("AddSession: %v", err)
 	}
 
-	h := LogoutHandler()
+	// Positivkontrolle: vor dem Abmelden steht die Anmeldung auf der Liste.
+	if listed, err := s.HasSession("alice", sessionId); err != nil || !listed {
+		t.Fatalf("Positivkontrolle: Anmeldung muss vor dem Abmelden gelistet sein (listed=%v err=%v)",
+			listed, err)
+	}
+
+	token := middleware.SignSessionWithID("alice", sessionId, logoutTestSecret)
 	req := httptest.NewRequest("POST", "/api/auth/logout", nil)
 	req.AddCookie(&http.Cookie{Name: "gz_session", Value: token})
 	w := httptest.NewRecorder()
-	h.ServeHTTP(w, req)
+	LogoutHandler(s, logoutTestSecret).ServeHTTP(w, req)
 
-	// After logout: blacklisted
-	if !middleware.IsBlacklisted(token) {
-		t.Error("token should be blacklisted after logout")
+	if listed, err := s.HasSession("alice", sessionId); err != nil || listed {
+		t.Errorf("Anmeldung muss nach dem Abmelden von der Gaesteliste verschwunden sein (listed=%v err=%v)",
+			listed, err)
+	}
+}
+
+// Ein Abmelde-Aufruf darf nur die eigene Anmeldung treffen, nicht die des
+// zweiten Geraets.
+func TestLogoutKeepsOtherSessionsOfSameUser(t *testing.T) {
+	s := newTestStore(t)
+	deviceA, _ := middleware.NewSessionID()
+	deviceB, _ := middleware.NewSessionID()
+	if err := s.AddSession("alice", deviceA); err != nil {
+		t.Fatalf("AddSession A: %v", err)
+	}
+	if err := s.AddSession("alice", deviceB); err != nil {
+		t.Fatalf("AddSession B: %v", err)
+	}
+
+	req := httptest.NewRequest("POST", "/api/auth/logout", nil)
+	req.AddCookie(&http.Cookie{
+		Name:  "gz_session",
+		Value: middleware.SignSessionWithID("alice", deviceA, logoutTestSecret),
+	})
+	LogoutHandler(s, logoutTestSecret).ServeHTTP(httptest.NewRecorder(), req)
+
+	if listed, _ := s.HasSession("alice", deviceA); listed {
+		t.Error("Geraet A muss abgemeldet sein")
+	}
+	if listed, _ := s.HasSession("alice", deviceB); !listed {
+		t.Error("Geraet B muss angemeldet bleiben")
 	}
 }
 
 func TestLogoutWithoutCookieStillReturns200(t *testing.T) {
-	h := LogoutHandler()
+	s := newTestStore(t)
+	h := LogoutHandler(s, logoutTestSecret)
 
 	req := httptest.NewRequest("POST", "/api/auth/logout", nil)
 	w := httptest.NewRecorder()

--- a/internal/handler/passkey.go
+++ b/internal/handler/passkey.go
@@ -253,17 +253,9 @@ func PasskeyLoginFinishHandler(s *store.Store, wa *webauthn.WebAuthn, cs *Challe
 			return
 		}
 
-		token := middleware.SignSession(entry.UserID, secret)
-		secure := r.Header.Get("X-Forwarded-Proto") == "https" || r.TLS != nil
-		http.SetCookie(w, &http.Cookie{
-			Name:     "gz_session",
-			Value:    token,
-			Path:     "/",
-			HttpOnly: true,
-			SameSite: http.SameSiteLaxMode,
-			MaxAge:   86400,
-			Secure:   secure,
-		})
+		if !issueSession(w, r, s, entry.UserID, secret) {
+			return
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]string{"id": entry.UserID})
@@ -362,17 +354,9 @@ func PasskeyLoginDiscoverableFinishHandler(s *store.Store, wa *webauthn.WebAuthn
 		}
 
 		userID := mu.WebAuthnName()
-		token := middleware.SignSession(userID, secret)
-		secure := r.Header.Get("X-Forwarded-Proto") == "https" || r.TLS != nil
-		http.SetCookie(w, &http.Cookie{
-			Name:     "gz_session",
-			Value:    token,
-			Path:     "/",
-			HttpOnly: true,
-			SameSite: http.SameSiteLaxMode,
-			MaxAge:   86400,
-			Secure:   secure,
-		})
+		if !issueSession(w, r, s, userID, secret) {
+			return
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]string{"id": userID})
@@ -572,17 +556,9 @@ func PasskeyRegisterPublicFinishHandler(s *store.Store, wa *webauthn.WebAuthn, c
 		// Begin-Schritt übermittelte Adresse dauerhaft unverifiziert.
 		dispatchVerificationMail(s, cfg, entry.UserID, &newUser)
 
-		token := middleware.SignSession(entry.UserID, secret)
-		secure := r.Header.Get("X-Forwarded-Proto") == "https" || r.TLS != nil
-		http.SetCookie(w, &http.Cookie{
-			Name:     "gz_session",
-			Value:    token,
-			Path:     "/",
-			HttpOnly: true,
-			SameSite: http.SameSiteLaxMode,
-			MaxAge:   86400,
-			Secure:   secure,
-		})
+		if !issueSession(w, r, s, entry.UserID, secret) {
+			return
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)

--- a/internal/handler/passkey_public_test.go
+++ b/internal/handler/passkey_public_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/henemm/gregor-api/internal/config"
 	"github.com/henemm/gregor-api/internal/mail"
+	"github.com/henemm/gregor-api/internal/middleware"
 	"github.com/henemm/gregor-api/internal/model"
 )
 
@@ -236,8 +237,9 @@ func TestPasskeyRegisterPublicRoundtrip_Success(t *testing.T) {
 	if sess.SameSite != http.SameSiteLaxMode {
 		t.Errorf("AC-5: expected SameSite=Lax, got %v", sess.SameSite)
 	}
-	if sess.MaxAge != 86400 {
-		t.Errorf("AC-5: expected MaxAge=86400, got %d", sess.MaxAge)
+	// Issue #2129: die Anmeldung gilt unbefristet, bis sie widerrufen wird.
+	if sess.MaxAge != middleware.SessionMaxAgeSeconds {
+		t.Errorf("AC-5: expected MaxAge=%d, got %d", middleware.SessionMaxAgeSeconds, sess.MaxAge)
 	}
 	if !strings.HasPrefix(sess.Value, "passwordless.") {
 		t.Errorf("AC-5: session value should start with 'passwordless.', got %q", sess.Value)

--- a/internal/handler/passkey_test.go
+++ b/internal/handler/passkey_test.go
@@ -416,8 +416,9 @@ func TestPasskeyLoginRoundtrip_Success(t *testing.T) {
 	if !sess.HttpOnly {
 		t.Errorf("AC-2: cookie should be HttpOnly")
 	}
-	if sess.MaxAge != 86400 {
-		t.Errorf("AC-2: expected MaxAge=86400, got %d", sess.MaxAge)
+	// Issue #2129: die Anmeldung gilt unbefristet, bis sie widerrufen wird.
+	if sess.MaxAge != middleware.SessionMaxAgeSeconds {
+		t.Errorf("AC-2: expected MaxAge=%d, got %d", middleware.SessionMaxAgeSeconds, sess.MaxAge)
 	}
 	if sess.SameSite != http.SameSiteLaxMode {
 		t.Errorf("AC-2: expected SameSite=Lax, got %v", sess.SameSite)
@@ -425,9 +426,10 @@ func TestPasskeyLoginRoundtrip_Success(t *testing.T) {
 	if !strings.HasPrefix(sess.Value, "alice.") {
 		t.Errorf("AC-2: cookie should start with 'alice.', got %q", sess.Value)
 	}
+	// Issue #2129: vierteilig — {userId}.{sessionId}.{ts}.{sig}.
 	parts := strings.Split(sess.Value, ".")
-	if len(parts) != 3 {
-		t.Errorf("AC-2: cookie expected 3 dot-segments, got %d", len(parts))
+	if len(parts) != 4 {
+		t.Errorf("AC-2: cookie expected 4 dot-segments, got %d", len(parts))
 	}
 	// F003 / AC-2: Cookie path must be "/" so the session is sent on all routes.
 	if sess.Path != "/" {

--- a/internal/handler/session_issuance_test.go
+++ b/internal/handler/session_issuance_test.go
@@ -1,0 +1,331 @@
+package handler
+
+// TDD RED — Issue #2129: dauerhafte Anmeldung mit widerrufbarem Anmelde-Merkmal.
+// Spec: docs/specs/modules/session_allowlist.md — AC-1, AC-13, AC-18.
+//
+// Alle SECHS Anmeldewege in einem Lauf. Das ist der Test mit dem größten
+// Selbstschadens-Schutz: wird beim Umbau auch nur EINE der sechs
+// Ausstellungsstellen vergessen, sperrt dieser Anmeldeweg alle seine Nutzer
+// aus — und ohne diesen Test fiele das erst in Produktion auf.
+//
+// Kein Mock-Theater: Google läuft gegen zwei echte httptest-Server, die drei
+// Passkey-Wege gegen den vorhandenen ECDSA-Testauthentifikator mit echter
+// Kryptographie, Magic-Link gegen den echten Verify-Handler. Kein Netz, kein
+// Versand — die Konten sind so geseedet, dass kein Verifikations-Dispatch
+// anläuft.
+//
+// Diese Datei liegt bewusst in `package handler`: vier der sechs Wege sind nur
+// paketintern anfahrbar (otpStore, registerForUser, newTestWebAuthn,
+// oauthFakeServers). Von außen bräuchte man einen echten WebAuthn-Client und
+// einen echten Google-Roundtrip.
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/henemm/gregor-api/internal/config"
+	"github.com/henemm/gregor-api/internal/middleware"
+	"github.com/henemm/gregor-api/internal/model"
+	"github.com/henemm/gregor-api/internal/store"
+)
+
+const issuanceSecret = "test-secret-32-chars-minimum-ok!"
+
+// minOneYearSeconds ist die geforderte Untergrenze der Cookie-Lebensdauer
+// (AC-18). Bewusst eine harte Zahl: ein Test, der "irgendeine Lebensdauer"
+// durchgehen ließe, ließe auch die heutigen 86400 Sekunden durch und prüfte
+// damit nichts.
+const minOneYearSeconds = 365 * 24 * 60 * 60
+
+// issued bündelt, was ein Anmeldeweg hinterlässt.
+type issued struct {
+	cookie  *http.Cookie
+	dataDir string
+	userID  string
+}
+
+func sessionCookieFrom(t *testing.T, w *httptest.ResponseRecorder, way string) *http.Cookie {
+	t.Helper()
+	for _, c := range w.Result().Cookies() {
+		if c.Name == "gz_session" {
+			return c
+		}
+	}
+	t.Fatalf("%s: kein gz_session-Cookie in der Antwort (Status %d): %s", way, w.Code, w.Body.String())
+	return nil
+}
+
+// probeIssuedCookie legt das ausgestellte Merkmal der echten AuthMiddleware vor.
+//
+// dataDir ist die Wurzel des Datenbestands: der Store wird FRISCH darüber
+// gebaut, nicht aus dem Ausstellungslauf übernommen. Damit misst die Sonde die
+// Gästeliste auf der Platte und nicht einen Prozesszustand, den die
+// Ausstellungsstelle zufällig noch hält.
+func probeIssuedCookie(t *testing.T, dataDir, cookieValue string) int {
+	t.Helper()
+	req := httptest.NewRequest("GET", "/api/trips", nil)
+	req.AddCookie(&http.Cookie{Name: "gz_session", Value: cookieValue})
+	rr := httptest.NewRecorder()
+	middleware.AuthMiddleware(issuanceSecret, store.New(dataDir, ""))(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			if middleware.UserIDFromContext(r.Context()) == "" {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		})).ServeHTTP(rr, req)
+	return rr.Code
+}
+
+// --- die sechs Anmeldewege -------------------------------------------------
+
+func mintViaPassword(t *testing.T) issued {
+	t.Helper()
+	s := newTestStore(t)
+	hash, _ := bcrypt.GenerateFromPassword([]byte("geheim123"), bcrypt.MinCost)
+	if err := s.SaveUser(model.User{ID: "alice", PasswordHash: string(hash), CreatedAt: time.Now()}); err != nil {
+		t.Fatalf("SaveUser: %v", err)
+	}
+
+	req := httptest.NewRequest("POST", "/api/auth/login",
+		strings.NewReader(`{"username":"alice","password":"geheim123"}`))
+	w := httptest.NewRecorder()
+	LoginHandler(s, issuanceSecret).ServeHTTP(w, req)
+	if w.Code != 200 {
+		t.Fatalf("Passwort-Anmeldung: erwartet 200, bekommen %d: %s", w.Code, w.Body.String())
+	}
+	return issued{cookie: sessionCookieFrom(t, w, "Passwort"), dataDir: s.DataDir, userID: "alice"}
+}
+
+func mintViaMagicLink(t *testing.T) issued {
+	t.Helper()
+	t.Cleanup(ResetOTPStoreForTest)
+
+	s := newTestStore(t)
+	const uid = "m-aabbccdd"
+	if err := s.SaveUser(model.User{ID: uid, Email: "magic@example.com", CreatedAt: time.Now()}); err != nil {
+		t.Fatalf("SaveUser: %v", err)
+	}
+	otpStore.Store("magic@example.com", &otpEntry{
+		code:      "123456",
+		userID:    uid,
+		expiresAt: time.Now().Add(15 * time.Minute),
+	})
+
+	cfg := &config.Config{SessionSecret: issuanceSecret}
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/magic-link/verify",
+		strings.NewReader(`{"email":"magic@example.com","code":"123456"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	MagicLinkVerifyHandler(s, cfg).ServeHTTP(w, req)
+	if w.Code != 200 {
+		t.Fatalf("Magic-Link: erwartet 200, bekommen %d: %s", w.Code, w.Body.String())
+	}
+	return issued{cookie: sessionCookieFrom(t, w, "Magic-Link"), dataDir: s.DataDir, userID: uid}
+}
+
+func mintViaGoogle(t *testing.T) issued {
+	t.Helper()
+	s := newTestStore(t)
+
+	// Konto vorab anlegen, damit der Callback den BESTANDS-Zweig nimmt: der
+	// legt kein Konto an und löst deshalb keinen Verifikations-Dispatch aus.
+	// Kein Mail-Versand aus diesem Test, auch nicht als Fire-and-Forget.
+	const uid = "g-11223344"
+	verified := time.Now()
+	if err := s.SaveUser(model.User{
+		ID: uid, Email: "google@example.com", OAuthProvider: "google", OAuthSub: "sub-2129",
+		EmailVerifiedAt: &verified, CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("SaveUser: %v", err)
+	}
+
+	userinfoURL, tokenURL := oauthFakeServers(t, "sub-2129", "google@example.com")
+	cfg := &config.Config{
+		GoogleClientID:     "test-client-id",
+		GoogleClientSecret: "test-secret",
+		GoogleRedirectURL:  "https://example.com/callback",
+		SessionSecret:      issuanceSecret,
+	}
+
+	const state = "state-2129"
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/auth/google/callback?code=test-code&state="+state, nil)
+	req.AddCookie(&http.Cookie{Name: "gz_oauth_state", Value: state})
+	w := httptest.NewRecorder()
+	GoogleOAuthCallbackHandlerWithEndpoints(cfg, s, userinfoURL, tokenURL).ServeHTTP(w, req)
+	if w.Code != http.StatusFound {
+		t.Fatalf("Google: erwartet 302, bekommen %d: %s", w.Code, w.Body.String())
+	}
+	return issued{cookie: sessionCookieFrom(t, w, "Google"), dataDir: s.DataDir, userID: uid}
+}
+
+func mintViaPasskeyLogin(t *testing.T) issued {
+	t.Helper()
+	rpID, origin := "localhost", "http://localhost"
+	s := newTestStore(t)
+	wa := newTestWebAuthn(t, rpID, origin)
+	cs := NewChallengeStore()
+	auth := registerForUser(t, s, wa, cs, "alice")
+
+	beginW := httptest.NewRecorder()
+	PasskeyLoginBeginHandler(s, wa, cs).ServeHTTP(beginW,
+		httptest.NewRequest("POST", "/api/auth/passkey/login/begin",
+			bytes.NewReader([]byte(`{"username":"alice"}`))))
+	if beginW.Code != 200 {
+		t.Fatalf("Passkey-Login begin: erwartet 200, bekommen %d: %s", beginW.Code, beginW.Body.String())
+	}
+	var beginResp struct {
+		PublicKey struct {
+			Challenge string `json:"challenge"`
+		} `json:"publicKey"`
+	}
+	if err := json.Unmarshal(beginW.Body.Bytes(), &beginResp); err != nil {
+		t.Fatalf("Passkey-Login begin decode: %v", err)
+	}
+
+	finishW := httptest.NewRecorder()
+	PasskeyLoginFinishHandler(s, wa, cs, issuanceSecret).ServeHTTP(finishW,
+		httptest.NewRequest("POST", "/api/auth/passkey/login/finish",
+			bytes.NewReader(auth.makeAssertionResponse(t, beginResp.PublicKey.Challenge, 1))))
+	if finishW.Code != 200 {
+		t.Fatalf("Passkey-Login finish: erwartet 200, bekommen %d: %s", finishW.Code, finishW.Body.String())
+	}
+	return issued{cookie: sessionCookieFrom(t, finishW, "Passkey-Login"), dataDir: s.DataDir, userID: "alice"}
+}
+
+func mintViaPasskeyDiscoverable(t *testing.T) issued {
+	t.Helper()
+	rpID, origin := "localhost", "http://localhost"
+	s := newTestStore(t)
+	wa := newTestWebAuthn(t, rpID, origin)
+	cs := NewChallengeStore()
+	const uid = "alice"
+	auth := registerForUser(t, s, wa, cs, uid)
+
+	beginW := httptest.NewRecorder()
+	PasskeyLoginDiscoverableBeginHandler(wa, cs).ServeHTTP(beginW,
+		httptest.NewRequest("POST", "/api/auth/passkey/discoverable/begin", nil))
+	if beginW.Code != http.StatusOK {
+		t.Fatalf("Passkey-discoverable begin: erwartet 200, bekommen %d: %s", beginW.Code, beginW.Body.String())
+	}
+	var beginResp map[string]interface{}
+	_ = json.Unmarshal(beginW.Body.Bytes(), &beginResp)
+	pk, _ := beginResp["publicKey"].(map[string]interface{})
+	challenge, _ := pk["challenge"].(string)
+
+	finishReq := httptest.NewRequest("POST", "/api/auth/passkey/discoverable/finish",
+		bytes.NewReader(auth.makeAssertionResponseDiscoverable(t, challenge, 1, uid)))
+	finishReq.Header.Set("Content-Type", "application/json")
+	finishW := httptest.NewRecorder()
+	PasskeyLoginDiscoverableFinishHandler(s, wa, cs, issuanceSecret).ServeHTTP(finishW, finishReq)
+	if finishW.Code != http.StatusOK {
+		t.Fatalf("Passkey-discoverable finish: erwartet 200, bekommen %d: %s", finishW.Code, finishW.Body.String())
+	}
+	return issued{cookie: sessionCookieFrom(t, finishW, "Passkey-discoverable"), dataDir: s.DataDir, userID: uid}
+}
+
+func mintViaPasskeyRegistration(t *testing.T) issued {
+	t.Helper()
+	rpID, origin := "localhost", "http://localhost"
+	s := newTestStore(t)
+	wa := newTestWebAuthn(t, rpID, origin)
+	cs := NewChallengeStore()
+
+	beginW := httptest.NewRecorder()
+	PasskeyRegisterPublicBeginHandler(s, wa, cs).ServeHTTP(beginW,
+		httptest.NewRequest("POST", "/api/auth/passkey/register/public/begin",
+			bytes.NewReader([]byte(`{"username":"passwordless","email":"pw@example.com"}`))))
+	if beginW.Code != http.StatusOK {
+		t.Fatalf("Passkey-Registrierung begin: erwartet 200, bekommen %d: %s", beginW.Code, beginW.Body.String())
+	}
+	var beginResp struct {
+		PublicKey struct {
+			Challenge string `json:"challenge"`
+		} `json:"publicKey"`
+	}
+	if err := json.Unmarshal(beginW.Body.Bytes(), &beginResp); err != nil {
+		t.Fatalf("Passkey-Registrierung begin decode: %v", err)
+	}
+
+	auth := newTestAuthenticator(t, rpID, origin)
+	finishW := httptest.NewRecorder()
+	// Leere config.Config: kein SMTPHost → kein Verifikations-Dispatch.
+	PasskeyRegisterPublicFinishHandler(s, wa, cs, issuanceSecret, config.Config{}).ServeHTTP(finishW,
+		httptest.NewRequest("POST", "/api/auth/passkey/register/public/finish",
+			bytes.NewReader(auth.makeAttestationResponse(t, beginResp.PublicKey.Challenge))))
+	if finishW.Code != http.StatusCreated {
+		t.Fatalf("Passkey-Registrierung finish: erwartet 201, bekommen %d: %s", finishW.Code, finishW.Body.String())
+	}
+	return issued{
+		cookie:  sessionCookieFrom(t, finishW, "Passkey-Registrierung"),
+		dataDir: s.DataDir,
+		userID:  "passwordless",
+	}
+}
+
+// AC-1 / AC-13 / AC-18: Jeder der sechs Anmeldewege stellt ein vierteiliges
+// Anmelde-Merkmal aus, das die eigene Prüfung besteht und mindestens ein Jahr
+// im Browser bleibt.
+func TestAllSixLoginPaths_IssueFourPartCookie(t *testing.T) {
+	ways := []struct {
+		name string
+		mint func(*testing.T) issued
+	}{
+		{"Passwort", mintViaPassword},
+		{"Magic-Link", mintViaMagicLink},
+		{"Google", mintViaGoogle},
+		{"Passkey-Login", mintViaPasskeyLogin},
+		{"Passkey-ohne-Kennungseingabe", mintViaPasskeyDiscoverable},
+		{"Passkey-Registrierung", mintViaPasskeyRegistration},
+	}
+
+	if len(ways) != 6 {
+		t.Fatalf("AC-13 verlangt sechs Anmeldewege, abgedeckt sind %d", len(ways))
+	}
+
+	for _, way := range ways {
+		t.Run(way.name, func(t *testing.T) {
+			got := way.mint(t)
+
+			// AC-1: vierteiliges Merkmal.
+			if n := len(strings.Split(got.cookie.Value, ".")); n != 4 {
+				t.Errorf("AC-1/%s: erwartet 4 Punkt-Segmente, sind %d (%q)", way.name, n, got.cookie.Value)
+			}
+			if !strings.HasPrefix(got.cookie.Value, got.userID+".") {
+				t.Errorf("AC-1/%s: Merkmal muss mit der Nutzerkennung %q beginnen, ist %q",
+					way.name, got.userID, got.cookie.Value)
+			}
+
+			// AC-18: Lebensdauer mindestens ein Jahr — der heutige Wert 86400
+			// darf diesen Nachweis nicht bestehen.
+			if got.cookie.MaxAge < minOneYearSeconds {
+				t.Errorf("AC-18/%s: MaxAge muss >= %d sein (ein Jahr), ist %d",
+					way.name, minOneYearSeconds, got.cookie.MaxAge)
+			}
+			if !got.cookie.HttpOnly {
+				t.Errorf("AC-18/%s: Merkmal muss HttpOnly bleiben", way.name)
+			}
+			if got.cookie.SameSite != http.SameSiteLaxMode {
+				t.Errorf("AC-18/%s: SameSite muss Lax bleiben, ist %v", way.name, got.cookie.SameSite)
+			}
+
+			// AC-13: das ausgestellte Merkmal besteht die eigene Prüfung. Nach
+			// GREEN ist das der Wächter dafür, dass diese Ausstellungsstelle
+			// die Anmeldung auch wirklich in die Gästeliste eingetragen hat —
+			// vergisst sie es, ist das Merkmal zwar wohlgeformt, aber nicht
+			// gelistet und damit ungültig.
+			if code := probeIssuedCookie(t, got.dataDir, got.cookie.Value); code != http.StatusOK {
+				t.Errorf("AC-13/%s: ausgestelltes Merkmal muss die eigene Prüfung bestehen, bekommen %d",
+					way.name, code)
+			}
+		})
+	}
+}

--- a/internal/handler/verify_email_test.go
+++ b/internal/handler/verify_email_test.go
@@ -237,7 +237,7 @@ func TestVerifyEmailHandler_PublicRoute_NotBlockedByAuthMiddleware_AC7(t *testin
 	seedVerifyEmailUser(t, s, "finn")
 	makeVerificationToken(t, s, "finn", "finn-token", time.Now().Add(24*time.Hour))
 
-	wrapped := middleware.AuthMiddleware("test-secret-32-chars-minimum-ok!")(VerifyEmailHandler(s))
+	wrapped := middleware.AuthMiddleware("test-secret-32-chars-minimum-ok!", s)(VerifyEmailHandler(s))
 	req := httptest.NewRequest("POST", "/api/auth/verify-email", strings.NewReader(`{"user":"finn","token":"finn-token"}`))
 	w := httptest.NewRecorder()
 	wrapped.ServeHTTP(w, req)

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -3,32 +3,48 @@ package middleware
 import (
 	"context"
 	"crypto/hmac"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"log"
 	"net/http"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
+
+	"github.com/henemm/gregor-api/internal/store"
 )
 
-var sessionBlacklist sync.Map
+// SessionMaxAgeSeconds ist die Lebensdauer des Anmelde-Cookies (Issue #2129).
+// 400 Tage: die Anmeldung gilt unbefristet, bis sie widerrufen wird, aber
+// Browser deckeln persistente Cookies inzwischen bei 400 Tagen -- ein hoeherer
+// Wert waere eine Zusage, die der Browser ohnehin nicht einloest.
+const SessionMaxAgeSeconds = 400 * 24 * 60 * 60
 
-func BlacklistSession(token string) {
-	sessionBlacklist.Store(token, struct{}{})
-}
-
-func IsBlacklisted(token string) bool {
-	_, ok := sessionBlacklist.Load(token)
-	return ok
-}
+// legacyMaxAgeSeconds ist die Ablauffrist, die fuer das ALTE dreiteilige
+// Merkmal scharf bleibt. Damit verschwindet der Altbestand binnen 24 Stunden
+// nach dem Deploy von selbst und der Legacy-Zweig kann spaeter ersatzlos
+// entfallen. Fuer das neue Format gibt es keine Frist -- dort traegt die
+// Gaesteliste die Gueltigkeit.
+const legacyMaxAgeSeconds = 86400
 
 type contextKey string
 
 const userIDContextKey contextKey = "userId"
 
-func AuthMiddleware(secret string) func(http.Handler) http.Handler {
+// SessionStore ist der Ausschnitt des Stores, den die Pruefstelle braucht.
+// Als Schnittstelle, damit die Middleware nicht am ganzen Store haengt.
+type SessionStore interface {
+	HasSession(userId, sessionId string) (bool, error)
+	AddSession(userId, sessionId string) error
+	LegacyRevokedAt(userId string) (*time.Time, error)
+	UserExists(userId string) bool
+}
+
+var _ SessionStore = (*store.Store)(nil)
+
+func AuthMiddleware(secret string, sessions SessionStore) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if r.URL.Path == "/api/health" || r.URL.Path == "/api/scheduler/status" ||
@@ -55,10 +71,28 @@ func AuthMiddleware(secret string) func(http.Handler) http.Handler {
 				return
 			}
 
-			userId, ok := validateSession(cookie.Value, secret)
-			if !ok || IsBlacklisted(cookie.Value) {
+			userId, sessionId, issuedAt, isNew, ok := validateSession(cookie.Value, secret)
+			if !ok {
 				http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
 				return
+			}
+
+			if isNew {
+				// Die einzige Gueltigkeitsfrage beim neuen Format: steht die
+				// Anmelde-Kennung noch auf der Gaesteliste? Kein
+				// Zwischenspeicher -- ein zweiter Zustandsbehaelter muesste
+				// genau die Widerrufs-Zusicherung tragen, auf der die
+				// unbefristete Anmeldung beruht.
+				listed, lookupErr := sessions.HasSession(userId, sessionId)
+				if lookupErr != nil || !listed {
+					http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
+					return
+				}
+			} else if !legacySessionValid(sessions, userId, issuedAt) {
+				http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
+				return
+			} else {
+				upgradeLegacySession(w, r, sessions, secret, userId)
 			}
 
 			ctx := context.WithValue(r.Context(), userIDContextKey, userId)
@@ -67,13 +101,73 @@ func AuthMiddleware(secret string) func(http.Handler) http.Handler {
 	}
 }
 
+// legacySessionValid beantwortet die beiden Fragen, die HMAC und Ablauffrist
+// beim Altformat NICHT beantworten (Issue #2129):
+//
+//  1. Existiert das Konto ueberhaupt noch? Ein Alt-Merkmal traegt keine
+//     Anmelde-Kennung, die man gegen eine Liste halten koennte — nach einer
+//     Kontoloeschung wuerde es sonst weiter durchgehen und die Hebung wuerde
+//     den geloeschten Nutzerordner sogar neu anlegen.
+//  2. Wurde seit der Ausstellung abgemeldet? Ohne diesen Vermerk gaebe es beim
+//     Abmelden mit einem Alt-Merkmal nichts zu widerrufen.
+//
+// Gleichstand zaehlt als widerrufen (Sekundenaufloesung): ein Merkmal aus
+// derselben Sekunde wie der Widerruf darf nicht ueberleben.
+func legacySessionValid(sessions SessionStore, userId string, issuedAt int64) bool {
+	if !sessions.UserExists(userId) {
+		return false
+	}
+	revokedAt, err := sessions.LegacyRevokedAt(userId)
+	if err != nil {
+		log.Printf("legacy session check: revocation lookup failed for %s: %v", userId, err)
+		return false
+	}
+	if revokedAt != nil && issuedAt <= revokedAt.Unix() {
+		return false
+	}
+	return true
+}
+
+// upgradeLegacySession hebt ein gueltiges Alt-Merkmal still auf das neue
+// Format: neue Anmelde-Kennung, Eintrag in die Gaesteliste, neues Cookie im
+// Antwort-Header. Niemand muss sich durch das Deploy neu anmelden.
+//
+// Schlaegt das Anlegen fehl, bleibt es beim Alt-Merkmal: es ist ja gueltig,
+// und den Nutzer wegen eines voruebergehenden Schreibfehlers hinauszuwerfen
+// waere die schlechtere Antwort. Beim naechsten Aufruf wird erneut versucht.
+func upgradeLegacySession(w http.ResponseWriter, r *http.Request, sessions SessionStore, secret, userId string) {
+	sessionId, err := NewSessionID()
+	if err != nil {
+		log.Printf("session upgrade: id generation failed for %s: %v", userId, err)
+		return
+	}
+	if err := sessions.AddSession(userId, sessionId); err != nil {
+		log.Printf("session upgrade: allowlist write failed for %s: %v", userId, err)
+		return
+	}
+	SetSessionCookie(w, r, SignSessionWithID(userId, sessionId, secret))
+}
+
 func UserIDFromContext(ctx context.Context) string {
 	uid, _ := ctx.Value(userIDContextKey).(string)
 	return uid
 }
 
-// SignSession creates a signed session token compatible with SvelteKit validation.
+// NewSessionID erzeugt eine Anmelde-Kennung: 16 Zufallsbytes hex.
+func NewSessionID() (string, error) {
+	buf := make([]byte, 16)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(buf), nil
+}
+
+// SignSession erzeugt ein Anmelde-Merkmal im ALTEN dreiteiligen Format.
 // Format: {userId}.{timestamp}.{hmacSig}
+//
+// Bleibt fuer den Uebergang bestehen (Bestandstests, Alt-Cookies), wird von
+// den Ausstellungsstellen aber nicht mehr benutzt -- die minten ueber
+// SignSessionWithID.
 func SignSession(userId, secret string) string {
 	ts := time.Now().Unix()
 	mac := hmac.New(sha256.New, []byte(secret))
@@ -82,39 +176,117 @@ func SignSession(userId, secret string) string {
 	return fmt.Sprintf("%s.%d.%s", userId, ts, sig)
 }
 
+// SignSessionWithID erzeugt das NEUE vierteilige Anmelde-Merkmal.
+// Format: {userId}.{sessionId}.{timestamp}.{hmacSig}, signiert ueber
+// "{userId}:{sessionId}:{timestamp}".
+//
+// Der Zeitstempel bleibt erhalten, obwohl er fuer die Gueltigkeit nicht mehr
+// gebraucht wird: er haelt die beiden Formate auseinander und ist der
+// Anhaltspunkt fuer eine spaetere Geraeteuebersicht.
+func SignSessionWithID(userId, sessionId, secret string) string {
+	ts := time.Now().Unix()
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(fmt.Sprintf("%s:%s:%d", userId, sessionId, ts)))
+	sig := hex.EncodeToString(mac.Sum(nil))
+	return fmt.Sprintf("%s.%s.%d.%s", userId, sessionId, ts, sig)
+}
+
+// SetSessionCookie setzt das Anmelde-Cookie. EINE Stelle fuer alle sechs
+// Ausstellungswege und die Legacy-Hebung -- vorher stand derselbe Block
+// sechsmal im Code, und genau so entsteht Drift zwischen den Wegen.
+func SetSessionCookie(w http.ResponseWriter, r *http.Request, token string) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     "gz_session",
+		Value:    token,
+		Path:     "/",
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+		MaxAge:   SessionMaxAgeSeconds,
+		Secure:   r.Header.Get("X-Forwarded-Proto") == "https" || r.TLS != nil,
+	})
+}
+
+// ClearSessionCookie loescht das Anmelde-Cookie im Browser.
+func ClearSessionCookie(w http.ResponseWriter) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     "gz_session",
+		Value:    "",
+		Path:     "/",
+		HttpOnly: true,
+		MaxAge:   -1,
+	})
+}
+
 // ContextWithUserID returns a new context with the given userId set.
 // Used by AuthMiddleware internally and by tests to simulate authenticated requests.
 func ContextWithUserID(ctx context.Context, userId string) context.Context {
 	return context.WithValue(ctx, userIDContextKey, userId)
 }
 
-func validateSession(value, secret string) (string, bool) {
-	parts := strings.SplitN(value, ".", 3)
-	if len(parts) != 3 {
-		return "", false
+// validateSession zerlegt und prueft ein Anmelde-Merkmal.
+// Liefert (Nutzerkennung, Anmelde-Kennung, Ausstellungszeit, neuesFormat, gueltig).
+//
+// BEIDE Formate werden VON RECHTS zerlegt: die letzten Segmente sind
+// Kennung/Zeitstempel/Signatur, alles davor ist die Nutzerkennung. Sonst
+// zerfiele eine Kennung mit Punkt ("alice.smith") in zwei Teile und wuerde
+// abgewiesen -- die Frontend-Pruefstelle macht es seit #425 richtig, die
+// Go-Seite wurde nie nachgezogen.
+//
+// Die Segmentzahl allein unterscheidet die Formate NICHT eindeutig: ein
+// Alt-Merkmal fuer "alice.smith" hat ebenfalls vier Segmente. Entschieden wird
+// darum ueber die Signatur -- erst das neue Format versuchen, dann das alte.
+// Beides sind HMAC-Vergleiche, die Reihenfolge kostet nichts.
+func validateSession(value, secret string) (string, string, int64, bool, bool) {
+	parts := strings.Split(value, ".")
+
+	if len(parts) >= 4 {
+		n := len(parts)
+		userId := strings.Join(parts[:n-3], ".")
+		sessionId, tsStr, sig := parts[n-3], parts[n-2], parts[n-1]
+		if userId != "" && sessionId != "" && tsStr != "" && sig != "" {
+			if ts, err := strconv.ParseInt(tsStr, 10, 64); err == nil {
+				expected := signatureFor(fmt.Sprintf("%s:%s:%d", userId, sessionId, ts), secret)
+				if hmac.Equal([]byte(sig), []byte(expected)) {
+					// Kein Ablauf: die Gaesteliste traegt die Gueltigkeit.
+					return userId, sessionId, ts, true, true
+				}
+			}
+		}
 	}
 
-	userId, tsStr, sig := parts[0], parts[1], parts[2]
-	if userId == "" || tsStr == "" || sig == "" {
-		return "", false
+	if len(parts) >= 3 {
+		n := len(parts)
+		userId := strings.Join(parts[:n-2], ".")
+		tsStr, sig := parts[n-2], parts[n-1]
+		if userId == "" || tsStr == "" || sig == "" {
+			return "", "", 0, false, false
+		}
+		ts, err := strconv.ParseInt(tsStr, 10, 64)
+		if err != nil {
+			return "", "", 0, false, false
+		}
+		if time.Now().Unix()-ts > legacyMaxAgeSeconds {
+			return "", "", 0, false, false
+		}
+		expected := signatureFor(fmt.Sprintf("%s:%d", userId, ts), secret)
+		if hmac.Equal([]byte(sig), []byte(expected)) {
+			return userId, "", ts, false, true
+		}
 	}
 
-	ts, err := strconv.ParseInt(tsStr, 10, 64)
-	if err != nil {
-		return "", false
-	}
+	return "", "", 0, false, false
+}
 
-	if time.Now().Unix()-ts > 86400 {
-		return "", false
-	}
-
+func signatureFor(payload, secret string) string {
 	mac := hmac.New(sha256.New, []byte(secret))
-	mac.Write([]byte(fmt.Sprintf("%s:%d", userId, ts)))
-	expected := hex.EncodeToString(mac.Sum(nil))
+	mac.Write([]byte(payload))
+	return hex.EncodeToString(mac.Sum(nil))
+}
 
-	if !hmac.Equal([]byte(sig), []byte(expected)) {
-		return "", false
-	}
-
-	return userId, true
+// SessionFromCookie zerlegt ein Anmelde-Merkmal fuer Aufrufer ausserhalb der
+// Middleware (Abmelden laeuft ueber einen oeffentlichen Pfad und hat deshalb
+// keinen Auth-Kontext, aus dem es die Nutzerkennung nehmen koennte).
+func SessionFromCookie(value, secret string) (userId, sessionId string, ok bool) {
+	uid, sid, _, _, valid := validateSession(value, secret)
+	return uid, sid, valid
 }

--- a/internal/middleware/auth_test.go
+++ b/internal/middleware/auth_test.go
@@ -9,6 +9,8 @@ import (
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/henemm/gregor-api/internal/store"
 )
 
 const testSecret = "test-secret-32-chars-minimum-ok!"
@@ -35,12 +37,17 @@ func TestValidCookie_Returns200(t *testing.T) {
 	ts := time.Now().Unix()
 	cookie := makeSessionCookie("default", ts, testSecret)
 
+	// Issue #2129: der Legacy-Zweig prueft, ob das Konto noch existiert —
+	// sonst wuerde ein Alt-Merkmal eine geloeschte Kontoerkennung ueberdauern.
+	dataDir := t.TempDir()
+	seedUserRecord(t, dataDir, "default")
+
 	// WHEN: request with valid cookie hits a protected endpoint
 	req := httptest.NewRequest("GET", "/api/trips", nil)
 	req.AddCookie(&http.Cookie{Name: "gz_session", Value: cookie})
 	rr := httptest.NewRecorder()
 
-	handler := AuthMiddleware(testSecret)(dummyHandler())
+	handler := AuthMiddleware(testSecret, store.New(dataDir, "test"))(dummyHandler())
 	handler.ServeHTTP(rr, req)
 
 	// THEN: 200 OK and userId in context
@@ -58,7 +65,7 @@ func TestNoCookie_Returns401(t *testing.T) {
 	req := httptest.NewRequest("GET", "/api/trips", nil)
 	rr := httptest.NewRecorder()
 
-	handler := AuthMiddleware(testSecret)(dummyHandler())
+	handler := AuthMiddleware(testSecret, store.New(t.TempDir(), "test"))(dummyHandler())
 	handler.ServeHTTP(rr, req)
 
 	// THEN: 401 Unauthorized
@@ -77,7 +84,7 @@ func TestExpiredCookie_Returns401(t *testing.T) {
 	req.AddCookie(&http.Cookie{Name: "gz_session", Value: cookie})
 	rr := httptest.NewRecorder()
 
-	handler := AuthMiddleware(testSecret)(dummyHandler())
+	handler := AuthMiddleware(testSecret, store.New(t.TempDir(), "test"))(dummyHandler())
 	handler.ServeHTTP(rr, req)
 
 	// THEN: 401 Unauthorized
@@ -96,7 +103,7 @@ func TestTamperedHMAC_Returns401(t *testing.T) {
 	req.AddCookie(&http.Cookie{Name: "gz_session", Value: cookie})
 	rr := httptest.NewRecorder()
 
-	handler := AuthMiddleware(testSecret)(dummyHandler())
+	handler := AuthMiddleware(testSecret, store.New(t.TempDir(), "test"))(dummyHandler())
 	handler.ServeHTTP(rr, req)
 
 	// THEN: 401 Unauthorized
@@ -121,7 +128,7 @@ func TestMalformedCookie_Returns401(t *testing.T) {
 		req.AddCookie(&http.Cookie{Name: "gz_session", Value: val})
 		rr := httptest.NewRecorder()
 
-		handler := AuthMiddleware(testSecret)(dummyHandler())
+		handler := AuthMiddleware(testSecret, store.New(t.TempDir(), "test"))(dummyHandler())
 		handler.ServeHTTP(rr, req)
 
 		if rr.Code != http.StatusUnauthorized {
@@ -136,7 +143,7 @@ func TestHealthEndpoint_NoAuthRequired(t *testing.T) {
 	req := httptest.NewRequest("GET", "/api/health", nil)
 	rr := httptest.NewRecorder()
 
-	handler := AuthMiddleware(testSecret)(dummyHandler())
+	handler := AuthMiddleware(testSecret, store.New(t.TempDir(), "test"))(dummyHandler())
 	handler.ServeHTTP(rr, req)
 
 	// THEN: 200 OK (health is exempt from auth)
@@ -155,7 +162,7 @@ func TestWrongSecret_Returns401(t *testing.T) {
 	req.AddCookie(&http.Cookie{Name: "gz_session", Value: cookie})
 	rr := httptest.NewRecorder()
 
-	handler := AuthMiddleware(testSecret)(dummyHandler())
+	handler := AuthMiddleware(testSecret, store.New(t.TempDir(), "test"))(dummyHandler())
 	handler.ServeHTTP(rr, req)
 
 	// THEN: 401 Unauthorized

--- a/internal/middleware/session_allowlist_test.go
+++ b/internal/middleware/session_allowlist_test.go
@@ -1,0 +1,362 @@
+package middleware
+
+// TDD RED — Issue #2129: dauerhafte Anmeldung mit widerrufbarem Anmelde-Merkmal.
+// Spec: docs/specs/modules/session_allowlist.md
+//
+// Diese Datei prüft die Prüfstelle selbst: Zerlegung des Anmelde-Merkmals,
+// Format-Weiche alt/neu, stille Hebung des Altformats und die Ablehnungsgründe.
+// Geprüft wird ausschließlich über die HTTP-Oberfläche (echte AuthMiddleware,
+// echter httptest-Request) — nicht über interne Funktionen: die Zusicherung
+// lautet "200 gegen 401", und dort muss sie gemessen werden.
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/henemm/gregor-api/internal/store"
+)
+
+// makeNewSessionCookie baut das neue vierteilige Anmelde-Merkmal:
+// {userId}.{sessionId}.{ts}.{sig}, HMAC-SHA256 über "{userId}:{sessionId}:{ts}".
+func makeNewSessionCookie(userId, sessionId string, ts int64, secret string) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(fmt.Sprintf("%s:%s:%d", userId, sessionId, ts)))
+	sig := hex.EncodeToString(mac.Sum(nil))
+	return fmt.Sprintf("%s.%s.%d.%s", userId, sessionId, ts, sig)
+}
+
+// seedUserRecord legt das Konto auf der Platte an. Noetig, weil der
+// Legacy-Zweig seit Issue #2129 prueft, ob das Konto ueberhaupt noch existiert
+// — ein Alt-Merkmal traegt keine Anmelde-Kennung, die man gegen eine Liste
+// halten koennte, und wuerde nach einer Kontoloeschung sonst weiter durchgehen.
+func seedUserRecord(t *testing.T, dataDir, userID string) {
+	t.Helper()
+	dir := filepath.Join(dataDir, "users", userID)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	body := fmt.Sprintf(`{"id":%q,"created_at":"2026-09-06T00:00:00Z"}`, userID)
+	if err := os.WriteFile(filepath.Join(dir, "user.json"), []byte(body), 0644); err != nil {
+		t.Fatalf("WriteFile user.json: %v", err)
+	}
+}
+
+// writeAllowlist legt die Gästeliste eines Nutzers auf der Platte an.
+//
+// RED-PHASEN-FESTLEGUNG: Die Spec legt die JSON-Gestalt von
+// data/users/<user_id>/sessions.json nicht fest. Sie wird hier an EINER Stelle
+// festgelegt (PO-/Lead-bestätigt 2026-09-05); die GREEN-Phase erzeugt entweder
+// genau dieses Format oder passt ausschließlich diesen Helfer an.
+//
+// Zwei Auflagen aus der Bestätigung, die die Gestalt mittragen muss:
+//   - Der Eintrag ist ein OBJEKT, kein blanker String — später kommt womöglich
+//     eine Geräteübersicht dazu (Known Limitations der Spec), und die darf
+//     ohne Formatbruch hineinwachsen.
+//   - Eine fehlende Datei bedeutet "leere Liste", nie einen Fehler. Bewacht
+//     von TestNewFormatCookie_NoAllowlistFile_Returns401NotServerError.
+func writeAllowlist(t *testing.T, dataDir, userID string, sessionIDs ...string) {
+	t.Helper()
+	seedUserRecord(t, dataDir, userID)
+	dir := filepath.Join(dataDir, "users", userID)
+	type entry struct {
+		ID        string    `json:"id"`
+		CreatedAt time.Time `json:"created_at"`
+	}
+	payload := struct {
+		Sessions []entry `json:"sessions"`
+	}{}
+	for _, id := range sessionIDs {
+		payload.Sessions = append(payload.Sessions, entry{ID: id, CreatedAt: time.Now()})
+	}
+	data, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "sessions.json"), data, 0644); err != nil {
+		t.Fatalf("WriteFile sessions.json: %v", err)
+	}
+}
+
+// authProbe schickt eine echte Anfrage mit dem gegebenen Cookie durch die echte
+// AuthMiddleware auf einen geschützten Pfad.
+//
+// dataDir ist die Wurzel des Datenbestands (dataDir/users/<id>/sessions.json),
+// aus der die Middleware ihre Gästeliste liest — bei jeder Anfrage direkt von
+// der Platte, ohne Zwischenspeicher.
+func authProbe(t *testing.T, dataDir, secret, cookieValue string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest("GET", "/api/trips", nil)
+	req.AddCookie(&http.Cookie{Name: "gz_session", Value: cookieValue})
+	rr := httptest.NewRecorder()
+	AuthMiddleware(secret, store.New(dataDir, ""))(dummyHandler()).ServeHTTP(rr, req)
+	return rr
+}
+
+// upgradedCookie liefert das im Antwort-Header nachgesetzte Anmelde-Merkmal
+// (leer, wenn keines gesetzt wurde).
+func upgradedCookie(rr *httptest.ResponseRecorder) string {
+	for _, c := range rr.Result().Cookies() {
+		if c.Name == "gz_session" {
+			return c.Value
+		}
+	}
+	return ""
+}
+
+func segments(value string) int {
+	return len(strings.Split(value, "."))
+}
+
+// AC-1 (Prüfseite): Ein vierteiliges Merkmal, dessen Anmelde-Kennung auf der
+// Gästeliste steht, wird angenommen und trägt die richtige Nutzerkennung.
+func TestNewFormatCookie_ListedSession_Returns200(t *testing.T) {
+	dataDir := t.TempDir()
+	writeAllowlist(t, dataDir, "alice", "sess-aaaa1111")
+
+	cookie := makeNewSessionCookie("alice", "sess-aaaa1111", time.Now().Unix(), testSecret)
+	if segments(cookie) != 4 {
+		t.Fatalf("Testaufbau kaputt: erwartet 4 Segmente, sind %d", segments(cookie))
+	}
+
+	rr := authProbe(t, dataDir, testSecret, cookie)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("AC-1: erwartet 200 für gelistete Anmelde-Kennung, bekommen %d", rr.Code)
+	}
+	if rr.Body.String() != "alice" {
+		t.Errorf("AC-1: erwartet Nutzerkennung 'alice' im Kontext, bekommen %q", rr.Body.String())
+	}
+}
+
+// AC-3: Das neue Merkmal bleibt jenseits der alten 24-Stunden-Grenze gültig.
+// Die Systemuhr wird nicht gestellt, sondern der Zeitstempel im Merkmal wird
+// vordatiert — dieselbe Wirkung, ohne Prozess-Zustand anzufassen.
+func TestNewFormatCookie_ValidBeyond24Hours(t *testing.T) {
+	dataDir := t.TempDir()
+	writeAllowlist(t, dataDir, "alice", "sess-old00001")
+
+	// 25 Stunden alt — nach der alten Regel längst abgelaufen.
+	ts := time.Now().Add(-25 * time.Hour).Unix()
+	cookie := makeNewSessionCookie("alice", "sess-old00001", ts, testSecret)
+
+	rr := authProbe(t, dataDir, testSecret, cookie)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("AC-3: 25 h altes vierteiliges Merkmal muss gültig bleiben, bekommen %d", rr.Code)
+	}
+}
+
+// AC-10: Ein gültiges dreiteiliges Alt-Merkmal wird angenommen UND im selben
+// Zug durch ein vierteiliges ersetzt.
+func TestLegacyCookie_AcceptedAndUpgradedToFourPart(t *testing.T) {
+	dataDir := t.TempDir()
+	seedUserRecord(t, dataDir, "alice")
+	legacy := makeSessionCookie("alice", time.Now().Unix(), testSecret)
+
+	rr := authProbe(t, dataDir, testSecret, legacy)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("AC-10: gültiges Alt-Merkmal muss angenommen werden, bekommen %d", rr.Code)
+	}
+	up := upgradedCookie(rr)
+	if up == "" {
+		t.Fatalf("AC-10: erwartet nachgesetztes gz_session-Cookie in der Antwort, keines gesetzt")
+	}
+	if segments(up) != 4 {
+		t.Fatalf("AC-10: nachgesetztes Merkmal muss 4 Segmente haben, hat %d (%q)", segments(up), up)
+	}
+	if !strings.HasPrefix(up, "alice.") {
+		t.Errorf("AC-10: nachgesetztes Merkmal muss auf 'alice' lauten, ist %q", up)
+	}
+
+	// Zweite Anfrage MIT dem gehobenen Merkmal. Ohne sie prüft der Test nur
+	// die FORM des neuen Cookies, nicht seine Brauchbarkeit — und wäre auch
+	// dann grün, wenn die Hebung das Merkmal gar nicht in die Gästeliste
+	// einträgt. Genau das ist der Fall, den AC-10 ausschließt: der Nutzer darf
+	// sich nicht erneut anmelden müssen, das gehobene Merkmal muss sofort
+	// tragen.
+	rrUpgraded := authProbe(t, dataDir, testSecret, up)
+	if rrUpgraded.Code != http.StatusOK {
+		t.Errorf("AC-10: das gehobene Merkmal muss sofort gültig sein, bekommen %d", rrUpgraded.Code)
+	}
+	if rrUpgraded.Body.String() != "alice" {
+		t.Errorf("AC-10: gehobenes Merkmal muss Nutzerkennung 'alice' tragen, bekommen %q",
+			rrUpgraded.Body.String())
+	}
+}
+
+// AC-11: Ein Alt-Merkmal jenseits von 24 Stunden wird abgewiesen.
+//
+// Positivkontrolle voran: ein frisches Alt-Merkmal MUSS durchkommen (und
+// gehoben werden). Ohne diese Kontrolle bestünde der Test auch dann, wenn die
+// Prüfstelle jedes Alt-Merkmal pauschal abwiese — er prüfte dann nichts.
+func TestLegacyCookie_OlderThan24Hours_Rejected(t *testing.T) {
+	dataDir := t.TempDir()
+	seedUserRecord(t, dataDir, "alice")
+
+	fresh := makeSessionCookie("alice", time.Now().Add(-23*time.Hour).Unix(), testSecret)
+	rrFresh := authProbe(t, dataDir, testSecret, fresh)
+	if rrFresh.Code != http.StatusOK {
+		t.Fatalf("AC-11 Positivkontrolle: 23 h altes Alt-Merkmal muss gültig sein, bekommen %d", rrFresh.Code)
+	}
+	if segments(upgradedCookie(rrFresh)) != 4 {
+		t.Errorf("AC-11 Positivkontrolle: 23 h altes Alt-Merkmal muss gehoben werden, nachgesetzt wurde %q",
+			upgradedCookie(rrFresh))
+	}
+
+	stale := makeSessionCookie("alice", time.Now().Add(-25*time.Hour).Unix(), testSecret)
+	rrStale := authProbe(t, dataDir, testSecret, stale)
+	if rrStale.Code != http.StatusUnauthorized {
+		t.Errorf("AC-11: 25 h altes Alt-Merkmal muss abgewiesen werden, bekommen %d", rrStale.Code)
+	}
+}
+
+// Fehlerzweig der Widerrufs-Prüfung: ist die Gästeliste unlesbar (kaputtes
+// oder halb geschriebenes JSON), wird das Alt-Merkmal abgewiesen — die
+// Prüfstelle macht ZU, nicht auf.
+//
+// Warum das zählt: bei fail-open würde eine beschädigte Datei jedes
+// Alt-Merkmal durchwinken, auch ein zuvor widerrufenes. Der Widerruf hinge
+// dann an der Unversehrtheit einer Datei, die niemand überwacht — dieselbe
+// Fehlerklasse wie ein Merkmal, das eine Kontolöschung überlebt, nur über
+// einen anderen Auslöser.
+//
+// Eine FEHLENDE Datei ist etwas anderes und bleibt der leere Stand
+// (TestNewFormatCookie_NoAllowlistFile_Returns401NotServerError, und die
+// Positivkontrolle hier läuft ebenfalls ohne Datei).
+func TestLegacyCookie_CorruptAllowlistFile_Rejected(t *testing.T) {
+	// Dasselbe Merkmal in beiden Hälften — der einzige Unterschied ist der
+	// Zustand der Datei.
+	legacy := makeSessionCookie("alice", time.Now().Unix(), testSecret)
+
+	// Positivkontrolle in EIGENEM Datenbestand: bei intaktem Bestand muss
+	// genau dieses Merkmal durchkommen. Ohne sie bestünde der Test auch dann,
+	// wenn Alt-Merkmale generell abgewiesen würden.
+	okDir := t.TempDir()
+	seedUserRecord(t, okDir, "alice")
+	if rr := authProbe(t, okDir, testSecret, legacy); rr.Code != http.StatusOK {
+		t.Fatalf("Positivkontrolle: bei intaktem Bestand muss das Alt-Merkmal gültig sein, bekommen %d",
+			rr.Code)
+	}
+
+	// Defektfall: sessions.json ist kein gültiges JSON.
+	badDir := t.TempDir()
+	seedUserRecord(t, badDir, "alice")
+	corrupt := filepath.Join(badDir, "users", "alice", "sessions.json")
+	if err := os.WriteFile(corrupt, []byte(`{"sessions": [ das ist kein JSON`), 0644); err != nil {
+		t.Fatalf("WriteFile sessions.json: %v", err)
+	}
+
+	rr := authProbe(t, badDir, testSecret, legacy)
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("unlesbare Gästeliste muss das Alt-Merkmal abweisen (fail-closed), bekommen %d", rr.Code)
+	}
+}
+
+// AC-12 (a): Ein einzeln verändertes Signatur-Segment wird abgewiesen.
+// Mit Positivkontrolle: dasselbe Merkmal unverändert muss angenommen werden.
+func TestNewFormatCookie_TamperedSignature_Rejected(t *testing.T) {
+	dataDir := t.TempDir()
+	writeAllowlist(t, dataDir, "alice", "sess-tamper01")
+
+	intact := makeNewSessionCookie("alice", "sess-tamper01", time.Now().Unix(), testSecret)
+	if rr := authProbe(t, dataDir, testSecret, intact); rr.Code != http.StatusOK {
+		t.Fatalf("AC-12a Positivkontrolle: unverändertes Merkmal muss gültig sein, bekommen %d", rr.Code)
+	}
+
+	parts := strings.Split(intact, ".")
+	sig := []byte(parts[3])
+	if sig[0] == 'a' {
+		sig[0] = 'b'
+	} else {
+		sig[0] = 'a'
+	}
+	parts[3] = string(sig)
+	tampered := strings.Join(parts, ".")
+
+	rr := authProbe(t, dataDir, testSecret, tampered)
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("AC-12a: manipulierte Signatur muss abgewiesen werden, bekommen %d", rr.Code)
+	}
+}
+
+// AC-12 (b): Ein korrekt signiertes Merkmal, dessen Anmelde-Kennung NICHT auf
+// der Gästeliste steht, wird abgewiesen.
+// Mit Positivkontrolle: dieselbe Kennung gelistet muss angenommen werden —
+// sonst bestünde der Test auch dann, wenn jedes vierteilige Merkmal abgewiesen
+// würde (genau der heutige Zustand).
+func TestNewFormatCookie_UnlistedSession_Rejected(t *testing.T) {
+	dataDir := t.TempDir()
+	writeAllowlist(t, dataDir, "alice", "sess-listed01")
+
+	listed := makeNewSessionCookie("alice", "sess-listed01", time.Now().Unix(), testSecret)
+	if rr := authProbe(t, dataDir, testSecret, listed); rr.Code != http.StatusOK {
+		t.Fatalf("AC-12b Positivkontrolle: gelistete Kennung muss gültig sein, bekommen %d", rr.Code)
+	}
+
+	unlisted := makeNewSessionCookie("alice", "sess-notlisted", time.Now().Unix(), testSecret)
+	rr := authProbe(t, dataDir, testSecret, unlisted)
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("AC-12b: nicht gelistete Anmelde-Kennung muss abgewiesen werden, bekommen %d", rr.Code)
+	}
+}
+
+// AC-12 (b), Sonderfall "Nutzer hat noch nie eine Gästeliste gehabt":
+// Eine FEHLENDE sessions.json bedeutet leere Liste, nicht Fehler. Das Merkmal
+// wird abgewiesen (401) — der Dienst darf daran nicht mit 5xx scheitern, sonst
+// sperrte ein fehlender Dateiname jeden Bestandsnutzer mit einem Serverfehler
+// aus statt mit einer Anmeldeaufforderung.
+func TestNewFormatCookie_NoAllowlistFile_Returns401NotServerError(t *testing.T) {
+	dataDir := t.TempDir() // bewusst leer: keine users/, keine sessions.json
+
+	cookie := makeNewSessionCookie("alice", "sess-nofile01", time.Now().Unix(), testSecret)
+	rr := authProbe(t, dataDir, testSecret, cookie)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("AC-12b: fehlende sessions.json muss 401 ergeben (leere Liste), bekommen %d", rr.Code)
+	}
+	if rr.Code >= 500 {
+		t.Errorf("AC-12b: fehlende sessions.json darf kein Serverfehler sein, bekommen %d", rr.Code)
+	}
+}
+
+// AC-14 (Go-Seite): Eine Nutzerkennung mit Punkt wird von rechts zerlegt —
+// beide Formate müssen dieselbe Kennung liefern und dürfen nicht abweisen.
+// Das Frontend-Gegenstück steht in frontend/src/lib/session_format.test.ts.
+func TestDottedUserID_SplitFromTheRight(t *testing.T) {
+	dataDir := t.TempDir()
+	const uid = "alice.smith"
+	writeAllowlist(t, dataDir, uid, "sess-dot00001")
+
+	t.Run("neues Format", func(t *testing.T) {
+		cookie := makeNewSessionCookie(uid, "sess-dot00001", time.Now().Unix(), testSecret)
+		rr := authProbe(t, dataDir, testSecret, cookie)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("AC-14: erwartet 200 für %q, bekommen %d", uid, rr.Code)
+		}
+		if rr.Body.String() != uid {
+			t.Errorf("AC-14: erwartet Nutzerkennung %q, bekommen %q", uid, rr.Body.String())
+		}
+	})
+
+	t.Run("Altformat", func(t *testing.T) {
+		cookie := makeSessionCookie(uid, time.Now().Unix(), testSecret)
+		rr := authProbe(t, dataDir, testSecret, cookie)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("AC-14: erwartet 200 für Alt-Merkmal mit %q, bekommen %d", uid, rr.Code)
+		}
+		if rr.Body.String() != uid {
+			t.Errorf("AC-14: erwartet Nutzerkennung %q, bekommen %q", uid, rr.Body.String())
+		}
+	})
+}

--- a/internal/middleware/sign_session_test.go
+++ b/internal/middleware/sign_session_test.go
@@ -34,14 +34,25 @@ func TestSignSessionValidateRoundtrip(t *testing.T) {
 	token := SignSession("bob", secret)
 
 	// WHEN: Validating with the same secret
-	userId, ok := validateSession(token, secret)
+	userId, sessionId, issuedAt, isNew, ok := validateSession(token, secret)
 
-	// THEN: Returns the original userId
+	// THEN: Returns the original userId, recognised as the LEGACY format
+	// (SignSession baut weiterhin dreiteilig — Issue #2129 haelt den
+	// Altformat-Zweig fuer den Uebergang offen).
 	if !ok {
 		t.Fatal("expected session to be valid")
 	}
 	if userId != "bob" {
 		t.Errorf("expected userId 'bob', got '%s'", userId)
+	}
+	if isNew {
+		t.Error("SignSession muss das Altformat liefern, nicht das vierteilige")
+	}
+	if sessionId != "" {
+		t.Errorf("Altformat traegt keine Anmelde-Kennung, bekommen '%s'", sessionId)
+	}
+	if issuedAt == 0 {
+		t.Error("Ausstellungszeit muss mitgeliefert werden — der Widerrufs-Vermerk fuer Alt-Merkmale braucht sie")
 	}
 }
 
@@ -50,7 +61,7 @@ func TestSignSessionInvalidWithWrongSecret(t *testing.T) {
 	token := SignSession("charlie", "correct-secret-32-chars-long!!!")
 
 	// WHEN: Validating with wrong secret
-	_, ok := validateSession(token, "wrong-secret-32-chars-long!!!!!")
+	_, _, _, _, ok := validateSession(token, "wrong-secret-32-chars-long!!!!!")
 
 	// THEN: Validation fails
 	if ok {

--- a/internal/router/briefing_subscription_test.go
+++ b/internal/router/briefing_subscription_test.go
@@ -59,6 +59,16 @@ func newBriefingTestRouter(t *testing.T) (http.Handler, *store.Store, string) {
 
 	s := store.New(cfg.DataDir, cfg.UserID)
 
+	// Issue #2129: der Legacy-Zweig der AuthMiddleware laesst ein
+	// dreiteiliges Merkmal nur noch durch, wenn das Konto existiert — sonst
+	// ueberdauerte es eine Kontoloeschung. sessionCookieFor signiert
+	// Alt-Merkmale, die Konten muessen also auf der Platte liegen.
+	for _, id := range []string{"user1", "userA", "userB"} {
+		if err := s.SaveUser(model.User{ID: id, CreatedAt: time.Now()}); err != nil {
+			t.Fatalf("SaveUser %s: %v", id, err)
+		}
+	}
+
 	wa, err := webauthn.New(&webauthn.Config{
 		RPID:          cfg.WebAuthnRPID,
 		RPDisplayName: cfg.WebAuthnRPDisplayName,

--- a/internal/router/legacy_subscription_routes_removed_test.go
+++ b/internal/router/legacy_subscription_routes_removed_test.go
@@ -19,12 +19,14 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/go-webauthn/webauthn/webauthn"
 
 	"github.com/henemm/gregor-api/internal/config"
 	"github.com/henemm/gregor-api/internal/handler"
 	authmw "github.com/henemm/gregor-api/internal/middleware"
+	"github.com/henemm/gregor-api/internal/model"
 	"github.com/henemm/gregor-api/internal/scheduler"
 	"github.com/henemm/gregor-api/internal/store"
 )
@@ -39,6 +41,12 @@ func newTestRouterForLegacySubscriptionCheck(t *testing.T) (http.Handler, string
 	cfg.DataDir = t.TempDir()
 
 	s := store.New(cfg.DataDir, cfg.UserID)
+
+	// Issue #2129: das unten signierte Alt-Merkmal kommt nur durch die
+	// AuthMiddleware, wenn das Konto existiert.
+	if err := s.SaveUser(model.User{ID: "legacy-sub-test-user", CreatedAt: time.Now()}); err != nil {
+		t.Fatalf("SaveUser: %v", err)
+	}
 
 	wa, err := webauthn.New(&webauthn.Config{
 		RPID:          cfg.WebAuthnRPID,

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -19,14 +19,14 @@ import (
 
 // Deps holds the dependencies required to build the application router.
 type Deps struct {
-	Config           *config.Config
-	Store            *store.Store
-	WeatherProvider  provider.WeatherProvider
-	WebAuthn         *webauthn.WebAuthn
-	ChallengeStore   *handler.ChallengeStore
-	Scheduler        *scheduler.Scheduler
+	Config             *config.Config
+	Store              *store.Store
+	WeatherProvider    provider.WeatherProvider
+	WebAuthn           *webauthn.WebAuthn
+	ChallengeStore     *handler.ChallengeStore
+	Scheduler          *scheduler.Scheduler
 	TelegramTokenStore *handler.TelegramTokenStore
-	GitCommit        string
+	GitCommit          string
 }
 
 // New builds the chi router with all application routes.
@@ -34,7 +34,7 @@ type Deps struct {
 func New(deps Deps) chi.Router {
 	r := chi.NewRouter()
 	r.Use(chimw.Logger)
-	r.Use(authmw.AuthMiddleware(deps.Config.SessionSecret))
+	r.Use(authmw.AuthMiddleware(deps.Config.SessionSecret, deps.Store))
 
 	// Auth endpoints (register/login exempt from AuthMiddleware)
 	// Rate-limit register: 5 attempts per IP per hour (Issue #117).
@@ -46,7 +46,11 @@ func New(deps Deps) chi.Router {
 	r.Post("/api/auth/login",
 		loginLimiter.Middleware(handler.LoginHandler(deps.Store, deps.Config.SessionSecret)).ServeHTTP,
 	)
-	r.Post("/api/auth/logout", handler.LogoutHandler())
+	r.Post("/api/auth/logout", handler.LogoutHandler(deps.Store, deps.Config.SessionSecret))
+	// Issue #2129: "auf allen Geraeten abmelden" — authentifiziert, bewusst
+	// NICHT in der Public-Allowlist von AuthMiddleware: der Endpunkt braucht
+	// die Nutzerkennung aus dem geprueften Merkmal.
+	r.Post("/api/auth/logout-all", handler.LogoutAllHandler(deps.Store))
 	forgotLimiter := authmw.NewIPRateLimiter(5, time.Hour)
 	r.Post("/api/auth/forgot-password",
 		forgotLimiter.Middleware(handler.ForgotPasswordHandler(deps.Store, bcrypt.DefaultCost, *deps.Config)).ServeHTTP,
@@ -63,7 +67,7 @@ func New(deps Deps) chi.Router {
 	r.Delete("/api/auth/account", handler.DeleteAccountHandler(deps.Store))
 	r.Get("/api/auth/profile", handler.GetProfileHandler(deps.Store))
 	r.Put("/api/auth/profile", handler.UpdateProfileHandler(deps.Store, *deps.Config))
-	r.Put("/api/auth/password", handler.ChangePasswordHandler(deps.Store, bcrypt.DefaultCost))
+	r.Put("/api/auth/password", handler.ChangePasswordHandler(deps.Store, bcrypt.DefaultCost, deps.Config.SessionSecret))
 	// Issue #1071 — Level-Änderungs-Antrag (authentifiziert, NICHT in Public-Allowlist)
 	r.Post("/api/auth/tier-change-request", handler.RequestTierChangeHandler(deps.Store, *deps.Config))
 	// Bug #590: Telegram /start-Flow — link generation + status polling + internal connect

--- a/internal/router/sms_fidelity_preview_test.go
+++ b/internal/router/sms_fidelity_preview_test.go
@@ -19,11 +19,13 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/go-webauthn/webauthn/webauthn"
 
 	"github.com/henemm/gregor-api/internal/config"
 	"github.com/henemm/gregor-api/internal/handler"
+	"github.com/henemm/gregor-api/internal/model"
 	"github.com/henemm/gregor-api/internal/scheduler"
 	"github.com/henemm/gregor-api/internal/store"
 )
@@ -42,6 +44,12 @@ func newSmsFidelityTestRouter(t *testing.T, pythonURL string) (http.Handler, str
 	cfg.PythonCoreURL = pythonURL
 
 	s := store.New(cfg.DataDir, cfg.UserID)
+
+	// Issue #2129: sessionCookieFor signiert ein Alt-Merkmal; der Legacy-Zweig
+	// laesst es nur durch, wenn das Konto existiert.
+	if err := s.SaveUser(model.User{ID: "user1", CreatedAt: time.Now()}); err != nil {
+		t.Fatalf("SaveUser: %v", err)
+	}
 
 	wa, err := webauthn.New(&webauthn.Config{
 		RPID:          cfg.WebAuthnRPID,

--- a/internal/store/sessions.go
+++ b/internal/store/sessions.go
@@ -1,0 +1,186 @@
+package store
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// Gaesteliste gueltiger Anmeldungen je Nutzer (Issue #2129, ADR-0060).
+//
+// Ablage BEWUSST in einer eigenen Datei data/users/<user_id>/sessions.json,
+// nicht in der user.json. Zwei Gruende: (1) die bestehenden SaveUser-Aufrufer
+// schreiben das GANZE Nutzerobjekt zurueck -- ein gleichzeitiger
+// Profil-Schreiber koennte einen Widerruf sonst schlicht ueberschreiben, und
+// ausgerechnet der Widerruf vertraegt diesen Verlust nicht; (2) es bleibt aus
+// dem model.User-Schema heraus und loest damit nicht bei jeder Anmeldung den
+// Schema-Backup-Hook aus.
+
+// Session ist ein Eintrag der Gaesteliste. Bewusst ein Objekt und kein blanker
+// String: eine spaetere Geraeteuebersicht ("angemeldet auf 3 Geraeten seit
+// ...") soll ohne Formatbruch hineinwachsen koennen.
+type Session struct {
+	ID        string    `json:"id"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+type sessionFile struct {
+	Sessions []Session `json:"sessions"`
+	// LegacyRevokedAt schliesst die Abmelde-Luecke des Uebergangs: ein
+	// Alt-Merkmal steht auf keiner Gaesteliste, es gaebe beim Abmelden also
+	// nichts zu entfernen, und es waere bis zu 24 Stunden weiter gueltig.
+	//
+	// Das ist KEINE wiederauferstandene Sperrliste: ein einzelner Wert je
+	// Nutzer, kein Verzeichnis einzelner Merkmale. Er faellt mit dem
+	// Legacy-Zweig ersatzlos weg.
+	LegacyRevokedAt *time.Time `json:"legacy_revoked_at,omitempty"`
+}
+
+func (s *Store) sessionsPath(userId string) string {
+	return filepath.Join(s.UserDir(userId), "sessions.json")
+}
+
+// readSessionFile liest die Datei ohne Sperre. Eine FEHLENDE Datei ist der
+// leere Stand, kein Fehler -- Bestandsnutzer haben noch keine, und ein Fehler
+// wuerde sie mit einem Serverfehler statt mit einer Anmeldeaufforderung
+// aussperren.
+func (s *Store) readSessionFile(userId string) (sessionFile, error) {
+	var f sessionFile
+	data, err := os.ReadFile(s.sessionsPath(userId))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return f, nil
+		}
+		return f, err
+	}
+	if err := json.Unmarshal(data, &f); err != nil {
+		return sessionFile{}, err
+	}
+	return f, nil
+}
+
+func (s *Store) writeSessionFile(userId string, f sessionFile) error {
+	dir := s.UserDir(userId)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+	if f.Sessions == nil {
+		f.Sessions = []Session{}
+	}
+	data, err := json.MarshalIndent(f, "", "  ")
+	if err != nil {
+		return err
+	}
+	return writeFileLogged(s.sessionsPath(userId), data)
+}
+
+// LoadSessions liefert die Gaesteliste eines Nutzers (leer, wenn keine da ist).
+func (s *Store) LoadSessions(userId string) ([]Session, error) {
+	unlock := lockSessions(userId)
+	defer unlock()
+	f, err := s.readSessionFile(userId)
+	return f.Sessions, err
+}
+
+// LegacyRevokedAt liefert den Zeitpunkt, ab dem Alt-Merkmale dieses Nutzers
+// nicht mehr gelten (nil, wenn nie widerrufen wurde).
+func (s *Store) LegacyRevokedAt(userId string) (*time.Time, error) {
+	unlock := lockSessions(userId)
+	defer unlock()
+	f, err := s.readSessionFile(userId)
+	return f.LegacyRevokedAt, err
+}
+
+// RevokeLegacySessions entwertet alle Alt-Merkmale dieses Nutzers, ohne die
+// Gaesteliste anzutasten. Gebraucht beim Abmelden mit einem Alt-Merkmal: dort
+// gibt es keinen Eintrag zu entfernen, und ohne diesen Vermerk bliebe die
+// Zusage "Abmelden wirkt" im Uebergangsfenster unerfuellt.
+func (s *Store) RevokeLegacySessions(userId string) error {
+	unlock := lockSessions(userId)
+	defer unlock()
+
+	f, err := s.readSessionFile(userId)
+	if err != nil {
+		return err
+	}
+	now := time.Now()
+	f.LegacyRevokedAt = &now
+	return s.writeSessionFile(userId, f)
+}
+
+// HasSession beantwortet die Frage, an der die gesamte unbefristete Anmeldung
+// haengt: steht diese Anmelde-Kennung noch auf der Gaesteliste?
+func (s *Store) HasSession(userId, sessionId string) (bool, error) {
+	if userId == "" || sessionId == "" {
+		return false, nil
+	}
+	unlock := lockSessions(userId)
+	defer unlock()
+
+	f, err := s.readSessionFile(userId)
+	if err != nil {
+		return false, err
+	}
+	for _, sess := range f.Sessions {
+		if sess.ID == sessionId {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// AddSession traegt eine neue Anmeldung ein. Lesen-Aendern-Schreiben laeuft
+// unter der Pro-Nutzer-Sperre, damit zwei gleichzeitige Anmeldungen desselben
+// Kontos einander nicht verdraengen.
+func (s *Store) AddSession(userId, sessionId string) error {
+	unlock := lockSessions(userId)
+	defer unlock()
+
+	f, err := s.readSessionFile(userId)
+	if err != nil {
+		return err
+	}
+	for _, sess := range f.Sessions {
+		if sess.ID == sessionId {
+			return nil
+		}
+	}
+	f.Sessions = append(f.Sessions, Session{ID: sessionId, CreatedAt: time.Now()})
+	return s.writeSessionFile(userId, f)
+}
+
+// RemoveSession entfernt genau eine Anmeldung ("dieses Geraet abmelden").
+func (s *Store) RemoveSession(userId, sessionId string) error {
+	unlock := lockSessions(userId)
+	defer unlock()
+
+	f, err := s.readSessionFile(userId)
+	if err != nil {
+		return err
+	}
+	kept := make([]Session, 0, len(f.Sessions))
+	for _, sess := range f.Sessions {
+		if sess.ID != sessionId {
+			kept = append(kept, sess)
+		}
+	}
+	if len(kept) == len(f.Sessions) {
+		return nil
+	}
+	f.Sessions = kept
+	return s.writeSessionFile(userId, f)
+}
+
+// ClearSessions leert die Gaesteliste ("auf allen Geraeten abmelden", ebenso
+// Passwortwechsel und Passwort-Zuruecksetzen) UND entwertet die Alt-Merkmale.
+// Ohne den zweiten Teil bliebe genau hier dieselbe Luecke offen wie beim
+// Abmelden: ein Alt-Merkmal steht auf keiner Liste, ein Leeren traefe es also
+// nicht.
+func (s *Store) ClearSessions(userId string) error {
+	unlock := lockSessions(userId)
+	defer unlock()
+
+	now := time.Now()
+	return s.writeSessionFile(userId, sessionFile{LegacyRevokedAt: &now})
+}

--- a/internal/store/sessions_lock.go
+++ b/internal/store/sessions_lock.go
@@ -1,0 +1,52 @@
+package store
+
+import "sync"
+
+// Sperre je Nutzer fuer die Gaesteliste gueltiger Anmeldungen (Issue #2129).
+// Vorbild und Begruendung wie briefing_lock.go: sie liegt auf PAKET-Ebene und
+// nicht als Feld im Store, weil WithUser eine flache Kopie zurueckgibt -- eine
+// Sperre im Struct waere pro Kopie eine andere und damit wirkungslos. Es laeuft
+// genau ein gregor-api-Prozess je Umgebung, darum reicht eine prozessinterne
+// Sperre.
+//
+// Der Schluessel ist die uebergebene Nutzerkennung, NICHT s.UserID: die
+// Gaesteliste wird aus der Middleware und aus oeffentlichen Endpunkten heraus
+// bearbeitet, wo der Store noch nicht auf den Nutzer eingeengt ist.
+var (
+	sessionLocksMu sync.Mutex
+	sessionLocks   = map[string]*sessionLock{}
+)
+
+type sessionLock struct {
+	mu   sync.Mutex
+	refs int
+}
+
+// lockSessions sperrt die Gaesteliste eines Nutzers und liefert die
+// Freigabe-Funktion. Der Aufrufer haelt die Sperre ueber den GANZEN
+// Lese-Aendern-Schreib-Zyklus (defer unlock()).
+func lockSessions(userId string) func() {
+	sessionLocksMu.Lock()
+	entry, ok := sessionLocks[userId]
+	if !ok {
+		entry = &sessionLock{}
+		sessionLocks[userId] = entry
+	}
+	entry.refs++
+	sessionLocksMu.Unlock()
+
+	entry.mu.Lock()
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			entry.mu.Unlock()
+			sessionLocksMu.Lock()
+			entry.refs--
+			if entry.refs == 0 {
+				delete(sessionLocks, userId)
+			}
+			sessionLocksMu.Unlock()
+		})
+	}
+}

--- a/openspec.yaml
+++ b/openspec.yaml
@@ -111,6 +111,16 @@ strict_code_gate:
     - "CHANGELOG"
     - "LICENSE"
     - "\\.test\\.ts$"
+    # PLUS "_test.go$": Go ERZWINGT, dass Testdateien im selben Paketordner
+    # neben der Quelldatei liegen — anders als bei TypeScript gibt es hier
+    # keinen Ausweichordner, den man stattdessen waehlen koennte. Ohne dieses
+    # Muster blockierte edit_gate.py jede Go-Testdatei als Produktivcode und
+    # machte eine Go-TDD-RED-Phase in diesem Projekt unmoeglich (193 vorhandene
+    # *_test.go-Dateien konnten so nie in Phase 5 entstehen). Gleiche Lage und
+    # gleiche Begruendung wie bei ".test.ts$"/#2110 — gefunden bei #2129.
+    # Kein Schutzverlust: Go kompiliert *_test.go nie ins Produktivbinary,
+    # und die Quelldateien daneben bleiben in Phase 5 weiterhin gesperrt.
+    - "_test\\.go$"
 
 # Specs Configuration
 specs:


### PR DESCRIPTION
Schliesst #2129 (Scheibe S2 von #2127).

## Problem

Die Anmeldung lief nach exakt 24 Stunden ab, hart ab dem Login und ohne Verlaengerung bei Nutzung. Auf einer mehrtaegigen Tour heisst das: jeden Tag neu anmelden, bei schlechtem Netz.

Die Bedingung des PO fuer eine unbefristete Anmeldung war eine Fern-Abmeldung, die tatsaechlich wirkt. Die gab es nicht:

- Die Sperrliste war eine prozesslokale `sync.Map`. Nach jedem Deploy war ein abgemeldetes Cookie wieder gueltig.
- ADR-0030 verwarf die serverseitige Sitzungsverwaltung mit der Begruendung, `Passwortwechsel als Notweg` genuege. Der Passwortwechsel hat Sessions **nie** invalidiert — den Notweg gab es nicht.
- Auch eine Kontoloeschung liess die Anmeldung weiterlaufen.
- Zwei Anmeldungen innerhalb derselben Sekunde erzeugten ein **identisches** Merkmal, weshalb ein Abmelden auf einem Geraet auch das andere hinauswarf.

## Loesung

Jeder Nutzer fuehrt eine Liste gueltiger Anmeldungen in `data/users/<id>/sessions.json`. Ein Merkmal gilt, solange seine Kennung dort steht — nicht, solange eine Frist laeuft.

- **Format** `{userId}.{sessionId}.{ts}.{sig}`, Cookie-Lebensdauer 400 Tage (Browser deckeln dort).
- **Eigene Datei**, nicht `user.json`: die 15 bestehenden `SaveUser`-Aufrufer schreiben stets das ganze Objekt zurueck; ein gleichzeitiger Profil-Schreiber koennte einen Widerruf sonst ueberschreiben.
- **Pro-Nutzer-Sperre** nach `briefing_lock.go`-Vorbild.
- **Kein Zwischenspeicher** — er muesste genau die Widerrufs-Zusicherung tragen, auf der die unbefristete Anmeldung beruht.
- **Zwei Abmelde-Wege:** einzelnes Geraet, und `POST /api/auth/logout-all` samt Bedienelement auf der Konto-Seite.
- **Passwortwechsel** meldet alle anderen Geraete ab und stellt dem eigenen ein frisches Merkmal aus; **Zuruecksetzen** und **Kontoloeschung** melden ueberall ab ohne neues Merkmal.

## Uebergang ohne Ausloggen

Alte dreiteilige Merkmale bleiben mit ihrer 24-Stunden-Grenze gueltig und werden beim naechsten Aufruf still gehoben; `legacy_revoked_at` macht auch sie widerrufbar. Der Altbestand verschwindet binnen 24 Stunden nach dem Deploy von selbst.

Beide Pruefstellen (Go und Frontend-Server) zerlegen **von rechts**. Die Segmentzahl unterscheidet die Formate nicht — eine Kennung mit Punkt hat auch im alten Format vier Segmente. Das behebt zugleich eine bestehende Divergenz: das Frontend war unter #425 gefixt worden, Go nie.

## Nachweis

18 von 18 Acceptance Criteria, PO-freigegeben. Adversary **VERIFIED** nach 4 Runden und 8 Mutationen — alle acht werden inzwischen von mindestens einem Test gefangen. Drei Testluecken wurden dabei gefunden und geschlossen, alle an sicherheitstragenden Zeilen; der Produktivcode war jeweils korrekt.

Die vier Neustart-Nachweise laufen ueber einen echten Kindprozess, der keinen Zustand mit dem Elternlauf teilt. Auf dem alten Stand liefert derselbe Cookie im Elternprozess 401 und im Kind 200 — der rote Ausgang war zugleich die Positivkontrolle der Mechanik.

AC-17 (Bedienelement) ist gebaut und verdrahtet; sein Browser-Nachweis gehoert in die Staging-Verifikation.

Loest ADR-0030 ab (**ADR-0060**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)