### PR TITLE
fix(#2140): Nutzer-Kennung aus dem Request-Body wird vor jedem Pfadbau geprueft

### DIFF
--- a/docs/context/fix-2140-pfad-traversal-id-validierung.md
+++ b/docs/context/fix-2140-pfad-traversal-id-validierung.md
@@ -1,0 +1,237 @@
+# Context: fix-2140-pfad-traversal-id-validierung
+
+## Request Summary
+
+Issue #2140 (priority:critical, Blocker, Teil von Epic #2138 Multi-User-Readiness): Client-gesetzte
+Entitäts-IDs (Trip, Ort, ComparePreset, Briefing) und Benutzernamen auf öffentlichen Auth-Routen
+gehen ungeprüft in `filepath.Join(...)` der Go-Seite. Weil `filepath.Join` `..`-Sequenzen
+normalisiert, kann eine ID wie `../../bob/user` aus dem eigenen Nutzerverzeichnis ausbrechen und in
+fremden Verzeichnissen lesen oder schreiben — bis hin zum Überschreiben von `bob`s `user.json`
+(Ziel endet immer auf `.json`), wonach das fremde Konto nicht mehr anmeldbar ist.
+
+## Related Files
+
+| File | Relevance |
+|------|-----------|
+| `internal/store/user.go:45` | `UserDir(id)` joint die Nutzer-Kennung roh — Wurzel aller nutzerbezogenen Pfade |
+| `internal/store/user.go:49,78,101,105,121,142,146` | `LoadUser`, `SaveUser`, Reset-/Verification-Token-Pfade über `UserDir(id)` |
+| `internal/store/sessions.go:41` | Session-Datei über `UserDir(userId)` |
+| `internal/store/trip.go:258` | `SaveTrip`: `filepath.Join(dir, trip.ID+".json")` — Schreib-Pfad mit Client-ID |
+| `internal/store/trip.go:176,263` | `LoadTrip`/`DeleteTrip` über `briefingsDir()` + `id` |
+| `internal/store/location.go:91` | `SaveLocation`: `filepath.Join(dir, loc.ID+".json")` |
+| `internal/store/location.go:62,95` | `LoadLocation`/`DeleteLocation` |
+| `internal/store/compare_preset.go:214` | `SaveComparePreset`: Schreib-Pfad mit Client-ID |
+| `internal/store/compare_preset.go:140,241` | Load/Delete-Pendants |
+| `internal/store/briefing_subscription.go:64` | `SaveBriefing`: Schreib-Pfad mit Client-ID |
+| `internal/store/briefing_subscription.go:32` | Load-Pendant |
+| `internal/store/briefing_fingerprint.go:28` | Liest über `briefingsDir()` + `id` |
+| `internal/handler/trip.go:180` | `CreateTripHandler` → `SaveTrip`, ID aus Request-Body, `validateTrip` prüft nur Leerstring |
+| `internal/handler/location.go:107,160` | Location-Anlage/Update mit Client-ID |
+| `internal/handler/auth.go:46` | Registrierung prüft bereits `validUsernameRe` — Login/Forgot/Reset/Verify NICHT |
+| `internal/handler/passkey.go:23` | `validUsernameRe = ^[a-zA-Z0-9_-]+$` — vorhandenes Muster, kanonische Go-Quelle |
+| `internal/handler/group.go:203` | Weiterer `SaveLocation`-Aufrufer (Dependent, oft übersehen) |
+| `internal/handler/weather_config.go:111,186` | Weitere `SaveTrip`/`SaveLocation`-Aufrufer |
+| `internal/handler/compare_preset.go:271,521,616` | Weitere `SaveComparePreset`-Aufrufer |
+| `internal/handler/briefing_subscription.go:276` | Weiterer `SaveComparePreset`-Aufrufer |
+| `src/app/loader.py:1150,1165` | Python-Vorbild: `VALID_USER_ID_RE`, erzwungen zentral in `get_data_dir()` |
+| `tests/unit/test_user_id_pattern_parity.py` | Bestehender Paritäts-Test Python↔Go (`# doc-compliance-test`) |
+
+## Existing Patterns
+
+- **Zentrale Durchsetzung am Pfadbau (Python, Vorbild):** `app.loader.get_data_dir()` wirft
+  `ValueError` bei einer Kennung, die nicht auf `^[a-zA-Z0-9_-]+$` passt — laut Kommentar bewusst
+  „zentral hier, damit alle Aufrufer gedeckt sind". Historie: #1352 (am GPX-Endpoint praktisch
+  vorgeführt) → #1364 (zentrale Prüfung). **Die Go-Seite hat diesen Schritt nie bekommen.**
+- **Muster-Parität ist bereits geregelt:** `tests/unit/test_user_id_pattern_parity.py` hält
+  `VALID_USER_ID_RE` (Python) und `validUsernameRe` (Go, `passkey.go`) deckungsgleich. Ein neues
+  Go-Regex-Literal an anderer Stelle würde diese Paritäts-Kette still umgehen — der Fix sollte
+  `validUsernameRe` wiederverwenden bzw. eine gemeinsame Go-Quelle etablieren, nicht ein zweites
+  Literal einführen.
+- **Handler-Fehlerform:** Handler nutzen `bailIf(w, cond, http.StatusBadRequest, "…")`-Muster
+  (z.B. `briefing_subscription.go:276`) — neue 400er sollten sich daran anlehnen.
+- **Store-Scoping:** `Store` trägt `UserID`; Verzeichnis-Helfer (`LocationsDir()`, `briefingsDir()`,
+  `UserDir(id)`) sind die Engstellen, durch die praktisch jeder Pfad läuft.
+
+## Dependencies
+
+- **Upstream:** `internal/model` (Entity-Structs mit `ID`-Feld), `internal/middleware`
+  (`UserIDFromContext`), JSON-Decoding der Request-Bodies in den Handlern.
+- **Downstream:** Alle Handler, die `Save*`/`Load*`/`Delete*` des Stores aufrufen — mehr als im
+  Ticket aufgezählt: zusätzlich `group.go`, `weather_config.go`, `compare_preset.go`,
+  `briefing_subscription.go`. Ebenso der Scheduler und der Proxy zum Python-Core, die über
+  denselben Store gehen.
+
+## Existing Specs
+
+- `docs/adr/0003-multi-tenant-isolation.md` — konsequente Mandantentrennung, kein `"default"`-Fallback;
+  fordert Zwei-Nutzer-Isolationstest, `"default"`-Fallback im authentifizierten Pfad ist Blocker
+- `docs/specs/modules/issue_1352_gpx_user_isolation.md` — der direkte Präzedenzfall auf der Python-Seite
+- `docs/specs/modules/user_scoped_store.md` — nutzerbezogene Store-Schnittstelle
+- `docs/specs/modules/user_auth_endpoints.md` — Auth-Routen (Login/Reset/Verify)
+- `docs/specs/modules/passkey_webauthn.md` — Herkunft von `validUsernameRe`
+
+## Risks & Considerations
+
+- **Nur-Handler-Fix greift zu kurz:** Es gibt deutlich mehr Store-Aufrufer als die im Ticket
+  genannten. Wird nur am Handler-Eingang geprüft, öffnet der nächste neue Aufrufer die Lücke erneut.
+  Die Prüfung gehört an die Wirkstelle (Pfadbau im Store), analog zum Python-Vorbild.
+- **Bestandsdaten:** Existieren real bereits IDs, die dem Muster nicht entsprechen (z.B. mit Punkt
+  oder Leerzeichen), würde eine harte Store-Prüfung sie unlesbar machen. Vor der Implementierung ist
+  der Ist-Bestand unter `data/users/` (und Prod: `/var/lib/gregor`) zu prüfen — sonst droht ein
+  stiller Datenverlust-Effekt statt eines Sicherheitsgewinns.
+- **Regex-Dopplung:** Ein neues Literal in `internal/store` würde am bestehenden Paritäts-Test
+  (`test_user_id_pattern_parity.py`, liest gezielt `passkey.go`) vorbeilaufen. Entweder gemeinsame
+  Go-Konstante oder Paritäts-Test mitziehen.
+- **Öffentliche Routen sind der heikelste Teil:** Login/Forgot/Reset/Verify sind ohne Anmeldung
+  erreichbar; dort entscheidet die Prüfung, ob ein Unangemeldeter überhaupt einen Pfad beeinflussen
+  kann. Reihenfolge zwingend: validieren **vor** jedem `Load*`/`Save*`.
+- **Fehlerform darf nichts verraten:** Bei Forgot-Password/Login darf die neue Ablehnung keine
+  Aussage über Existenz eines Kontos erzeugen (User-Enumeration) — dieselbe generische Antwort wie
+  bisher.
+- **Kein Laufzeit-Nachweis im Ticket:** Der Befund ist am Code eindeutig, wurde aber laut Issue nie
+  laufend reproduziert (Go-Toolchain in der Audit-Sitzung nicht ladbar). Ein reproduzierender Test
+  (RED) ist deshalb Teil des Nachweises, nicht Kür.
+
+---
+
+# Analysis
+
+## Type
+
+**Bug** — Sicherheitsdefekt (Pfad-Traversal), priority:critical, Blocker.
+
+## Laufzeit-Nachweis (erbracht — schließt die Lücke des Tickets)
+
+Go 1.25.0 liegt unter `/usr/local/go/bin/go` (nicht im PATH — daher die Fehlannahme
+„Toolchain nicht verfügbar"). `go build ./internal/...` läuft grün. Ein Testlauf gegen den
+**unveränderten** Stand zeigt den Traversal real:
+
+| Aufruf | Beobachtet |
+|---|---|
+| `POST /api/trips` mit `id="../../bob/briefings/bobs-trip"` | **201 Created** — Trip landet in Bobs Verzeichnis |
+| `POST /api/password-forgot` mit `username="../marker"` | **200** + Log „token written but not sent" — Reset-Token außerhalb geschrieben |
+| `POST /api/locations` / `POST /api/trips` mit `id="../../bob/evil"` | 500 `store_error` — **nur** weil Bobs Verzeichnis im Testaufbau fehlte; existiert der fremde Nutzer, greift der Angriff durch |
+
+Damit ist der Befund nicht mehr nur hergeleitet, sondern gemessen.
+
+## Drei Achsen — eine davon ist entwarnt
+
+| Achse | Wert kommt aus | Client-steuerbar | Konsequenz |
+|---|---|---|---|
+| **A — Nutzer-Kennung** | Request-Body der öffentlichen Auth-Routen | **ja, roh** | absichern |
+| **B — Entitäts-ID** | Body oder URL-Parameter | **ja, roh** | absichern |
+| **C — `s.UserID`** | `WithUser(middleware.UserIDFromContext(...))` | **nein** — HMAC-signiertes Cookie (`internal/middleware/auth.go:74,86,98`) | **nicht anfassen** |
+
+Achse C umfasst 8 rohe `s.UserID`-Joins, die an `UserDir()` vorbeilaufen
+(`briefing_subscription.go:20`, `location.go:15`, `group.go:15,135`, `metric_preset.go:15,131`,
+`log.go:24,64`). Sie sind kein offener Vektor. Zusätzlich: `WithUser("")` ist ein dokumentierter
+No-op (`store.go:15-22`) — eine Prüfung dort würde Bestandsverhalten kippen.
+
+## 🔴 Zentrale Korrektur an der Ticket-Vorgabe
+
+Das Ticket verlangt **ein** Muster `^[a-zA-Z0-9_-]+$` für alle IDs. **Das würde produktive Daten
+des PO unbrauchbar machen.** Im Prod-Bestand (`/var/lib/gregor/users/henning/locations/`) liegen
+sechs Orte mit Diakritika: `pollença`, `hochfügen`, `mühlbach`, `übergangsjoch-zillertal-arena`,
+`berstation-hochfügen`, `serfaus-schöngamp-berg`. Mit dem strengen Muster wären sie per
+`PUT`/`DELETE /api/locations/{id}` nicht mehr editier- oder löschbar — und der Ausfall wäre
+**still**, weil `LoadLocations` das Verzeichnis scannt (`location.go:21`) statt IDs zu joinen.
+
+**Deshalb zwei Regeln statt einer:**
+
+| Fläche | Regel | Begründung |
+|---|---|---|
+| Nutzer-IDs | `^[a-zA-Z0-9_-]+$` | Python-Parität (`src/app/loader.py:1150`), Bestand vollständig konform (`default`, `henning`, `steffi`, `validator-issue110`), Generatoren erzeugen nur Sauberes |
+| Entitäts-IDs | Pfadsegment-Regel: nicht leer, nicht `.`/`..`, kein `/`, kein `\`, kein NUL, kein führender Punkt, ≤128 Zeichen | blockt jede Traversal, lässt `pollença` unangetastet |
+
+Der führende Punkt ist ausgeschlossen, weil `writeFileAtomic` Temp-Dateien als
+`"."+Base+".tmp-*"` anlegt (`internal/store/write.go:37`) — Namensraum-Kollision.
+
+## Affected Files (with changes)
+
+### Scheibe 1 — Nutzer-Achse + öffentliche Auth-Routen
+
+| File | Change Type | Description |
+|---|---|---|
+| `internal/store/pathsafe.go` | CREATE | `ValidUserIDRe`, `ValidUserID()` — kanonische Go-Quelle des Musters |
+| `internal/store/user.go` | MODIFY | 11 Methoden prüfen die Kennung vor dem Pfadbau (alle geben bereits `error` zurück — keine Signaturänderung) |
+| `internal/store/sessions.go` | MODIFY | 5 Einstiege (`LoadSessions`, `HasSession`, `AddSession`, `RemoveSession`, `ClearSessions`) |
+| `internal/handler/auth.go` | MODIFY | 4 öffentliche Routen: flächengerechte Ablehnung vor jedem Store-Zugriff |
+| `internal/handler/passkey.go` | MODIFY | `validUsernameRe` zieht die Konstante aus `store` — **kein zweites Literal** |
+| `internal/handler/auth_traversal_test.go` | CREATE | Ablehnung je Route + Nachweis, dass die Fremddatei unberührt bleibt |
+| `internal/store/pathsafe_test.go` | CREATE | Store-Ebene, Zwei-Nutzer-Isolation (ADR-0003) |
+| `tests/unit/test_user_id_pattern_parity.py` | MODIFY | Pfad + Variablenname auf `pathsafe.go` umhängen |
+
+### Scheibe 2 — Entitäts-Achse
+
+| File | Change Type | Description |
+|---|---|---|
+| `internal/store/pathsafe.go` | MODIFY | `ValidEntityID()` (Pfadsegment-Regel) ergänzen |
+| `internal/store/trip.go` · `location.go` · `compare_preset.go` · `briefing_subscription.go` | MODIFY | je 3 Methoden (Load/Save/Delete) |
+| `internal/store/briefing_fingerprint.go` | MODIFY | 1 Lesemethode |
+| `internal/handler/location.go` | MODIFY | Prüfung **nach** `toKebab` (`:70`), sonst rutscht die leere Auto-ID durch |
+| Traversal-Tests je Entitätstyp | CREATE | 4 Typen |
+| Regressionstest Umlaut-Ort | CREATE | `pollença` muss speicher- und löschbar bleiben |
+
+## Scope Assessment
+
+- **Scheibe 1:** ~105 LoC produktiv + ~115 LoC Tests = **~220** → unter dem Limit 250
+- **Scheibe 2:** ~59 LoC produktiv + ~85 LoC Tests = **~144** → unter dem Limit 250
+- In einem Workflow: ~364 LoC → Override auf 500 nötig
+- **Risk Level: HIGH** (Auth-Fläche, Multi-User-Isolation, Bestandsdaten-Regressionsrisiko in S2)
+
+## Technical Approach
+
+**Zwei Schichten, zwei Muster, zwei Scheiben.**
+
+1. **Tragende Schicht: die öffentlichen Store-Methoden.** Alle betroffenen Methoden geben bereits
+   `error` zurück — die Prüfung kostet keine einzige Signaturänderung. Das folgt dem Python-Vorbild
+   (`src/app/loader.py:1165`: „Zentral hier, damit alle Aufrufer gedeckt sind"), das die Lehre aus
+   #1352/#1364 trägt.
+2. **Zweite Schicht: Handler-Vorprüfung nur auf den vier öffentlichen Auth-Routen** — nicht wegen
+   der Sicherheit (Schicht 1 hält), sondern damit die Ablehnung flächengerecht antwortet und die
+   Absicht im Code lesbar bleibt.
+3. **Konstanten in `internal/store/pathsafe.go`** — importzyklusfrei (`handler` → `store` → `model`,
+   `store` importiert `handler` nicht), von `handler` und `middleware` nutzbar.
+
+**Fehlerantwort — bewusst NICHT einheitlich.** Eine ungültige ID wird exakt so behandelt wie
+„diesen Nutzer gibt es nicht", kein neuer Statuscode, kein neuer Antwortpfad:
+
+| Route | Antwort |
+|---|---|
+| `POST /api/auth/login` | 401 `{"error":"invalid credentials"}` — identischer Body wie heute |
+| `POST /api/password-forgot` | **200 `{"status":"ok"}`, still abbrechen** — die Route antwortet heute bewusst immer 200 gegen Konto-Enumeration (`auth.go:231`); ein unterscheidbarer zweiter Antwortpfad wäre eine Härtungs-Regression |
+| `POST /api/password-reset` | 400 `{"error":"invalid token"}` |
+| `POST /api/verify-email` | 400 `{"error":"invalid token"}` |
+| authentifizierte Entitäts-Endpunkte | 400 `{"error":"validation failed"}` — Nutzer ist angemeldet, es gibt nichts zu enumerieren |
+
+**Verworfen (mit Begründung):** `writeFileLogged` als tragende Sperre (sieht die ID nicht mehr,
+deckt weder Lese- noch Löschpfade — insbesondere nicht `os.RemoveAll` in `DeleteUser:172` — und
+kein `os.MkdirAll`); `UserDir()` auf `(string, error)` umbauen (12 Aufrufer, deckt trotzdem nur
+Achse A); ein zweites Regex-Literal in Go (liefe an der Paritätskette vorbei).
+
+## Dependencies
+
+- **Upstream:** `internal/model`, `internal/middleware` (Session-Auflösung), JSON-Decoding in den Handlern
+- **Downstream:** alle Store-Aufrufer — über das Ticket hinaus auch `group.go:203`,
+  `weather_config.go:111,186`, `compare_preset.go:271,521,616`, `briefing_subscription.go:276`;
+  Scheduler nur über `tier_request_health.go:36` (`uid` stammt aus `os.ReadDir`, nicht vom Client)
+- **Reihenfolge:** S1 zuerst — einzige Fläche ohne Anmeldung. S2 danach, weil sie das
+  Bestandsdaten-Regressionsrisiko trägt und ein angemeldetes Konto voraussetzt.
+
+## Geprüft und für unkritisch befunden
+
+- `alert_state/` und `compare_weather_snapshots/` tragen krumme Namen (Doppelpunkte, Umlaute),
+  werden aber **ausschließlich vom Python-Kern** geschrieben — Go fasst sie nicht an
+- Bestehende Go-Tests: keine krummen ID-Literale gefunden
+- `LockBriefing`/`lockSessions` sind In-Memory, kein Pfadbau
+- `toKebab("❄️")` → `""` erzeugt heute eine Datei namens `.json` — bereits jetzt defekt; die neue
+  Regel macht daraus ein sauberes 400
+
+## Open Questions
+
+- [ ] Keine für den PO. Die einzige echte Weggabelung — striktes Muster (Ticket-Wortlaut) vs.
+      Pfadsegment-Regel für Entitäts-IDs — ist durch den Prod-Bestand entschieden: der Ticket-Wortlaut
+      würde sechs Orte des PO unbrauchbar machen und ist damit keine Option.
+- [ ] Offen für die Spec (technisch, in S2 zu klären): Reaktion des Frontends auf ein neues 400 bei
+      `PUT`/`DELETE /api/locations/{id}`; Weiterleitung an den Python-Kern (`internal/router`) wurde
+      nicht daraufhin angesehen, ob dort IDs in URLs zusammengebaut werden.

--- a/docs/specs/modules/fix_2140_pfad_traversal_nutzer_kennung.md
+++ b/docs/specs/modules/fix_2140_pfad_traversal_nutzer_kennung.md
@@ -1,0 +1,287 @@
+---
+entity_id: fix_2140_pfad_traversal_nutzer_kennung
+type: bug
+created: 2026-09-06
+updated: 2026-09-06
+status: draft
+version: "1.0"
+tags: [security, path-traversal, multi-tenant, auth]
+---
+
+# Pfad-Traversal-Sperre für Nutzer-Kennungen (Scheibe 1 von 2)
+
+## Approval
+
+- [x] Approved — PO-Freigabe 2026-09-06
+
+## Purpose
+
+Die vier öffentlichen Auth-Routen (`login`, `password-forgot`, `password-reset`, `verify-email`)
+reichen die vom Client gesetzte Nutzer-Kennung (`username`/`user`) ungeprüft an
+`Store.UserDir(id)` durch, das sie roh mit `filepath.Join` verbindet. Weil `filepath.Join`
+`..`-Sequenzen normalisiert, kann eine Kennung wie `../marker` oder `../bob/x` aus dem eigenen
+Nutzerverzeichnis ausbrechen. Laufzeit-Nachweis am unveränderten Stand: `POST
+/api/password-forgot` mit `username="../marker"` antwortet **200** und schreibt einen
+Passwort-Reset-Token **außerhalb** des Nutzerbaums (Log: „token written but not sent"). Existiert
+das Zielverzeichnis eines echten zweiten Nutzers, schreibt derselbe Mechanismus in dessen
+Verzeichnis hinein — bis zum Überschreiben von dessen `user.json`, wonach das fremde Konto nicht
+mehr anmeldbar ist.
+
+Diese Spec schließt die Lücke für die Nutzer-Achse (Achse A): eine kanonische Go-Prüfung am
+Pfadbau in `internal/store` plus flächengerechte Ablehnung an den vier öffentlichen Routen, ohne
+das bestehende Antwortverhalten (insbesondere den Enumerationsschutz von `password-forgot`) zu
+verändern.
+
+## Source
+
+- **File:** `internal/store/pathsafe.go` (NEU)
+- **Identifier:** `ValidUserIDRe`, `ValidUserID()`
+- **File:** `internal/store/user.go`
+- **Identifier:** `LoadUser`, `SaveUser`, `DeleteUser`, `ProvisionUserDirs`, `SaveResetToken`,
+  `LoadResetToken`, `DeleteResetToken`, `SaveVerificationToken`, `LoadVerificationToken`,
+  `DeleteVerificationToken`, `UserExists`
+- **File:** `internal/store/sessions.go`
+- **Identifier:** `LoadSessions`, `HasSession`, `AddSession`, `RemoveSession`, `ClearSessions`
+- **File:** `internal/handler/auth.go`
+- **Identifier:** `LoginHandler`, `ForgotPasswordHandler`, `ResetPasswordHandler`,
+  `VerifyEmailHandler`
+- **File:** `internal/handler/passkey.go`
+- **Identifier:** `validUsernameRe`
+- **File:** `tests/unit/test_user_id_pattern_parity.py`
+- **Identifier:** `test_python_muster_ist_deckungsgleich_mit_go` (Bestand, `# doc-compliance-test`)
+
+**Schicht:** Go-API (`internal/store`, `internal/handler`) plus der bestehende
+Python↔Go-Paritätstest in `tests/unit/`, der auf die verschobene Go-Quelle umgehängt wird.
+
+## Estimated Scope
+
+- **LoC:** ~105 produktiv, ~115 Tests (~220 gesamt)
+- **Files:** 8 (2 neu, 6 geändert)
+- **Effort:** medium
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `internal/middleware.UserIDFromContext` | go function | Liefert die Session-Nutzer-ID (Achse C, HMAC-signiertes Cookie) — bleibt in dieser Spec unangetastet |
+| `src/app/loader.VALID_USER_ID_RE` | python constant | Referenzmuster, gegen das der bestehende Paritätstest `ValidUserIDRe` abgleicht |
+| ADR-0003 | adr | Konsequente Mandantentrennung, Zwei-Nutzer-Pflichttest — diese Spec setzt sie auf der Go-Seite durch |
+| `internal/handler/passkey.go::validUsernameRe` | go var | Bisherige alleinige Quelle des Musters; wird auf `store.ValidUserIDRe` umgehängt statt verdoppelt |
+
+## Implementation Details
+
+1. **`internal/store/pathsafe.go` (neu)** — kanonische Go-Quelle des Musters:
+   ```go
+   var ValidUserIDRe = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+
+   func ValidUserID(id string) bool {
+       return ValidUserIDRe.MatchString(id)
+   }
+   ```
+   Importzyklusfrei: `handler` importiert `store`, `store` importiert `handler` nicht.
+
+2. **`internal/store/user.go`** — jede der 11 Methoden prüft `ValidUserID(id)` (bzw. den
+   jeweiligen ID-Parameter) als erste Anweisung, vor jedem `filepath.Join`/`os.MkdirAll`/
+   `os.ReadFile`/`os.RemoveAll`. Alle betroffenen Methoden geben bereits `error` zurück — **keine
+   Signaturänderung**. `UserExists` gibt `bool` zurück und liefert bei ungültiger Kennung schlicht
+   `false`, ohne `os.Stat` aufzurufen. `DeleteUser` ist die schärfste Stelle (`os.RemoveAll`,
+   `user.go:172`) — ohne Prüfung würde eine Traversal-Kennung dort ein fremdes Verzeichnis löschen.
+
+3. **`internal/store/sessions.go`** — `sessionsPath(userId)` (`:41`) ist die gemeinsame Engstelle
+   für alle fünf Einstiege (`LoadSessions`, `HasSession`, `AddSession`, `RemoveSession`,
+   `ClearSessions`); die Prüfung sitzt dort einmal, nicht fünfmal dupliziert. `HasSession` liefert
+   bei ungültiger `userId` `(false, error)` statt `(false, nil)` — bewusst unterscheidbar vom
+   „Kennung ist syntaktisch gültig, aber es gibt keine Session"-Fall, damit der Aufrufer eine
+   Traversal-Kennung nicht mit einer schlicht abgemeldeten Sitzung verwechseln kann.
+
+4. **`internal/handler/auth.go`** — an allen vier öffentlichen Routen eine explizite
+   Vorprüfung, **bevor** der erste Store-Aufruf erfolgt (Schicht 1 in `internal/store` hält
+   bereits, diese Schicht dient der lesbaren Absicht und der flächengerechten Antwort):
+   - `LoginHandler` (`:148`): `req.Username` gegen `store.ValidUserID` prüfen → bei Fehltreffer
+     identisch zum bestehenden „Nutzer nicht gefunden"-Zweig antworten: 401
+     `{"error":"invalid credentials"}`.
+   - `ForgotPasswordHandler` (`:217`): bei Fehltreffer **200** `{"status":"ok"}`, sofort
+     zurückkehren — identischer Code- und Antwortpfad wie der bestehende
+     „`user == nil`"-Zweig (`:233`), damit der Enumerationsschutz der Route erhalten bleibt.
+   - `ResetPasswordHandler` (`:322`): bei Fehltreffer 400 `{"error":"invalid token"}` — identisch
+     zum bestehenden Zweig bei fehlendem/ungültigem Reset-Token.
+   - `VerifyEmailHandler` (`:403`): bei Fehltreffer 400 `{"error":"invalid token"}` — identisch
+     zum bestehenden Zweig bei fehlendem/ungültigem Verifikations-Token.
+   - Bei jeder abgelehnten Kennung zusätzlich ein serverseitiger `log.Printf`-Eintrag (Route +
+     abgelehnte Kennung, **nicht** im Response-Body) — analog zum bestehenden
+     `log.Printf("login: user.json unreadable/corrupt for %s: %v", ...)`-Muster (`:160`).
+
+5. **`internal/handler/passkey.go:23`** — `validUsernameRe` wird zu `store.ValidUserIDRe`
+   umgehängt (kein eigenes Regex-Literal mehr). Die beiden Aufrufstellen `auth.go:46`
+   (`RegisterHandler`) und `passkey.go:462` bleiben unverändert, da sie bereits über den Namen
+   `validUsernameRe` auf das Paket-Level-Var zugreifen.
+
+6. **`tests/unit/test_user_id_pattern_parity.py`** — `_PASSKEY_GO` zeigt künftig auf
+   `internal/store/pathsafe.go`, die Regex-Suche im Test auf den Variablennamen
+   `ValidUserIDRe\s*=\s*regexp\.MustCompile`. Dieser Test wird beim reinen Verschieben des
+   Musters zwischenzeitlich rot (Variable existiert noch nicht in `pathsafe.go`) — das ist
+   erwartet und gehört als solches ins RED-Artefakt, nicht als „vorbestehend rot" verbucht.
+
+**Achse C wird nicht angefasst:** `s.UserID` stammt ausschließlich aus dem HMAC-signierten
+Session-Cookie (`internal/middleware/auth.go:74,86,98`), ist nicht client-steuerbar und damit
+kein offener Vektor. `WithUser("")` ist ein dokumentierter No-op (`store.go:16-19`) — dort ergänzt
+diese Spec lediglich einen klarstellenden Kommentar, dass der leere String bewusst NICHT über
+`ValidUserID` läuft (er würde sonst fälschlich als „ungültig" statt als „No-op" behandelt und
+bestehendes Verhalten kippen).
+
+## Expected Behavior
+
+- **Input:** Client-gesetzte Nutzer-Kennung in `username` (Login, Forgot, Reset) bzw. `user`
+  (Verify-Email) im JSON-Request-Body der vier öffentlichen Auth-Routen.
+- **Output:** Für eine Kennung, die nicht `^[a-zA-Z0-9_-]+$` entspricht, antwortet jede Route mit
+  demselben Statuscode und Body, den sie heute bereits für „Nutzer/Token existiert nicht" liefert
+  (siehe Implementation Details Punkt 4) — kein neuer Statuscode, keine neue Fehlerform. Für eine
+  gültige Kennung ändert sich nichts am bestehenden Verhalten.
+- **Side effects:** Bei ungültiger Kennung entsteht **keine** Datei-, Verzeichnis- oder
+  Lösch-Operation außerhalb bzw. innerhalb irgendeines Nutzerverzeichnisses — insbesondere kein
+  Reset-Token, kein Verifikations-Token, keine Session-Datei. Zusätzlich ein Log-Eintrag
+  serverseitig.
+
+## Acceptance Criteria
+
+- **AC-1:** Given eine Pfad-Traversal-Kennung wie `../marker` im `username`-Feld / When `POST
+  /api/auth/login` damit aufgerufen wird / Then antwortet die Route mit 401
+  `{"error":"invalid credentials"}` — demselben Body wie bei einem schlicht unbekannten Nutzer.
+  - Test: `POST /api/auth/login` mit `{"username":"../marker","password":"x"}`; Statuscode und
+    Response-Body mit dem Aufruf für einen garantiert unbekannten, aber syntaktisch gültigen
+    Nutzernamen vergleichen — beide identisch.
+
+- **AC-2:** Given ein real registrierter Nutzer mit korrektem Passwort / When `POST
+  /api/auth/login` aufgerufen wird / Then meldet sich der Nutzer weiterhin erfolgreich an
+  (Positivkontrolle).
+  - Test: Test-Nutzer anlegen, `POST /api/auth/login` mit dessen echten Zugangsdaten aufrufen,
+    200 und Session-Cookie prüfen.
+
+- **AC-3:** Given eine Pfad-Traversal-Kennung wie `../marker` im `username`-Feld / When `POST
+  /api/password-forgot` damit aufgerufen wird / Then antwortet die Route mit 200
+  `{"status":"ok"}`, und es entsteht **keine** `password_reset.json` außerhalb des
+  Nutzerverzeichnis-Baums (Kern des Laufzeit-Nachweises: heute landet dort ein Token).
+  - Test: `POST /api/password-forgot` mit `{"username":"../marker"}`; danach das Dateisystem
+    oberhalb von `data/users/` nach einer neu entstandenen `password_reset.json` durchsuchen —
+    keine gefunden.
+
+- **AC-4:** Given eine Pfad-Traversal-Kennung UND eine syntaktisch gültige, aber unbekannte
+  Kennung / When beide nacheinander gegen `POST /api/password-forgot` aufgerufen werden / Then
+  sind Statuscode und Response-Body für beide Fälle identisch — die Route bleibt gegen
+  Konto-Enumeration ununterscheidbar.
+  - Test: Zwei Aufrufe von `POST /api/password-forgot`, einmal mit `"../marker"`, einmal mit
+    `"garantiert-unbekannt-xyz"`; beide Antworten byte-genau vergleichen.
+
+- **AC-5:** Given ein real registrierter Nutzer mit hinterlegter E-Mail-Adresse / When `POST
+  /api/password-forgot` mit dessen echter Kennung aufgerufen wird / Then wird für ihn weiterhin
+  ein Reset-Token geschrieben (Positivkontrolle).
+  - Test: Test-Nutzer mit `MailTo`/`Email` anlegen, `POST /api/password-forgot` mit dessen
+    Kennung aufrufen, danach `password_reset.json` im eigenen Nutzerverzeichnis vorfinden.
+
+- **AC-6:** Given eine Pfad-Traversal-Kennung im `username`-Feld / When `POST
+  /api/password-reset` damit aufgerufen wird / Then antwortet die Route mit 400
+  `{"error":"invalid token"}`, und kein `PasswordHash` irgendeines Nutzers wird verändert.
+  - Test: `POST /api/password-reset` mit `{"username":"../bob","token":"x","new_password":"12345678"}`;
+    Statuscode/Body prüfen und den `PasswordHash` in Bobs `user.json` vor/nach dem Aufruf
+    byte-genau vergleichen.
+
+- **AC-7:** Given ein real registrierter Nutzer mit gültigem, ungelaufenem Reset-Token / When
+  `POST /api/password-reset` mit dessen echter Kennung und dem passenden Token aufgerufen wird /
+  Then wird das Passwort weiterhin erfolgreich zurückgesetzt (Positivkontrolle).
+  - Test: Reset-Token für einen Test-Nutzer erzeugen, `POST /api/password-reset` mit korrekten
+    Werten aufrufen, 200 erhalten und den neuen Login mit dem neuen Passwort erfolgreich
+    durchführen.
+
+- **AC-8:** Given eine Pfad-Traversal-Kennung im `user`-Feld / When `POST /api/verify-email`
+  damit aufgerufen wird / Then antwortet die Route mit 400 `{"error":"invalid token"}`, und
+  `EmailVerifiedAt` keines Nutzers wird gesetzt.
+  - Test: `POST /api/verify-email` mit `{"user":"../bob","token":"x"}`; Statuscode/Body prüfen
+    und Bobs `user.json` vor/nach byte-genau vergleichen.
+
+- **AC-9:** Given ein real registrierter Nutzer mit gültigem, ungelaufenem
+    Verifikations-Token / When `POST /api/verify-email` mit dessen echter Kennung und dem
+    passenden Token aufgerufen wird / Then wird `EmailVerifiedAt` weiterhin gesetzt
+    (Positivkontrolle).
+  - Test: Verifikations-Token für einen Test-Nutzer erzeugen, `POST /api/verify-email` mit
+    korrekten Werten aufrufen, 200 erhalten und `EmailVerifiedAt` im neu geladenen Nutzerobjekt
+    gesetzt vorfinden.
+
+- **AC-10:** Given zwei real angelegte Nutzer / When gegen den ersten Nutzer ein
+    Traversal-Angriff über `password-forgot` mit einer auf das Verzeichnis des zweiten Nutzers
+    zielenden Kennung (`../users/<zweiter-nutzer>` — trifft das Verzeichnis des realen zweiten
+    Nutzers; das kürzere `../<zweiter-nutzer>` landet dagegen neben `users/` und ist als
+    eigenständiger Ausbruch-aus-dem-Baum-Fall ebenfalls abgedeckt) gefahren wird / Then bleibt das Verzeichnis
+    des zweiten Nutzers byte-identisch (Inhalt und Änderungszeit jeder Datei unverändert) — der
+    Zwei-Nutzer-Nachweis nach ADR-0003.
+  - Test: `internal/store/pathsafe_test.go`, zwei Test-Nutzer `alice`/`bob` anlegen, Inhalt und
+    `mtime` von Bobs `user.json` vor dem Angriff sichern, `POST /api/password-forgot` mit
+    `{"username":"../bob"}` aufrufen, danach Inhalt und `mtime` erneut lesen und vergleichen.
+
+- **AC-11:** Given eine Pfad-Traversal-Kennung wie `../bob` / When `Store.LoadUser`,
+    `Store.SaveUser` oder `Store.DeleteUser` direkt mit dieser Kennung aufgerufen werden / Then
+    liefert jeder Aufruf einen Fehler, und es entsteht/verändert/verschwindet keine Datei
+    außerhalb des Verzeichnisses der aufrufenden Kennung.
+  - Test: `internal/store/pathsafe_test.go`, drei Aufrufe (`LoadUser`, `SaveUser`, `DeleteUser`)
+    mit `"../bob"`; jeweils `err != nil` prüfen und danach Bobs realen Nutzerordner unverändert
+    vorfinden.
+
+- **AC-12:** Given eine Pfad-Traversal-`userId` wie `../bob` / When `Store.AddSession`,
+    `Store.RemoveSession`, `Store.HasSession` oder `Store.ClearSessions` direkt damit aufgerufen
+    werden / Then liefern sie einen Fehler (`HasSession`: `(false, error)`), und es entsteht
+    keine `sessions.json` außerhalb des Nutzerverzeichnis-Baums.
+  - Test: `internal/store/pathsafe_test.go`, alle vier Methoden mit `"../bob"` aufrufen; Fehler
+    prüfen und das Dateisystem oberhalb von `data/users/` nach einer neuen `sessions.json`
+    durchsuchen — keine gefunden.
+
+- **AC-13:** Given die real im Bestand vorkommenden Nutzer-Kennungen (`default`, `henning`,
+    `steffi`, `validator-issue110`) / When sie gegen `store.ValidUserID` geprüft werden / Then
+    liefert jede `true` — der Bestand bleibt vollständig funktionsfähig.
+  - Test: `internal/store/pathsafe_test.go`, `store.ValidUserID` für jede der vier Kennungen
+    aufrufen und `true` erwarten.
+
+- **AC-14:** Given der bestehende Python↔Go-Paritätstest / When er nach dem Umzug des Musters
+    auf `internal/store/pathsafe.go` läuft / Then bleibt er grün — `VALID_USER_ID_RE` (Python)
+    und `ValidUserIDRe` (Go, `pathsafe.go`) sind weiterhin deckungsgleich.
+  - Test: `tests/unit/test_user_id_pattern_parity.py::test_python_muster_ist_deckungsgleich_mit_go`
+    (Bestand, `# doc-compliance-test`, Pfad/Variablenname umgehängt).
+
+- **AC-15:** Given eine der vier öffentlichen Auth-Routen wird mit einer ungültigen Kennung
+    aufgerufen / When die Anfrage verarbeitet wird / Then entsteht serverseitig ein Log-Eintrag,
+    der die Ablehnung und die Route erkennen lässt — unabhängig vom (unveränderten)
+    Response-Body.
+  - Test: `internal/handler/auth_traversal_test.go`, Log-Output (z.B. via `log.SetOutput` auf
+    einen `bytes.Buffer`) während eines Aufrufs mit `"../marker"` einfangen und auf einen
+    Treffer für die abgelehnte Kennung prüfen.
+
+## Known Limitations
+
+- **Scheibe 2 (Entitäts-IDs) ist bewusst nachgelagert.** Trip-, Location-, ComparePreset- und
+  Briefing-IDs (Achse B) bleiben in dieser Spec ungeprüft und folgen in einem eigenen Vorgang.
+  Begründung: Scheibe 2 trägt ein Bestandsdaten-Regressionsrisiko, das Scheibe 1 nicht hat — im
+  Prod-Bestand liegen sechs Orte mit Diakritika (`pollença`, `hochfügen`, `mühlbach` u.a.), für
+  die ein zu strenges Muster (wie es das Ticket wörtlich für „alle IDs" verlangt) den
+  Editier-/Lösch-Zugriff des PO stillschweigend brechen würde; die richtige Regel dafür ist eine
+  Pfadsegment-Prüfung statt des Nutzer-Kennung-Musters und braucht einen eigenen
+  Regressionstest. Zusätzlich setzt Achse B ein angemeldetes Konto voraus, während die vier
+  Routen dieser Spec die einzige Fläche sind, die ganz ohne Anmeldung erreichbar ist — die
+  dringlichere Fläche zuerst.
+- Die Reaktion des Frontends auf eine neue Ablehnung wurde nicht untersucht — für die vier
+  betroffenen Routen ändert sich weder Statuscode noch Response-Form gegenüber dem bestehenden
+  „Nutzer/Token unbekannt"-Zweig, ein Frontend-Effekt ist daher nicht zu erwarten, wurde aber
+  nicht durch UI-Tests belegt.
+- `internal/router` (Weiterleitung an den Python-Kern) wurde nicht daraufhin angesehen, ob dort
+  Nutzer-Kennungen in URLs zusammengebaut werden, die von dieser Prüfung nicht erfasst wären.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** ADR-0003 (Konsequente Mandantentrennung, kein `"default"`-Fallback)
+- **Rationale:** Diese Spec trifft keine neue Grundsatzentscheidung, sondern setzt eine bereits
+  getroffene (ADR-0003: Isolation pro Nutzer unter `data/users/<user_id>/`, Pflicht zum
+  Zwei-Nutzer-Test) auf einem bislang übersehenen Pfad durch — der Go-Seite fehlte die
+  zentrale Pfad-Absicherung, die die Python-Seite seit #1364 bereits kennt (`app.loader.get_data_dir`).
+  Ein eigenes ADR ist nicht nötig, weil weder eine neue Alternative abgewogen noch eine
+  bestehende Entscheidung geändert wird.
+
+## Changelog
+
+- 2026-09-06: Initial spec (Issue #2140, Scheibe 1 von 2)

--- a/internal/handler/auth.go
+++ b/internal/handler/auth.go
@@ -155,6 +155,18 @@ func LoginHandler(s *store.Store, secret string) http.HandlerFunc {
 			return
 		}
 
+		// Issue #2140: pfadunsichere Kennung wird abgewiesen, BEVOR sie in den
+		// Pfadbau geht — und zwar mit exakt der Antwort des "Nutzer unbekannt"-
+		// Zweigs unten, damit die Route nicht verraet, welche Kennungen
+		// syntaktisch auffallen.
+		if !store.ValidUserID(req.Username) {
+			log.Printf("login: rejected path-unsafe user id %q", req.Username)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(401)
+			w.Write([]byte(`{"error":"invalid credentials"}`))
+			return
+		}
+
 		user, err := s.LoadUser(req.Username)
 		if err != nil {
 			log.Printf("login: user.json unreadable/corrupt for %s: %v", req.Username, err)
@@ -228,6 +240,15 @@ func ForgotPasswordHandler(s *store.Store, bcryptCost int, cfg config.Config) ht
 
 		// Always return 200 (no user enumeration)
 		w.Header().Set("Content-Type", "application/json")
+
+		// Issue #2140: identischer Antwortpfad wie der "user == nil"-Zweig
+		// unten — der Enumerationsschutz dieser Route darf durch die neue
+		// Ablehnung keinen unterscheidbaren Fall bekommen.
+		if !store.ValidUserID(req.Username) {
+			log.Printf("password reset: rejected path-unsafe user id %q", req.Username)
+			w.Write([]byte(`{"status":"ok"}`))
+			return
+		}
 
 		user, _ := s.LoadUser(req.Username)
 		if user == nil {
@@ -341,6 +362,15 @@ func ResetPasswordHandler(s *store.Store, bcryptCost int) http.HandlerFunc {
 			return
 		}
 
+		// Issue #2140: vor dem ersten Store-Zugriff, Antwort identisch zum
+		// "Token fehlt/passt nicht"-Zweig direkt darunter.
+		if !store.ValidUserID(req.Username) {
+			log.Printf("password reset confirm: rejected path-unsafe user id %q", req.Username)
+			w.WriteHeader(400)
+			w.Write([]byte(`{"error":"invalid token"}`))
+			return
+		}
+
 		resetToken, err := s.LoadResetToken(req.Username)
 		if err != nil || resetToken == nil {
 			w.WriteHeader(400)
@@ -410,6 +440,15 @@ func VerifyEmailHandler(s *store.Store) http.HandlerFunc {
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.User == "" || req.Token == "" {
 			w.WriteHeader(400)
 			w.Write([]byte(`{"error":"invalid request"}`))
+			return
+		}
+
+		// Issue #2140: vor dem ersten Store-Zugriff, Antwort identisch zum
+		// "Token fehlt/passt nicht"-Zweig direkt darunter.
+		if !store.ValidUserID(req.User) {
+			log.Printf("email verification: rejected path-unsafe user id %q", req.User)
+			w.WriteHeader(400)
+			w.Write([]byte(`{"error":"invalid token"}`))
 			return
 		}
 

--- a/internal/handler/auth_traversal_test.go
+++ b/internal/handler/auth_traversal_test.go
@@ -1,0 +1,695 @@
+package handler
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/fs"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/henemm/gregor-api/internal/config"
+	"github.com/henemm/gregor-api/internal/model"
+	"github.com/henemm/gregor-api/internal/store"
+)
+
+// TDD RED — Issue #2140 Scheibe 1 (Nutzer-Achse). SPEC:
+// docs/specs/modules/fix_2140_pfad_traversal_nutzer_kennung.md
+//
+// Diese Tests belegen, dass die vier oeffentlichen Auth-Routen eine
+// Pfad-Traversal-Kennung (z.B. "../marker") heute UNGEPRUEFT an
+// Store.UserDir(id) durchreichen, wodurch Store-Operationen ausserhalb des
+// data/users/-Baums greifen. Sie muessen gegen den UNVERAENDERTEN
+// Produktivcode fehlschlagen.
+//
+// Methodik: weil filepath.Join("<DataDir>/users", "../marker") NACH "users"
+// zurueckspringt und bei "<DataDir>/marker" landet (Geschwister-Verzeichnis
+// von "users", NICHT innerhalb eines existierenden Nutzers), wird der reale
+// Ziel-Pfad ueber die exportierte Methode s.UserDir(id) ermittelt und dort
+// gezielt ein "Opfer"-Datensatz platziert. Das bildet exakt den im Kontext-
+// Dokument beschriebenen Laufzeit-Nachweis nach (Token/Datei ausserhalb des
+// Nutzerbaums).
+
+// writeJSONFile schreibt beliebige Rohdaten an einen Pfad, legt das
+// Verzeichnis bei Bedarf an. Wird genutzt, um "Opfer"-Dateien AUSSERHALB des
+// von Store vorgesehenen data/users/-Baums zu platzieren (simuliert, was ein
+// Traversal-Angriff dort vorfinden bzw. anlegen kann).
+func writeJSONFile(t *testing.T, dir, name string, v any) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", dir, err)
+	}
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, name), data, 0644); err != nil {
+		t.Fatalf("WriteFile(%s/%s): %v", dir, name, err)
+	}
+}
+
+// readFileOrEmpty liefert den Inhalt einer Datei oder "" wenn sie nicht existiert.
+func readFileOrEmpty(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return ""
+		}
+		t.Fatalf("ReadFile(%s): %v", path, err)
+	}
+	return string(data)
+}
+
+// findFilesOutsideUsersTree durchsucht dataDir nach Dateien mit dem
+// angegebenen Namen, die NICHT unter dataDir/users/ liegen — das ist exakt
+// die Prüfung, die AC-3/AC-12 verlangen ("das Dateisystem oberhalb von
+// data/users/ durchsuchen").
+func findFilesOutsideUsersTree(t *testing.T, dataDir, filename string) []string {
+	t.Helper()
+	usersRoot := filepath.Join(dataDir, "users")
+	var found []string
+	err := filepath.WalkDir(dataDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if d.Name() != filename {
+			return nil
+		}
+		rel, relErr := filepath.Rel(usersRoot, path)
+		if relErr == nil && !strings.HasPrefix(rel, "..") {
+			return nil // liegt innerhalb von data/users/
+		}
+		found = append(found, path)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("WalkDir(%s): %v", dataDir, err)
+	}
+	return found
+}
+
+// -----------------------------------------------------------------------
+// AC-1 / AC-2 — LoginHandler
+// -----------------------------------------------------------------------
+
+// AC-1: Traversal-Kennung im username-Feld muss wie ein schlicht unbekannter
+// Nutzer behandelt werden (401, identischer Body). Heute liest LoadUser
+// klaglos aus dem per ".." erreichten Verzeichnis — existiert dort ein
+// user.json mit passendem Passwort-Hash, meldet sich der Angreifer
+// erfolgreich an (200 + Session-Cookie statt 401).
+func TestLoginHandler_TraversalUsername_RejectedSameAsUnknownUser_AC1(t *testing.T) {
+	s := newTestStore(t)
+
+	// Opfer-Datei GENAU dort platzieren, wo UserDir("../marker") heute landet
+	// (Geschwister von "users", siehe Methodik-Kommentar oben).
+	victimHash, _ := bcrypt.GenerateFromPassword([]byte("attackerpass123"), bcrypt.MinCost)
+	victimDir := s.UserDir("../marker")
+	writeJSONFile(t, victimDir, "user.json", model.User{
+		ID: "../marker", PasswordHash: string(victimHash), CreatedAt: time.Now(),
+	})
+
+	secret := "test-secret-32-chars-long-enough"
+	h := LoginHandler(s, secret)
+
+	attack := httptest.NewRequest("POST", "/api/auth/login",
+		strings.NewReader(`{"username":"../marker","password":"attackerpass123"}`))
+	wAttack := httptest.NewRecorder()
+	h.ServeHTTP(wAttack, attack)
+
+	unknown := httptest.NewRequest("POST", "/api/auth/login",
+		strings.NewReader(`{"username":"garantiert-unbekannt-xyz","password":"irrelevant123"}`))
+	wUnknown := httptest.NewRecorder()
+	h.ServeHTTP(wUnknown, unknown)
+
+	if wAttack.Code != 401 {
+		t.Errorf("AC-1: expected 401 for traversal username, got %d: %s", wAttack.Code, wAttack.Body.String())
+	}
+	if wAttack.Body.String() != `{"error":"invalid credentials"}` {
+		t.Errorf("AC-1: expected body '{\"error\":\"invalid credentials\"}', got %q", wAttack.Body.String())
+	}
+	if wAttack.Code != wUnknown.Code || wAttack.Body.String() != wUnknown.Body.String() {
+		t.Errorf("AC-1: traversal response must be byte-identical to unknown-user response: attack=%d %q vs unknown=%d %q",
+			wAttack.Code, wAttack.Body.String(), wUnknown.Code, wUnknown.Body.String())
+	}
+}
+
+// AC-1 (Cross-User-Nutzlast) — Nachschärfung auf PO-Wunsch: "../marker" landet
+// nur GESCHWISTER von "users" und trifft nie einen real registrierten
+// Zweitnutzer (siehe Methodik-Kommentar oben). Die Nutzlast "../users/bob"
+// dagegen kappt "users" und haengt es sofort wieder an:
+// filepath.Join(DataDir,"users","../users/bob") = DataDir/users/bob — GENAU
+// das Verzeichnis des real registrierten "bob". Dieser Test prueft, ob sich
+// ein Angreifer damit tatsaechlich als der REALE Bob anmelden kann.
+func TestLoginHandler_TraversalUsersBobPayload_CanImpersonateRealUser_AC1(t *testing.T) {
+	s := newTestStore(t)
+
+	bobHash, _ := bcrypt.GenerateFromPassword([]byte("bobs-real-pass"), bcrypt.MinCost)
+	if err := s.SaveUser(model.User{ID: "bob", PasswordHash: string(bobHash), CreatedAt: time.Now()}); err != nil {
+		t.Fatalf("SaveUser(bob): %v", err)
+	}
+
+	h := LoginHandler(s, "test-secret-32-chars-long-enough")
+	req := httptest.NewRequest("POST", "/api/auth/login",
+		strings.NewReader(`{"username":"../users/bob","password":"bobs-real-pass"}`))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code == 200 {
+		t.Errorf("AC-1 (Cross-User): '../users/bob' + bob's real password IMPERSONATES the real second user — got 200: %s", w.Body.String())
+	}
+	if w.Code != 401 || w.Body.String() != `{"error":"invalid credentials"}` {
+		t.Errorf("AC-1 (Cross-User): expected 401 {\"error\":\"invalid credentials\"} after the fix, got %d %q", w.Code, w.Body.String())
+	}
+}
+
+// AC-2 (Positivkontrolle): ein real registrierter Nutzer meldet sich weiterhin an.
+func TestLoginHandler_ValidCredentials_StillWorks_AC2(t *testing.T) {
+	s := newTestStore(t)
+	hash, _ := bcrypt.GenerateFromPassword([]byte("geheim123"), bcrypt.MinCost)
+	if err := s.SaveUser(model.User{ID: "alice", PasswordHash: string(hash), CreatedAt: time.Now()}); err != nil {
+		t.Fatalf("SaveUser: %v", err)
+	}
+
+	h := LoginHandler(s, "test-secret-32-chars-long-enough")
+	req := httptest.NewRequest("POST", "/api/auth/login", strings.NewReader(`{"username":"alice","password":"geheim123"}`))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != 200 {
+		t.Fatalf("AC-2: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	found := false
+	for _, c := range w.Result().Cookies() {
+		if c.Name == "gz_session" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("AC-2: expected gz_session cookie to be set")
+	}
+}
+
+// -----------------------------------------------------------------------
+// AC-3 / AC-4 / AC-5 — ForgotPasswordHandler
+// -----------------------------------------------------------------------
+
+// AC-3: Traversal-Kennung darf KEINE password_reset.json ausserhalb des
+// Nutzerbaums erzeugen. Heute erzeugt sie eine, sobald am Zielpfad ein
+// e-mail-loser "Nutzer" liegt (identischer Mechanismus wie der
+// dokumentierte Laufzeit-Nachweis, Log "token written but not sent").
+func TestForgotPassword_TraversalUsername_NoFileOutsideTree_AC3(t *testing.T) {
+	s := newTestStore(t)
+
+	victimDir := s.UserDir("../marker")
+	writeJSONFile(t, victimDir, "user.json", model.User{ID: "../marker", CreatedAt: time.Now()})
+
+	h := ForgotPasswordHandler(s, bcrypt.MinCost, config.Config{PublicHost: "https://test.example.com"})
+	req := httptest.NewRequest("POST", "/api/auth/forgot-password", strings.NewReader(`{"username":"../marker"}`))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != 200 || w.Body.String() != `{"status":"ok"}` {
+		t.Errorf("AC-3: expected 200 {\"status\":\"ok\"}, got %d %q", w.Code, w.Body.String())
+	}
+	if _, err := os.Stat(filepath.Join(victimDir, "password_reset.json")); err == nil {
+		t.Error("AC-3: password_reset.json must NOT be created outside the users tree")
+	}
+	if outside := findFilesOutsideUsersTree(t, s.DataDir, "password_reset.json"); len(outside) > 0 {
+		t.Errorf("AC-3: found password_reset.json outside data/users/: %v", outside)
+	}
+}
+
+// AC-4: Traversal-Kennung und syntaktisch gueltige, aber unbekannte Kennung
+// muessen byte-identische Antworten liefern (Enumerationsschutz).
+// Hinweis: diese AC ist bereits am unveraenderten Stand gruen (die Route
+// antwortet fuer BEIDE Faelle ohne Opfer-Datei sofort 200 {"status":"ok"}) —
+// sie bewacht ab jetzt gegen Rueckschritt, nicht gegen den urspruenglichen Bug.
+func TestForgotPassword_TraversalVsUnknownUser_IdenticalResponse_AC4(t *testing.T) {
+	s := newTestStore(t)
+	h := ForgotPasswordHandler(s, bcrypt.MinCost, config.Config{PublicHost: "https://test.example.com"})
+
+	traversal := httptest.NewRequest("POST", "/api/auth/forgot-password", strings.NewReader(`{"username":"../marker2"}`))
+	wTraversal := httptest.NewRecorder()
+	h.ServeHTTP(wTraversal, traversal)
+
+	unknown := httptest.NewRequest("POST", "/api/auth/forgot-password", strings.NewReader(`{"username":"garantiert-unbekannt-xyz"}`))
+	wUnknown := httptest.NewRecorder()
+	h.ServeHTTP(wUnknown, unknown)
+
+	if wTraversal.Code != wUnknown.Code || wTraversal.Body.String() != wUnknown.Body.String() {
+		t.Errorf("AC-4: expected byte-identical responses, got traversal=%d %q vs unknown=%d %q",
+			wTraversal.Code, wTraversal.Body.String(), wUnknown.Code, wUnknown.Body.String())
+	}
+}
+
+// AC-5 (Positivkontrolle): ein real registrierter Nutzer mit E-Mail bekommt
+// weiterhin ein Reset-Token in seinem EIGENEN Verzeichnis.
+func TestForgotPassword_RealUserStillGetsResetToken_AC5(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.SaveUser(model.User{ID: "erika", Email: "erika@beispiel.de", CreatedAt: time.Now()}); err != nil {
+		t.Fatalf("SaveUser: %v", err)
+	}
+
+	h := ForgotPasswordHandler(s, bcrypt.MinCost, config.Config{PublicHost: "https://test.example.com"})
+	req := httptest.NewRequest("POST", "/api/auth/forgot-password", strings.NewReader(`{"username":"erika"}`))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != 200 {
+		t.Fatalf("AC-5: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	tokenFile := filepath.Join(s.UserDir("erika"), "password_reset.json")
+	if _, err := os.Stat(tokenFile); os.IsNotExist(err) {
+		t.Error("AC-5: password_reset.json should be created in erika's own directory")
+	}
+}
+
+// -----------------------------------------------------------------------
+// AC-6 / AC-7 — ResetPasswordHandler
+// -----------------------------------------------------------------------
+
+// AC-6: Traversal-Kennung + (fuer den Angreifer erreichbares) passendes
+// Token darf das Passwort NICHT setzen — weder das eines ausserhalb
+// erreichten Datensatzes noch das eines real registrierten zweiten Nutzers.
+// Heute prueft ResetPasswordHandler die Kennung nicht vor dem Store-Zugriff:
+// stimmen Token und Pfad ueberein, wird das Passwort am ausserhalb liegenden
+// Datensatz TATSAECHLICH geaendert und die Route antwortet 200 statt 400.
+func TestResetPassword_TraversalUsername_RejectedNoHashChange_AC6(t *testing.T) {
+	s := newTestStore(t)
+
+	// Opfer ausserhalb des Baums, exakt am Ziel von UserDir("../bob").
+	victimDir := s.UserDir("../bob")
+	oldHash, _ := bcrypt.GenerateFromPassword([]byte("victim-old-pass"), bcrypt.MinCost)
+	writeJSONFile(t, victimDir, "user.json", model.User{ID: "../bob", PasswordHash: string(oldHash), CreatedAt: time.Now()})
+	tokenHash, _ := bcrypt.GenerateFromPassword([]byte("attackertoken123"), bcrypt.MinCost)
+	writeJSONFile(t, victimDir, "password_reset.json", model.PasswordResetToken{
+		TokenHash: string(tokenHash), ExpiresAt: time.Now().Add(30 * time.Minute),
+	})
+
+	// Real registrierter zweiter Nutzer "bob" — muss unberuehrt bleiben.
+	realHash, _ := bcrypt.GenerateFromPassword([]byte("bobs-real-pass"), bcrypt.MinCost)
+	if err := s.SaveUser(model.User{ID: "bob", PasswordHash: string(realHash), CreatedAt: time.Now()}); err != nil {
+		t.Fatalf("SaveUser(bob): %v", err)
+	}
+	realUserFileBefore := readFileOrEmpty(t, filepath.Join(s.UserDir("bob"), "user.json"))
+
+	h := ResetPasswordHandler(s, bcrypt.MinCost)
+	req := httptest.NewRequest("POST", "/api/auth/reset-password",
+		strings.NewReader(`{"username":"../bob","token":"attackertoken123","new_password":"newpass1234"}`))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != 400 || w.Body.String() != `{"error":"invalid token"}` {
+		t.Errorf("AC-6: expected 400 {\"error\":\"invalid token\"}, got %d %q", w.Code, w.Body.String())
+	}
+
+	victimUserData := readFileOrEmpty(t, filepath.Join(victimDir, "user.json"))
+	var victimUser model.User
+	json.Unmarshal([]byte(victimUserData), &victimUser)
+	if victimUser.PasswordHash != string(oldHash) {
+		t.Error("AC-6: password hash of the out-of-tree victim must not change")
+	}
+
+	realUserFileAfter := readFileOrEmpty(t, filepath.Join(s.UserDir("bob"), "user.json"))
+	if realUserFileBefore != realUserFileAfter {
+		t.Error("AC-6: real second user's user.json must stay byte-identical")
+	}
+}
+
+// AC-6 (Cross-User-Nutzlast) — Nachschärfung auf PO-Wunsch: "../users/bob"
+// kappt "users" und haengt es sofort wieder an, trifft also GENAU das
+// Verzeichnis des real registrierten "bob" (siehe AC-1-Pendant oben). Dieser
+// Test prueft die schwerste Folge: kann ein Angreifer mit Bobs eigenem,
+// gueltigem Reset-Token das Passwort des REALEN Bob setzen?
+func TestResetPassword_TraversalUsersBobPayload_HitsRealSecondUser_AC6(t *testing.T) {
+	s := newTestStore(t)
+
+	oldHash, _ := bcrypt.GenerateFromPassword([]byte("bobs-old-pass"), bcrypt.MinCost)
+	if err := s.SaveUser(model.User{ID: "bob", PasswordHash: string(oldHash), CreatedAt: time.Now()}); err != nil {
+		t.Fatalf("SaveUser(bob): %v", err)
+	}
+	tokenHash, _ := bcrypt.GenerateFromPassword([]byte("bobs-real-token"), bcrypt.MinCost)
+	if err := s.SaveResetToken("bob", model.PasswordResetToken{
+		TokenHash: string(tokenHash), ExpiresAt: time.Now().Add(30 * time.Minute),
+	}); err != nil {
+		t.Fatalf("SaveResetToken(bob): %v", err)
+	}
+	bobFile := filepath.Join(s.UserDir("bob"), "user.json")
+	infoBefore, err := os.Stat(bobFile)
+	if err != nil {
+		t.Fatalf("Stat(bob) before: %v", err)
+	}
+	contentBefore := readFileOrEmpty(t, bobFile)
+
+	h := ResetPasswordHandler(s, bcrypt.MinCost)
+	req := httptest.NewRequest("POST", "/api/auth/reset-password",
+		strings.NewReader(`{"username":"../users/bob","token":"bobs-real-token","new_password":"attackerchosen1"}`))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code == 200 {
+		t.Errorf("AC-6 (Cross-User): '../users/bob' + bob's own valid token changed the REAL user's password — got 200: %s", w.Body.String())
+	}
+	if w.Code != 400 || w.Body.String() != `{"error":"invalid token"}` {
+		t.Errorf("AC-6 (Cross-User): expected 400 {\"error\":\"invalid token\"} after the fix, got %d %q", w.Code, w.Body.String())
+	}
+
+	contentAfter := readFileOrEmpty(t, bobFile)
+	if contentBefore != contentAfter {
+		t.Error("AC-6 (Cross-User): bob's real user.json content must stay byte-identical")
+	}
+	infoAfter, err := os.Stat(bobFile)
+	if err != nil {
+		t.Fatalf("Stat(bob) after: %v", err)
+	}
+	if !infoBefore.ModTime().Equal(infoAfter.ModTime()) {
+		t.Error("AC-6 (Cross-User): bob's real user.json mtime must stay unchanged")
+	}
+}
+
+// AC-7 (Positivkontrolle): ein real registrierter Nutzer mit gueltigem Token
+// kann sein Passwort weiterhin zuruecksetzen.
+func TestResetPassword_RealUserStillWorks_AC7(t *testing.T) {
+	s := newTestStore(t)
+	oldHash, _ := bcrypt.GenerateFromPassword([]byte("oldpass"), bcrypt.MinCost)
+	if err := s.SaveUser(model.User{ID: "carla", PasswordHash: string(oldHash), CreatedAt: time.Now()}); err != nil {
+		t.Fatalf("SaveUser: %v", err)
+	}
+	tokenHash, _ := bcrypt.GenerateFromPassword([]byte("realtoken123"), bcrypt.MinCost)
+	if err := s.SaveResetToken("carla", model.PasswordResetToken{
+		TokenHash: string(tokenHash), ExpiresAt: time.Now().Add(30 * time.Minute),
+	}); err != nil {
+		t.Fatalf("SaveResetToken: %v", err)
+	}
+
+	h := ResetPasswordHandler(s, bcrypt.MinCost)
+	req := httptest.NewRequest("POST", "/api/auth/reset-password",
+		strings.NewReader(`{"username":"carla","token":"realtoken123","new_password":"brandneu1234"}`))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != 200 {
+		t.Fatalf("AC-7: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	loginHandler := LoginHandler(s, "test-secret-32-chars-long-enough")
+	loginReq := httptest.NewRequest("POST", "/api/auth/login", strings.NewReader(`{"username":"carla","password":"brandneu1234"}`))
+	wLogin := httptest.NewRecorder()
+	loginHandler.ServeHTTP(wLogin, loginReq)
+	if wLogin.Code != 200 {
+		t.Errorf("AC-7: expected login with new password to succeed, got %d: %s", wLogin.Code, wLogin.Body.String())
+	}
+}
+
+// -----------------------------------------------------------------------
+// AC-8 / AC-9 — VerifyEmailHandler
+// -----------------------------------------------------------------------
+
+// AC-8: Traversal-Kennung im user-Feld darf EmailVerifiedAt keines Nutzers
+// setzen — weder ausserhalb noch bei einem real registrierten zweiten Nutzer.
+func TestVerifyEmail_TraversalUsername_RejectedNoVerification_AC8(t *testing.T) {
+	s := newTestStore(t)
+
+	victimDir := s.UserDir("../bob")
+	writeJSONFile(t, victimDir, "user.json", model.User{ID: "../bob", CreatedAt: time.Now()})
+	tokenHash, _ := bcrypt.GenerateFromPassword([]byte("attackertoken123"), bcrypt.MinCost)
+	writeJSONFile(t, victimDir, "email_verification.json", model.EmailVerificationToken{
+		TokenHash: string(tokenHash), ExpiresAt: time.Now().Add(24 * time.Hour),
+	})
+
+	if err := s.SaveUser(model.User{ID: "bob", CreatedAt: time.Now()}); err != nil {
+		t.Fatalf("SaveUser(bob): %v", err)
+	}
+
+	h := VerifyEmailHandler(s)
+	req := httptest.NewRequest("POST", "/api/verify-email",
+		strings.NewReader(`{"user":"../bob","token":"attackertoken123"}`))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != 400 || w.Body.String() != `{"error":"invalid token"}` {
+		t.Errorf("AC-8: expected 400 {\"error\":\"invalid token\"}, got %d %q", w.Code, w.Body.String())
+	}
+
+	victimUserData := readFileOrEmpty(t, filepath.Join(victimDir, "user.json"))
+	var victimUser model.User
+	json.Unmarshal([]byte(victimUserData), &victimUser)
+	if victimUser.EmailVerifiedAt != nil {
+		t.Error("AC-8: EmailVerifiedAt of the out-of-tree victim must stay nil")
+	}
+
+	realBob, err := s.LoadUser("bob")
+	if err != nil || realBob == nil {
+		t.Fatalf("LoadUser(bob): %v", err)
+	}
+	if realBob.EmailVerifiedAt != nil {
+		t.Error("AC-8: real second user's EmailVerifiedAt must stay nil")
+	}
+}
+
+// AC-8 (Cross-User-Nutzlast) — Nachschärfung auf PO-Wunsch: "../users/bob"
+// trifft GENAU das Verzeichnis des real registrierten "bob" (siehe
+// AC-1/AC-6-Pendants oben). Prueft, ob ein Angreifer mit Bobs eigenem,
+// gueltigem Verifikations-Token dessen E-Mail-Adresse als "verifiziert"
+// markieren kann.
+func TestVerifyEmail_TraversalUsersBobPayload_HitsRealSecondUser_AC8(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.SaveUser(model.User{ID: "bob", CreatedAt: time.Now()}); err != nil {
+		t.Fatalf("SaveUser(bob): %v", err)
+	}
+	tokenHash, _ := bcrypt.GenerateFromPassword([]byte("bobs-real-verify-token"), bcrypt.MinCost)
+	if err := s.SaveVerificationToken("bob", model.EmailVerificationToken{
+		TokenHash: string(tokenHash), ExpiresAt: time.Now().Add(24 * time.Hour),
+	}); err != nil {
+		t.Fatalf("SaveVerificationToken(bob): %v", err)
+	}
+
+	h := VerifyEmailHandler(s)
+	req := httptest.NewRequest("POST", "/api/verify-email",
+		strings.NewReader(`{"user":"../users/bob","token":"bobs-real-verify-token"}`))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code == 200 {
+		t.Errorf("AC-8 (Cross-User): '../users/bob' + bob's own valid token verified the REAL user's email — got 200: %s", w.Body.String())
+	}
+	if w.Code != 400 || w.Body.String() != `{"error":"invalid token"}` {
+		t.Errorf("AC-8 (Cross-User): expected 400 {\"error\":\"invalid token\"} after the fix, got %d %q", w.Code, w.Body.String())
+	}
+
+	realBob, err := s.LoadUser("bob")
+	if err != nil || realBob == nil {
+		t.Fatalf("LoadUser(bob): %v", err)
+	}
+	if realBob.EmailVerifiedAt != nil {
+		t.Error("AC-8 (Cross-User): real second user's EmailVerifiedAt must stay nil")
+	}
+}
+
+// AC-9 (Positivkontrolle): ein real registrierter Nutzer mit gueltigem Token
+// wird weiterhin verifiziert.
+func TestVerifyEmail_RealUserStillWorks_AC9(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.SaveUser(model.User{ID: "dieter", CreatedAt: time.Now()}); err != nil {
+		t.Fatalf("SaveUser: %v", err)
+	}
+	tokenHash, _ := bcrypt.GenerateFromPassword([]byte("realtoken123"), bcrypt.MinCost)
+	if err := s.SaveVerificationToken("dieter", model.EmailVerificationToken{
+		TokenHash: string(tokenHash), ExpiresAt: time.Now().Add(24 * time.Hour),
+	}); err != nil {
+		t.Fatalf("SaveVerificationToken: %v", err)
+	}
+
+	h := VerifyEmailHandler(s)
+	req := httptest.NewRequest("POST", "/api/verify-email", strings.NewReader(`{"user":"dieter","token":"realtoken123"}`))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != 200 {
+		t.Fatalf("AC-9: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	user, err := s.LoadUser("dieter")
+	if err != nil || user == nil || user.EmailVerifiedAt == nil {
+		t.Errorf("AC-9: expected EmailVerifiedAt to be set, err=%v user=%+v", err, user)
+	}
+}
+
+// -----------------------------------------------------------------------
+// AC-10 — Zwei-Nutzer-Nachweis (ADR-0003)
+// -----------------------------------------------------------------------
+
+// AC-10: zwei real angelegte Nutzer; ein Traversal-Angriff ueber
+// password-forgot darf weder den realen zweiten Nutzer beruehren noch
+// ausserhalb des Baums ein Token hinterlassen.
+func TestForgotPassword_TwoRealUsers_SecondUserUntouched_AC10(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.SaveUser(model.User{ID: "alice", Email: "alice@beispiel.de", CreatedAt: time.Now()}); err != nil {
+		t.Fatalf("SaveUser(alice): %v", err)
+	}
+	if err := s.SaveUser(model.User{ID: "bob", Email: "bob@beispiel.de", CreatedAt: time.Now()}); err != nil {
+		t.Fatalf("SaveUser(bob): %v", err)
+	}
+	bobFile := filepath.Join(s.UserDir("bob"), "user.json")
+	infoBefore, err := os.Stat(bobFile)
+	if err != nil {
+		t.Fatalf("Stat(bob user.json) before attack: %v", err)
+	}
+	contentBefore := readFileOrEmpty(t, bobFile)
+
+	// Zusaetzlich ein e-mail-loses Opfer GENAU am Ziel von "../bob" platzieren
+	// (Geschwister von "users", siehe Methodik-Kommentar) — das macht den
+	// Angriff wirksam nachweisbar (Log "token written but not sent").
+	victimDir := s.UserDir("../bob")
+	writeJSONFile(t, victimDir, "user.json", model.User{ID: "../bob", CreatedAt: time.Now()})
+
+	h := ForgotPasswordHandler(s, bcrypt.MinCost, config.Config{PublicHost: "https://test.example.com"})
+	req := httptest.NewRequest("POST", "/api/auth/forgot-password", strings.NewReader(`{"username":"../bob"}`))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != 200 {
+		t.Fatalf("AC-10: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	infoAfter, err := os.Stat(bobFile)
+	if err != nil {
+		t.Fatalf("Stat(bob user.json) after attack: %v", err)
+	}
+	contentAfter := readFileOrEmpty(t, bobFile)
+	if contentBefore != contentAfter {
+		t.Error("AC-10: bob's real user.json content must stay byte-identical")
+	}
+	if !infoBefore.ModTime().Equal(infoAfter.ModTime()) {
+		t.Error("AC-10: bob's real user.json mtime must stay unchanged")
+	}
+
+	if _, err := os.Stat(filepath.Join(victimDir, "password_reset.json")); err == nil {
+		t.Error("AC-10: password_reset.json must NOT be created outside the users tree")
+	}
+
+	// Nachschärfung auf PO-Wunsch: "../bob" trifft den realen Bob NICHT
+	// (siehe Methodik-Kommentar oben) — die Nutzlast, die "users" kappt und
+	// sofort wieder anhängt, ist "../users/bob" und landet exakt in Bobs
+	// echtem Verzeichnis (filepath.Join(DataDir,"users","../users/bob") =
+	// DataDir/users/bob). Bob hat bereits eine E-Mail-Adresse hinterlegt
+	// (s.o.), er hatte bislang aber KEIN password_reset.json — entsteht nach
+	// diesem Aufruf eins in seinem ECHTEN Verzeichnis, ist das der direkte
+	// Cross-User-Nachweis (kein Geschwister-Verzeichnis, kein Opfer-Platzhalter).
+	realResetFile := filepath.Join(s.UserDir("bob"), "password_reset.json")
+	if _, err := os.Stat(realResetFile); err == nil {
+		t.Fatalf("AC-10 setup invariant broken: bob already has a password_reset.json before the cross-user payload")
+	}
+
+	req2 := httptest.NewRequest("POST", "/api/auth/forgot-password", strings.NewReader(`{"username":"../users/bob"}`))
+	w2 := httptest.NewRecorder()
+	h.ServeHTTP(w2, req2)
+
+	if w2.Code != 200 {
+		t.Fatalf("AC-10 (Cross-User): expected 200, got %d: %s", w2.Code, w2.Body.String())
+	}
+	if _, err := os.Stat(realResetFile); err == nil {
+		t.Error("AC-10 (Cross-User): '../users/bob' created a password_reset.json in BOB'S REAL directory — cross-user reachability confirmed")
+	}
+}
+
+// -----------------------------------------------------------------------
+// AC-15 — Server-seitiger Log-Eintrag bei Ablehnung
+// -----------------------------------------------------------------------
+
+// AC-15: eine abgelehnte Traversal-Kennung muss serverseitig geloggt werden —
+// auf ALLEN VIER oeffentlichen Routen, nicht nur beim Login (F001 aus dem
+// Fix-Loop: die Vorpruefungen der drei uebrigen Routen liessen sich entfernen,
+// ohne dass ein Test rot wurde).
+//
+// Geprueft wird je Route dreierlei: die abgelehnte Kennung steht im Log, die
+// Route ist am Log-Praefix erkennbar, und die Ablehnung ist als solche
+// ausgewiesen — nicht als generischer Sammel-Fehler. Beim Login ist das der
+// Kern des Adversary-Einwands: die Meldung darf nicht mit dem bestehenden
+// "user.json unreadable/corrupt"-Zweig verschwimmen, sonst laesst sich aus dem
+// Log nicht ablesen, ob die Sperre gegriffen hat oder eine Datei kaputt war.
+func TestAuthRoutes_TraversalRejection_LogsRoute_AC15(t *testing.T) {
+	const attack = "../marker3"
+	const rejectionPhrase = "rejected path-unsafe user id"
+
+	cases := []struct {
+		name    string
+		prefix  string // Erkennungsmerkmal der Route im Log
+		request func(s *store.Store) (http.Handler, *http.Request)
+	}{
+		{
+			name:   "LoginHandler",
+			prefix: "login:",
+			request: func(s *store.Store) (http.Handler, *http.Request) {
+				return LoginHandler(s, "test-secret-32-chars-long-enough"),
+					httptest.NewRequest("POST", "/api/auth/login",
+						strings.NewReader(`{"username":"`+attack+`","password":"x"}`))
+			},
+		},
+		{
+			name:   "ForgotPasswordHandler",
+			prefix: "password reset:",
+			request: func(s *store.Store) (http.Handler, *http.Request) {
+				return ForgotPasswordHandler(s, bcrypt.MinCost, config.Config{PublicHost: "https://test.example.com"}),
+					httptest.NewRequest("POST", "/api/auth/forgot-password",
+						strings.NewReader(`{"username":"`+attack+`"}`))
+			},
+		},
+		{
+			name:   "ResetPasswordHandler",
+			prefix: "password reset confirm:",
+			request: func(s *store.Store) (http.Handler, *http.Request) {
+				return ResetPasswordHandler(s, bcrypt.MinCost),
+					httptest.NewRequest("POST", "/api/auth/reset-password",
+						strings.NewReader(`{"username":"`+attack+`","token":"x","new_password":"12345678"}`))
+			},
+		},
+		{
+			name:   "VerifyEmailHandler",
+			prefix: "email verification:",
+			request: func(s *store.Store) (http.Handler, *http.Request) {
+				return VerifyEmailHandler(s),
+					httptest.NewRequest("POST", "/api/verify-email",
+						strings.NewReader(`{"user":"`+attack+`","token":"x"}`))
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newTestStore(t)
+
+			var logBuf bytes.Buffer
+			log.SetOutput(&logBuf)
+			defer log.SetOutput(os.Stderr)
+
+			h, req := tc.request(s)
+			h.ServeHTTP(httptest.NewRecorder(), req)
+
+			got := logBuf.String()
+			if !strings.Contains(got, attack) {
+				t.Errorf("AC-15: expected a log entry mentioning the rejected id %q, got: %q", attack, got)
+			}
+			if !strings.Contains(got, tc.prefix) {
+				t.Errorf("AC-15: expected the log entry to identify the route via %q, got: %q", tc.prefix, got)
+			}
+			if !strings.Contains(got, rejectionPhrase) {
+				t.Errorf("AC-15: expected the log entry to name the rejection (%q), got: %q", rejectionPhrase, got)
+			}
+			if strings.Contains(got, "unreadable/corrupt") {
+				t.Errorf("AC-15: the traversal rejection must not be logged as the generic corrupt-file case, got: %q", got)
+			}
+		})
+	}
+}

--- a/internal/handler/passkey.go
+++ b/internal/handler/passkey.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
-	"regexp"
 	"strings"
 	"time"
 
@@ -20,7 +19,10 @@ import (
 	"github.com/henemm/gregor-api/internal/store"
 )
 
-var validUsernameRe = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+// validUsernameRe haengt an der kanonischen Quelle in internal/store
+// (Issue #2140) — ein zweites Regex-Literal koennte von der Pfad-Sperre
+// abdriften und Kennungen durchlassen, die der Store dann ablehnt.
+var validUsernameRe = store.ValidUserIDRe
 
 // Passkey/WebAuthn handlers — Issue #450 V1 Add-on.
 //

--- a/internal/middleware/session_allowlist_test.go
+++ b/internal/middleware/session_allowlist_test.go
@@ -331,32 +331,86 @@ func TestNewFormatCookie_NoAllowlistFile_Returns401NotServerError(t *testing.T) 
 }
 
 // AC-14 (Go-Seite): Eine Nutzerkennung mit Punkt wird von rechts zerlegt —
-// beide Formate müssen dieselbe Kennung liefern und dürfen nicht abweisen.
-// Das Frontend-Gegenstück steht in frontend/src/lib/session_format.test.ts.
+// beide Formate müssen dieselbe Kennung liefern.
+//
+// GEMESSEN WIRD SEIT ISSUE #2140 die Zerlegung selbst (validateSession), nicht
+// mehr die Ende-zu-Ende-Strecke über authProbe: die Pfad-Traversal-Sperre
+// lässt eine Kennung mit Punkt nicht mehr an den Datenbestand
+// (store.ValidUserID, `^[a-zA-Z0-9_-]+$`) — ein 200 ist mit dieser Fixture
+// also strukturell nicht mehr erreichbar, die 200-Erwartung hätte den Wächter
+// nur noch über einen Stellvertreter gemessen. Die #2129-Zusicherung "von
+// RECHTS zerlegen" bleibt unverändert bewacht, jetzt an der Stelle, an der sie
+// wirkt. Das Frontend-Gegenstück steht in frontend/src/lib/session_format.test.ts.
 func TestDottedUserID_SplitFromTheRight(t *testing.T) {
-	dataDir := t.TempDir()
 	const uid = "alice.smith"
-	writeAllowlist(t, dataDir, uid, "sess-dot00001")
+	const sid = "sess-dot00001"
 
 	t.Run("neues Format", func(t *testing.T) {
-		cookie := makeNewSessionCookie(uid, "sess-dot00001", time.Now().Unix(), testSecret)
-		rr := authProbe(t, dataDir, testSecret, cookie)
-		if rr.Code != http.StatusOK {
-			t.Fatalf("AC-14: erwartet 200 für %q, bekommen %d", uid, rr.Code)
+		cookie := makeNewSessionCookie(uid, sid, time.Now().Unix(), testSecret)
+		gotUID, gotSID, _, isNew, ok := validateSession(cookie, testSecret)
+		if !ok {
+			t.Fatalf("AC-14: Merkmal mit %q muss gültig zerlegt werden, wurde verworfen", uid)
 		}
-		if rr.Body.String() != uid {
-			t.Errorf("AC-14: erwartet Nutzerkennung %q, bekommen %q", uid, rr.Body.String())
+		if !isNew {
+			t.Errorf("AC-14: vierteiliges Merkmal muss als neues Format gelesen werden")
+		}
+		if gotUID != uid {
+			t.Errorf("AC-14: erwartet Nutzerkennung %q, bekommen %q", uid, gotUID)
+		}
+		if gotSID != sid {
+			t.Errorf("AC-14: erwartet Anmelde-Kennung %q, bekommen %q", sid, gotSID)
 		}
 	})
 
 	t.Run("Altformat", func(t *testing.T) {
 		cookie := makeSessionCookie(uid, time.Now().Unix(), testSecret)
-		rr := authProbe(t, dataDir, testSecret, cookie)
-		if rr.Code != http.StatusOK {
-			t.Fatalf("AC-14: erwartet 200 für Alt-Merkmal mit %q, bekommen %d", uid, rr.Code)
+		gotUID, gotSID, _, isNew, ok := validateSession(cookie, testSecret)
+		if !ok {
+			t.Fatalf("AC-14: Alt-Merkmal mit %q muss gültig zerlegt werden, wurde verworfen", uid)
 		}
-		if rr.Body.String() != uid {
-			t.Errorf("AC-14: erwartet Nutzerkennung %q, bekommen %q", uid, rr.Body.String())
+		if isNew {
+			t.Errorf("AC-14: dreiteiliges Merkmal darf nicht als neues Format gelesen werden")
+		}
+		if gotUID != uid {
+			t.Errorf("AC-14: erwartet Nutzerkennung %q, bekommen %q", uid, gotUID)
+		}
+		if gotSID != "" {
+			t.Errorf("AC-14: Alt-Merkmal trägt keine Anmelde-Kennung, bekommen %q", gotSID)
 		}
 	})
+}
+
+// Issue #2140: Die Pfad-Traversal-Sperre muss auch auf dem Weg durch die
+// Anmelde-Prüfung wirken — und zwar mit 401, NICHT mit einem Serverfehler.
+// Dieselbe Zusicherung wie bei der fehlenden sessions.json
+// (TestNewFormatCookie_NoAllowlistFile_Returns401NotServerError): ein Fehler
+// aus dem Datenbestand darf nie als 5xx durchschlagen.
+//
+// Der scharfe Fall ist "../users/bob": filepath.Join(dataDir, "users",
+// "../users/bob") landet GENAU im Verzeichnis des real angelegten "bob" — vor
+// der Sperre las die Middleware dort dessen echte Gästeliste, fand die
+// Anmelde-Kennung und ließ den Angreifer mit fremder Nutzerkennung durch.
+func TestTraversalUserIDInCookie_Returns401NotServerError(t *testing.T) {
+	dataDir := t.TempDir()
+	writeAllowlist(t, dataDir, "bob", "sess-bobs00001")
+
+	cases := []struct {
+		name   string
+		cookie string
+	}{
+		{"neues Format", makeNewSessionCookie("../bob", "sess-bobs00001", time.Now().Unix(), testSecret)},
+		{"Altformat", makeSessionCookie("../bob", time.Now().Unix(), testSecret)},
+		{"users-Nutzlast trifft Bobs echtes Verzeichnis", makeNewSessionCookie("../users/bob", "sess-bobs00001", time.Now().Unix(), testSecret)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rr := authProbe(t, dataDir, testSecret, tc.cookie)
+			if rr.Code >= 500 {
+				t.Fatalf("#2140: Traversal-Kennung darf keinen Serverfehler ergeben, bekommen %d", rr.Code)
+			}
+			if rr.Code != http.StatusUnauthorized {
+				t.Errorf("#2140: erwartet 401 für Traversal-Kennung, bekommen %d (Kontext-Kennung %q)", rr.Code, rr.Body.String())
+			}
+		})
+	}
 }

--- a/internal/store/pathsafe.go
+++ b/internal/store/pathsafe.go
@@ -1,0 +1,31 @@
+package store
+
+import (
+	"errors"
+	"regexp"
+)
+
+// Pfad-Traversal-Sperre fuer Nutzer-Kennungen (Issue #2140, Scheibe 1).
+//
+// Jede Store-Methode, die aus einer Nutzer-Kennung einen Dateipfad baut,
+// prueft sie hier ZUERST. Ohne diese Sperre normalisiert filepath.Join eine
+// Kennung wie "../bob" oder "../users/bob" und laesst den Aufrufer aus dem
+// eigenen Nutzerverzeichnis ausbrechen — bis hin zum Ueberschreiben oder
+// Loeschen fremder Konten (ADR-0003: konsequente Mandantentrennung).
+//
+// ValidUserIDRe ist die KANONISCHE Go-Quelle des Musters. internal/handler
+// (Registrierung, Passkey) haengt daran, statt es zu verdoppeln; der
+// Python-Kern haelt mit app.loader.VALID_USER_ID_RE dagegen (Paritaetstest
+// tests/unit/test_user_id_pattern_parity.py, #1364).
+var ValidUserIDRe = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+
+// ErrInvalidUserID meldet eine Kennung, die kein einzelnes, sicheres
+// Pfadsegment ist. Bewusst ein eigener Fehler und kein stilles "nicht
+// gefunden": der Aufrufer soll eine Traversal-Kennung nicht mit einem
+// schlicht unbekannten Nutzer verwechseln koennen.
+var ErrInvalidUserID = errors.New("invalid user id")
+
+// ValidUserID prueft, ob eine Nutzer-Kennung dem Zulassungsmuster entspricht.
+func ValidUserID(id string) bool {
+	return ValidUserIDRe.MatchString(id)
+}

--- a/internal/store/pathsafe_test.go
+++ b/internal/store/pathsafe_test.go
@@ -1,0 +1,306 @@
+package store
+
+import (
+	"encoding/json"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/henemm/gregor-api/internal/model"
+)
+
+// TDD RED — Issue #2140 Scheibe 1 (Nutzer-Achse), Store-Ebene. SPEC:
+// docs/specs/modules/fix_2140_pfad_traversal_nutzer_kennung.md AC-11, AC-12.
+//
+// AC-13 (store.ValidUserID) liegt bewusst in einer EIGENEN Datei
+// (valid_user_id_test.go) — sie referenziert eine noch nicht existierende
+// Funktion und wuerde sonst das gesamte Paket am Kompilieren hindern und
+// damit diese verhaltensbasierten Tests unsichtbar machen.
+//
+// Methodik wie im Handler-Pendant (auth_traversal_test.go): eine
+// Traversal-Kennung wie "../bob" landet ueber UserDir("../bob") NICHT im
+// Verzeichnis eines gleichnamigen, real registrierten Nutzers unter
+// data/users/bob, sondern in einem GESCHWISTER-Verzeichnis von "users"
+// (filepath.Join kappt "users" beim Auswerten von ".."). Jeder Test prueft
+// deshalb zusaetzlich zum realen Zweitnutzer explizit die tatsaechliche
+// Zielposition ueber s.UserDir(id).
+
+func findFilesOutsideUsersTree(t *testing.T, dataDir, filename string) []string {
+	t.Helper()
+	usersRoot := filepath.Join(dataDir, "users")
+	var found []string
+	err := filepath.WalkDir(dataDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if d.Name() != filename {
+			return nil
+		}
+		rel, relErr := filepath.Rel(usersRoot, path)
+		if relErr == nil && !strings.HasPrefix(rel, "..") {
+			return nil
+		}
+		found = append(found, path)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("WalkDir(%s): %v", dataDir, err)
+	}
+	return found
+}
+
+// AC-11: LoadUser/SaveUser/DeleteUser mit einer Traversal-Kennung muessen
+// jeweils einen Fehler liefern, ohne den realen Zweitnutzer zu beruehren.
+//
+// Heutiger Stand (RED):
+//   - LoadUser("../bob"):  Ziel-Datei existiert nicht -> (nil, nil), KEIN Fehler
+//   - SaveUser({ID:"../bob"}): schreibt klaglos ausserhalb des Baums, KEIN Fehler
+//   - DeleteUser("../bob"): os.RemoveAll auf nicht existierendes Verzeichnis
+//     liefert ebenfalls KEINEN Fehler
+func TestPathTraversal_UserMethods_RejectInvalidID_AC11(t *testing.T) {
+	tmpDir := t.TempDir()
+	s := New(tmpDir, "default")
+
+	// Real registrierter zweiter Nutzer — muss in JEDEM Teiltest unberuehrt bleiben.
+	realHash := "$2a$04$realbobhashplaceholderxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+	if err := s.SaveUser(model.User{ID: "bob", PasswordHash: realHash, CreatedAt: time.Now()}); err != nil {
+		t.Fatalf("SaveUser(bob): %v", err)
+	}
+	bobFile := filepath.Join(s.UserDir("bob"), "user.json")
+	bobBefore, err := os.ReadFile(bobFile)
+	if err != nil {
+		t.Fatalf("ReadFile(bob): %v", err)
+	}
+
+	t.Run("LoadUser", func(t *testing.T) {
+		u, err := s.LoadUser("../bob")
+		if err == nil {
+			t.Errorf("AC-11: LoadUser(\"../bob\") expected an error, got user=%+v err=nil", u)
+		}
+	})
+
+	t.Run("SaveUser", func(t *testing.T) {
+		err := s.SaveUser(model.User{ID: "../bob", PasswordHash: "x", CreatedAt: time.Now()})
+		if err == nil {
+			t.Error("AC-11: SaveUser({ID:\"../bob\"}) expected an error, got nil")
+		}
+		if _, statErr := os.Stat(filepath.Join(s.UserDir("../bob"), "user.json")); statErr == nil {
+			t.Error("AC-11: SaveUser must not create a file outside the users tree")
+		}
+	})
+
+	t.Run("DeleteUser", func(t *testing.T) {
+		err := s.DeleteUser("../bob")
+		if err == nil {
+			t.Error("AC-11: DeleteUser(\"../bob\") expected an error, got nil")
+		}
+	})
+
+	bobAfter, err := os.ReadFile(bobFile)
+	if err != nil {
+		t.Fatalf("ReadFile(bob) after attack: %v", err)
+	}
+	if string(bobBefore) != string(bobAfter) {
+		t.Error("AC-11: real second user's user.json must stay byte-identical")
+	}
+}
+
+// AC-12: AddSession/RemoveSession/HasSession/ClearSessions mit einer
+// Traversal-userId muessen jeweils einen Fehler liefern (HasSession:
+// (false, error)), ohne eine sessions.json ausserhalb des Nutzerbaums
+// zu hinterlassen.
+//
+// Heutiger Stand (RED): alle vier Methoden liefern nil/false ohne Fehler,
+// UND AddSession/ClearSessions schreiben tatsaechlich eine sessions.json
+// ausserhalb des Baums (Geschwister von "users").
+func TestPathTraversal_SessionMethods_RejectInvalidID_AC12(t *testing.T) {
+	tmpDir := t.TempDir()
+	s := New(tmpDir, "default")
+
+	if err := s.AddSession("../bob", "sess-attack-1"); err == nil {
+		t.Error("AC-12: AddSession(\"../bob\", ...) expected an error, got nil")
+	}
+	if err := s.RemoveSession("../bob", "sess-attack-1"); err == nil {
+		t.Error("AC-12: RemoveSession(\"../bob\", ...) expected an error, got nil")
+	}
+	has, err := s.HasSession("../bob", "sess-attack-1")
+	if err == nil {
+		t.Errorf("AC-12: HasSession(\"../bob\", ...) expected (false, error), got (%v, nil)", has)
+	}
+	if err := s.ClearSessions("../bob"); err == nil {
+		t.Error("AC-12: ClearSessions(\"../bob\") expected an error, got nil")
+	}
+
+	if outside := findFilesOutsideUsersTree(t, tmpDir, "sessions.json"); len(outside) > 0 {
+		t.Errorf("AC-12: found sessions.json outside data/users/: %v", outside)
+	}
+}
+
+// -----------------------------------------------------------------------
+// F001 (Fix-Loop #2140): Direkttests fuer die uebrigen Spec-Methoden
+// -----------------------------------------------------------------------
+
+// seedTraversalVictim baut den Aufbau, an dem sich eine fehlende Sperre
+// ZEIGT: einen realen Nutzer "bob" IM Nutzerbaum und daneben einen
+// vollstaendigen Opfer-Datensatz GENAU dort, wo UserDir("../bob") landet
+// (Geschwister von "users", siehe Methodik-Kommentar oben).
+//
+// Ohne diesen Opfer-Datensatz waeren die Lese- und Loeschmethoden nicht
+// pruefbar: sie liefern auf einem leeren Zielpfad auch ungeprueft klaglos
+// "nichts gefunden" — die Sperre koennte ersatzlos entfallen, ohne dass ein
+// Test es merkt.
+func seedTraversalVictim(t *testing.T) (*Store, string) {
+	t.Helper()
+	tmpDir := t.TempDir()
+	s := New(tmpDir, "default")
+
+	if err := s.SaveUser(model.User{ID: "bob", PasswordHash: "bobs-real-hash", CreatedAt: time.Now()}); err != nil {
+		t.Fatalf("SaveUser(bob): %v", err)
+	}
+
+	victim := s.UserDir("../bob")
+	if err := os.MkdirAll(victim, 0755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", victim, err)
+	}
+	files := map[string]any{
+		"user.json":               model.User{ID: "../bob", PasswordHash: "victim-hash", CreatedAt: time.Now()},
+		"password_reset.json":     model.PasswordResetToken{TokenHash: "victim-reset", ExpiresAt: time.Now().Add(time.Hour)},
+		"email_verification.json": model.EmailVerificationToken{TokenHash: "victim-verify", ExpiresAt: time.Now().Add(time.Hour)},
+		"sessions.json":           sessionFile{Sessions: []Session{{ID: "victim-sess", CreatedAt: time.Now()}}},
+	}
+	for name, v := range files {
+		data, err := json.Marshal(v)
+		if err != nil {
+			t.Fatalf("Marshal(%s): %v", name, err)
+		}
+		if err := os.WriteFile(filepath.Join(victim, name), data, 0644); err != nil {
+			t.Fatalf("WriteFile(%s): %v", name, err)
+		}
+	}
+	return s, victim
+}
+
+// mustRead liefert den Inhalt einer Opfer-Datei; fehlt sie, ist das ein
+// Testabbruch (der Aufbau haette sie angelegt).
+func mustRead(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", path, err)
+	}
+	return string(data)
+}
+
+// F001: Die Spec (Source-Sektion) nennt elf user.go-Methoden plus fuenf
+// Sessions-Einstiege. LoadUser/SaveUser/DeleteUser sind oben abgedeckt,
+// AddSession/RemoveSession/HasSession/ClearSessions in AC-12 — hier folgen
+// die uebrigen, damit KEINE der Sperren spurlos verschwinden kann.
+//
+// Je Methode wird beides geprueft: der Fehler (bzw. false bei UserExists)
+// UND die ausbleibende Wirkung auf den Opfer-Datensatz ausserhalb des
+// Nutzerbaums.
+func TestPathTraversal_RemainingUserMethods_RejectInvalidID_AC11(t *testing.T) {
+	const attack = "../bob"
+
+	t.Run("ProvisionUserDirs", func(t *testing.T) {
+		s, victim := seedTraversalVictim(t)
+		if err := s.ProvisionUserDirs(attack); err == nil {
+			t.Error("AC-11: ProvisionUserDirs(\"../bob\") expected an error, got nil")
+		}
+		for _, sub := range []string{"locations", "gpx", "weather_snapshots"} {
+			if _, err := os.Stat(filepath.Join(victim, sub)); err == nil {
+				t.Errorf("AC-11: ProvisionUserDirs must not create %q outside the users tree", sub)
+			}
+		}
+	})
+
+	t.Run("SaveResetToken", func(t *testing.T) {
+		s, victim := seedTraversalVictim(t)
+		before := mustRead(t, filepath.Join(victim, "password_reset.json"))
+		if err := s.SaveResetToken(attack, model.PasswordResetToken{TokenHash: "attacker", ExpiresAt: time.Now().Add(time.Hour)}); err == nil {
+			t.Error("AC-11: SaveResetToken(\"../bob\", ...) expected an error, got nil")
+		}
+		if after := mustRead(t, filepath.Join(victim, "password_reset.json")); before != after {
+			t.Error("AC-11: SaveResetToken must not overwrite a file outside the users tree")
+		}
+	})
+
+	t.Run("LoadResetToken", func(t *testing.T) {
+		s, _ := seedTraversalVictim(t)
+		token, err := s.LoadResetToken(attack)
+		if err == nil {
+			t.Error("AC-11: LoadResetToken(\"../bob\") expected an error, got nil")
+		}
+		if token != nil {
+			t.Errorf("AC-11: LoadResetToken must not read a token outside the users tree, got %+v", token)
+		}
+	})
+
+	t.Run("DeleteResetToken", func(t *testing.T) {
+		s, victim := seedTraversalVictim(t)
+		if err := s.DeleteResetToken(attack); err == nil {
+			t.Error("AC-11: DeleteResetToken(\"../bob\") expected an error, got nil")
+		}
+		if _, err := os.Stat(filepath.Join(victim, "password_reset.json")); err != nil {
+			t.Error("AC-11: DeleteResetToken must not remove a file outside the users tree")
+		}
+	})
+
+	t.Run("SaveVerificationToken", func(t *testing.T) {
+		s, victim := seedTraversalVictim(t)
+		before := mustRead(t, filepath.Join(victim, "email_verification.json"))
+		if err := s.SaveVerificationToken(attack, model.EmailVerificationToken{TokenHash: "attacker", ExpiresAt: time.Now().Add(time.Hour)}); err == nil {
+			t.Error("AC-11: SaveVerificationToken(\"../bob\", ...) expected an error, got nil")
+		}
+		if after := mustRead(t, filepath.Join(victim, "email_verification.json")); before != after {
+			t.Error("AC-11: SaveVerificationToken must not overwrite a file outside the users tree")
+		}
+	})
+
+	t.Run("LoadVerificationToken", func(t *testing.T) {
+		s, _ := seedTraversalVictim(t)
+		token, err := s.LoadVerificationToken(attack)
+		if err == nil {
+			t.Error("AC-11: LoadVerificationToken(\"../bob\") expected an error, got nil")
+		}
+		if token != nil {
+			t.Errorf("AC-11: LoadVerificationToken must not read a token outside the users tree, got %+v", token)
+		}
+	})
+
+	t.Run("DeleteVerificationToken", func(t *testing.T) {
+		s, victim := seedTraversalVictim(t)
+		if err := s.DeleteVerificationToken(attack); err == nil {
+			t.Error("AC-11: DeleteVerificationToken(\"../bob\") expected an error, got nil")
+		}
+		if _, err := os.Stat(filepath.Join(victim, "email_verification.json")); err != nil {
+			t.Error("AC-11: DeleteVerificationToken must not remove a file outside the users tree")
+		}
+	})
+
+	t.Run("UserExists", func(t *testing.T) {
+		s, _ := seedTraversalVictim(t)
+		// Am Zielpfad LIEGT eine user.json — ohne Sperre antwortet die
+		// Methode deshalb "ja, den gibt es".
+		if s.UserExists(attack) {
+			t.Error("AC-11: UserExists(\"../bob\") expected false, got true")
+		}
+	})
+
+	t.Run("LoadSessions", func(t *testing.T) {
+		s, _ := seedTraversalVictim(t)
+		sessions, err := s.LoadSessions(attack)
+		if err == nil {
+			t.Error("AC-12: LoadSessions(\"../bob\") expected an error, got nil")
+		}
+		if len(sessions) > 0 {
+			t.Errorf("AC-12: LoadSessions must not read a guest list outside the users tree, got %+v", sessions)
+		}
+	})
+}

--- a/internal/store/sessions.go
+++ b/internal/store/sessions.go
@@ -37,8 +37,15 @@ type sessionFile struct {
 	LegacyRevokedAt *time.Time `json:"legacy_revoked_at,omitempty"`
 }
 
-func (s *Store) sessionsPath(userId string) string {
-	return filepath.Join(s.UserDir(userId), "sessions.json")
+// sessionsPath ist die gemeinsame Engstelle aller fuenf Einstiege
+// (LoadSessions, HasSession, AddSession, RemoveSession, ClearSessions) — die
+// Pfad-Traversal-Sperre (Issue #2140) sitzt deshalb HIER einmal statt
+// fuenffach in den Methoden.
+func (s *Store) sessionsPath(userId string) (string, error) {
+	if !ValidUserID(userId) {
+		return "", ErrInvalidUserID
+	}
+	return filepath.Join(s.UserDir(userId), "sessions.json"), nil
 }
 
 // readSessionFile liest die Datei ohne Sperre. Eine FEHLENDE Datei ist der
@@ -47,7 +54,11 @@ func (s *Store) sessionsPath(userId string) string {
 // aussperren.
 func (s *Store) readSessionFile(userId string) (sessionFile, error) {
 	var f sessionFile
-	data, err := os.ReadFile(s.sessionsPath(userId))
+	path, err := s.sessionsPath(userId)
+	if err != nil {
+		return f, err
+	}
+	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return f, nil
@@ -61,6 +72,10 @@ func (s *Store) readSessionFile(userId string) (sessionFile, error) {
 }
 
 func (s *Store) writeSessionFile(userId string, f sessionFile) error {
+	path, err := s.sessionsPath(userId)
+	if err != nil {
+		return err
+	}
 	dir := s.UserDir(userId)
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return err
@@ -72,7 +87,7 @@ func (s *Store) writeSessionFile(userId string, f sessionFile) error {
 	if err != nil {
 		return err
 	}
-	return writeFileLogged(s.sessionsPath(userId), data)
+	return writeFileLogged(path, data)
 }
 
 // LoadSessions liefert die Gaesteliste eines Nutzers (leer, wenn keine da ist).
@@ -111,6 +126,10 @@ func (s *Store) RevokeLegacySessions(userId string) error {
 
 // HasSession beantwortet die Frage, an der die gesamte unbefristete Anmeldung
 // haengt: steht diese Anmelde-Kennung noch auf der Gaesteliste?
+//
+// Bei einer pfadunsicheren userId ist die Antwort (false, error), nicht
+// (false, nil) — der Aufrufer soll eine Traversal-Kennung nicht mit einer
+// schlicht abgemeldeten Sitzung verwechseln koennen (Issue #2140).
 func (s *Store) HasSession(userId, sessionId string) (bool, error) {
 	if userId == "" || sessionId == "" {
 		return false, nil

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -13,6 +13,11 @@ func New(dataDir, userID string) *Store {
 
 // WithUser returns a shallow copy of the Store with a different UserID.
 // Empty userId is a no-op: returns the original Store unchanged.
+//
+// Der leere String laeuft BEWUSST nicht ueber ValidUserID (Issue #2140): er
+// wuerde dort als "ungueltig" gelten, obwohl er hier seit jeher schlicht "kein
+// Wechsel" bedeutet. Die Pfadsicherheit haengt nicht an dieser Stelle, sondern
+// an den Store-Methoden, die aus einer Kennung einen Pfad bauen.
 func (s *Store) WithUser(userId string) *Store {
 	if userId == "" {
 		return s

--- a/internal/store/user.go
+++ b/internal/store/user.go
@@ -46,6 +46,9 @@ func (s *Store) UserDir(id string) string {
 }
 
 func (s *Store) LoadUser(id string) (*model.User, error) {
+	if !ValidUserID(id) {
+		return nil, ErrInvalidUserID
+	}
 	path := filepath.Join(s.UserDir(id), "user.json")
 
 	data, err := os.ReadFile(path)
@@ -65,6 +68,9 @@ func (s *Store) LoadUser(id string) (*model.User, error) {
 }
 
 func (s *Store) SaveUser(user model.User) error {
+	if !ValidUserID(user.ID) {
+		return ErrInvalidUserID
+	}
 	dir := s.UserDir(user.ID)
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return err
@@ -80,6 +86,9 @@ func (s *Store) SaveUser(user model.User) error {
 
 // ProvisionUserDirs creates the standard subdirectories for a new user.
 func (s *Store) ProvisionUserDirs(id string) error {
+	if !ValidUserID(id) {
+		return ErrInvalidUserID
+	}
 	base := s.UserDir(id)
 	for _, sub := range []string{"locations", "gpx", "weather_snapshots"} {
 		if err := os.MkdirAll(filepath.Join(base, sub), 0755); err != nil {
@@ -90,6 +99,9 @@ func (s *Store) ProvisionUserDirs(id string) error {
 }
 
 func (s *Store) SaveResetToken(userId string, token model.PasswordResetToken) error {
+	if !ValidUserID(userId) {
+		return ErrInvalidUserID
+	}
 	dir := s.UserDir(userId)
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return err
@@ -102,6 +114,9 @@ func (s *Store) SaveResetToken(userId string, token model.PasswordResetToken) er
 }
 
 func (s *Store) LoadResetToken(userId string) (*model.PasswordResetToken, error) {
+	if !ValidUserID(userId) {
+		return nil, ErrInvalidUserID
+	}
 	path := filepath.Join(s.UserDir(userId), "password_reset.json")
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -118,6 +133,9 @@ func (s *Store) LoadResetToken(userId string) (*model.PasswordResetToken, error)
 }
 
 func (s *Store) DeleteResetToken(userId string) error {
+	if !ValidUserID(userId) {
+		return ErrInvalidUserID
+	}
 	path := filepath.Join(s.UserDir(userId), "password_reset.json")
 	err := os.Remove(path)
 	if os.IsNotExist(err) {
@@ -131,6 +149,9 @@ func (s *Store) DeleteResetToken(userId string) error {
 // SaveResetToken. Overwrites an existing file without warning — a second
 // address change intentionally invalidates the first token (AC-7).
 func (s *Store) SaveVerificationToken(userId string, token model.EmailVerificationToken) error {
+	if !ValidUserID(userId) {
+		return ErrInvalidUserID
+	}
 	dir := s.UserDir(userId)
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return err
@@ -143,6 +164,9 @@ func (s *Store) SaveVerificationToken(userId string, token model.EmailVerificati
 }
 
 func (s *Store) LoadVerificationToken(userId string) (*model.EmailVerificationToken, error) {
+	if !ValidUserID(userId) {
+		return nil, ErrInvalidUserID
+	}
 	path := filepath.Join(s.UserDir(userId), "email_verification.json")
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -159,6 +183,9 @@ func (s *Store) LoadVerificationToken(userId string) (*model.EmailVerificationTo
 }
 
 func (s *Store) DeleteVerificationToken(userId string) error {
+	if !ValidUserID(userId) {
+		return ErrInvalidUserID
+	}
 	path := filepath.Join(s.UserDir(userId), "email_verification.json")
 	err := os.Remove(path)
 	if os.IsNotExist(err) {
@@ -167,12 +194,21 @@ func (s *Store) DeleteVerificationToken(userId string) error {
 	return err
 }
 
+// DeleteUser ist die schaerfste Stelle des Pfadbaus (os.RemoveAll): ohne die
+// Kennungspruefung wuerde eine Traversal-Kennung hier ein FREMDES Verzeichnis
+// loeschen.
 func (s *Store) DeleteUser(id string) error {
+	if !ValidUserID(id) {
+		return ErrInvalidUserID
+	}
 	dir := s.UserDir(id)
 	return os.RemoveAll(dir)
 }
 
 func (s *Store) UserExists(id string) bool {
+	if !ValidUserID(id) {
+		return false
+	}
 	path := filepath.Join(s.UserDir(id), "user.json")
 	_, err := os.Stat(path)
 	return err == nil

--- a/internal/store/valid_user_id_test.go
+++ b/internal/store/valid_user_id_test.go
@@ -1,0 +1,21 @@
+package store
+
+import "testing"
+
+// TDD RED — Issue #2140 Scheibe 1, AC-13. SPEC:
+// docs/specs/modules/fix_2140_pfad_traversal_nutzer_kennung.md
+//
+// Bewusst in einer EIGENEN Datei (siehe pathsafe_test.go, Kopf-Kommentar):
+// store.ValidUserID existiert noch nicht (pathsafe.go ist NEU laut Spec) —
+// dieser Test erzeugt heute einen Compile-Fehler fuer das gesamte Paket
+// "internal/store". Das ist das erwartete RED fuer AC-13; er wird getrennt
+// von pathsafe_test.go (AC-11/AC-12, rein verhaltensbasiert) ausgefuehrt,
+// damit deren Assertion-Fehlschläge sichtbar bleiben.
+func TestValidUserID_AcceptsExistingBestandUserIDs_AC13(t *testing.T) {
+	cases := []string{"default", "henning", "steffi", "validator-issue110"}
+	for _, id := range cases {
+		if !ValidUserID(id) {
+			t.Errorf("AC-13: ValidUserID(%q) expected true, got false", id)
+		}
+	}
+}

--- a/tests/unit/test_user_id_pattern_parity.py
+++ b/tests/unit/test_user_id_pattern_parity.py
@@ -2,10 +2,11 @@
 """user_id-Muster-Paritaet Python <-> Go (#1364).
 
 Das Zulassungsmuster fuer Nutzer-Kennungen existiert zweimal: in der
-Go-Registrierung (internal/handler/passkey.go, erzwingt es beim Anlegen)
-und im Python-Core (app.loader.VALID_USER_ID_RE, erzwingt es beim
-Pfadbau). Driften beide, sperrt Python real registrierte Nutzer aus oder
-laesst Kennungen durch, die Go nie vergeben haette.
+kanonischen Go-Quelle (internal/store/pathsafe.go, erzwingt es beim
+Anlegen UND beim Pfadbau — seit #2140; internal/handler/passkey.go haengt
+nur noch daran) und im Python-Core (app.loader.VALID_USER_ID_RE, erzwingt
+es beim Pfadbau). Driften beide, sperrt Python real registrierte Nutzer
+aus oder laesst Kennungen durch, die Go nie vergeben haette.
 
 Strukturregel auf Quelltext-als-Daten: das Go-Muster ist aus Python nur
 als Text erreichbar (kein Go-Toolchain-Aufruf im Kernlauf) — gleiche
@@ -20,16 +21,16 @@ from pathlib import Path
 from app.loader import VALID_USER_ID_RE
 
 _REPO = Path(__file__).resolve().parents[2]
-_PASSKEY_GO = _REPO / "internal" / "handler" / "passkey.go"
+_PASSKEY_GO = _REPO / "internal" / "store" / "pathsafe.go"
 
 
 def test_python_muster_ist_deckungsgleich_mit_go():
-    """Given das Go-Registrierungsmuster in passkey.go / When das Python-
+    """Given das kanonische Go-Muster in store/pathsafe.go / When das Python-
     Muster daneben gelegt wird / Then sind beide identisch (#1364:
     'beide Stellen gehoeren zusammen')."""
     go_src = _PASSKEY_GO.read_text(encoding="utf-8")
     m = re.search(
-        r"validUsernameRe\s*=\s*regexp\.MustCompile\(`([^`]+)`\)", go_src
+        r"ValidUserIDRe\s*=\s*regexp\.MustCompile\(`([^`]+)`\)", go_src
     )
-    assert m, "validUsernameRe nicht in passkey.go gefunden — Muster verschoben?"
+    assert m, "ValidUserIDRe nicht in pathsafe.go gefunden — Muster verschoben?"
     assert VALID_USER_ID_RE.pattern == m.group(1)


### PR DESCRIPTION
Die vier oeffentlichen Auth-Routen (Login, Forgot, Reset, Verify-Email) haben
die vom Client gesetzte Kennung ungeprueft in Dateipfade gebaut. Eine Nutzlast
wie "../users/bob" uebernahm real das Konto eines zweiten Nutzers: Login gab
Session statt 401, Passwort-Reset aenderte Bobs echten Hash, Verify-Email setzte
dessen EmailVerifiedAt. Zusaetzlich war ein Ausbruch aus dem Nutzerbaum moeglich.

Jede Kennung laeuft jetzt vor dem Pfadbau ueber store.ValidUserID; ungueltige
Kennungen beantworten die Routen identisch zu "Nutzer existiert nicht" (keine
Unterscheidbarkeit) und erzeugen einen routen-identifizierenden Log-Eintrag.
Der Guard sitzt zusaetzlich direkt in den Store-Methoden, die aus einer Kennung
einen Pfad bilden — die Zusicherung wirkt dort, wo der Pfad entsteht.

Nachweis: 15 ACs, RED-Artefakt mit 12 Fehlschlaegen vor dem Fix, Zwei-Nutzer-
Nachweis (AC-10) auf Inhalt und mtime. Adversary VERIFIED nach zwei Runden;
16 Einzel-Mutationen, jede von einem Test gefangen.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CwoKYqHVkhLJZdfAftgdQ6
