### PR TITLE
feat(#2126): Ad-hoc-Antwort geht nur noch an den anfragenden Kanal

### DIFF
--- a/docs/context/feat-2126-kanaltreue-adhoc-antwort.md
+++ b/docs/context/feat-2126-kanaltreue-adhoc-antwort.md
@@ -1,0 +1,403 @@
+# Context: feat-2126-kanaltreue-adhoc-antwort
+
+**Issue:** #2126 — Ad-hoc-Anfrage soll nur auf dem Eingangsweg beantwortet werden
+**Epic:** #2133 „Ad-hoc-Abruf so reich wie das Briefing", Scheibe **S3**
+**Erstellt:** 2026-09-06 · **Track:** Full Process
+**Basis:** `origin/main` @ `366ec4de` (enthält den #2134-Katalog-Umbau an `_trigger_on_demand`)
+
+## Request Summary
+
+Eine Ad-hoc-Anfrage (`heute` / `morgen`) soll auf dem Weg beantwortet werden, über den sie
+gestellt wurde — und nur dort. Zweiter, vom PO nachgereichter Teil: sie soll auch **an den
+tatsächlichen Absender** gehen, nicht an eine fest hinterlegte Adresse. Kanaltreue heißt
+zweierlei: richtiger **Weg** und richtige **Adresse**.
+
+## Ist-Stand — was die Bestandserhebung ergeben hat
+
+### A) Der Weg: die Herkunftskennung existiert bereits und bricht an EINER Stelle ab
+
+`InboundMessage.channel` (`src/services/trip_command_processor.py:61`) trägt den Eingangsweg und
+wird von beiden Readern korrekt gesetzt. Im Prozessor ist sie sogar in aktivem Gebrauch — die
+Drilldown-Zweige reichen `msg.channel` durch (`:585`, `:607`) und steuern damit die
+Emoji-Darstellung (`with_emoji = channel == "telegram"`, `:883`, `:982`, `:1008`).
+
+**Der Abbruch ist eine einzige Zeile:** `:627` ruft `_handle_query(trip, actual_query_key,
+msg.received_at, msg.user_id)` — ohne `msg.channel`, im Unterschied zu den unmittelbaren
+Nachbarzeilen. Von dort fehlt die Information die gesamte Kette hinunter:
+
+```
+trip_command_processor.py:627   _handle_query(...)                     ← channel fällt hier weg
+  :736  _handle_query(self, trip, query_key, received_at, user_id)
+  :759-762  Zweige heute/morgen
+  :826  _trigger_on_demand(self, trip, report_type, label, user_id)    ← kein channel
+  :845  TripReportSchedulerService(user_id=...).send_on_demand_report(trip, report_type)
+trip_report_scheduler.py
+  :1095 send_on_demand_report(self, trip, report_type) -> OnDemandErgebnis
+  :1132 _send_trip_report_outcome(..., on_demand=True, angefordert=True, target_date=zieltag)
+  :1166 _send_trip_report_outcome(self, trip, report_type, allow_test_fallback=False,
+                                  on_demand=False, catchup_prefix=None,
+                                  angefordert=False, target_date=None) -> str
+  :1484 _build_trip_report_request(...)
+  :1743-1752  ← HIER fallen die vier Kanal-Flags
+notification_service.py
+  :448  send_trip_report(request)   → :552-666 tatsächlicher Versand je Kanal
+```
+
+Die Kanal-Auflösung selbst (wortgleich an **zwei** Stellen: `:1743-1752` Haupt-Request,
+`:1371-1379` No-Data-Hint-Zweig):
+
+```python
+send_email       = not config or config.send_email
+send_sms         = config is not None and config.send_sms and sms_allowed(self._user_id)
+send_premium_sms = config is not None and config.send_premium_sms and premium_sms_allowed(...)
+send_telegram    = config is not None and config.send_telegram
+```
+
+### B) Es gibt nur ZWEI Eingangswege, nicht vier
+
+| Weg | Ist er ein Befehlskanal? | Beleg |
+|---|---|---|
+| **E-Mail** | ✅ ja | `inbound_email_reader.py:144-154` baut `InboundMessage(channel="email", …)` → `process()` |
+| **Telegram** | ✅ ja | `inbound_telegram_reader.py:229-236` (Poll + Webhook laufen durch dasselbe `_process_update`), Callback-Query-Pfad `:325-332` |
+| **SMS (regulär)** | ❌ **existiert nicht** | `channel="sms"` kommt in keinem `InboundMessage(...)`-Aufruf in `src/`+`api/` vor |
+| **Premium-SMS (Garmin)** | ❌ **nur Adress-Lerner** | `inbound_sms_reader.py:162-171`: erkennt den `inreachlink.com`-Marker, meldet **nur die Absendernummer** an `POST /api/internal/premium-sms-learn`; der Nachrichtentext wird verworfen, es entsteht nie ein `InboundMessage` |
+
+Das Ticket formuliert AC-2 als „analog für SMS und Premium-SMS". Für zwei der vier genannten
+Wege beschreibt das einen Fall, den es heute nicht gibt. Premium-SMS als Eingangsweg ist
+**Scheibe S4** des Epics und hängt ausdrücklich von S3 ab („sonst kostet jede Satellitenfrage
+vier Antworten").
+
+### C) Alle anderen Befehle sind längst kanaltreu
+
+`ruhetag`, `abbruch`, `pause`, `status`, `hilfe` usw. geben ihre Bestätigung über
+`CommandResult.confirmation_body` zurück, die der jeweilige Reader auf seinem eigenen Draht
+verschickt. Kanaltreue entsteht dort durch die Architektur (getrennte Reader, getrennter
+Rückweg). Betroffen ist **ausschliesslich** der `heute`/`morgen`-Vollbriefing-Pfad, der den
+regulären Versand-Fan-out benutzt.
+
+### D) Planmässig vs. angefordert: zwei Flags, aber ohne Wirkung auf die Kanalwahl
+
+`on_demand` und `angefordert` kommen bis zur Auflösungsstelle durch, haben aber bewusst
+verschiedene Bedeutung (Docstring `trip_report_scheduler.py:1186-1214`): `on_demand` hat sieben
+andere Wirkstellen, `angefordert` fliesst **nur** in `briefing_log.json`. Die Formel
+`:1743-1752` fragt **keines von beiden** ab. Es gibt heute also keinen Unterschied in der
+Kanalwahl zwischen Slot-Briefing und Ad-hoc-Abruf.
+
+Durch dieselbe Kette laufen ausserdem: Test-Versand (`send_test_report_outcome`) und das
+`report`-Kommando (`_trigger_report`). Alarme laufen **separat**
+(`notification_service.py::send_official_alert` / `_dispatch_alert_message`, eigene
+Vier-Kanal-Auflösung) und sind nicht Teil dieser Kette.
+
+### E) Deaktivierter Kanal: heute keine stille Lücke, sondern eine stille UMLEITUNG
+
+- **Alle vier deaktiviert** → `no_channel_configured=True` (`notification_service.py:533-540`)
+  → `"no_channels"` → `_on_demand_failure_body` (`trip_command_processor.py:465-469`) liefert
+  eine explizite Fehlermeldung. Sauber.
+- **Nur der anfragende Draht deaktiviert** (der eigentliche #2126-Fall) → das System sendet über
+  die anderen aktiven Kanäle und meldet Erfolg. Der Fragende bekommt auf seinem Draht nichts vom
+  Briefing zu sehen. Das ist AC-4 des Tickets — und die heutige Antwort darauf ist nicht
+  „stiller Nichtversand", sondern eine **stille Umleitung mit Erfolgsmeldung**.
+
+### F) Die Adresse: Behauptung bestätigt, aber die Wirkung ist eine andere als gedacht
+
+**Bestätigt:**
+- `send_command_reply_email` (`notification_service.py:1795-1807`) ruft `EmailOutput.send()`
+  **ohne** `to=`, obwohl der Parameter existiert (`email.py:607-617`) → Rückfall auf
+  `settings.mail_to` (`email.py:647-650`).
+- `send_command_reply_telegram(result, chat_id, settings)` (`:1809-1826`) benutzt `chat_id`
+  **nur im Fehler-Log** (`:1825`). `TelegramOutput.send()` (`telegram.py:379-382`) hat dafür
+  überhaupt keinen Parameter — der Chat kommt immer aus `self._settings.telegram_chat_id`
+  (`telegram.py:403`). Dasselbe Muster in `send_telegram_message` (`:1828-1845`) und
+  `edit_telegram_message_text` (`:1847-1868`).
+
+**Wichtige Korrektur an der Ticket-Prämisse:** Die Begründung „fällt heute nicht auf, weil es
+dieselbe Person ist" ist zu schwach — es ist kein Zufall, sondern Konstruktion. Beide Reader
+lösen vor der Antwort `user_settings = base_settings.with_user_profile(user_id)` auf, und
+`user_id` wird per `lookup_user_by_telegram_chat_id` / `lookup_user_by_email`
+(`app/loader.py:1220-1264`) **exakt über den Treffer auf `telegram_chat_id` / `mail_to` im
+Profil** gefunden. Für einen erkannten Nutzer ist die hinterlegte Adresse per Konstruktion
+identisch mit der Absenderadresse — auch bei vielen Nutzern.
+
+**Sichtbar wird der Defekt nur, wenn kein Profil-Treffer existiert** (`user_id == "default"`):
+Der Registrierungshinweis an eine unbekannte Telegram-`chat_id`
+(`inbound_telegram_reader.py:181-194`, `:305-317`) geht an den `telegram_chat_id` des
+Default-/Betreiberprofils statt an den fremden Chat, der gerade geschrieben hat. Analog
+„Trip nicht gefunden" per E-Mail (`inbound_email_reader.py:106`, `:121-132`).
+
+**Empfänger-Override ist strukturell nur bei E-Mail möglich:**
+
+| Kanal | Signatur | Empfänger-Parameter | Ohne Parameter |
+|---|---|---|---|
+| E-Mail | `EmailOutput.send(subject, body, html=True, plain_text_body=None, to=None, …)` (`email.py:607`) | ✅ `to` | `settings.mail_to` |
+| Telegram | `TelegramOutput.send(subject, body, reply_markup=None, *, parse_mode=None, suppress_subject_line=False)` (`telegram.py:379`) | ❌ | `settings.telegram_chat_id` |
+| SMS | `SevenIoChannelBase.send(subject, body)` (`seven_io_base.py:155`) | ❌ | `settings.sms_to` (`sms.py:41-42`) |
+| Premium-SMS | dieselbe Signatur, `PremiumSmsOutput` | ❌ | `settings.premium_sms_reply_to` (`premium_sms.py:64-73`, inkl. 30-Tage-TTL) |
+
+Es gibt **kein** `send_command_reply_sms` / `send_command_reply_premium_sms` — nur E-Mail und
+Telegram haben Kommando-Antwortfunktionen.
+
+Alle vier Empfängerfelder sind pro Nutzer über `Settings.with_user_profile(user_id)`
+(`app/config.py:355-405`) überschreibbar; Infrastruktur (SMTP-Host, Bot-Token) bleibt global.
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `src/services/trip_command_processor.py` | `InboundMessage` (`:56-63`), `process` (`:545`), Abbruchzeile `:627`, `_handle_query` (`:736`), `_trigger_on_demand` (`:826`), `_on_demand_failure_body` (`:465`) |
+| `src/services/trip_report_scheduler.py` | `send_on_demand_report` (`:1095`), `_send_trip_report_outcome` (`:1166`), `_build_trip_report_request` (`:1484`), Kanal-Auflösung (`:1743-1752`, `:1371-1379`), `_append_briefing_log` (`:1931`) |
+| `src/services/notification_service.py` | `send_trip_report` (`:448`), Versand je Kanal (`:552-666`), `send_command_reply_email` (`:1795`), `send_command_reply_telegram` (`:1809`) |
+| `src/services/inbound_email_reader.py` | `_process_single` (`:94-162`), `_authorize` (`:188-202`), Default-Fall (`:106`, `:121-132`) |
+| `src/services/inbound_telegram_reader.py` | `_process_update` (`:151-284`), Callback-Pfad (`:325-332`), Unbekannt-Chat-Hinweis (`:181-194`, `:305-317`) |
+| `src/services/inbound_sms_reader.py` | Premium-SMS-Adress-Lerner (`:162-171`) — belegt, dass dieser Weg kein Befehlskanal ist |
+| `src/output/channels/email.py` | `send(..., to=None, …)` (`:607`), Rückfall (`:647-650`) |
+| `src/output/channels/telegram.py` | `send()` ohne chat_id-Parameter (`:379-382`), Chat aus Settings (`:403`) |
+| `src/output/channels/sms.py`, `premium_sms.py`, `seven_io_base.py` | `_resolve_recipient()`, kein Override |
+| `src/app/config.py` | `with_user_profile` (`:355-405`), `can_send_*` (`:305`, `:407`, `:424`) |
+| `src/app/loader.py` | `lookup_user_by_email` / `lookup_user_by_telegram_chat_id` (`:1220-1264`) |
+| `src/services/user_tier.py` | `sms_allowed` (`:9-20`), `premium_sms_allowed` (`:23-42`), beide fail-closed |
+
+## Existing Patterns
+
+- **Herkunftskennung wird bereits durchgereicht** — die Drilldown-Zweige (`:585`, `:607`) sind
+  das vorhandene Muster; `_handle_query` ist die Ausnahme, nicht die Regel. Die Änderung folgt
+  einem Bestandsmuster, sie erfindet keines.
+- **Zwei Wirkflags nebeneinander** (`on_demand`, `angefordert`) mit bewusst getrennter
+  Bedeutung — das Projekt trennt Anlass-Flags schon heute, statt eines zu überladen.
+- **Fail-closed bei Berechtigungen** (`user_tier.py`) — fehlende/kaputte `user.json` heisst
+  „nicht erlaubt", nicht „erlaubt".
+- **Empfänger pro Nutzer über `with_user_profile`**, Infrastruktur global.
+
+## Dependencies
+
+- **Upstream (was wir benutzen):** `InboundMessage.channel`, `Settings.with_user_profile`,
+  `report_config`-Flags, `sms_allowed`/`premium_sms_allowed`.
+- **Downstream (was auf uns aufbaut):** `briefing_log.channels` — geschrieben in
+  `_append_briefing_log` (`:1931`) aus `result.sent_channels`, nur im Erfolgsfall
+  (`:1619-1622`); Kanal-Bezeichner sind die String-Literale `"email"` (`notification_service.py:555`),
+  `"sms"` (`:584`), `"premium_sms"` (`:602`), `"telegram"` (`:625`/`:662`). Gelesen von Go
+  (`GET /api/cockpit/status` → Cockpit-Kachel „Was geht heute raus", #393) und von
+  `briefing_slots._log_bezeugt_versand` (überspringt `angefordert=True`, AC-12).
+- **Epic-Abhängigkeit:** Scheibe **S4** (Premium-SMS erreicht den Kommandoverarbeiter) baut
+  ausdrücklich auf dieser Scheibe auf.
+
+## Existing Specs
+
+| Spec | Inhalt |
+|---|---|
+| `docs/specs/modules/inbound_command_channels.md:90` | Design-Prinzip „Antwort auf gleichem Kanal" — auf **Kanal**-Ebene, ohne Aussage zur Adresse |
+| `docs/specs/modules/trip_command_processor.md:65` | Prozessor „ist für den Antwort-Kanal verantwortlich" (Kanalwahl, nicht Adresswahl) |
+| `docs/specs/modules/telegram_webhook_inbound.md:85,116` | „Antwort an Nutzer via bestehender TelegramOutput-Pfad" |
+| `docs/specs/modules/feat_2134_adhoc_abruf_metrik_katalog.md:254-257` | Grenzt Kanaltreue ausdrücklich als S3/#2126 ab |
+
+Keine Spec formuliert bisher „die Antwort geht an dieselbe Adresse, von der die Anfrage kam" als
+geprüfte Zusicherung. `docs/adr/` enthält nichts zu Antwortadressen (ADR-0049 führt Premium-SMS
+als vierten Kanal ein, ohne Bezug hierzu).
+
+## Test-Ist-Stand: nichts bewacht die Zusicherung
+
+- **Kein** Test prüft, dass eine `heute`/`morgen`-Anfrage nur auf dem anfragenden Kanal
+  beantwortet wird. Konsistent damit, dass die Information den Versand nie erreicht — es gibt
+  heute nichts zu bewachen.
+- **Kein** Kern-Test prüft den tatsächlichen Empfänger einer Kommando-Antwort (kein `To:`-Header,
+  keine `chat_id` im Telegram-Payload, keine SMS-Zielnummer).
+- `tests/tdd/test_issue_1009_1019_inbound_robustness.py:458-487` (live, `GZ_TELEGRAM_LIVE=1`)
+  prüft nur, dass `"/start"` **im Text** vorkommt — er würde den Adress-Defekt nicht fangen,
+  weil im Live-Aufbau `settings.telegram_chat_id` zufällig mit der Test-Chat-ID übereinstimmt.
+- Nachbartests ohne Kanalprüfung: `test_send_idempotenz_lock.py`,
+  `test_briefing_slot_idempotenz.py`, `test_adhoc_abruf_am_telegram_draht.py` (Kommando-Erkennung),
+  `test_issue_1069_tier_channel_gating.py` (Tier-Gating, unabhängig vom Anfrageweg).
+
+### Wächter, der bei Signaturänderungen zu beachten ist
+
+`tests/test_success_status_guard.py` führt eine Registry mit Schlüsseln
+`"<datei>::<funktion>::<index>"` — **namensbasiert über einen AST-Scanner, nicht
+zeilennummernbasiert**. Relevant: `"…trip_command_processor.py::_trigger_on_demand": 1`
+(`:1866`) und `"…::_handle_query": 4` (`:1882`). Ein zusätzlicher `channel`-Parameter bricht den
+Wächter **nicht**. Er bricht, wenn (a) `_trigger_on_demand` umbenannt oder aufgespalten wird
+oder (b) `success` künftig tatsächlich vom `outcome` abhängt — dann ist die Registry bewusst zu
+pflegen (Kopfkommentar `:1966f`: „Erwartung wird zur Behebung NICHT gekürzt").
+
+## Risks & Considerations
+
+1. **Geteilte Auflösungsstelle — AC-3 ist das eigentliche Risiko.** Wer bei `:1743-1752`
+   filtert, ohne den Anlass sauber zu unterscheiden, beschneidet auch planmässige Briefings,
+   Test-Versand und das `report`-Kommando. Das Duplikat bei `:1371-1379` darf dabei nicht
+   vergessen werden.
+2. **Zwei wortgleiche Vorkommen der Formel** — eine Änderung an nur einer Stelle erzeugt genau
+   die Art von halbem Fix, die grün aussieht.
+3. **AC-2 ist für die Hälfte der genannten Wege heute unerfüllbar** (kein SMS-Befehlskanal,
+   Premium-SMS verwirft den Text). Die Spec muss das ausdrücklich abgrenzen, statt eine
+   unerfüllbare Zusicherung zu formulieren.
+4. **AC-4 braucht eine Produktentscheidung**, keine technische: Fragt jemand über einen Draht,
+   der im Trip deaktiviert ist — antworten oder ablehnen? Heute wird still umgeleitet und Erfolg
+   gemeldet.
+5. **Adress-Teil: Telegram/SMS/Premium-SMS haben keinen Empfänger-Parameter.** Der Empfänger
+   steckt im `Settings`-Objekt. Eine Adress-Zusicherung ist entweder über
+   `with_user_profile`-Auflösung zu bewachen (was heute schon korrekt ist) oder erfordert einen
+   Eingriff in die Kanal-Signaturen. Das ist eine echte Zuschnitt-Entscheidung für die Analyse.
+6. **Mutations-Gegenprobe muss an der WIRKSTELLE ansetzen.** Ein Test, der nur prüft, dass
+   `channel` im `InboundMessage` steht (wie `test_inbound_telegram_reader.py:217`), bewacht
+   nichts — die Zusicherung wirkt erst an der Kanal-Auflösung bzw. an
+   `briefing_log.channels` / `result.sent_channels`.
+7. **Nebenbefund aus #2124 nicht vorschnell zuordnen.** Am 30.08. buchte ein On-Demand-Versand
+   um 19:33:23 UTC nur `["email"]`, ein zweiter um 19:34:57 alle vier. Das fiel in das Zeitfenster
+   des nginx-60-Sekunden-Abbruchs (#2124) und könnte der GUI-„senden"-Pfad gewesen sein, nicht
+   der Ad-hoc-Abruf. Vor jeder Erklärung ist zu messen, welcher Pfad diese Einträge erzeugte —
+   sonst wird eine Kanaleinschränkung auf eine bereits anderweitig erklärte Ursache gebaut.
+8. **Mandantentrennung:** `send_on_demand_report` läuft über
+   `TripReportSchedulerService(user_id=user_id)`; jeder neue datenbewegende Pfad ist mit **zwei
+   verschiedenen Nutzern** zu testen.
+9. **Referenzfeger nach Signaturänderung** (Hinweis der Parallelsitzung): nach jeder
+   Signaturänderung `grep -rln "<funktionsname>" tests/ src/` — Signatur-Wächter liegen
+   regelmässig in fremden Testdateien. Werden zusätzliche Abrufe eingebaut statt nur die Signatur
+   erweitert, schlägt dieser Feger nicht an; dann nach dem Naht-Namen fegen.
+
+## Offene Fragen für die Analyse-Phase
+
+- **Zuschnitt Weg vs. Adresse:** Beide Teile in eine Scheibe, oder Adresse getrennt? Der
+  Adressteil ist heute für erkannte Nutzer *funktional korrekt* und nur *unbewacht* — der Weg-Teil
+  ist funktional falsch.
+- **AC-4-Verhalten** (antworten vs. ablehnen bei deaktiviertem Anfrage-Draht).
+- **Unbekannter Absender** (`user_id == "default"`): Antwort an den Fragenden ist heute nicht
+  möglich und geht an den Betreiber. Reparieren oder ausdrücklich ausgrenzen?
+- **Wo greift die Einschränkung?** Am Request-Aufbau (`_build_trip_report_request`) oder als
+  eigener Parameter durch die Kette — und wie bleibt die Wirkung für Slot-Briefings garantiert
+  unverändert.
+
+*(Alle vier Fragen sind im Abschnitt `## Analysis` beantwortet.)*
+
+---
+
+## Analysis
+
+### Type
+
+**Feature.** Kein Bugfix: Das heutige Verhalten war nie anders spezifiziert. Die Spec
+`inbound_command_channels.md:90-91` formuliert das Prinzip „Antwort auf gleichem Kanal" zwar
+bereits — aber ausdrücklich für `CommandResult.confirmation_body`, den kurzen Bestätigungstext,
+den der Reader selbst verschickt. Der `heute`/`morgen`-Pfad entzieht sich dem, weil er nicht über
+`confirmation_body` antwortet, sondern den regulären Briefing-Versand auslöst. **#2126 erfindet
+keine neue Regel, sondern zieht den einen Pfad nach, der sich der bereits dokumentierten Regel
+entzieht.**
+
+### Technical Approach (Entscheidung)
+
+**Wirkort und Transportweg sind zu trennen.**
+
+1. **Wirkort — eine neue Hilfsfunktion, die das bestehende Duplikat beseitigt.** Die vier
+   Kanal-Flags werden heute an zwei wortgleichen Stellen berechnet (`trip_report_scheduler.py:1743-1752`
+   Hauptpfad, `:1371-1379` No-Data-Hint-Zweig). Beide ziehen in
+   `_resolve_channel_flags(config, user_id, restrict_to_channel=None)`. Die Einschränkung greift
+   dort, **wo die Flags entstehen**, nicht wo sie verbraucht werden. `NotificationService` bleibt
+   unverändert — es kennt „Kanaltreue" nicht, es bekommt bereits korrekte Flags.
+2. **Transportweg — rein additive, keyword-only Parameter mit Default `None`.**
+   `_handle_query` → `_trigger_on_demand` → `send_on_demand_report` → `_send_trip_report_outcome`
+   → `_build_trip_report_request`. `None` ist das neutrale Element: exakt die alte Formel.
+   **Ein Default auf einen Kanalnamen scheidet aus** — er würde für jeden Aufrufer, der nichts
+   angibt, still eine Einschränkung erzeugen, also genau den Fehler bauen, den wir beheben.
+3. **Der Parameter bleibt optional, er wird NICHT zur Pflicht.** `send_on_demand_report` hat einen
+   produktiven Aufrufer und **neun** in Tests (`test_timeline_folgt_der_ortszeit.py:821`,
+   `test_send_idempotenz_lock.py:410,415,458`, `test_issue_1087_trip_official_alerts.py:236`,
+   `test_briefing_slot_idempotenz.py:970,991,1112`, `test_official_alert_time_window.py:347`).
+   Ein Pflichtparameter zwänge neun Testdateien, die Idempotenz-Sperren, Alarm-Zeitfenster und
+   Zeitachse prüfen, zu einer Kanalangabe, die dort nichts bedeutet — Lärm statt Explizitheit.
+
+**AC-4-Bypass: die Richtung ist der kritische Punkt.** Für den anfragenden Kanal muss die
+Einschränkung die **Trip-Konfiguration überschreiben** (`send_X = True`, wenn `X` der anfragende
+Kanal ist), nicht zusätzlich UND-verknüpfen. Andernfalls kippt AC-4 von „stille Umleitung" auf
+„stilles Nichts" — schlechter als heute. Die Tier-Gates (`sms_allowed`, `premium_sms_allowed`)
+werden dabei **nicht** übersprungen: überschrieben wird die Trip-Einstellung, nicht die
+Berechtigung. In dieser Scheibe ist das ohnehin gegenstandslos, weil nur E-Mail und Telegram
+`_handle_query` erreichen können.
+
+### Affected Files
+
+| Datei | Change | Beschreibung |
+|---|---|---|
+| `src/services/trip_command_processor.py` | MODIFY | `msg.channel` bei `:627` mitgeben; `_handle_query` (`:736`) und `_trigger_on_demand` (`:826`) nehmen den Kanal entgegen und reichen ihn an `send_on_demand_report` |
+| `src/services/trip_report_scheduler.py` | MODIFY | neue `_resolve_channel_flags(...)`; beide Formelstellen (`:1743-1752`, `:1371-1379`) darauf umstellen; keyword-only Parameter durch `send_on_demand_report` (`:1095`), `_send_trip_report_outcome` (`:1166`), `_build_trip_report_request` (`:1687`) |
+| `src/services/notification_service.py` | — | **keine Änderung**; `TripReportRequest` (`:60-124`) bekommt kein neues Feld |
+| `tests/tdd/test_adhoc_antwort_kanaltreue.py` | CREATE | neue Testdatei, nach Verhalten benannt |
+| `docs/specs/modules/inbound_command_channels.md` | MODIFY | Prinzip „Antwort auf gleichem Kanal" auf den angeforderten Briefing-Pfad ausweiten |
+| `docs/specs/modules/feat_2126_kanaltreue_adhoc_antwort.md` | CREATE | Spec dieser Scheibe |
+
+Nicht betroffen (belegt): Go (`internal/store/log.go:24`, `cockpit.go:21`, `briefing_history.go:25`
+lesen `briefing_log` nur), Frontend, Alarme (`_effective_alert_channels`,
+`trip_alert.py:2871-2925`, eigene Auflösung ohne `TripReportRequest`),
+`test_issue_1069_tier_channel_gating.py` (liest die vier bestehenden Flags, setzt den neuen
+Parameter nicht).
+
+### Scope Assessment
+
+- **Dateien:** 4 Code/Test + 2 Doku
+- **Geschätzte LoC:** Produktivcode +55 bis +85, Tests +120 bis +180 → **~180-265**
+- **LoC-Limit:** 250. Wird voraussichtlich gerissen → `workflow.py set-field loc_limit_override 500`
+  setzen, sobald `status` es zeigt, statt am Ende Tests zu kürzen.
+- **Risk Level: MEDIUM.** Additive Signaturen, ein einziger Wirkort, Alarme und Go unberührt —
+  aber vier Versandpfade teilen sich diesen Wirkort, und der Fehler wäre unsichtbar (zu wenige
+  Kanäle beim planmässigen Briefing merkt niemand sofort).
+
+### Dependencies
+
+- **Aufwärts:** `InboundMessage.channel`, `report_config`, `sms_allowed`/`premium_sms_allowed`,
+  `Settings.with_user_profile`.
+- **Abwärts:** `briefing_log.channels` (Go liest es für die Cockpit-Kachel „Was geht heute raus")
+  — nach der Änderung stehen bei **angeforderten** Briefings weniger Kanäle drin. Das ist die
+  gewollte Wirkung und zugleich der beste Messpunkt für einen Test ohne Stellvertreter.
+- **Epic:** Scheibe **S4** (Premium-SMS erreicht den Kommandoverarbeiter) baut hierauf auf.
+
+### Zuschnitt-Entscheidung: Weg und Adresse trennen
+
+Teil B des Tickets zerfällt in zwei verschiedene Fälle, die nicht denselben Pfad betreffen:
+
+| Fall | Stand | Zuordnung |
+|---|---|---|
+| **Erkannter Nutzer** | funktional korrekt (`with_user_profile` setzt `mail_to`/`telegram_chat_id` aus genau dem Profil, das über die Absenderadresse gefunden wurde), aber **unbewacht** | **in dieser Scheibe** — als reiner Regressionstest, kein Produktivcode, kein Risiko |
+| **Unbekannter Absender** (`user_id == "default"`) | **kaputt**: Registrierungshinweis geht an die Betreiber-Adresse statt an den Fragenden | **eigenes Issue** — anderer Pfad (`inbound_telegram_reader.py:181-194`, `:305-317`; `inbound_email_reader.py:106`, `:121-132`), erreicht den Report-Versand nie |
+
+Nebenbefund-Triage: Der zweite Fall ist nutzersichtbares Fehlverhalten (Kriterium a) und
+verdient nach Projektregel ein eigenes Issue statt einer Sammel-Zeile.
+
+### Zwei Mutationen, an denen sich die Gegenprobe messen muss
+
+1. **Halber Fix am Duplikat.** Einschränkung nur an `:1743-1752` anwenden, den
+   `send_no_data_hint`-Zweig `:1371-1379` vergessen. Fängt **nur** ein Test, der einen
+   On-Demand-Abruf mit vollständigem Wetterausfall **und** gesetztem Kanal auslöst. Ein Test, der
+   nur den Erfolgspfad abdeckt, bleibt grün.
+2. **Bypass-Richtung verdreht.** Das Override (`send_telegram = True`, wenn der Anfrageweg
+   Telegram ist) zurück zu einem UND mit `config.send_telegram` drehen. Fängt **nur** ein Test,
+   dessen Trip-Fixture den anfragenden Kanal **explizit deaktiviert** hat. Standard-Fixtures mit
+   allen Kanälen aktiv fangen das nicht.
+
+Beide zwingen die RED-Phase zu mindestens zwei Fällen jenseits des Happy Path.
+
+### Weitere Risiken
+
+- **Nachweis am Draht, nicht am Literal.** Ein Test, der `send_on_demand_report(channel="telegram")`
+  direkt aufruft, bewacht die Verdrahtung **nicht** — die Bildungsstelle ist `msg.channel` im
+  `InboundMessage`. Der Nachweis muss bei `TripCommandProcessor.process(InboundMessage(channel=…))`
+  beginnen und am tatsächlichen Versand bzw. an `briefing_log.channels` enden.
+- **Referenzfeger nach der Signaturänderung** ist Pflicht: `grep -rln` über `tests/` und `src/`.
+  Rund 24 fremde Testdateien rufen `_send_trip_report_outcome`/`_build_trip_report_request`
+  direkt auf, mehrere als **Unterklasse, die die Methode überschreibt**. Die Einschätzung, dass
+  keyword-only + Default `None` sie alle unberührt lässt, ist aus Zweck-Lektüre abgeleitet und
+  **nicht gemessen** — in `/40-tdd-red` ist ein vollständiger Lauf über diese Dateien zu fahren.
+- **Zwei Nutzer testen** (Mandantentrennung): `send_on_demand_report` läuft über
+  `TripReportSchedulerService(user_id=…)`.
+- **Nebenbefund #2124 nicht vorschnell zuordnen** (siehe Risiko 7 oben) — der `["email"]`-Eintrag
+  vom 30.08. fiel in das nginx-Abbruchfenster und war womöglich der GUI-„senden"-Pfad.
+
+### Open Questions
+
+- [ ] **AC-4 — Produktentscheidung für den PO:** Fragt jemand über einen Kanal, der im Trip
+      deaktiviert ist — antworten oder ablehnen? Empfehlung: **antworten** (Konfiguration wird für
+      den Anfrageweg überschrieben). Begründung: Die Empfangslage ist unterwegs unvorhersehbar;
+      wer über einen Draht schreibt, hat ihn damit als den gerade verfügbaren ausgewiesen. Eine
+      Ablehnung wäre schlechter als die heutige stille Umleitung, weil der Wanderer dann gar
+      nichts bekommt. Geht als AC in die Spec.
+- [x] Wirkort der Einschränkung — entschieden (Hilfsfunktion an der Entstehungsstelle).
+- [x] AC-3-Garantie — entschieden (keyword-only, Default `None`).
+- [x] Zuschnitt Weg/Adresse — entschieden (erkannter Nutzer hier als Test, unbekannter Absender
+      eigenes Issue).
+- [x] AC-2-Abgrenzung — SMS und Premium-SMS sind heute keine Befehlskanäle; die Spec grenzt sie
+      ausdrücklich als Scheibe S4 aus, statt eine unerfüllbare Zusicherung zu formulieren.

--- a/docs/specs/modules/feat_2126_kanaltreue_adhoc_antwort.md
+++ b/docs/specs/modules/feat_2126_kanaltreue_adhoc_antwort.md
@@ -1,0 +1,314 @@
+---
+entity_id: feat_2126_kanaltreue_adhoc_antwort
+type: module
+created: 2026-09-06
+updated: 2026-09-06
+status: draft
+version: "1.0"
+tags: [kanaltreue, adhoc-abruf, trip-command-processor, trip-report-scheduler, epic-2133]
+---
+
+# Kanaltreue der Ad-hoc-Antwort
+
+## Approval
+
+- [x] Approved — PO-Freigabe am 2026-09-06 (inkl. AC-4: Anfrage über einen im Trip
+  deaktivierten Kanal wird dennoch über genau diesen Kanal beantwortet)
+
+## Purpose
+
+Eine Ad-hoc-Anfrage (`heute` / `morgen`) löst heute den regulären Briefing-Fan-out über
+**alle** im Trip aktivierten Kanäle aus — unabhängig davon, über welchen Kanal die Anfrage
+gestellt wurde. Diese Spec zieht den bereits an anderer Stelle dokumentierten Grundsatz
+„Antwort auf gleichem Kanal" (`docs/specs/modules/inbound_command_channels.md:90`) auf den
+einen Pfad nach, der sich ihm bislang entzieht, weil er nicht über `confirmation_body`
+antwortet, sondern den vollständigen Briefing-Versand auslöst. Scheibe **S3** von Epic #2133,
+Ticket #2126.
+
+## Source
+
+- **File:** `src/services/trip_report_scheduler.py`
+- **Identifier:** `_resolve_channel_flags` (neu), `send_on_demand_report`,
+  `_send_trip_report_outcome`, `_build_trip_report_request`
+- **Aufrufende Datei:** `src/services/trip_command_processor.py`
+  (`_handle_query`, `_trigger_on_demand`)
+
+Python-Core (`src/services/`) — keine Berührung mit Go (`internal/`) oder Frontend.
+
+## Estimated Scope
+
+- **LoC:** ~900 (Produktivcode +55 bis +85, Tests **+817 gemessen** — die ursprüngliche
+  Schätzung „+120 bis +180" war zu niedrig: acht ACs, davon vier mit Positivkontrolle und zwei
+  mit Zwei-Nutzer-Aufbau)
+- **Files:** 4 Code/Test-Dateien + 2 Doku
+- **Effort:** medium
+- **Risk:** MEDIUM — vier Versandpfade (Slot-Briefing, Ad-hoc-Abruf, Test-Versand,
+  `report`-Kommando) teilen sich denselben Wirkort; ein Fehler dort wäre unsichtbar, weil ein
+  zu wenig versendeter Kanal beim planmässigen Briefing niemandem sofort auffällt.
+- **LoC-Limit:** 250 wird gerissen → `workflow.py set-field loc_limit_override 1000`
+  (500 reicht nach der RED-Messung nicht).
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|---|---|---|
+| `InboundMessage.channel` (`trip_command_processor.py:61`) | field | Herkunftskennung — bereits vorhanden, bricht heute nur an `:627` ab |
+| `sms_allowed` / `premium_sms_allowed` (`src/services/user_tier.py`) | function | Tier-Gates, bleiben auch im Override-Fall wirksam |
+| `TripReportConfig` (`src/app/models.py:1104`; Trip-Einstellungen `send_email`/`send_sms`/`send_premium_sms`/`send_telegram`) | model | Wird für den anfragenden Kanal überschrieben, sonst unverändert gelesen |
+| `Settings.with_user_profile` (`src/app/config.py:355`) | function | Löst Empfängeradresse für erkannten Nutzer bereits korrekt auf (hier nur Regressionstest, kein neuer Code) |
+| `briefing_log.channels` (`_append_briefing_log`, `trip_report_scheduler.py:1931`) | field | Downstream-Konsument (Go-Cockpit-Kachel #393) — Messpunkt für die Tests dieser Spec |
+
+## Implementation Details
+
+### Wirkort: neue Hilfsfunktion ersetzt zwei wortgleiche Formelstellen
+
+Die vier Kanal-Flags werden heute an **zwei** identischen Stellen berechnet
+(`trip_report_scheduler.py:1743-1752` im Haupt-Request, `:1371-1379` im
+No-Data-Hint-Zweig):
+
+```python
+send_email       = not config or config.send_email
+send_sms         = config is not None and config.send_sms and sms_allowed(self._user_id)
+send_premium_sms = config is not None and config.send_premium_sms and premium_sms_allowed(...)
+send_telegram    = config is not None and config.send_telegram
+```
+
+Beide Stellen ziehen in eine gemeinsame Hilfsfunktion, die die Einschränkung dort anwendet,
+**wo die Flags entstehen**, nicht wo sie verbraucht werden:
+
+```python
+def _resolve_channel_flags(
+    self,
+    config: TripReportConfig | None,
+    user_id: str,
+    *,
+    restrict_to_channel: str | None = None,
+) -> tuple[bool, bool, bool, bool]:
+    """Liefert (send_email, send_sms, send_premium_sms, send_telegram).
+
+    `restrict_to_channel` überschreibt für den genannten Kanal die
+    Trip-Konfiguration (send_X = True) und setzt alle anderen Kanäle auf
+    False — es wird nicht zusätzlich UND-verknüpft. Tier-Gates
+    (sms_allowed/premium_sms_allowed) werden dabei NICHT übersprungen:
+    überschrieben wird die Trip-Einstellung, nicht die Berechtigung.
+    `None` ist das neutrale Element und liefert exakt die alte Formel.
+    """
+    if restrict_to_channel is not None:
+        return (
+            restrict_to_channel == "email",
+            restrict_to_channel == "sms" and sms_allowed(user_id),
+            restrict_to_channel == "premium_sms" and premium_sms_allowed(user_id),
+            restrict_to_channel == "telegram",
+        )
+
+    send_email = not config or config.send_email
+    send_sms = config is not None and config.send_sms and sms_allowed(user_id)
+    send_premium_sms = (
+        config is not None and config.send_premium_sms and premium_sms_allowed(user_id)
+    )
+    send_telegram = config is not None and config.send_telegram
+    return send_email, send_sms, send_premium_sms, send_telegram
+```
+
+`NotificationService` bleibt **unverändert** — es kennt „Kanaltreue" nicht, es bekommt bereits
+korrekt aufgelöste Flags. `TripReportRequest` bekommt kein neues Feld.
+
+### Transportweg: additive, keyword-only Parameter mit Default `None`
+
+```
+trip_command_processor.py
+  :627   _handle_query(trip, actual_query_key, msg.received_at, msg.user_id, channel=msg.channel)
+  :736   _handle_query(self, trip, query_key, received_at, user_id, *, channel=None)
+  :826   _trigger_on_demand(self, trip, report_type, label, user_id, *, channel=None)
+         → TripReportSchedulerService(user_id=user_id).send_on_demand_report(
+               trip, report_type, restrict_to_channel=channel)
+trip_report_scheduler.py
+  :1095  send_on_demand_report(self, trip, report_type, *, restrict_to_channel=None) -> OnDemandErgebnis
+  :1166  _send_trip_report_outcome(..., restrict_to_channel=None) -> str
+  :1687  _build_trip_report_request(..., restrict_to_channel=None)   ← Definition
+         (Aufrufstelle ist :1484)
+         → _resolve_channel_flags(config, self._user_id, restrict_to_channel=restrict_to_channel)
+  :1361-1385  No-Data-Hint-Zweig — liegt IN _send_trip_report_outcome selbst, nicht im
+         Request-Bau. Er speist vier Keyword-Argumente an send_no_data_hint(...) und muss
+         seine Flags aus DEMSELBEN _resolve_channel_flags-Aufruf beziehen. Wer nur den
+         Request-Bau umstellt, baut exakt Mutation 1.
+```
+
+`None` ist an jeder Stelle das neutrale Element: exakt die alte Formel, keine Einschränkung.
+Ein Default auf einen Kanalnamen scheidet aus — er würde für jeden Aufrufer, der nichts angibt,
+still eine Einschränkung erzeugen. Der Parameter bleibt **optional**: `send_on_demand_report`
+hat einen produktiven Aufrufer und neun bestehende Testaufrufe
+(`test_timeline_folgt_der_ortszeit.py`, `test_send_idempotenz_lock.py`,
+`test_issue_1087_trip_official_alerts.py`, `test_briefing_slot_idempotenz.py`,
+`test_official_alert_time_window.py`), die keine Kanalangabe machen und keine Einschränkung
+erhalten dürfen.
+
+## Expected Behavior
+
+- **Input:** `InboundMessage(channel="email"|"telegram", …)` mit Anfragewort `heute`/`morgen`,
+  verarbeitet von `TripCommandProcessor.process`.
+- **Output:** Der ausgelöste Briefing-Versand erreicht **ausschliesslich** den anfragenden
+  Kanal — unabhängig davon, welche Kanäle der Trip sonst aktiviert hat. Ist der anfragende
+  Kanal im Trip deaktiviert, wird er für diese eine Antwort dennoch bedient (Override), sofern
+  ein etwaiges Tier-Gate ihn erlaubt.
+- **Side effects:** `briefing_log.channels` enthält bei angeforderten Briefings künftig nur
+  noch den anfragenden Kanal statt aller im Trip aktivierten Kanäle. Planmässige
+  Slot-Briefings, Test-Versand und das `report`-Kommando bleiben unverändert
+  mehrkanalig, weil sie `restrict_to_channel` nicht setzen.
+
+## Acceptance Criteria
+
+- **AC-1:** Given ein Trip hat alle vier Kanäle aktiviert (E-Mail, SMS, Premium-SMS,
+  Telegram) / When ein Nutzer per E-Mail `heute` sendet / Then wird das Briefing
+  ausschliesslich per E-Mail versendet und `briefing_log.channels == ["email"]`.
+  - Test: `TripCommandProcessor.process(InboundMessage(channel="email", text="heute", …))`
+    auslösen, tatsächlichen Versand über `briefing_log.channels` bzw.
+    `result.sent_channels` prüfen — kein direkter Aufruf von `send_on_demand_report`.
+
+- **AC-2:** Given derselbe Trip mit allen vier aktivierten Kanälen / When derselbe Nutzer
+  per Telegram `morgen` sendet / Then wird das Briefing ausschliesslich per Telegram
+  versendet und `briefing_log.channels == ["telegram"]`.
+  - Test: `TripCommandProcessor.process(InboundMessage(channel="telegram", text="morgen", …))`
+    auslösen, Versand über `briefing_log.channels` prüfen.
+
+- **AC-3:** Given ein planmässiger Slot-Auslöser (kein Anfrageweg), ein Test-Versand oder das
+  `report`-Kommando / When einer dieser drei Pfade ein Briefing auslöst / Then werden weiterhin
+  **alle** im Trip aktivierten Kanäle bedient, unverändert zum Stand vor dieser Änderung.
+  - Test: je ein Bestandsaufruf ohne `restrict_to_channel` (Slot-Auslösung,
+    `send_test_report_outcome`, `report`-Kommando) — `briefing_log.channels`/`sent_channels`
+    enthält weiterhin alle aktivierten Kanäle, keine Regression durch den neuen Parameter.
+  - **Falle:** Das `report`-Kommando läuft über **denselben Draht mit derselben
+    Herkunftskennung** (`trip_command_processor.py:675` → `_trigger_report`). Wer die
+    Einschränkung an `msg.channel` in `process()` festmacht statt am `heute`/`morgen`-Zweig in
+    `_handle_query` (`:759-762`), beschneidet `report` mit — der Wirkort ist der
+    Anfragewort-Zweig, nicht der Nachrichteneingang.
+
+- **AC-4:** ✅ *PO-Entscheidung am 2026-09-06 erteilt: antworten statt ablehnen.*
+  Given der anfragende Kanal ist im Trip **deaktiviert** (z. B. `send_telegram = False`) /
+  When der Nutzer trotzdem über diesen Kanal `heute`/`morgen` anfragt / Then wird
+  **geantwortet**, und zwar genau über diesen einen Kanal (Trip-Konfiguration wird für diesen
+  Kanal überschrieben) — statt heute stiller Umleitung auf die anderen aktiven Kanäle mit
+  Erfolgsmeldung. Begründung: Die Empfangslage unterwegs ist unvorhersehbar; wer über einen
+  Draht schreibt, hat ihn damit als den gerade verfügbaren ausgewiesen. Eine Ablehnung wäre
+  schlechter als die heutige stille Umleitung, weil der Wanderer dann gar nichts bekäme.
+  - Test: Trip-Fixture mit `send_telegram = False`, Anfrage per Telegram → Versand geht
+    dennoch per Telegram hinaus, `briefing_log.channels == ["telegram"]`.
+
+- **AC-5:** Given ein Nutzer ohne SMS-Tier-Berechtigung (`sms_allowed(user_id) == False`) /
+  When er über einen SMS-artigen Kanal anfragen würde bzw. `restrict_to_channel="sms"`
+  aufgelöst wird / Then bleibt `send_sms` auch im Override-Fall `False` — das Override
+  überschreibt nur die Trip-Einstellung, nicht die Tier-Berechtigung.
+  - Test: zwei **echte** Nutzerprofile auf der Platte — eines ohne SMS-Tier, eines mit —,
+    beide durch `_resolve_channel_flags(config, user_id, restrict_to_channel="sms")`. Ohne
+    Tier `send_sms == False`, mit Tier `send_sms == True`. Kein Stub von `sms_allowed`: die
+    fail-closed-Auflösung aus `user.json` ist Teil der Zusicherung. (Direkter Aufruf der
+    Auflösungsfunktion ist hier zulässig und notwendig, weil SMS heute kein Eingangsweg ist
+    und der Fall den Draht gar nicht erreichen kann — siehe Known Limitations.)
+
+- **AC-6:** Given ein Briefing-Lauf, bei dem sämtliche Wetterdaten ausfallen (Hinweistext statt
+  Briefing) und für den eine Kanaleinschränkung gesetzt ist / When der No-Data-Hint-Zweig
+  (`trip_report_scheduler.py:1361-1385`) den Hinweistext versendet / Then bezieht er seine vier
+  Kanal-Flags aus **derselben** `_resolve_channel_flags`-Auflösung wie der Haupt-Request und
+  geht ausschliesslich an den eingeschränkten Kanal.
+  - Test: Lauf mit vollständigem Wetterausfall und gesetztem `restrict_to_channel` auslösen;
+    Hinweistext-Versand geht nur an diesen Kanal (fängt Mutation 1 — den halben Fix, der nur
+    den Request-Bau anpasst und `:1361-1385` vergisst). Partner-Positivkontrolle ohne
+    Einschränkung belegt, dass der Zweig überhaupt erreicht wird und sonst mehrkanalig ist.
+  - **Faktenkorrektur zur ursprünglichen Fassung (2026-09-06, aus der RED-Phase):** Die erste
+    Fassung dieses AC beschrieb einen *On-Demand-Abruf* mit Wetterausfall. Diesen Fall gibt es
+    nicht: Der Zweig läuft nur unter `if not on_demand:` (`:1363`), und
+    `send_on_demand_report` setzt immer `on_demand=True` (`:1132-1133`). Beim Ad-hoc-Ausfall
+    antwortet stattdessen der Prozessor selbst über `_on_demand_failure_body`
+    (`trip_command_processor.py:453-484`, gerufen `:846-855`) — dieser Weg ist von Haus aus
+    kanaltreu. Die Zusicherung bleibt inhaltlich dieselbe (der Ausfallhinweis darf nicht am
+    eingeschränkten Kanal vorbeigehen), nur der Auslöser ist korrekt benannt.
+
+- **AC-6b:** Wächter gegen die falsche Reparatur. Given ein Ad-hoc-Abruf mit vollständigem
+  Wetterausfall / When er verarbeitet wird / Then bleibt es bei **genau einer** Ausfallmeldung —
+  der synchronen Antwort des Prozessors. Der No-Data-Hint-Zweig darf **nicht** für On-Demand
+  geöffnet werden; wer das tut, erzeugt eine doppelte Ausfallmeldung.
+  - Test: Ad-hoc-Abruf mit Totalausfall auslösen, Zahl der abgesetzten Ausfallmeldungen prüfen.
+
+- **AC-7:** Given ein per E-Mail erkannter Nutzer (Profiltreffer über die Absenderadresse) /
+  When er `heute` anfragt / Then trägt die versendete Antwort als `To:` genau die
+  Absenderadresse dieses Nutzerprofils; analog trägt eine Telegram-Antwort die `chat_id`
+  desselben Profils (Regressionstest — die Auflösung selbst ist bereits korrekt und wird durch
+  diese Spec nicht verändert).
+  - Test: Anfrage mit bekanntem Absender/`chat_id` durchlaufen lassen, tatsächlichen
+    Empfänger im Versand (`To:`-Header bzw. `chat_id` im Telegram-Payload) prüfen — kein
+    Dateiinhalt-Check, sondern Prüfung am tatsächlich gesendeten Objekt.
+
+- **AC-8:** Mandantentrennung. Given zwei verschiedene Nutzer mit je eigenem Trip, eigener
+  E-Mail-Adresse und eigener `chat_id` / When beide unabhängig voneinander per E-Mail bzw.
+  Telegram anfragen / Then erhält jeder Nutzer seine Antwort auf seinem eigenen Weg an seine
+  eigene Adresse — keine Kreuzung zwischen den beiden Nutzern.
+  - Test: beide Anfragen in einem Testlauf gegen `TripReportSchedulerService(user_id=…)` mit
+    unterschiedlichen `user_id`, Prüfung, dass Nutzer A nichts an die Adresse von Nutzer B
+    sendet und umgekehrt.
+
+## Mutations-Gegenprobe
+
+- **Mutation 1 — halber Fix am Duplikat:** `restrict_to_channel` nur in
+  `_build_trip_report_request`/Haupt-Request-Formel (`:1743-1752`) anwenden, den
+  No-Data-Hint-Zweig (`:1371-1379`) unverändert auf der alten Formel belassen. **Muss AC-6**
+  rot werden lassen — ein Test, der nur den Erfolgspfad (AC-1/AC-2) prüft, bleibt fälschlich
+  grün.
+- **Mutation 2 — Bypass-Richtung verdreht:** Das Override in `_resolve_channel_flags` von
+  `restrict_to_channel == "telegram"` zurück zu einem UND mit `config.send_telegram` drehen
+  (`restrict_to_channel == "telegram" and config.send_telegram`). **Muss AC-4** rot werden
+  lassen — Standard-Fixtures mit allen Kanälen aktiv (AC-1/AC-2) fangen das nicht, nur eine
+  Fixture mit explizit deaktiviertem Anfragekanal tut es.
+
+## Known Limitations
+
+- **SMS und Premium-SMS als Eingangsweg sind heute nicht möglich.** Regulär-SMS ist kein
+  Befehlskanal (`InboundMessage(channel="sms", …)` kommt nirgends vor), Premium-SMS ist nur
+  Adress-Lerner und verwirft den Nachrichtentext (`inbound_sms_reader.py:162-171`). Diese Spec
+  formuliert dafür bewusst **keine** unerfüllbare Zusicherung — `_resolve_channel_flags` ist so
+  gebaut, dass sie für alle vier Kanalnamen korrekt auflöst, sobald sie eintreffen können.
+  Premium-SMS als Eingangsweg ist Scheibe **S4** von Epic #2133 und baut ausdrücklich auf
+  dieser Scheibe auf.
+- **Unbekannter Absender (`user_id == "default"`) bleibt unrepariert.** Der
+  Registrierungshinweis an eine unbekannte `chat_id`/E-Mail-Adresse geht weiterhin an das
+  Default-/Betreiberprofil statt an den tatsächlichen Absender
+  (`inbound_telegram_reader.py:181-194`, `:305-317`; `inbound_email_reader.py:106`, `:121-132`).
+  Dieser Pfad erreicht `_handle_query`/`send_on_demand_report` nie und ist damit von dieser
+  Spec strukturell nicht erfasst — eigenes Issue nach Projektregel (nutzersichtbares
+  Fehlverhalten).
+- **Adress-ACs (AC-7/AC-8) sind für Test-Nutzer und Staging strukturell blind.**
+  `Settings.with_user_profile` setzt `force_test` bei einer Test-User-ID oder `env == "staging"`
+  (`src/app/config.py:369`) und verwirft dann die Profil-`telegram_chat_id` (`:387`). Testkennungen
+  für AC-7/AC-8 dürfen daher **nicht** auf ein Test-Präfix normalisiert werden — sonst prüfen
+  beide ACs nichts mehr. Auf Staging ist die Adress-Zusicherung aus demselben Grund nicht
+  messbar; sie gehört in die Kern-Schicht.
+
+- **`briefing_log.channels` enthält bei angeforderten Briefings künftig weniger Kanäle als
+  bisher.** Das ist die gewollte Wirkung dieser Spec, wirkt sich aber auf die von Go gelesene
+  Cockpit-Kachel „Was geht heute raus" (#393) aus — bei angeforderten Briefings zeigt sie
+  künftig nur noch den tatsächlich bedienten Kanal, nicht mehr alle Trip-Kanäle.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Diese Spec folgt einem bereits dokumentierten Grundsatz
+  (`inbound_command_channels.md:90`, „Antwort auf gleichem Kanal") und einem bestehenden Muster
+  im Code (Herkunftskennung wird bereits an anderen Stellen durchgereicht, `:585`/`:607`). Sie
+  eröffnet keine neue Entscheidungsfläche (Kanäle, Provider, Datenmodell, Auth) und lässt
+  ADR-0049 (Premium-SMS als vierter Kanal) unberührt — kein neues ADR nötig.
+  `_resolve_channel_flags` erfüllt dabei ausdrücklich die **Folgepflicht aus ADR-0049**
+  (`docs/adr/0049-premium-sms-vierter-kanal.md:115-117`: „Wer eine neue Stelle baut, die ein
+  Kanal-Set auflöst, muss `premium_sms` mitführen oder begründen, warum nicht"): Premium-SMS ist
+  als viertes Tupel-Element geführt, mit eigenem Tier-Gate `premium_sms_allowed()` statt
+  `sms_allowed()` — im Override- wie im Normalfall (AC-5).
+
+## Changelog
+
+- 2026-09-06: Initial spec created
+- 2026-09-06: AC-5 auf echte Nutzerprofile statt gestubbtem `sms_allowed` umgestellt
+- 2026-09-06: PO-Freigabe erteilt (AC-4 bestätigt: antworten statt ablehnen)
+- 2026-09-06 (RED-Phase, Faktenkorrekturen ohne Zieländerung): AC-6 auf den tatsächlich
+  existierenden Auslöser umformuliert (der No-Data-Hint-Zweig ist für On-Demand strukturell
+  unerreichbar) und um AC-6b als Wächter gegen die doppelte Ausfallmeldung ergänzt;
+  `ReportChannelConfig` → `TripReportConfig`; Definitionszeile von `_build_trip_report_request`
+  auf `:1687` korrigiert; AC-3 um die `report`-Falle ergänzt; `force_test`-Grenze der Adress-ACs
+  als Known Limitation aufgenommen; LoC-Schätzung auf den gemessenen Wert gezogen.

--- a/src/services/trip_command_processor.py
+++ b/src/services/trip_command_processor.py
@@ -624,7 +624,10 @@ class TripCommandProcessor:
                     trip_name=msg.trip_name,
                     reply_markup=_GLANCE_BUTTONS,
                 )
-            return self._handle_query(trip, actual_query_key, msg.received_at, msg.user_id)
+            return self._handle_query(
+                trip, actual_query_key, msg.received_at, msg.user_id,
+                channel=msg.channel,
+            )
 
         # hilfe braucht keinen Trip-Lookup
         if key == "hilfe":
@@ -735,8 +738,15 @@ class TripCommandProcessor:
 
     def _handle_query(
         self, trip: Trip, query_key: str, received_at: datetime, user_id: str,
+        *, channel: str | None = None,
     ) -> CommandResult:
         """Dispatch read-only query. Never mutates trip state.
+
+        Issue #2126: `channel` ist der Anfrageweg und geht NUR in den
+        heute/morgen-Zweig, weil nur der einen Briefing-Versand auslöst. Das
+        `report`-Kommando läuft über denselben Draht mit derselben
+        Herkunftskennung und bleibt bewusst mehrkanalig — deshalb sitzt die
+        Einschränkung hier und nicht am Nachrichteneingang in `process()`.
 
         Fix #1795 (ADR-0044): "heute"/"morgen" folgen dem ORTStag der Tour,
         nicht dem UTC-Tag von ``received_at`` — EINE Auflösung
@@ -757,9 +767,13 @@ class TripCommandProcessor:
         # der Scheduler die Wetterdaten selbst holt (keine WeatherExtractor-
         # Timeline nötig).
         if query_key == "heute":
-            return self._trigger_on_demand(trip, "morning", "Heute", user_id)
+            return self._trigger_on_demand(
+                trip, "morning", "Heute", user_id, channel=channel,
+            )
         elif query_key == "morgen":
-            return self._trigger_on_demand(trip, "evening", "Morgen", user_id)
+            return self._trigger_on_demand(
+                trip, "evening", "Morgen", user_id, channel=channel,
+            )
 
         from services.weather_extractor import WeatherExtractor
         extractor = WeatherExtractor(user_id=user_id)
@@ -825,6 +839,7 @@ class TripCommandProcessor:
 
     def _trigger_on_demand(
         self, trip: Trip, report_type: str, label: str, user_id: str,
+        *, channel: str | None = None,
     ) -> CommandResult:
         """Issue #1007: heute/morgen lösen das volle Tages-Briefing aus statt
         des bisherigen Einzeiler-Aggregats. Wiederverwendung des On-Demand-
@@ -837,12 +852,18 @@ class TripCommandProcessor:
         `send_on_demand_report` benutzten Zieltag (`OnDemandErgebnis.zieltag`)
         — kein eigener, im Aufrufer aus `received_at` geratener `target_date`
         mehr (Nebengewinn: der Parameter entfaellt hier ersatzlos).
+
+        Issue #2126: `channel` (der Anfrageweg) wird als `restrict_to_channel`
+        durchgereicht — die Antwort geht ueber GENAU den Draht hinaus, ueber
+        den gefragt wurde, auch wenn er im Trip abgeschaltet ist.
         """
         from services.trip_report_scheduler import TripReportSchedulerService
         query_key = "heute" if report_type == "morning" else "morgen"
         buttons = _HEUTE_BUTTONS if report_type == "morning" else _MORGEN_BUTTONS
         service = TripReportSchedulerService(user_id=user_id)
-        ergebnis = service.send_on_demand_report(trip, report_type)
+        ergebnis = service.send_on_demand_report(
+            trip, report_type, restrict_to_channel=channel,
+        )
         if ergebnis.outcome != "sent":
             return CommandResult(
                 success=True, command=query_key,

--- a/src/services/trip_report_scheduler.py
+++ b/src/services/trip_report_scheduler.py
@@ -45,6 +45,7 @@ from utils.geo import haversine_km
 from utils.timezone import local_dt, tz_for_coords
 
 if TYPE_CHECKING:
+    from app.models import TripReportConfig
     from app.trip import Stage, Trip
     from services.report_config_resolver import ReportRenderOptions
 
@@ -1092,7 +1093,13 @@ class TripReportSchedulerService:
         finally:
             _release_send_lock(self._user_id, trip.id, report_type)
 
-    def send_on_demand_report(self, trip: "Trip", report_type: str) -> OnDemandErgebnis:
+    def send_on_demand_report(
+        self,
+        trip: "Trip",
+        report_type: str,
+        *,
+        restrict_to_channel: str | None = None,
+    ) -> OnDemandErgebnis:
         """
         Send an on-demand full briefing triggered by an inbound heute/morgen command.
 
@@ -1111,6 +1118,12 @@ class TripReportSchedulerService:
         Args:
             trip: Trip object
             report_type: "morning" (heute) or "evening" (morgen)
+            restrict_to_channel: Issue #2126 — Kanaltreue der Ad-hoc-Antwort.
+                Kanalname ("email"/"sms"/"premium_sms"/"telegram") des
+                Anfragewegs; der Versand geht dann ausschliesslich dorthin,
+                auch wenn der Kanal im Trip abgeschaltet ist (AC-4). `None`
+                (Default) ist das neutrale Element: keine Einschraenkung,
+                exakt die bisherige Kanal-Auflösung.
 
         Returns:
             OnDemandErgebnis(outcome, zieltag) — outcome: "sent" | "no_stage" |
@@ -1131,6 +1144,7 @@ class TripReportSchedulerService:
             # bedeuten Verschiedenes, siehe `_send_trip_report_outcome`.
             outcome = self._send_trip_report_outcome(
                 trip, report_type, on_demand=True, angefordert=True, target_date=zieltag,
+                restrict_to_channel=restrict_to_channel,
             )
         finally:
             _release_send_lock(self._user_id, trip.id, report_type)
@@ -1172,6 +1186,7 @@ class TripReportSchedulerService:
         catchup_prefix: str | None = None,
         angefordert: bool = False,
         target_date: date | None = None,
+        restrict_to_channel: str | None = None,
     ) -> str:
         """
         Generate and send report for a single trip.
@@ -1219,6 +1234,13 @@ class TripReportSchedulerService:
                 sechs bestehenden Aufrufer bleiben unverändert, die Funktion
                 löst den Zieltag wie bisher selbst zum Ausführungszeitpunkt
                 auf.
+            restrict_to_channel: Issue #2126 — Kanalname des Anfragewegs oder
+                `None` (neutral). Wird an `_resolve_channel_flags` gereicht,
+                und zwar an BEIDEN Stellen, an denen Kanal-Flags entstehen:
+                im Haupt-Request (`_build_trip_report_request`) UND im
+                No-Data-Hint-Zweig unten. Nur den Request-Bau umzustellen
+                liesse den Ausfall-Hinweis am eingeschränkten Kanal vorbei
+                laufen.
 
         Returns:
             "no_stage" if no matching stage, "no_weather" if the weather
@@ -1363,20 +1385,21 @@ class TripReportSchedulerService:
             if not on_demand:
                 # On-Demand (#1007) erzeugt weder Hinweis-Versand noch Marker —
                 # der Bot antwortet synchron mit eigenem Hinweistext.
-                config = trip.report_config
+                # Issue #2126: dieselbe Auflösung wie der Haupt-Request — sonst
+                # ginge der Ausfall-Hinweis am eingeschränkten Kanal vorbei.
+                hint_email, hint_sms, hint_premium_sms, hint_telegram = (
+                    self._resolve_channel_flags(
+                        trip.report_config, self._user_id,
+                        restrict_to_channel=restrict_to_channel,
+                    )
+                )
                 self._notification_service.send_no_data_hint(
                     trip,
                     report_type,
-                    send_email=not config or config.send_email,
-                    send_sms=config is not None and config.send_sms and sms_allowed(self._user_id),
-                    send_telegram=config is not None and config.send_telegram,
-                    # Issue #1676 S2a: eigenes Tier-Gate (nur premium), NICHT
-                    # sms_allowed() -- das laesst standard durch (Spec D7).
-                    send_premium_sms=(
-                        config is not None
-                        and config.send_premium_sms
-                        and premium_sms_allowed(self._user_id)
-                    ),
+                    send_email=hint_email,
+                    send_sms=hint_sms,
+                    send_telegram=hint_telegram,
+                    send_premium_sms=hint_premium_sms,
                 )
                 self._write_pending_marker(
                     trip, report_type, target_date,
@@ -1502,6 +1525,7 @@ class TripReportSchedulerService:
             partial_outage_hint=partial_outage_hint,
             render_options=render_options,
             starkregen_nowcast=starkregen_nowcast,
+            restrict_to_channel=restrict_to_channel,
         )
         # 8b. Issue #1467 S2 AG5: Anker und Melde-Gedächtnis hängen an EINER
         # Bedingung, in EINEM geteilten Baustein, den auch der Ortsvergleich
@@ -1684,6 +1708,54 @@ class TripReportSchedulerService:
             return "channels_unreachable"
         return "sent"
 
+    def _resolve_channel_flags(
+        self,
+        config: Optional["TripReportConfig"],
+        user_id: str,
+        *,
+        restrict_to_channel: str | None = None,
+    ) -> tuple[bool, bool, bool, bool]:
+        """Liefert (send_email, send_sms, send_premium_sms, send_telegram).
+
+        Issue #2126: EINE Stelle für die Kanal-Auflösung, die vorher wortgleich
+        zweimal im Fliesstext stand (Haupt-Request und No-Data-Hint-Zweig).
+
+        `restrict_to_channel` überschreibt für den genannten Kanal die
+        Trip-Konfiguration (send_X = True) und setzt alle anderen Kanäle auf
+        False — es wird NICHT zusätzlich UND-verknüpft, sonst bliebe ein im
+        Trip abgeschalteter Anfrageweg stumm (AC-4). Die Tier-Gates
+        (`sms_allowed`/`premium_sms_allowed`) werden dabei nicht übersprungen:
+        überschrieben wird die Trip-Einstellung, nicht die Berechtigung (AC-5).
+        `None` ist das neutrale Element und liefert exakt die alte Formel.
+
+        🔴 Premium-SMS hängt an `premium_sms_allowed()`, NICHT an
+        `sms_allowed()` — in BEIDEN Zweigen (Issue #1676 S2a, ADR-0049,
+        Spec D7). `sms_allowed()` lässt `standard` durch; Premium-SMS spricht
+        ein Satellitengerät an, jede Nachricht kostet, und eine
+        Wiederverwendung des SMS-Gates wäre eine stille Rechte-Ausweitung.
+        Die Unterscheidung war ein eigenes Ticket wert und stand vor #2126
+        als Kommentar an beiden Formelstellen; sie lebt jetzt hier.
+        """
+        if restrict_to_channel is not None:
+            return (
+                restrict_to_channel == "email",
+                restrict_to_channel == "sms" and sms_allowed(user_id),
+                restrict_to_channel == "premium_sms" and premium_sms_allowed(user_id),
+                restrict_to_channel == "telegram",
+            )
+
+        send_email = not config or config.send_email
+        send_sms = config is not None and config.send_sms and sms_allowed(user_id)
+        # Issue #1676 S2a: eigenes Tier-Gate (nur premium), NICHT
+        # sms_allowed() -- das laesst standard durch (Spec D7).
+        send_premium_sms = (
+            config is not None
+            and config.send_premium_sms
+            and premium_sms_allowed(user_id)
+        )
+        send_telegram = config is not None and config.send_telegram
+        return send_email, send_sms, send_premium_sms, send_telegram
+
     def _build_trip_report_request(
         self,
         *,
@@ -1710,6 +1782,7 @@ class TripReportSchedulerService:
             Tuple[str, Optional[int], Optional[int], bool, bool, Optional[int]]
         ] = None,  # Issue #2050 S2b: fuenftes Glied `already_running`;
         # Issue #2051 S3: sechstes Glied `source_reach_minutes`
+        restrict_to_channel: str | None = None,
     ) -> TripReportRequest:
         """Baut das DTO, das an den NotificationService übergeben wird (Issue #1022).
 
@@ -1719,6 +1792,13 @@ class TripReportSchedulerService:
         """
         config = trip.report_config
         errors = [s for s in segment_weather if s.has_error]
+        # Issue #2126: Kanal-Flags entstehen in `_resolve_channel_flags` —
+        # dieselbe Auflösung benutzt der No-Data-Hint-Zweig.
+        send_email, send_sms, send_premium_sms, send_telegram = (
+            self._resolve_channel_flags(
+                config, self._user_id, restrict_to_channel=restrict_to_channel,
+            )
+        )
         return TripReportRequest(
             trip=trip,
             report_type=report_type,
@@ -1740,16 +1820,10 @@ class TripReportSchedulerService:
             shortcode=getattr(trip, 'shortcode', None) or None,
             stage_total=len(trip.stages) if trip.stages else None,
             trip_url=f"https://gregor20.henemm.com/trips/{trip.id}",
-            send_email=not config or config.send_email,
-            send_sms=config is not None and config.send_sms and sms_allowed(self._user_id),
-            # Issue #1676 S2a: eigenes Tier-Gate (nur premium), NICHT
-            # sms_allowed() -- das laesst standard durch (Spec D7).
-            send_premium_sms=(
-                config is not None
-                and config.send_premium_sms
-                and premium_sms_allowed(self._user_id)
-            ),
-            send_telegram=config is not None and config.send_telegram,
+            send_email=send_email,
+            send_sms=send_sms,
+            send_premium_sms=send_premium_sms,
+            send_telegram=send_telegram,
             test_prefix=allow_test_fallback,
             on_demand_prefix=on_demand,
             catchup_prefix=catchup_prefix,

--- a/tests/tdd/test_kanaltreue_adhoc_antwort.py
+++ b/tests/tdd/test_kanaltreue_adhoc_antwort.py
@@ -1,0 +1,945 @@
+"""TDD RED — Kanaltreue der Ad-hoc-Antwort (Issue #2126, Epic #2133 Scheibe S3).
+
+SPEC: docs/specs/modules/feat_2126_kanaltreue_adhoc_antwort.md (AC-1..AC-8)
+Kontext: docs/context/feat-2126-kanaltreue-adhoc-antwort.md
+
+Zielverhalten: Eine ``heute``/``morgen``-Anfrage wird ueber GENAU den Kanal
+beantwortet, ueber den sie gestellt wurde — auch wenn dieser Kanal im Trip
+abgeschaltet ist (AC-4, Override). Slot-Briefing, Test-Versand und das
+``report``-Kommando bleiben unveraendert mehrkanalig (AC-3).
+
+RED heute: ``msg.channel`` faellt in ``trip_command_processor.py`` bei
+``_handle_query`` weg und erreicht die Kanal-Aufloesung nie;
+``_resolve_channel_flags`` existiert nicht. Der Versand geht an ALLE im Trip
+aktivierten Kanaele.
+
+Messpunkt: der TATSAECHLICHE Versand, abgegriffen an den vier Kanal-Ausgaengen
+des ``NotificationService``, plus ``briefing_log.channels``. Der Nachweis
+beginnt bei ``TripCommandProcessor.process(InboundMessage(channel=...))` —
+``msg.channel`` ist die Bildungsstelle der Zusicherung, ein direkter
+``send_on_demand_report``-Aufruf bewachte die Verdrahtung nicht.
+
+Mock-frei: echte Trips/Profile auf der isolierten Datenwurzel (autouse-Fixture
+aus tests/conftest.py, #1133), echter Prozessor, echter Scheduler, echter
+Renderer. Offline sind nur die beiden NAEHTE nach aussen — der Wetterabruf
+ueber die etablierte ``GZ_TEST_FIXTURE_DIR``-Substitution
+(``# fake-provider-seam``, #346; AC-6 lenkt sie auf ein LEERES Verzeichnis und
+erzeugt so einen echten Provider-Ausfall) und die vier Kanal-Ausgaenge,
+ersetzt durch echte Aufzeichner-Klassen (kein ``Mock()``/``patch()``). Die
+Aufzeichner sind zugleich die Sicherung, dass aus diesem Lauf nichts
+hinausgeht (#1477) — zusaetzlich zu durchweg unbrauchbaren Zugangsdaten.
+
+Nutzerkennungen tragen bewusst KEIN "tdd"/"test": ``is_test_user_id`` erzwaenge
+sonst ``Settings.for_testing()``, und das ueberschreibt die
+``telegram_chat_id`` des Profils (``config.py``: ``if
+profile.get("telegram_chat_id") and not force_test``). AC-7/AC-8 maessen dann
+die Test-Umleitung statt der Profil-Aufloesung.
+
+RED-Charakter: AC-1/AC-2/AC-4/AC-6/AC-8 sind Fehlernachweise (ROT), AC-5 ist
+rot mangels ``_resolve_channel_flags``. AC-3 und AC-7 sind REGRESSIONSWAECHTER
+und starten GRUEN. AC-3 ist zugleich die Positivkontrolle fuer AC-1/AC-2/AC-4:
+gleiche Fixture, gleiche Aufzeichner, alle vier Kanaele tatsaechlich bedient —
+ohne diesen Gegenpol koennte ein leeres Ergebnis auch schlicht "Zustellung
+fehlgeschlagen" heissen.
+"""
+from __future__ import annotations
+
+import inspect
+import json
+import sys
+import uuid
+from datetime import datetime, time, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+for _p in (str(ROOT), str(ROOT / "src")):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from app.loader import get_data_dir, load_all_trips, save_trip  # noqa: E402
+from app.models import TripReportConfig  # noqa: E402
+from app.trip import Stage, Trip, Waypoint  # noqa: E402
+from services.trip_command_processor import (  # noqa: E402
+    InboundMessage,
+    TripCommandProcessor,
+)
+from services.trip_report_scheduler import TripReportSchedulerService  # noqa: E402
+from utils.timezone import tz_for_coords  # noqa: E402
+
+#: Exakter Standort aus ``providers/fixture.py::_FIXTURE_LOCATIONS`` — so
+#: trifft der Nearest-Neighbour-Zuordner garantiert ``innsbruck.json``.
+INNSBRUCK = (47.2692, 11.4041)
+
+#: Versand-Reihenfolge in ``NotificationService.send_trip_report`` — dieselbe
+#: Reihenfolge steht in ``briefing_log.channels``.
+ALLE_KANAELE = ("email", "sms", "premium_sms", "telegram")
+
+VIER_KANAELE_AN = {
+    "send_email": True, "send_sms": True,
+    "send_premium_sms": True, "send_telegram": True,
+}
+
+#: Jedes Transport-Feld ausdruecklich belegt (#1477) — ein weggelassenes Feld
+#: faellt bei pydantic still auf die Prod-``.env`` zurueck. Unbrauchbar, aber
+#: VOLLSTAENDIG: ``can_send_sms()``/``can_send_telegram()`` muessen True
+#: liefern, sonst waere "Kanal nicht bedient" nur fehlende Zugangsdaten.
+_TRANSPORT_ENV = {
+    "GZ_ENV": "development",
+    "GZ_SMTP_HOST": "smtp.invalid",
+    "GZ_SMTP_USER": "unbrauchbar",
+    "GZ_SMTP_PASS": "unbrauchbar",
+    "GZ_MAIL_FROM": "gregor@example.invalid",
+    # Globaler Rueckfall — er DARF in AC-7/AC-8 nie auftauchen.
+    "GZ_MAIL_TO": "globaler-rueckfall@example.invalid",
+    "GZ_TEST_SMTP_HOST": "smtp.invalid",
+    "GZ_TEST_SMTP_USER": "",
+    "GZ_TEST_SMTP_PASS": "",
+    "GZ_TELEGRAM_BOT_TOKEN": "0000000:unbrauchbar",
+    "GZ_TELEGRAM_CHAT_ID": "globaler-rueckfall-chat",
+    "GZ_TELEGRAM_TEST_BOT_TOKEN": "",
+    "GZ_TELEGRAM_TEST_CHAT_ID": "",
+    "GZ_SMS_GATEWAY_URL": "https://gateway.invalid/api/sms",
+    "GZ_SEVEN_API_KEY": "unbrauchbar",
+    "GZ_SEVEN_SANDBOX_KEY": "",
+    "GZ_SMS_TO": "+490000000000",
+}
+
+
+# ---------------------------------------------------------------------------
+# Aufzeichner an den vier Kanal-Ausgaengen
+# ---------------------------------------------------------------------------
+
+
+class Kanalmitschrift:
+    """Was tatsaechlich hinausging — je Kanal Empfaenger und Betreff."""
+
+    def __init__(self) -> None:
+        self.je_kanal: dict[str, list[dict]] = {k: [] for k in ALLE_KANAELE}
+
+    @property
+    def kanaele(self) -> list[str]:
+        """Bediente Kanaele in der Versand-Reihenfolge des Produktivcodes."""
+        return [k for k in ALLE_KANAELE if self.je_kanal[k]]
+
+    def empfaenger(self, kanal: str) -> list[str]:
+        return [e["empfaenger"] for e in self.je_kanal[kanal]]
+
+    def leeren(self) -> None:
+        self.je_kanal = {k: [] for k in ALLE_KANAELE}
+
+    def __repr__(self) -> str:  # erscheint in jeder Fehlermeldung
+        return f"Kanalmitschrift({({k: v for k, v in self.je_kanal.items() if v})})"
+
+
+def _aufzeichner_installieren(monkeypatch) -> Kanalmitschrift:
+    """Echte Klassen mit den echten ``send()``-Signaturen ersetzen die vier
+    Ausgaenge. Sie ersetzen die Naht zum Netz, NICHT die Entscheidung darueber,
+    wer bedient wird — die faellt weiter im Produktivcode."""
+    from services import notification_service as ns
+
+    mit = Kanalmitschrift()
+
+    def _buchen(kanal: str, empfaenger, subject: str) -> None:
+        mit.je_kanal[kanal].append({"empfaenger": empfaenger, "subject": subject})
+
+    class _EmailAufzeichner:
+        def __init__(self, settings) -> None:
+            self._s = settings
+
+        def send(self, subject, body, html=True, plain_text_body=None, to=None,
+                 mail_type=None, mail_format=None, compare_hourly_enabled=None):
+            # Ohne `to=` faellt `EmailOutput` auf `settings.mail_to` zurueck
+            # (email.py:647-650) — genau die Aufloesung, die AC-7 prueft.
+            ziel = to if to else self._s.mail_to
+            _buchen("email", ziel if isinstance(ziel, str) else list(ziel)[0], subject)
+
+    class _SmsAufzeichner:
+        def __init__(self, settings) -> None:
+            self._s = settings
+
+        def send(self, subject, body) -> None:
+            _buchen("sms", self._s.sms_to, subject)
+
+    class _PremiumSmsAufzeichner:
+        def __init__(self, settings) -> None:
+            self._s = settings
+
+        def send(self, subject, body) -> None:
+            _buchen("premium_sms", self._s.premium_sms_reply_to, subject)
+
+    class _TelegramAufzeichner:
+        def __init__(self, settings) -> None:
+            self._s = settings
+
+        def send(self, subject, body, reply_markup=None, *, parse_mode=None,
+                 suppress_subject_line=False) -> int:
+            _buchen("telegram", self._s.telegram_chat_id, subject)
+            return 1
+
+    monkeypatch.setattr(ns, "EmailOutput", _EmailAufzeichner)
+    monkeypatch.setattr(ns, "SMSOutput", _SmsAufzeichner)
+    monkeypatch.setattr(ns, "PremiumSmsOutput", _PremiumSmsAufzeichner)
+    monkeypatch.setattr(ns, "TelegramOutput", _TelegramAufzeichner)
+    return mit
+
+
+@pytest.fixture
+def mitschrift(monkeypatch) -> Kanalmitschrift:
+    for name, wert in _TRANSPORT_ENV.items():
+        monkeypatch.setenv(name, wert)
+    return _aufzeichner_installieren(monkeypatch)
+
+
+# ---------------------------------------------------------------------------
+# Aufbau-Helfer (echte Dateien auf der isolierten Datenwurzel)
+# ---------------------------------------------------------------------------
+
+
+def _kennung(praefix: str) -> str:
+    """Mandantenkennung OHNE "tdd"/"test" — Begruendung im Modul-Docstring."""
+    return f"kanaltreue-{praefix}-{uuid.uuid4().hex[:6]}"
+
+
+def _nutzer_anlegen(user_id: str, *, mail: str, chat_id: str,
+                    tier: str = "premium") -> None:
+    """Echtes ``user.json`` — Tier UND Empfaengeradressen von der Platte."""
+    ordner = get_data_dir(user_id)
+    ordner.mkdir(parents=True, exist_ok=True)
+    (ordner / "user.json").write_text(json.dumps({
+        "id": user_id,
+        "tier": tier,
+        "mail_to": mail,
+        "telegram_chat_id": chat_id,
+        "sms_to": "+490000000001",
+        "premium_sms_reply_to": "+490000000002",
+        "premium_sms_reply_at": datetime.now(timezone.utc).isoformat(),
+    }))
+
+
+def _trip_anlegen(user_id: str, *, name: str, kanaele: dict | None = None) -> Trip:
+    """Drei Etappen (gestern/heute/morgen, Ortstag) am Fixture-Standort.
+
+    "heute" fuehrt auf ``report_type="morning"`` (Zieltag = Ortstag), "morgen"
+    auf ``"evening"`` (Folgetag) — beide brauchen eine Etappe, sonst endet der
+    Abruf in ``no_stage`` statt in einem Versand. ``official_alerts_enabled=
+    False``: amtliche Warnungen kennen keine Fixture-Naht und haengten diesen
+    Kern-Test sonst ans Netz.
+    """
+    zone = tz_for_coords(*INNSBRUCK)
+    heute = datetime.now(timezone.utc).astimezone(zone).date()
+    trip_id = f"kanaltreue-{uuid.uuid4().hex[:8]}"
+    stages = [
+        Stage(
+            id=f"T{i}", name=f"Etappe {i}", date=heute + timedelta(days=i - 1),
+            waypoints=[
+                Waypoint(id=f"G{i}a", name="Start",
+                         lat=INNSBRUCK[0], lon=INNSBRUCK[1], elevation_m=600),
+                Waypoint(id=f"G{i}b", name="Ziel",
+                         lat=INNSBRUCK[0] + 0.02, lon=INNSBRUCK[1] + 0.02,
+                         elevation_m=900),
+            ],
+        )
+        for i in range(3)
+    ]
+    trip = Trip(
+        id=trip_id, name=name, stages=stages, official_alerts_enabled=False,
+        report_config=TripReportConfig(trip_id=trip_id, **(kanaele or VIER_KANAELE_AN)),
+    )
+    save_trip(trip, user_id)
+    # Zurueck von der Platte: ``save_trip`` rechnet Ankunftszeiten neu.
+    return next(t for t in load_all_trips(user_id) if t.id == trip_id)
+
+
+def _ueber_den_draht(trip: Trip, wort: str, *, kanal: str, user_id: str,
+                     absender: str):
+    """Getippte Anfrage -> ECHTER ``TripCommandProcessor.process``."""
+    return TripCommandProcessor().process(InboundMessage(
+        trip_name=trip.name, body=f"### query: {wort}", sender=absender,
+        channel=kanal, received_at=datetime.now(timezone.utc), user_id=user_id,
+    ))
+
+
+def _log_kanaele(user_id: str, trip_id: str) -> list[str]:
+    pfad = get_data_dir(user_id) / "briefing_log.json"
+    roh = json.loads(pfad.read_text()).get("entries", []) if pfad.exists() else []
+    eintraege = [e for e in roh if e.get("trip_id") == trip_id]
+    assert len(eintraege) == 1, (
+        f"Erwartet GENAU EINEN briefing_log-Eintrag fuer {trip_id!r}, gefunden "
+        f"{len(eintraege)}: {eintraege} — ein fehlender Eintrag heisst "
+        f"'Zustellung fehlgeschlagen', nicht 'Kanal unterdrueckt'."
+    )
+    return list(eintraege[0].get("channels", []))
+
+
+# ═══════════════════════════ AC-1 ════════════════════════════════════════════
+
+
+def test_ac1_email_anfrage_wird_nur_per_email_beantwortet(mitschrift):
+    """AC-1.
+
+    GIVEN ein Trip mit allen vier aktivierten Kanaelen und ein Premium-Nutzer.
+    WHEN  der Nutzer per E-MAIL ``heute`` sendet und die Nachricht durch
+          ``TripCommandProcessor.process`` laeuft.
+    THEN  geht das Briefing ausschliesslich per E-Mail hinaus und
+          ``briefing_log.channels == ["email"]``.
+
+    RED heute: der Ad-hoc-Abruf loest den Fan-out ueber alle vier Kanaele aus.
+    Positivkontrolle gegen "Versand schlicht gescheitert": ``test_ac3_*``.
+    """
+    uid = _kennung("ac1")
+    _nutzer_anlegen(uid, mail="ac1@example.invalid", chat_id="chat-ac1")
+    trip = _trip_anlegen(uid, name="Kanaltreue AC1")
+
+    ergebnis = _ueber_den_draht(
+        trip, "heute", kanal="email", user_id=uid, absender="ac1@example.invalid",
+    )
+
+    assert ergebnis.success, f"Vorbedingung: der Abruf muss durchlaufen: {ergebnis}"
+    assert mitschrift.kanaele == ["email"], (
+        f"AC-1: eine per E-Mail gestellte Anfrage darf NUR per E-Mail "
+        f"beantwortet werden, bedient wurden {mitschrift.kanaele} ({mitschrift!r})"
+    )
+    assert _log_kanaele(uid, trip.id) == ["email"], (
+        f"AC-1: briefing_log.channels muss ['email'] sein, ist "
+        f"{_log_kanaele(uid, trip.id)}"
+    )
+
+
+# ═══════════════════════════ AC-2 ════════════════════════════════════════════
+
+
+def test_ac2_telegram_anfrage_wird_nur_per_telegram_beantwortet(mitschrift):
+    """AC-2.
+
+    GIVEN derselbe Trip mit allen vier aktivierten Kanaelen.
+    WHEN  derselbe Nutzer per TELEGRAM ``morgen`` sendet.
+    THEN  geht das Briefing ausschliesslich per Telegram hinaus und
+          ``briefing_log.channels == ["telegram"]``.
+
+    RED heute: wie AC-1 — der Fan-out kennt den Anfrageweg nicht.
+    """
+    uid = _kennung("ac2")
+    _nutzer_anlegen(uid, mail="ac2@example.invalid", chat_id="chat-ac2")
+    trip = _trip_anlegen(uid, name="Kanaltreue AC2")
+
+    ergebnis = _ueber_den_draht(
+        trip, "morgen", kanal="telegram", user_id=uid, absender="chat-ac2",
+    )
+
+    assert ergebnis.success, f"Vorbedingung: der Abruf muss durchlaufen: {ergebnis}"
+    assert mitschrift.kanaele == ["telegram"], (
+        f"AC-2: eine per Telegram gestellte Anfrage darf NUR per Telegram "
+        f"beantwortet werden, bedient wurden {mitschrift.kanaele} ({mitschrift!r})"
+    )
+    assert _log_kanaele(uid, trip.id) == ["telegram"], (
+        f"AC-2: briefing_log.channels muss ['telegram'] sein, ist "
+        f"{_log_kanaele(uid, trip.id)}"
+    )
+
+
+# ═══════════════════════════ AC-3 ════════════════════════════════════════════
+# Regressionswaechter UND Positivkontrolle: gleiche Fixture, gleiche
+# Aufzeichner — hier MUESSEN alle vier Kanaele bedient werden.
+
+
+@pytest.mark.parametrize("slot_stunde", [9, 18])
+def test_ac3_planmaessiges_slot_briefing_bedient_weiter_alle_kanaele(
+    mitschrift, slot_stunde,
+):
+    """AC-3 (Slot-Ausloesung) — Regressionswaechter, heute GRUEN.
+
+    GIVEN ein Trip mit vier aktiven Kanaelen, dessen Morgen-Slot zur
+          BEZUGSStunde des Laufs faellig ist.
+    WHEN  ``send_due_reports(now_utc)`` mit genau dieser Bezugszeit laeuft —
+          ohne jede Kanalangabe.
+    THEN  wird GENAU EIN Briefing versendet und dabei alle vier Kanaele
+          bedient.
+
+    Wert nach dem Fix: faengt eine Einschraenkung, die den Anlass nicht
+    unterscheidet und das planmaessige Briefing mit beschneidet (Spec-Risiko 1
+    — der Fehler waere unsichtbar, weil ein fehlender Kanal beim Slot-Briefing
+    niemandem sofort auffaellt).
+
+    Die Bezugszeit ist FEST und parametrisiert, nicht ``datetime.now()``: mit
+    der Systemuhr als Slot-Stunde kollidierte der Morgen-Slot mit dem
+    Abend-Default 18:00 (``models.py``: ``evening_time``), und weil
+    Faelligkeit ein Fenster von ``NACHHOL_FENSTER_STUNDEN = 3`` ist
+    (``trip_report_scheduler.py``), waren BEIDE Slots zwischen 18 und 20 Uhr
+    Ortszeit faellig — der Lauf versendete zwei Briefings und der Test war
+    jeden Abend drei Stunden lang rot, ohne dass etwas kaputt war. Der Abend-
+    Slot wird deshalb aus dem Fenster herausgesetzt, und ``slot_stunde=18``
+    haelt genau die Konstellation fest, die vorher stolperte. Die Zusicherung
+    (alle vier Kanaele) bleibt unangetastet.
+    """
+    uid = _kennung("ac3slot")
+    _nutzer_anlegen(uid, mail="ac3slot@example.invalid", chat_id="chat-ac3slot")
+    trip = _trip_anlegen(uid, name=f"Kanaltreue AC3 Slot {slot_stunde}")
+
+    # Ortstag der Etappen, aber feste Stunde — der Ausgang darf nicht davon
+    # abhaengen, zu welcher Tageszeit der Testlauf stattfindet.
+    jetzt = datetime.now(timezone.utc).astimezone(
+        tz_for_coords(*INNSBRUCK)
+    ).replace(hour=slot_stunde, minute=0, second=0, microsecond=0).astimezone(
+        timezone.utc
+    )
+    trip.report_config.morning_time = time(slot_stunde, 0)
+    # Eine Stunde SPAETER heisst: ausserhalb des Nachhol-Fensters, denn das
+    # oeffnet erst ab der konfigurierten Stunde.
+    trip.report_config.evening_time = time(slot_stunde + 1, 0)
+    save_trip(trip, uid)
+
+    gesendet, fehlgeschlagen = TripReportSchedulerService(
+        user_id=uid
+    ).send_due_reports(jetzt)
+
+    assert (gesendet, fehlgeschlagen) == (1, 0), (
+        f"Vorbedingung: der faellige Slot muss genau ein Briefing versenden, "
+        f"erhalten sent={gesendet}, failed={fehlgeschlagen}"
+    )
+    assert mitschrift.kanaele == list(ALLE_KANAELE), (
+        f"AC-3: das planmaessige Slot-Briefing muss weiterhin ALLE aktivierten "
+        f"Kanaele bedienen, bedient wurden {mitschrift.kanaele} ({mitschrift!r})"
+    )
+    assert _log_kanaele(uid, trip.id) == list(ALLE_KANAELE), (
+        f"AC-3: briefing_log.channels des Slot-Briefings ist "
+        f"{_log_kanaele(uid, trip.id)}"
+    )
+
+
+def test_ac3_testversand_bedient_weiter_alle_kanaele(mitschrift):
+    """AC-3 (Test-Versand-Knopf) — Regressionswaechter, heute GRUEN.
+
+    GIVEN derselbe Trip mit allen vier aktivierten Kanaelen.
+    WHEN  ``send_test_report_outcome(trip, "evening")`` laeuft — der Pfad des
+          Test-Versand-Knopfs, ohne Kanalangabe.
+    THEN  werden weiterhin alle vier Kanaele bedient.
+    """
+    uid = _kennung("ac3test")
+    _nutzer_anlegen(uid, mail="ac3test@example.invalid", chat_id="chat-ac3test")
+    trip = _trip_anlegen(uid, name="Kanaltreue AC3 Testversand")
+
+    ausgang = TripReportSchedulerService(user_id=uid).send_test_report_outcome(
+        trip, "evening",
+    )
+
+    assert ausgang == "sent", f"Vorbedingung: Testversand-Ausgang war {ausgang!r}"
+    assert mitschrift.kanaele == list(ALLE_KANAELE), (
+        f"AC-3: der Test-Versand muss weiterhin ALLE aktivierten Kanaele "
+        f"bedienen, bedient wurden {mitschrift.kanaele} ({mitschrift!r})"
+    )
+
+
+def test_ac3_report_kommando_bedient_weiter_alle_kanaele(mitschrift):
+    """AC-3 (``report``-Kommando am Draht) — Regressionswaechter, heute GRUEN.
+
+    GIVEN derselbe Trip mit allen vier aktivierten Kanaelen.
+    WHEN  der Nutzer per Telegram ``### report: morning`` sendet.
+    THEN  werden weiterhin alle vier Kanaele bedient.
+
+    Der schaerfste der drei AC-3-Faelle: er laeuft ueber DENSELBEN Draht wie
+    AC-1/AC-2 und traegt dieselbe Herkunftskennung. Wer die Einschraenkung
+    pauschal an ``msg.channel`` haengt statt am Anfragewort, wird hier rot.
+    """
+    uid = _kennung("ac3report")
+    _nutzer_anlegen(uid, mail="ac3report@example.invalid", chat_id="chat-ac3report")
+    trip = _trip_anlegen(uid, name="Kanaltreue AC3 Report")
+
+    ergebnis = TripCommandProcessor().process(InboundMessage(
+        trip_name=trip.name, body="### report: morning", sender="chat-ac3report",
+        channel="telegram", received_at=datetime.now(timezone.utc), user_id=uid,
+    ))
+
+    assert ergebnis.success, f"Vorbedingung: das report-Kommando lief nicht: {ergebnis}"
+    assert mitschrift.kanaele == list(ALLE_KANAELE), (
+        f"AC-3: das 'report'-Kommando muss weiterhin ALLE aktivierten Kanaele "
+        f"bedienen, bedient wurden {mitschrift.kanaele} ({mitschrift!r})"
+    )
+
+
+# ═══════════════════════════ AC-4 ════════════════════════════════════════════
+
+
+def test_ac4_deaktivierter_anfragekanal_wird_dennoch_bedient(mitschrift):
+    """AC-4 (PO-Entscheid: antworten statt ablehnen).
+
+    GIVEN ein Trip, in dem Telegram AUSDRUECKLICH abgeschaltet ist
+          (``send_telegram=False``), E-Mail/SMS/Premium-SMS aber aktiv sind.
+    WHEN  der Nutzer trotzdem per Telegram ``heute`` anfragt.
+    THEN  wird geantwortet, und zwar GENAU ueber Telegram — die
+          Trip-Einstellung wird fuer den Anfrageweg ueberschrieben, die drei
+          anderen Kanaele bleiben stumm.
+
+    RED heute: das System leitet still auf E-Mail/SMS/Premium-SMS um und meldet
+    Erfolg; auf dem Draht, ueber den gefragt wurde, kommt nichts an.
+
+    Diese Fixture ist die EINZIGE, die Mutation 2 der Spec faengt (Override zu
+    ``restrict_to_channel == "telegram" and config.send_telegram`` verdreht):
+    mit vier aktiven Kanaelen (AC-1/AC-2) bliebe die Verdrehung unsichtbar.
+    """
+    uid = _kennung("ac4")
+    _nutzer_anlegen(uid, mail="ac4@example.invalid", chat_id="chat-ac4")
+    trip = _trip_anlegen(uid, name="Kanaltreue AC4", kanaele={
+        "send_email": True, "send_sms": True,
+        "send_premium_sms": True, "send_telegram": False,
+    })
+    assert trip.report_config.send_telegram is False, (
+        "Testaufbau: Telegram muss im Trip abgeschaltet sein, sonst faengt "
+        "dieser Test Mutation 2 nicht"
+    )
+
+    ergebnis = _ueber_den_draht(
+        trip, "heute", kanal="telegram", user_id=uid, absender="chat-ac4",
+    )
+
+    assert ergebnis.success, f"Vorbedingung: der Abruf muss durchlaufen: {ergebnis}"
+    assert mitschrift.kanaele == ["telegram"], (
+        f"AC-4: die Anfrage kam ueber den im Trip DEAKTIVIERTEN Telegram-Draht "
+        f"— genau dieser muss die Antwort tragen, alle anderen nicht. Bedient "
+        f"wurden {mitschrift.kanaele} ({mitschrift!r})"
+    )
+    assert _log_kanaele(uid, trip.id) == ["telegram"], (
+        f"AC-4: briefing_log.channels muss ['telegram'] sein, ist "
+        f"{_log_kanaele(uid, trip.id)}"
+    )
+
+
+# ═══════════════════════════ AC-5 ════════════════════════════════════════════
+
+
+def _kanal_flags(trip, user_id: str, *, restrict_to_channel):
+    """``_resolve_channel_flags`` aufrufen — mit sprechendem RED-Grund.
+
+    Direktaufruf ist hier laut Spec zulaessig und noetig: SMS ist heute kein
+    Eingangsweg, der Fall kann den Draht gar nicht erreichen.
+    """
+    fn = getattr(TripReportSchedulerService, "_resolve_channel_flags", None)
+    assert fn is not None, (
+        "src/services/trip_report_scheduler.py hat keine Methode "
+        "`_resolve_channel_flags()` — die Kanal-Aufloesung steht weiterhin "
+        "zweimal wortgleich im Fliesstext (:1743-1752 und :1371-1379) und "
+        "kennt keine Kanal-Einschraenkung (Spec-Sektion 'Wirkort')."
+    )
+    scheduler = TripReportSchedulerService(user_id=user_id)
+    return fn(scheduler, trip.report_config, user_id,
+              restrict_to_channel=restrict_to_channel)
+
+
+def test_ac5_sms_override_ueberspringt_das_tier_gate_nicht(mitschrift):
+    """AC-5.
+
+    GIVEN zwei ECHTE Nutzerprofile auf der Platte — eines ohne SMS-Tier
+          (``free``), eines mit (``standard``) —, beide mit einem Trip, in dem
+          ``send_sms`` AUSGESCHALTET ist.
+    WHEN  fuer beide ``_resolve_channel_flags(config, user_id,
+          restrict_to_channel="sms")`` aufgeloest wird.
+    THEN  bleibt ``send_sms`` ohne Tier ``False`` und wird mit Tier ``True``:
+          das Override ueberschreibt die TRIP-Einstellung, nicht die
+          BERECHTIGUNG.
+
+    Kein Stub von ``sms_allowed`` — die fail-closed-Auflosung aus ``user.json``
+    ist Teil der Zusicherung. RED heute: ``_resolve_channel_flags`` fehlt.
+    """
+    ohne, mit_tier = _kennung("ac5-ohne"), _kennung("ac5-mit")
+    _nutzer_anlegen(ohne, mail="ac5a@example.invalid", chat_id="chat-ac5a", tier="free")
+    _nutzer_anlegen(mit_tier, mail="ac5b@example.invalid", chat_id="chat-ac5b",
+                    tier="standard")
+    ohne_sms = {"send_email": True, "send_sms": False,
+                "send_premium_sms": False, "send_telegram": False}
+    trip_ohne = _trip_anlegen(ohne, name="Kanaltreue AC5 ohne Tier", kanaele=ohne_sms)
+    trip_mit = _trip_anlegen(mit_tier, name="Kanaltreue AC5 mit Tier", kanaele=ohne_sms)
+
+    # Vorbedingung am ECHTEN Tier-Gate, nicht an der Annahme ueber die Datei.
+    from services.user_tier import sms_allowed
+    assert sms_allowed(ohne) is False and sms_allowed(mit_tier) is True, (
+        f"Testaufbau: sms_allowed muss die beiden Profile unterscheiden, "
+        f"erhalten ohne={sms_allowed(ohne)}, mit={sms_allowed(mit_tier)}"
+    )
+
+    flags_ohne = _kanal_flags(trip_ohne, ohne, restrict_to_channel="sms")
+    flags_mit = _kanal_flags(trip_mit, mit_tier, restrict_to_channel="sms")
+
+    assert flags_ohne[1] is False, (
+        f"AC-5: ohne SMS-Tier muss send_sms auch im Override-Fall False "
+        f"bleiben, erhalten {flags_ohne!r}"
+    )
+    assert flags_mit[1] is True, (
+        f"AC-5: mit SMS-Tier muss das Override die abgeschaltete "
+        f"Trip-Einstellung ueberschreiben, erhalten {flags_mit!r}"
+    )
+    assert flags_mit[0] is False and flags_mit[3] is False, (
+        f"AC-5: die Einschraenkung auf 'sms' muss E-Mail und Telegram "
+        f"abschalten, erhalten {flags_mit!r}"
+    )
+
+
+def test_ac5_ohne_einschraenkung_bleibt_die_alte_formel(mitschrift):
+    """AC-5 (Gegenprobe): ``restrict_to_channel=None`` ist das NEUTRALE Element.
+
+    GIVEN ein Premium-Nutzer und ein Trip mit allen vier Kanaelen.
+    WHEN  ``_resolve_channel_flags(..., restrict_to_channel=None)`` aufgeloest
+          wird.
+    THEN  kommen exakt die vier Trip-Einstellungen zurueck.
+
+    Ohne diese Gegenprobe waere AC-5 auch von einer Auflosung erfuellt, die
+    IMMER einschraenkt.
+    """
+    uid = _kennung("ac5-neutral")
+    _nutzer_anlegen(uid, mail="ac5c@example.invalid", chat_id="chat-ac5c")
+    trip = _trip_anlegen(uid, name="Kanaltreue AC5 neutral")
+
+    assert _kanal_flags(trip, uid, restrict_to_channel=None) == (True, True, True, True), (
+        f"AC-5: ohne Einschraenkung muessen die vier Trip-Einstellungen "
+        f"unveraendert durchkommen, erhalten "
+        f"{_kanal_flags(trip, uid, restrict_to_channel=None)!r}"
+    )
+
+
+# --- AC-5, gemessen am AUSGELIEFERTEN Kanal (Adversary F001) ----------------
+# Die beiden AC-5-Tests darueber pruefen die Unterscheidung am Rueckgabewert
+# von `_resolve_channel_flags`, und nur im Override-Zweig. Damit blieb der
+# Weg VOM Rueckgabe-Tupel BIS zum Transport unbewacht: das Unpacking in
+# `_build_trip_report_request` und die vier Keyword-Argumente an
+# `send_no_data_hint`. Alle anderen Tests dieser Datei fahren `tier="premium"`
+# — dort sind `sms_allowed` und `premium_sms_allowed` beide True und die
+# beiden Kanaele nicht auseinanderzuhalten.
+
+#: `sms_allowed` laesst `standard` durch, `premium_sms_allowed` nicht
+#: (`user_tier.py`, #1676 S2a). Genau EIN Tier trennt die beiden Gates — mit
+#: `free` waeren beide zu, mit `premium` beide offen.
+TRENNENDES_TIER = "standard"
+
+#: Beide SMS-artigen Kanaele im Trip AN — die Trip-Einstellung darf den
+#: Unterschied nicht schon vorwegnehmen, sonst misst der Test das Gate nicht.
+BEIDE_SMS_AN = {
+    "send_email": False, "send_sms": True,
+    "send_premium_sms": True, "send_telegram": False,
+}
+
+
+def _nutzer_mit_trennendem_tier(praefix: str):
+    uid = _kennung(praefix)
+    _nutzer_anlegen(uid, mail=f"{praefix}@example.invalid",
+                    chat_id=f"chat-{praefix}", tier=TRENNENDES_TIER)
+    from services.user_tier import premium_sms_allowed, sms_allowed
+    assert sms_allowed(uid) is True and premium_sms_allowed(uid) is False, (
+        f"Testaufbau: Tier {TRENNENDES_TIER!r} muss die beiden Gates TRENNEN, "
+        f"erhalten sms={sms_allowed(uid)}, premium={premium_sms_allowed(uid)} "
+        f"— sonst kann dieser Test eine Vertauschung nicht sehen."
+    )
+    return uid
+
+
+def test_ac5_briefing_bedient_sms_und_nicht_premium_sms(mitschrift):
+    """AC-5 am Auslieferungspfad (Erfolgsfall).
+
+    GIVEN ein Nutzer, dessen Tier die beiden SMS-Gates TRENNT (``standard``:
+          SMS erlaubt, Premium-SMS nicht), und ein Trip, in dem BEIDE
+          SMS-artigen Kanaele eingeschaltet sind.
+    WHEN  ein Briefing ohne jede Kanaleinschraenkung ausgeliefert wird.
+    THEN  geht es ueber SMS hinaus und NICHT ueber Premium-SMS.
+
+    Misst am tatsaechlich bedienten Ausgang, nicht am Rueckgabewert der
+    Auflosung: faengt eine Vertauschung der beiden Gates in der neutralen
+    Formel EBENSO wie eine Vertauschung beim Unpacking der vier Flags in
+    `_build_trip_report_request`. Kein Stub — die Gates lesen das echte
+    ``user.json``.
+    """
+    uid = _nutzer_mit_trennendem_tier("ac5liefer")
+    trip = _trip_anlegen(uid, name="Kanaltreue AC5 Auslieferung",
+                         kanaele=BEIDE_SMS_AN)
+
+    ausgang = TripReportSchedulerService(user_id=uid).send_test_report_outcome(
+        trip, "evening",
+    )
+
+    assert ausgang == "sent", f"Vorbedingung: Ausgang war {ausgang!r}"
+    assert mitschrift.kanaele == ["sms"], (
+        f"AC-5: mit Tier {TRENNENDES_TIER!r} darf NUR der SMS-Kanal bedient "
+        f"werden — Premium-SMS ist ein Premium-Merkmal (#1676 S2a). Bedient "
+        f"wurden {mitschrift.kanaele} ({mitschrift!r}). ['premium_sms'] heisst: "
+        f"die beiden Tier-Gates sind irgendwo auf dem Weg von "
+        f"`_resolve_channel_flags` bis zum Transport vertauscht."
+    )
+
+
+def test_ac5_ausfallhinweis_bedient_sms_und_nicht_premium_sms(
+    mitschrift, monkeypatch, tmp_path,
+):
+    """AC-5 am Auslieferungspfad (Ausfallfall).
+
+    GIVEN derselbe Aufbau und ein VOLLSTAENDIGER Wetterausfall.
+    WHEN  der No-Data-Hint-Zweig den Hinweistext ohne Kanaleinschraenkung
+          versendet.
+    THEN  geht auch er ueber SMS hinaus und NICHT ueber Premium-SMS.
+
+    Eigener Test, weil der Hinweis-Zweig die vier Flags als vier EINZELNE
+    Keyword-Argumente an ``send_no_data_hint`` weiterreicht — eine dort
+    vertauschte Zuordnung faengt der Erfolgsfall darueber nicht.
+
+    ``_leeres_fixture_verzeichnis`` steht weiter unten im AC-6-Block.
+    """
+    _leeres_fixture_verzeichnis(monkeypatch, tmp_path)
+    uid = _nutzer_mit_trennendem_tier("ac5ausfall")
+    trip = _trip_anlegen(uid, name="Kanaltreue AC5 Ausfall",
+                         kanaele=BEIDE_SMS_AN)
+
+    ausgang = TripReportSchedulerService(user_id=uid)._send_trip_report_outcome(
+        trip, "morning",
+    )
+
+    assert ausgang == "no_weather", (
+        f"Vorbedingung: der leere Fixture-Ordner muss einen Totalausfall "
+        f"erzeugen, Ausgang war {ausgang!r}"
+    )
+    assert mitschrift.kanaele == ["sms"], (
+        f"AC-5: der Ausfall-Hinweis darf mit Tier {TRENNENDES_TIER!r} nur ueber "
+        f"SMS gehen, bedient wurden {mitschrift.kanaele} ({mitschrift!r}) — "
+        f"['premium_sms'] heisst: die vier Keyword-Argumente an "
+        f"`send_no_data_hint` sind vertauscht."
+    )
+
+
+# ═══════════════════════════ AC-6 ════════════════════════════════════════════
+
+
+def _leeres_fixture_verzeichnis(monkeypatch, tmp_path) -> None:
+    """``# fake-provider-seam``: Fixture-Ordner OHNE Dateien -> JEDER
+    Wetterabruf scheitert real (``ProviderError``), also Totalausfall."""
+    leer = tmp_path / "fixtures_leer"
+    leer.mkdir()
+    monkeypatch.setenv("GZ_TEST_FIXTURE_DIR", str(leer))
+
+
+def test_ac6_positivkontrolle_ausfallhinweis_geht_ohne_einschraenkung_an_alle(
+    mitschrift, monkeypatch, tmp_path,
+):
+    """AC-6 Positivkontrolle — heute GRUEN, Vorbedingung fuer den Test darunter.
+
+    GIVEN ein Trip mit vier Kanaelen und ein VOLLSTAENDIGER Wetterausfall.
+    WHEN  ein planmaessiger Briefing-Lauf ohne Kanalangabe laeuft.
+    THEN  liefert er ``no_weather`` UND der Ausfall-Hinweis geht an alle vier
+          Kanaele.
+
+    Belegt, ohne das der Test darunter nichts messen wuerde: der
+    No-Data-Hint-Zweig (``trip_report_scheduler.py:1371-1379``) wird von diesem
+    Aufbau WIRKLICH erreicht und ist ohne Einschraenkung mehrkanalig.
+    """
+    _leeres_fixture_verzeichnis(monkeypatch, tmp_path)
+    uid = _kennung("ac6pos")
+    _nutzer_anlegen(uid, mail="ac6pos@example.invalid", chat_id="chat-ac6pos")
+    trip = _trip_anlegen(uid, name="Kanaltreue AC6 Positivkontrolle")
+
+    ausgang = TripReportSchedulerService(user_id=uid)._send_trip_report_outcome(
+        trip, "morning",
+    )
+
+    assert ausgang == "no_weather", (
+        f"Vorbedingung: der leere Fixture-Ordner muss einen Totalausfall "
+        f"erzeugen, Ausgang war {ausgang!r}"
+    )
+    assert mitschrift.kanaele == list(ALLE_KANAELE), (
+        f"Vorbedingung: der Ausfall-Hinweis muss ohne Einschraenkung an alle "
+        f"vier Kanaele gehen, bedient wurden {mitschrift.kanaele} ({mitschrift!r})"
+    )
+
+
+def test_ac6_ausfallhinweis_folgt_dem_anfragekanal(mitschrift, monkeypatch, tmp_path):
+    """AC-6.
+
+    GIVEN derselbe vollstaendige Wetterausfall, derselbe Trip mit vier Kanaelen.
+    WHEN  derselbe Lauf MIT gesetzter Kanal-Einschraenkung (``telegram``) laeuft.
+    THEN  geht auch der Hinweistext ausschliesslich an Telegram — der
+          No-Data-Hint-Zweig folgt derselben Auflosung wie der Haupt-Request.
+
+    Dies ist der Test gegen Mutation 1 der Spec (halber Fix, der nur
+    ``:1743-1752`` anfasst und ``:1371-1379`` vergisst): AC-1/AC-2/AC-4
+    beruehren den Ausfallzweig nie und blieben bei diesem halben Fix gruen.
+
+    Warum hier direkt am Scheduler statt am Draht: ``send_on_demand_report``
+    setzt ``on_demand=True``, und der Ausfallzweig laeuft ausdruecklich nur bei
+    ``not on_demand`` (``:1363``) — ueber den Ad-hoc-Draht ist er strukturell
+    unerreichbar (der Prozessor antwortet stattdessen selbst, siehe Test
+    darunter). Gemessen wird an der naechstgelegenen erreichbaren Stelle.
+
+    RED heute: ``_send_trip_report_outcome`` kennt keinen
+    ``restrict_to_channel``-Parameter.
+    """
+    _leeres_fixture_verzeichnis(monkeypatch, tmp_path)
+    uid = _kennung("ac6")
+    _nutzer_anlegen(uid, mail="ac6@example.invalid", chat_id="chat-ac6")
+    trip = _trip_anlegen(uid, name="Kanaltreue AC6")
+
+    scheduler = TripReportSchedulerService(user_id=uid)
+    assert "restrict_to_channel" in inspect.signature(
+        scheduler._send_trip_report_outcome
+    ).parameters, (
+        "`_send_trip_report_outcome` nimmt keinen `restrict_to_channel` "
+        "entgegen — die Kanalangabe erreicht weder den Haupt-Request noch den "
+        "No-Data-Hint-Zweig (Spec-Sektion 'Transportweg')."
+    )
+    ausgang = scheduler._send_trip_report_outcome(
+        trip, "morning", restrict_to_channel="telegram",
+    )
+
+    assert ausgang == "no_weather", (
+        f"Vorbedingung: es muss weiterhin ein Totalausfall sein, Ausgang war "
+        f"{ausgang!r}"
+    )
+    assert mitschrift.kanaele == ["telegram"], (
+        f"AC-6: der Ausfall-Hinweis muss dem Anfragekanal folgen, bedient "
+        f"wurden {mitschrift.kanaele} ({mitschrift!r}) — ein halber Fix, der "
+        f"nur die Haupt-Formel anfasst, faellt genau hier auf."
+    )
+
+
+def test_ac6_adhoc_ausfall_antwortet_auf_dem_anfrageweg(mitschrift, monkeypatch,
+                                                        tmp_path):
+    """AC-6b (Waechter gegen die falsche Reparatur) — Regressionswaechter, heute GRUEN.
+
+    GIVEN derselbe Totalausfall.
+    WHEN  der Nutzer per Telegram ``heute`` anfragt.
+    THEN  geht KEIN Briefing und KEIN Ausfall-Hinweis ueber irgendeinen Kanal
+          hinaus; der Prozessor beantwortet die Anfrage selbst
+          (``confirmation_body``), also auf dem Anfrageweg.
+
+    Haelt fest, warum AC-6 oben nicht am Draht messbar ist. Wuerde eine
+    Umsetzung den Hinweis-Zweig fuer On-Demand oeffnen, bekaeme der Nutzer die
+    Ausfallmeldung doppelt — das faengt dieser Waechter.
+    """
+    _leeres_fixture_verzeichnis(monkeypatch, tmp_path)
+    uid = _kennung("ac6draht")
+    _nutzer_anlegen(uid, mail="ac6draht@example.invalid", chat_id="chat-ac6draht")
+    trip = _trip_anlegen(uid, name="Kanaltreue AC6 Draht")
+
+    ergebnis = _ueber_den_draht(
+        trip, "heute", kanal="telegram", user_id=uid, absender="chat-ac6draht",
+    )
+
+    assert mitschrift.kanaele == [], (
+        f"AC-6: der Ad-hoc-Ausfall darf keinen zusaetzlichen Hinweis-Versand "
+        f"ausloesen, bedient wurden {mitschrift.kanaele} ({mitschrift!r})"
+    )
+    assert "nicht verfügbar" in (ergebnis.confirmation_body or ""), (
+        f"AC-6: der Prozessor muss die Ausfallmeldung selbst auf dem Anfrageweg "
+        f"beantworten, erhalten {ergebnis.confirmation_body!r}"
+    )
+
+
+# ═══════════════════════════ AC-7 ════════════════════════════════════════════
+
+
+def test_ac7_email_antwort_geht_an_die_profiladresse(mitschrift):
+    """AC-7 (E-Mail) — Regressionswaechter, heute GRUEN.
+
+    GIVEN ein per E-Mail erkannter Nutzer, dessen Profil ``mail_to`` traegt.
+    WHEN  er ``heute`` anfragt.
+    THEN  traegt die versendete Antwort als Empfaenger genau diese Adresse —
+          nicht den globalen ``GZ_MAIL_TO``-Rueckfall.
+
+    Die Auflosung (``Settings.with_user_profile``) ist bereits korrekt und wird
+    von dieser Scheibe nicht veraendert; bewacht war sie bisher nicht.
+    """
+    uid = _kennung("ac7mail")
+    _nutzer_anlegen(uid, mail="ac7-eigene@example.invalid", chat_id="chat-ac7")
+    trip = _trip_anlegen(uid, name="Kanaltreue AC7 Mail")
+
+    _ueber_den_draht(trip, "heute", kanal="email", user_id=uid,
+                     absender="ac7-eigene@example.invalid")
+
+    assert mitschrift.empfaenger("email") == ["ac7-eigene@example.invalid"], (
+        f"AC-7: die E-Mail-Antwort muss an die Profiladresse gehen, zugestellt "
+        f"an {mitschrift.empfaenger('email')} — der globale Rueckfall "
+        f"{_TRANSPORT_ENV['GZ_MAIL_TO']!r} waere ein Fremdempfaenger."
+    )
+
+
+def test_ac7_telegram_antwort_geht_an_die_profil_chat_id(mitschrift):
+    """AC-7 (Telegram) — Regressionswaechter, heute GRUEN.
+
+    GIVEN ein per Telegram erkannter Nutzer mit ``telegram_chat_id`` im Profil.
+    WHEN  er ``heute`` anfragt.
+    THEN  traegt die Telegram-Antwort genau diese ``chat_id`` — nicht den
+          globalen ``GZ_TELEGRAM_CHAT_ID``-Rueckfall.
+    """
+    uid = _kennung("ac7tg")
+    _nutzer_anlegen(uid, mail="ac7tg@example.invalid", chat_id="chat-ac7-eigen")
+    trip = _trip_anlegen(uid, name="Kanaltreue AC7 Telegram")
+
+    _ueber_den_draht(trip, "heute", kanal="telegram", user_id=uid,
+                     absender="chat-ac7-eigen")
+
+    assert set(mitschrift.empfaenger("telegram")) == {"chat-ac7-eigen"}, (
+        f"AC-7: die Telegram-Antwort muss an die chat_id des Profils gehen, "
+        f"zugestellt an {mitschrift.empfaenger('telegram')} — der globale "
+        f"Rueckfall {_TRANSPORT_ENV['GZ_TELEGRAM_CHAT_ID']!r} waere ein "
+        f"fremder Chat."
+    )
+
+
+# ═══════════════════════════ AC-8 ════════════════════════════════════════════
+
+
+def test_ac8_zwei_nutzer_bekommen_ihre_antwort_je_auf_ihrem_weg(mitschrift):
+    """AC-8 (Mandantentrennung).
+
+    GIVEN zwei verschiedene Nutzer mit je eigenem Trip, eigener E-Mail-Adresse
+          und eigener ``chat_id``.
+    WHEN  Nutzer A per E-Mail und Nutzer B per Telegram unabhaengig voneinander
+          ``heute`` anfragt.
+    THEN  bekommt A seine Antwort ausschliesslich per E-Mail an SEINE Adresse
+          und B ausschliesslich per Telegram an SEINE ``chat_id`` — keine
+          Kreuzung zwischen beiden.
+
+    RED heute: beide Anfragen loesen den vollen Vier-Kanal-Fan-out aus. Der
+    Kreuzungsteil ist heute schon erfuellt und bleibt der Waechter gegen eine
+    Umsetzung, die die Einschraenkung an einem prozessweiten Zustand statt am
+    Aufruf festmacht.
+    """
+    uid_a, uid_b = _kennung("ac8-a"), _kennung("ac8-b")
+    _nutzer_anlegen(uid_a, mail="ac8-a@example.invalid", chat_id="chat-ac8-a")
+    _nutzer_anlegen(uid_b, mail="ac8-b@example.invalid", chat_id="chat-ac8-b")
+    trip_a = _trip_anlegen(uid_a, name="Kanaltreue AC8 Nutzer A")
+    trip_b = _trip_anlegen(uid_b, name="Kanaltreue AC8 Nutzer B")
+
+    _ueber_den_draht(trip_a, "heute", kanal="email", user_id=uid_a,
+                     absender="ac8-a@example.invalid")
+    kanaele_a = mitschrift.kanaele
+    adressen_a = {k: list(mitschrift.empfaenger(k)) for k in ALLE_KANAELE}
+
+    mitschrift.leeren()
+    _ueber_den_draht(trip_b, "heute", kanal="telegram", user_id=uid_b,
+                     absender="chat-ac8-b")
+    kanaele_b = mitschrift.kanaele
+    adressen_b = {k: list(mitschrift.empfaenger(k)) for k in ALLE_KANAELE}
+
+    # Keine Kreuzung (heute schon erfuellt — Waechter).
+    assert "ac8-b@example.invalid" not in adressen_a["email"], (
+        f"AC-8: Nutzer A hat an die Adresse von Nutzer B gesendet: {adressen_a}"
+    )
+    assert "chat-ac8-a" not in adressen_b["telegram"], (
+        f"AC-8: Nutzer B hat an den Chat von Nutzer A gesendet: {adressen_b}"
+    )
+
+    # Kanaltreue je Nutzer (heute ROT).
+    assert kanaele_a == ["email"], (
+        f"AC-8: Nutzer A fragte per E-Mail und darf nur per E-Mail bedient "
+        f"werden, bedient wurden {kanaele_a} ({adressen_a})"
+    )
+    assert kanaele_b == ["telegram"], (
+        f"AC-8: Nutzer B fragte per Telegram und darf nur per Telegram bedient "
+        f"werden, bedient wurden {kanaele_b} ({adressen_b})"
+    )
+    assert adressen_a["email"] == ["ac8-a@example.invalid"], (
+        f"AC-8: A muss seine eigene Adresse bekommen: {adressen_a}"
+    )
+    assert set(adressen_b["telegram"]) == {"chat-ac8-b"}, (
+        f"AC-8: B muss seinen eigenen Chat bekommen: {adressen_b}"
+    )
+    assert _log_kanaele(uid_a, trip_a.id) == ["email"], (
+        f"AC-8: briefing_log von A ist {_log_kanaele(uid_a, trip_a.id)}"
+    )
+    assert _log_kanaele(uid_b, trip_b.id) == ["telegram"], (
+        f"AC-8: briefing_log von B ist {_log_kanaele(uid_b, trip_b.id)}"
+    )


### PR DESCRIPTION
Schliesst #2126 · Scheibe **S3** von Epic #2133

## Worum es geht

Eine Ad-hoc-Anfrage (`heute`/`morgen`) loeste bisher den regulaeren Briefing-Fan-out ueber **alle** im Trip aktivierten Kanaele aus — unabhaengig davon, worueber gefragt wurde. Kuenftig wird **ausschliesslich der anfragende Kanal** bedient.

Der Grundsatz „Antwort auf gleichem Kanal" (`inbound_command_channels.md:90`) galt bislang nur fuer die kurzen Bestaetigungstexte. Der Vollbriefing-Pfad entzog sich ihm, weil er nicht ueber `confirmation_body` antwortet, sondern den Versand-Fan-out ausloest. Dieser PR zieht den einen Pfad nach — er erfindet keine neue Regel.

## Wirkort

Die Einschraenkung greift dort, wo die Kanal-Flags **entstehen**, nicht wo sie verbraucht werden. `_resolve_channel_flags` loest die bisher **zweimal wortgleiche** Formel ab (Haupt-Request und No-Data-Hint-Zweig). `restrict_to_channel=None` ist das neutrale Element und liefert exakt die alte Formel — planmaessige Slot-Briefings, Test-Versand und das `report`-Kommando bleiben unveraendert mehrkanalig.

Ist der anfragende Kanal im Trip **deaktiviert**, wird er fuer diese eine Antwort dennoch bedient (PO-Entscheid 2026-09-06: antworten statt ablehnen). Das Override ueberschreibt die Trip-Einstellung, **nicht** die Tier-Berechtigung — Premium-SMS mit eigenem Gate (ADR-0049-Folgepflicht, #1676 S2a).

## Nachweis

| | |
|---|---|
| Zieltests | 17 gruen, 0 rot |
| Regressionsfeger | **1942 gruen ueber 186 Dateien**, 0 rot |
| Akzeptanzkriterien | 12/12 belegt |
| Adversary-Verdict | **VERIFIED** (2 Runden) |
| Mutations-Gegenprobe | 8 Mutationen, alle relevanten gefangen |

**Der Adversary fand im ersten Durchgang eine echte Luecke (F001, MEDIUM):** Die Vertauschung von SMS und Premium-SMS an den zwei Stellen, die dieser PR neu zusammenfuehrt, blieb von der eigenen Testsuite ungefangen — nur eine fremde, aeltere Testdatei bemerkte sie. Geschlossen mit zwei Tests, die am tatsaechlich bedienten Kanal messen (Erfolgs- und Ausfallpfad getrennt) und vom Finder eigenhaendig gegengeprueft.

## Nebenwirkung

`briefing_log.channels` enthaelt bei angeforderten Briefings nur noch den bedienten Kanal statt aller Trip-Kanaele. Gelesen von der Cockpit-Kachel „Was geht heute raus" (#393). Gewollte Wirkung, in der Spec als Known Limitation vermerkt.

## Was offen bleibt

- **#1199 (LOW):** Ein unbekannter `restrict_to_channel`-Wert mutet still alle vier Kanaele, ohne Log oder Fehler. Heute unerreichbar (nur `email`/`telegram` kommen an), relevant ab **Scheibe S4** (Premium-SMS als Eingangsweg).
- **SMS und Premium-SMS sind heute kein Eingangsweg** — Regulaer-SMS ist kein Befehlskanal, Premium-SMS verwirft den Nachrichtentext und lernt nur die Absendernummer. Fuer diese beiden aendert sich praktisch nichts; sie kommen mit S4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KbRSjSm75PyX2repxsW8w1
