### PR TITLE
fix(#2168): Registrierungs-Hinweis geht an den fragenden Chat

### DIFF
--- a/docs/context/fix-2168-antwort-an-den-fragenden.md
+++ b/docs/context/fix-2168-antwort-an-den-fragenden.md
@@ -1,0 +1,199 @@
+# Context: fix-2168-antwort-an-den-fragenden
+
+**Issue:** #2168 — Antwort an unbekannte Absender geht an den Betreiber statt an den Fragenden
+**Herkunft:** herausgelöst aus #2126 (Scheibe S3 von Epic #2133)
+**Erstellt:** 2026-09-07 · **Track:** Bug
+**Basis:** `origin/main` @ `c7949887`
+
+## Analysis
+
+### Type
+
+**Bug.**
+
+### Request Summary
+
+Schreibt jemand dem Telegram-Bot von einer Chat-ID, die keinem Nutzerprofil zugeordnet ist,
+geht der Registrierungshinweis an die Chat-ID des **Basis-/Betreiberprofils** statt an den
+Fragenden. Der Fragende bekommt nichts, der Betreiber bekommt es bei jeder fremden Nachricht
+erneut — zugleich ein Flut-Vektor gegen den Betreiber-Chat.
+
+### Ist-Stand — die Bestandserhebung hat den Ticket-Umfang auf ein Drittel reduziert
+
+Das Issue nannte **drei** Fundstellen. Nachgemessen hält **eine** stand.
+
+| Ticket-Fundstelle | Befund |
+|---|---|
+| Telegram `_process_update`, Zweig `user_id == "default"` (`inbound_telegram_reader.py:181-191`) | ✅ **Defekt bestätigt** |
+| Telegram-Callback (`inbound_telegram_reader.py:305-317`) | ❌ **widerlegt** — korrekt |
+| E-Mail (`inbound_email_reader.py:106,121-132`) | ❌ **widerlegt** — unerreichbar |
+| SMS / Premium-SMS | ❌ kein Antwort-Rückkanal vorhanden |
+
+#### A) Der bestätigte Defekt — genau eine Zeile
+
+```
+inbound_telegram_reader.py:182-191   send_telegram_message(chat_id=chat_id, …, settings=settings)
+                                                                                        ^^^^^^^^
+                                                        Basis-Settings statt der Absender-Adresse
+  notification_service.py:1828-1845  send_telegram_message(...)  ← chat_id NUR im Fehler-Log (:1844)
+    telegram.py:379-403              TelegramOutput.send(...)    ← kein Chat-Parameter
+      :403                           chat_id = self._guard_code_origin(self._settings.telegram_chat_id)
+```
+
+Der Aufruf übergibt die richtige `chat_id` — sie wird nur nirgends **verwendet**. Die
+tatsächlich gesendete Adresse ist `settings.telegram_chat_id`.
+
+#### B) Nur der `default`-Zweig weicht ab — alle anderen sechs Aufrufer sind korrekt
+
+| Aufrufer in `inbound_telegram_reader.py` | übergebene `settings` | Adresse == Absender? |
+|---|---|---|
+| `:182-191` Registrierungshinweis (`user_id=="default"`) | `settings` (Basis) | **NEIN — der Defekt** |
+| `:203-208` kein aktiver Trip | `user_settings` | ja |
+| `:217-224` unbekannter Befehl | `user_settings` | ja |
+| `:241-246` Lade-Nachricht | `user_settings` | ja |
+| `:268-272` / `:277-281` `send_command_reply_telegram` | `user_settings` | ja |
+| `:437-442` `_process_start_command` | `settings.model_copy(update={"telegram_chat_id": chat_id})` | ja — **Muster-Beleg** |
+
+Warum die sechs strukturell stimmen: `_resolve_user_for_chat` (`:406-423`) findet den `user_id`
+per `lookup_user_by_telegram_chat_id` (`app/loader.py:1244-1265`) **exakt über den Treffer auf
+`profile["telegram_chat_id"] == chat_id`**, und `with_user_profile` (`app/config.py:387-388`)
+übernimmt diesen Wert 1:1. Bei jedem Treffer ist `user_settings.telegram_chat_id == chat_id`
+per Konstruktion. Nur `with_user_profile("default")` fällt mangels
+`data/users/default/user.json` unverändert auf die Basis zurück (`config.py:376-377`) — genau
+die Adresse des Betreibers.
+
+**Leere/ungültige `chat_id`?** Ausgeschlossen: `:166` filtert vorher (`if not text or not
+chat_id: return False`), `:165` liefert immer einen gestringten Telegram-Integer.
+
+#### C) Warum der Callback-Pfad korrekt ist
+
+`edit_telegram_message_text` (`notification_service.py:1859-1864`) reicht `chat_id` an
+`TelegramOutput.edit_message_text(chat_id, …)` durch, und die Methode setzt sie in den Payload
+(`telegram.py:550,561`). Der Button-Klick eines unbekannten Chats wird in **seinem** Chat
+editiert. Die Nachbarfunktion sah nur gleich aus.
+
+#### D) Warum der E-Mail-Pfad unerreichbar ist
+
+`_authorize` (`inbound_email_reader.py:188-202`) läuft in `_process_single` **vor** dem
+Trip-Lookup (`:107-109`) und lässt nur Absender durch, die `mail_to` oder `inbound_address` des
+aufgelösten Profils sind. Für `user_id == "default"` ist das die Betreiber-Adresse; ein Fremder
+wird auf `\Seen` gesetzt und verworfen — es geht **gar keine** Antwort raus, an niemanden.
+
+Gegenprobe auf einen Umgehungsweg: kein zweiter Einlass. Die einzige Instanziierung von
+`InboundEmailReader` außerhalb von Tests ist `api/routers/scheduler.py:130,138`
+(`POST /api/scheduler/inbound-commands`) → `poll_and_process` → `_process_single` → `_authorize`.
+
+#### E) Missbrauchsfrage aus „Zu klären vor der Umsetzung" — entschieden
+
+Die Telegram-Bot-API erlaubt `sendMessage` nur an Chats, die den Bot selbst angeschrieben
+haben. Eine Antwort an den Fragenden kann also **nicht** genutzt werden, um unbeteiligte Dritte
+zu belästigen. Der heutige Zustand ist der riskantere: er lenkt jede fremde Nachricht in den
+Betreiber-Chat um. Für E-Mail (Absender fälschbar, echter Verstärker-Vektor) stellt sich die
+Frage nicht, weil dort ohnehin nicht geantwortet wird. **Entscheidung: antworten, wie heute
+beabsichtigt — nur an die richtige Adresse.**
+
+### Affected Files (with changes)
+
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `src/services/inbound_telegram_reader.py` | MODIFY | `:190` — `settings=settings` → `settings.model_copy(update={"telegram_chat_id": chat_id})`, spiegelbildlich zu `:436` |
+| `tests/tdd/test_antwort_an_den_fragenden.py` | CREATE | Kern-Tests AC-1/AC-3/AC-4 (Telegram) |
+| `tests/tdd/test_unbekannter_absender_bleibt_unbeantwortet.py` | CREATE | Kern-Test AC-2 (E-Mail-Schweigen + Positivkontrolle) |
+
+**Ausdrücklich NICHT anzufassen:** `notification_service.py:1809-1845` (keine Signaturänderung
+nötig), `telegram.py:162-252` (Wächter bleiben unverändert), `inbound_email_reader.py`
+Produktivcode (kein Defekt — nur Testlücke), `inbound_telegram_reader.py:305-317` (korrekt).
+
+### Scope Assessment
+
+- Files: **3** (1 MODIFY, 2 CREATE)
+- Estimated LoC: Produktivcode **+2/-1**, Tests **+100…170** → unter dem Limit von 250
+- Risk Level: **LOW**
+
+### Technical Approach
+
+**Gewählt: `settings.model_copy(update={"telegram_chat_id": chat_id})` am Aufrufort.**
+
+Begründung gegenüber der Alternative (neuer `chat_id`-Parameter an `TelegramOutput.send()`):
+Die drei Telegram-Wächter `_guard_code_origin` (`telegram.py:162-195`),
+`_guard_test_mode_chat_id` (`:197-216`) und `_guard_test_mode_target_chat` (`:236-252`) hängen
+an `settings.telegram_chat_id`. Setzt der Fix genau diese Größe, greifen alle drei unverändert,
+weil sie dann die **tatsächlich verwendete** Adresse messen. Ein zusätzlicher Parameter würde
+`_guard_test_mode_chat_id` an der falschen Größe messen lassen — der Wächter würde still zum
+Stellvertreter. Zudem existiert das Muster bereits im selben Modul (`:436`), es wird an einer
+Stelle nur nicht angewendet.
+
+### Nachweisform — die Messstelle ist erzwungen, nicht frei gewählt
+
+**Am Draht (`httpx.post`-Payload) ist der Empfänger nicht messbar.** `_guard_code_origin`
+(`telegram.py:162-195`) hängt nicht an `is_test_mode`, sondern an der **Herkunft des Codes**
+(`app/origin_guard.py:30-41`, exakter Pfadvergleich gegen die Prod-/Staging-Wurzel). Aus jedem
+Worktree — also in jedem Testlauf — schaltet er die Ziel-Chat-ID auf `telegram_test_chat_id`
+um oder bricht hart ab. Ein Payload-Test sähe immer nur die Test-Chat-ID und wäre ein blinder
+Wächter.
+
+**Die höchste erreichbare Messstelle ist damit die Konstruktor-Naht von `TelegramOutput`** —
+dort liegt die Adresse fest, die `send()` benutzen wird. Muster im Bestand:
+`Kanalmitschrift` / `_aufzeichner_installieren`
+(`tests/tdd/test_kanaltreue_adhoc_antwort.py:115-192`, konkret `:178`) ersetzt
+`notification_service.TelegramOutput` durch eine echte Klasse, die
+`settings.telegram_chat_id` in `__init__` mitschneidet. `Mock()`-frei, wiederverwendbar.
+
+**Korrektur einer naheliegenden Falle:** Ein Test, der am Notifier nur das **`chat_id`-Argument**
+abgreift (Muster `_MitschnittNotifier`,
+`tests/tdd/test_kommandoliste_einzelquelle.py:234-247`), wäre **heute schon grün** — dieses
+Argument wird bereits korrekt übergeben, es wird nur nicht verwendet. Gemessen werden muss die
+**verwendete Adresse**, nicht das ignorierte Argument. Der Notifier-Aufzeichner darf nur als
+Einstiegs-Blaupause dienen (`:250-272` zeigt den Aufruf über
+`reader._process_update(update, settings)` mit gesetztem `reader._notification_service`), nicht
+als Messgröße.
+
+**Einstieg für alle Telegram-ACs:** `InboundTelegramReader._process_update(update, settings)` mit
+einer **nicht** registrierten `chat_id`. Der Einstieg über `TripCommandProcessor().process(...)`
+(wie `test_kanaltreue_adhoc_antwort.py:255-261`) erreicht den `default`-Zweig **nicht** — er
+überspringt den Reader.
+
+### Dependencies
+
+- `app/config.py` — `with_user_profile` (`:355-399`), `telegram_chat_id` (`:207`, reines `str`
+  ohne Validator), `is_test_mode` (`:167,328,344`)
+- `app/loader.py:1244-1265` — `lookup_user_by_telegram_chat_id`
+- `output/channels/telegram.py:162-252` — die drei Wächter (bleiben unverändert)
+- `app/origin_guard.py:30-41` — Herkunftssperre, bestimmt die Messstelle
+
+### Vorgeschlagene Acceptance Criteria (Freigabe in `/30-write-spec`)
+
+- **AC-1:** Given eine Telegram-Nachricht von einer Chat-ID, die keinem Nutzerprofil zugeordnet
+  ist / When das System mit dem Registrierungshinweis antwortet / Then ist die zum Versand
+  verwendete Adresse **genau diese** Chat-ID und nicht die des Basis-/Betreiberprofils.
+- **AC-2:** Given eine E-Mail von einem Absender ohne Nutzerprofil / When der Reader sie
+  verarbeitet / Then wird **überhaupt keine** Antwort versendet — weder an ihn noch an den
+  Betreiber; und dieselbe Testanordnung sendet bei einem bekannten Absender sehr wohl
+  (Positivkontrolle, sonst belegt das Ausbleiben nur einen kaputten Testaufbau).
+- **AC-3:** Given ein erkannter Nutzer / When er einen Befehl schickt / Then bleibt das
+  Verhalten unverändert — die verwendete Adresse ist seine Profil-Adresse.
+- **AC-4:** Given die Zusicherung aus AC-1 / When die Adress-Auflösung im Produktivcode wieder
+  auf die Basis-Adresse zurückfällt / Then wird mindestens ein Test rot
+  (Mutations-Gegenprobe).
+
+### Open Questions
+
+- [x] Soll auf Nachrichten unbekannter Absender überhaupt geantwortet werden? → **Ja**, siehe
+  Abschnitt E. Kein Verstärker-Risiko bei Telegram; der heutige Zustand ist der riskantere.
+- [x] Scope auf Telegram eingrenzen? → **Ja.** E-Mail und SMS haben keinen wirksamen Defekt;
+  E-Mail bekommt nur den fehlenden Wächter (AC-2).
+- [ ] **Bewusst zu entscheidender Randfall (in der Spec festzuhalten):** Trägt die
+  Basis-`settings` bereits `is_test_mode=True` (Staging), prüft
+  `_guard_test_mode_chat_id` (`telegram.py:206-216`) die neu gesetzte echte Absender-Chat-ID
+  gegen `telegram_test_chat_id` und wirft `OutputConfigError`. Das `try/except` in
+  `send_telegram_message` (`notification_service.py:1838-1845`) fängt sie — der Hinweis geht
+  dann an **niemanden** statt an den Betreiber. Bewertung: **gewünschtes Fail-Closed**; Staging
+  darf keine echten Fremden anschreiben. Heute deckt kein Test diese Kombination ab.
+
+### Nebenbefund (nicht Teil dieses Zuschnitts)
+
+`user_id == "default"` dient als reiner String-Sentinel für „kein Profil-Treffer"
+(`inbound_telegram_reader.py:181`, `:305`, `:422`). Ein *echter* Nutzer mit `user_id ==
+"default"` würde fälschlich in diesen Zweig fallen; kein Code-Invariant verbietet das, der
+Docstring `:178-180` schließt es nur über die Datenlage aus. → Kandidat für die Sammelstelle
+#1199.

--- a/docs/specs/modules/feat_2126_kanaltreue_adhoc_antwort.md
+++ b/docs/specs/modules/feat_2126_kanaltreue_adhoc_antwort.md
@@ -268,13 +268,17 @@ erhalten dürfen.
   gebaut, dass sie für alle vier Kanalnamen korrekt auflöst, sobald sie eintreffen können.
   Premium-SMS als Eingangsweg ist Scheibe **S4** von Epic #2133 und baut ausdrücklich auf
   dieser Scheibe auf.
-- **Unbekannter Absender (`user_id == "default"`) bleibt unrepariert.** Der
-  Registrierungshinweis an eine unbekannte `chat_id`/E-Mail-Adresse geht weiterhin an das
-  Default-/Betreiberprofil statt an den tatsächlichen Absender
-  (`inbound_telegram_reader.py:181-194`, `:305-317`; `inbound_email_reader.py:106`, `:121-132`).
-  Dieser Pfad erreicht `_handle_query`/`send_on_demand_report` nie und ist damit von dieser
-  Spec strukturell nicht erfasst — eigenes Issue nach Projektregel (nutzersichtbares
-  Fehlverhalten).
+- **Unbekannter Absender (`user_id == "default"`) — durch #2168 erledigt.** Die frühere Fassung
+  dieses Punkts behauptete, der Registrierungshinweis gehe auf **drei** Pfaden an das
+  Default-/Betreiberprofil. Nachgemessen hielt davon nur einer stand:
+  - Telegram-Text-Nachricht (`inbound_telegram_reader.py:181-196`) — **war** betroffen,
+    seit #2168 behoben: der Hinweis geht an die anfragende `chat_id`.
+  - Telegram-Callback-Query (`:305-317`) — **war nie betroffen**: `edit_telegram_message_text`
+    bekommt `chat_id=chat_id` explizit übergeben; `settings` liefert dort nur das Bot-Token.
+  - E-Mail (`inbound_email_reader.py:106`) — **war nie betroffen**: `_authorize` verwirft einen
+    unbekannten Absender **vor** jeder Antwortstelle, es geht überhaupt keine Antwort raus.
+  Der Pfad erreicht `_handle_query`/`send_on_demand_report` weiterhin nie und ist damit von
+  dieser Spec strukturell nicht erfasst; ein eigenes Issue ist dafür nicht mehr offen.
 - **Adress-ACs (AC-7/AC-8) sind für Test-Nutzer und Staging strukturell blind.**
   `Settings.with_user_profile` setzt `force_test` bei einer Test-User-ID oder `env == "staging"`
   (`src/app/config.py:369`) und verwirft dann die Profil-`telegram_chat_id` (`:387`). Testkennungen

--- a/docs/specs/modules/fix_2168_antwort_an_den_fragenden.md
+++ b/docs/specs/modules/fix_2168_antwort_an_den_fragenden.md
@@ -1,0 +1,186 @@
+---
+entity_id: fix_2168_antwort_an_den_fragenden
+type: module
+created: 2026-09-07
+updated: 2026-09-07
+status: draft
+version: "1.0"
+tags: [bug, inbound, telegram, kanaltreue, issue-2168]
+---
+
+# Antwort an den Fragenden statt an den Betreiber (#2168)
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Eine eingehende Telegram-Nachricht von einer Chat-ID, die keinem Nutzerprofil zugeordnet ist,
+wird heute mit dem Registrierungshinweis beantwortet — aber die Antwort geht an die Chat-ID des
+Basis-/Betreiberprofils, nicht an den Fragenden. Dieser Fix richtet die Antwort an den Absender
+und nagelt zugleich das (korrekte) Schweigen des E-Mail-Pfads gegenüber unbekannten Absendern
+fest, das heute von keinem Test bewacht ist.
+
+## Source
+
+- **File:** `src/services/inbound_telegram_reader.py`
+- **Identifier:** `InboundTelegramReader._process_update`, Zweig `user_id == "default"`
+  (`:181-191`, wirksame Zeile `:190`)
+
+Schicht: **Python-Core / Domain-Backend** (`src/services/`). Kein Go-, kein Frontend-Anteil.
+
+## Estimated Scope
+
+- **LoC:** Produktivcode ~+2/-1, Tests ~+100…170
+- **Files:** 3 (1 MODIFY, 2 CREATE)
+- **Effort:** low
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `NotificationService.send_telegram_message` (`src/services/notification_service.py:1828-1845`) | unverändert | Naht zum Kanal; nimmt `chat_id` entgegen, nutzt sie nur im Fehler-Log |
+| `TelegramOutput.send` (`src/output/channels/telegram.py:379-421`) | unverändert | liest die Zieladresse ausschließlich aus `settings.telegram_chat_id` (`:403`) |
+| `TelegramOutput`-Wächter (`telegram.py:162-252`) | unverändert | `_guard_code_origin`, `_guard_test_mode_chat_id`, `_guard_test_mode_target_chat` — alle hängen an `settings.telegram_chat_id` |
+| `Settings.with_user_profile` (`src/app/config.py:355-399`) | unverändert | übernimmt `profile["telegram_chat_id"]` 1:1 (`:387-388`); fällt für `"default"` auf die Basis zurück (`:376-377`) |
+| `lookup_user_by_telegram_chat_id` (`src/app/loader.py:1244-1265`) | unverändert | findet den Nutzer exakt über den Treffer auf `telegram_chat_id` |
+| `running_origin` (`src/app/origin_guard.py:30-41`) | unverändert | Herkunftssperre — bestimmt, wo ein Test messen kann |
+| `InboundEmailReader._process_single` / `_authorize` (`src/services/inbound_email_reader.py:94-162`, `:188-202`) | unverändert | Prüfling für AC-2, **kein** Codeeingriff |
+
+## Implementation Details
+
+Der Aufruf im `default`-Zweig übergibt die richtige `chat_id` bereits — sie wird nur nirgends
+verwendet. Gesendet wird an `settings.telegram_chat_id`. Der Fix setzt genau diese Größe:
+
+```python
+# src/services/inbound_telegram_reader.py, Zweig `user_id == "default"` (~:182-191)
+mid = self._notification_service.send_telegram_message(
+    chat_id=chat_id,
+    subject="Registrierung erforderlich",
+    body=(...),
+    settings=settings.model_copy(update={"telegram_chat_id": chat_id}),
+)
+```
+
+**Warum diese Form und nicht ein neuer `chat_id`-Parameter an `TelegramOutput.send()`:** Die
+drei Telegram-Wächter (`telegram.py:162-252`) messen an `settings.telegram_chat_id`. Setzt der
+Fix genau diese Größe, prüfen alle drei weiterhin die **tatsächlich verwendete** Adresse. Ein
+zusätzlicher Parameter würde `_guard_test_mode_chat_id` (`:197-216`) an der falschen Größe
+messen lassen — der Wächter würde still zum Stellvertreter. Das Muster existiert bereits im
+selben Modul: `_process_start_command` (`:436`) baut genau dieses `model_copy`.
+
+**Kein weiterer Eingriff.** Ausdrücklich unverändert bleiben:
+`inbound_telegram_reader.py:305-317` (Callback-Pfad — reicht die `chat_id` bis in den Payload
+durch, `telegram.py:550,561`, korrekt), `notification_service.py:1809-1845` (keine
+Signaturänderung), `telegram.py:162-252`, und der gesamte Produktivcode von
+`inbound_email_reader.py` (dort ist kein Defekt, nur eine Testlücke).
+
+### Nachweisform — die Messstelle ist erzwungen, nicht frei gewählt
+
+**Am Draht (`httpx.post`-Payload) ist der Empfänger nicht messbar.** `_guard_code_origin`
+(`telegram.py:162-195`) hängt nicht an `is_test_mode`, sondern an der Herkunft des Codes
+(`origin_guard.py:30-41`, exakter Pfadvergleich gegen die Prod-/Staging-Wurzel). Aus jedem
+Worktree — also in jedem Testlauf — schaltet er die Ziel-Chat-ID auf `telegram_test_chat_id`
+um oder bricht hart ab. Ein Payload-Test sähe immer nur die Test-Chat-ID und wäre ein blinder
+Wächter.
+
+**Höchste erreichbare Messstelle: die Konstruktor-Naht von `TelegramOutput`.** Muster im
+Bestand: `Kanalmitschrift` / `_aufzeichner_installieren`
+(`tests/tdd/test_kanaltreue_adhoc_antwort.py:115-192`, konkret `:178`) ersetzt
+`notification_service.TelegramOutput` durch eine echte Klasse, die `settings.telegram_chat_id`
+in `__init__` mitschneidet. `Mock()`-frei.
+
+**Falle, die ein Test vermeiden MUSS:** Ein Aufzeichner, der am Notifier nur das
+**`chat_id`-Argument** abgreift (Muster `_MitschnittNotifier`,
+`tests/tdd/test_kommandoliste_einzelquelle.py:234-247`), ist **heute schon grün** — dieses
+Argument wird bereits korrekt übergeben, es wird nur nicht benutzt. Gemessen werden muss die
+**verwendete Adresse**, nicht das ignorierte Argument. Der Notifier-Aufzeichner darf nur als
+Einstiegs-Blaupause dienen (`:250-272` zeigt den Aufruf über
+`reader._process_update(update, settings)` mit gesetztem `reader._notification_service`).
+
+**Einstieg für alle Telegram-Kriterien:** `InboundTelegramReader._process_update(update,
+settings)` mit einer **nicht** registrierten `chat_id`. Der Einstieg über
+`TripCommandProcessor().process(...)` (wie `test_kanaltreue_adhoc_antwort.py:255-261`) erreicht
+den `default`-Zweig **nicht** — er überspringt den Reader.
+
+## Expected Behavior
+
+- **Input:** Ein Telegram-Update mit `message.chat.id`, zu dem kein `data/users/<id>/user.json`
+  einen Treffer auf `telegram_chat_id` liefert.
+- **Output:** Der Registrierungshinweis („Dieser Chat ist noch nicht mit einem
+  Gregor-Zwanzig-Konto verknuepft. Sende /start …") geht an **diese** Chat-ID.
+- **Side effects:** Keine Persistenz, keine Trip-/Wetterdaten (unverändert). Die Chat-ID des
+  Basis-/Betreiberprofils erhält nichts mehr.
+
+## Acceptance Criteria
+
+- **AC-1:** Given eine Telegram-Nachricht von einer Chat-ID, zu der kein Nutzerprofil existiert
+  / When das System mit dem Registrierungshinweis antwortet / Then ist die zum Versand
+  verwendete Adresse genau diese Chat-ID und nicht die des Basis-/Betreiberprofils.
+  - Test: `_process_update` mit einer nicht registrierten Chat-ID aufrufen, bei der die
+    Basis-Einstellungen eine **abweichende** Chat-ID tragen; der Aufzeichner an der
+    `TelegramOutput`-Konstruktor-Naht muss die Absender-Chat-ID sehen und die Basis-Chat-ID
+    darf in keiner Aufzeichnung vorkommen.
+
+- **AC-2:** Given eine E-Mail von einem Absender, zu dem kein Nutzerprofil existiert / When der
+  Reader diese Nachricht verarbeitet / Then wird überhaupt keine Antwort versendet — weder an
+  den Absender noch an das Basis-/Betreiberprofil.
+  - Test: `_process_single` vollständig durchlaufen lassen (Fake-IMAP, das nur `fetch` und
+    `store` bereitstellt) mit einem fremden `From:`; der Versand-Aufzeichner darf **keinen**
+    Aufruf sehen. Das isolierte `_authorize(...) is False` genügt NICHT — es gibt es bereits
+    (`tests/tdd/test_bug_inbound_email_loop.py:71-77`) und es misst nicht das Ausbleiben des
+    Versands.
+
+- **AC-3:** Given dieselbe Testanordnung wie in AC-2, aber mit einem bekannten Absender und
+  einem existierenden Trip im Betreff / When der Reader diese Nachricht verarbeitet / Then wird
+  sehr wohl eine Antwort versendet.
+  - Test: Positivkontrolle zu AC-2 — ohne sie ist ein leeres Ergebnis in AC-2 genauso gut
+    durch einen kaputten Testaufbau erklärbar wie durch korrektes Blocken.
+
+- **AC-4:** Given ein Telegram-Absender, dessen Chat-ID einem Nutzerprofil zugeordnet ist /
+  When er einen Befehl schickt / Then bleibt das Verhalten unverändert und die zum Versand
+  verwendete Adresse ist die Chat-ID aus seinem Profil.
+  - Test: registrierte Chat-ID über `_process_update` schicken; der Aufzeichner sieht die
+    Profil-Chat-ID. Sichert, dass der Fix die sechs bereits korrekten Aufrufer nicht verschiebt.
+
+- **AC-5:** Given die Zusicherung aus AC-1 / When die Adress-Auflösung im Produktivcode wieder
+  auf die Basis-Adresse zurückfällt (Mutation: das `model_copy` durch die unveränderten
+  Basis-Einstellungen ersetzen) / Then wird mindestens einer der Tests aus AC-1 rot.
+  - Test: Mutations-Gegenprobe per String-Ersetzung mit externer Sicherungskopie, Protokoll im
+    Adversary-Dialog. Zusätzlich die Umkehrprobe zu AC-2: wird im E-Mail-Reader die
+    Autorisierungsprüfung (`inbound_email_reader.py:107-109`) entfernt, muss der AC-2-Test rot
+    werden — sonst bewacht er das Schweigen nicht.
+
+## Known Limitations
+
+- **Fail-Closed auf Staging (bewusst so entschieden):** Trägt die an `_process_update`
+  übergebene Basis-`settings` bereits `is_test_mode=True`, prüft `_guard_test_mode_chat_id`
+  (`telegram.py:206-216`) die neu gesetzte echte Absender-Chat-ID gegen `telegram_test_chat_id`
+  und wirft `OutputConfigError`. Das `try/except` in `send_telegram_message`
+  (`notification_service.py:1838-1845`) fängt sie ab — der Hinweis geht dann an **niemanden**
+  statt (fehlerhaft) an den Betreiber. Das ist gewollt: Staging darf keine echten fremden
+  Chats anschreiben. In Produktion ist `is_test_mode` nicht gesetzt, dort greift der Fix normal.
+- **Nur Telegram.** E-Mail und SMS/Premium-SMS haben keinen wirksamen Defekt: der E-Mail-Pfad
+  verwirft unbekannte Absender vor der Antwortstelle, der SMS-Eingangsweg antwortet überhaupt
+  nicht (`src/services/inbound_sms_reader.py` lernt nur die Rückantwort-Adresse; bei
+  uneindeutiger Zuordnung lehnt `internal/handler/premium_sms_connect.go:98-104` mit HTTP 409
+  ab, ohne Fallback auf `default`).
+- **Sentinel-Kollision bleibt offen (Nebenbefund, nicht Teil dieses Zuschnitts):**
+  `user_id == "default"` dient als reiner String-Sentinel für „kein Profil-Treffer"
+  (`inbound_telegram_reader.py:181`, `:305`, `:422`). Ein *echter* Nutzer mit
+  `user_id == "default"` würde fälschlich in diesen Zweig fallen; kein Code-Invariant verbietet
+  das. → Sammelstelle #1199.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Keine Entscheidungsfläche berührt. Kanäle, Datenmodell, Auth und
+  Test-/Deploy-Strategie bleiben unverändert; der Fix wendet ein im selben Modul bereits
+  etabliertes Muster (`inbound_telegram_reader.py:436`) an der ausgelassenen Stelle an. Die
+  Produktvorgabe „jeder Kanal muss jede Frage beantworten können" wird nicht angetastet — im
+  Gegenteil, die Adressierung wird für den Eingangskanal erst hergestellt.
+
+## Changelog
+
+- 2026-09-07: Initial spec created (Issue #2168, herausgelöst aus #2126 / Epic #2133)

--- a/src/services/inbound_telegram_reader.py
+++ b/src/services/inbound_telegram_reader.py
@@ -187,7 +187,9 @@ class InboundTelegramReader:
                     "verknuepft. Sende /start gefolgt von deinem Token (zu finden "
                     "im Account-Bereich auf gregor20.henemm.com)."
                 ),
-                settings=settings,
+                # #2168: an den fragenden Chat antworten, nicht an die Basis-
+                # /Betreiber-Chat-ID (Muster wie `_process_start_command`).
+                settings=settings.model_copy(update={"telegram_chat_id": chat_id}),
             )
             if mid is not None:
                 self.sent_message_ids.append(mid)

--- a/tests/tdd/test_antwort_an_den_fragenden.py
+++ b/tests/tdd/test_antwort_an_den_fragenden.py
@@ -1,0 +1,172 @@
+"""TDD RED — Antwort an den Fragenden statt an den Betreiber (Issue #2168).
+
+SPEC: docs/specs/modules/fix_2168_antwort_an_den_fragenden.md (AC-1, AC-4)
+Kontext: docs/context/fix-2168-antwort-an-den-fragenden.md
+
+Defekt: ``InboundTelegramReader._process_update``, Zweig ``user_id ==
+"default"`` (``inbound_telegram_reader.py:182-191``), ruft
+``send_telegram_message(chat_id=chat_id, ..., settings=settings)`` mit den
+BASIS-Settings auf. ``TelegramOutput.send()`` liest die Zieladresse
+ausschliesslich aus ``settings.telegram_chat_id`` (``telegram.py:403``) — die
+korrekt uebergebene ``chat_id`` wird nirgends verwendet. Der
+Registrierungshinweis geht deshalb an den Betreiber statt an den Fragenden.
+
+Nachweisform (zwingend, s. Spec-Abschnitt "Nachweisform"):
+* NICHT am Draht (``httpx.post``-Payload) — ``_guard_code_origin``
+  (``telegram.py:162-195``) haengt an der Code-HERKUNFT
+  (``app/origin_guard.py:30-41``), nicht an ``is_test_mode``: aus jedem
+  Worktree schaltet er die Ziel-Chat-ID auf ``telegram_test_chat_id`` um oder
+  bricht hart ab. Ein Payload-Test saehe immer nur die Test-Chat-ID.
+* NICHT das ``chat_id``-Argument am Notifier abgreifen (Muster
+  ``_MitschnittNotifier``, ``test_kommandoliste_einzelquelle.py:234-247``) —
+  dieses Argument wird bereits HEUTE korrekt uebergeben, es wird nur nicht
+  benutzt. Ein Test darauf waere heute schon gruen und faengt den Bug nicht.
+* Gemessen wird an der Konstruktor-Naht von ``TelegramOutput`` (Muster
+  ``Kanalmitschrift``/``_aufzeichner_installieren``,
+  ``test_kanaltreue_adhoc_antwort.py:115-192``) — dort liegt die Adresse fest,
+  die ``send()`` tatsaechlich benutzen wird.
+* Einstieg ist ``InboundTelegramReader._process_update(update, settings)``,
+  NICHT ``TripCommandProcessor().process(...)`` — letzterer ueberspringt den
+  Reader und erreicht den ``default``-Zweig nie.
+
+Mock-frei: echte ``InboundTelegramReader``/``Settings``-Instanzen, echte
+Aufzeichner-Klasse statt ``Mock()``/``patch()``. Isolierte Datenwurzel per
+autouse-Fixture aus ``tests/conftest.py`` (#1133).
+"""
+from __future__ import annotations
+
+import json
+import sys
+import uuid
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+for _p in (str(ROOT), str(ROOT / "src")):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from app.config import Settings  # noqa: E402
+from app.loader import get_data_dir  # noqa: E402
+from services.inbound_telegram_reader import InboundTelegramReader  # noqa: E402
+
+
+def _kennung(praefix: str) -> str:
+    """Mandantenkennung OHNE "tdd"/"test" — sonst erzwingt ``is_test_user_id``
+    ``Settings.for_testing()`` und ``with_user_profile`` ueberschreibt die
+    ``telegram_chat_id`` des Profils nicht mehr (``config.py:387-388``)."""
+    return f"antwort-fragend-{praefix}-{uuid.uuid4().hex[:6]}"
+
+
+def _aufzeichner_installieren(monkeypatch) -> list[str]:
+    """Ersetzt ``notification_service.TelegramOutput`` durch eine echte
+    Klasse, die die Zieladresse in ``__init__`` mitschneidet — genau die
+    Groesse, die ``send()`` tatsaechlich verwenden wird (``telegram.py:403``).
+    Kein ``Mock()``. Muster: ``Kanalmitschrift``/``_aufzeichner_installieren``
+    (``test_kanaltreue_adhoc_antwort.py:115-192``)."""
+    from services import notification_service as ns
+
+    aufgezeichnete_chat_ids: list[str] = []
+
+    class _TelegramAufzeichner:
+        def __init__(self, settings) -> None:
+            aufgezeichnete_chat_ids.append(settings.telegram_chat_id)
+
+        def send(self, subject, body, reply_markup=None, *, parse_mode=None,
+                 suppress_subject_line=False) -> int:
+            return 1
+
+    monkeypatch.setattr(ns, "TelegramOutput", _TelegramAufzeichner)
+    return aufgezeichnete_chat_ids
+
+
+# ═══════════════════════════ AC-1 ════════════════════════════════════════════
+
+
+def test_ac1_antwort_an_unbekannten_chat_geht_an_den_absender_nicht_an_die_basis(
+    monkeypatch,
+):
+    """AC-1.
+
+    GIVEN eine Telegram-Nachricht von einer Chat-ID, zu der kein
+          Nutzerprofil existiert, und Basis-Einstellungen mit einer
+          ABWEICHENDEN ``telegram_chat_id`` (Betreiber-Chat).
+    WHEN  ``_process_update`` die Nachricht verarbeitet (Registrierungs-
+          Hinweis).
+    THEN  ist die zum Versand VERWENDETE Adresse genau die Absender-Chat-ID
+          — und die Basis-/Betreiber-Chat-ID kommt in KEINER Aufzeichnung vor.
+
+    RED heute: der ``default``-Zweig uebergibt ``settings=settings`` (Basis)
+    statt der Absender-Chat-ID — der Aufzeichner sieht die Betreiber-Chat-ID.
+    """
+    aufzeichnungen = _aufzeichner_installieren(monkeypatch)
+
+    fragender_chat = "fragender-chat-" + uuid.uuid4().hex[:8]
+    basis_chat = "betreiber-chat-" + uuid.uuid4().hex[:8]
+    basis_settings = Settings(telegram_chat_id=basis_chat)
+
+    reader = InboundTelegramReader()
+    verarbeitet = reader._process_update(
+        {"message": {"text": "hallo gregor", "chat": {"id": fragender_chat}}},
+        basis_settings,
+    )
+
+    assert verarbeitet, "Vorbedingung: der Reader muss das Update verarbeitet haben"
+    assert fragender_chat in aufzeichnungen, (
+        f"AC-1: der Aufzeichner muss die Absender-Chat-ID {fragender_chat!r} "
+        f"sehen, aufgezeichnet wurden {aufzeichnungen!r}"
+    )
+    assert basis_chat not in aufzeichnungen, (
+        f"AC-1: die Basis-/Betreiber-Chat-ID {basis_chat!r} darf in KEINER "
+        f"Aufzeichnung vorkommen — der Hinweis ginge sonst an den Betreiber "
+        f"statt an den Fragenden. Aufgezeichnet wurden {aufzeichnungen!r}"
+    )
+
+
+# ═══════════════════════════ AC-4 ════════════════════════════════════════════
+
+
+def test_ac4_registrierter_chat_bekommt_antwort_weiterhin_an_seine_profil_chat_id(
+    monkeypatch,
+):
+    """AC-4 (Regressionswaechter, startet GRUEN).
+
+    GIVEN ein Telegram-Absender, dessen Chat-ID einem Nutzerprofil
+          zugeordnet ist, und eine ABWEICHENDE Basis-/Betreiber-Chat-ID.
+    WHEN  er eine Nachricht schickt (hier: ohne aktiven Trip — einer der
+          sechs bereits korrekten Aufrufer, ``:203-208``).
+    THEN  ist die verwendete Adresse die Chat-ID AUS SEINEM PROFIL — nicht
+          die Basis-Chat-ID.
+
+    Sichert, dass der Fix fuer AC-1 die sechs bereits korrekten Aufrufer
+    nicht verschiebt (Spec-Tabelle "Nur der `default`-Zweig weicht ab").
+    """
+    aufzeichnungen = _aufzeichner_installieren(monkeypatch)
+
+    user_id = _kennung("ac4")
+    profil_chat = "profil-chat-" + uuid.uuid4().hex[:8]
+    basis_chat = "betreiber-chat-" + uuid.uuid4().hex[:8]
+
+    ordner = get_data_dir(user_id)
+    ordner.mkdir(parents=True, exist_ok=True)
+    (ordner / "user.json").write_text(json.dumps({
+        "id": user_id,
+        "telegram_chat_id": profil_chat,
+    }))
+
+    basis_settings = Settings(telegram_chat_id=basis_chat)
+    reader = InboundTelegramReader()
+    verarbeitet = reader._process_update(
+        {"message": {"text": "irgendein text", "chat": {"id": profil_chat}}},
+        basis_settings,
+    )
+
+    assert verarbeitet, "Vorbedingung: der Reader muss das Update verarbeitet haben"
+    assert aufzeichnungen == [profil_chat], (
+        f"AC-4: die Antwort an einen registrierten Nutzer muss an seine "
+        f"Profil-Chat-ID {profil_chat!r} gehen, aufgezeichnet wurden "
+        f"{aufzeichnungen!r}"
+    )
+    assert basis_chat not in aufzeichnungen, (
+        f"AC-4: die Basis-/Betreiber-Chat-ID {basis_chat!r} darf hier nicht "
+        f"auftauchen, aufgezeichnet wurden {aufzeichnungen!r}"
+    )

--- a/tests/tdd/test_unbekannter_absender_bleibt_unbeantwortet.py
+++ b/tests/tdd/test_unbekannter_absender_bleibt_unbeantwortet.py
@@ -1,0 +1,220 @@
+"""TDD RED-Nachbarschaft — unbekannter E-Mail-Absender bleibt unbeantwortet
+(Issue #2168, AC-2/AC-3).
+
+SPEC: docs/specs/modules/fix_2168_antwort_an_den_fragenden.md (AC-2, AC-3)
+Kontext: docs/context/fix-2168-antwort-an-den-fragenden.md
+
+Kein Produktivcode-Defekt hier: ``InboundEmailReader._authorize``
+(``inbound_email_reader.py:188-202``) laeuft in ``_process_single`` VOR dem
+Trip-Lookup (``:107-109``) und laesst nur Absender durch, die ``mail_to``
+oder ``inbound_address`` des aufgeloesten Profils sind. Ein Fremder wird auf
+``\\Seen`` gesetzt und verworfen — es geht KEINE Antwort raus, an niemanden.
+Das ist das gewuenschte Verhalten; es war bisher nur nicht durch einen Test
+bewacht, der die tatsaechliche AUSBLEIBENDE Zustellung misst (das isolierte
+``_authorize(...) is False`` existiert bereits in
+``test_bug_inbound_email_loop.py:71-77`` und misst nicht den Versand).
+
+AC-2 (Schweigen) und AC-3 (Positivkontrolle) teilen sich denselben
+Testaufbau: echter ``InboundEmailReader._process_single``-Durchlauf mit einem
+Fake-IMAP, das nur ``fetch``/``store`` bereitstellt (genau die beiden
+Methoden, die ``_process_single`` benutzt), und einem echten Versand-
+Aufzeichner an der ``EmailOutput``-Konstruktor-Naht (Muster
+``_EmailAufzeichner``, ``test_kanaltreue_adhoc_antwort.py:147-156``). Kein
+``Mock()``/``patch()``, kein Netz, kein echtes Postfach.
+"""
+from __future__ import annotations
+
+import email.message
+import sys
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+for _p in (str(ROOT), str(ROOT / "src")):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from app.config import Settings  # noqa: E402
+from app.loader import load_all_trips, save_trip  # noqa: E402
+from app.trip import Stage, Trip, Waypoint  # noqa: E402
+from services.inbound_email_reader import InboundEmailReader  # noqa: E402
+
+#: Exakter Standort aus ``providers/fixture.py::_FIXTURE_LOCATIONS`` — nur
+#: als Timezone-Anker fuer ``trip_local_today`` gebraucht, kein Wetterabruf
+#: findet in ``_show_status`` statt.
+INNSBRUCK = (47.2692, 11.4041)
+
+BASIS_MAIL_TO = "bekannt@example.invalid"
+BASIS_MAIL_FROM = "system@example.invalid"
+
+
+def _basis_settings() -> Settings:
+    return Settings(
+        mail_to=BASIS_MAIL_TO,
+        mail_from=BASIS_MAIL_FROM,
+        smtp_host="smtp.invalid",
+        smtp_user="unbrauchbar",
+        smtp_pass="unbrauchbar",
+    )
+
+
+def _email_aufzeichner_installieren(monkeypatch) -> list[dict]:
+    """Ersetzt ``notification_service.EmailOutput`` — echte Klasse an der
+    Konstruktor-Naht, kein ``Mock()``. Muster: ``_EmailAufzeichner``
+    (``test_kanaltreue_adhoc_antwort.py:147-156``)."""
+    from services import notification_service as ns
+
+    aufzeichnungen: list[dict] = []
+
+    class _EmailAufzeichner:
+        def __init__(self, settings) -> None:
+            self._s = settings
+
+        def send(self, subject, body, html=True, plain_text_body=None, to=None,
+                 mail_type=None, mail_format=None, compare_hourly_enabled=None):
+            ziel = to if to else self._s.mail_to
+            aufzeichnungen.append({"empfaenger": ziel, "subject": subject})
+
+    monkeypatch.setattr(ns, "EmailOutput", _EmailAufzeichner)
+    return aufzeichnungen
+
+
+class _FakeImap:
+    """Stellt genau die zwei Methoden bereit, die ``_process_single``
+    benutzt (``inbound_email_reader.py:101-102,108,116,133,162``)."""
+
+    def __init__(self, raw: bytes) -> None:
+        self._raw = raw
+        self.store_aufrufe: list[tuple] = []
+
+    def fetch(self, uid, spec):
+        return ("OK", [(None, self._raw)])
+
+    def store(self, uid, flags, val):
+        self.store_aufrufe.append((uid, flags, val))
+
+
+def _raw_mail(*, from_addr: str, subject: str, body: str) -> bytes:
+    msg = email.message.EmailMessage()
+    msg["From"] = from_addr
+    msg["To"] = BASIS_MAIL_TO
+    msg["Subject"] = subject
+    msg.set_content(body)
+    return msg.as_bytes()
+
+
+def _trip_anlegen(user_id: str, *, name: str) -> Trip:
+    """Ein einfacher Trip mit drei Etappen (gestern/heute/morgen) am
+    Fixture-Standort — genug fuer ``### status``, keine Weiterverarbeitung
+    braucht Wetterdaten."""
+    trip_id = f"unbeantwortet-{uuid.uuid4().hex[:8]}"
+    heute = datetime.now(timezone.utc).date()
+    stages = [
+        Stage(
+            id=f"T{i}", name=f"Etappe {i}", date=heute + timedelta(days=i - 1),
+            waypoints=[
+                Waypoint(id=f"G{i}a", name="Start",
+                         lat=INNSBRUCK[0], lon=INNSBRUCK[1], elevation_m=600),
+                Waypoint(id=f"G{i}b", name="Ziel",
+                         lat=INNSBRUCK[0] + 0.02, lon=INNSBRUCK[1] + 0.02,
+                         elevation_m=900),
+            ],
+        )
+        for i in range(3)
+    ]
+    trip = Trip(id=trip_id, name=name, stages=stages, official_alerts_enabled=False)
+    save_trip(trip, user_id)
+    return next(t for t in load_all_trips(user_id) if t.id == trip_id)
+
+
+# ═══════════════════════════ AC-2 ════════════════════════════════════════════
+
+
+def test_ac2_unbekannter_absender_erhaelt_ueberhaupt_keine_antwort(monkeypatch):
+    """AC-2 (Regressionswaechter, heute GRUEN — kein Produktivcode-Defekt).
+
+    GIVEN eine E-Mail von einem Absender, zu dem kein Nutzerprofil existiert
+          (und der nicht der Basis-``mail_to`` entspricht).
+    WHEN  ``_process_single`` diese Nachricht VOLLSTAENDIG durchlaeuft.
+    THEN  wird UEBERHAUPT KEINE Antwort versendet — weder an den Absender
+          noch an das Basis-/Betreiberprofil. Der Versand-Aufzeichner sieht
+          keinen einzigen Aufruf.
+
+    Isoliertes ``_authorize(...) is False`` genuegt hierfuer NICHT (existiert
+    bereits, misst aber nicht das Ausbleiben des Versands, siehe
+    ``test_bug_inbound_email_loop.py:71-77``).
+    """
+    aufzeichnungen = _email_aufzeichner_installieren(monkeypatch)
+    settings = _basis_settings()
+    reader = InboundEmailReader()
+
+    raw = _raw_mail(
+        from_addr="fremder@example.invalid",
+        subject="[Irgendein Trip] Status",
+        body="status",
+    )
+    imap = _FakeImap(raw)
+
+    verarbeitet = reader._process_single(imap, b"1", settings)
+
+    assert verarbeitet == 0, (
+        f"Vorbedingung: ein unbekannter Absender darf keinen Befehl "
+        f"verarbeitet bekommen, erhalten {verarbeitet!r}"
+    )
+    assert aufzeichnungen == [], (
+        f"AC-2: bei einem unbekannten Absender darf UEBERHAUPT KEINE Antwort "
+        f"versendet werden — weder an ihn noch an den Betreiber. Aufgezeichnet "
+        f"wurden {aufzeichnungen!r}"
+    )
+    assert imap.store_aufrufe, (
+        "Testaufbau: die Mail muss trotzdem als gelesen markiert werden "
+        "(kein endloses Wiederverarbeiten)"
+    )
+
+
+# ═══════════════════════════ AC-3 ════════════════════════════════════════════
+
+
+def test_ac3_bekannter_absender_mit_existierendem_trip_erhaelt_sehr_wohl_eine_antwort(
+    monkeypatch,
+):
+    """AC-3 (Positivkontrolle zu AC-2, MUSS GRUEN SEIN).
+
+    GIVEN DERSELBE Testanordnung wie AC-2, aber mit einem bekannten Absender
+          (== Basis-``mail_to``) und einem existierenden Trip im Betreff.
+    WHEN  ``_process_single`` diese Nachricht verarbeitet.
+    THEN  wird SEHR WOHL eine Antwort versendet.
+
+    Ohne diese Kontrolle waere das leere Ergebnis in AC-2 genauso gut durch
+    einen kaputten Testaufbau erklaerbar wie durch korrektes Blocken.
+    """
+    aufzeichnungen = _email_aufzeichner_installieren(monkeypatch)
+    settings = _basis_settings()
+    reader = InboundEmailReader()
+
+    # Der bekannte Absender ist HIER "default" (kein Profil-Match noetig) --
+    # `_authorize` laesst ihn durch, weil er == settings.mail_to ist.
+    trip = _trip_anlegen("default", name="AC3 Bekannter Absender Trip")
+
+    raw = _raw_mail(
+        from_addr=BASIS_MAIL_TO,
+        subject=f"[{trip.name}] Status",
+        body="status",
+    )
+    imap = _FakeImap(raw)
+
+    verarbeitet = reader._process_single(imap, b"1", settings)
+
+    assert verarbeitet == 1, (
+        f"Vorbedingung: ein bekannter Absender mit existierendem Trip muss "
+        f"verarbeitet werden, erhalten {verarbeitet!r}"
+    )
+    assert aufzeichnungen, (
+        "AC-3: ein bekannter Absender mit existierendem Trip muss SEHR WOHL "
+        "eine Antwort erhalten — der Aufzeichner sah keinen einzigen Aufruf."
+    )
+    assert aufzeichnungen[0]["empfaenger"] == BASIS_MAIL_TO, (
+        f"AC-3: die Antwort muss an die bekannte Adresse gehen, erhalten "
+        f"{aufzeichnungen!r}"
+    )


### PR DESCRIPTION
Behebt #2168.

## Das Problem

Eine Telegram-Nachricht von einer Chat-ID ohne hinterlegtes Nutzerprofil beantwortet der Bot mit einem Registrierungs-Hinweis. Der ging bisher an die Basis-/Betreiber-Chat-ID aus den globalen Settings statt an den Chat, der gefragt hat — der Fragende bekam nichts, der Betreiber bekam fremde Hinweise.

## Der Fix

`_process_update` übergibt im Zweig `user_id == "default"` jetzt eine Kopie der Settings mit der Absender-Chat-ID, spiegelbildlich zum bereits korrekten Muster in `_process_start_command`:

```python
settings=settings.model_copy(update={"telegram_chat_id": chat_id}),
```

Ein Verstärker gegen Dritte ist ausgeschlossen: Die Telegram-Bot-API erlaubt `sendMessage` nur an Chats, die den Bot selbst angeschrieben haben.

## Was der Zuschnitt aus dem Ticket gemacht hat

Von den drei im Ticket genannten Fundstellen hielt nur eine der Gegenprobe stand. Die „Known Limitations" der #2126-Spec, die alle drei als offen führten, werden entsprechend richtiggestellt:

- **Telegram-Textnachricht** — war betroffen, hiermit behoben.
- **Telegram-Callback-Query** — war nie betroffen: `edit_telegram_message_text` bekommt `chat_id` explizit übergeben, `settings` liefert dort nur das Bot-Token.
- **E-Mail** — war nie betroffen: `_authorize` verwirft einen unbekannten Absender **vor** jeder Antwortstelle, es geht überhaupt keine Antwort raus.

## Nachweis

- `tests/tdd/test_antwort_an_den_fragenden.py` — AC-1 (Antwort an den Fragenden, Betreiber-Chat-ID in keiner Aufzeichnung) und AC-4 (Regression: registrierter Nutzer weiterhin an seine Profil-Chat-ID).
- `tests/tdd/test_unbekannter_absender_bleibt_unbeantwortet.py` — AC-2 (unbekannter E-Mail-Absender erhält überhaupt keine Antwort) und AC-3 (Positivkontrolle: bekannter Absender sehr wohl).
- Mutations-Gegenproben dokumentiert: Aushebeln von `_authorize` macht AC-2 rot, Rückdrehen eines bereits korrekten Aufrufers auf die Basis-Settings macht AC-4 rot.
- Regression: 191 passed / 0 failed über alle 21 Testdateien, die den Inbound-Telegram-Reader berühren.
- Adversary-Verdict: VERIFIED.

## Known Limitation

Auf Staging geht der Hinweis fail-closed an niemanden (Test-Modus-Wächter in `Settings.with_user_profile`). Das ist gewollt und in der Spec vermerkt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KbRSjSm75PyX2repxsW8w1