### PR TITLE
fix(#2141): Telegram-Chat-ID gehoert genau einem Nutzer

### DIFF
--- a/docs/context/fix-2141-telegram-chat-id-hijacking.md
+++ b/docs/context/fix-2141-telegram-chat-id-hijacking.md
@@ -1,0 +1,193 @@
+# Context: fix-2141-telegram-chat-id-hijacking
+
+Issue: [#2141](https://github.com/henemm/gregor_zwanzig/issues/2141) — `priority:critical`, `bug`, Teil von Epic #2138 (Multi-User-Readiness).
+
+## Request Summary
+
+`PUT /api/auth/profile` nimmt `telegram_chat_id` ungeprüft entgegen. Damit kann Nutzer B die
+Chat-ID von Nutzer A eintragen und den localhost-gesperrten Einmal-Token-Flow vollständig
+umgehen — Briefings/Alarme von B landen im Chat von A, und eingehende Kommandos von A werden
+je nach Sortierreihenfolge dem Konto B zugeordnet.
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `internal/handler/auth.go:659–735` | `UpdateProfileHandler`. Read-Modify-Write über `LoadUser` (662) → Feld-Updates (684–719) → `SaveUser` (721). **Zeile 675** deklariert `TelegramChatID *string`, **717–719** schreibt ihn ohne jede Prüfung. |
+| `internal/handler/telegram_connect.go:171–205` | `PostTelegramConnectHandler` — der saubere Weg. `requireLocalOnly` (173), `ResolveAndDelete` (186), **Zeile 197 setzt `user.TelegramChatID`**, `SaveUser` (198). **Keine Kollisionsprüfung.** |
+| `internal/handler/telegram_connect.go:72–102` | `TelegramTokenStore`: Token = 16 Byte hex, TTL 24 h, Einmal-Verbrauch über `ResolveAndDelete`. |
+| `internal/store/user.go:16–40, 48–85, 219–256` | `ListUserIDs`, `LoadUser`, `SaveUser`, `FindUserByOAuthSub`, `FindUserByEmail`. Letztere beide sind das vorhandene Muster „über alle Nutzer suchen". |
+| `src/app/loader.py:1256–1277` | `lookup_user_by_telegram_chat_id` — String-toleranter Vergleich, **`return uid` beim ersten Treffer**, keine Mehrdeutigkeitsprüfung. |
+| `src/app/loader.py:1202–1229` | `list_all_user_ids` — `sorted()`, echte Nutzer vor Test-Nutzern. Reihenfolge ist deterministisch alphabetisch, nicht zufällig. |
+| `src/services/inbound_telegram_reader.py:406–423` | `_resolve_user_for_chat` — **Zeile 422: `… or "default"`**. Rückfall auf `"default"` im authentifizierten Pfad. |
+| `src/services/inbound_telegram_reader.py:151–223` | Eingangskette: `chat_id` aus dem Update (165) → `_resolve_user_for_chat` (176) → bei `"default"` Registrierungs-Hinweis an die **ursprüngliche** `chat_id` (181–194) → sonst Kommando mit `user_settings` (202–223). |
+| `src/services/inbound_telegram_reader.py:425–449` | `_process_start_command` — ruft `POST http://localhost:8090/api/internal/telegram-connect`. Bei Status ≠ 200 **nur ein Log-Warning**, der Nutzer erfährt nichts. `model_copy` in 436 ist reine In-Memory-Kopie für die Bestätigungsnachricht, **kein** Persistenzpfad. |
+| `frontend/src/routes/account/+page.svelte:250–254` | `disconnectTelegram()` sendet `PUT /api/auth/profile { telegram_chat_id: '' }` — der **einzige** Schreibzugriff des Frontends auf das Feld. |
+| `frontend/src/routes/account/+page.svelte:202–217` | `save()` sendet nur `display_name`, `mail_to`, `sms_to` — schreibt die Chat-ID nicht. |
+| `docs/reference/api_contract.md:2963–2998` | Kontrakt für `PUT /api/auth/profile`. `telegram_chat_id` ist dort **gar nicht dokumentiert**, wird aber akzeptiert. |
+| `internal/handler/profile_test.go` | Bestehende Handler-Tests, u. a. `TestUpdateProfileHandlerIgnoresPremiumSmsReplyFields` (Präzedenzfall) und `TestGetProfileTierTwoUsersNoCrossLeak:305–341` (Zwei-Nutzer-Muster). |
+
+## Existing Patterns
+
+**1. Der Präzedenzfall steht schon im Kontrakt** (`api_contract.md:2984–2990`, Issue #1717 S3, AC-7):
+`premium_sms_reply_to` & Co. sind aus dem Decode-Struct **entfernt**, damit ein Nutzer keine fremde
+Nummer eintragen und bezahlte Premium-SMS dorthin umleiten kann. Bewacht von
+`TestUpdateProfileHandlerIgnoresPremiumSmsReplyFields`. Die Begründung dort ist wortgleich auf
+`telegram_chat_id` übertragbar — die Regel existiert, sie wurde für Telegram nur nie gezogen.
+
+**2. Eindeutigkeit über alle Nutzer** gibt es als Store-Muster: `FindUserByEmail`
+(`internal/store/user.go:238–256`) iteriert `ListUserIDs` und vergleicht. Ein Pendant
+`FindUserByTelegramChatID` fehlt.
+
+**3. Konflikt-Statuscode:** 409 ist im Haus etabliert — Registrierung
+(`internal/handler/auth.go:62–64`, `{"error":"user already exists"}`) und Metrik-Presets
+(`api_contract.md:1895, 1947`, `{"error":"name_exists"}`).
+
+**4. Zwei-Nutzer-Test:** `middleware.ContextWithUserID(req.Context(), userID)` + `req.WithContext(ctx)`
+(`profile_test.go:35`, `display_name_642_test.go:46`). Helfer: `newTestStore`
+(`trip_write_test.go:15`), `mustSaveUser` / `mustLoadUser` (`premium_sms_connect_test.go:49, 56`).
+
+## Dependencies
+
+- **Upstream:** `internal/store.Store` (Laden/Speichern, Iteration über alle Nutzer);
+  `middleware.UserIDFromContext` als Identitätsquelle; `TelegramTokenStore` für den Einmal-Token.
+- **Downstream:** Frontend `account/+page.svelte` (Verbinden/Trennen), Go-Endpunkte
+  `/api/auth/telegram-link` und `/api/auth/telegram-status` (`internal/router/router.go:74–76`),
+  Python-Inbound (`inbound_telegram_reader.py`), alle Telegram-Versandpfade, die
+  `profile.telegram_chat_id` lesen.
+
+## Existing Specs
+
+- `docs/specs/modules/user_profile_channels.md:25–44` — Profil-Endpunkte und Kanal-Felder.
+- `docs/specs/modules/telegram_webhook_inbound.md` — Inbound-Handler, Token-Setup.
+- `docs/specs/modules/telegram_output.md`, `telegram_send_pacing.md` — Versandseite.
+- **Nicht vorhanden:** eine Spec zum Connect-Token-Flow (`/api/internal/telegram-connect`) selbst.
+
+## ADRs
+
+| ADR | Aussage | Bezug |
+|---|---|---|
+| **ADR-0003** | Konsequente Mandantentrennung, **kein `"default"`-Fallback** im authentifizierten Pfad; Tests mit zwei Nutzern sind Pflicht. | Direkt verletzt durch `inbound_telegram_reader.py:422` |
+| ADR-0060 | Dauerhafte Anmeldung mit dateibasierter Sperrliste; Session-Daten bewusst **getrennt** vom User-Datensatz, um RMW-Überschreiber zu vermeiden. | Erinnert daran, dass Schreibpfade auf `user.json` sparsam bleiben sollen |
+
+## Risks & Considerations
+
+1. **Löschen muss möglich bleiben.** Das Frontend trennt Telegram ausschließlich über
+   `PUT /api/auth/profile { telegram_chat_id: '' }`. Ein ersatzloses Entfernen des Feldes aus dem
+   Decode-Struct (wie bei `premium_sms_reply_to`) würde die Trennen-Funktion **still** kaputt
+   machen — die Oberfläche meldete Erfolg, die Verknüpfung bliebe bestehen. Erlaubt sein darf
+   also genau der Leerstring; jeder nicht-leere Wert muss abgewiesen werden.
+2. **Bestandsdaten könnten bereits doppelt belegt sein.** Wenn der Python-Lookup künftig bei
+   Mehrfachtreffern fehlschlägt, verlieren betroffene Nutzer den Inbound-Kanal. Verhalten dafür
+   muss die Spec festlegen (Fehlschlag + Log ist die sichere Variante; „erster gewinnt" ist der
+   Bug).
+3. **Der `"default"`-Rückfall in Zeile 422 ist ein eigener ADR-0003-Verstoß.** Er ist nicht
+   Wortlaut des Issues, hängt aber unmittelbar am selben Lookup. Entscheidung in der Analyse:
+   mitfixen oder als eigenes Ticket abtrennen.
+4. **Stiller 409 im `/start`-Pfad.** `_process_start_command` protokolliert einen
+   Nicht-200-Status nur. Führt der Connect künftig 409 zurück, erfährt der Nutzer im Chat nichts —
+   die Rückmeldung muss mitgedacht werden, sonst ist der Fix aus Nutzersicht ein Stillstand.
+5. **Reihenfolge ist deterministisch, nicht zufällig.** `list_all_user_ids` sortiert alphabetisch.
+   Ein Angreifer mit passender `user_id` gewinnt also verlässlich — der Angriff ist nicht auf
+   Verzeichnisglück angewiesen. Der Issue-Text („je nach Verzeichnisreihenfolge") untertreibt.
+6. **Nachweisform:** Ein Test, der nur den Handler mit einem Nutzer aufruft, beweist nichts. Der
+   Nachweis muss zwei Nutzer anlegen und prüfen, dass B die Chat-ID von A weder über das Profil
+   noch über den Connect-Endpunkt übernehmen kann, **und** dass A's `user.json` danach unverändert ist.
+
+---
+
+## Analysis
+
+### Type
+
+**Bug** — Sicherheitslücke, `priority:critical`, Blocker aus Epic #2138.
+
+### Root Cause
+
+`ddc41ea8` (F13 Phase 4a, #12) führte `telegram_chat_id` als frei beschreibbares Profil-Feld im
+generischen Decoder ein. `c816d1c8` (#590) baute später den Einmal-Token-Flow **daneben**, ohne den
+alten Schreibweg zu schließen. Es gab nie einen Fix an dieser Stelle (`git log -S"TelegramChatID"`).
+Der Token-Flow ist damit keine Schranke, sondern nur eine bequemere Alternative zum offenen Feld.
+
+### Geprüft und verworfen
+
+| Vermutung | Befund |
+|---|---|
+| Weitere Go-Schreibwege | Keine. `TelegramChatID =` nur in `auth.go:718` und `telegram_connect.go:197`; alle 13 Body-Decoder in `internal/handler/` durchsucht, nur `auth.go` deklariert das JSON-Tag; kein `SaveUser`-Aufrufer setzt es nebenbei. |
+| Python schreibt persistent | Nein. `inbound_telegram_reader.py:436` ist eine In-Memory-`model_copy` allein für die Bestätigungsnachricht; kein Python-Modul schreibt `user.json`. |
+| `requireLocalOnly` umgehbar | Nein — `internal/handler/localhost_guard.go` prüft seit dem Team-Lead-Befund vom 2026-08-10 zusätzlich auf Abwesenheit von `X-Forwarded-For`/`X-Real-IP`/`X-Forwarded-Proto`. |
+| Fremde Chat-ID auslesbar | Nein. `chat_id_suffix` (`telegram_connect.go:108, 145`) wird nur für die eigene `userID` aus dem Auth-Kontext gebildet. |
+| Mehrere Chat-IDs je Nutzer | Nicht möglich — `model.User.TelegramChatID` ist ein einzelnes String-Feld (`internal/model/user.go:18`). |
+
+### Der Konflikt mit Issue #1013 (entscheidend für die ACs)
+
+Die Issue-Erwartung „Lookup schlägt bei Mehrfachtreffer fehl" kollidiert mit einer bestehenden,
+getesteten Zusicherung: `tests/tdd/test_issue_1013_telegram_test_isolation.py:87–101` verlangt, dass
+bei **identischer Chat-ID von echtem Nutzer und Test-Nutzern** deterministisch der echte Nutzer
+gewinnt — genau dafür wurde die Vorrang-Sortierung in `list_all_user_ids` gebaut (sonst erhielt der
+PO Test-Briefings über den Prod-Bot).
+
+**Folge für die Regel:** Der Fehlerfall ist Mehrdeutigkeit **unter echten Nutzern**. Test-Nutzer
+bleiben ausgenommen und verlieren gegen den echten Nutzer wie bisher. Dasselbe gilt für die
+409-Prüfung beim Connect — sonst könnte der PO sich auf Staging nicht mehr verbinden, sobald die
+Fixture `tg-live-e2e` seine Chat-ID trägt. Das Prädikat existiert auf beiden Seiten:
+`app.config.is_test_user_id` (`src/app/config.py:56`) und `model.IsTestUserID`
+(`internal/model/test_user.go:20`).
+
+### Affected Files
+
+| Datei | Art | Beschreibung |
+|---|---|---|
+| `internal/handler/auth.go` | MODIFY | `UpdateProfileHandler`: nur noch der Leerstring wird übernommen, jeder nicht-leere Wert fließt nirgends ein. |
+| `internal/store/user.go` | MODIFY | Neu `FindUserByTelegramChatID` nach Vorbild `FindUserByEmail:238–256`, Test-Nutzer übersprungen. |
+| `internal/handler/telegram_connect.go` | MODIFY | Kollisionsprüfung vor `SaveUser` → 409 `chat_id_already_linked`; Re-Connect desselben Nutzers ist kein Konflikt; Prüfen-und-Schreiben unter einem paketweiten Mutex. |
+| `src/app/loader.py` | MODIFY | `lookup_user_by_telegram_chat_id`: mehrere **echte** Treffer → `None` + `logger.error` statt erster Treffer. |
+| `src/services/inbound_telegram_reader.py` | MODIFY | `_process_start_command`: bei 409 eine verständliche Antwort in den Chat statt nur Log. |
+| `internal/handler/profile_test.go` | MODIFY | `TestUpdateProfileHandler:105–107` fordert heute das verwundbare Verhalten ein — wird ersetzt, nicht gelöscht. |
+| `internal/handler/telegram_connect_uniqueness_test.go` | CREATE | Zwei-Nutzer-Tests für 409, Re-Connect, Test-Nutzer-Ausnahme. |
+| `tests/tdd/test_telegram_chat_id_ownership.py` | CREATE | Mehrfachtreffer-Verhalten inkl. Alt-Duplikaten und #1013-Regress. |
+| `docs/reference/api_contract.md` | MODIFY | `PUT /api/auth/profile` + Connect-Konflikt dokumentieren (zählt nicht gegen das LoC-Limit). |
+
+### Scope Assessment
+
+- Dateien: 9 (2 neu)
+- Geschätzte LoC: ~+280 — **über dem 250er-Limit**, `loc_limit_override 500` vor der Implementierung setzen.
+- Risiko: **MEDIUM** — Angriffsfläche wird kleiner, aber Bestandsdaten mit Doppelbelegung ändern ihr Verhalten.
+
+### Technical Approach
+
+1. **Profil-Endpunkt:** Feld bleibt im Decode-Struct, aber nur `""` wird übernommen. Kein 400 — die
+   Antwort liefert ohnehin den unveränderten Wert zurück, und kein legitimer Aufrufer sendet je einen
+   nicht-leeren Wert. Konsistent mit dem `premium_sms_reply_to`-Präzedenzfall.
+   *Verworfen:* eigener `DELETE /api/auth/telegram-link`-Endpunkt. Architektonisch sauberer (der
+   generische Decoder bliebe frei von Sonderfällen), kostet aber einen neuen Endpunkt plus
+   Frontend-Änderung auf einem kritischen Sicherheits-Hotfix. Die Sicherheitszusicherung ist in
+   beiden Varianten identisch. → Nachfolge-Eintrag in #1199.
+2. **Connect-Endpunkt:** `FindUserByTelegramChatID` (Test-Nutzer übersprungen) → gehört die ID einem
+   **anderen echten** Nutzer, 409 und die bestehende Verknüpfung bleibt unangetastet. Prüfen und
+   Speichern unter einem paketweiten `sync.Mutex` gegen die TOCTOU-Lücke bei gleichzeitigen Connects.
+3. **Python-Lookup:** mehrere echte Treffer → `None` + `logger.error` mit den kollidierenden IDs.
+   Kein Wurf: eine Exception würde in `poll_and_process:122–125` nur geloggt, der Mensch im Chat
+   bliebe komplett stumm. `None` nutzt den vorhandenen „kein Treffer"-Pfad und liefert wenigstens den
+   Registrierungs-Hinweis.
+4. **409 im Chat beantworten:** `_process_start_command` bekommt für 409 eine eigene Antwort.
+
+### Abgetrennt (eigenes Ticket)
+
+Der `or "default"`-Rückfall (`inbound_telegram_reader.py:422`) bleibt. Die ursprüngliche Einschätzung
+als ADR-0003-Verstoß war zu scharf: ADR-0003 verbietet den Rückfall im **authentifizierten** Pfad —
+der Telegram-Inbound hat vor der Auflösung überhaupt keine Identität, und `_process_update:181` fängt
+`"default"` sofort als Sentinel ab, ohne Daten eines etwaigen Nutzers `default` zu laden. Es bleibt ein
+Namenskollisions-Randfall (ein echter Nutzer namens `default` bekäme fälschlich den
+Registrierungs-Hinweis) — ein False Negative, kein Leck. Eigenes Issue, niedrigere Priorität.
+
+### Nachweisformen, die trügen würden
+
+- Ablehnungs-Test mit **einem** Nutzer — beweist nicht, dass A's `user.json` unangetastet bleibt.
+- Kollisionsprüfung gegen einen gestubbten Store — eine fehlende Iteration über alle Nutzer bliebe unbemerkt.
+- Nur der Go-Schreibweg getestet — **Alt-Duplikate** aus der Zeit vor dem Fix blieben wirkungslos abgedeckt.
+- Kein No-Op-Fall geprüft — sendet ein Nutzer seine **eigene** aktuelle Chat-ID mit, darf das kein Fehler sein.
+
+### Open Questions
+
+Keine offenen Fragen an den PO. Alle Design-Abwägungen sind oben entschieden und begründet.

--- a/docs/features/architecture.md
+++ b/docs/features/architecture.md
@@ -186,7 +186,10 @@ mehr der Produktivpfad.
 **Lookup-Funktionen** (`src/app/loader.py`):
 - `list_all_user_ids(data_dir)` – alle User-IDs unter `data/users/` (ausschließt test_ / _ Präfixe)
 - `lookup_user_by_email(email)` – sucht User mit `mail_to == email` (case-insensitive)
-- `lookup_user_by_telegram_chat_id(chat_id)` – sucht User mit `telegram_chat_id == chat_id`
+- `lookup_user_by_telegram_chat_id(chat_id)` – sucht User mit `telegram_chat_id == chat_id`; tragen
+  mehrere echte Nutzer dieselbe Chat-ID (Bestandsdaten von vor Issue #2141), liefert die Funktion
+  `None` statt einer der beiden IDs und protokolliert die Kollision (`logger.error`) — ein echter
+  Treffer hat weiterhin Vorrang vor Test-Nutzern (Issue #1013)
 
 **Konfiguration:** Nutzer-Profile liegen in `data/users/<user_id>/user.json` mit Feldern `mail_to` und `telegram_chat_id`.
 

--- a/docs/reference/api_contract.md
+++ b/docs/reference/api_contract.md
@@ -2988,6 +2988,15 @@ Returns updated profile object (same as `GET /api/auth/profile`).
   exclusively the learned reply address, never configuration" would collapse: a user could enter a
   foreign number and have paid Premium-SMS delivered there. Guarded by
   `internal/handler/profile_test.go::TestUpdateProfileHandlerIgnoresPremiumSmsReplyFields`
+- **`telegram_chat_id` accepts only the empty string (Issue #2141):** die Chat-ID ist eine
+  Identitätszuordnung, keine Einstellung, und wird ausschließlich über den localhost-gesperrten
+  Einmal-Token-Flow gesetzt (`POST /api/internal/telegram-connect`, siehe unten). Sendet dieser
+  Endpoint `{"telegram_chat_id":""}`, wird die bestehende Verknüpfung gelöscht ("Telegram trennen"
+  im Konto-Bereich); ein nicht-leerer Wert wird stillschweigend ignoriert — kein 400, die Antwort
+  zeigt weiterhin den zuvor gespeicherten Wert. Ohne diese Sperre könnte ein Nutzer die Chat-ID
+  eines fremden Kontos übernehmen und dessen Telegram-Nachrichten mitlesen bzw. eigene als dieses
+  Konto empfangen (Chat-ID-Hijacking). Guarded by
+  `internal/handler/profile_telegram_chat_id_test.go`
 
 **Error Responses:**
 
@@ -2995,6 +3004,43 @@ Returns updated profile object (same as `GET /api/auth/profile`).
 |--------|------|----------|
 | 400 | `{"error":"bad_request"}` | JSON not decodable |
 | 401 | (via `AuthMiddleware`) | No valid session cookie or session expired |
+
+#### POST /api/internal/telegram-connect
+
+Internal endpoint, localhost-only (`requireLocalOnly`) — called only by the Python
+`InboundTelegramReader` after a user sends `/start <token>` to the Telegram bot. Resolves the
+one-time deep-link token issued by `GET /api/auth/telegram-link` to a `user_id` and persists the
+sending chat's `chat_id` on that user (Issue #2141: erst nach einer Eindeutigkeitsprüfung).
+
+**Request Body:**
+```json
+{
+  "token": "<hex token from GET /api/auth/telegram-link>",
+  "chat_id": "55501"
+}
+```
+
+**Response 200:**
+```json
+{"status": "ok"}
+```
+
+**Error Responses:**
+
+| Status | Body | Scenario |
+|--------|------|----------|
+| 400 | `{"error":"bad request"}` | JSON not decodable, or `token`/`chat_id` empty |
+| 404 | `{"error":"user not found"}` | Token resolved to a `user_id` whose `user.json` no longer exists |
+| 409 | `{"error":"chat_id_already_linked"}` | **(Issue #2141)** `chat_id` is already linked to a **different** real user's account — re-connecting the account that already owns it is explicitly not a conflict (200); test users (`model.IsTestUserID`) never trigger this and never win a collision, see `internal/store/user.go::FindUserByTelegramChatID`. `SaveUser` does not run in this case, the existing owner's link is untouched |
+| 422 | `{"error":"token invalid or expired"}` | Token unknown or past its 24h TTL |
+| 500 | `{"error":"lookup failed"}` | `FindUserByTelegramChatID` failed |
+| 500 | `{"error":"save failed"}` | `SaveUser` failed |
+| 403 | `forbidden` (plain text) | Request did not originate from `127.0.0.1`/`::1`, or arrived via a proxy header (`requireLocalOnly`) |
+
+**Notes:**
+- Uniqueness check and `SaveUser` run under the same process-wide mutex (`telegramConnectMu`) to
+  close a TOCTOU window between two concurrent connect attempts targeting the same `chat_id`
+  (Issue #2141).
 
 #### POST /api/auth/tier-change-request
 
@@ -3048,7 +3094,7 @@ type User struct {
     CreatedAt          time.Time              `json:"created_at"`
     MailTo             string                 `json:"mail_to,omitempty"`
     SmsTo              string                 `json:"sms_to,omitempty"`  // NEW (Issue #609) — SMS recipient phone number
-    TelegramChatID     string                 `json:"telegram_chat_id,omitempty"`
+    TelegramChatID     string                 `json:"telegram_chat_id,omitempty"`  // Identitätszuordnung, keine Einstellung (Issue #2141): einziger Schreiber ist `POST /api/internal/telegram-connect`; `PUT /api/auth/profile` nimmt nur den Leerstring an (Trennen)
     OAuthProvider      string                 `json:"oauth_provider,omitempty"`
     OAuthSub           string                 `json:"oauth_sub,omitempty"`
     DisplayName        string                 `json:"display_name,omitempty"`  // NEW (Issue #642) — user's chosen display name; omitempty if not set

--- a/docs/specs/modules/telegram_chat_id_ownership.md
+++ b/docs/specs/modules/telegram_chat_id_ownership.md
@@ -1,0 +1,163 @@
+---
+entity_id: telegram_chat_id_ownership
+type: module
+created: 2026-09-07
+updated: 2026-09-07
+status: draft
+version: "1.0"
+tags: [security, multi-user, telegram, issue-2141, epic-2138]
+---
+
+# Telegram-Chat-ID: Besitz und Eindeutigkeit
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Die Telegram-Chat-ID eines Nutzers ist eine Identitätszuordnung, keine Einstellung. Dieses Modul
+legt fest, dass sie ausschließlich über den Einmal-Token-Flow gesetzt werden kann, nur einem echten
+Konto gehören darf und bei Mehrdeutigkeit keine Zuordnung stattfindet. Es schließt Issue #2141
+(Nachrichten- und Identitäts-Hijacking, `priority:critical`, Blocker aus Epic #2138).
+
+## Source
+
+- **File:** `internal/handler/auth.go` — **Identifier:** `UpdateProfileHandler`
+- **File:** `internal/handler/telegram_connect.go` — **Identifier:** `PostTelegramConnectHandler`
+- **File:** `internal/store/user.go` — **Identifier:** `FindUserByTelegramChatID` (neu)
+- **File:** `src/app/loader.py` — **Identifier:** `lookup_user_by_telegram_chat_id`
+- **File:** `src/services/inbound_telegram_reader.py` — **Identifier:** `_process_start_command`
+
+## Estimated Scope
+
+- **LoC:** ~280 (über dem 250er-Limit — `loc_limit_override 500` vor der Implementierung setzen)
+- **Files:** 9 (davon 2 neue Testdateien)
+- **Effort:** medium
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `internal/model/test_user.go` → `IsTestUserID` | Go-Prädikat | Test-Nutzer von Eindeutigkeit und Mehrdeutigkeit ausnehmen |
+| `src/app/config.py` → `is_test_user_id` | Python-Prädikat | Dasselbe auf der Python-Seite |
+| `internal/store/user.go` → `ListUserIDs`, `LoadUser` | Store | Iteration über alle Nutzer (Vorbild `FindUserByEmail`) |
+| `docs/specs/modules/issue_1013_telegram_test_isolation.md` | Spec | Vorrang echter Nutzer vor Test-Nutzern darf nicht brechen |
+| `internal/handler/localhost_guard.go` → `requireLocalOnly` | Guard | Schützt den Connect-Endpunkt bereits gegen externen Zugriff |
+
+## Implementation Details
+
+```
+1) internal/handler/auth.go — UpdateProfileHandler (heute Zeile 717-719)
+   Das Feld bleibt im Decode-Struct, damit "Telegram trennen" weiter funktioniert.
+   Übernommen wird ausschließlich der Leerstring:
+
+       if update.TelegramChatID != nil && *update.TelegramChatID == "" {
+           user.TelegramChatID = ""
+       }
+
+   Kein else-Zweig, kein 400: ein nicht-leerer Wert fliesst nirgends ein. Die Antwort
+   (toProfileResponse) liefert den unveraenderten gespeicherten Wert zurueck, der Aufrufer
+   sieht die Nicht-Uebernahme also unmittelbar. Muster wie premium_sms_reply_to
+   (api_contract.md:2984-2990).
+
+2) internal/store/user.go — neu FindUserByTelegramChatID(chatID string) (*model.User, error)
+   Vorbild FindUserByEmail (user.go:238-256): ListUserIDs -> LoadUser -> Vergleich.
+   Exakter String-Vergleich (Chat-IDs sind numerisch, kein EqualFold).
+   Nutzer mit model.IsTestUserID(uid) == true werden UEBERSPRUNGEN.
+   Leerer chatID -> nil, nil (ein leeres Feld ist keine Verknuepfung).
+
+3) internal/handler/telegram_connect.go — PostTelegramConnectHandler
+   Zwischen LoadUser (192) und SaveUser (198), unter einem paketweiten sync.Mutex,
+   der Pruefung UND Speichern umschliesst (TOCTOU bei gleichzeitigen Connects):
+
+       existing, err := s.FindUserByTelegramChatID(body.ChatID)
+       err != nil                              -> 500
+       existing != nil && existing.ID != pt.UserID
+           -> 409 {"error":"chat_id_already_linked"}, KEIN SaveUser
+       sonst -> wie bisher
+
+   Re-Connect desselben Nutzers ist bewusst kein Konflikt.
+
+4) src/app/loader.py — lookup_user_by_telegram_chat_id
+   Nicht mehr beim ersten Treffer abbrechen, sondern alle Treffer sammeln und in
+   echte Nutzer / Test-Nutzer trennen (is_test_user_id):
+     - genau ein echter Treffer          -> dessen user_id
+     - kein echter, aber Test-Treffer    -> erster Test-Treffer (Verhalten wie bisher)
+     - mehr als ein echter Treffer       -> None + logger.error mit allen kollidierenden IDs
+     - gar kein Treffer                  -> None
+   KEINE Exception: sie wuerde in poll_and_process (122-125) nur geloggt, der Mensch
+   im Chat bliebe stumm. None laeuft in den bestehenden "kein Treffer"-Pfad, der den
+   Registrierungs-Hinweis verschickt.
+
+5) src/services/inbound_telegram_reader.py — _process_start_command (425-449)
+   Der else-Zweig (445-446) unterscheidet 409 von anderen Fehlern und schickt bei 409
+   eine verstaendliche Nachricht an die eingehende chat_id, analog zum
+   Bestaetigungs-Muster in 437-442. Andere Statuscodes bleiben still geloggt.
+```
+
+## Expected Behavior
+
+- **Input:** (a) `PUT /api/auth/profile` mit `telegram_chat_id`; (b) `POST /api/internal/telegram-connect` mit Token und Chat-ID; (c) eingehende Telegram-Nachricht mit einer Chat-ID.
+- **Output:** (a) Profil ohne übernommene Chat-ID, außer beim Leerstring; (b) 200 bei freier oder eigener Chat-ID, 409 `chat_id_already_linked` bei fremder; (c) genau ein zuständiges Konto oder gar keins.
+- **Side effects:** `data/users/<user_id>/user.json` wird nur noch über den Token-Flow oder das Löschen verändert. Bei 409 bleibt die bestehende Verknüpfung des anderen Kontos unangetastet. Mehrdeutige Bestandsdaten erzeugen einen `logger.error`-Eintrag mit den kollidierenden Nutzer-IDs.
+
+## Acceptance Criteria
+
+- **AC-1:** Given Nutzer A hat die Telegram-Chat-ID `55501` und Nutzer B ist angemeldet / When B `PUT /api/auth/profile` mit `{"telegram_chat_id":"55501"}` sendet / Then bleibt B's gespeicherte Chat-ID leer, A's `user.json` trägt unverändert `55501`, und die Antwort an B zeigt nicht `55501`.
+  - Test: Go-Handler-Test mit zwei über `SaveUser` persistierten Nutzern; nach dem Request werden **beide** Profile über `LoadUser` neu gelesen und geprüft.
+
+- **AC-2:** Given Nutzer B hat bereits die Chat-ID `77702` verknüpft / When B `PUT /api/auth/profile` mit `{"telegram_chat_id":""}` sendet / Then ist B's Chat-ID danach leer und die Antwort zeigt sie als leer — das Trennen im Konto-Bereich funktioniert weiter.
+  - Test: Go-Handler-Test, der nach dem Request `LoadUser` liest; deckt den Aufruf ab, den `account/+page.svelte:251` tatsächlich absetzt.
+
+- **AC-3:** Given Nutzer B hat bereits die Chat-ID `77702` verknüpft / When B `PUT /api/auth/profile` mit genau seiner eigenen `{"telegram_chat_id":"77702"}` sendet / Then antwortet der Endpunkt mit 200, B's Chat-ID bleibt `77702` und die übrigen gesendeten Felder werden normal übernommen.
+  - Test: Go-Handler-Test, der zusätzlich ein zweites Feld (`mail_to`) mitsendet und dessen Übernahme prüft — ein wiederholtes Speichern des unveränderten Profils darf nichts kaputtmachen.
+
+- **AC-4:** Given Nutzer A hat die Chat-ID `55501` und Nutzer B besitzt einen gültigen Einmal-Token / When `POST /api/internal/telegram-connect` mit B's Token und Chat-ID `55501` aufgerufen wird / Then antwortet der Endpunkt mit 409 und `{"error":"chat_id_already_linked"}`, B's Chat-ID bleibt leer und A's Verknüpfung bleibt `55501`.
+  - Test: Go-Handler-Test mit zwei persistierten Nutzern über den echten `store.Store`; beide Profile werden nach dem Request von der Platte gelesen.
+
+- **AC-5:** Given Nutzer B hat die Chat-ID `77702` bereits verknüpft und löst einen neuen Einmal-Token aus / When `POST /api/internal/telegram-connect` mit diesem Token und derselben Chat-ID `77702` aufgerufen wird / Then antwortet der Endpunkt mit 200 und B's Chat-ID bleibt `77702` — ein erneutes Verbinden desselben Kontos ist kein Konflikt.
+  - Test: Go-Handler-Test; verhindert, dass die Eindeutigkeitsprüfung den legitimen Re-Connect blockiert.
+
+- **AC-6:** Given der Test-Nutzer `tg-live-e2e` trägt die Chat-ID `55501` und der echte Nutzer A besitzt einen gültigen Einmal-Token / When `POST /api/internal/telegram-connect` mit A's Token und `55501` aufgerufen wird / Then antwortet der Endpunkt mit 200 und A's Chat-ID ist `55501` — Test-Nutzer blockieren echte Nutzer nicht.
+  - Test: Go-Handler-Test mit einem Test-Nutzer und einem echten Nutzer; hält die Zusicherung aus Issue #1013 auf der Go-Seite offen.
+
+- **AC-7:** Given zwei echte Nutzer `anna` und `bertram` tragen beide die Chat-ID `55501` in ihrer `user.json` (Bestandsdaten aus der Zeit vor dem Fix) / When `lookup_user_by_telegram_chat_id("55501")` aufgerufen wird / Then liefert die Funktion `None` statt einer der beiden IDs.
+  - Test: Python-Test auf echtem Dateisystem (`tmp_path`), zwei echte Nutzerprofile geschrieben; prüft den Rückgabewert, nicht den Quelltext.
+
+- **AC-8:** Given der echte Nutzer `henning` und die Test-Nutzer `tg-live-e2e`, `test_aaa`, `tdd-zzz` tragen alle die Chat-ID `999888` / When `lookup_user_by_telegram_chat_id("999888")` aufgerufen wird / Then liefert die Funktion `henning` — der Vorrang des echten Nutzers vor Test-Nutzern aus Issue #1013 bleibt erhalten.
+  - Test: Python-Test auf echtem Dateisystem; entspricht dem Aufbau von `test_issue_1013_telegram_test_isolation.py:87-101` und ist der Regressionsschutz für diese Zusicherung.
+
+- **AC-9:** Given zwei echte Nutzer teilen sich die Chat-ID `55501` / When von dieser Chat-ID eine Telegram-Nachricht eingeht / Then wird kein Trip und keine Einstellung eines der beiden Konten geladen, der Absender erhält stattdessen den bestehenden Registrierungs-Hinweis, und im Log steht ein `error`-Eintrag, der beide kollidierenden Nutzer-IDs nennt.
+  - Test: Python-Test, der eine eingehende Nachricht durch `_process_update` schickt und die tatsächlich versendete Antwort sowie den Log-Eintrag prüft.
+
+- **AC-10:** Given die Chat-ID `55501` gehört bereits einem anderen echten Konto / When ein Nutzer im Telegram-Chat `/start <token>` sendet und die Go-API mit 409 antwortet / Then erhält er in seinem Chat eine verständliche Nachricht, dass diese Chat-Verbindung bereits mit einem anderen Konto verknüpft ist — statt wie bisher gar keiner Rückmeldung.
+  - Test: Python-Test, der `_process_start_command` gegen eine 409-Antwort laufen lässt und prüft, dass eine Nachricht an die eingehende Chat-ID hinausgeht.
+
+## Known Limitations
+
+- **Bestandsdaten mit Doppelbelegung** werden nicht automatisch bereinigt. Betroffene Nutzer verlieren
+  den Inbound-Kanal (AC-9) statt fälschlich einem Konto zugeordnet zu werden. Das ist der gewollte
+  sichere Zustand, aber ein Verhaltenssprung — nach dem Deploy einmal gegen den Prod-Bestand unter
+  `/var/lib/gregor` prüfen, ob es solche Duplikate überhaupt gibt.
+- **Der `or "default"`-Rückfall** in `inbound_telegram_reader.py:422` bleibt bestehen. Ein echter
+  Nutzer mit der ID `default` bekäme fälschlich den Registrierungs-Hinweis. Kein Datenleck, sondern
+  ein Namenskollisions-Randfall → eigenes Issue.
+- **Kein dedizierter Trenn-Endpunkt.** Das Löschen bleibt ein Sonderfall im Profil-Decoder. Ein
+  `DELETE /api/auth/telegram-link` wäre sauberer, kostet aber Endpunkt plus Frontend-Änderung auf
+  einem kritischen Hotfix → Nachfolge-Eintrag in #1199.
+- **Der Mutex wirkt prozessintern.** Bei mehreren `gregor-api`-Prozessen auf denselben Daten wäre die
+  TOCTOU-Lücke wieder offen. Je Umgebung läuft genau ein Prozess, deshalb ausreichend.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine (bestätigt ADR-0003)
+- **Rationale:** Es wird keine neue Grundsatzentscheidung getroffen, sondern eine bestehende
+  durchgesetzt: ADR-0003 verlangt konsequente Mandantentrennung. Die Regel „Identitätszuordnungen
+  sind nicht über den generischen Profil-Decoder schreibbar" existiert bereits als Präzedenzfall für
+  `premium_sms_reply_to` (#1717 S3, AC-7) und wird hier nur auf `telegram_chat_id` angewandt. Die
+  Ausnahme für Test-Nutzer folgt der bestehenden Entscheidung aus Issue #1013.
+
+## Changelog
+
+- 2026-09-07: Initial spec created (Issue #2141)

--- a/internal/handler/auth.go
+++ b/internal/handler/auth.go
@@ -714,8 +714,16 @@ func UpdateProfileHandler(s *store.Store, cfg config.Config) http.HandlerFunc {
 		if update.SmsTo != nil {
 			user.SmsTo = *update.SmsTo
 		}
-		if update.TelegramChatID != nil {
-			user.TelegramChatID = *update.TelegramChatID
+		// Issue #2141: die Telegram-Chat-ID ist eine Identitätszuordnung, keine
+		// Einstellung — gesetzt wird sie ausschließlich über den
+		// localhost-gesperrten Einmal-Token-Flow (PostTelegramConnectHandler).
+		// Über diesen generischen Profil-Decoder kommt nur der Leerstring durch,
+		// damit "Telegram trennen" im Konto-Bereich weiter funktioniert. Ein
+		// nicht-leerer Wert fließt nirgends ein; die Antwort (toProfileResponse)
+		// zeigt den unveränderten gespeicherten Wert, der Aufrufer sieht die
+		// Nicht-Übernahme also unmittelbar. Muster wie premium_sms_reply_to.
+		if update.TelegramChatID != nil && *update.TelegramChatID == "" {
+			user.TelegramChatID = ""
 		}
 
 		if err := s.SaveUser(*user); err != nil {

--- a/internal/handler/profile_telegram_chat_id_test.go
+++ b/internal/handler/profile_telegram_chat_id_test.go
@@ -1,0 +1,141 @@
+package handler
+
+// TDD RED: Issue #2141 — Telegram-Chat-ID ist eine Identitaetszuordnung, keine
+// Einstellung. Spec: docs/specs/modules/telegram_chat_id_ownership.md, AC-1..AC-3.
+//
+// Diese Datei deckt den PROFIL-Schreibweg (PUT /api/auth/profile) ab. Heute
+// uebernimmt UpdateProfileHandler (auth.go:717-719) jeden gesendeten Wert
+// ungeprueft — damit kann Nutzer B die Chat-ID von Nutzer A eintragen und den
+// localhost-gesperrten Einmal-Token-Flow vollstaendig umgehen.
+//
+// Nachweisform (Kontext-Dokument, "Nachweisformen, die truegen wuerden"):
+// echter store.Store gegen ein temporaeres Verzeichnis, ZWEI persistierte
+// Nutzer, und nach jedem Request werden BEIDE user.json frisch von der Platte
+// gelesen. Ein Test, der nur den Angreifer prueft, belegt nicht, dass das
+// Opfer unangetastet blieb.
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/henemm/gregor-api/internal/config"
+	"github.com/henemm/gregor-api/internal/middleware"
+	"github.com/henemm/gregor-api/internal/model"
+)
+
+// victimChatID / ownChatID: erfundene Chat-IDs aus der Spec (Repo ist oeffentlich).
+const (
+	victimChatID = "55501"
+	ownChatID    = "77702"
+)
+
+// profileChatIDOf liest telegram_chat_id aus einer Profil-Antwort. Das Feld
+// traegt omitempty, ein leerer Wert fehlt also ganz — beides gilt als "leer".
+func profileChatIDOf(t *testing.T, raw []byte) string {
+	t.Helper()
+	var resp map[string]interface{}
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		t.Fatalf("Profil-Antwort ist kein gueltiges JSON: %v (body=%s)", err, string(raw))
+	}
+	v, ok := resp["telegram_chat_id"]
+	if !ok || v == nil {
+		return ""
+	}
+	s, ok := v.(string)
+	if !ok {
+		t.Fatalf("telegram_chat_id ist kein String: %#v", v)
+	}
+	return s
+}
+
+// AC-1: Nutzer A haelt die Chat-ID 55501. Nutzer B traegt sie ueber sein
+// eigenes Profil ein. Danach muss B's Chat-ID leer sein, A's user.json
+// unveraendert 55501 tragen, und B darf 55501 auch nicht in der Antwort sehen.
+func TestUpdateProfileRejectsForeignTelegramChatID(t *testing.T) {
+	s := newTestStore(t)
+	mustSaveUser(t, s, model.User{ID: "anna", TelegramChatID: victimChatID})
+	mustSaveUser(t, s, model.User{ID: "bertram"})
+
+	h := UpdateProfileHandler(s, config.Config{})
+
+	body := `{"telegram_chat_id":"` + victimChatID + `"}`
+	req := httptest.NewRequest("PUT", "/api/auth/profile", strings.NewReader(body))
+	req = req.WithContext(middleware.ContextWithUserID(req.Context(), "bertram"))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	// Angreifer-Seite: nichts uebernommen.
+	attacker := mustLoadUser(t, s, "bertram")
+	if attacker.TelegramChatID != "" {
+		t.Errorf("chat id von anna wurde uebernommen: bertram traegt %q, erwartet %q",
+			attacker.TelegramChatID, "")
+	}
+
+	// Opfer-Seite: unangetastet.
+	victim := mustLoadUser(t, s, "anna")
+	if victim.TelegramChatID != victimChatID {
+		t.Errorf("anna's user.json wurde veraendert: %q, erwartet %q",
+			victim.TelegramChatID, victimChatID)
+	}
+
+	// Antwort verraet die fremde Chat-ID nicht zurueck.
+	if got := profileChatIDOf(t, w.Body.Bytes()); got == victimChatID {
+		t.Errorf("Antwort an bertram zeigt die fremde chat id %q", got)
+	}
+}
+
+// AC-2: Trennen muss weiter funktionieren — der Leerstring ist der einzige
+// Wert, den das Profil uebernimmt. Genau diesen Aufruf setzt
+// frontend/src/routes/account/+page.svelte:251 ab.
+func TestUpdateProfileClearsOwnTelegramChatID(t *testing.T) {
+	s := newTestStore(t)
+	mustSaveUser(t, s, model.User{ID: "bertram", TelegramChatID: ownChatID})
+
+	h := UpdateProfileHandler(s, config.Config{})
+
+	req := httptest.NewRequest("PUT", "/api/auth/profile", strings.NewReader(`{"telegram_chat_id":""}`))
+	req = req.WithContext(middleware.ContextWithUserID(req.Context(), "bertram"))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != 200 {
+		t.Fatalf("erwartet 200 beim Trennen, bekam %d: %s", w.Code, w.Body.String())
+	}
+	user := mustLoadUser(t, s, "bertram")
+	if user.TelegramChatID != "" {
+		t.Errorf("Trennen wirkungslos: bertram traegt weiter %q", user.TelegramChatID)
+	}
+	if got := profileChatIDOf(t, w.Body.Bytes()); got != "" {
+		t.Errorf("Antwort zeigt nach dem Trennen noch %q, erwartet leer", got)
+	}
+}
+
+// AC-3: Sendet ein Nutzer seine EIGENE, unveraenderte Chat-ID mit, ist das
+// kein Fehler — 200, die Verknuepfung bleibt bestehen, und die uebrigen Felder
+// desselben Requests werden normal uebernommen. Regressionsschutz gegen einen
+// zu scharfen Fix (400 / stilles Loeschen / Abbruch vor mail_to).
+func TestUpdateProfileKeepsOwnTelegramChatIDAndSavesOtherFields(t *testing.T) {
+	s := newTestStore(t)
+	mustSaveUser(t, s, model.User{ID: "bertram", TelegramChatID: ownChatID})
+
+	h := UpdateProfileHandler(s, config.Config{})
+
+	body := `{"telegram_chat_id":"` + ownChatID + `","mail_to":"bertram@example.com"}`
+	req := httptest.NewRequest("PUT", "/api/auth/profile", strings.NewReader(body))
+	req = req.WithContext(middleware.ContextWithUserID(req.Context(), "bertram"))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != 200 {
+		t.Fatalf("erwartet 200 beim No-Op-Update, bekam %d: %s", w.Code, w.Body.String())
+	}
+	user := mustLoadUser(t, s, "bertram")
+	if user.TelegramChatID != ownChatID {
+		t.Errorf("eigene chat id verloren: %q, erwartet %q", user.TelegramChatID, ownChatID)
+	}
+	if user.MailTo != "bertram@example.com" {
+		t.Errorf("mail_to nicht uebernommen: %q, erwartet %q", user.MailTo, "bertram@example.com")
+	}
+}

--- a/internal/handler/profile_test.go
+++ b/internal/handler/profile_test.go
@@ -84,7 +84,10 @@ func TestUpdateProfileHandler(t *testing.T) {
 
 	h := UpdateProfileHandler(s, config.Config{})
 
-	// WHEN: Bob updates his channel settings
+	// WHEN: Bob updates his channel settings and smuggles a telegram_chat_id in
+	// (Issue #2141: die Chat-ID ist eine Identitaetszuordnung und darf ueber
+	// diesen generischen Decoder nicht gesetzt werden — nur der Leerstring zum
+	// Trennen kommt durch, siehe TestUpdateProfileClearsOwnTelegramChatID).
 	body := `{"mail_to":"bob@example.com","telegram_chat_id":"42"}`
 	req := httptest.NewRequest("PUT", "/api/auth/profile", strings.NewReader(body))
 	ctx := middleware.ContextWithUserID(req.Context(), "bob")
@@ -102,8 +105,13 @@ func TestUpdateProfileHandler(t *testing.T) {
 	if resp["mail_to"] != "bob@example.com" {
 		t.Errorf("expected mail_to 'bob@example.com', got '%v'", resp["mail_to"])
 	}
-	if resp["telegram_chat_id"] != "42" {
-		t.Errorf("expected telegram_chat_id '42', got '%v'", resp["telegram_chat_id"])
+	// THEN: die mitgeschickte telegram_chat_id wurde NICHT uebernommen.
+	if got, ok := resp["telegram_chat_id"]; ok && got != "" {
+		t.Errorf("telegram_chat_id must NOT be settable via profile update, got '%v'", got)
+	}
+	onDisk := mustLoadUser(t, s, "bob")
+	if onDisk.TelegramChatID != "" {
+		t.Errorf("telegram_chat_id landete in user.json: %q, erwartet leer", onDisk.TelegramChatID)
 	}
 	// password_hash must not leak
 	if _, hasHash := resp["password_hash"]; hasHash {

--- a/internal/handler/telegram_connect.go
+++ b/internal/handler/telegram_connect.go
@@ -165,6 +165,11 @@ func GetTelegramStatusHandler(s *store.Store) http.HandlerFunc {
 	}
 }
 
+// telegramConnectMu serialisiert Kollisionsprüfung und Speichern im
+// Connect-Endpunkt (Issue #2141). Wirkt prozessintern — je Umgebung läuft
+// genau ein gregor-api-Prozess auf demselben Datenverzeichnis.
+var telegramConnectMu sync.Mutex
+
 // PostTelegramConnectHandler — POST /api/internal/telegram-connect
 // Called only by the Python InboundTelegramReader (localhost only).
 // Resolves the one-time token to a user_id and saves the chat_id.
@@ -194,6 +199,25 @@ func PostTelegramConnectHandler(s *store.Store, ts *TelegramTokenStore) http.Han
 			http.Error(w, "user not found", http.StatusNotFound)
 			return
 		}
+		// Issue #2141: Eindeutigkeit der Chat-ID. Prüfung UND Speichern laufen
+		// unter demselben Lock, sonst könnten zwei gleichzeitige Connects
+		// beide an der Prüfung vorbeikommen (TOCTOU).
+		telegramConnectMu.Lock()
+		defer telegramConnectMu.Unlock()
+
+		existing, err := s.FindUserByTelegramChatID(body.ChatID)
+		if err != nil {
+			http.Error(w, "lookup failed", http.StatusInternalServerError)
+			return
+		}
+		if existing != nil && existing.ID != pt.UserID {
+			// Re-Connect desselben Nutzers ist bewusst kein Konflikt.
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusConflict)
+			json.NewEncoder(w).Encode(map[string]string{"error": "chat_id_already_linked"})
+			return
+		}
+
 		user.TelegramChatID = body.ChatID
 		if err := s.SaveUser(*user); err != nil {
 			http.Error(w, "save failed", http.StatusInternalServerError)

--- a/internal/handler/telegram_connect_uniqueness_test.go
+++ b/internal/handler/telegram_connect_uniqueness_test.go
@@ -1,0 +1,146 @@
+package handler
+
+// TDD RED: Issue #2141 — Eindeutigkeit der Telegram-Chat-ID im Token-Flow.
+// Spec: docs/specs/modules/telegram_chat_id_ownership.md, AC-4..AC-6.
+//
+// PostTelegramConnectHandler (telegram_connect.go:192-201) laedt den Nutzer
+// zum Token und schreibt die Chat-ID ohne jede Kollisionspruefung. Gehoert die
+// ID bereits einem anderen ECHTEN Konto, muss der Endpunkt mit 409
+// {"error":"chat_id_already_linked"} antworten und darf nichts speichern.
+//
+// Test-Nutzer (model.IsTestUserID) sind bewusst ausgenommen: Issue #1013 haelt
+// fest, dass der echte Nutzer gegen die Fixture gewinnt — sonst koennte sich
+// der PO auf Staging nicht mehr verbinden, sobald tg-live-e2e seine Chat-ID
+// traegt.
+//
+// Nachweisform: echter store.Store gegen ein temporaeres Verzeichnis (ein
+// gestubbter Store wuerde eine fehlende Iteration ueber alle Nutzer nicht
+// auffallen lassen), zwei persistierte Nutzer, beide user.json nach dem
+// Request frisch von der Platte gelesen. Aufrufe kommen von echtem Loopback
+// ohne Proxy-Header, passieren requireLocalOnly also wie der lokale
+// Python-Core.
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/henemm/gregor-api/internal/model"
+)
+
+// connectErrorCode liest das error-Feld aus einer Connect-Antwort.
+func connectErrorCode(t *testing.T, raw []byte) string {
+	t.Helper()
+	var resp map[string]interface{}
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		t.Fatalf("Connect-Antwort ist kein gueltiges JSON: %v (body=%s)", err, string(raw))
+	}
+	v, ok := resp["error"]
+	if !ok || v == nil {
+		return ""
+	}
+	s, ok := v.(string)
+	if !ok {
+		t.Fatalf("error ist kein String: %#v", v)
+	}
+	return s
+}
+
+// AC-4: Nutzer anna haelt 55501. bertram loest einen gueltigen Einmal-Token
+// aus und verbindet damit dieselbe Chat-ID. Erwartet 409
+// chat_id_already_linked; bertram bleibt ohne Verknuepfung, anna behaelt ihre.
+func TestTelegramConnectRejectsChatIDOwnedByAnotherUser(t *testing.T) {
+	s := telegramConnectTestStore(t)
+	ts := NewTelegramTokenStore(t.TempDir())
+	mustSaveUser(t, s, model.User{ID: "anna", TelegramChatID: victimChatID})
+	mustSaveUser(t, s, model.User{ID: "bertram"})
+	token := ts.CreateToken("bertram")
+
+	h := PostTelegramConnectHandler(s, ts)
+	req := newTelegramConnectRequest("127.0.0.1:54321", nil,
+		map[string]any{"token": token, "chat_id": victimChatID})
+	rr := httptest.NewRecorder()
+	h(rr, req)
+
+	if rr.Code != http.StatusConflict {
+		t.Errorf("erwartet 409 fuer fremde chat id, bekam %d, body=%s", rr.Code, rr.Body.String())
+	}
+	if got := connectErrorCode(t, rr.Body.Bytes()); got != "chat_id_already_linked" {
+		t.Errorf("erwartet error=%q, bekam %q (body=%s)",
+			"chat_id_already_linked", got, rr.Body.String())
+	}
+
+	attacker := mustLoadUser(t, s, "bertram")
+	if attacker.TelegramChatID != "" {
+		t.Errorf("chat id von anna wurde uebernommen: bertram traegt %q, erwartet %q",
+			attacker.TelegramChatID, "")
+	}
+	victim := mustLoadUser(t, s, "anna")
+	if victim.TelegramChatID != victimChatID {
+		t.Errorf("anna's Verknuepfung wurde veraendert: %q, erwartet %q",
+			victim.TelegramChatID, victimChatID)
+	}
+}
+
+// AC-5: Derselbe Nutzer verbindet dieselbe Chat-ID erneut — kein Konflikt.
+// Verhindert, dass die Eindeutigkeitspruefung den legitimen Re-Connect
+// blockiert (z. B. nach einem Bot-Wechsel oder erneutem /start).
+func TestTelegramConnectAllowsReconnectOfSameUser(t *testing.T) {
+	s := telegramConnectTestStore(t)
+	ts := NewTelegramTokenStore(t.TempDir())
+	mustSaveUser(t, s, model.User{ID: "bertram", TelegramChatID: ownChatID})
+	token := ts.CreateToken("bertram")
+
+	h := PostTelegramConnectHandler(s, ts)
+	req := newTelegramConnectRequest("127.0.0.1:54321", nil,
+		map[string]any{"token": token, "chat_id": ownChatID})
+	rr := httptest.NewRecorder()
+	h(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("erwartet 200 fuer Re-Connect desselben Nutzers, bekam %d, body=%s",
+			rr.Code, rr.Body.String())
+	}
+	user := mustLoadUser(t, s, "bertram")
+	if user.TelegramChatID != ownChatID {
+		t.Errorf("Re-Connect hat die eigene chat id veraendert: %q, erwartet %q",
+			user.TelegramChatID, ownChatID)
+	}
+}
+
+// AC-6: Der Test-Nutzer tg-live-e2e traegt 55501. Ein echter Nutzer verbindet
+// dieselbe Chat-ID — Test-Nutzer duerfen echte Nutzer nicht blockieren
+// (Issue #1013, Vorrang des echten Kontos).
+func TestTelegramConnectIgnoresTestUserHoldingSameChatID(t *testing.T) {
+	const fixtureUserID = "tg-live-e2e"
+	if !model.IsTestUserID(fixtureUserID) {
+		t.Fatalf("Testvoraussetzung verletzt: %q gilt nicht als Test-Nutzer", fixtureUserID)
+	}
+
+	s := telegramConnectTestStore(t)
+	ts := NewTelegramTokenStore(t.TempDir())
+	mustSaveUser(t, s, model.User{ID: fixtureUserID, TelegramChatID: victimChatID})
+	mustSaveUser(t, s, model.User{ID: "anna"})
+	token := ts.CreateToken("anna")
+
+	h := PostTelegramConnectHandler(s, ts)
+	req := newTelegramConnectRequest("127.0.0.1:54321", nil,
+		map[string]any{"token": token, "chat_id": victimChatID})
+	rr := httptest.NewRecorder()
+	h(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("Test-Nutzer %q blockiert den echten Nutzer: erwartet 200, bekam %d, body=%s",
+			fixtureUserID, rr.Code, rr.Body.String())
+	}
+	real := mustLoadUser(t, s, "anna")
+	if real.TelegramChatID != victimChatID {
+		t.Errorf("anna's chat id nicht gesetzt: %q, erwartet %q", real.TelegramChatID, victimChatID)
+	}
+	fixture := mustLoadUser(t, s, fixtureUserID)
+	if fixture.TelegramChatID != victimChatID {
+		t.Errorf("Fixture-Konto wurde nebenbei veraendert: %q, erwartet %q",
+			fixture.TelegramChatID, victimChatID)
+	}
+}

--- a/internal/store/user.go
+++ b/internal/store/user.go
@@ -254,3 +254,33 @@ func (s *Store) FindUserByEmail(email string) (*model.User, error) {
 	}
 	return nil, nil
 }
+
+// FindUserByTelegramChatID searches all users for one whose TelegramChatID
+// matches exactly (Chat-IDs sind numerisch — kein EqualFold). Returns
+// (nil, nil) if no match found or if chatID is empty: ein leeres Feld ist
+// keine Verknüpfung. Test-Nutzer (model.IsTestUserID) werden übersprungen —
+// Issue #1013 hält fest, dass ein echter Nutzer gegen die Fixture gewinnt,
+// sonst könnte sich der PO auf Staging nicht mehr verbinden, sobald
+// tg-live-e2e dieselbe Chat-ID trägt. Issue #2141.
+func (s *Store) FindUserByTelegramChatID(chatID string) (*model.User, error) {
+	if strings.TrimSpace(chatID) == "" {
+		return nil, nil
+	}
+	ids, err := s.ListUserIDs()
+	if err != nil {
+		return nil, err
+	}
+	for _, id := range ids {
+		if model.IsTestUserID(id) {
+			continue
+		}
+		u, err := s.LoadUser(id)
+		if err != nil || u == nil {
+			continue
+		}
+		if u.TelegramChatID == chatID {
+			return u, nil
+		}
+	}
+	return nil, nil
+}

--- a/src/app/loader.py
+++ b/src/app/loader.py
@@ -1256,24 +1256,56 @@ def lookup_user_by_email(email: str, data_dir: str | None = None) -> str | None:
 def lookup_user_by_telegram_chat_id(chat_id: str, data_dir: str | None = None) -> str | None:
     """Find user_id whose telegram_chat_id matches the given chat_id (int/str-tolerant).
 
+    Eindeutigkeit ist Pflicht (Issue #2141): tragen ZWEI echte Nutzer dieselbe
+    Chat-ID (Bestandsdaten aus der Zeit vor dem Fix), gibt es keine zulässige
+    Zuordnung — die Funktion liefert None und protokolliert die Kollision. Der
+    Aufrufer läuft damit in den bestehenden "kein Treffer"-Pfad, der den
+    Registrierungs-Hinweis verschickt; eine Exception bliebe im Chat stumm.
+
+    Mehrdeutigkeit gilt nur unter ECHTEN Nutzern: der Vorrang des echten
+    Kontos vor Test-Nutzern (Issue #1013) bleibt erhalten.
+
     Args:
         chat_id: Telegram chat ID to match (compared as strings)
         data_dir: Root data directory (default: get_data_root())
 
     Returns:
-        Matching user_id or None if no match found
+        Matching user_id or None if no match found or the match is ambiguous
     """
+    from app.config import is_test_user_id
+
     if data_dir is None:
         data_dir = str(get_data_root())
+
+    real_matches: list[str] = []
+    test_matches: list[str] = []
     for uid in list_all_user_ids(data_dir):
         profile_path = Path(data_dir) / "users" / uid / "user.json"
-        if profile_path.exists():
-            try:
-                profile = json.loads(profile_path.read_text(encoding="utf-8"))
-                if str(profile.get("telegram_chat_id", "")) == str(chat_id):
-                    return uid
-            except Exception:
-                continue
+        if not profile_path.exists():
+            continue
+        try:
+            profile = json.loads(profile_path.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        if str(profile.get("telegram_chat_id", "")) != str(chat_id):
+            continue
+        if is_test_user_id(uid, data_dir=data_dir):
+            test_matches.append(uid)
+        else:
+            real_matches.append(uid)
+
+    if len(real_matches) > 1:
+        logger.error(
+            "Telegram-Chat-ID %s ist mehrdeutig — keine Zuordnung. "
+            "Kollidierende Nutzer: %s (Issue #2141)",
+            chat_id,
+            ", ".join(real_matches),
+        )
+        return None
+    if real_matches:
+        return real_matches[0]
+    if test_matches:
+        return test_matches[0]
     return None
 
 

--- a/src/services/inbound_telegram_reader.py
+++ b/src/services/inbound_telegram_reader.py
@@ -444,6 +444,26 @@ class InboundTelegramReader:
                     )
                 except Exception as ce:
                     logger.warning(f"Bestätigungsnachricht fehlgeschlagen: {ce}")
+            elif resp.status_code == 409:
+                # Issue #2141: die Chat-ID gehört bereits einem anderen Konto.
+                # Ohne Rückmeldung wäre das aus Nutzersicht ein Stillstand.
+                logger.warning(
+                    f"telegram-connect: chat_id {chat_id} bereits mit einem anderen Konto verknüpft"
+                )
+                try:
+                    conflict_settings = settings.model_copy(update={"telegram_chat_id": chat_id})
+                    self._notification_service.send_telegram_message(
+                        chat_id=chat_id,
+                        subject="Verbinden nicht möglich",
+                        body=(
+                            "Dieser Chat ist bereits mit einem anderen Gregor-Konto verbunden. "
+                            "Trenne die Verbindung zuerst im Konto-Bereich des anderen Kontos "
+                            "und sende danach erneut /start."
+                        ),
+                        settings=conflict_settings,
+                    )
+                except Exception as ce:
+                    logger.warning(f"Konflikt-Nachricht fehlgeschlagen: {ce}")
             else:
                 logger.warning(f"telegram-connect returned {resp.status_code}")
         except Exception as e:

--- a/tests/tdd/test_telegram_chat_id_ownership.py
+++ b/tests/tdd/test_telegram_chat_id_ownership.py
@@ -43,7 +43,6 @@ from datetime import date, datetime, time, timedelta, timezone
 from pathlib import Path
 
 import httpx
-import pytest
 
 from app import loader
 from app.config import Settings, is_test_user_id

--- a/tests/tdd/test_telegram_chat_id_ownership.py
+++ b/tests/tdd/test_telegram_chat_id_ownership.py
@@ -1,0 +1,346 @@
+"""TDD RED — Besitz und Eindeutigkeit der Telegram-Chat-ID (Python-Seite).
+
+Deckt AC-7 bis AC-10 der Spec ``docs/specs/modules/telegram_chat_id_ownership.md``
+(Issue #2141, priority:critical, Epic #2138):
+
+* AC-7  Mehrdeutige Chat-ID unter ECHTEN Nutzern -> ``lookup_...`` liefert ``None``
+        statt des alphabetisch ersten Treffers (heute gewinnt "anna" verlaesslich).
+* AC-8  Echter Nutzer schlaegt Test-Nutzer weiter (Vorrang aus Issue #1013) --
+        bewusst GRUEN: Regressionsschutz gegen einen zu grob gezogenen Fix, der
+        jede Mehrfachbelegung zu ``None`` machen wuerde.
+* AC-9  Eingehende Nachricht von einer mehrdeutigen Chat-ID: kein Trip, keine
+        Einstellung eines der Konten -- stattdessen der Registrierungs-Hinweis
+        plus ``logger.error`` mit BEIDEN kollidierenden Nutzer-IDs.
+* AC-10 ``/start <token>`` gegen eine 409-Antwort der Go-API -> verstaendliche
+        Nachricht in den Chat statt eines stillen Log-Warnings.
+
+Nachweisform (CLAUDE.md, Mock-Verbot):
+
+* Echtes Dateisystem (``tmp_path``) mit echten ``users/<id>/user.json``-Profilen
+  und einer ueber ``save_trip`` echt persistierten Tour.
+* Gefakt wird AUSSCHLIESSLICH die aeussere Netzgrenze: ``httpx.post``. Beide
+  betroffenen Aufrufer (``services.inbound_telegram_reader`` und
+  ``output.channels.telegram``) rufen dasselbe Modulattribut auf, ein Recorder
+  bedient daher den Telegram-Versand UND den Go-Connect-Endpunkt. Alles
+  dazwischen -- Reader, NotificationService, TelegramOutput, Egress-Guards,
+  Nutzlast-Aufbau -- ist Produktivcode.
+* Geprueft wird die TATSAECHLICH hinausgehende Nachricht (Nutzlast-Text an der
+  HTTP-Grenze) und die vom Reader adressierte Chat-ID, nicht der Aufruf einer
+  internen Funktion.
+
+Zur adressierten Chat-ID an der Draht-Grenze: ``TelegramOutput._guard_code_origin``
+(Issue #1476) zwingt JEDEN aus einem Arbeitsordner/Worktree laufenden Versand auf
+``telegram_test_chat_id`` um. Die Nutzlast-``chat_id`` ist im Testlauf damit
+guard-bestimmt und als Messgroesse wertlos; gemessen wird deshalb die vom Reader
+gewaehlte Empfaengeradresse (aufgezeichnet an der NotificationService-Naht, die
+den Versand ueber ``super()`` wirklich ausfuehrt) plus der Text am Draht.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from datetime import date, datetime, time, timedelta, timezone
+from pathlib import Path
+
+import httpx
+import pytest
+
+from app import loader
+from app.config import Settings, is_test_user_id
+from app.loader import lookup_user_by_telegram_chat_id, save_trip
+from app.trip import Stage, TimeWindow, Trip, Waypoint
+from services.inbound_telegram_reader import InboundTelegramReader
+from services.notification_service import NotificationService
+
+AMBIGUOUS_CHAT_ID = "55501"
+
+
+def _write_user(data_root: Path, user_id: str, chat_id: str = "", mail_to: str = "") -> None:
+    """Echtes Nutzerprofil auf die Platte schreiben (kein gemocktes Listing)."""
+    user_dir = data_root / "users" / user_id
+    user_dir.mkdir(parents=True, exist_ok=True)
+    profile = {"id": user_id, "telegram_chat_id": chat_id, "mail_to": mail_to}
+    (user_dir / "user.json").write_text(json.dumps(profile), encoding="utf-8")
+
+
+def _make_active_trip(user_id: str, name: str) -> Trip:
+    """Echt persistierte, heute aktive Tour (drei Tage, damit die Ortstag-
+    Rechnung an der Tagesgrenze nicht danebenliegt)."""
+    today = date.today()
+    waypoints = [
+        Waypoint(id="G1", name="Start", lat=47.2692, lon=11.4041, elevation_m=600,
+                 time_window=TimeWindow(start=time(0, 0), end=time(0, 0)),
+                 arrival_override="08:00"),
+        Waypoint(id="G2", name="Ziel", lat=47.2950, lon=11.4420, elevation_m=800,
+                 time_window=TimeWindow(start=time(23, 59), end=time(23, 59)),
+                 arrival_override="18:00"),
+    ]
+    stages = [
+        Stage(id=f"T{i}", name=f"{name}-Etappe-{i}", date=today + timedelta(days=offset),
+              start_time=time(8, 0), waypoints=waypoints)
+        for i, offset in enumerate((-1, 0, 1))
+    ]
+    trip = Trip(id=f"trip-{user_id}", name=name, stages=stages)
+    save_trip(trip, user_id=user_id)
+    return trip
+
+
+class _WireRecorder:
+    """Fake an der EINZIGEN echten Aussengrenze: dem HTTP-POST.
+
+    Bedient beide Ziele des Inbound-Pfades und schneidet die Nutzlast mit:
+    ``api.telegram.org`` (ausgehende Nachricht) und ``localhost:8090``
+    (``/api/internal/telegram-connect`` der Go-API). Jeder andere Host ist im
+    deterministischen Kern ein Fehler und fliegt sofort auf.
+    """
+
+    def __init__(self, connect_status: int = 200) -> None:
+        self.telegram: list[dict] = []
+        self.connect: list[dict] = []
+        self._connect_status = connect_status
+
+    def post(self, url, **kwargs):
+        payload = kwargs.get("json") or {}
+        if "api.telegram.org" in str(url):
+            self.telegram.append({"url": str(url), "payload": payload})
+            return httpx.Response(
+                200, json={"ok": True, "result": {"message_id": len(self.telegram)}}
+            )
+        if "telegram-connect" in str(url):
+            self.connect.append({"url": str(url), "payload": payload})
+            body = (
+                {"error": "chat_id_already_linked"}
+                if self._connect_status == 409
+                else {"status": "ok"}
+            )
+            return httpx.Response(self._connect_status, json=body)
+        raise AssertionError(f"unerwarteter HTTP-POST im Kern-Test: {url}")
+
+    def texts(self) -> list[str]:
+        return [str(p["payload"].get("text", "")) for p in self.telegram]
+
+
+class _RecordingNotificationService(NotificationService):
+    """Echte Subklasse (KEIN Mock): merkt sich die adressierte Chat-ID und
+    fuehrt den Versand ueber ``super()`` wirklich aus -- durch den echten
+    TelegramOutput bis an die gefakte HTTP-Grenze."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.addressed: list[str] = []
+
+    def send_telegram_message(self, *, chat_id, subject, body, settings, reply_markup=None):
+        self.addressed.append(str(chat_id))
+        return super().send_telegram_message(
+            chat_id=chat_id, subject=subject, body=body,
+            settings=settings, reply_markup=reply_markup,
+        )
+
+    def send_command_reply_telegram(self, result, chat_id, settings):
+        self.addressed.append(str(chat_id))
+        return super().send_command_reply_telegram(
+            result=result, chat_id=chat_id, settings=settings,
+        )
+
+
+def _base_settings(chat_id: str) -> Settings:
+    """Basis-Settings des Bots. ``telegram_test_chat_id`` == Ziel-Chat, damit die
+    Herkunftssperre (#1476) den Versand nicht auf einen fremden Chat umlenkt."""
+    return Settings(
+        env="production",
+        is_test_mode=False,
+        telegram_bot_token="tdd-bot-token",
+        telegram_chat_id=chat_id,
+        telegram_test_bot_token="tdd-bot-token",
+        telegram_test_chat_id=chat_id,
+    )
+
+
+def _incoming_update(chat_id: str, text: str) -> dict:
+    return {
+        "update_id": 42,
+        "message": {
+            "message_id": 7,
+            "from": {"id": int(chat_id), "is_bot": False, "first_name": "Wanderer"},
+            "chat": {"id": int(chat_id), "type": "private"},
+            "date": int(datetime.now(tz=timezone.utc).timestamp()),
+            "text": text,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# AC-7: zwei echte Nutzer mit derselben Chat-ID -> keine Zuordnung
+# ---------------------------------------------------------------------------
+
+
+def test_lookup_returns_none_when_two_real_users_share_a_chat_id(tmp_path):
+    """AC-7: GIVEN "anna" und "bertram" tragen beide die Chat-ID 55501
+    (Bestandsdaten aus der Zeit vor dem Fix)
+    WHEN lookup_user_by_telegram_chat_id("55501") laeuft
+    THEN None -- heute gewinnt der alphabetisch erste Treffer ("anna")
+    deterministisch, ein Angreifer mit passender user_id uebernimmt damit
+    verlaesslich fremde Kommandos."""
+    _write_user(tmp_path, "anna", chat_id=AMBIGUOUS_CHAT_ID)
+    _write_user(tmp_path, "bertram", chat_id=AMBIGUOUS_CHAT_ID)
+
+    result = lookup_user_by_telegram_chat_id(AMBIGUOUS_CHAT_ID, data_dir=str(tmp_path))
+
+    assert result is None, (
+        f"#2141: mehrdeutige Chat-ID {AMBIGUOUS_CHAT_ID} wurde dem Konto {result!r} "
+        f"zugeordnet (erwartet: None) -- Nachrichten-Hijacking zwischen zwei echten Konten"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-8: Vorrang des echten Nutzers vor Test-Nutzern bleibt (Issue #1013)
+# ---------------------------------------------------------------------------
+
+
+def test_lookup_still_prefers_real_user_over_test_users_sharing_the_chat_id(tmp_path):
+    """AC-8: GIVEN der echte Nutzer "henning" und drei Test-Nutzer tragen
+    dieselbe Chat-ID 999888
+    WHEN lookup_user_by_telegram_chat_id("999888") laeuft
+    THEN "henning" -- Mehrdeutigkeit gilt nur unter ECHTEN Nutzern. Ohne diese
+    Zusicherung bekaeme der PO seine Test-Briefings ueber den Prod-Bot (#1013).
+
+    Bewusst GRUEN vor dem Fix: Regressionsschutz gegen einen zu grob gezogenen
+    AC-7-Fix, der jede Mehrfachbelegung zu None machen wuerde."""
+    chat_id = "999888"
+    test_user_ids = ["tg-live-e2e", "test_aaa", "tdd-zzz"]
+    for uid in test_user_ids:
+        _write_user(tmp_path, uid, chat_id=chat_id)
+    _write_user(tmp_path, "henning", chat_id=chat_id)
+
+    # Die Test-Nutzer sind aus dem zentralen Praedikat abgeleitet, nicht geraten.
+    for uid in test_user_ids:
+        assert is_test_user_id(uid, data_dir=str(tmp_path)) is True, uid
+    assert is_test_user_id("henning", data_dir=str(tmp_path)) is False
+
+    result = lookup_user_by_telegram_chat_id(chat_id, data_dir=str(tmp_path))
+
+    assert result == "henning", (
+        f"Vorrang des echten Nutzers vor Test-Nutzern (#1013) gebrochen: {result!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-9: eingehende Nachricht von einer mehrdeutigen Chat-ID
+# ---------------------------------------------------------------------------
+
+
+def test_incoming_message_from_ambiguous_chat_id_leaks_no_account_data(
+    tmp_path, monkeypatch, caplog,
+):
+    """AC-9: GIVEN "anna" (mit aktiver Tour) und "bertram" teilen sich die
+    Chat-ID 55501
+    WHEN von dieser Chat-ID die Nachricht "status" eingeht
+    THEN geht KEIN Trip und KEINE Einstellung eines der beiden Konten hinaus,
+    der Absender bekommt den bestehenden Registrierungs-Hinweis, und im Log
+    steht ein error-Eintrag mit BEIDEN kollidierenden Nutzer-IDs.
+
+    Heute loest der Reader die Chat-ID auf "anna" auf und schickt deren
+    Etappenliste an einen Chat, der genauso gut "bertram" gehoeren kann."""
+    monkeypatch.setattr(loader, "_DATA_ROOT", str(tmp_path))
+    _write_user(tmp_path, "anna", chat_id=AMBIGUOUS_CHAT_ID, mail_to="anna@example.com")
+    _write_user(tmp_path, "bertram", chat_id=AMBIGUOUS_CHAT_ID, mail_to="bertram@example.com")
+    trip = _make_active_trip("anna", "Anna-Geheimtour")
+
+    recorder = _WireRecorder()
+    monkeypatch.setattr(httpx, "post", recorder.post)
+
+    reader = InboundTelegramReader()
+    reader._notification_service = _RecordingNotificationService()
+
+    with caplog.at_level(logging.ERROR):
+        handled = reader._process_update(
+            _incoming_update(AMBIGUOUS_CHAT_ID, "status"),
+            _base_settings(AMBIGUOUS_CHAT_ID),
+        )
+
+    assert handled is True
+    assert recorder.telegram, "Der Absender bekam ueberhaupt keine Antwort"
+    sent = "\n".join(recorder.texts())
+
+    assert trip.name not in sent, (
+        f"#2141: Daten des Kontos 'anna' gingen an eine mehrdeutige Chat-ID hinaus "
+        f"-- gesendeter Text: {sent!r}"
+    )
+    assert "/start" in sent, (
+        f"#2141: statt des Registrierungs-Hinweises ging etwas anderes hinaus "
+        f"-- gesendeter Text: {sent!r}"
+    )
+    assert reader._notification_service.addressed == [AMBIGUOUS_CHAT_ID], (
+        f"Antwort ging nicht (nur) an die eingehende Chat-ID: "
+        f"{reader._notification_service.addressed!r}"
+    )
+
+    error_messages = [r.getMessage() for r in caplog.records if r.levelno >= logging.ERROR]
+    assert any("anna" in m and "bertram" in m for m in error_messages), (
+        f"#2141: kein error-Log mit BEIDEN kollidierenden Nutzer-IDs "
+        f"-- vorhandene error-Eintraege: {error_messages!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-10: /start gegen eine 409-Antwort der Go-API
+# ---------------------------------------------------------------------------
+
+
+def test_start_command_answers_in_chat_when_connect_returns_conflict(monkeypatch):
+    """AC-10: GIVEN die Chat-ID gehoert bereits einem anderen echten Konto
+    WHEN "/start <token>" gesendet wird und die Go-API mit 409 antwortet
+    THEN erhaelt der Absender eine verstaendliche Nachricht in seinem Chat.
+
+    Heute wird der Nicht-200-Status nur als Log-Warning abgelegt -- im Chat
+    passiert gar nichts, der Fix waere aus Nutzersicht ein Stillstand."""
+    recorder = _WireRecorder(connect_status=409)
+    monkeypatch.setattr(httpx, "post", recorder.post)
+
+    reader = InboundTelegramReader()
+    reader._notification_service = _RecordingNotificationService()
+
+    handled = reader._process_start_command(
+        token="tdd-einmal-token",
+        chat_id=AMBIGUOUS_CHAT_ID,
+        settings=_base_settings(AMBIGUOUS_CHAT_ID),
+    )
+
+    assert handled is True
+    assert recorder.connect, "Der Connect-Endpunkt der Go-API wurde gar nicht gerufen"
+    assert recorder.telegram, (
+        "#2141: Bei 409 (chat_id_already_linked) ging KEINE Nachricht in den Chat "
+        "hinaus -- der Nutzer erfaehrt nicht, warum das Verbinden scheitert"
+    )
+    assert reader._notification_service.addressed == [AMBIGUOUS_CHAT_ID], (
+        f"Konflikt-Nachricht ging nicht an die eingehende Chat-ID: "
+        f"{reader._notification_service.addressed!r}"
+    )
+
+    sent = "\n".join(recorder.texts()).lower()
+    assert "konto" in sent and ("bereits" in sent or "schon" in sent), (
+        f"Die Konflikt-Nachricht nennt den Grund nicht verstaendlich: {sent!r}"
+    )
+
+
+def test_start_command_stays_silent_for_other_error_statuses(monkeypatch):
+    """Gegenstueck zu AC-10 (Spec: "Andere Statuscodes bleiben still geloggt"):
+    ein 500 der Go-API darf KEINE Chat-Nachricht ausloesen. Ohne diesen Waechter
+    wuerde ein pauschales "bei jedem Nicht-200 antworten" als AC-10-Fix
+    durchgehen. Vor dem Fix bereits gruen."""
+    recorder = _WireRecorder(connect_status=500)
+    monkeypatch.setattr(httpx, "post", recorder.post)
+
+    reader = InboundTelegramReader()
+    reader._notification_service = _RecordingNotificationService()
+
+    reader._process_start_command(
+        token="tdd-einmal-token",
+        chat_id=AMBIGUOUS_CHAT_ID,
+        settings=_base_settings(AMBIGUOUS_CHAT_ID),
+    )
+
+    assert recorder.connect, "Der Connect-Endpunkt der Go-API wurde gar nicht gerufen"
+    assert not recorder.telegram, (
+        f"Ein 500 der Go-API loeste eine Chat-Nachricht aus: {recorder.texts()!r}"
+    )


### PR DESCRIPTION
Schliesst #2141.

## Problem

Eine Telegram-Chat-ID war bisher kein exklusiver Besitz. Wer eine fremde
Chat-ID kannte, konnte sie im eigenen Profil eintragen — das System nahm sie
still an. Folge: Briefings und Alarme des fremden Nutzers landeten im eigenen
Chat, und dem Bestohlenen fiel nichts auf.

## Loesung

- **Go-Store** (`internal/store/user.go`): Beim Setzen einer Chat-ID wird
  ueber alle Nutzer geprueft, ob sie bereits jemand anderem gehoert.
- **Profil-Update** (`internal/handler/auth.go`) und **Telegram-Connect**
  (`internal/handler/telegram_connect.go`): antworten mit **409 Conflict**
  statt die fremde ID zu uebernehmen.
- **Python-Loader** (`src/app/loader.py`) und **Inbound-Reader**
  (`src/services/inbound_telegram_reader.py`): loesen eine Chat-ID nur noch
  auf den besitzenden Nutzer auf; der Absender bekommt bei 409 eine
  verstaendliche Rueckmeldung in seinen Chat statt Stillstand.

## Nachweis

- 10/10 Acceptance Criteria erfuellt, 0 Regressionen
- Neue Tests: `internal/handler/profile_telegram_chat_id_test.go`,
  `internal/handler/telegram_connect_uniqueness_test.go`,
  `tests/tdd/test_telegram_chat_id_ownership.py`
- Adversary-Verdict: **VERIFIED** (49 passed). 8 Mutationen gesetzt,
  6 gefangen; die zwei ungefangenen sind Deckungsluecken ohne
  Nutzerwirkung und wurden in #1196 gebucht.
- Empfaenger-Zuordnung an der `NotificationService`-Naht gemessen, nicht am
  Draht.

## Doku

`docs/reference/api_contract.md` (409-Kontrakt) und
`docs/features/architecture.md` nachgezogen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CwoKYqHVkhLJZdfAftgdQ6
