### PR TITLE
fix(#2167): Ad-hoc-Abruf Sun liefert Sonnenstunden statt Strahlung

### DIFF
--- a/docs/context/fix-2167-sonnenstunden-einheit.md
+++ b/docs/context/fix-2167-sonnenstunden-einheit.md
@@ -1,0 +1,233 @@
+# Context: fix-2167-sonnenstunden-einheit
+
+**Issue:** #2167 — Ad-hoc-Abruf: `Sun` liefert Strahlungswerte mit Stunden-Etikett (781.5 h)
+**Herkunft:** Nebenbefund aus der Staging-Verifikation von #2134 (Scheibe S1 von Epic #2133)
+**Erstellt:** 2026-09-07 · **Track:** Bug
+**Basis:** `origin/main` @ `2234d037`
+
+## Analysis
+
+### Type
+
+**Bug.**
+
+### Request Summary
+
+Fragt der Wanderer per Telegram oder E-Mail-Antwort nach `Sun`, antwortet das System mit
+Zeilen wie `15:00  781.5 h`. Der Zahlenwert ist die Direktstrahlung in W/m², das Etikett
+kommt aus dem Katalog und sagt „h". Eine Stunde kann höchstens **1,0** Sonnenstunde
+enthalten — die Angabe ist um rund den Faktor 800 daneben und dabei nicht als falsch
+erkennbar. Das ist schlimmer als eine Fehlermeldung.
+
+### Ursache — der Katalog beschreibt die Größe zweigeteilt, und die Teilung steht nirgends
+
+| Glied | Beleg |
+|---|---|
+| Katalogeintrag sagt Einheit `h`, zeigt aber auf das Rohfeld `dni_wm2` (W/m²) | `src/app/metric_catalog.py:596-597` |
+| Rohfeld im Datenmodell | `src/app/models.py:143` (`dni_wm2: Optional[float]  # Direct Normal Irradiance (W/m²)`) |
+| Umrechnung liegt abseits vom Katalog | `src/services/weather_metrics.py:329-347` `dni_to_sunny_fraction()` — `<=min` → 0,0 · `>=max` → 1,0 · dazwischen linear |
+| Band konfigurierbar, Defaults 60/180 W/m² | `src/app/config.py:139-140` |
+| Ad-hoc-Pfad liest generisch das Rohfeld | `src/services/trip_command_processor.py:993-995` |
+| … und beschriftet es mit der Katalog-Einheit | `:379-383` → `format_value(metric.id, value)`; Einheit angehängt in `src/output/metric_format.py:112,126-128` |
+
+### Warum es bis #2134 nicht auffiel
+
+Jeder bisherige Anzeigepfad ging über einen Renderer, der die Metrik **namentlich** kennt
+und den Katalogwert verwirft:
+
+```
+src/output/renderers/email/helpers.py:811-819
+    if key == "sunshine":
+        hours = row.get("_sunny_hours")      # vorberechnet in :139 (je Stunde) / :235 (je Block)
+        return f"{hours:.1f} h"              # dieselbe Einheit — aus einer ANDEREN Zahl
+```
+
+#2134 macht den Katalog erstmals zur direkten Quelle einer Anzeige und legt den
+Widerspruch damit offen. **Nicht durch #2134 verursacht, aber durch #2134 sichtbar.**
+
+### Die Bestandsaufnahme aus dem Issue — sie fällt beruhigend aus
+
+Alle 30 Katalogeinträge gegeneinander gehalten (`unit` gegen die physikalische Größe des
+`dp_field`). Die Rohfeldnamen tragen ihre Einheit im Namen und stimmen durchweg:
+`t2m_c`↔°C · `wind10m_kmh`↔km/h · `pop_pct`↔% · `cape_jkg`↔J/kg · `pressure_msl_hpa`↔hPa ·
+`snow_depth_cm`↔cm · `snowfall_limit_m`↔m · `freezing_level_m`↔m.
+
+- **`sunshine` ist der einzige Eintrag mit echtem Einheitenbruch.**
+- Der einzige weitere Abweichungsfall — `visibility`, `unit="m"` + `display_unit="km"`
+  (`metric_catalog.py:571-578`) — ist bereits sauber modelliert und wird über die
+  Faktortabelle `src/output/metric_format.py:71-73` aufgelöst (angewandt `:116-121`).
+
+Die im Issue befürchtete Streuung („wo steht das sonst noch?") existiert nicht. Das
+Problem ist ein Einzelfall — aber ein struktureller, weil der katalog-getriebene Ansatz
+Zielbild ist (#1372, #1514).
+
+### Alle vier Briefing-Pfade rechnen korrekt — falsch ist ausschließlich der Ad-hoc-Abruf
+
+| Pfad | Beleg |
+|---|---|
+| E-Mail (Zelle je Stunde / je Block) | `src/output/renderers/email/helpers.py:139`, `:235` |
+| Trip-Report | `src/output/renderers/trip_report.py:641`, `:686` |
+| SMS / Premium-SMS | `src/output/renderers/sms_trip.py:419-422` |
+| Ortsvergleich | `src/services/comparison_engine.py:261,560` |
+
+Alle rufen dieselbe Funktion `WeatherMetricsService.calculate_sunny_hours()`. Es gibt
+**keine** zweite, abweichende W/m²→h-Umrechnung im Bestand. Der Fix muss also nichts
+geradeziehen, sondern nur die eine fehlende Umrechnung nachtragen.
+
+### Entschieden: der Ad-hoc-Abruf RECHNET, er verweigert nicht
+
+Der Ortsvergleich löst denselben Widerspruch durch **Ausschluss** —
+`HOURLY_EXCLUDED_METRIC_IDS` (`src/output/renderers/compare_hourly_metric_ids.py:56-64`,
+PO-Entscheid 2026-08-01) enthält `sunshine` mit der Begründung `:70-74`:
+
+> „Stuendlich nur als Einstrahlung (W/m²) verfuegbar, nicht als Sonnenstunden …"
+
+**Diese Begründung ist am Trip-Bestand widerlegt.** `email/helpers.py:139` ruft
+`calculate_sunny_hours([dp])` für einen **einzelnen** Datenpunkt — der Stundenwert in
+Stunden existiert und wird täglich ausgeliefert (Beleg #2104: „Stunden 08..14 je 1,0 h").
+Entsprechend enthält die **trip-seitige** Ausschlussmenge `NO_HOURLY_COLUMN_METRIC_IDS`
+(`email/helpers.py:104-108`) `sunshine` **nicht** — nur die sechs Fenster-Kennzahlen.
+
+Der Ausschluss im Ortsvergleich hält damit eine Umsetzungslücke fest, keine Eigenschaft
+der Größe. Für den Ad-hoc-Abruf gilt die trip-seitige Regel: die Größe hat einen
+Stundenwert, also wird er gerechnet. Zusätzlich stützt das die eigene Hilfe des Systems,
+die `Sun / SU – Sonnenstunden (h)` ausgibt (`trip_command_processor.py:1663-1677`) — heute
+widerspricht die Antwort der eigenen Hilfe.
+
+**Der Ortsvergleich bleibt unangetastet** (Compare-Themen sind zurückgestellt).
+
+### Technical Approach
+
+**Vierter `dp_field`-Zweig in `_metric_formatter()`** (`src/services/trip_command_processor.py:354-384`).
+
+Die Funktion dispatcht dort bereits nach Eigenschaft des Katalogeintrags — `is_level`
+(`:363`), `dp_field == "wind_direction_deg"` (`:365`), `dp_field == "precip_type"` (`:371`).
+Die Spec zu #2134 führt diese Tabelle ausdrücklich
+(`docs/specs/modules/feat_2134_adhoc_abruf_metrik_katalog.md:106-117`); der Fix ergänzt
+eine vierte Zeile, statt ein neues Muster zu erfinden.
+
+Erreicht **beide** Ad-hoc-Einstiege, weil beide `_metric_formatter()` benutzen:
+`_handle_drilldown` (Button-Token, `:907-911`) und `_handle_metric_drilldown`
+(getipptes Wort, `:984-1002`); die Ausgabezeile entsteht gemeinsam in `_format_drilldown`
+(`:1172`).
+
+**Verworfene Alternativen:**
+
+1. **Umrechnung in `format_value()`** — bricht die beiden anderen Aufrufer. Nachgemessen:
+   `src/output/renderers/comparison.py:118` und `src/output/renderers/email/helpers.py:1634`
+   übergeben dort bereits **fertige Stunden** (`style="bare"` + eigenes „h"). Eine
+   Umrechnung in `format_value` würde dort doppelt rechnen.
+2. **Neues Katalogfeld, das auf die Rechenfunktion zeigt** — würde die Schichtung umdrehen.
+   `metric_catalog` liegt in `app/`, `weather_metrics` in `services/`; `app/models.py:714-720`
+   hält ausdrücklich fest, dass der Katalog dort bereits in einer Import-Klemme steckt
+   (`models` importiert den Katalog nur lokal). Ein String-Key plus Registry in einem
+   dritten Modul wäre der Ausweg — deutlich mehr Fläche für einen Einheiten-Bugfix.
+   *(Korrektur zur Zwischenbewertung: einen harten Importzyklus gäbe es NICHT —
+   `weather_metrics.py` importiert `metric_catalog` auf Modulebene gar nicht, der einzige
+   Treffer `:577` ist ein Kommentar. Der Grund ist die Schichtung, nicht ein Zyklus.)*
+3. **`unit` auf `W/m²` umstellen** (Vorschlag 2 des Issues) — ändert die Briefing-Anzeige,
+   die seit #347/#1401 PO-freigegeben ist.
+
+**Umsetzungshinweis:** Die `Settings()`-Instanz für das DNI-Band gehört **außerhalb** der
+Formatierer-Closure geholt — sonst wird sie je Stundenzeile neu gebaut (24×).
+
+### Affected Files (with changes)
+
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `src/services/trip_command_processor.py` | MODIFY | `_metric_formatter()` `:354-384` — vierter Zweig `dp_field == "dni_wm2"`: Rohwert über `dni_to_sunny_fraction()` in Stunden, dann unverändert durch `format_value()` |
+| `tests/tdd/test_adhoc_metrik_formatierung.py` | MODIFY | neuer AC-Fall in der bestehenden Reihe (AC-13…AC-16); Vorrichtung `tests/helpers/adhoc_metrik_fixtures.py` existiert bereits |
+
+**Ausdrücklich NICHT anzufassen:**
+`src/output/metric_format.py` (`format_value` bleibt unberührt) ·
+`src/app/metric_catalog.py` (kein neues Feld) ·
+`src/output/renderers/email/helpers.py` und `trip_report.py` (Briefing-Sonderwissen bleibt —
+s. „Bewusst nicht in diesem Zuschnitt") ·
+`src/output/renderers/compare_hourly_metric_ids.py` (Ortsvergleich zurückgestellt).
+
+### Scope Assessment
+
+- Files: **2** (beide MODIFY)
+- Estimated LoC: Produktivcode **+12…16**, Tests **+40…60** → deutlich unter dem Limit 250
+- Risk Level: **LOW**
+
+### Risiko — die sechs Bestandstests einzeln geprüft
+
+Keiner läuft durch die geänderte Zeile:
+
+| Test | Warum unberührt |
+|---|---|
+| `tests/unit/test_issue_347_sunshine_hours.py` | prüft `calculate_sunny_hours()` direkt, kein Import von `trip_command_processor` |
+| `tests/tdd/test_renderer_katalog_schwellen.py:314` | Pill-Kette `helpers.py:1628`, andere Aufrufkette |
+| `tests/tdd/test_issue_808_sonne_pill.py` | dieselbe Pill-Kette |
+| `tests/unit/test_compare_hourly_catalog_columns.py:327-336` | Compare-Ausschluss, wird nicht angefasst |
+| `tests/tdd/test_channel_metric_matrix.py:3931-3935` | laut eigenem Kommentar bereits als tautologisch markiert |
+| `tests/tdd/test_adhoc_metrik_formatierung.py` | enthält heute **keinen** Sonne-Fall — hier entsteht der neue Test |
+
+Restrisiko ist Vollständigkeit, nicht Bruch: der Verlauf zeigt künftig je Stunde einen
+Bruchwert 0,0–1,0 h. Das deckt sich mit dem Briefing und mit dem Muster der übrigen
+Drilldowns (Gewitter/Wind/Regen zeigen ebenfalls Stundenwerte, keine Tagessummen).
+
+### Dependencies
+
+- `src/services/weather_metrics.py:329-347` — `dni_to_sunny_fraction()`, heute nur von
+  `calculate_sunny_hours()` (`:350`) gerufen; wird zum zweiten Aufrufer erweitert
+- `src/app/config.py:139-140` — DNI-Band
+- `src/output/metric_format.py:79-129` — `format_value()`, unverändert
+- `tests/helpers/adhoc_metrik_fixtures.py` — Mock-freie Vorrichtung (`lege_trip_an`,
+  `sende`, `standard_felder`, `katalog_eintrag_ersetzt`)
+
+### Vorgeschlagene Acceptance Criteria (Freigabe in `/30-write-spec`)
+
+- **AC-1:** Given `sunshine` trägt im Katalog `unit="h"` und `dp_field="dni_wm2"`, und die
+  Stundenwerte führen eine Direktstrahlung oberhalb des Sonnen-Bands / When ein Nutzer
+  `Sun` sendet / Then trägt jede Stundenzeile einen Wert von höchstens 1,0 h, und die rohe
+  W/m²-Zahl steht nirgends in der Antwort.
+- **AC-2:** Given eine Stunde mit einer Direktstrahlung unterhalb des unteren Bandwerts /
+  When `Sun` abgerufen wird / Then weist diese Stunde 0,0 h aus — der Verlauf
+  unterscheidet sonnige von trüben Stunden, statt überall denselben Wert zu zeigen.
+- **AC-3:** Given dieselben Stundendaten / When einmal das Trip-Briefing gerendert und
+  einmal `Sun` abgerufen wird / Then nennen beide für dieselbe Stunde denselben
+  Sonnenstundenwert — die beiden Wege teilen die Umrechnung, statt sie zweimal zu führen.
+- **AC-4:** Given die übrigen Ad-hoc-Größen / When `Visib`, `Thdr`, `WDir` und `PType`
+  abgerufen werden / Then bleibt ihre Ausgabe unverändert (Positivkontrolle gegen
+  Überkorrektur).
+- **AC-5:** Given die Zusicherung aus AC-1 / When die Umrechnung im Produktivcode wieder
+  entfernt wird, sodass der Rohwert durchgereicht wird / Then wird mindestens ein Test rot
+  (Mutations-Gegenprobe).
+
+### Open Questions
+
+- [x] Rechnen oder verweigern? → **Rechnen.** Die trip-seitige Regel
+  (`NO_HOURLY_COLUMN_METRIC_IDS`) führt `sunshine` nicht als stundenwertlos, das Briefing
+  liefert den Stundenwert täglich aus, und die eigene Hilfe verspricht „(h)".
+- [x] Vorschlag 1 oder 2 des Issues? → **1**, aber an der Datenpunkt-Naht statt in
+  `format_value` (s. Technical Approach).
+- [x] Briefing-Sonderwissen im selben Zug abräumen? → **Nein**, s. unten.
+- [x] Ist der Ad-hoc-Abruf von Fenster-Kennzahlen (`Night`, `DayMin` …) ein zweiter Bug?
+  → **Nein.** Die Spec zu #2134 hat das ausdrücklich entschieden
+  (`feat_2134_adhoc_abruf_metrik_katalog.md:243-249`: „Das ist hinzunehmen und zu
+  dokumentieren, nicht wegzukürzen"). Sie zeigen auf echte Stundenfelder (`t2m_c`,
+  `wind_chill_c`) und liefern einen echten Verlauf, keinen 24-fach wiederholten Skalar.
+
+### Bewusst NICHT in diesem Zuschnitt
+
+- **Briefing-Sonderwissen abräumen** (`email/helpers.py:811-819`, `trip_report.py`).
+  Zwei Gründe, beide am Risiko: (a) Der Sonderzweig maskiert einen **latenten
+  Zweitfehler** — weil `sunshine` `default_aggregations=("sum",)` trägt, summieren die
+  generischen Zeilenbauer die rohen W/m² in `row["sunshine"]`
+  (`trip_report.py:617-618`, `helpers.py:212-213`); wer den Zweig entfernt, muss das
+  mitlösen. (b) Beide Dateien sind Mail-Inhalts-Dateien und lösen das
+  **Renderer-Commit-Gate** aus, `trip_command_processor.py` nicht.
+  → Sammel-Eintrag **#1199**, kein eigenes Ticket (kein nutzersichtbares Fehlverhalten,
+  der Wert wird nie ausgeliefert).
+- **Provider ohne DNI.** `calculate_sunny_hours()` weicht auf die Bewölkung aus, wenn
+  **kein** Datenpunkt DNI trägt (`weather_metrics.py:363-365,399-411`). Der Ad-hoc-Pfad
+  liest über den Ein-Feld-Vertrag von `WeatherExtractor.drilldown()` stur `dni_wm2` und
+  meldet über `_traegt_werte()` (`trip_command_processor.py:430-440`) korrekt „nicht
+  verfügbar". Das ist vorbestehendes Verhalten, das dieser Fix weder verursacht noch
+  verschlimmert; es zu schließen hieße, den Ein-Feld-Vertrag auf einen Mehrfeld-Abruf
+  (DNI + drei Wolkenfelder + Höhenlage) zu erweitern. → Sammel-Eintrag **#1199**.
+- **Ortsvergleich.** Der Ausschluss von `sunshine` aus dem Compare-Stundenverlauf bleibt
+  bestehen, obwohl seine Begründung überholt ist — Compare-Themen sind zurückgestellt.
+  → Sammel-Eintrag **#1199**.

--- a/docs/specs/modules/feat_2134_adhoc_abruf_metrik_katalog.md
+++ b/docs/specs/modules/feat_2134_adhoc_abruf_metrik_katalog.md
@@ -112,6 +112,7 @@ Keine neue Liste — Dispatch nach Eigenschaft des `MetricDefinition`-Eintrags:
 | `metric.is_level` | `_thunder_fmt` (bereits katalog-gespeist über `THUNDER_LABEL_DE`) | `metric_format.py:283` |
 | `dp_field == "wind_direction_deg"` | `degrees_to_compass()` | `src/utils/geo.py:32` |
 | `dp_field == "precip_type"` | neues `PRECIP_TYPE_LABEL_DE` (analog zu `THUNDER_LABEL_DE`) | neu in `src/output/metric_format.py` |
+| `dp_field == "dni_wm2"` | `WeatherMetricsService.dni_to_sunny_fraction()` → `format_value()` (rechnet W/m² in Sonnenstunden um, bevor die Katalog-Einheit „h" angehängt wird) | nachgetragen durch Fix #2167, `docs/specs/modules/fix_2167_sonnenstunden_einheit.md`, `trip_command_processor.py:379-400` |
 | sonst | `format_value(metric.id, value)` | `metric_format.py:78-130` — rundet, hängt Einheit an, rechnet `display_unit` m→km (Sichtweite) |
 
 Die Prüfung geht auf `metric.is_level`, **nicht** auf `metric.id == "thunder"`

--- a/docs/specs/modules/fix_2167_sonnenstunden_einheit.md
+++ b/docs/specs/modules/fix_2167_sonnenstunden_einheit.md
@@ -1,0 +1,216 @@
+---
+entity_id: fix_2167_sonnenstunden_einheit
+type: module
+created: 2026-09-07
+updated: 2026-09-07
+status: draft
+version: "1.0"
+tags: [bug, adhoc-abruf, metrik-katalog, einheiten, issue-2167]
+---
+
+# Fix #2167 — Ad-hoc-Abruf `Sun` liefert Sonnenstunden statt Strahlungswerte
+
+## Approval
+
+- [x] Approved — PO, 2026-09-07
+
+## Purpose
+
+Der Ad-hoc-Abruf der Größe `sunshine` soll Sonnenstunden ausgeben, wie es die Einheit im
+Metrik-Katalog und die eigene Hilfe des Systems versprechen — heute gibt er die rohe
+Direktstrahlung in W/m² aus und beschriftet sie mit „h". Der Fix trägt die Umrechnung nach,
+die alle Briefing-Pfade längst anwenden, und schließt damit die letzte Stelle, an der
+Katalog-Einheit und Katalog-Rohfeld auseinanderfallen.
+
+## Source
+
+- **File:** `src/services/trip_command_processor.py`
+- **Identifier:** `_metric_formatter(metric)` (`:354-384`)
+
+Schicht: **Python-Core / Domain-Backend** (`src/services/`). Weder Go-API noch Frontend sind
+betroffen; der Metrik-Katalog (`src/app/`) wird nicht geändert.
+
+## Estimated Scope
+
+- **LoC:** ~55–75 (Produktivcode +12…16, Tests +40…60)
+- **Files:** 2 (beide MODIFY)
+- **Effort:** low
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `src/services/weather_metrics.py:329-347` `dni_to_sunny_fraction()` | READ | Die einzige Umrechnung W/m² → Sonnenstunden im Bestand; bekommt einen zweiten Aufrufer |
+| `src/app/config.py:139-140` `sunny_dni_min_wm2` / `sunny_dni_max_wm2` | READ | Das Sonnen-Band (Defaults 60/180 W/m²) |
+| `src/app/metric_catalog.py:594-613` Eintrag `sunshine` | READ | Liefert `unit="h"`, `decimals=1`, `dp_field="dni_wm2"` — **unverändert** |
+| `src/output/metric_format.py:79-129` `format_value()` | READ | Rundung und Einheiten-Suffix — **unverändert** |
+| `tests/helpers/adhoc_metrik_fixtures.py` | READ | Mock-freie Vorrichtung (`lege_trip_an`, `sende`, `standard_felder`) |
+| `docs/specs/modules/feat_2134_adhoc_abruf_metrik_katalog.md:106-117` | READ | Die Dispatch-Tabelle „Formatierer folgt aus dem Katalogeintrag", die dieser Fix erweitert |
+
+## Implementation Details
+
+### Der Widerspruch, den der Fix auflöst
+
+```
+src/app/metric_catalog.py:596-597
+    id="sunshine", label_de="Sonnenstunden", unit="h",
+    dp_field="dni_wm2", ...
+                ^^^^^^^^         ^^^
+                W/m²             Stunden
+```
+
+Der Ad-hoc-Pfad liest das Rohfeld generisch (`trip_command_processor.py:993-995`,
+`WeatherExtractor.drilldown(trip.id, metric.dp_field, …)`) und beschriftet es mit der
+Katalog-Einheit (`:383` → `format_value(metric.id, value)`). Ergebnis: `781.5 h`.
+
+Die Briefing-Pfade rechnen dagegen um, weil sie die Metrik **namentlich** kennen
+(`src/output/renderers/email/helpers.py:811-819`, Vorberechnung `:139` je Einzelstunde).
+
+### Die Änderung: vierte Zeile in einer bestehenden Dispatch-Tabelle
+
+`_metric_formatter()` wählt den Formatierer bereits nach Eigenschaft des Katalogeintrags —
+`is_level` (`:363`), `dp_field == "wind_direction_deg"` (`:365`), `dp_field == "precip_type"`
+(`:371`), sonst `format_value()` (`:380-383`). Ergänzt wird ein vierter Zweig:
+
+```
+if metric.dp_field == "dni_wm2":
+    # Band einmal je Abruf holen, NICHT je Stundenzeile (24 Aufrufe).
+    <dni_min, dni_max aus Settings>
+    def _sonnenstunden(value, *, with_emoji: bool = True) -> str:
+        if value is None:
+            return "· keine Daten"
+        anteil = WeatherMetricsService.dni_to_sunny_fraction(value, dni_min, dni_max)
+        return format_value(metric.id, anteil)
+    return _sonnenstunden
+```
+
+Der Import von `WeatherMetricsService` erfolgt lokal in der Funktion — dasselbe Muster wie
+die bestehenden lokalen Imports derselben Datei (`:905`, `:982`).
+
+**Warum diese Stelle:** Beide Ad-hoc-Einstiege benutzen `_metric_formatter()` —
+`_handle_drilldown` (Telegram-Knopf, `:907-911`) und `_handle_metric_drilldown` (getipptes
+Wort, `:984-1002`). Die Ausgabezeile entsteht gemeinsam in `_format_drilldown` (`:1172`).
+Ein Eingriff deckt beide Wege.
+
+**Warum je Stunde ein Bruchwert richtig ist:** `calculate_sunny_hours([dp])` — der Weg, den
+das Briefing je Einzelstunde geht (`helpers.py:139`) — reduziert sich für einen einzelnen
+Datenpunkt mit DNI exakt auf `dni_to_sunny_fraction()`. Beide Wege liefern damit denselben
+Stundenwert (AC-3).
+
+### Verworfene Alternativen
+
+| Alternative | Warum verworfen |
+|---|---|
+| Umrechnung in `format_value()` | Die beiden anderen Aufrufer übergeben dort bereits **fertige Stunden** — `src/output/renderers/comparison.py:118` und `src/output/renderers/email/helpers.py:1634` (beide `style="bare"` + eigenes „h"). Es würde doppelt gerechnet. |
+| Neues Katalogfeld, das auf die Rechenfunktion zeigt | Dreht die Schichtung um: `metric_catalog` liegt in `app/`, `weather_metrics` in `services/`. `src/app/models.py:714-720` hält fest, dass der Katalog dort bereits in einer Import-Klemme steckt. Ein String-Schlüssel plus Registry in einem dritten Modul wäre der Ausweg — zu viel Fläche für einen Einheiten-Fix. |
+| `unit` auf `W/m²` umstellen (Vorschlag 2 des Issues) | Ändert die Briefing-Anzeige, die seit #347/#1401 PO-freigegeben ist. |
+
+### Betroffene Dateien
+
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `src/services/trip_command_processor.py` | MODIFY | `_metric_formatter()` `:354-384` — vierter `dp_field`-Zweig für `dni_wm2` |
+| `tests/tdd/test_adhoc_metrik_formatierung.py` | MODIFY | Neue AC-Fälle in der bestehenden Reihe (heute AC-13…AC-16) |
+
+**Ausdrücklich NICHT anzufassen:** `src/output/metric_format.py` ·
+`src/app/metric_catalog.py` · `src/output/renderers/email/helpers.py` ·
+`src/output/renderers/trip_report.py` · `src/output/renderers/compare_hourly_metric_ids.py`.
+
+## Expected Behavior
+
+- **Input:** Ad-hoc-Abruf des Wortes `Sun` (oder des Kürzels `SU`) per Telegram oder
+  E-Mail-Antwort gegen einen Trip mit stündlichen `dni_wm2`-Werten.
+- **Output:** Stündlicher Verlauf, je Zeile ein Sonnenstundenwert zwischen `0.0 h` und
+  `1.0 h` — dieselbe Zahl, die das Trip-Briefing für dieselbe Stunde in der Sonne-Spalte
+  ausweist.
+- **Side effects:** Keine. Kein Versand, keine Persistenz, kein geänderter API-Vertrag.
+  Alle übrigen Abrufgrößen bleiben unverändert.
+
+## Acceptance Criteria
+
+- **AC-1:** Given der Katalog führt `sunshine` mit `unit="h"` und `dp_field="dni_wm2"`, und
+  die Stundenwerte des Trips tragen eine Direktstrahlung deutlich oberhalb des oberen
+  Bandwerts (z. B. 781,5 W/m²) / When ein Nutzer `Sun` sendet / Then trägt jede Stundenzeile
+  einen Sonnenstundenwert von höchstens 1,0 h, und die rohe W/m²-Zahl erscheint nirgends in
+  der Antwort.
+  - Test: Trip über die bestehende Vorrichtung anlegen, `Sun` per Kanal-Eingang senden,
+    jede Stundenzeile der Antwort auf den Zahlenwert prüfen; zusätzlich die Zeichenkette der
+    Rohzahl im gesamten Antworttext ausschließen.
+
+- **AC-2:** Given ein Trip, dessen Stunden teils oberhalb und teils unterhalb des unteren
+  Bandwerts liegen / When `Sun` abgerufen wird / Then unterscheidet der Verlauf diese
+  Stunden — die trüben Stunden weisen 0,0 h aus, die sonnigen einen Wert größer null; es
+  steht nicht in allen Zeilen derselbe Wert.
+  - Test: Stundenpunkte mit wechselnder Direktstrahlung (unter 60 und über 180 W/m²)
+    belegen, Antwort auslesen und prüfen, dass mindestens eine Zeile 0,0 h und mindestens
+    eine Zeile einen Wert über 0,0 h trägt.
+
+- **AC-3:** Given dieselben Stundendaten / When einmal das Trip-Briefing die Sonne-Spalte
+  rendert und einmal `Sun` ad hoc abgerufen wird / Then nennen beide für dieselbe Stunde
+  denselben Sonnenstundenwert — die beiden Wege teilen die Umrechnung, statt sie zweimal zu
+  führen.
+  - Test: Für einen Stundenpunkt den Briefing-Zellwert über den Renderer-Pfad und den
+    Ad-hoc-Zeilenwert über den Kanal-Eingang ermitteln und vergleichen. Der erwartete Wert
+    wird **nicht** als Literal eingetippt, sondern aus beiden Pfaden gelesen.
+
+- **AC-4:** Given die übrigen Ad-hoc-Größen mit eigenem Formatierer-Zweig / When `Visib`,
+  `Thdr`, `WDir` und `PType` abgerufen werden / Then bleibt ihre Ausgabe unverändert
+  gegenüber dem Stand vor dieser Änderung — die Sichtweite kommt weiterhin in km, das
+  Gewitter als Stufenwort, die Windrichtung als Himmelsrichtung, die Niederschlagsart als
+  deutsches Wort.
+  - Test: Die vier bestehenden Testfälle AC-13 bis AC-16 in
+    `tests/tdd/test_adhoc_metrik_formatierung.py` bleiben unverändert grün
+    (Positivkontrolle gegen Überkorrektur).
+
+- **AC-5:** Given die Zusicherung aus AC-1 / When die Umrechnung im Produktivcode entfernt
+  wird, sodass der Rohwert wieder unverändert durch `format_value()` läuft / Then wird
+  mindestens einer der neuen Tests rot.
+  - Test: Mutations-Gegenprobe per String-Ersetzung mit externer Sicherungskopie; der
+    mutierte Zweig muss vom Test tatsächlich erreicht werden.
+
+## Known Limitations
+
+- **Provider ohne Direktstrahlung.** `calculate_sunny_hours()` weicht auf die Bewölkung aus,
+  wenn **kein** Datenpunkt DNI trägt (`src/services/weather_metrics.py:363-365,399-411`).
+  Der Ad-hoc-Pfad liest über den Ein-Feld-Vertrag von `WeatherExtractor.drilldown()` stur
+  `dni_wm2` und meldet über `_traegt_werte()` (`trip_command_processor.py:430-440`) korrekt
+  „nicht verfügbar". Das ist vorbestehendes Verhalten, das dieser Fix weder verursacht noch
+  verschlimmert; es zu schließen hieße, den Ein-Feld-Vertrag auf einen Mehrfeld-Abruf (DNI +
+  drei Wolkenfelder + Höhenlage) zu erweitern. → Sammel-Eintrag #1199.
+- **Latenter Zweitfehler im Briefing bleibt maskiert.** Weil `sunshine`
+  `default_aggregations=("sum",)` trägt, summieren die generischen Zeilenbauer die rohen
+  W/m² in `row["sunshine"]` (`src/output/renderers/trip_report.py:617-618`,
+  `src/output/renderers/email/helpers.py:212-213`). Sichtbar wird das nur deshalb nicht,
+  weil der namentliche Sonderzweig `helpers.py:811` den Zellwert verwirft. Dieser Fix
+  berührt den Pfad nicht. Ein Abräumen des Sonderwissens müsste den Aggregations-Fehler
+  mitlösen und würde zusätzlich das Renderer-Commit-Gate auslösen. → Sammel-Eintrag #1199.
+- **Ortsvergleich bleibt ausgeschlossen.** `HOURLY_EXCLUDED_METRIC_IDS`
+  (`src/output/renderers/compare_hourly_metric_ids.py:56-64`) nimmt `sunshine` vom
+  Compare-Stundenverlauf aus, mit der Begründung `:70-74`, die Größe sei stündlich „nur als
+  Einstrahlung (W/m²) verfuegbar, nicht als Sonnenstunden". Diese Begründung ist am
+  Trip-Bestand widerlegt (`email/helpers.py:139` rechnet je Einzelstunde um; die
+  trip-seitige Ausschlussmenge `email/helpers.py:104-108` führt `sunshine` **nicht**). Der
+  Ausschluss bleibt dennoch stehen — Compare-Themen sind zurückgestellt. → Sammel-Eintrag
+  #1199.
+- **Kein Rückbau der Briefing-Anzeige.** `unit="h"` und die Beschriftung „Sonnenstunden"
+  bleiben, wie seit #347/#1401 freigegeben.
+- **Rundung.** `calculate_sunny_hours()` rundet über `round(x, 1)`, der Ad-hoc-Pfad über das
+  `decimals=1` des Katalogs in `format_value()`. Beides ist Ein-Nachkommastellen-Rundung;
+  eine Abweichung im Randfall (exakte 0,05-Schritte) ist nicht ausgeschlossen und für AC-3
+  entsprechend zu behandeln.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine neue.
+- **Rationale:** Der Fix erfüllt ADR-0037/ADR-0055 (Katalog als Quelle statt handgepflegter
+  Liste), indem er die bestehende, in
+  `docs/specs/modules/feat_2134_adhoc_abruf_metrik_katalog.md:106-117` festgehaltene
+  Dispatch-Tabelle „Formatierer folgt aus dem Katalogeintrag" um eine vierte Zeile ergänzt.
+  Es entsteht keine neue Liste, kein neues Katalogfeld und keine zweite Umrechnung —
+  `dni_to_sunny_fraction()` bleibt die einzige Quelle der W/m²→h-Wandlung im Bestand und
+  bekommt lediglich einen zweiten Aufrufer.
+
+## Changelog
+
+- 2026-09-07: Initial spec created (Issue #2167, Nebenbefund aus der Staging-Verifikation
+  von #2134)

--- a/src/services/trip_command_processor.py
+++ b/src/services/trip_command_processor.py
@@ -376,6 +376,28 @@ def _metric_formatter(metric):
             name = name.rsplit(".", 1)[-1]
             return PRECIP_TYPE_LABEL_DE.get(name, "· keine Daten")
         return _precip_type
+    if metric.dp_field == "dni_wm2":
+        # Issue #2167: der Katalog fuehrt `sunshine` mit unit="h", das Rohfeld
+        # traegt aber W/m². Ohne diesen Zweig laeuft die Direktstrahlung
+        # unveraendert durch `format_value()` und wird als `781.5 h`
+        # beschriftet. `dni_to_sunny_fraction()` ist die EINE Umrechnung im
+        # Bestand — dieselbe, die das Briefing je Einzelstunde geht.
+        from app.config import Settings
+        from services.weather_metrics import WeatherMetricsService
+
+        # Band EINMAL je Abruf holen, nicht je Stundenzeile (24 Aufrufe).
+        _settings = Settings()
+        dni_min = _settings.sunny_dni_min_wm2
+        dni_max = _settings.sunny_dni_max_wm2
+
+        def _sonnenstunden(value, *, with_emoji: bool = True) -> str:
+            if value is None:
+                return "· keine Daten"
+            anteil = WeatherMetricsService.dni_to_sunny_fraction(
+                value, dni_min, dni_max
+            )
+            return format_value(metric.id, anteil)
+        return _sonnenstunden
 
     def _katalog(value, *, with_emoji: bool = True) -> str:
         if value is None:

--- a/tests/tdd/test_adhoc_metrik_formatierung.py
+++ b/tests/tdd/test_adhoc_metrik_formatierung.py
@@ -4,13 +4,20 @@ folgt der EIGENSCHAFT des Katalogeintrags, nicht seinem Namen.
 SPEC: docs/specs/modules/feat_2134_adhoc_abruf_metrik_katalog.md
       AC-13, AC-14, AC-15, AC-16 (Sektion "Formatierer folgt aus dem
       Katalogeintrag").
+SPEC: docs/specs/modules/fix_2167_sonnenstunden_einheit.md
+      AC-1, AC-2, AC-3 (Issue #2167 — `Sun` liefert Sonnenstunden statt
+      roher Direktstrahlung).
 
-RED-Ursache: es gibt heute nur `_DRILLDOWN_METRICS`
+RED-Ursache (#2134): es gibt heute nur `_DRILLDOWN_METRICS`
 (trip_command_processor.py:287-291) mit drei fest verdrahteten Formatierern;
 `Thdr`/`WDir`/`PType`/`Visib` sind ueberhaupt keine Abrufwoerter. Zusaetzlich
 fehlt `PRECIP_TYPE_LABEL_DE` in `src/output/metric_format.py`, und
 `format_value("wind_direction", 315)` liefert heute die Gradzahl `'315 °'`
 statt einer Himmelsrichtung.
+
+RED-Ursache (#2167): `_metric_formatter()` hat fuer `dp_field == "dni_wm2"`
+keinen eigenen Zweig, der Rohwert laeuft unveraendert durch `format_value()`
+und wird mit der Katalog-Einheit "h" beschriftet (`781.5 h` statt `1.0 h`).
 
 Mock-frei: echter Snapshot-Roundtrip, echter `process()`-Aufruf. Die
 Gegenprobe zu AC-13 veraendert den Katalog ueber `dataclasses.replace`
@@ -20,15 +27,37 @@ from __future__ import annotations
 
 import re
 
-from app.models import PrecipType, ThunderLevel
+from app.metric_catalog import build_default_display_config
+from app.models import ForecastDataPoint, PrecipType, ThunderLevel
+from output.renderers.email.helpers import dp_to_row, fmt_val
 
 from tests.helpers.adhoc_metrik_fixtures import (
+    TRIP_TZ,
     ist_unbekannt,
     katalog_eintrag_ersetzt,
     lege_trip_an,
     sende,
     standard_felder,
+    stundenzeilen,
 )
+
+# Zahlenwert einer Stundenzeile, unabhaengig von deren Praefix/Emoji — z.B.
+# "08:00  Sonne: 0.5 h" -> 0.5. Bewusst KEIN fester "h"-Anker im Präfix, damit
+# derselbe Helfer auch andere Ad-hoc-Groessen lesen könnte.
+_ZAHL_VOR_H = re.compile(r"(\d+(?:[.,]\d+)?)\s*h\b")
+
+
+def _sonnenstundenwerte(body: str) -> list[float]:
+    """Je Stundenzeile den ersten '<Zahl> h'-Treffer als float."""
+    werte = []
+    for zeile in stundenzeilen(body):
+        treffer = _ZAHL_VOR_H.search(zeile)
+        assert treffer is not None, (
+            f"Stundenzeile ohne '<Zahl> h'-Treffer — Formatierer liefert kein "
+            f"h-Format mehr:\n{zeile!r}\nGesamtantwort:\n{body}"
+        )
+        werte.append(float(treffer.group(1).replace(",", ".")))
+    return werte
 
 # THUNDER_LABEL_DE = {NONE:"kein", LOW:"leicht", MED:"mittel", HIGH:"hoch"}
 # (src/output/metric_format.py:283) — die Woerter werden hier NICHT eingetippt,
@@ -221,4 +250,262 @@ def test_ac16_visib_wird_in_km_umgerechnet_nicht_in_metern_gezeigt():
     assert "2000" not in body, (
         f"AC-16: die rohe Meterzahl 2000 steht in der Antwort — die "
         f"display_unit-Umrechnung m->km hat nicht stattgefunden:\n{body}"
+    )
+
+
+# ===========================================================================
+# Fix #2167 — `Sun` liefert Sonnenstunden statt roher Direktstrahlung
+# ===========================================================================
+
+def test_2167_ac1_sun_liefert_sonnenstunden_nicht_die_rohe_dni_zahl():
+    """AC-1 GIVEN alle Stundenpunkte tragen eine Direktstrahlung deutlich
+    oberhalb des oberen Bandwerts (781,5 W/m², Band 60/180) WHEN ein Nutzer
+    `Sun` sendet THEN traegt jede Stundenzeile hoechstens 1,0 h, und die rohe
+    W/m²-Zahl erscheint nirgends in der Antwort."""
+    fix = lege_trip_an("2167ac1", lambda i: {**standard_felder(i), "dni_wm2": 781.5})
+
+    result = sende(fix, "Sun", channel="telegram")
+
+    assert not ist_unbekannt(result), (
+        f"AC-1: `Sun` muss als Abrufwort erkannt werden, erhalten "
+        f"command={result.command!r} / body={result.confirmation_body!r}"
+    )
+    body = result.confirmation_body
+    werte = _sonnenstundenwerte(body)
+    assert werte, f"AC-1: keine Stundenzeilen mit '<Zahl> h' gefunden:\n{body}"
+    ueberschreitung = [w for w in werte if w > 1.0]
+    assert not ueberschreitung, (
+        f"AC-1: Stundenwerte > 1.0 h gefunden ({ueberschreitung}) — das sind "
+        f"rohe W/m²-Werte statt Sonnenstunden:\n{body}"
+    )
+    assert "781" not in body, (
+        f"AC-1: die rohe Direktstrahlung '781' steht noch in der Antwort — "
+        f"der Rohwert laeuft unveraendert durch format_value():\n{body}"
+    )
+
+
+def test_2167_ac2_sun_unterscheidet_truebe_und_sonnige_stunden():
+    """AC-2 GIVEN Stundenpunkte im Wechsel unter dem unteren (30.0) und ueber
+    dem oberen Bandwert (800.0) WHEN `Sun` abgerufen wird THEN traegt
+    mindestens eine Zeile 0,0 h und mindestens eine einen Wert > 0,0 h — nicht
+    ueberall derselbe Wert."""
+    fix = lege_trip_an(
+        "2167ac2",
+        lambda i: {**standard_felder(i), "dni_wm2": (30.0, 800.0)[i % 2]},
+    )
+
+    result = sende(fix, "Sun", channel="telegram")
+
+    assert not ist_unbekannt(result), (
+        f"AC-2: `Sun` muss als Abrufwort erkannt werden, erhalten "
+        f"body={result.confirmation_body!r}"
+    )
+    body = result.confirmation_body
+    werte = _sonnenstundenwerte(body)
+    einzigartig = set(werte)
+    assert len(einzigartig) > 1, (
+        f"AC-2: alle Stundenzeilen tragen denselben Wert {einzigartig} — der "
+        f"Verlauf unterscheidet truebe/sonnige Stunden nicht:\n{body}"
+    )
+    assert 0.0 in einzigartig, (
+        f"AC-2: keine Stundenzeile mit 0,0 h fuer die truebe Stunde (30 W/m² "
+        f"< unterer Bandwert), gefundene Werte {einzigartig}:\n{body}"
+    )
+
+
+def test_2167_ac3_ad_hoc_und_briefing_nennen_denselben_wert():
+    """AC-3 GIVEN konstante Direktstrahlung 120,0 W/m² (mitten im 60/180-Band)
+    auf jedem Stundenpunkt WHEN einmal das Trip-Briefing die Sonne-Spalte
+    rendert und einmal `Sun` ad hoc abgerufen wird THEN nennen beide fuer
+    dieselbe Stunde denselben Sonnenstundenwert. Der erwartete Wert wird NICHT
+    eingetippt, sondern aus beiden Pfaden gelesen (Docstring-Warnung der
+    Fixtur: konstanter DNI macht den Vergleich unabhaengig vom Zeitfenster)."""
+    dni = 120.0
+    fix = lege_trip_an("2167ac3", lambda i: {**standard_felder(i), "dni_wm2": dni})
+
+    # Briefing-Pfad: derselbe Produktivcode, den render_email() verwendet.
+    dc = build_default_display_config()
+    for mc in dc.metrics:
+        mc.enabled = mc.metric_id == "sunshine"
+    dp = ForecastDataPoint(ts=fix.now, dni_wm2=dni)
+    row = dp_to_row(dp, dc, tz=TRIP_TZ)
+    briefing_zelle = fmt_val("sunshine", row.get("sunshine"), row=row)
+    briefing_treffer = _ZAHL_VOR_H.search(briefing_zelle)
+    assert briefing_treffer is not None, (
+        f"AC-3: Briefing-Zelle liefert kein '<Zahl> h'-Format: {briefing_zelle!r}"
+    )
+    briefing_wert = float(briefing_treffer.group(1).replace(",", "."))
+
+    # Ad-hoc-Pfad: echter Kanal-Eingang.
+    result = sende(fix, "Sun", channel="telegram")
+    assert not ist_unbekannt(result), (
+        f"AC-3: `Sun` muss als Abrufwort erkannt werden, erhalten "
+        f"body={result.confirmation_body!r}"
+    )
+    adhoc_werte = set(_sonnenstundenwerte(result.confirmation_body))
+    assert adhoc_werte == {briefing_wert}, (
+        f"AC-3: Ad-hoc-Werte {adhoc_werte} weichen vom Briefing-Wert "
+        f"{briefing_wert} ab — beide Pfade muessten dieselbe Umrechnung "
+        f"teilen:\n{result.confirmation_body}"
+    )
+
+
+def _nach_uhrzeit(zeile: str) -> str:
+    """Der Teil einer Stundenzeile HINTER der Uhrzeit — die Darstellung
+    selbst, ohne den je Stunde verschiedenen Zeitstempel."""
+    return zeile.strip().split(None, 1)[1].strip()
+
+
+def test_2167_f001_fehlende_dni_bleibt_keine_daten_und_wird_nicht_zu_null():
+    """Adversary-Finding F001 GIVEN ein Fenster, in dem die Direktstrahlung
+    auf geraden Stundenindizes GANZ FEHLT und auf ungeraden deutlich ueber dem
+    oberen Bandwert liegt (200,0) WHEN `Sun` abgerufen wird THEN bleibt die
+    fehlende Stunde als "keine Daten" kenntlich und wird NICHT zu 0,0 h.
+
+    Warum das eine eigene Zusicherung braucht: `dni_to_sunny_fraction(None)`
+    liefert selbst 0.0 (weather_metrics.py:341-342). Ohne den None-Zweig im
+    Formatierer wuerde die Luecke also klanglos zu "0.0 h" — aus "keine
+    Aussage" wuerde "sicher truebe". Eine Provider-Luecke ist kein
+    Theoriefall: `WeatherExtractor.drilldown()` sammelt je Stundenpunkt
+    `getattr(p, metric, None)`, und `_traegt_werte()` laesst das Fenster
+    bereits bei EINEM Nicht-None-Wert durch.
+
+    Der zweite Trip ist die Positivkontrolle, die beide Faelle
+    UNTERSCHEIDBAR macht: 30,0 W/m² ist eine ECHTE Truebstunde und muss 0,0 h
+    ergeben. Die Darstellung der fehlenden Stunde wird gegen diese echte
+    Nullstunde gehalten, statt gegen eine im Test eingetippte Erwartung.
+    """
+    fix = lege_trip_an(
+        "2167f001",
+        lambda i: {
+            **standard_felder(i),
+            **({"dni_wm2": 200.0} if i % 2 else {}),
+        },
+    )
+
+    result = sende(fix, "Sun", channel="telegram")
+
+    assert not ist_unbekannt(result), (
+        f"F001: `Sun` muss als Abrufwort erkannt werden, erhalten "
+        f"body={result.confirmation_body!r}"
+    )
+    body = result.confirmation_body
+    zeilen = stundenzeilen(body)
+    assert zeilen, f"F001: keine Stundenzeilen in der Antwort:\n{body}"
+
+    ohne_wert = [z for z in zeilen if _ZAHL_VOR_H.search(z) is None]
+    mit_wert = [
+        float(_ZAHL_VOR_H.search(z).group(1).replace(",", "."))
+        for z in zeilen
+        if _ZAHL_VOR_H.search(z) is not None
+    ]
+    assert ohne_wert, (
+        f"F001: KEINE Zeile ohne Stundenwert — die Stunden ohne "
+        f"Direktstrahlung wurden zu einem Zahlenwert verrechnet, statt als "
+        f"fehlend kenntlich zu bleiben. Gefundene Werte {mit_wert}:\n{body}"
+    )
+    assert mit_wert, (
+        f"F001: keine einzige Stunde mit echtem Wert — die Fixtur oder das "
+        f"Fenster traegt die 200 W/m²-Stunden nicht:\n{body}"
+    )
+    assert 0.0 not in set(mit_wert), (
+        f"F001: eine Stundenzeile traegt 0,0 h, obwohl jede VORHANDENE "
+        f"Direktstrahlung (200 W/m²) oberhalb des Bandes liegt — die fehlende "
+        f"Stunde ist zu einer Nullstunde geworden. Werte {mit_wert}:\n{body}"
+    )
+
+    # Positivkontrolle: eine ECHTE Truebstunde (30 W/m² < unterer Bandwert).
+    fix_trueb = lege_trip_an(
+        "2167f001b", lambda i: {**standard_felder(i), "dni_wm2": 30.0},
+    )
+    body_trueb = sende(fix_trueb, "Sun", channel="telegram").confirmation_body
+    trueb_werte = set(_sonnenstundenwerte(body_trueb))
+    assert trueb_werte == {0.0}, (
+        f"F001-Positivkontrolle: eine echte Truebstunde muss 0,0 h ergeben, "
+        f"gefunden {trueb_werte}:\n{body_trueb}"
+    )
+
+    fehlend_dargestellt = {_nach_uhrzeit(z) for z in ohne_wert}
+    trueb_dargestellt = {_nach_uhrzeit(z) for z in stundenzeilen(body_trueb)}
+    assert not (fehlend_dargestellt & trueb_dargestellt), (
+        f"F001: fehlende Stunde und echte Truebstunde sehen gleich aus "
+        f"({fehlend_dargestellt & trueb_dargestellt}) — der Leser kann "
+        f"'keine Aussage' nicht von 'sicher truebe' unterscheiden."
+    )
+
+
+def _fehlend_dargestellt() -> set[str]:
+    """Wie eine Stunde OHNE Direktstrahlung dargestellt wird — gemessen am
+    laufenden Produktivpfad, nicht als Zeichenkette eingetippt.
+
+    Gemischtes Fenster, weil ein Fenster GANZ ohne Werte gar nicht als
+    Stundenverlauf beantwortet wird (``_traegt_werte`` verlangt einen
+    Nicht-None-Wert): gerade Indizes ohne Feld, ungerade mit 200,0 W/m².
+    """
+    fix = lege_trip_an(
+        "2167ref",
+        lambda i: {
+            **standard_felder(i),
+            **({"dni_wm2": 200.0} if i % 2 else {}),
+        },
+    )
+    body = sende(fix, "Sun", channel="telegram").confirmation_body
+    formen = {
+        _nach_uhrzeit(z)
+        for z in stundenzeilen(body)
+        if _ZAHL_VOR_H.search(z) is None
+    }
+    assert formen, (
+        f"Referenzmessung fehlgeschlagen: keine Zeile ohne Stundenwert — die "
+        f"Darstellung der fehlenden Stunde ist nicht ablesbar:\n{body}"
+    )
+    return formen
+
+
+def test_2167_f002_gemessene_nullstrahlung_bleibt_nullstunde():
+    """Adversary-Finding F002 GIVEN jeder Stundenpunkt traegt eine EXAKT
+    gemessene Nullstrahlung (`dni_wm2 == 0.0`, Feld vorhanden) WHEN `Sun`
+    abgerufen wird THEN weist jede Stunde 0,0 h aus und KEINE erscheint als
+    "keine Daten".
+
+    Der Spiegelfall zu F001: waere die Fallunterscheidung des Formatierers
+    ein `if not value:` statt `if value is None:`, kippte die echte Nullstunde
+    in "keine Aussage" — aus "sicher truebe" wuerde "unbekannt". Es ist der
+    HAEUFIGSTE Fall, nicht der seltenste: Open-Meteo liefert
+    `direct_normal_irradiance` fuer Nachtstunden explizit als 0.0
+    (src/providers/openmeteo.py:933), in jedem 24-Stunden-Fenster steckt also
+    eine Nacht voller echter Nullen.
+
+    Die Unterscheidung wird GEMESSEN, nicht behauptet: die Darstellung der
+    fehlenden Stunde stammt aus `_fehlend_dargestellt()` (zweiter Lauf durch
+    denselben Produktivpfad) und wird gegen die Nullstunden-Zeilen gehalten.
+    """
+    fix = lege_trip_an(
+        "2167f002", lambda i: {**standard_felder(i), "dni_wm2": 0.0},
+    )
+
+    result = sende(fix, "Sun", channel="telegram")
+
+    assert not ist_unbekannt(result), (
+        f"F002: `Sun` muss als Abrufwort erkannt werden, erhalten "
+        f"body={result.confirmation_body!r}"
+    )
+    body = result.confirmation_body
+    zeilen = stundenzeilen(body)
+    assert zeilen, f"F002: keine Stundenzeilen in der Antwort:\n{body}"
+
+    # `_sonnenstundenwerte` verlangt fuer JEDE Zeile einen '<Zahl> h'-Treffer —
+    # eine als "keine Daten" ausgewiesene Nullstunde faellt hier bereits auf.
+    werte = set(_sonnenstundenwerte(body))
+    assert werte == {0.0}, (
+        f"F002: eine gemessene Nullstrahlung muss 0,0 h ergeben, gefundene "
+        f"Werte {werte}:\n{body}"
+    )
+
+    null_dargestellt = {_nach_uhrzeit(z) for z in zeilen}
+    ueberschneidung = null_dargestellt & _fehlend_dargestellt()
+    assert not ueberschneidung, (
+        f"F002: die gemessene Nullstunde wird dargestellt wie eine FEHLENDE "
+        f"({ueberschneidung}) — der Leser kann 'sicher truebe' nicht von "
+        f"'keine Aussage' unterscheiden:\n{body}"
     )


### PR DESCRIPTION
## Was war kaputt

Der Ad-hoc-Abruf der Größe `sunshine` (`Sun` / `SU` per Telegram oder E-Mail-Antwort) gab die rohe Direktstrahlung aus und beschriftete sie mit der Katalog-Einheit „h" — aus 781,5 W/m² wurde `781.5 h`. Katalog-Einheit (`unit="h"`) und Katalog-Rohfeld (`dp_field="dni_wm2"`) fielen an dieser einen Stelle auseinander. Alle Briefing-Pfade rechnen längst um, weil sie die Metrik namentlich kennen.

## Was sich ändert

`_metric_formatter()` wählt den Formatierer bereits nach Eigenschaft des Katalogeintrags (`is_level`, `wind_direction_deg`, `precip_type`). Ergänzt wird ein vierter Zweig: Einträge mit `dp_field == "dni_wm2"` laufen über `WeatherMetricsService.dni_to_sunny_fraction()`, bevor `format_value()` sie beschriftet. Die Bandgrenzen (`sunny_dni_min_wm2` / `sunny_dni_max_wm2`) kommen aus `Settings` und werden **einmal je Abruf** gelesen, nicht je Stundenzeile.

Beide Ad-hoc-Einstiege — Telegram-Knopf (`_handle_drilldown`) und getipptes Wort (`_handle_metric_drilldown`) — teilen diese Stelle; ein Eingriff deckt beide Wege.

Der None-Guard prüft bewusst `value is None`, **nicht** `not value`: eine gemessene Nullstrahlung (jede Nachtstunde liefert Open-Meteo explizit als `0.0`) muss `0.0 h` ergeben, eine Provider-Lücke dagegen `· keine Daten`.

**Produktivcode: +22 Zeilen in einer Datei.** `metric_format.py`, `metric_catalog.py` und die Renderer bleiben unberührt.

## Nachweis

| Prüfung | Ergebnis |
|---|---|
| Feature-Tests | 10/10 grün |
| Regression (55 Testdateien um `trip_command_processor`) | keine |
| Acceptance Criteria | 5/5 erfüllt |
| Adversary-Verdict | **VERIFIED** (4 Runden, 26 Punkte) |

Die Mutations-Gegenprobe umfasst sieben Familien (a–g), jede mit externer Sicherungskopie und MD5-verifizierter Rücknahme. Mutation (a) — Umrechnung entfernt — macht 3 Tests rot. Zwei dabei aufgedeckte Lücken sind mit eigenen Tests geschlossen:

- **F001:** ein fehlender Wert hätte als `0.0 h` erscheinen können — „keine Aussage" wäre zu „keine Sonne" geworden.
- **F002:** die Umkehrung — eine plausible Vereinfachung zu `if not value:` hätte jede gemessene Nullstunde als `· keine Daten` maskiert.

## Was offen bleibt

Vier Nebenbefunde sind in #1199 gebucht, keiner davon blockierend — darunter **F003 (MEDIUM):** die Settings-Anbindung der Bandgrenzen hängt allein am AC-3-Test; wird der künftig als „redundant" vereinfacht, ist sie ungesichert.

Closes #2167

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KbRSjSm75PyX2repxsW8w1
