### PR TITLE
fix 2142 core auth shared secret

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,14 @@ GZ_PO_EMAIL=gregor_zwanzig@henemm.com
 TELEGRAM_BOT_USERNAME=GregorZwanzig_bot
 GZ_TELEGRAM_TEST_BOT_TOKEN=       # Telegram Test-/Staging-Bot-Token — wird in Test/Staging automatisch statt des Produktiv-Bots verwendet; MUSS in Staging UND Prod gesetzt sein (Prod: Test-Nutzer springen in Test-Modus an, #1363)
 
+# Gemeinsames Geheimnis Go-API -> Python-Core (#2142). MUSS gesetzt sein:
+# mindestens 32 Zeichen, individuell erzeugt (z.B. `openssl rand -hex 32`).
+# Go liest es als GZ_CORE_SHARED_SECRET und sendet es als Header
+# X-GZ-Core-Auth mit; der Python-Core erzwingt es auf jedem Endpoint ausser
+# /health. Fehlt der Wert, startet die Go-API nicht und der Python-Core
+# antwortet mit 503 (fail-closed). Beide Prozesse lesen dieselbe Datei.
+GZ_CORE_SHARED_SECRET=      # HIER ein eigenes Geheimnis eintragen, nie den Platzhalter uebernehmen
+
 # seven.io SMS-Versand (API-Key global, Rufnummer pro Nutzer im Admin-Interface)
 GZ_SEVEN_API_KEY=your_seven_io_api_key
 GZ_SEVEN_SANDBOX_KEY=       # seven.io Sandbox-Zugang für Test/Staging — sendet nie, kostet nie; wird in Test/Staging automatisch statt GZ_SEVEN_API_KEY verwendet (#1336)

--- a/api/main.py
+++ b/api/main.py
@@ -6,9 +6,11 @@ Runs on localhost:8000 (internal only).
 """
 import logging
 import os
+import secrets
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
+from fastapi.responses import JSONResponse
 
 from api.routers import config, compare, forecast, gpx, health, internal, notify, preview, scheduler, validator, webhook
 from app.config import Settings
@@ -114,3 +116,62 @@ app.include_router(webhook.router)
 if os.environ.get("GZ_ENV") == "staging":
     from api.routers import debug as _debug_router
     app.include_router(_debug_router.router)
+
+
+# ---------------------------------------------------------------------------
+# Issue #2142 — Core-Auth: der Python-Core erzwingt das gemeinsame Geheimnis
+# ---------------------------------------------------------------------------
+
+CORE_AUTH_HEADER = "X-GZ-Core-Auth"
+
+# Einzige Ausnahme (AC-8): Go ruft /health selbst ohne Header ab und
+# ci-stack.sh pollt ihn als Boot-Pruefung, bevor irgendetwas konfiguriert sein
+# kann. Der Endpoint liefert keine Nutzerdaten.
+CORE_AUTH_EXEMPT_PATHS = frozenset({"/health"})
+
+
+def _core_shared_secret() -> str:
+    """Das im Prozess konfigurierte gemeinsame Geheimnis, zur Anfragezeit gelesen.
+
+    Zuerst die Umgebung (so kommt es in Prod/Staging und im CI-Stack an, und
+    das ohne pydantic-Aufbau je Anfrage), sonst ueber ``Settings`` — dort
+    greift zusaetzlich die ``.env``-Quelle. Bewusst KEIN Zwischenspeicher: ein
+    einmal gemerkter Wert wuerde die Fail-closed-Zusicherung an einen
+    Prozesszustand binden, der beim Start zufaellig galt.
+    """
+    from_env = os.environ.get("GZ_CORE_SHARED_SECRET")
+    if from_env:
+        return from_env
+    return Settings().core_shared_secret or ""
+
+
+@app.middleware("http")
+async def enforce_core_auth(request, call_next):  # noqa: ANN001
+    """Jede Anfrage ausser ``/health`` muss das gemeinsame Geheimnis tragen.
+
+    Middleware statt ``lifespan``-Hook: der ``lifespan`` laeuft unter
+    ``TestClient(app)`` ohne ``with``-Block NICHT — eine Pruefung dort waere
+    fuer den groessten Teil der Testsuite unwirksam. Die Middleware greift bei
+    jedem Request, unabhaengig vom Lifespan-Zustand.
+
+    Fail-closed (AC-9): ist gar kein Geheimnis konfiguriert, antwortet der Core
+    mit 503 statt unauthentifiziert durchzulassen — dasselbe Muster wie
+    ``telegram_webhook.go`` ("webhook not configured").
+    """
+    if request.url.path in CORE_AUTH_EXEMPT_PATHS:
+        return await call_next(request)
+
+    expected = _core_shared_secret()
+    if not expected:
+        logger.error(
+            "GZ_CORE_SHARED_SECRET ist im Python-Core nicht gesetzt — jede Anfrage wird mit 503 abgewiesen (#2142)"
+        )
+        return JSONResponse(
+            status_code=503, content={"detail": "core shared secret not configured"}
+        )
+
+    presented = request.headers.get(CORE_AUTH_HEADER, "")
+    if not secrets.compare_digest(presented, expected):
+        return JSONResponse(status_code=401, content={"detail": "unauthorized"})
+
+    return await call_next(request)

--- a/api/routers/webhook.py
+++ b/api/routers/webhook.py
@@ -13,9 +13,11 @@ SPEC: docs/specs/modules/telegram_webhook_inbound.md v1.0 (Issue #637)
 from __future__ import annotations
 
 import logging
+import os
+import secrets
 from collections import deque
 
-from fastapi import APIRouter, Body
+from fastapi import APIRouter, Body, Header, HTTPException
 
 from app.config import Settings
 
@@ -48,14 +50,34 @@ def _already_seen(update_id: int) -> bool:
 
 
 @router.post("/api/internal/telegram-webhook")
-def telegram_webhook(update: dict = Body(...)):
+def telegram_webhook(
+    update: dict = Body(...),
+    x_telegram_bot_api_secret_token: str | None = Header(default=None),
+):
     """Verarbeitet ein einzelnes von Go weitergeleitetes Telegram-Update.
 
     Idempotent gegen Doppel-Zustellung (update_id-Dedup). Immer 200, auch bei
     Duplikat — verhindert Telegram-Retry-Sturm.
+
+    Issue #2142 (AC-10, Defense in Depth): Das Telegram-Secret wird hier ein
+    zweites Mal geprueft — die allgemeine Core-Auth-Pruefung in ``api/main.py``
+    genuegt nicht, denn wer das gemeinsame Geheimnis kennt (jeder Prozess mit
+    Lesezugriff auf die ``.env``), koennte sonst Kommandos fuer ein fremdes
+    Konto ausloesen. Die Pruefung laeuft VOR dem Dedup: ein abgewiesener
+    Request darf die ``update_id`` nicht verbrauchen.
     """
     global _reader
     from services.inbound_telegram_reader import InboundTelegramReader
+
+    expected_telegram_secret = os.environ.get("TELEGRAM_WEBHOOK_SECRET", "")
+    if not expected_telegram_secret:
+        # fail-closed, exakt wie internal/handler/telegram_webhook.go.
+        raise HTTPException(status_code=503, detail="webhook not configured")
+    if not secrets.compare_digest(
+        x_telegram_bot_api_secret_token or "", expected_telegram_secret
+    ):
+        logger.warning("telegram-webhook: 403 — Telegram-Secret fehlt oder ist falsch (#2142)")
+        raise HTTPException(status_code=403, detail="forbidden")
 
     update_id = update.get("update_id")
     if isinstance(update_id, int) and _already_seen(update_id):

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -10,6 +10,7 @@ import (
 	"golang.org/x/crypto/bcrypt"
 
 	"github.com/henemm/gregor-api/internal/config"
+	"github.com/henemm/gregor-api/internal/coreauth"
 	"github.com/henemm/gregor-api/internal/egress"
 	"github.com/henemm/gregor-api/internal/handler"
 	"github.com/henemm/gregor-api/internal/model"
@@ -24,6 +25,19 @@ import (
 // gitCommit is injected at build time via -ldflags "-X main.gitCommit=<sha>".
 var gitCommit = "dev"
 
+// installGuards installiert die Transport-Waechter in der verbindlichen
+// Reihenfolge (Issue #2142, AC-4): ZUERST coreauth.Install, DANACH
+// egress.Install. egress.Install merkt sich den beim Aufruf vorgefundenen
+// Transport und stellt ihn bei Uninstall zeiger-identisch wieder her; liefe
+// coreauth.Install danach, ginge der Auth-Header bei einem egress.Uninstall()
+// still verloren und der Python-Core wiese ab Scheibe 2 jede Anfrage mit 401
+// ab. main() ruft ausschliesslich diese Funktion — die Reihenfolge steht
+// damit an genau einer Stelle und ist ueber main_test.go pruefbar.
+func installGuards(cfg *config.Config) {
+	coreauth.Install(cfg)
+	egress.Install(cfg)
+}
+
 func main() {
 	cfg, err := config.Load()
 	if err != nil {
@@ -36,9 +50,16 @@ func main() {
 		log.Fatalf("session secret invalid: %v", err)
 	}
 
-	// Issue #1337 — Egress-Waechter: in Staging/Test laufen alle ausgehenden
-	// HTTP-Rufe gegen das Host-Inventar. In Prod ein No-Op.
-	egress.Install(cfg)
+	// Issue #2142 — Core-Shared-Secret Fail-Fast: ohne Geheimnis sendet die
+	// Go-API keinen Auth-Header und der Python-Core riegelt jede Anfrage ab.
+	if err := config.ValidateCoreSharedSecret(cfg); err != nil {
+		log.Fatalf("core shared secret invalid: %v", err)
+	}
+
+	// Issue #2142 F002 — Reihenfolge der Transport-Waechter steht an genau
+	// dieser einen Stelle; installGuards() ist auch der Pruefling von
+	// cmd/server/main_test.go (AC-4).
+	installGuards(cfg)
 
 	s := store.New(cfg.DataDir, cfg.UserID)
 	telegramTokenStore := handler.NewTelegramTokenStore(cfg.DataDir)

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -1,0 +1,62 @@
+// TDD fuer Issue #2142 Adversary-Finding F002: die Installationsreihenfolge
+// der Transport-Waechter muss dort geprueft werden, wo sie wirkt — in der von
+// main() tatsaechlich aufgerufenen installGuards() — nicht in einer im
+// Testkoerper nachgebauten Aufrufkette.
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/henemm/gregor-api/internal/config"
+	"github.com/henemm/gregor-api/internal/coreauth"
+	"github.com/henemm/gregor-api/internal/egress"
+)
+
+func TestInstallGuardsOrderSurvivesEgressUninstall(t *testing.T) {
+	var hits int
+	var gotHeader string
+	coreSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		gotHeader = r.Header.Get("X-GZ-Core-Auth")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer coreSrv.Close()
+
+	const secret = "core-shared-secret-fuer-main-test-0123456789"
+	cfg := &config.Config{
+		PythonCoreURL:    coreSrv.URL,
+		CoreSharedSecret: secret,
+		// Env=staging, weil egress.Install nur in Staging bzw. mit
+		// TestFixtureDir installiert; ohne echten Egress-Waechter-Zyklus
+		// waere die Reihenfolge nicht pruefbar.
+		Env: "staging",
+	}
+
+	orig := http.DefaultTransport
+	t.Cleanup(func() {
+		egress.Uninstall()
+		coreauth.Uninstall()
+		http.DefaultTransport = orig
+	})
+
+	// Das ist die Pruefstelle: dieselbe Funktion, die main() aufruft.
+	installGuards(cfg)
+
+	// egress.Uninstall() darf den Auth-Header-Transport NICHT mit entfernen.
+	egress.Uninstall()
+
+	resp, err := http.Get(coreSrv.URL + "/config")
+	if err != nil {
+		t.Fatalf("GET fehlgeschlagen: %v", err)
+	}
+	resp.Body.Close()
+
+	if hits != 1 {
+		t.Fatalf("Positivkontrolle: Python-Core-Fake wurde nicht erreicht (hits=%d)", hits)
+	}
+	if gotHeader != secret {
+		t.Fatalf("Auth-Header nach egress.Uninstall() verloren: erwartet %q, angekommen %q", secret, gotHeader)
+	}
+}

--- a/docs/adr/0015-dual-stack-zielarchitektur.md
+++ b/docs/adr/0015-dual-stack-zielarchitektur.md
@@ -1,6 +1,6 @@
 # ADR-0015: Dual-Stack (Go + Python) als dauerhafte Zielarchitektur
 
-- **Status:** Akzeptiert (PO-Entscheidung E-0, „go" 2026-07-05)
+- **Status:** Teilweise abgelöst durch ADR-0062 (Regel 2, Auth-Teil) — im Übrigen akzeptiert (PO-Entscheidung E-0, „go" 2026-07-05)
 - **Datum:** 2026-07-05
 - **Bezug:** [ADR-0001](0001-go-sveltekit-migration.md) (präzisiert dessen Endzustand),
   `docs/project/architektur-roadmap-2026-07.md` (Entscheidung E-0),
@@ -42,6 +42,13 @@ Daraus folgende Regeln:
 2. **Neue API-/Auth-/Persistenz-Belange entstehen im Go-Backend.** Der Python-Core bekommt
    keine eigene Auth und keine neuen direkt exponierten Endpoints; er bleibt hinter dem Go-Proxy
    (interne Ports nur für Betrieb/Validierung).
+   > **Abgelöst durch [ADR-0062](0062-python-core-authentifiziert-gegenueber-go.md) (2026-09-07,
+   > Issue #2142) — aber nur im Auth-Teil:** Der Python-Core prüft seit #2142 selbst, ob eine
+   > Anfrage von der Go-API stammt (gemeinsames Geheimnis `X-GZ-Core-Auth`, fail-closed). Die
+   > Netzwerk-Isolation stand ausschließlich in der systemd-Unit eines fremden Repos und war
+   > damit keine Zusicherung dieses Codes. **Unverändert gültig bleibt:** keine neuen direkt
+   > exponierten Endpoints im Python-Core, Nutzer-Auth und Mandantentrennung vollständig in Go
+   > — die neue Prüfung ist Dienst-zu-Dienst-Auth, keine Nutzer-Auth.
 3. **Keine Logik-Duplizierung zwischen den Stacks.** Wo heute Doppel-Logik existiert
    (z. B. Schema-Migrationen im Go-Schreibpfad vs. Python-Loader, siehe Issue #1000), ist pro
    Fall genau EINE Seite als Owner zu bestimmen und die andere abzubauen.

--- a/docs/adr/0062-python-core-authentifiziert-gegenueber-go.md
+++ b/docs/adr/0062-python-core-authentifiziert-gegenueber-go.md
@@ -1,0 +1,115 @@
+# ADR-0062: Der Python-Core authentifiziert den Aufrufer selbst — gemeinsames Geheimnis statt Netzwerk-Vertrauen
+
+- **Status:** Akzeptiert (Issue #2142, Blocker aus Epic #2138)
+- **Datum:** 2026-09-07
+- **Bezug:** löst [ADR-0015](0015-dual-stack-zielarchitektur.md) **Regel 2** in dem Punkt ab,
+  dass der Python-Core „keine eigene Auth" bekommt (alle übrigen Regeln von ADR-0015 bleiben
+  unverändert gültig); ergänzt [ADR-0030](0030-session-auth-hmac-cookie.md)/[ADR-0060](0060-dauerhafte-anmeldung-mit-widerrufsliste.md)
+  (Nutzer-Auth am Go-Rand) um die Dienst-zu-Dienst-Ebene;
+  Spec `docs/specs/bugfix/core_shared_secret_auth.md`,
+  Kontext `docs/context/fix-2142-core-auth-shared-secret.md`
+
+## Kontext
+
+ADR-0015 hält als Regel 2 fest: „Der Python-Core bekommt keine eigene Auth und keine neuen
+direkt exponierten Endpoints; er bleibt hinter dem Go-Proxy." Die Zusicherung dahinter war
+**Netzwerk-Isolation**: Wer den Core nicht erreichen kann, braucht dort auch keine Auth.
+
+Issue #2142 zeigt, dass diese Zusicherung nicht dort steht, wo sie wirken müsste. Das gesamte
+Anti-Spoofing steckt in einer einzigen Go-Funktion (`internal/handler/proxy.go`,
+`appendUserID`), die eine client-gelieferte `user_id` durch die authentifizierte ersetzt. Wer
+den Python-Core direkt anspricht — ein beliebiger lokaler Prozess auf demselben Server —,
+umgeht diese Stelle vollständig: mit frei gewählter `?user_id=` liest er fremde Daten,
+verschickt fremde Briefings und löst über `POST /api/internal/telegram-webhook` gefälschte
+Telegram-Kommandos für ein fremdes Konto aus.
+
+Vorab gemessen: Beide Dienste binden heute nur auf Loopback (`ss -ltnp`), der Angriff ist also
+nicht aus dem Netz erreichbar. Das entwertet den Befund nicht — die Loopback-Bindung steht
+ausschließlich in der systemd-Unit (Repo `henemm-infra`, nicht im Anwendungs-Repo). Sie ist
+damit eine **Betriebszusicherung, keine Code-Zusicherung**, und genau die Annahme, die
+Epic #2138 für den Mehrnutzer-Betrieb ausräumt.
+
+## Entscheidung
+
+Der Python-Core **authentifiziert seinen Aufrufer selbst**. Go und Python teilen ein
+gemeinsames Geheimnis aus derselben Umgebungsvariablen `GZ_CORE_SHARED_SECRET`; Go sendet es
+bei jeder Anfrage an den Core als Header `X-GZ-Core-Auth` mit, der Core erzwingt es auf jedem
+Endpoint.
+
+Damit gilt ADR-0015 Regel 2 in ihrem Auth-Teil nicht mehr. Was **unverändert** bleibt: der
+Python-Core bekommt weiterhin **keine neuen direkt exponierten Endpoints** und bleibt hinter
+dem Go-Proxy; die Nutzer-Auth (Sitzungen, Mandantentrennung) bleibt vollständig in Go. Die
+neue Prüfung ist eine **Dienst-zu-Dienst-Auth**, keine Nutzer-Auth — sie beantwortet
+ausschließlich die Frage „stammt diese Anfrage von unserer Go-API?".
+
+Daraus folgende Regeln:
+
+1. **Go sendet, nicht die einzelne Aufrufstelle.** Ein umhüllender Transport auf
+   `http.DefaultTransport` (`internal/coreauth`) setzt den Header — gefiltert auf **Host und
+   Port** aus `cfg.PythonCoreURL`. Keine der 20 Aufrufstellen wird angefasst, die 21. ist
+   automatisch mit abgedeckt. An jedes andere Ziel (Open-Meteo, Google Maps, Komoot,
+   BetterStack) geht das Geheimnis **nicht** mit.
+2. **Installationsreihenfolge ist eine Zusicherung.** `coreauth.Install` läuft **vor**
+   `egress.Install`. Der Egress-Wächter stellt bei `Uninstall` den vorgefundenen Transport
+   zeiger-identisch wieder her; umgekehrt installiert verschwände der Auth-Header dabei still.
+3. **Python erzwingt in einer Middleware, nicht im `lifespan`.** Der `lifespan` läuft in 64 von
+   66 Testdateien nicht mit — eine Prüfung dort wäre für fast die ganze Testsuite unwirksam.
+   Die Durchsetzung sitzt in einer `@app.middleware("http")` auf Modulebene.
+4. **Fail-closed, niemals offen.** Fehlender oder falscher Header → **401**. Geheimnis im
+   Prozess gar nicht konfiguriert → **503** statt unauthentifizierter Durchlass (dasselbe
+   Muster wie `telegram_webhook.go`, „webhook not configured"). Ein Fail-Fast beim Start
+   sichert die Go-Seite zusätzlich ab (`config.ValidateCoreSharedSecret`, Mindestlänge 32
+   Zeichen, Ausnahme nur für den isolierten CI-Stack).
+5. **Genau eine Ausnahme: `/health`.** Go ruft diesen Pfad selbst ohne Header ab und
+   `ci-stack.sh` pollt ihn als Boot-Prüfung, bevor überhaupt etwas konfiguriert sein kann. Der
+   Endpoint liefert keine Nutzerdaten. Jede weitere Ausnahme braucht ein eigenes ADR.
+6. **Defense in Depth am Telegram-Webhook.** Das gemeinsame Geheimnis allein genügt dort
+   nicht: Wer es kennt, könnte sonst Kommandos für ein fremdes Konto auslösen. Der Core prüft
+   deshalb zusätzlich `X-Telegram-Bot-Api-Secret-Token` gegen `TELEGRAM_WEBHOOK_SECRET`; Go
+   reicht dieses Secret beim Weiterleiten mit.
+7. **Kein Testlauf-Bypass.** Die Testsuite wird zentral mit dem gültigen Header versorgt
+   (autouse-Fixture in `tests/conftest.py`), die Prüfung selbst bleibt scharf. Ein eigener
+   Test fragt bewusst ohne Header an und erwartet 401 — ohne ihn wäre die Fixture der blinde
+   Fleck.
+
+## Verworfene Alternativen
+
+- **Alles beim Alten lassen und auf die Loopback-Bindung vertrauen** — verworfen: Die Bindung
+  steht in einem fremden Repo und ist damit keine Zusicherung dieses Codes. Netzwerk-Isolation
+  als einziger Schutz ist genau die Annahme, die Epic #2138 ausräumt.
+- **Ein Bind-Guard, der `127.0.0.1` im Startpfad erzwingt** (Punkt 2 des Issues) — als eigenes
+  Folge-Ticket **abgetrennt**, nicht verworfen. Es gibt kein `uvicorn.run()` im Repo; die
+  saubere Bauform wäre ein repo-eigener Einstiegspunkt plus Umstellung der systemd-Units im
+  Repo `henemm-infra` — eine Abhängigkeit über Repo-Grenzen hinweg. Mit scharfem Geheimnis ist
+  der Bind-Guard nur noch zweite Verteidigungslinie.
+- **Ein gemeinsames Client-Paket in Go statt eines umhüllenden Transports** — verworfen: 17
+  eigenständige Clients mit 17 unterschiedlichen Timeouts müssten umgebaut werden, jeder
+  Umbau eine Gelegenheit, ein Timeout zu verfälschen. Einzelpflaster an den 20 Aufrufstellen
+  scheitern am selben Punkt und bieten keinen strukturellen Schutz gegen die 21. Stelle.
+- **Prüfung im `lifespan`-Hook statt in einer Middleware** — verworfen, weil messbar
+  wirkungslos für 64 von 66 Testdateien. Dasselbe Muster hat schon einmal falsches Grün
+  geliefert.
+- **Ein Soft-Enforce-Schalter für den Übergang** — verworfen: Die feste Reihenfolge „erst Go
+  sendet, dann Python erzwingt" lässt gar kein Fenster entstehen, in dem ein Schalter nötig
+  wäre. Er wäre außerdem ein Fremdkörper (`src/app/config.py` hat sich bewusst gegen solche
+  Ausnahmen in `Settings` entschieden) und müsste später wieder ausgebaut werden.
+- **mTLS oder signierte Anfragen zwischen den Prozessen** — verworfen für diesen Schnitt:
+  deutlich höherer Betriebsaufwand (Zertifikatsverwaltung, Rotation) ohne zusätzlichen Schutz
+  gegen das hier behandelte Angriffsbild. Beide Prozesse laufen auf demselben Host, der
+  Transportweg ist nicht das Risiko.
+
+## Konsequenzen
+
+- **Betriebsschritt vor jedem Code-Merge:** `GZ_CORE_SHARED_SECRET` muss von Hand in die
+  Staging- **und** die Prod-`.env` eingetragen werden. `deploy-gregor-prod.sh` fasst diese
+  Dateien nicht an — ein vergessener Eintrag zeigt sich nicht beim Deploy-Lauf, sondern erst
+  beim nächsten Prozessneustart: die Go-API startet dann nicht mehr (Fail-Fast). Entlastend:
+  Go und Python lesen je Umgebung dieselbe Datei, die beiden Seiten können nicht auseinanderlaufen.
+- **Grenze des Schutzes:** Das Geheimnis schützt gegen einen beliebigen lokalen Prozess, nicht
+  gegen einen Angreifer, der die `.env` selbst lesen kann — der hat ohnehin alle dort
+  hinterlegten Zugangsdaten.
+- **Fernwirkung:** Ein künftiger Go-Client mit eigenem `Transport` verliert den Header still.
+  Dagegen steht der Sweep-Test über `chi.Router.Walk()`, der alle registrierten Routen
+  selbsttätig aufzählt und an einem Fake-Python-Core misst, was dort tatsächlich ankommt.
+- **Bereits laufende Prozesse** ändern ihr Verhalten nicht rückwirkend — der Schutz wirkt erst
+  beim nächsten Prozessstart nach dem Eintragen des Geheimnisses.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -77,7 +77,7 @@ bzw. in den Specs unter `docs/specs/`.
 | [0012](0012-telegram-parse-mode-html.md) | Telegram-Formatierung — parse_mode=HTML statt Markdown/MarkdownV2 | Akzeptiert |
 | [0013](0013-alert-threshold-ist-delta-sensitivitaet.md) | Alert-Renderer: `threshold` ist immer Δ-Sensitivitätsschwelle, nie Absolutwert-Referenz | Akzeptiert |
 | [0014](0014-telegram-multi-bubble-format.md) | Telegram-Ausgabe: Multi-Bubble-Tabellenformat ersetzt Prosa | Akzeptiert |
-| [0015](0015-dual-stack-zielarchitektur.md) | Dual-Stack (Go + Python) als dauerhafte Zielarchitektur — präzisiert 0001 | Akzeptiert |
+| [0015](0015-dual-stack-zielarchitektur.md) | Dual-Stack (Go + Python) als dauerhafte Zielarchitektur — präzisiert 0001 | Teilweise abgelöst durch 0062 (Regel 2, Auth-Teil) |
 | [0016](0016-amtliche-warnungen-additiver-typ.md) | Amtliche Warnungen als additiver externer Alert-Typ (Nachtrag im Index) | Akzeptiert |
 | [0017](0017-output-paket-konsolidierung.md) | Ein Output-Paket: `src/output/` mit `renderers/` + `channels/`; `formatters/`+`outputs/` aufgelöst | Akzeptiert |
 | [0018](0018-provider-fallback-ohne-kaschieren.md) | Modell-Fallback bei Wetter-Quell-Ausfall — mit Ausweichen, aber ohne Kaschieren | Akzeptiert |
@@ -124,3 +124,4 @@ bzw. in den Specs unter `docs/specs/`.
 | [0059](0059-compare-ausblick-erbt-grundauswahl.md) | Der 3-Tages-Ausblick verhält sich wie ein Kanal — Grundauswahl statt eigener Liste, für Trip UND Ortsvergleich (löst 0053 Punkt 1 ab, schreibt 0050/0055 fort, Issue #1848 Scheibe A3) | Akzeptiert |
 | [0060](0060-dauerhafte-anmeldung-mit-widerrufsliste.md) | Dauerhafte Anmeldung mit dateibasierter Liste gültiger Sitzungen — Widerruf überlebt den Neustart, „auf allen Geräten abmelden" (löst 0030 ab, Issue #2129 Scheibe S2 von #2127) | Akzeptiert |
 | [0061](0061-pwa-service-worker-bauform.md) | PWA-Bauform: handgeführter Service Worker statt vite-plugin-pwa/Workbox — vier Speicherregeln mit harter `/api/`-Grenze, kein automatisches `skipWaiting`, Inhalte erst in Scheibe 4 (ergänzt 0003, Issue #2128 Scheibe 1 von #2127) | Akzeptiert |
+| [0062](0062-python-core-authentifiziert-gegenueber-go.md) | Der Python-Core authentifiziert den Aufrufer selbst — gemeinsames Geheimnis `X-GZ-Core-Auth` statt Netzwerk-Vertrauen, fail-closed (löst 0015 Regel 2 im Auth-Teil ab, Issue #2142 aus Epic #2138) | Akzeptiert |

--- a/docs/context/fix-2142-core-auth-shared-secret.md
+++ b/docs/context/fix-2142-core-auth-shared-secret.md
@@ -1,0 +1,328 @@
+# Context: fix-2142-core-auth-shared-secret
+
+## Request Summary
+
+Der Python-Core (FastAPI, `api/main.py`) hat **keinerlei Authentifizierung**. Das gesamte
+Anti-Spoofing steckt in einer einzigen Go-Funktion (`internal/handler/proxy.go:140-157`,
+`appendUserID`), die eine client-gelieferte `user_id` durch die authentifizierte ersetzt.
+Wer den Python-Core direkt anspricht, umgeht diese Stelle vollständig und kann mit frei
+gewählter `?user_id=` fremde Daten lesen, fremde Briefings verschicken und über
+`POST /api/internal/telegram-webhook` gefälschte Telegram-Kommandos für ein fremdes Konto
+ausführen. Blocker aus Epic #2138.
+
+**Erwartung laut Issue:** Shared Secret Go↔Python als Header, Fail-Fast auf beiden Seiten
+bei fehlendem Secret, Python lehnt jede Anfrage ohne gültiges Secret mit 401 ab; Bind auf
+`127.0.0.1` im Startpfad erzwingen (nicht nur in der Doku); Webhook-Secret zusätzlich in
+Python prüfen (Defense in Depth).
+
+### Vorab gemessene Einordnung der Dringlichkeit
+
+Auf dem Server binden **beide** Dienste bereits nur auf Loopback — gemessen mit `ss -ltnp`:
+`127.0.0.1:8090` (Go) und `127.0.0.1:8000` (Python); die systemd-Unit `gregor-python.service`
+startet mit `uvicorn api.main:app --host 127.0.0.1 --port 8000`. Der Angriff ist damit heute
+**nicht aus dem Netz erreichbar**, sondern nur für einen lokalen Prozess auf dem Server.
+
+Das entwertet den Befund nicht:
+
+1. Die Loopback-Bindung steht **ausschließlich in der systemd-Unit** (Repo `henemm-infra`),
+   nicht im Anwendungs-Repo. Ein Umzug, ein Container, eine geänderte Startzeile — und der
+   Schutz ist still weg, ohne dass ein Test oder ein Gate anschlägt.
+2. Netzwerk-Isolation als einziger Schutz ist genau die Annahme, die Epic #2138 für den
+   Mehrnutzer-Betrieb ausräumt. Sie ist eine Betriebszusicherung, keine Code-Zusicherung.
+
+## Related Files
+
+### Go — sendende Seite (20 Aufrufstellen, 17 unabhängige Clients)
+
+| File | Relevance |
+|------|-----------|
+| `internal/handler/proxy.go` | **14** Aufrufstellen; jede Handler-Funktion baut ihren **eigenen** `&http.Client{Timeout: …}` (Timeouts 2 s bis 300 s). Enthält `appendUserID` (Z.140-157) — der einzige bestehende Schutz |
+| `internal/handler/preview_proxy.go` | 2 Aufrufstellen (`ComparePreviewProxyHandler` Z.34, `PreviewProxyHandler` Z.72), je eigener Client |
+| `internal/handler/compare_preset.go:674` | 1 Aufrufstelle (`SendComparePresetHandler`), eigener Client |
+| `internal/handler/telegram_webhook.go:37-74` | 1 Aufrufstelle; Modul-Level-Client (Z.38); reicht den rohen Telegram-Body an Python weiter (Z.63-64) **ohne jeden Auth-Nachweis** — der Kern des Webhook-Teils von #2142 |
+| `internal/scheduler/scheduler.go` | 3 Aufrufstellen (Z.478, 619, 675), alle über **einen geteilten** `s.client` (Struct-Feld, gesetzt in `New()` Z.161) |
+| `internal/config/config.go` | Config-Struct, `envconfig.Process("GZ", &cfg)` (Z.52) — Präfix `GZ_`. **Alle** Felder haben Defaults, envconfig bricht nie ab |
+| `internal/config/session_secret_gate.go` | `ValidateSessionSecret(cfg)` — **fertiges Fail-Fast-Vorbild aus dem Geschwister-Issue #2139** |
+| `cmd/server/main.go:28-41` | Startreihenfolge: `config.Load()` → `ValidateSessionSecret` (`log.Fatalf`, Z.35-37) → `egress.Install(cfg)` → … → `ListenAndServe(cfg.Host+":"+cfg.Port)` (Z.109). Ein neues Secret-Gate reiht sich nach Z.37 ein |
+| `internal/router/router.go:97-127` | Bekommt `cfg` vollständig über `Deps.Config`, reicht an die Handler-Konstruktoren aber nur `pythonURL string` durch — das Secret muss zusätzlich durchgereicht oder wie `TELEGRAM_WEBHOOK_SECRET` per `os.Getenv` gelesen werden |
+| `internal/egress/guard.go:59-70` | Bestehender globaler Transport-Patch (`http.DefaultTransport`) — Vorbild für „ein RoundTripper, der an jedem Request etwas ändert"; trifft aber **alle** Ziele (Open-Meteo, Google Maps, Komoot), müsste also auf den Python-Host filtern |
+
+### Python — empfangende Seite
+
+| File | Relevance |
+|------|-----------|
+| `api/main.py:102-116` | Registriert 11 Router (`health`, `config`, `forecast`, `gpx`, `scheduler`, `compare`, `notify`, `internal`, `preview`, `validator`, `webhook`) + `debug` nur bei `GZ_ENV=staging`. Hier greift eine App-weite Prüfung |
+| `api/main.py:88-98` (`lifespan`) | Einzige Stelle, die beim echten Prozessstart läuft — Vorbild für Fail-Fast **und** für den Bind-Guard |
+| `src/app/egress_guard.py:133-161` | Bestes Vorbild für „Wächter im echten Laufzeitprozess": Aktivierungsbedingung, Idempotenz-Flag, Einbau im `lifespan` |
+| `src/app/config.py:100-117` | `Settings(BaseSettings)`, `env_prefix="GZ_"`, `.env`-Support. **Kein einziges Pflichtfeld ohne Default** |
+| `src/app/config.py:271-286` (`_resend_default_deny`) | Dokumentierte Design-Entscheidung **gegen** Fail-Fast in `Settings()`: „ein Raise würde ganze Apps beim Settings-Konstrukt crashen". Der Fail-Fast gehört also **nicht** in `Settings`, sondern in den `lifespan` |
+| `src/app/config.py:31-33` (`_in_pytest`) | Bestehende Testlauf-Erkennung — **mit Vorsicht zu behandeln**, siehe Risiken |
+| `api/routers/health.py` | Trivial, ohne Nutzerdaten. Muss ausgenommen bleiben (Begründung unter Risiken) |
+| `api/routers/webhook.py:50-71` | Verarbeitet jeden POST-Body ohne eigene Prüfung; Docstring schreibt den Localhost-Trust als Soll fest. `_seen_ids` (Z.34-35) ist prozessglobal |
+| `api/routers/notify.py:18`, `api/routers/scheduler.py:26-123, 204, 290` | Sendende Endpoints — hier entsteht echter Versand an fremde Empfänger |
+| `api/routers/internal.py:29,55`, `preview.py:30,56,86,129`, `compare.py:27`, `validator.py:183,336,472`, `gpx.py:22` | Lesende bzw. schreibende Endpoints mit `user_id`-Parameter |
+
+### Betrieb und CI
+
+| File | Relevance |
+|------|-----------|
+| `frontend/e2e/ci-stack.sh` | **Einziger** Ort im Repo, der beide Prozesse als echte Dienste startet (Z.50: `uvicorn … --host 127.0.0.1`). Setzt `GZ_PORT`, `GZ_PYTHON_CORE_URL`, `GZ_DATA_DIR`, `GZ_CACHE_DIR`, `GZ_TEST_FIXTURE_DIR`, `GZ_USER_ID=admin`, `GZ_AUTH_PASS`, `GZ_ENV=staging`; `GZ_SESSION_SECRET` bleibt bewusst ungesetzt |
+| `.github/workflows/ci.yml` | `ci-stack.sh` läuft **nur** im `e2e`-Job. `test` (pytest) und `go-test` laufen rein in-process (`TestClient` / `httptest`), ohne Netzwerk-Bind |
+| `.env.example`, `.env.tpl`, `.env.e2e` | Die drei ENV-Vorlagen im Repo |
+| `henemm-infra` → `gregor-python.service`, `gregor-api.service` | Lesen in Prod **dieselbe** Datei `/home/hem/gregor_zwanzig/.env` (Staging analog `/home/hem/gregor_zwanzig_staging/.env`) |
+| `henemm-infra/scripts/deploy-gregor-prod.sh` | Fasst **keine** `.env` an — neue Variablen müssen von Hand auf den Server |
+
+## Existing Patterns
+
+- **Fail-Fast in `main()`, nicht im Config-Load** (Go): `cmd/server/main.go:35-37` prüft nach
+  `config.Load()` und beendet mit `log.Fatalf`. Grund: `internal/config/config_test.go` räumt
+  die Umgebung leer und erwartet Defaults — eine Prüfung in `Load()` bräche diese Tests.
+- **Fail-Fast im `lifespan`, nicht in `Settings()`** (Python): ausdrücklich so entschieden in
+  `config.py:271-286`. `install_egress_guard` zeigt die Bauform.
+- **Testlauf-Erkennung** existiert doppelt und uneinheitlich: Go über `cfg.TestFixtureDir != ""`
+  (`egress/guard.go`, `session_secret_gate.go`), Python über `_in_pytest()` und
+  `settings.is_test_mode`.
+- **Secret als Header statt im Pfad** ist im Haus bereits entschieden und begründet:
+  `internal/handler/telegram_webhook.go:9-12` prüft `X-Telegram-Bot-Api-Secret-Token` und
+  erklärt in einem Kommentar, warum das URL-Segment nur noch Routing-Beiwerk ist (Log-Leaks).
+- **Fail-closed bei fehlender Konfiguration** ebenda: leeres Secret → HTTP 503
+  „webhook not configured" statt offener Endpoint.
+- **Namenskonvention `GZ_`** auf beiden Seiten — mit genau einem Ausreißer:
+  `TELEGRAM_WEBHOOK_SECRET` (`telegram_webhook.go:40`, ohne Präfix, per `os.Getenv`).
+
+## Dependencies
+
+- **Upstream (Go):** `envconfig` liefert die Konfiguration; `cfg.PythonCoreURL` bestimmt das
+  Ziel aller 20 Aufrufe.
+- **Upstream (Python):** `pydantic_settings.BaseSettings` liest `GZ_`-Variablen und `.env`.
+- **Downstream:** **Jede** Funktion des Produkts, die den Python-Core berührt — Briefing-Versand,
+  Vorschauen, Ortsvergleich, GPX-Import, Alarme, Scheduler, Telegram-Inbound. Eine vergessene
+  Aufrufstelle bedeutet nicht „etwas unsicherer", sondern **diese Funktion ist tot** (401).
+- **Dritter Prozess:** Das Frontend spricht ausschließlich die Go-API an, nie Python direkt —
+  es ist von dieser Änderung nicht betroffen.
+
+## Existing Specs
+
+| Dokument | Inhalt |
+|----------|--------|
+| `docs/adr/0015-dual-stack-zielarchitektur.md` | **Konfliktpunkt:** hält fest, Python „bleibt hinter dem Go-Proxy, keine eigene Auth, keine neuen direkt exponierten Endpoints" |
+| `docs/adr/0003-multi-tenant-isolation.md` | Pflicht zur echten `user_id` aus dem Auth-Kontext, nie `"default"` |
+| `docs/adr/0030-session-auth-hmac-cookie.md` | Session-Cookie Frontend↔Go — nicht betroffen |
+| `docs/specs/modules/go_api_setup.md` | Ursprungsarchitektur Go-Proxy → Python (:8000), ohne Auth |
+| `docs/specs/modules/python_userid_integration.md` | Python liest `user_id` als reinen Query-Parameter |
+| `docs/specs/bugfix/go_api_bind_localhost.md` | Strukturgleicher Vorgänger: Bind-Härtung für die **Go**-API (Issue #116), `GZ_HOST` mit Default `127.0.0.1` |
+| `docs/context/fix-2139-session-secret-failfast.md` | Kontext des Geschwister-Issues, aus dem das Fail-Fast-Muster stammt |
+
+**Es gibt keine Spec, die einen Auth-Vertrag Go→Python beschreibt.** Genau diese Lücke schließt
+#2142.
+
+## Risks & Considerations
+
+### R1 — ADR-0015 wird umgekehrt (Prozess-Pflicht)
+
+ADR-0015 hält „keine eigene Auth" in Python als Entscheidung fest. #2142 dreht das um. Nach
+Hausregel wird eine dokumentierte Entscheidung nie still zurückgenommen: Es braucht ein
+**neues ADR**, das ADR-0015 in diesem Punkt ablöst. Das ist kein Nebenprodukt, sondern ein
+Liefergegenstand.
+
+### R2 — 68 Testdateien bauen sich je einen eigenen `TestClient(app)`
+
+Es gibt **keine** gemeinsame Client-Fixture; jede Datei importiert `from api.main import app`
+und baut lokal ihren Client, teils mehrfach je Datei. Eine App-weite Pflichtprüfung bricht
+diese Tests breit.
+
+Der naheliegende Ausweg — die Prüfung bei `_in_pytest()` überspringen — ist **die gefährlichste
+Option**: Dann ist der Wächter im gesamten Testlauf abgeschaltet und **kein** Test kann
+beweisen, dass er wirkt. Genau dieses Muster hat uns hier schon einmal ein falsches Grün
+geliefert (wirkungsloser Code schirmt die Tests ab). Der Entwurf muss stattdessen dafür sorgen,
+dass die Prüfung **auch im Testlauf scharf** ist und die 68 Dateien den Header an **einer**
+zentralen Stelle mitgeliefert bekommen (z. B. autouse-Fixture in `tests/conftest.py`), während
+ein eigener Test bewusst **ohne** Header anfragt und 401 erwartet. Das ist in der Analyse-Phase
+zu entscheiden und in der Spec als Akzeptanzkriterium festzuhalten.
+
+### R3 — Ausrollen kann die Anwendung abschalten
+
+Fail-Fast plus `deploy-gregor-prod.sh`, das die `.env` nicht anfasst, ergibt: Fehlt der Eintrag,
+startet der Dienst nach dem Deploy nicht mehr. Entlastend wirkt, dass Go und Python in Prod
+**dieselbe** `.env` lesen — ein Eintrag genügt je Umgebung, die beiden Seiten können nicht
+auseinanderlaufen. Die Reihenfolge (erst Staging-`.env`, dann Prod-`.env`, dann Merge/Deploy)
+gehört als ausdrücklicher Schritt in die Spec, nicht in eine Fußnote. Präzedenzfall aus dem
+Deploy-Skript-Kommentar: eine ergänzte `EnvironmentFile`-Zeile lag wochenlang inaktiv und ließ
+eine Ausfallmeldung still verschwinden.
+
+### R4 — 20 Aufrufstellen, 17 eigene Clients: eine vergessene Stelle killt eine Funktion
+
+Weil die Prüfung fail-closed ist, ist eine übersehene Aufrufstelle kein Schönheitsfehler,
+sondern ein Funktionsausfall (401). Drei Bauformen stehen zur Wahl — Entscheidung gehört in
+die Analyse:
+(a) 20 Stellen einzeln um ein `Header.Set` ergänzen — maximal fehleranfällig, keine Sperre
+gegen die 21. Stelle;
+(b) ein gemeinsames Client-Paket (`internal/coreclient`), das alle 17 lokalen
+`&http.Client{Timeout: …}` ersetzt — ein Engpass, durch den alles muss;
+(c) ein globaler RoundTripper analog `egress.Install`, der auf den Python-Host filtert.
+Unabhängig davon braucht es einen Nachweis, der **an der Wirkstelle** misst: nicht „Funktion X
+setzt den Header", sondern „jede über den Go-Router erreichbare Python-Route kommt am
+Empfänger mit gültigem Header an".
+
+### R5 — `/health` muss ausgenommen bleiben
+
+Go ruft `pythonURL + "/health"` bei jedem `/api/health` selbst auf (`proxy.go:22`), und
+`ci-stack.sh:27-28` pollt den Python-Health direkt als Boot-Prüfung, bevor überhaupt etwas
+konfiguriert sein kann. Der Endpoint liefert nur `{"status","version"}`, keine Nutzerdaten —
+eine Ausnahme ist vertretbar, muss aber in der Spec begründet und **eng** gefasst sein
+(genau dieser eine Pfad).
+
+### R6 — Der Bind-Guard hat im Repo keinen Angriffspunkt
+
+Es gibt **kein** `uvicorn.run()` im Repo; die App wird über die uvicorn-Kommandozeile gestartet
+(systemd bzw. `ci-stack.sh`). Ein Guard innerhalb von `api/main.py` sieht die Bind-Adresse
+darum nicht ohne Weiteres. Optionen: ein repo-eigener Einstiegspunkt (Startskript oder
+`uvicorn.run()`-Wrapper), auf den die systemd-Units umgestellt werden — dann liegt die
+Zusicherung wirklich im Repo, wie das Issue verlangt; oder ein Guard, der die Startparameter
+des laufenden Prozesses auswertet. Der Vorgänger `docs/specs/bugfix/go_api_bind_localhost.md`
+konnte das für Go sauber lösen, weil Go seinen Server selbst startet — für Python gilt das
+nicht. **Nicht vorschnell entscheiden:** Ist das Shared Secret erst scharf, ist der Bind-Guard
+nur noch zweite Verteidigungslinie; ein schlecht gebauter Guard, der beim Start falsch
+anschlägt, richtet mehr Schaden an als er verhindert.
+
+### R7 — CI-Stack muss das Secret kennen
+
+`ci-stack.sh` startet beide Prozesse und ist der einzige Ort, an dem die neue Variable für die
+Ampel gesetzt werden muss. Anders als bei `GZ_SESSION_SECRET` (dort bewusst ungesetzt, weil
+halbseitig gesetzt die Cookie-Signatur bricht) ist das hier unkritisch: Das Skript exportiert
+die Variable für **beide** Prozesse gleichzeitig, sie können also gar nicht auseinanderlaufen.
+
+### R8 — Angrenzende Issues nicht mitschleifen
+
+- **#2159** (Lokalhost-Guard hängt allein am nginx-Header-Verhalten) — verwandt, eigener Zuschnitt.
+- **#1814** (Telegram-Webhook-Secret im URL-Pfad, Staging) — berührt dieselbe Datei, ist aber
+  die *öffentliche* Seite; #2142 betrifft die *interne* Weitergabe Go→Python.
+- **#2139** (Session-Secret-Fail-Fast) — liefert das Muster, läuft in einer anderen Sitzung.
+
+### R9 — Namenswahl der Variablen
+
+`GZ_`-Präfix ist die Hausregel (`envconfig.Process("GZ", …)` und `env_prefix="GZ_"`), also
+liest dieselbe Variable auf beiden Seiten ohne Zusatzaufwand. Der einzige Gegenbeleg
+(`TELEGRAM_WEBHOOK_SECRET` ohne Präfix) ist ein bekannter Ausreißer und **kein** Vorbild.
+
+---
+
+## Analysis
+
+### Type
+
+**Bug** (Security, Blocker aus Epic #2138).
+
+### Empirisch geklärt (nicht vermutet)
+
+| Frage | Messergebnis |
+|-------|--------------|
+| Läuft der FastAPI-`lifespan` unter `TestClient(app)` ohne `with`-Block? | **Nein.** Belegt gegen `api.main:app`: ohne `with` wird `install_egress_guard` 0-mal aufgerufen, mit `with` 1-mal. Nur **2 von 66** Testdateien benutzen den `with`-Block |
+| Erreicht eine autouse-Fixture in `tests/conftest.py` alle Testdateien? | **Ja**, über `monkeypatch.setattr(TestClient, "__init__", …)`. Praktisch nachgestellt mit zwei Testdateien: Default-Header greift, expliziter Header im Testkörper überschreibt weiterhin. Grenze: Clients, die auf **Modulebene** gebaut werden, erreicht der Patch nicht — im Repo kommt das laut `grep -rn "^client = TestClient" tests/` **0-mal** vor |
+| Kann die App ihre Bind-Adresse von innen erkennen? | **Ja**, auf drei Wegen (`sys.argv`, `gc`-Introspektion des uvicorn-`Server`-Objekts, `/proc/self/fd`). Der `gc`-Weg liest sogar den tatsächlich gebundenen Socket. Nicht gemessen: `--reload`, Multi-Worker, IPv6 |
+| Setzt ein Go-Client einen eigenen `Transport`? | **Nein.** Alle Python-Core-Clients hängen an `http.DefaultTransport` |
+| Ersetzt oder umhüllt `egress.Install` den Transport? | **Umhüllt** (`&guardedTransport{next: original}`), `Uninstall` stellt `original` zeiger-identisch wieder her |
+
+### Affected Files (with changes)
+
+**Scheibe 1 — „Go sendet"**
+
+| File | Change | Description |
+|------|--------|-------------|
+| `internal/coreauth/transport.go` | CREATE | `Install(cfg)` umhüllt `http.DefaultTransport` und setzt den Header **nur** bei Treffer auf Host **und Port** aus `cfg.PythonCoreURL`. Bauform 1:1 nach `internal/egress/guard.go` |
+| `internal/config/config.go` | MODIFY | Neues Feld `CoreSharedSecret` (`GZ_CORE_SHARED_SECRET`), Default `""` |
+| `internal/config/core_secret_gate.go` | CREATE | `ValidateCoreSharedSecret(cfg)` — Klon des Musters aus `session_secret_gate.go` (#2139), inkl. Ausnahme `TestFixtureDir != ""` |
+| `cmd/server/main.go` | MODIFY | Gate nach `ValidateSessionSecret` (Z.37); `coreauth.Install(cfg)` **vor** `egress.Install(cfg)` |
+| `frontend/e2e/ci-stack.sh` | MODIFY | `GZ_CORE_SHARED_SECRET` exportieren (erreicht beide Prozesse gleichzeitig) |
+| `internal/router/core_auth_sweep_test.go` | CREATE | Der eigentliche Wächter, siehe unten |
+| `.env.example` | MODIFY | Neue Variable dokumentieren |
+
+**Scheibe 2 — „Python erzwingt"**
+
+| File | Change | Description |
+|------|--------|-------------|
+| `api/main.py` | MODIFY | `@app.middleware("http")` auf Modulebene: Header prüfen, `/health` ausnehmen, 401 bei falschem/fehlendem Header, 503 bei nicht konfiguriertem Secret |
+| `src/app/config.py` | MODIFY | Feld `core_shared_secret` (`GZ_CORE_SHARED_SECRET`) |
+| `api/routers/webhook.py` | MODIFY | Zusätzliche Telegram-Secret-Prüfung (Defense in Depth) |
+| `internal/handler/telegram_webhook.go` | MODIFY | Telegram-Secret beim Weiterreichen an Python mitsenden |
+| `tests/conftest.py` | MODIFY | Autouse-Fixture: Secret in die Umgebung + `TestClient.__init__` patchen |
+| `tests/tdd/test_core_auth_enforcement.py` | CREATE | Positiv-/Negativnachweis inkl. Anfrage **ohne** Header → 401 |
+| `docs/adr/00XX-python-core-authentifiziert-gegenueber-go.md` | CREATE | Löst ADR-0015 in diesem Punkt ab |
+
+### Scope Assessment
+
+- Dateien: 7 (Scheibe 1) + 7 (Scheibe 2)
+- Geschätzte LoC: Scheibe 1 ≈ 180–250, Scheibe 2 ≈ 135–190 → **zusammen über dem Workflow-Limit von 250**, `loc_limit_override 500` erforderlich
+- Risiko: **MITTEL-HOCH** — fail-closed über 20 Aufrufstellen. Ein falscher Host-Filter, eine falsche Installationsreihenfolge oder ein fehlender `.env`-Eintrag legt den gesamten Python-Core lahm
+
+### Technical Approach
+
+**A1 — Go: ein umhüllender Transport statt 20 Einzelpflaster.**
+Alle 20 Aufrufstellen bauen `&http.Client{Timeout: …}` ohne eigenen `Transport`, hängen also
+am selben `http.DefaultTransport`. Ein neues Paket `internal/coreauth` umhüllt diesen einmal
+und setzt den Header ausschließlich bei Anfragen an Host **und Port** des Python-Cores. Damit
+bleiben alle 17 unterschiedlichen Timeouts unangetastet, und keine der 20 Stellen wird
+angefasst. Verworfen: ein gemeinsames Client-Paket (17 Umbaustellen, jede eine Gelegenheit,
+ein Timeout zu verfälschen) und Einzelpflaster (kein struktureller Schutz gegen die 21. Stelle).
+Der Preis ist Fernwirkung: ein künftiger Client mit eigenem `Transport` verliert den Header
+still — genau dagegen steht A2.
+
+**A1a — Installationsreihenfolge ist eine Zusicherung, keine Stilfrage.**
+`coreauth.Install` muss **vor** `egress.Install` laufen. Grund (am Code geprüft): `egress`
+merkt sich beim Installieren den vorgefundenen Transport und stellt ihn bei `Uninstall`
+zeiger-identisch wieder her. Bei umgekehrter Reihenfolge würde ein `egress.Uninstall` den
+Auth-Header mit entfernen. Das gehört als Kommentar an die Stelle **und** als Testfall.
+
+**A2 — Der Nachweis läuft über den echten Router, nicht über die Funktion.**
+Ein Sweep-Test zählt mit `chi.Router.Walk()` **alle** registrierten Routen selbsttätig auf
+(kein handgepflegter Katalog — das ist der Punkt: die 21. Route wird automatisch erfasst),
+schickt gegen jede eine authentifizierte Anfrage und prüft an einem `httptest`-Fake-Python-Core
+nur eines: Jeder dort eingetroffene Request trägt den korrekten Header. Routen, die schon vor
+dem Python-Aufruf abbrechen, tauchen am Fake gar nicht auf und werden nicht gezählt — gemessen
+wird an der Wirkstelle. Präzedenzfälle für „echter Router + Fake-Backend" existieren bereits
+(`internal/router/sms_fidelity_preview_test.go`, `briefing_subscription_test.go`).
+
+**A3 — Python: Middleware, nicht `lifespan`.**
+Gemessen: Der `lifespan` läuft in 64 von 66 Testdateien nicht. Eine Prüfung, die dort sitzt,
+wäre für fast die ganze Testsuite unwirksam — dasselbe Muster, das uns schon einmal falsches
+Grün geliefert hat. Die Durchsetzung gehört deshalb in eine `@app.middleware("http")` auf
+Modulebene, die bei **jedem** Request greift, unabhängig vom Lifespan-Zustand.
+Verhalten: Header fehlt oder falsch → **401**; Secret gar nicht konfiguriert → **503**
+„not configured" (fail-closed, exakt das Muster aus `telegram_webhook.go:41-45`).
+Ausgenommen ist **genau** `/health` — Go ruft ihn selbst ohne Header auf (`proxy.go:22`) und
+`ci-stack.sh:27-28` pollt ihn als Boot-Prüfung; der Endpoint liefert keine Nutzerdaten.
+
+**A4 — Die 68 Testdateien werden zentral versorgt, der Wächter bleibt scharf.**
+Eine autouse-Fixture in `tests/conftest.py` setzt das Secret in die Umgebung und patcht
+`TestClient.__init__`, sodass jede Instanz den Header trägt — die Testsuite verhält sich damit
+wie die Go-API in Produktion. Ausdrücklich **kein** `_in_pytest()`-Bypass: Die Prüfung bleibt
+im Testlauf aktiv, und ein eigener Test fragt bewusst **ohne** Header an und erwartet 401.
+Ohne diesen Negativtest wäre die Fixture selbst der blinde Fleck.
+
+**A5 — Zwei Scheiben in fester Reihenfolge, kein Übergangsschalter.**
+Zuerst „Go sendet" (allein deploybar, Python prüft noch nicht — kein Verhalten ändert sich),
+danach „Python erzwingt". Diese Reihenfolge lässt kein Fenster entstehen, in dem Python
+bereits blockt, während Go noch nichts sendet. Ein Soft-Enforce-Schalter wäre ein Fremdkörper
+(das Haus hat sich in `config.py:271-286` bewusst gegen solche Ausnahmen in `Settings`
+entschieden) und müsste später wieder ausgebaut werden.
+
+**A6 — Schritt 0 ist ein Liefergegenstand, keine Fußnote.**
+`GZ_CORE_SHARED_SECRET` muss **vor** Scheibe 1 von Hand in die Staging- **und** die Prod-`.env`
+eingetragen werden; `deploy-gregor-prod.sh` fasst diese Dateien nicht an. Entlastend: Go und
+Python lesen je Umgebung dieselbe Datei, die beiden Seiten können nicht auseinanderlaufen.
+Der Präzedenzfall steht im Deploy-Skript selbst — eine ergänzte Umgebungszeile lag dort einmal
+wochenlang inaktiv und ließ eine Ausfallmeldung still verschwinden.
+
+**A7 — Der Bind-Guard wird bewusst abgetrennt.**
+Er ist zwar baubar (empirisch geprüft, drei Wege), aber jeder davon ist Introspektion eines
+fremden Laufzeitobjekts. Die saubere Bauform wäre ein repo-eigener Einstiegspunkt plus
+Umstellung der systemd-Units im Repo `henemm-infra` — eine Abhängigkeit über Repo-Grenzen
+hinweg, die dieses Ticket nicht nebenbei mitziehen sollte. Ist das Shared Secret scharf,
+schließt es die eigentliche Lücke vollständig; der Bind-Guard ist dann zweite
+Verteidigungslinie. **Das ist eine Verkleinerung des Ticket-Umfangs und daher vom PO zu
+bestätigen** — sie wird in der Spec ausdrücklich als abgetrennte Scheibe ausgewiesen, nicht
+stillschweigend weggelassen.
+
+### Open Questions (dem PO mit der Spec vorzulegen)
+
+- [ ] Bind-Guard (Issue-Punkt 2) als eigenes Folge-Ticket abtrennen — einverstanden?

--- a/docs/features/architecture.md
+++ b/docs/features/architecture.md
@@ -38,7 +38,9 @@ Das Backend besteht aus zwei klar getrennten Schichten (siehe `docs/adr/0015-dua
   Scheduler, Alert-System, Inbound-Handler.
 
 Die Vertragsgrenze zwischen Go und Python ist HTTP mit den DTOs aus
-`docs/reference/api_contract.md`.
+`docs/reference/api_contract.md`. Seit Issue #2142 authentifiziert sich die Go-API gegenüber
+dem Python-Core mit einem gemeinsamen Geheimnis (`GZ_CORE_SHARED_SECRET`, Header
+`X-GZ-Core-Auth`) — Details siehe `docs/adr/0062-python-core-authentifiziert-gegenueber-go.md`.
 
 ### Python-Core: Wetter-Pipeline und Rendering
 

--- a/docs/reference/operations_playbook.md
+++ b/docs/reference/operations_playbook.md
@@ -235,6 +235,13 @@ dessen CI-Ampel (alle 5 Checks) auf dem letzten Stand grün ist. Danach in diese
 | 4b | Post-Deploy-Selftest | `python3 .claude/hooks/prod_selftest.py` (Commit/Health/AC-Attestation) — nur Exit 0 fährt weiter |
 | 5 | Issue schließen | `gh issue close <N>` — nur wenn 4b Exit 0 |
 
+**Seit #2142 zusätzliche Pflicht-Voraussetzung vor Schritt 4:** `GZ_CORE_SHARED_SECRET`
+(≥32 Zeichen, identischer Wert in beiden Prozessen) muss von Hand in der `.env` **beider**
+Umgebungen (Staging **und** Produktion) eingetragen sein, **bevor** der neue Stand live geht.
+Fehlt die Variable, beendet sich die Go-API beim Start (Fail-Fast), und der Python-Core
+weist ohne gesetztes Geheimnis jede Anfrage außer `/health` mit `503` ab. Siehe
+`docs/adr/0062-python-core-authentifiziert-gegenueber-go.md`.
+
 `systemctl restart` allein **reicht nie** — `deploy-gregor-prod.sh` macht `flock-Lock → hart
 auf origin/main syncen (Daten unberührt, WIP gesichert) → Go-Binary bauen → Frontend bauen →
 alle 3 Services restarten → Smoke-Test`. Ohne diesen vollen Lauf entsteht Code-Drift, den

--- a/docs/specs/bugfix/core_shared_secret_auth.md
+++ b/docs/specs/bugfix/core_shared_secret_auth.md
@@ -1,0 +1,212 @@
+---
+entity_id: core_shared_secret_auth
+type: bugfix
+created: 2026-09-07
+updated: 2026-09-07
+status: draft
+version: "1.0"
+tags: [security, bugfix, go-api, python-core, auth, multi-user, issue-2142]
+---
+
+# Core Shared-Secret Auth (Go → Python)
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Behebt eine Auth-Bypass-Lücke (Issue #2142, Blocker aus Epic #2138): Der Python-Core (FastAPI, `api/main.py`) hat **keinerlei Authentifizierung**. Das gesamte Anti-Spoofing steckt bislang in einer einzigen Go-Funktion (`internal/handler/proxy.go:140-157`, `appendUserID`), die eine client-gelieferte `user_id` durch die authentifizierte ersetzt. Wer den Python-Core direkt anspricht — z. B. ein lokaler Prozess auf demselben Server —, umgeht diese Stelle vollständig und kann mit frei gewählter `?user_id=` fremde Daten lesen, fremde Briefings verschicken und über `POST /api/internal/telegram-webhook` gefälschte Telegram-Kommandos für ein fremdes Konto ausführen. Der Fix führt ein gemeinsames Geheimnis (Shared Secret) ein, das Go bei **jeder** Anfrage an Python als Header mitsendet und das Python bei **jeder** eingehenden Anfrage erzwingt.
+
+Vorab gemessen: Auf dem Server binden beide Dienste bereits nur auf Loopback (`ss -ltnp`), der Angriff ist heute nicht aus dem Netz erreichbar. Das entwertet den Befund nicht — die Loopback-Bindung steht ausschließlich in der systemd-Unit (Repo `henemm-infra`, nicht im Anwendungs-Repo) und ist damit eine Betriebszusicherung, keine Code-Zusicherung. Netzwerk-Isolation als einziger Schutz ist genau die Annahme, die Epic #2138 für den Mehrnutzer-Betrieb ausräumt.
+
+## Source
+
+- **File:** `internal/handler/proxy.go`
+- **Identifier:** `appendUserID` (Zeile 140-157) — bestehender, unzureichender Schutz; wirkt nur, solange der Python-Core ausschließlich über den Go-Proxy erreicht wird
+- **Secondary File:** `api/main.py`
+- **Identifier:** Router-Registrierung (Zeile 102-116) — Python-Core besitzt an dieser Stelle keine eigene Auth-Prüfung
+
+> **Schicht-Hinweis:** Zwei getrennte Prozesse, zwei getrennte Scheiben — Go-API (`cmd/server/`, `internal/`) sendet das Geheimnis, Python-Core (`api/`, `src/app/`) erzwingt es. Beide lesen dieselbe Umgebungsvariable `GZ_CORE_SHARED_SECRET` unabhängig voneinander (`envconfig` mit Präfix `GZ` auf Go-Seite, `env_prefix="GZ_"` auf Python-Seite) — kein manueller Abgleich der Variablenwerte nötig, solange beide Prozesse dieselbe `.env`-Datei lesen.
+
+## Estimated Scope
+
+- **LoC:** Scheibe 1 ≈ 180–250, Scheibe 2 ≈ 135–190 — zusammen über dem Workflow-Limit von 250, `loc_limit_override 500` erforderlich
+- **Files:** 7 (Scheibe 1) + 7 (Scheibe 2) = 14
+- **Effort:** high (fail-closed über 20 Aufrufstellen; ein falscher Host-Filter, eine falsche Installationsreihenfolge oder ein fehlender `.env`-Eintrag legt den gesamten Python-Core lahm)
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `internal/egress/guard.go` (`Install`) | Reference Pattern | Bestehender globaler Transport-Patch (`http.DefaultTransport`) — Vorbild für den umhüllenden Auth-Transport; muss auf den Python-Host **und Port** gefiltert werden, sonst leckt das Geheimnis an fremde Ziele (Open-Meteo, Google Maps, Komoot, BetterStack) |
+| `internal/config/session_secret_gate.go` (`ValidateSessionSecret`) | Reference Pattern | Fertiges Fail-Fast-Vorbild aus dem Geschwister-Issue #2139 — gleiche Bauform für `ValidateCoreSharedSecret` |
+| `cmd/server/main.go` | Consumer | Startreihenfolge: `config.Load()` → `ValidateSessionSecret` → **neu:** `ValidateCoreSharedSecret` → `coreauth.Install(cfg)` → `egress.Install(cfg)` → `ListenAndServe` |
+| `internal/router/router.go` | Consumer | Registriert alle Handler-Routen — Grundlage für den `chi.Router.Walk()`-Sweep-Test |
+| `src/app/egress_guard.py` (`install_egress_guard`) | Reference Pattern | Bestes Vorbild für „Wächter im echten Laufzeitprozess" auf Python-Seite — Aktivierungsbedingung, Idempotenz-Flag |
+| `src/app/config.py` (`Settings`, `_resend_default_deny`) | Reference Pattern | Dokumentierte Design-Entscheidung gegen Fail-Fast im Settings-Konstrukt — der Fail-Fast gehört in den `lifespan`/die Middleware, nicht in `Settings()` |
+| `internal/handler/telegram_webhook.go` (`TELEGRAM_WEBHOOK_SECRET`-Prüfung) | Reference Pattern | Bereits entschiedene Bauform „Secret als Header, fail-closed bei fehlender Konfiguration (503)" — Vorbild für die zusätzliche Telegram-Secret-Prüfung in Python |
+| `frontend/e2e/ci-stack.sh` | Test Infrastructure | Einziger Ort, der beide Prozesse als echte Dienste startet — muss `GZ_CORE_SHARED_SECRET` für beide Prozesse gleichzeitig exportieren |
+| `tests/conftest.py` | Test Infrastructure | Muss eine autouse-Fixture bekommen, die alle 66 Testdateien zentral mit dem Header versorgt, ohne die Prüfung selbst abzuschalten |
+| **Downstream:** jede Funktion, die den Python-Core berührt | Consumer | Briefing-Versand, Vorschauen, Ortsvergleich, GPX-Import, Alarme, Scheduler, Telegram-Inbound — eine vergessene Aufrufstelle bedeutet nicht „etwas unsicherer", sondern diese Funktion ist ab Scheibe 2 tot (401) |
+
+## Implementation Details
+
+**Scheibe 1 — „Go sendet" (allein deploybar, ändert kein Verhalten, solange Python noch nicht prüft):**
+
+```
+internal/coreauth/transport.go          CREATE  Install(cfg) umhüllt http.DefaultTransport,
+                                                 setzt Header X-GZ-Core-Auth NUR bei Treffer
+                                                 auf Host UND Port aus cfg.PythonCoreURL
+                                                 (Bauform 1:1 nach internal/egress/guard.go)
+internal/config/config.go               MODIFY  neues Feld CoreSharedSecret
+                                                 (GZ_CORE_SHARED_SECRET), Default ""
+internal/config/core_secret_gate.go     CREATE  ValidateCoreSharedSecret(cfg) — Klon aus
+                                                 session_secret_gate.go (#2139), inkl.
+                                                 Ausnahme TestFixtureDir != ""
+cmd/server/main.go                      MODIFY  Gate direkt nach ValidateSessionSecret;
+                                                 coreauth.Install(cfg) VOR egress.Install(cfg)
+                                                 — siehe Reihenfolge-AC unten
+frontend/e2e/ci-stack.sh                MODIFY  GZ_CORE_SHARED_SECRET exportieren
+internal/router/core_auth_sweep_test.go CREATE  Sweep-Test über chi.Router.Walk()
+.env.example                            MODIFY  neue Variable dokumentieren
+```
+
+Reihenfolge-Begründung: `egress` merkt sich beim Installieren den vorgefundenen Transport und stellt ihn bei `Uninstall` zeiger-identisch wieder her. Läuft `coreauth.Install` nach `egress.Install`, verschwindet der Auth-Header bei einem `egress.Uninstall()` still mit.
+
+**Scheibe 2 — „Python erzwingt":**
+
+```
+api/main.py                       MODIFY  @app.middleware("http") auf Modulebene: Header
+                                           prüfen, /health ausnehmen, 401 bei fehlendem/
+                                           falschem Header, 503 bei nicht konfiguriertem
+                                           Secret (fail-closed)
+src/app/config.py                 MODIFY  Feld core_shared_secret (GZ_CORE_SHARED_SECRET)
+api/routers/webhook.py            MODIFY  zusätzliche Telegram-Secret-Prüfung
+                                           (Defense in Depth)
+internal/handler/telegram_webhook.go MODIFY  Telegram-Secret beim Weiterreichen an Python
+                                              mitsenden (heute fehlt das, Zeile 63-64)
+tests/conftest.py                 MODIFY  autouse-Fixture: Secret in die Umgebung setzen +
+                                           TestClient.__init__ patchen (Patch erreicht
+                                           Modul-Level-Clients NICHT — im Repo laut
+                                           `grep -rn "^client = TestClient" tests/` 0 Treffer,
+                                           also unkritisch)
+tests/tdd/test_core_auth_enforcement.py CREATE  Positiv-/Negativnachweis inkl. Anfrage
+                                                 OHNE Header → 401
+docs/adr/0062-python-core-authentifiziert-gegenueber-go.md  CREATE  löst ADR-0015 in
+                                                                     diesem Punkt ab
+```
+
+Middleware statt `lifespan`-Hook: Gemessen läuft der `lifespan` in 64 von 66 Testdateien nicht mit (nur 2 Dateien nutzen den `with TestClient(app)`-Block). Eine Prüfung im `lifespan` wäre für fast die ganze Testsuite unwirksam. Die Durchsetzung sitzt deshalb in einer `@app.middleware("http")`, die bei jedem Request greift, unabhängig vom Lifespan-Zustand.
+
+Header-Name auf beiden Seiten: `X-GZ-Core-Auth`. Variablenname auf beiden Seiten: `GZ_CORE_SHARED_SECRET` (Go: `envconfig` mit Präfix `GZ`; Python: `env_prefix="GZ_"` — dieselbe Variable, kein Abgleich nötig, solange Go und Python dieselbe `.env` lesen, was in Prod und Staging bereits der Fall ist).
+
+## Expected Behavior
+
+- **Input (Go → Python, jede der 20 Aufrufstellen):** eine ausgehende HTTP-Anfrage an `cfg.PythonCoreURL`.
+- **Output:** die Anfrage trägt den Header `X-GZ-Core-Auth` mit dem Wert aus `GZ_CORE_SHARED_SECRET`.
+- **Input (Go → fremdes Ziel, z. B. Open-Meteo):** eine ausgehende HTTP-Anfrage an einen anderen Host/Port als `cfg.PythonCoreURL`.
+- **Output:** kein `X-GZ-Core-Auth`-Header wird gesetzt.
+- **Input (Python, Anfrage ohne oder mit falschem Header):** beliebiger Endpoint außer `/health`.
+- **Output:** HTTP 401, kein Seiteneffekt (kein Versand, keine Daten in der Antwort).
+- **Input (Python, Secret im Prozess nicht konfiguriert):** beliebiger Endpoint außer `/health`.
+- **Output:** HTTP 503 auf allen Routen außer `/health` (fail-closed).
+- **Input (Go-API-Start ohne oder mit zu kurzem `GZ_CORE_SHARED_SECRET`):** Prozessstart.
+- **Output:** Prozess beendet sich sofort (Fail-Fast), kein HTTP-Server startet — Ausnahme `TestFixtureDir != ""` (CI-Stack).
+- **Side effects:** Bei korrekt gesetztem Secret auf beiden Seiten ändert sich das Laufzeitverhalten aller bestehenden Funktionen (Briefing-Versand, Vorschauen, Ortsvergleich, GPX-Import, Alarme, Scheduler, Telegram-Inbound) nicht.
+
+## Test Plan
+
+### Automated Tests (TDD RED)
+
+#### Go Tests
+
+- [ ] Test 1: GIVEN eine `Config` mit `CoreSharedSecret: ""` und leerem `TestFixtureDir` WHEN `ValidateCoreSharedSecret(cfg)` aufgerufen wird THEN liefert die Funktion einen Fehler ungleich `nil` zurück.
+- [ ] Test 2: GIVEN eine `Config` mit gesetztem `TestFixtureDir` und leerem `CoreSharedSecret` WHEN `ValidateCoreSharedSecret(cfg)` aufgerufen wird THEN liefert die Funktion `nil` zurück (CI-E2E-Ausnahme greift).
+- [ ] Test 3: GIVEN der echte Router über `router.New(...)` mit installiertem `coreauth.Install` WHEN `chi.Router.Walk()` alle registrierten Routen aufzählt und jede über einen authentifizierten Test-Client gegen einen `httptest`-Fake-Python-Core angefragt wird THEN trägt **jeder** am Fake eingetroffene Request den korrekten `X-GZ-Core-Auth`-Header.
+- [ ] Test 4: GIVEN `coreauth.Install(cfg)` gefolgt von `egress.Install(cfg)` und anschließendem `egress.Uninstall()` WHEN eine Anfrage an den Python-Core gesendet wird THEN trägt sie weiterhin den `X-GZ-Core-Auth`-Header (Reihenfolge-Zusicherung).
+- [ ] Test 5: GIVEN eine Anfrage an ein fremdes Ziel (anderer Host oder anderer Port als `cfg.PythonCoreURL`) WHEN sie über den mit `coreauth.Install` präparierten `http.DefaultTransport` läuft THEN trägt sie **keinen** `X-GZ-Core-Auth`-Header.
+
+#### Python Tests
+
+- [ ] Test 6: GIVEN das Secret ist im Prozess konfiguriert WHEN eine Anfrage an einen beliebigen Endpoint (außer `/health`) **ohne** `X-GZ-Core-Auth`-Header gesendet wird THEN antwortet der Prozess mit 401 und löst keinen Seiteneffekt aus (kein Versand, keine Daten in der Antwort).
+- [ ] Test 7: GIVEN das Secret ist im Prozess konfiguriert WHEN eine Anfrage mit **falschem** `X-GZ-Core-Auth`-Header gesendet wird THEN antwortet der Prozess mit 401.
+- [ ] Test 8: GIVEN das Secret ist im Prozess konfiguriert WHEN eine Anfrage mit **korrektem** `X-GZ-Core-Auth`-Header gesendet wird THEN verhält sich der Endpoint unverändert wie vor dieser Änderung.
+- [ ] Test 9: GIVEN das Secret ist im Prozess **nicht** konfiguriert WHEN eine Anfrage an einen beliebigen Endpoint (außer `/health`) gesendet wird THEN antwortet der Prozess mit 503.
+- [ ] Test 10: GIVEN beliebiger Konfigurationszustand des Secrets WHEN `GET /health` **ohne** `X-GZ-Core-Auth`-Header angefragt wird THEN antwortet der Prozess mit 200.
+- [ ] Test 11: GIVEN der Telegram-Webhook-Endpoint erhält einen gültigen `X-GZ-Core-Auth`-Header, aber ein fehlendes oder falsches Telegram-Secret WHEN der Request verarbeitet wird THEN wird **kein** Telegram-Kommando ausgeführt (Defense in Depth, zusätzlich zur Core-Auth-Prüfung).
+- [ ] Test 12: GIVEN die autouse-Fixture in `tests/conftest.py` versorgt `TestClient`-Instanzen zentral mit dem Header WHEN ein eigener Test bewusst eine Anfrage **ohne** Header stellt (Header explizit entfernt/überschrieben) THEN antwortet der Prozess mit 401 — der Wächter bleibt auch im Testlauf scharf.
+
+## Acceptance Criteria
+
+**Scheibe 1 — Go sendet**
+
+- **AC-1:** Given die Go-API ist gestartet und `GZ_CORE_SHARED_SECRET` ist gültig konfiguriert / When irgendeine der bestehenden Funktionen (Briefing-Versand, Vorschau, Ortsvergleich, GPX-Import, Alarm, Scheduler, Telegram-Inbound) eine Anfrage an den Python-Core auslöst / Then trägt diese Anfrage nachweislich den Header mit dem gemeinsamen Geheimnis — geprüft über einen Sweep, der **alle** vom Router registrierten Routen selbsttätig aufzählt, nicht über eine von Hand gepflegte Liste, sodass eine künftig hinzukommende Aufrufstelle automatisch mitgeprüft wird.
+  - Test: `internal/router/core_auth_sweep_test.go`, Test 3.
+
+- **AC-2:** Given eine Anfrage der Go-API geht an ein Ziel, das **nicht** der Python-Core ist (z. B. Open-Meteo, Google Maps, Komoot, BetterStack) / When diese Anfrage über denselben, mit dem Auth-Mechanismus präparierten HTTP-Transport läuft / Then enthält diese Anfrage das gemeinsame Geheimnis **nicht** — die Filterung erfolgt anhand von Host **und** Port aus der konfigurierten Python-Core-Adresse.
+  - Test: `internal/coreauth/transport_test.go` (bzw. gleichwertig benannt), Test 5.
+
+- **AC-3:** Given die Go-API wird ohne `GZ_CORE_SHARED_SECRET` oder mit einem zu kurzen Wert gestartet, und `GZ_TEST_FIXTURE_DIR` ist nicht gesetzt / When der Prozess startet / Then beendet sich der Prozess sofort (Fail-Fast) und der HTTP-Server nimmt keine Anfragen an — mit derselben Ausnahme für den isolierten CI-Stack (`GZ_TEST_FIXTURE_DIR` gesetzt) wie beim Session-Secret-Gate aus #2139.
+  - Test: `internal/config/core_secret_gate_test.go`, Test 1 und Test 2.
+
+- **AC-4:** Given `coreauth.Install` und `egress.Install` sind beide aktiv, in dieser Reihenfolge installiert / When anschließend `egress.Uninstall()` aufgerufen wird und danach eine Anfrage an den Python-Core geht / Then trägt diese Anfrage weiterhin den Auth-Header — der Auth-Mechanismus überlebt das Deinstallieren des Egress-Guards, weil er zuerst installiert wurde.
+  - Test: `internal/router/core_auth_sweep_test.go` bzw. eigener Reihenfolge-Test, Test 4.
+
+**Scheibe 2 — Python erzwingt**
+
+- **AC-5:** Given der Python-Core hat ein gültiges Geheimnis konfiguriert / When eine Anfrage an einen beliebigen Endpoint ohne den Auth-Header eintrifft / Then antwortet der Python-Core mit 401, und es entsteht kein Seiteneffekt — kein E-Mail-/Telegram-/SMS-Versand, keine Daten werden in der Antwort preisgegeben.
+  - Test: `tests/tdd/test_core_auth_enforcement.py`, Test 6.
+
+- **AC-6:** Given der Python-Core hat ein gültiges Geheimnis konfiguriert / When eine Anfrage mit einem falschen Header-Wert eintrifft / Then antwortet der Python-Core mit 401.
+  - Test: `tests/tdd/test_core_auth_enforcement.py`, Test 7.
+
+- **AC-7:** Given der Python-Core hat ein gültiges Geheimnis konfiguriert / When eine Anfrage mit dem korrekten Header-Wert eintrifft / Then verhält sich der angefragte Endpoint unverändert wie vor dieser Änderung — bestehende Funktionen bleiben für authentifizierte Aufrufer vollständig nutzbar.
+  - Test: `tests/tdd/test_core_auth_enforcement.py`, Test 8.
+
+- **AC-8:** Given beliebiger Konfigurationszustand des Geheimnisses / When `GET /health` ohne Auth-Header angefragt wird / Then antwortet der Python-Core mit 200 — als einzige, eng gefasste Ausnahme, weil Go diesen Pfad selbst ohne Header abruft und der CI-Stack ihn als Boot-Prüfung nutzt, und weil der Endpoint keine Nutzerdaten liefert.
+  - Test: `tests/tdd/test_core_auth_enforcement.py`, Test 10.
+
+- **AC-9:** Given der Python-Core läuft, aber `GZ_CORE_SHARED_SECRET` ist im Prozess gar nicht gesetzt / When eine Anfrage an einen beliebigen Endpoint außer `/health` eintrifft / Then antwortet der Python-Core mit 503 statt die Anfrage unauthentifiziert durchzulassen — fail-closed, niemals offen.
+  - Test: `tests/tdd/test_core_auth_enforcement.py`, Test 9.
+
+- **AC-10:** Given eine Anfrage an den Telegram-Webhook-Endpoint trägt einen gültigen Core-Auth-Header, aber kein oder ein falsches Telegram-Secret / When der Request verarbeitet wird / Then wird kein Telegram-Kommando ausgeführt — die Telegram-Secret-Prüfung wirkt zusätzlich zur allgemeinen Core-Auth-Prüfung (Defense in Depth), und Go sendet dieses Secret beim Weiterreichen an Python mit (heute fehlt das).
+  - Test: `tests/tdd/test_core_auth_enforcement.py`, Test 11.
+
+- **AC-11:** Given die gesamte Python-Testsuite läuft mit einer zentralen autouse-Fixture, die alle `TestClient`-Instanzen automatisch mit dem gültigen Header versorgt / When ein einzelner, bewusst dafür geschriebener Test eine Anfrage ohne diesen Header stellt / Then antwortet der Python-Core mit 401 — die Durchsetzung ist auch im Testlauf scharf, es gibt keine testlauf-spezifische Ausnahme, die die Prüfung insgesamt abschaltet.
+  - Test: `tests/tdd/test_core_auth_enforcement.py`, Test 12.
+
+## Known Limitations
+
+- Das gemeinsame Geheimnis schützt gegen einen beliebigen lokalen Prozess auf demselben Server, **nicht** gegen einen Angreifer, der die `.env`-Datei selbst lesen kann — in diesem Fall hat er ohnehin bereits alle anderen dort hinterlegten Zugangsdaten.
+- Der im Issue geforderte Bind-Guard („`127.0.0.1` im Startpfad erzwingen") ist bewusst **nicht** Teil dieser Spec — siehe eigener Abschnitt „Abgetrennter Umfang" unten.
+- Die Loopback-Bindung beider Dienste bleibt weiterhin eine reine Betriebszusicherung (systemd-Unit im Repo `henemm-infra`), keine Code-Zusicherung. Mit scharfem Shared Secret ist das kein Restrisiko mehr für den in diesem Issue beschriebenen Angriff, wohl aber für andere, hier nicht behandelte Angriffsflächen.
+- Bereits laufende Prozesse ändern ihr Verhalten nicht rückwirkend — der Fix wirkt erst beim nächsten Prozessstart nach dem Eintragen des Geheimnisses in die jeweilige `.env`.
+
+## Rollout-Reihenfolge
+
+Die Reihenfolge ist eine Zusicherung, kein Vorschlag — eine vertauschte Reihenfolge legt den Python-Core lahm oder lässt ein Zeitfenster mit widersprüchlichem Verhalten entstehen.
+
+1. **Schritt 0 — Betriebsschritt, vor jedem Code-Merge:** `GZ_CORE_SHARED_SECRET` wird von Hand in `/home/hem/gregor_zwanzig_staging/.env` **und** `/home/hem/gregor_zwanzig/.env` eingetragen. `deploy-gregor-prod.sh` fasst diese Dateien nicht an — ein vergessener Eintrag zeigt sich nicht beim Deploy-Lauf, sondern erst beim nächsten Prozessneustart. Entlastend: Go und Python lesen je Umgebung dieselbe Datei, die beiden Seiten können nicht auseinanderlaufen.
+   - **Folge eines vergessenen Eintrags:** Sobald Scheibe 1 (Fail-Fast-Gate) live ist, startet der Go-Dienst nach einem Neustart/Deploy nicht mehr — der Prozess bricht beim Start ab, bevor er Anfragen annimmt.
+2. **Scheibe 1 („Go sendet"):** allein deploybar. Python prüft noch nichts, das Laufzeitverhalten ändert sich für Nutzer nicht — Go sendet ab jetzt lediglich zusätzlich den Header mit.
+3. **Scheibe 2 („Python erzwingt"):** erst danach. Ab diesem Zeitpunkt lehnt der Python-Core unauthentifizierte Anfragen ab.
+
+Diese feste Reihenfolge verhindert, dass ein Zustand entsteht, in dem Python bereits blockt, während Go den Header noch nicht sendet (kompletter Ausfall) oder umgekehrt ein Übergangsschalter nötig würde, der später wieder ausgebaut werden müsste.
+
+## Abgetrennter Umfang
+
+Der im Issue geforderte **Bind-Guard** („`127.0.0.1` im Startpfad erzwingen") wird als **eigenes Folge-Ticket abgetrennt** und ist **nicht** Teil dieser Spec.
+
+**Begründung:** Es gibt kein `uvicorn.run()` im Repo — die App wird ausschließlich über die uvicorn-Kommandozeile gestartet (systemd-Unit bzw. `ci-stack.sh`). Die saubere Bauform wäre ein repo-eigener Einstiegspunkt plus Umstellung der systemd-Units im Repo `henemm-infra` — eine Abhängigkeit über Repo-Grenzen hinweg, die dieses Ticket nicht nebenbei mitziehen soll. Ist das gemeinsame Geheimnis erst scharf (Scheibe 1 + Scheibe 2 dieser Spec), schließt es die im Issue beschriebene Lücke bereits vollständig; der Bind-Guard wäre dann nur noch eine zweite Verteidigungslinie.
+
+**Diese Verkleinerung des Ticket-Umfangs bedarf der Freigabe durch den Product Owner** — sie wird hier ausdrücklich benannt, nicht stillschweigend weggelassen.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** ADR-0062 (neu, nächste freie Nummer)
+- **Rationale:** `docs/adr/0015-dual-stack-zielarchitektur.md` hält als Regel 2 fest: „Der Python-Core bekommt keine eigene Auth und keine neuen direkt exponierten Endpoints; er bleibt hinter dem Go-Proxy." Diese Spec dreht genau diesen Punkt um — der Python-Core bekommt eine eigene Auth-Prüfung. Nach Hausregel wird eine dokumentierte Entscheidung nie still zurückgenommen: Es braucht ein neues ADR, das ADR-0015 in diesem einen Punkt ablöst (Status von ADR-0015 wird auf „Abgelöst durch ADR-0062" gesetzt, alle übrigen Regeln von ADR-0015 — Zuständigkeitsgrenzen, kein Logik-Duplizierung — bleiben unverändert bestehen). Kontext, Entscheidung und verworfene Alternativen für das neue ADR stehen bereits vollständig in `docs/context/fix-2142-core-auth-shared-secret.md` (Abschnitte „Technical Approach" A1–A7 und „Risks & Considerations" R1–R9) und werden beim Anlegen des ADR-Dokuments daraus übernommen.
+
+## Changelog
+
+- 2026-09-07: Initial spec created based on Issue #2142 analysis (`docs/context/fix-2142-core-auth-shared-secret.md`)

--- a/frontend/e2e/ci-stack.sh
+++ b/frontend/e2e/ci-stack.sh
@@ -27,6 +27,13 @@ PY_PORT="${GZ_CI_STACK_PY_PORT:-8000}"
 PY_HEALTH_URL="http://127.0.0.1:${PY_PORT}/health"
 GO_HEALTH_URL="http://127.0.0.1:${GO_PORT}/api/health"
 HEALTH_TIMEOUT_SEC="${GZ_CI_STACK_HEALTH_TIMEOUT:-60}"
+# #2142 — gemeinsames Geheimnis Go -> Python-Core. Anders als
+# GZ_SESSION_SECRET MUSS es hier gesetzt werden, und zwar fuer BEIDE Prozesse
+# mit demselben Wert: der Python-Core riegelt ohne konfiguriertes Geheimnis
+# jede Anfrage mit 503 ab (fail-closed), der Stack kaeme nie ueber seine
+# Boot-Pruefung hinaus. Fester Wert statt Zufall, damit ein Neustart eines
+# einzelnen Prozesses den Stack nicht zerreisst.
+CORE_SHARED_SECRET="${GZ_CORE_SHARED_SECRET:-ci-stack-core-shared-secret-0123456789}"
 
 wait_for_health() {
 	local url="$1" name="$2" waited=0
@@ -47,6 +54,7 @@ start_stack() {
 		cd "$REPO_ROOT"
 		GZ_DATA_DIR="$DATA_ROOT" GZ_CACHE_DIR="$DATA_ROOT/cache" \
 			GZ_TEST_FIXTURE_DIR=fixtures/openmeteo \
+			GZ_CORE_SHARED_SECRET="$CORE_SHARED_SECRET" \
 			uv run uvicorn api.main:app --host 127.0.0.1 --port "$PY_PORT" \
 			> "$STATE_DIR/python-core.log" 2>&1 &
 		echo $! > "$STATE_DIR/python-core.pid"
@@ -54,6 +62,7 @@ start_stack() {
 	GZ_PORT="$GO_PORT" GZ_PYTHON_CORE_URL="http://localhost:${PY_PORT}" \
 		GZ_DATA_DIR="$DATA_ROOT" GZ_CACHE_DIR="$DATA_ROOT/cache" \
 		GZ_TEST_FIXTURE_DIR="$REPO_ROOT/fixtures/openmeteo" \
+		GZ_CORE_SHARED_SECRET="$CORE_SHARED_SECRET" \
 		GZ_USER_ID=admin GZ_AUTH_PASS=test1234 GZ_ENV=staging \
 		"$GO_BIN" > "$STATE_DIR/go-server.log" 2>&1 &
 	echo $! > "$STATE_DIR/go-server.pid"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,6 +14,9 @@ type Config struct {
 	OpenMeteoRetries  int    `envconfig:"OPENMETEO_RETRIES" default:"5"`
 	CacheDir          string `envconfig:"CACHE_DIR" default:"data/cache"`
 	SessionSecret     string `envconfig:"SESSION_SECRET" default:"dev-secret-change-me"`
+	// Issue #2142 — gemeinsames Geheimnis Go -> Python-Core. Default bewusst
+	// leer: ein Platzhalter-Literal waere ein oeffentlich bekanntes Secret.
+	CoreSharedSecret  string `envconfig:"CORE_SHARED_SECRET" default:""`
 	AuthUser          string `envconfig:"AUTH_USER" default:"admin"`
 	AuthPass          string `envconfig:"AUTH_PASS" default:""`
 	HeartbeatComparePresets string `envconfig:"HEARTBEAT_COMPARE_PRESETS" default:""`

--- a/internal/config/core_secret_gate.go
+++ b/internal/config/core_secret_gate.go
@@ -1,0 +1,31 @@
+package config
+
+import "errors"
+
+// minCoreSharedSecretLen ist die Mindestlaenge fuer das gemeinsame Geheimnis
+// Go -> Python-Core — dieselbe Schwelle wie beim Session-Secret (#2139).
+const minCoreSharedSecretLen = 32
+
+// ValidateCoreSharedSecret prueft, ob das gemeinsame Geheimnis fuer den
+// Produktivbetrieb taugt.
+//
+// Issue #2142: Ohne Geheimnis sendet die Go-API keinen Auth-Header, und der
+// Python-Core riegelt ab Scheibe 2 jede Anfrage mit 503 ab. Ein stiller Start
+// mit leerem Wert waere also ein Totalausfall, der erst im Betrieb auffiele —
+// der Aufrufer (cmd/server/main.go) beendet den Prozess deshalb beim Start.
+//
+// Ausnahme: Ist TestFixtureDir gesetzt, laeuft der Prozess im CI-E2E-Stack
+// (frontend/e2e/ci-stack.sh), der sein Geheimnis selbst mitbringt bzw. ohne
+// auskommt.
+func ValidateCoreSharedSecret(cfg *Config) error {
+	if cfg.TestFixtureDir != "" {
+		return nil
+	}
+	if cfg.CoreSharedSecret == "" {
+		return errors.New("GZ_CORE_SHARED_SECRET ist nicht gesetzt")
+	}
+	if len(cfg.CoreSharedSecret) < minCoreSharedSecretLen {
+		return errors.New("GZ_CORE_SHARED_SECRET ist kuerzer als 32 Zeichen")
+	}
+	return nil
+}

--- a/internal/config/core_secret_gate_test.go
+++ b/internal/config/core_secret_gate_test.go
@@ -1,0 +1,52 @@
+// TDD-RED fuer Issue #2142 Scheibe 1 (AC-3): Fail-Fast-Gate fuer das gemeinsame
+// Geheimnis Go -> Python-Core. Bauform und Schwelle 1:1 aus
+// session_secret_gate_test.go (#2139) uebernommen — 32 Zeichen Mindestlaenge,
+// Ausnahme TestFixtureDir != "" fuer den isolierten CI-Stack.
+package config
+
+import "testing"
+
+// Test 1 (AC-3): kein Secret, kein TestFixtureDir -> Fehler.
+func TestValidateCoreSharedSecret_UnsetFails(t *testing.T) {
+	cfg := &Config{CoreSharedSecret: "", TestFixtureDir: ""}
+	if err := ValidateCoreSharedSecret(cfg); err == nil {
+		t.Fatal("expected error for unset GZ_CORE_SHARED_SECRET, got nil")
+	}
+}
+
+// Test 2 (AC-3): CI-E2E-Ausnahme — TestFixtureDir gesetzt, Secret leer -> nil.
+func TestValidateCoreSharedSecret_TestFixtureDirException(t *testing.T) {
+	cfg := &Config{CoreSharedSecret: "", TestFixtureDir: "/tmp/fixtures"}
+	if err := ValidateCoreSharedSecret(cfg); err != nil {
+		t.Fatalf("expected nil for TestFixtureDir exception, got: %v", err)
+	}
+}
+
+// AC-3, Teil "zu kurzer Wert": Schwelle vom Session-Secret-Gate uebernommen.
+func TestValidateCoreSharedSecret_TooShortFails(t *testing.T) {
+	cfg := &Config{CoreSharedSecret: "kurz"}
+	if err := ValidateCoreSharedSecret(cfg); err == nil {
+		t.Fatal("expected error for secret shorter than 32 chars, got nil")
+	}
+}
+
+func TestValidateCoreSharedSecret_OneBelowMinLengthFails(t *testing.T) {
+	cfg := &Config{CoreSharedSecret: "abcdefghijklmnopqrstuvwxyz01234"} // 31 Zeichen
+	if err := ValidateCoreSharedSecret(cfg); err == nil {
+		t.Fatal("expected error for secret of 31 chars, got nil")
+	}
+}
+
+func TestValidateCoreSharedSecret_ExactlyMinLengthPasses(t *testing.T) {
+	cfg := &Config{CoreSharedSecret: "abcdefghijklmnopqrstuvwxyz012345"} // 32 Zeichen
+	if err := ValidateCoreSharedSecret(cfg); err != nil {
+		t.Fatalf("expected nil for secret of exactly 32 chars, got: %v", err)
+	}
+}
+
+func TestValidateCoreSharedSecret_ValidSecretPasses(t *testing.T) {
+	cfg := &Config{CoreSharedSecret: "a-genuinely-random-forty-char-secret-1234"}
+	if err := ValidateCoreSharedSecret(cfg); err != nil {
+		t.Fatalf("expected nil for valid 40-char secret, got: %v", err)
+	}
+}

--- a/internal/coreauth/order_test.go
+++ b/internal/coreauth/order_test.go
@@ -1,0 +1,52 @@
+// TDD-RED fuer Issue #2142 Scheibe 1 (AC-4, Test 4): Installationsreihenfolge
+// ist eine Zusicherung, keine Stilfrage.
+//
+// egress.Install merkt sich den vorgefundenen Transport und stellt ihn bei
+// Uninstall zeiger-identisch wieder her. Laeuft coreauth.Install NACH
+// egress.Install, verschwindet der Auth-Header bei einem egress.Uninstall()
+// still mit — und jeder Aufruf an den Python-Core liefe ab Scheibe 2 in 401.
+package coreauth
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/henemm/gregor-api/internal/config"
+	"github.com/henemm/gregor-api/internal/egress"
+)
+
+func TestCoreAuthSurvivesEgressUninstall(t *testing.T) {
+	var core captured
+	coreSrv := newCapturingServer(t, &core)
+
+	// Env=staging, weil egress.Install nur in Staging bzw. mit TestFixtureDir
+	// installiert; ohne echten Egress-Waechter waere die Reihenfolge nicht
+	// pruefbar.
+	cfg := &config.Config{
+		PythonCoreURL:    coreSrv.URL,
+		CoreSharedSecret: testCoreSecret,
+		Env:              "staging",
+	}
+
+	orig := http.DefaultTransport
+	Install(cfg)
+	installed := egress.Install(cfg)
+	t.Cleanup(func() {
+		egress.Uninstall()
+		Uninstall()
+		http.DefaultTransport = orig
+	})
+	if !installed {
+		t.Fatal("egress.Install haette in Staging installieren muessen — Reihenfolge sonst nicht pruefbar")
+	}
+
+	egress.Uninstall()
+
+	mustGet(t, coreSrv.URL+"/config")
+	if core.hits != 1 {
+		t.Fatalf("Positivkontrolle: Python-Core-Fake wurde nicht erreicht (hits=%d)", core.hits)
+	}
+	if core.header != testCoreSecret {
+		t.Fatalf("Auth-Header nach egress.Uninstall() verloren: erwartet %q, angekommen %q", testCoreSecret, core.header)
+	}
+}

--- a/internal/coreauth/transport.go
+++ b/internal/coreauth/transport.go
@@ -1,0 +1,131 @@
+// Package coreauth haengt das gemeinsame Geheimnis (Issue #2142) an jede
+// ausgehende Anfrage an den Python-Core.
+//
+// Bauform 1:1 nach internal/egress/guard.go: ein umhuellender RoundTripper auf
+// http.DefaultTransport — dem gemeinsamen Ausgang aller Go-Clients im Repo, die
+// als &http.Client{Timeout: ...} ohne eigenen Transport gebaut werden. Damit
+// traegt jede der ~20 Aufrufstellen den Header, ohne dass eine von ihnen
+// angefasst werden muesste; eine kuenftig hinzukommende ebenso.
+//
+// Gefiltert wird auf Host UND Port aus cfg.PythonCoreURL. Ohne diesen Filter
+// ginge das Geheimnis an jedes andere Ziel mit (Open-Meteo, Google Maps,
+// Komoot, BetterStack).
+package coreauth
+
+import (
+	"log"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+
+	"github.com/henemm/gregor-api/internal/config"
+)
+
+// HeaderName ist der Traeger des gemeinsamen Geheimnisses. Derselbe Name wird
+// in api/main.py erzwungen.
+const HeaderName = "X-GZ-Core-Auth"
+
+var (
+	mu        sync.Mutex
+	installed bool
+	// original ist der Transport, der im Moment des Install unter dem
+	// Auth-Transport sass — Restore-Ziel fuer Uninstall.
+	original http.RoundTripper
+)
+
+// authTransport setzt den Auth-Header, bevor der Request den darunterliegenden
+// Transport erreicht.
+type authTransport struct {
+	next http.RoundTripper
+	// target ist "host:port" des Python-Core, kleingeschrieben.
+	target string
+	secret string
+}
+
+func (a *authTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if hostPort(req.URL) != a.target {
+		return a.next.RoundTrip(req)
+	}
+	// Klonen statt mutieren: der RoundTripper-Vertrag verbietet, den
+	// uebergebenen Request zu veraendern.
+	cloned := req.Clone(req.Context())
+	cloned.Header.Set(HeaderName, a.secret)
+	return a.next.RoundTrip(cloned)
+}
+
+// hostPort normalisiert eine URL auf "host:port" (kleingeschrieben), mit dem
+// Standard-Port des Schemas, wenn keiner angegeben ist. Ohne die
+// Port-Ergaenzung wuerde "http://localhost:80" nicht auf "http://localhost"
+// passen — und umgekehrt ein fremder Host auf demselben Port faelschlich
+// passen, wenn nur der Host verglichen wuerde.
+func hostPort(u *url.URL) string {
+	if u == nil {
+		return ""
+	}
+	host := strings.ToLower(u.Hostname())
+	if host == "" {
+		return ""
+	}
+	port := u.Port()
+	if port == "" {
+		switch strings.ToLower(u.Scheme) {
+		case "https":
+			port = "443"
+		default:
+			port = "80"
+		}
+	}
+	return host + ":" + port
+}
+
+// Install ersetzt http.DefaultTransport durch den Auth-Transport. No-Op ohne
+// konfiguriertes Geheimnis oder mit unlesbarer PythonCoreURL — der Fail-Fast
+// dafuer sitzt in config.ValidateCoreSharedSecret, nicht hier.
+//
+// Rueckgabe: true genau dann, wenn dieser Aufruf den Patch gesetzt hat.
+//
+// Reihenfolge (Issue #2142, AC-4): MUSS vor egress.Install laufen. Der
+// Egress-Waechter merkt sich beim Installieren den vorgefundenen Transport und
+// stellt ihn bei Uninstall zeiger-identisch wieder her — andersherum
+// verschwaende ein egress.Uninstall() den Auth-Header still mit.
+func Install(cfg *config.Config) bool {
+	if cfg == nil || cfg.CoreSharedSecret == "" {
+		return false
+	}
+	parsed, err := url.Parse(cfg.PythonCoreURL)
+	if err != nil {
+		log.Printf("[coreauth] PythonCoreURL %q unlesbar: %v — Auth-Header inaktiv", cfg.PythonCoreURL, err)
+		return false
+	}
+	target := hostPort(parsed)
+	if target == "" {
+		log.Printf("[coreauth] PythonCoreURL %q ohne Host — Auth-Header inaktiv", cfg.PythonCoreURL)
+		return false
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if installed {
+		return false
+	}
+
+	original = http.DefaultTransport
+	http.DefaultTransport = &authTransport{next: original, target: target, secret: cfg.CoreSharedSecret}
+	installed = true
+	log.Printf("[coreauth] Auth-Header aktiv für %s", target)
+	return true
+}
+
+// Uninstall stellt den beim Install gemerkten Transport zeiger-identisch wieder
+// her. No-Op, wenn nicht installiert.
+func Uninstall() {
+	mu.Lock()
+	defer mu.Unlock()
+	if !installed {
+		return
+	}
+	http.DefaultTransport = original
+	original = nil
+	installed = false
+}

--- a/internal/coreauth/transport_test.go
+++ b/internal/coreauth/transport_test.go
@@ -1,0 +1,145 @@
+// TDD-RED fuer Issue #2142 Scheibe 1 (AC-2, Test 5): der umhuellende
+// Auth-Transport setzt X-GZ-Core-Auth ausschliesslich bei Anfragen an Host UND
+// Port aus cfg.PythonCoreURL — an jedes andere Ziel darf das Geheimnis nicht
+// mitgehen (Open-Meteo, Google Maps, Komoot, BetterStack).
+//
+// Gemessen wird am Empfaenger, nicht an der Funktion: die Ziele sind echte
+// httptest.Server, die den tatsaechlich eingetroffenen Header festhalten. Fuer
+// den wirklich fremden Host (api.open-meteo.com) kann es keinen erreichbaren
+// Server geben; dort haengt der Test — Bauform aus internal/egress/guard_test.go
+// — einen Sentinel UNTER den Waechter, der den Request vor dem Netz abfaengt
+// und seine Header protokolliert.
+package coreauth
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/henemm/gregor-api/internal/config"
+)
+
+const testCoreSecret = "core-shared-secret-fuer-tests-0123456789"
+
+// captured haelt fest, was am Ziel-Server tatsaechlich ankam.
+type captured struct {
+	hits   int
+	header string
+}
+
+func newCapturingServer(t *testing.T, c *captured) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.hits++
+		c.header = r.Header.Get("X-GZ-Core-Auth")
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// installForTest installiert den Waechter und raeumt den globalen
+// Transport-Patch am Testende vollstaendig ab — sonst leckt er in fremde
+// Testdateien desselben Pakets.
+func installForTest(t *testing.T, cfg *config.Config) {
+	t.Helper()
+	orig := http.DefaultTransport
+	Install(cfg)
+	t.Cleanup(func() {
+		Uninstall()
+		http.DefaultTransport = orig
+	})
+}
+
+func mustGet(t *testing.T, url string) {
+	t.Helper()
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	resp.Body.Close()
+}
+
+// Test 5 (AC-2), Teil 1: gleicher Host, ANDERER Port als cfg.PythonCoreURL.
+// Positivkontrolle im selben Test: exakt Host+Port aus cfg.PythonCoreURL traegt
+// den Header — ohne sie prueft der Negativfall nichts.
+func TestCoreAuthTransport_HeaderOnlyForPythonCoreHostAndPort(t *testing.T) {
+	var core, otherPort captured
+	coreSrv := newCapturingServer(t, &core)
+	otherSrv := newCapturingServer(t, &otherPort)
+
+	cfg := &config.Config{PythonCoreURL: coreSrv.URL, CoreSharedSecret: testCoreSecret}
+	installForTest(t, cfg)
+
+	mustGet(t, coreSrv.URL+"/config")
+	if core.hits != 1 {
+		t.Fatalf("Positivkontrolle: Python-Core-Fake wurde nicht erreicht (hits=%d)", core.hits)
+	}
+	if core.header != testCoreSecret {
+		t.Fatalf("am Python-Core erwartet X-GZ-Core-Auth=%q, angekommen %q", testCoreSecret, core.header)
+	}
+
+	mustGet(t, otherSrv.URL+"/v1/forecast")
+	if otherPort.hits != 1 {
+		t.Fatalf("Fremd-Ziel wurde nicht erreicht (hits=%d)", otherPort.hits)
+	}
+	if otherPort.header != "" {
+		t.Fatalf("Geheimnis an fremden Port geleckt: X-GZ-Core-Auth=%q", otherPort.header)
+	}
+}
+
+var errSentinelReached = errors.New("sentinel: transport reached")
+
+// sentinelTransport faengt jeden Request ab, bevor er das Netz erreicht, und
+// protokolliert den Auth-Header je Ziel-URL.
+type sentinelTransport struct {
+	seen map[string]string
+}
+
+func (s *sentinelTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	s.seen[req.URL.String()] = req.Header.Get("X-GZ-Core-Auth")
+	return nil, errSentinelReached
+}
+
+// Test 5 (AC-2), Teil 2: wirklich FREMDER Host. Positivkontrolle im selben Test
+// ist der Python-Core-Host — beide laufen ueber denselben Sentinel, der
+// Unterschied liegt also allein am Host-Filter.
+func TestCoreAuthTransport_ForeignHostGetsNoHeader(t *testing.T) {
+	sentinel := &sentinelTransport{seen: map[string]string{}}
+	orig := http.DefaultTransport
+	http.DefaultTransport = sentinel
+
+	cfg := &config.Config{PythonCoreURL: "http://127.0.0.1:8000", CoreSharedSecret: testCoreSecret}
+	Install(cfg)
+	t.Cleanup(func() {
+		Uninstall()
+		http.DefaultTransport = orig
+	})
+
+	const foreignURL = "https://api.open-meteo.com/v1/forecast"
+	const coreURL = "http://127.0.0.1:8000/config"
+	// Beide Aufrufe enden am Sentinel mit errSentinelReached — gewollt.
+	if resp, err := http.Get(foreignURL); err == nil {
+		resp.Body.Close()
+	}
+	if resp, err := http.Get(coreURL); err == nil {
+		resp.Body.Close()
+	}
+
+	got, seen := sentinel.seen[foreignURL]
+	if !seen {
+		t.Fatalf("Sentinel hat den Request an %s nie gesehen — Messung ungueltig", foreignURL)
+	}
+	if got != "" {
+		t.Fatalf("Geheimnis an fremden Host geleckt: X-GZ-Core-Auth=%q", got)
+	}
+
+	coreGot, coreSeen := sentinel.seen[coreURL]
+	if !coreSeen {
+		t.Fatalf("Positivkontrolle: Sentinel hat den Request an %s nie gesehen", coreURL)
+	}
+	if coreGot != testCoreSecret {
+		t.Fatalf("Positivkontrolle: am Python-Core erwartet %q, angekommen %q", testCoreSecret, coreGot)
+	}
+}

--- a/internal/handler/telegram_webhook.go
+++ b/internal/handler/telegram_webhook.go
@@ -61,7 +61,16 @@ func TelegramWebhookHandler(pythonCoreURL string) http.HandlerFunc {
 		// und ein Retry-Sturm ausgeschlossen ist. Fehler beim Forward werden geloggt
 		// und ändern die 200-Antwort an Telegram nicht — Telegram soll nie retrien.
 		url := pythonCoreURL + "/api/internal/telegram-webhook"
-		resp, err := client.Post(url, "application/json", bytes.NewReader(body))
+		fwd, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+		if err != nil {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		fwd.Header.Set("Content-Type", "application/json")
+		// Issue #2142 (AC-10): Python prüft das Telegram-Secret ein zweites Mal
+		// (Defense in Depth) — ohne diesen Header antwortet der Core mit 403.
+		fwd.Header.Set("X-Telegram-Bot-Api-Secret-Token", secret)
+		resp, err := client.Do(fwd)
 		if err != nil {
 			log.Printf("[telegram-webhook] forward error: %v", err)
 		} else {

--- a/internal/handler/telegram_webhook_secret_forwarding_test.go
+++ b/internal/handler/telegram_webhook_secret_forwarding_test.go
@@ -1,0 +1,62 @@
+package handler
+
+// Issue #2142, AC-10: Das Telegram-Secret muss beim Weiterreichen an den
+// Python-Core MITGESENDET werden — der Core prueft es dort ein zweites Mal
+// (Defense in Depth) und antwortet sonst mit 403.
+//
+// Gemessen wird am Draht: der echte Handler laeuft in einem httptest.Server,
+// ein zweiter httptest.Server spielt den Python-Core und prueft den Header, der
+// bei IHM ankommt. Ein Test, der nur das Python-Endpoint mit von Hand gesetztem
+// Header aufruft, wuerde das Fehlen der Weiterreichung nicht bemerken.
+//
+// Ausfuehrung: go test ./internal/handler/... -run TestTelegramWebhookForwardsSecret -v
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+)
+
+func TestTelegramWebhookForwardsSecretHeaderToPythonCore(t *testing.T) {
+	const secret = "s3cr3t-2142"
+	os.Setenv("TELEGRAM_WEBHOOK_SECRET", secret)
+	defer os.Unsetenv("TELEGRAM_WEBHOOK_SECRET")
+
+	var coreHits int
+	var arrivedSecret string
+	core := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		coreHits++
+		arrivedSecret = r.Header.Get("X-Telegram-Bot-Api-Secret-Token")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer core.Close()
+
+	gateway := httptest.NewServer(TelegramWebhookHandler(core.URL))
+	defer gateway.Close()
+
+	body := `{"update_id":42,"message":{"chat":{"id":12345},"text":"status"}}`
+	req, err := http.NewRequest(http.MethodPost, gateway.URL+"/api/webhooks/telegram/whatever", bytes.NewBufferString(body))
+	if err != nil {
+		t.Fatalf("Request-Bau fehlgeschlagen: %v", err)
+	}
+	req.Header.Set("X-Telegram-Bot-Api-Secret-Token", secret)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Gateway nicht erreichbar: %v", err)
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("erwartet 200 vom Gateway, bekam %d", resp.StatusCode)
+	}
+	// Positivkontrolle: ohne erreichten Core waere die Header-Pruefung wertlos.
+	if coreHits != 1 {
+		t.Fatalf("Python-Core-Fake wurde nicht genau einmal erreicht (hits=%d)", coreHits)
+	}
+	if arrivedSecret != secret {
+		t.Fatalf("Telegram-Secret kam beim Python-Core nicht an: erwartet %q, angekommen %q — der Core antwortet darauf mit 403 (AC-10)", secret, arrivedSecret)
+	}
+}

--- a/internal/router/core_auth_sweep_test.go
+++ b/internal/router/core_auth_sweep_test.go
@@ -1,0 +1,197 @@
+// TDD-RED fuer Issue #2142 Scheibe 1 (AC-1, Test 3): Sweep ueber ALLE vom
+// Router registrierten Routen.
+//
+// Der Nachweis laeuft an der Wirkstelle, nicht an der Funktion: chi.Walk zaehlt
+// die Routen selbsttaetig auf (kein handgepflegter Katalog — die 21. Route wird
+// automatisch mitgeprueft), jede wird authentifiziert angefragt, und gemessen
+// wird ausschliesslich an einem Fake-Python-Core, was dort ankommt. Routen, die
+// schon vor dem Python-Aufruf abbrechen, tauchen dort gar nicht auf.
+//
+// Positivkontrolle ist Pflicht: kommt am Fake KEIN Request an, ist "alle
+// eingetroffenen Requests trugen den Header" bei leerer Menge trivial wahr und
+// der Sweep bewacht nichts. Der Test schlaegt dann fehl.
+package router
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-webauthn/webauthn/webauthn"
+
+	"github.com/henemm/gregor-api/internal/config"
+	"github.com/henemm/gregor-api/internal/coreauth"
+	"github.com/henemm/gregor-api/internal/handler"
+	"github.com/henemm/gregor-api/internal/model"
+	"github.com/henemm/gregor-api/internal/scheduler"
+	"github.com/henemm/gregor-api/internal/store"
+)
+
+const (
+	sweepCoreSecret = "core-shared-secret-fuer-tests-0123456789"
+	sweepUserPrefix = "sweepuser"
+
+	// minPythonCallsReached bewacht die MESSGRUNDLAGE, nicht die Routenliste —
+	// aufgezaehlt wird weiterhin selbsttaetig ueber chi.Walk.
+	//
+	// Ist-Wert bei Anlage dieses Tests: 27 am Fake eingetroffene Requests.
+	// Eine blosse "> 0"-Kontrolle ist zu schwach: gemessen brach die Menge
+	// schon einmal von 27 auf 7 ein, weil POST /api/auth/logout mitten im
+	// Sweep die Sitzung entwertete und alle spaeteren Routen auf 401 liefen —
+	// 7 ist ebenfalls "> 0" und waere still durchgegangen.
+	//
+	// Faellt diese Zahl: Ursache suchen (Sitzung entwertet? Transport nicht
+	// installiert? Fake nicht erreichbar?) — NICHT die Konstante senken.
+	// Der Abstand von 3 zum Ist-Wert deckt das Entfernen einzelner
+	// Python-Routen ab, ohne einen Einbruch der Groessenordnung zu verpassen.
+	minPythonCallsReached = 24
+)
+
+// routeParamRe ersetzt chi-Platzhalter wie {id} oder {waypointId} durch einen
+// konkreten Wert, damit der Pfad ueberhaupt routbar ist.
+var routeParamRe = regexp.MustCompile(`\{[^}]+\}`)
+
+// newCoreAuthSweepRouter baut den echten Produktions-Router (dieselbe
+// Verdrahtung wie cmd/server/main.go) gegen einen Fake-Python-Core.
+func newCoreAuthSweepRouter(t *testing.T, pythonURL string) (chi.Router, *config.Config, *store.Store) {
+	t.Helper()
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("config.Load: %v", err)
+	}
+	cfg.DataDir = t.TempDir()
+	cfg.PythonCoreURL = pythonURL
+	cfg.CoreSharedSecret = sweepCoreSecret
+	// Kein SMTP im Sweep: einzelne Handler (z.B. Tier-Change) versenden sonst
+	// echte Mail.
+	cfg.SMTPHost, cfg.GoogleSMTPHost, cfg.FallbackSMTPHost = "", "", ""
+
+	s := store.New(cfg.DataDir, cfg.UserID)
+
+	wa, err := webauthn.New(&webauthn.Config{
+		RPID:          cfg.WebAuthnRPID,
+		RPDisplayName: cfg.WebAuthnRPDisplayName,
+		RPOrigins:     []string{"http://localhost:5173"},
+	})
+	if err != nil {
+		t.Fatalf("webauthn.New: %v", err)
+	}
+
+	sched, err := scheduler.New(cfg, s)
+	if err != nil {
+		t.Fatalf("scheduler.New: %v", err)
+	}
+	t.Cleanup(sched.Stop)
+
+	r := New(Deps{
+		Config:             cfg,
+		Store:              s,
+		WeatherProvider:    nil,
+		WebAuthn:           wa,
+		ChallengeStore:     handler.NewChallengeStore(),
+		Scheduler:          sched,
+		TelegramTokenStore: handler.NewTelegramTokenStore(cfg.DataDir),
+		GitCommit:          "test",
+	})
+	return r, cfg, s
+}
+
+// callSweepRoute schickt einen authentifizierten Request. Panics werden
+// abgefangen: Handler, die ohne vollstaendige Deps (z.B. WeatherProvider)
+// panisch werden, erreichen den Python-Fake ohnehin nicht — gemessen wird
+// ausschliesslich, was dort ankommt.
+//
+// Jede Route bekommt ein FRISCHES Konto samt frischem Cookie. Sonst vergiftet
+// der Sweep sich selbst: DELETE /api/auth/account loescht das Konto und
+// POST /api/auth/logout entwertet die Sitzung — gemessen liefen danach alle
+// alphabetisch spaeteren Routen auf 401 und erreichten den Python-Fake nie.
+func callSweepRoute(t *testing.T, r http.Handler, s *store.Store, secret, userID, method, path string) {
+	t.Helper()
+	defer func() {
+		if rec := recover(); rec != nil {
+			t.Logf("Route %s %s panicked (nicht gemessen): %v", method, path, rec)
+		}
+	}()
+	if err := s.SaveUser(model.User{ID: userID, CreatedAt: time.Now()}); err != nil {
+		t.Fatalf("SaveUser: %v", err)
+	}
+	req := httptest.NewRequest(method, path, bytes.NewReader([]byte(`{}`)))
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(sessionCookieFor(userID, secret))
+	r.ServeHTTP(httptest.NewRecorder(), req)
+}
+
+// Test 3 (AC-1).
+func TestCoreAuthHeaderOnEveryPythonCallFromRouter(t *testing.T) {
+	var mu sync.Mutex
+	arrived := 0
+	var unauthenticated []string
+
+	py := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		arrived++
+		if got := r.Header.Get("X-GZ-Core-Auth"); got != sweepCoreSecret {
+			unauthenticated = append(unauthenticated, r.Method+" "+r.URL.Path+" -> "+got)
+		}
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{}`))
+	}))
+	defer py.Close()
+
+	r, cfg, s := newCoreAuthSweepRouter(t, py.URL)
+
+	origTransport := http.DefaultTransport
+	coreauth.Install(cfg)
+	t.Cleanup(func() {
+		coreauth.Uninstall()
+		http.DefaultTransport = origTransport
+	})
+
+	type route struct{ method, path string }
+	var routes []route
+	err := chi.Walk(r, func(method, pattern string, h http.Handler, mws ...func(http.Handler) http.Handler) error {
+		routes = append(routes, route{method, routeParamRe.ReplaceAllString(pattern, "sweep")})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("chi.Walk: %v", err)
+	}
+	if len(routes) == 0 {
+		t.Fatal("chi.Walk hat keine einzige Route gefunden — Messung ungueltig")
+	}
+
+	for i, rt := range routes {
+		callSweepRoute(t, r, s, cfg.SessionSecret, fmt.Sprintf("%s%d", sweepUserPrefix, i), rt.method, rt.path)
+	}
+
+	mu.Lock()
+	sweepArrived := arrived
+	mu.Unlock()
+
+	// Zweite Messgrundlagen-Kontrolle, direkt aus der gefundenen Regression:
+	// nach der letzten Route muss eine authentifizierte Anfrage weiterhin
+	// moeglich sein. Bricht die Sitzungsfaehigkeit unterwegs weg (Logout,
+	// geloeschtes Konto), sinkt die Messmenge still — genau der Einbruch, der
+	// oben nur an der Untergrenze auffiele.
+	callSweepRoute(t, r, s, cfg.SessionSecret, sweepUserPrefix+"final", "GET", "/api/config")
+
+	mu.Lock()
+	defer mu.Unlock()
+	if arrived == sweepArrived {
+		t.Fatal("nach der letzten Route erreichte keine authentifizierte Anfrage mehr den Python-Core — der Sweep hat die Sitzungsfaehigkeit unterwegs zerstoert, die Messmenge ist wertlos")
+	}
+	if sweepArrived < minPythonCallsReached {
+		t.Fatalf("nur %d von erwarteten mindestens %d Requests am Python-Core-Fake angekommen (%d Routen aufgezaehlt) — der Sweep erreicht den Python-Core nicht mehr flaechendeckend", sweepArrived, minPythonCallsReached, len(routes))
+	}
+	if len(unauthenticated) > 0 {
+		t.Fatalf("%d von %d am Python-Core eingetroffenen Requests ohne gueltigen X-GZ-Core-Auth-Header: %v", len(unauthenticated), arrived, unauthenticated)
+	}
+}

--- a/src/app/config.py
+++ b/src/app/config.py
@@ -177,6 +177,17 @@ class Settings(BaseSettings):
     # Deployment environment (GZ_ENV)
     env: str = Field(default="production", description="Deployment environment (GZ_ENV)")
 
+    # Issue #2142 — gemeinsames Geheimnis Go-API -> Python-Core. Dieselbe
+    # Umgebungsvariable, die die Go-Seite als GZ_CORE_SHARED_SECRET liest;
+    # beide Prozesse lesen je Umgebung dieselbe .env, ein Abgleich entfaellt.
+    # Bewusst KEIN Fail-Fast hier (wie bei _resend_default_deny): Settings()
+    # wird auch von CLI und Tests gebaut, die den Core gar nicht ansprechen.
+    # Die Durchsetzung sitzt in der Middleware von api/main.py.
+    core_shared_secret: str = Field(
+        default="",
+        description="Gemeinsames Geheimnis Go -> Python-Core (env: GZ_CORE_SHARED_SECRET, #2142)",
+    )
+
     # SMS settings (for sms channel)
     sms_gateway_url: str = Field(default="https://gateway.seven.io/api/sms", description="SMS gateway HTTP endpoint")
     seven_api_key: Optional[str] = Field(default=None, description="seven.io API key (env: GZ_SEVEN_API_KEY)")
@@ -428,6 +439,9 @@ class Settings(BaseSettings):
     _SENSITIVE_FIELDS = {
         "smtp_pass", "imap_pass", "test_smtp_pass", "test_imap_pass",
         "seven_api_key", "telegram_bot_token",
+        # Issue #2142: repr(settings) landet in Logzeilen — das gemeinsame
+        # Geheimnis darf dort nie im Klartext auftauchen.
+        "core_shared_secret",
         # Issue #1676: die gelernte Geraete-Rufnummer gehoert nach S1-Vorgabe
         # nur maskiert in Protokolle — repr(settings) landet in Logzeilen.
         "premium_sms_reply_to",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,84 @@ def _use_fixture_provider(request):
         os.environ.pop("GZ_TEST_FIXTURE_DIR", None)
 
 
+# ---------------------------------------------------------------------------
+# Issue #2142: Core-Auth-Header zentral fuer jeden TestClient
+# ---------------------------------------------------------------------------
+
+CORE_AUTH_HEADER = "X-GZ-Core-Auth"
+CORE_SECRET_ENV = "GZ_CORE_SHARED_SECRET"
+# Nur fuer den Testlauf. Kein Produktivwert, steht bewusst im Repo.
+_CORE_AUTH_TEST_SECRET = "pytest-core-shared-secret-0123456789abcdef"
+
+# Beim IMPORT dieser conftest, nicht in einer Fixture: Testmodule werden vor
+# dem ersten Fixture-Lauf eingesammelt, und ein dort auf Modulebene gebauter
+# TestClient braucht das Geheimnis bereits. ``setdefault`` laesst einen von
+# aussen gesetzten Wert (Server-.env, CI) unangetastet.
+os.environ.setdefault(CORE_SECRET_ENV, _CORE_AUTH_TEST_SECRET)
+
+
+def _patch_testclient_with_core_auth() -> None:
+    """Versorgt JEDE ``TestClient``-Instanz mit dem gueltigen Auth-Header.
+
+    Ohne das braechen die ~68 Bestands-Testdateien geschlossen mit 401, sobald
+    ``api/main.py`` die Pruefung durchsetzt. Der Waechter selbst wird dabei
+    NICHT abgeschaltet — es gibt keinen ``_in_pytest()``-Bypass: ein Test, der
+    den Header aus seinem Client wieder entfernt, bekommt weiterhin 401
+    (AC-11, ``tests/tdd/test_core_auth_enforcement.py``).
+
+    Der Wert wird bei jeder Instanziierung frisch aus der Umgebung gelesen,
+    damit ein Test, der das Geheimnis per ``monkeypatch.setenv`` aendert,
+    danach auch einen dazu passenden Client bekommt.
+
+    Gepatcht wird ``starlette.testclient.TestClient`` — ``fastapi.testclient``
+    re-exportiert genau diese Klasse.
+    """
+    from starlette.testclient import TestClient
+
+    if getattr(TestClient, "_gz_core_auth_patched", False):
+        return
+
+    original_init = TestClient.__init__
+
+    def __init__(self, *args, **kwargs):  # noqa: ANN001, ANN202
+        original_init(self, *args, **kwargs)
+        secret = os.environ.get(CORE_SECRET_ENV, "")
+        if secret:
+            self.headers[CORE_AUTH_HEADER] = secret
+
+    TestClient.__init__ = __init__
+    TestClient._gz_core_auth_patched = True
+
+
+_patch_testclient_with_core_auth()
+
+
+@pytest.fixture(autouse=True)
+def _core_auth_secret_configured():
+    """Stellt fuer jeden Test sicher, dass ein Geheimnis konfiguriert ist.
+
+    Fehlt es (weil ein vorheriger Test es ohne monkeypatch aus der Umgebung
+    geraeumt hat), antwortete der Core mit 503 statt mit dem erwarteten
+    Verhalten. Tests, die den unkonfigurierten Zustand BEWUSST herstellen
+    wollen, ueberschreiben das per eigenem ``monkeypatch.delenv`` im Test —
+    diese Fixture laeuft als autouse zuerst und wird danach ueberstimmt.
+
+    BEWUSST OHNE ``monkeypatch``: als autouse-Fixture wuerde sie den
+    function-scoped ``monkeypatch`` VOR ``_isolate_data_root`` aufbauen. Damit
+    liefe ``monkeypatch.undo()`` erst NACH dessen Restore — ein Test, der
+    ``loader._DATA_ROOT`` per ``monkeypatch.setattr`` umbiegt (z. B.
+    ``tests/tdd/test_compare_dispatch_failed_tally.py``), setzte den Wert am
+    Ende auf SEINEN tmp-Pfad zurueck statt auf den echten Baum. Alle folgenden
+    ``@pytest.mark.real_data_root``-Tests lasen dann eine leere Wegwerf-Wurzel
+    und scheiterten mit 404 ("Trip ... nicht gefunden"). Reines
+    ``os.environ``-Setzen hat keine Fixture-Abhaengigkeit und verschiebt die
+    Reihenfolge nicht.
+    """
+    if not os.environ.get(CORE_SECRET_ENV):
+        os.environ[CORE_SECRET_ENV] = _CORE_AUTH_TEST_SECRET
+    yield
+
+
 _REPO_DATA_USERS = root / "data" / "users"
 
 # Issue #1624: die frueher unter ``<repo>/data/users`` COMMITTETEN

--- a/tests/tdd/test_core_auth_enforcement.py
+++ b/tests/tdd/test_core_auth_enforcement.py
@@ -1,0 +1,421 @@
+"""TDD RED fuer Issue #2142, Scheibe 2 — "Python erzwingt".
+
+Spec: docs/specs/bugfix/core_shared_secret_auth.md (AC-5 bis AC-11).
+
+Der Python-Core hat heute KEINERLEI Authentifizierung: wer ihn direkt anspricht
+(lokaler Prozess auf demselben Server), umgeht ``appendUserID`` in
+``internal/handler/proxy.go`` vollstaendig und liest mit frei gewaehlter
+``?user_id=`` fremde Daten. Diese Datei misst die kuenftige
+``@app.middleware("http")`` in ``api/main.py`` an der Wirkstelle: echte
+``TestClient``-Anfragen gegen ``api.main:app``, keine Mocks.
+
+Pruefling fuer den Nutzdaten-Nachweis ist
+``GET /api/_internal/trip/{trip_id}/loaded?user_id=...`` — ein Endpoint, der
+OHNE Auth heute tatsaechlich etwas tut: er liefert den vollstaendig hydrierten
+Trip eines beliebigen, frei waehlbaren Nutzers als JSON aus. Genau daran ist
+"kein Seiteneffekt, keine Daten in der Antwort" ueberhaupt messbar; ein
+Endpoint, der ohne Auth ohnehin nur 422 antwortet, koennte das nicht belegen.
+
+Warum Middleware und nicht ``lifespan``: der FastAPI-``lifespan`` laeuft unter
+``TestClient(app)`` ohne ``with``-Block NICHT (gemessen, Kontext-Dokument).
+Alle Tests hier bauen den Client bewusst ohne ``with`` — was hier gruen wird,
+wird von der Middleware bewacht, nicht vom Startup-Hook.
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.main import app
+
+CORE_AUTH_HEADER = "X-GZ-Core-Auth"
+CORE_SECRET_ENV = "GZ_CORE_SHARED_SECRET"
+GUELTIGES_SECRET = "tdd-2142-core-secret-abcdefghijklmnop"
+
+# Realer Bestand aus tests/fixtures/data_root (Session-Fixture in
+# tests/conftest.py materialisiert ihn nach data/users/): ein Trip, der einem
+# konkreten Nutzer gehoert. Ohne Auth gibt der Core ihn heute jedem heraus.
+FREMDER_TRIP = "gr221-mallorca"
+FREMDER_USER = "default"
+GESCHUETZTER_PFAD = f"/api/_internal/trip/{FREMDER_TRIP}/loaded"
+
+
+def client_ohne_core_auth() -> TestClient:
+    """``TestClient`` mit nachweislich ENTFERNTEM ``X-GZ-Core-Auth``-Header.
+
+    Ab der GREEN-Phase versorgt eine autouse-Fixture in ``tests/conftest.py``
+    jede ``TestClient``-Instanz zentral mit dem gueltigen Header (sonst braechen
+    die ~68 Bestands-Testdateien). Ein Test, der den Header einfach "nicht
+    setzt", wuerde ihn dann trotzdem mitschicken und still gruen werden. Hier
+    wird er darum aktiv aus den Client-Kopfzeilen entfernt und die Entfernung
+    anschliessend geprueft.
+    """
+    client = TestClient(app)
+    client.headers.pop(CORE_AUTH_HEADER, None)
+    assert CORE_AUTH_HEADER not in client.headers, (
+        f"{CORE_AUTH_HEADER} liess sich nicht aus dem TestClient entfernen — "
+        "ohne diese Entfernung misst kein Negativtest dieser Datei etwas."
+    )
+    return client
+
+
+@pytest.fixture
+def secret_konfiguriert(monkeypatch) -> str:
+    """Der Prozess kennt ein gueltiges gemeinsames Geheimnis."""
+    monkeypatch.setenv(CORE_SECRET_ENV, GUELTIGES_SECRET)
+    return GUELTIGES_SECRET
+
+
+@pytest.fixture
+def secret_nicht_konfiguriert(monkeypatch) -> None:
+    """Der Prozess kennt GAR KEIN gemeinsames Geheimnis (AC-9, fail-closed).
+
+    Zwei Quellen muessen dafuer schweigen: die Umgebungsvariable UND die
+    ``.env``-Datei, die ``Settings`` ueber ``env_file`` mitliest. Wird nur die
+    Variable geloescht, entscheidet der zufaellige Inhalt der lokalen ``.env``
+    ueber das Testergebnis — auf dem Server steht das Geheimnis dort (Schritt 0
+    der Rollout-Reihenfolge), in der CI nicht. Deshalb wird die ``.env``-Quelle
+    fuer die Dauer des Tests abgeschaltet (monkeypatch stellt sie danach
+    wieder her).
+    """
+    from app.config import Settings
+
+    monkeypatch.delenv(CORE_SECRET_ENV, raising=False)
+    monkeypatch.setitem(Settings.model_config, "env_file", None)
+
+
+def _antwort_enthaelt_keine_trip_daten(response) -> None:
+    """Kein Byte des fremden Trips darf in der Antwort stehen (AC-5)."""
+    text = response.text
+    for verraeterisch in ("GR221", "display_config", '"stages"', "aggregation"):
+        assert verraeterisch not in text, (
+            f"Die abgewiesene Antwort gibt Nutzdaten preis ({verraeterisch!r} "
+            f"im Koerper): {text[:400]!r}"
+        )
+
+
+@pytest.mark.real_data_root
+def test_ohne_header_401_und_keine_nutzdaten(secret_konfiguriert):
+    """AC-5 / Test 6: Secret konfiguriert, Anfrage OHNE Header → 401, kein Seiteneffekt.
+
+    Given der Python-Core hat ein gueltiges Geheimnis konfiguriert
+    When ``GET /api/_internal/trip/gr221-mallorca/loaded?user_id=default`` ohne
+         ``X-GZ-Core-Auth`` eintrifft
+    Then antwortet der Core mit 401 und gibt keine Trip-Daten heraus.
+
+    Der Endpoint ist rein lesend — ein Versand kann hier gar nicht entstehen;
+    der messbare Seiteneffekt ist die Datenherausgabe, und genau die wird
+    geprueft.
+    """
+    client = client_ohne_core_auth()
+
+    response = client.get(GESCHUETZTER_PFAD, params={"user_id": FREMDER_USER})
+
+    assert response.status_code == 401, (
+        f"Ohne {CORE_AUTH_HEADER} muss der Python-Core 401 antworten, bekam "
+        f"{response.status_code}. Heute hat er keine Auth-Pruefung — genau das "
+        "ist der Befund aus #2142."
+    )
+    _antwort_enthaelt_keine_trip_daten(response)
+
+
+@pytest.mark.real_data_root
+def test_falscher_header_wert_401(secret_konfiguriert):
+    """AC-6 / Test 7: falscher Header-Wert → 401.
+
+    Given der Python-Core hat ein gueltiges Geheimnis konfiguriert
+    When eine Anfrage mit falschem ``X-GZ-Core-Auth``-Wert eintrifft
+    Then antwortet der Core mit 401 und gibt keine Trip-Daten heraus.
+    """
+    client = client_ohne_core_auth()
+
+    response = client.get(
+        GESCHUETZTER_PFAD,
+        params={"user_id": FREMDER_USER},
+        headers={CORE_AUTH_HEADER: GUELTIGES_SECRET + "-falsch"},
+    )
+
+    assert response.status_code == 401, (
+        f"Ein falscher {CORE_AUTH_HEADER}-Wert muss mit 401 abgewiesen werden, "
+        f"bekam {response.status_code}."
+    )
+    _antwort_enthaelt_keine_trip_daten(response)
+
+
+@pytest.mark.real_data_root
+def test_korrekter_header_endpoint_unveraendert(secret_konfiguriert):
+    """AC-7 / Test 8: korrekter Header → Endpoint verhaelt sich unveraendert.
+
+    REGRESSIONSSCHUTZ — dieser Test ist im RED-Stand bereits GRUEN und soll es
+    bleiben. Er ist der Gegenpol zu den Negativtests: er faellt um, sobald die
+    Middleware authentifizierte Aufrufer mitblockt. Genau das waere der teure
+    Fehler dieser Scheibe (fail-closed ueber 20 Aufrufstellen — eine zu strenge
+    Pruefung legt den gesamten Core lahm).
+    """
+    client = TestClient(app)
+
+    response = client.get(
+        GESCHUETZTER_PFAD,
+        params={"user_id": FREMDER_USER},
+        headers={CORE_AUTH_HEADER: GUELTIGES_SECRET},
+    )
+
+    assert response.status_code == 200, (
+        f"Mit korrektem {CORE_AUTH_HEADER} muss der Endpoint unveraendert "
+        f"antworten, bekam {response.status_code}: {response.text[:300]!r}"
+    )
+    daten = response.json()
+    assert daten["id"] == FREMDER_TRIP
+    assert "display_config" in daten
+    assert daten["stages"], "Trip-Hydration muss unveraendert Etappen liefern"
+
+
+@pytest.mark.real_data_root
+@pytest.mark.parametrize("leerer_wert", [False, True])
+def test_secret_nicht_konfiguriert_503(monkeypatch, secret_nicht_konfiguriert, leerer_wert):
+    """AC-9 / Test 9: Secret im Prozess nicht konfiguriert → 503 (fail-closed).
+
+    Zwei Auspraegungen von "nicht konfiguriert" werden geprueft: Variable und
+    ``.env``-Eintrag fehlen ganz, sowie Variable auf leeren Wert gesetzt (so
+    kommt es an, wenn jemand die Zeile in der ``.env`` leer laesst). Beide
+    duerfen NIE offen durchlassen — 503 statt unauthentifizierter Antwort, exakt
+    das Muster aus ``telegram_webhook.go`` ("webhook not configured").
+    """
+    if leerer_wert:
+        monkeypatch.setenv(CORE_SECRET_ENV, "")
+
+    client = client_ohne_core_auth()
+
+    response = client.get(GESCHUETZTER_PFAD, params={"user_id": FREMDER_USER})
+
+    assert response.status_code == 503, (
+        "Ohne konfiguriertes Geheimnis muss der Python-Core mit 503 abriegeln "
+        f"statt die Anfrage durchzulassen, bekam {response.status_code}."
+    )
+    _antwort_enthaelt_keine_trip_daten(response)
+
+
+def test_health_ohne_header_immer_200(monkeypatch):
+    """AC-8 / Test 10: ``GET /health`` ohne Header → 200, in BEIDEN Zustaenden.
+
+    Heute bereits GRUEN und muss es bleiben: Go ruft diesen Pfad selbst ohne
+    Header ab (``proxy.go``) und ``ci-stack.sh`` pollt ihn als Boot-Pruefung,
+    bevor ueberhaupt etwas konfiguriert sein kann. Der Test faellt um, sobald
+    die Ausnahme zu weit (dann greifen die Negativtests nicht mehr) oder zu eng
+    (dann sperrt sich der Core beim Start selbst aus) gefasst wird.
+    """
+    from app.config import Settings
+
+    # Zustand 1: Geheimnis konfiguriert
+    monkeypatch.setenv(CORE_SECRET_ENV, GUELTIGES_SECRET)
+    response = client_ohne_core_auth().get("/health")
+    assert response.status_code == 200, (
+        f"/health muss bei konfiguriertem Geheimnis ohne Header 200 liefern, "
+        f"bekam {response.status_code}."
+    )
+    assert response.json()["status"] == "ok"
+
+    # Zustand 2: Geheimnis gar nicht konfiguriert
+    monkeypatch.delenv(CORE_SECRET_ENV, raising=False)
+    monkeypatch.setitem(Settings.model_config, "env_file", None)
+    response = client_ohne_core_auth().get("/health")
+    assert response.status_code == 200, (
+        "/health muss AUCH ohne konfiguriertes Geheimnis 200 liefern — sonst "
+        "kommt der CI-Stack nie ueber seine Boot-Pruefung hinaus, bekam "
+        f"{response.status_code}."
+    )
+    assert response.json()["status"] == "ok"
+
+
+def test_health_praefix_pfad_bleibt_authpflichtig(secret_konfiguriert):
+    """AC-8 Grenzfall: ein Pfad, der nur mit ``/health`` BEGINNT, bleibt auth-pflichtig.
+
+    ``CORE_AUTH_EXEMPT_PATHS`` ist als exakte Menge definiert
+    (``frozenset({"/health"})``), nicht als Praefix-Regel. ``/health/sub``
+    existiert in KEINEM Router (kein 404-Risiko durch die Ausnahme selbst) —
+    die Middleware laeuft ohnehin VOR dem Routing, entscheidet also bei
+    fehlendem Header zuerst: 401. Wuerde der Vergleich zu
+    ``path.startswith("/health")`` aufgeweicht, kaeme der Request unauth an
+    den (nicht existenten) Router durch und liefe in ein Router-404 statt in
+    das Middleware-401 dieses Tests — der Test faellt dann rot um.
+    """
+    client = client_ohne_core_auth()
+
+    response = client.get("/health/sub")
+
+    assert response.status_code == 401, (
+        "Ein Pfad, der nur mit /health BEGINNT, muss weiterhin auth-pflichtig "
+        f"sein (exakter Vergleich, keine Praefix-Ausnahme), bekam "
+        f"{response.status_code}."
+    )
+
+
+def test_health_mit_query_bleibt_ausnahme(secret_konfiguriert):
+    """AC-8 Gegenprobe: ``/health?...`` bleibt die Ausnahme.
+
+    ``request.url.path`` enthaelt den Query-String NICHT — dieser Fall darf
+    trotz der Grenzpruefung oben NICHT rot werden, sonst waere ein Boot-Poll
+    mit angehaengtem Query kaputt.
+    """
+    client = client_ohne_core_auth()
+
+    response = client.get("/health", params={"probe": "1"})
+
+    assert response.status_code == 200, (
+        "GET /health?probe=1 muss weiterhin die Ausnahme sein (path ohne "
+        f"Query bleibt exakt '/health'), bekam {response.status_code}."
+    )
+
+
+class KommandoRekorder:
+    """Echter Aufzeichner an der Stelle, an der Telegram-Kommandos ausgefuehrt
+    werden (``InboundTelegramReader._process_update``).
+
+    Kein ``Mock``: eine gewoehnliche Klasse, die den einen Aufruf mitschreibt,
+    den der Webhook-Endpoint gegen den Reader taetigt. Gemessen wird damit die
+    WIRKUNG ("wurde ein Kommando ausgefuehrt?"), nicht ein Statuscode — ein
+    stiller 200 mit trotzdem ausgefuehrtem Kommando waere der gefaehrliche Fall.
+    """
+
+    def __init__(self) -> None:
+        self.aufrufe: list[dict] = []
+
+    def _process_update(self, update: dict, settings) -> bool:  # noqa: ANN001
+        self.aufrufe.append(update)
+        return True
+
+
+@pytest.fixture
+def telegram_rekorder(monkeypatch) -> KommandoRekorder:
+    """Setzt den Modul-Reader des Webhooks auf den Aufzeichner und leert den
+    prozessglobalen Dedup-Speicher (``_seen_ids`` ueberlebt sonst zwischen
+    Tests und wuerde ein Update still als Duplikat verwerfen)."""
+    from api.routers import webhook
+
+    rekorder = KommandoRekorder()
+    monkeypatch.setattr(webhook, "_reader", rekorder)
+    webhook._seen_ids.clear()
+    webhook._seen_order.clear()
+    return rekorder
+
+
+def _telegram_update(update_id: int) -> dict:
+    return {
+        "update_id": update_id,
+        "message": {
+            "message_id": 1,
+            "chat": {"id": 424242, "type": "private"},
+            "text": "/wetter",
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    "telegram_header",
+    [None, "falsches-telegram-secret"],
+    ids=["telegram-secret-fehlt", "telegram-secret-falsch"],
+)
+def test_webhook_ohne_telegram_secret_fuehrt_kein_kommando_aus(
+    monkeypatch, secret_konfiguriert, telegram_rekorder, telegram_header
+):
+    """AC-10 / Test 11: gueltige Core-Auth, aber fehlendes/falsches Telegram-Secret
+    → KEIN Telegram-Kommando wird ausgefuehrt (Defense in Depth).
+
+    Given ``POST /api/internal/telegram-webhook`` mit gueltigem
+          ``X-GZ-Core-Auth``, aber ohne bzw. mit falschem
+          ``X-Telegram-Bot-Api-Secret-Token``
+    When der Request verarbeitet wird
+    Then erreicht das Update die Kommando-Verarbeitung nicht.
+
+    Heute reicht ``webhook.py`` jeden Body ungeprueft an
+    ``InboundTelegramReader._process_update`` weiter — der Docstring dort
+    schreibt den Localhost-Trust sogar als Soll fest. Die Core-Auth-Pruefung
+    allein genuegt nicht: wer das gemeinsame Geheimnis kennt (jeder Prozess mit
+    Lesezugriff auf die ``.env``), koennte sonst Kommandos fuer ein fremdes
+    Konto ausloesen.
+    """
+    monkeypatch.setenv("TELEGRAM_WEBHOOK_SECRET", "echtes-telegram-webhook-secret")
+
+    headers = {CORE_AUTH_HEADER: secret_konfiguriert}
+    if telegram_header is not None:
+        headers["X-Telegram-Bot-Api-Secret-Token"] = telegram_header
+
+    client = TestClient(app)
+    client.post(
+        "/api/internal/telegram-webhook",
+        json=_telegram_update(920142001),
+        headers=headers,
+    )
+
+    assert telegram_rekorder.aufrufe == [], (
+        "Ohne gueltiges Telegram-Secret darf KEIN Kommando ausgefuehrt werden, "
+        f"es wurden aber {len(telegram_rekorder.aufrufe)} Update(s) an die "
+        "Kommando-Verarbeitung durchgereicht."
+    )
+
+
+def test_webhook_mit_telegram_secret_fuehrt_kommando_aus(
+    monkeypatch, secret_konfiguriert, telegram_rekorder
+):
+    """AC-10 (Positivkontrolle): mit gueltigem Telegram-Secret wird das Kommando
+    ausgefuehrt.
+
+    Ohne diese Gegenprobe wuerde der Negativtest oben auch dann gruen, wenn die
+    Kommando-Verarbeitung aus einem ganz anderen Grund nie erreicht wird (z. B.
+    weil der Aufzeichner gar nicht am Draht haengt) — dann maesse er nichts.
+    Heute bereits GRUEN: ``webhook.py`` fuehrt jedes Update aus.
+    """
+    monkeypatch.setenv("TELEGRAM_WEBHOOK_SECRET", "echtes-telegram-webhook-secret")
+
+    client = TestClient(app)
+    client.post(
+        "/api/internal/telegram-webhook",
+        json=_telegram_update(920142002),
+        headers={
+            CORE_AUTH_HEADER: secret_konfiguriert,
+            "X-Telegram-Bot-Api-Secret-Token": "echtes-telegram-webhook-secret",
+        },
+    )
+
+    assert len(telegram_rekorder.aufrufe) == 1, (
+        "Mit gueltigem Telegram-Secret MUSS das Update die "
+        "Kommando-Verarbeitung erreichen — sonst misst der Negativtest nichts."
+    )
+
+
+@pytest.mark.real_data_root
+def test_waechter_bleibt_im_testlauf_scharf(secret_konfiguriert):
+    """AC-11 / Test 12: die zentrale Test-Fixture darf den Waechter nicht abschalten.
+
+    Given ``tests/conftest.py`` versorgt ab der GREEN-Phase jede
+          ``TestClient``-Instanz automatisch mit dem gueltigen Header
+    When ein Test diesen Header ausdruecklich wieder ENTFERNT
+    Then antwortet der Python-Core mit 401.
+
+    Zwei Zusicherungen in einem Test, weil erst beide zusammen etwas beweisen:
+    (a) ein unveraenderter Client traegt den Header — die Fixture wirkt, die
+    ~68 Bestandsdateien laufen weiter; (b) nach dem Entfernen kommt 401 — es
+    gibt KEINE testlauf-spezifische Ausnahme (kein ``_in_pytest()``-Bypass),
+    die die Pruefung insgesamt stilllegt. Ohne (a) koennte (b) auch dann gruen
+    sein, wenn die Fixture gar nichts tut; ohne (b) waere die Fixture selbst
+    der blinde Fleck.
+    """
+    versorgter_client = TestClient(app)
+    assert versorgter_client.headers.get(CORE_AUTH_HEADER) == secret_konfiguriert, (
+        "Die autouse-Fixture in tests/conftest.py versorgt TestClient-Instanzen "
+        "nicht mit dem gueltigen Header — ohne sie brechen die Bestandstests "
+        f"breit. Vorgefunden: {versorgter_client.headers.get(CORE_AUTH_HEADER)!r}"
+    )
+
+    entbloesster_client = client_ohne_core_auth()
+    response = entbloesster_client.get(
+        GESCHUETZTER_PFAD, params={"user_id": FREMDER_USER}
+    )
+
+    assert response.status_code == 401, (
+        "Der Waechter ist im Testlauf nicht scharf: eine Anfrage mit "
+        f"nachweislich entferntem {CORE_AUTH_HEADER} kam mit "
+        f"{response.status_code} durch. Ein Testlauf-Bypass wuerde bedeuten, "
+        "dass KEIN Test der Suite die Durchsetzung noch belegen kann."
+    )
+    _antwort_enthaelt_keine_trip_daten(response)


### PR DESCRIPTION
- **docs(#2142): Kontext und freigegebene Spec fuer Core-Auth per Shared Secret**
- **fix(#2142): Python-Core authentifiziert sich gegenueber der Go-API per Shared Secret**
