### PR TITLE
fix(#1196): Telegram-Live-Test AC-3 bekommt den Timeout-Marker seines Nachbarn

### DIFF
--- a/tests/tdd/test_issue_686_telegram_functional_live.py
+++ b/tests/tdd/test_issue_686_telegram_functional_live.py
@@ -141,6 +141,7 @@ def test_ac1_fixture_ensures_user_with_active_trip(tmp_path):
 # ---------------------------------------------------------------------------
 
 @pytest.mark.real_data_root
+@pytest.mark.timeout(240)
 @pytest.mark.skipif(
     not live_telegram_enabled(),
     reason="GZ_TELEGRAM_LIVE=1 nicht gesetzt — Live-Sends nur opt-in (#1014)",
@@ -162,6 +163,15 @@ def test_ac3_all_seven_commands_produce_meaningful_content():
 
     Läuft gegen das CWD-`data`-Verzeichnis (get_data_dir ist CWD-relativ) — in der
     Validierung im Staging-Tree mit echten Wetter-Providern.
+
+    @pytest.mark.timeout(240) (statt globalem 30s-Default, Issue #1210 AC-1
+    erlaubt deklarierte Ausnahmen): der Test macht für sieben Kommandos echte
+    Wetterabrufe. Ist die Primärquelle für Gewittersignale nicht erreichbar,
+    greift die Ersatzquelle mit GRIB-Rasterlesen, und die Summe sprengt 30s —
+    gemessen 52s am 2026-09-07, ohne dass irgendetwas defekt war. Der Nachbar
+    AC-4 trug den Marker von Anfang an; hier fehlte er, was jede
+    Telegram-Auslieferung zwang, diesen Pflicht-Test als Rot abzubuchen
+    (zweimal am 2026-09-07 aufgetreten, gebucht in #1196).
     """
     from tests.tdd._telegram_live_fixture import (
         TEST_USER_ID,


### PR DESCRIPTION
## Das Problem

`test_ac3_all_seven_commands_produce_meaningful_content` macht für sieben Kommandos **echte** Wetterabrufe, lief aber gegen den globalen 30-Sekunden-Default. Ist die Primärquelle für Gewittersignale nicht erreichbar, greift die Ersatzquelle mit GRIB-Rasterlesen — und die Summe sprengt das Budget.

Gemessen am 07.09. bei der #2185-Auslieferung:

```
--timeout=600 → 1 passed in 52.52s
Default (30s) → Failed: Timeout (>30.0s)
```

52 Sekunden echte Laufzeit gegen 30 Sekunden Budget. Nichts war defekt.

## Warum das zählt

Der Telegram-Live-Test ist **Pflicht** bei jeder Auslieferung, die den Telegram-Pfad berührt. Solange AC-3 strukturell nicht bestehen kann, muss jede solche Lieferung ihn als Rot abbuchen — allein am 07.09. zweimal (#2168, #2185). Das ist ein Gate, das nichts bewacht, sondern nur Zeit kostet.

## Der Fix

Eine Zeile: `@pytest.mark.timeout(240)`, genau der Marker, den sein direkter Nachbar `test_ac4_live_delivery_and_cleanup` seit jeher trägt — obwohl AC-3 dieselben echten Abrufe macht. Issue #1210 AC-1 sieht solche **deklarierten** Ausnahmen ausdrücklich vor; die Begründung steht im Docstring, in derselben Form wie bei AC-4.

Keine Schwellen-Aufweichung: 52 s gemessene Laufzeit gegen 240 s Budget lässt reichlich Luft, ohne einen echten Hänger durchzuwinken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KbRSjSm75PyX2repxsW8w1