### PR TITLE
docs(#2132): Mini-Spec Datenverbrauch messen + Kompression einschalten

### DIFF
--- a/docs/specs/fast/fast-2132-datenkompression.md
+++ b/docs/specs/fast/fast-2132-datenkompression.md
@@ -1,0 +1,33 @@
+# Mini-Spec: #2132 Datenverbrauch messen + Kompression der Daten-Nachladungen einschalten
+
+## Was ändert sich
+- Vorher-Messung: Netzwerk-Mitschnitt einer typischen Handy-Sitzung gegen Produktion
+  (Login → Trip öffnen → Briefing ansehen → Ortsvergleich öffnen), übertragene Bytes summiert
+  und im Ticket #2132 dokumentiert (Bezugszahl).
+- `henemm-infra/nginx/nginx.conf`: `gzip_types` aktivieren (Zeile 53 ist auskommentiert und
+  enthält bereits `application/json` — der für die Daten-Nachladungen relevante Content-Type).
+  Selbst committen in `henemm-infra` (keine MQ-Nachricht an `infra` — [[reference_all_parallel_sessions_are_claude_code]]).
+  BREACH-Abwägung wird im Commit/Ticket sichtbar dokumentiert (Kompression bei
+  Anmelde-Bezug ist theoretisch angreifbar, hier aber nicht ausnutzbar, da kein Angreifer
+  eigenen Inhalt in unsere Antworten einschleusen kann).
+- Nachher-Messung: dieselbe Sitzung, dieselbe Methode, Vergleichszahl im Ticket #2132.
+
+## Was darf sich nicht ändern
+- Programmdateien-Caching (`cache-control: public,max-age=31536000,immutable`, Brotli) bleibt
+  unangetastet — bereits gut, siehe Ticket.
+- Keine Kompression auf der Strecke Go-Dienst ↔ Frontend (localhost) — dort wirkungslos,
+  nicht Gegenstand dieser Änderung.
+- Kein Code in `gregor_zwanzig` selbst (weder `src/`, `api/`, `internal/`, `frontend/`).
+
+## Manuelle Test-Schritte
+1. Vorher-Mitschnitt: Login + Trip öffnen + Briefing ansehen + Ortsvergleich öffnen gegen
+   Produktion (`https://gregor20.henemm.com`), Netzwerk-Bytes der Daten-Antworten summieren.
+2. `gzip_types` in `henemm-infra/nginx/nginx.conf` aktivieren, `nginx -t` + reload, in
+   `henemm-infra` committen.
+3. Nachher-Mitschnitt: identische Schrittfolge, Bytes summieren, `Content-Encoding: gzip` an
+   den Daten-Antworten in den Response-Headern verifizieren.
+4. Vorher/Nachher-Zahlen ins Issue #2132 eintragen.
+
+## Inline-Test (wird während Implementierung geschrieben)
+- [ ] Kein automatisierter Test — reine Infrastruktur-/Messaufgabe ohne Code in diesem Repo.
+  Nachweis ist die dokumentierte Vorher/Nachher-Messung (siehe manuelle Test-Schritte).


### PR DESCRIPTION
## Summary
- Mini-Spec + Dokumentation für #2132 (Scheibe 5 zu #2127): Datenverbrauch unterwegs gemessen und Kompression der Daten-Nachladungen eingeschaltet
- Eigentlicher Fix liegt in `henemm-infra` (Commit `365c47d`) — `gzip_types` + `gzip_proxied any` in `nginx.conf`, bereits live angewendet
- Vorher/Nachher-Messung (Trip-Liste 26.151 → 1.855 Byte, Faktor ~14×) und BREACH-Abwägung im Issue #2132 dokumentiert
- Kein Code-Change in `gregor_zwanzig` selbst, reine Doku-/Spec-Datei

## Test plan
- [x] Manuelle Messung Staging vor/nach dem Fix (`/api/trips`, `/api/trips/{id}`, `/stages/weather`)
- [x] Produktion `/api/health` direkt per curl nach Reload verifiziert (`Content-Encoding: gzip`)
- [x] `nginx -t` vor Live-Reload bestanden
- Docs-only in diesem Repo → Staging-Validierung/Deploy hier nicht erforderlich

Closes #2132

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Twb74vYKN2q8dXavSwoR1C