### PR TITLE
feat(#2186): Ad-hoc-Tageswert gilt ab dem Anfragezeitpunkt

### DIFF
--- a/docs/context/feat-2186-tagesaggregat-ab-jetzt.md
+++ b/docs/context/feat-2186-tagesaggregat-ab-jetzt.md
@@ -1,0 +1,322 @@
+# Context: feat-2186-tagesaggregat-ab-jetzt
+
+**Issue:** #2186 — Tages-Aggregate im Ad-hoc-Abruf rechnen die vergangenen Stunden mit
+(Teil A aus Scheibe S2 von Epic #2133)
+**Track:** Full Process
+**Erstellt:** 2026-09-08
+
+## Request Summary
+
+Wer mittags `glance`, `heute_gewitter` oder `timeline_heute` abruft, bekommt den bereits
+vergangenen Vormittag mitgerechnet — der Regen von 08:00 fließt in den Tageswert ein. Der
+Abruf beantwortet den Kalendertag, nicht das verbleibende Fenster. Für **morgen** darf sich
+dagegen nichts ändern: ein noch nicht begonnener Tag wird durch „ab jetzt" nicht eingeschränkt.
+
+Der stündliche Einzelgrößen-Verlauf ist bereits gefenstert (S1, #2134, `_day_window`) — nur die
+**Tages-Aggregate** hängen noch am vollen Kalendertag.
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `src/services/trip_command_processor.py:1304` | `_aggregate_day()` — der Prüfling. Aggregiert `TimelinePoint.metrics` über den ganzen Ortstag |
+| `src/services/trip_command_processor.py:1381` | `_fmt_glance()` — Leser (heute + morgen, zwei Aufrufe `:1395`/`:1396`) |
+| `src/services/trip_command_processor.py:1410` | `_fmt_gewitter()` — Leser (nur heute, `:1420`) |
+| `src/services/trip_command_processor.py:1508` | `_timeline_buttons()` — Leser (beide Tage, `:1513`) |
+| `src/services/trip_command_processor.py:1448` | `_fmt_timeline()` — **filtert eigenständig** auf Kalendertag, ruft `_aggregate_day` NICHT. Eigene Behandlung nötig |
+| `src/services/trip_command_processor.py:761` | `_handle_query()` — einziger Aufrufer aller vier Formatierer, hält `received_at` (`:762`), berechnet Tage/Zonen (`:781-785`) |
+| `src/services/trip_command_processor.py:1133` | `_day_window()` — bestehende Fensterlogik der Drilldowns |
+| `src/app/day_window.py:89` | `segment_window_points(start_time, end_time, points)` — generischer Stundenschnitt, beliebige Grenzen |
+| `src/services/weather_metrics.py:462` | `compute_basis_metrics()` — geteilte Stunden→Aggregat-Rechnung |
+| `src/services/weather_extractor.py:80-116` | `timeline()`/`_punkte()` — baut `TimelinePoint` aus Snapshot; **reicht die Stundenreihe nicht durch** |
+| `src/services/weather_snapshot.py:484` | `_serialize_segment()` — schreibt `entry["hourly"]` |
+| `src/services/weather_snapshot.py:546` | `_deserialize_timeseries()` — rekonstruiert die Reihe beim Laden |
+| `src/app/models.py:103` | `ForecastDataPoint` — Stundenpunkt, `ts` ist **naive UTC** |
+| `src/app/models.py:443` | `SegmentWeatherSummary` — das fertige Etappen-Aggregat |
+
+## Gemessener Ist-Stand (2026-09-08, echte Prod-Snapshots)
+
+Gemessen an `/var/lib/gregor/users/henning/weather_snapshots/` (`5f534011.json`,
+`5f534011_2026-08-30.json`, `5f534011_alarm_anchor.json`).
+
+### Die Stundenreihe liegt im Bestand vor
+
+Alle geprüften Snapshots, alle Segmente: `hourly` mit **24 Punkten**, Spanne `00:00`–`23:00`
+UTC. Die Reihe überlebt den JSON-Roundtrip. Die Lösungsform „aus Stundenreihen rechnen" ist
+also tragfähig — nicht nur laut Typ-Annotation, sondern im Bestand.
+
+### 🔴 Die Stundenreihe deckt den GANZEN Tag, das Aggregat nur die Gehzeit
+
+Das ist der zentrale Befund. Pro Segment liegt die **volle Tagesreihe** der Segment-Position,
+das gespeicherte `aggregated` ist aber auf das **Etappenfenster** beschnitten:
+
+| Segment (Tour 05.09.) | Etappenfenster | Stunden im Fenster | gespeichert `t_max` | über alle 24 h |
+|---|---|---|---|---|
+| 1 | 06:00–07:20 | 1 | 16.8 °C | 20.7 °C |
+| 2 | 07:20–09:22 | 2 | 18.2 °C | 20.0 °C |
+| 3 | 09:22–11:23 | 2 | 22.7 °C | 24.2 °C |
+| 4 | 11:23–12:09 | 1 | 27.2 °C | 28.1 °C |
+| Ziel | 12:09–19:00 | 6 | 28.0 °C | 28.0 °C |
+
+**Folge:** Ein Fix, der `_aggregate_day` naiv auf die rohen Stundenreihen umstellt, zieht die
+**Nachtstunden** ins Tagesaggregat. Das ist genau der unter #1653 abgewehrte Fehler („das
+24 h-Aggregat erfindet ein Tagesgewitter, das im Tagesfenster nie stattfand") und widerspricht
+dem dreifach bestätigten PO-Entscheid „strikt nur Tagesfenster" (#1841/#1848 A3).
+
+Das korrekte Fenster ist die **Schnittmenge**: `Etappenfenster ∩ [jetzt … Ortsmitternacht]`.
+
+### Der Stundenschnitt hat eine exakte Rundungsregel — nicht selbst nachbauen
+
+`segment_window_points()` rundet beide Grenzen auf volle Stunden ab und schließt die Endstunde
+aus (`[start_floor, end_floor)`, Bug #806; Sonderfall Ein-Stunden-Segment, Bug #856). Eine
+naive Nachrechnung mit `start <= ts < end` wich in der Messung um 1,3 °C ab (18.1 statt 16.8),
+weil sie die Stunde 07:00 des 06:00–07:20-Segments mitnahm. Der Helfer ist Pflicht.
+
+### `hail_flag` fehlt in den Stundenpunkten des Bestands
+
+In allen drei geprüften Snapshots trägt **kein** Stundenpunkt `hail_flag` (die Serialisierung
+lässt `None` weg), und auch `aggregated.hail_flag` fehlt. Der Hagel-Pfad ist im Bestand also
+durchgehend „unbekannt" — heute wie nach dem Fix. Kein Regressionsrisiko, aber auch **kein
+Beweisträger**: ein Test, der Hagel über echte Snapshots prüfen will, misst nichts.
+
+### `pop_max_pct` ist nicht in `compute_basis_metrics`
+
+`pop_max_pct` entsteht nur in `compute_extended_metrics()` (`weather_metrics.py:1156`), und
+die läuft **ausschließlich im Fetch-Pfad** (`segment_weather.py:314`), nie beim Snapshot-Laden.
+Wer die Tageswerte über `compute_basis_metrics()` neu rechnet, bekommt dort still `None` — und
+`None` sieht in der Ausgabe aus wie „keine Daten", nicht wie ein Fehler.
+
+**Aber:** der Rohwert `pop_pct` liegt in jedem Stundenpunkt vor. Die Größe ist aus der
+Stundenreihe direkt herleitbar; sie braucht nur eine ausdrückliche Behandlung.
+
+## Existing Patterns
+
+- **`_day_window()` (`:1133`)** ist das etablierte Muster für „welches Fenster meint dieses
+  Tages-Token". Es unterscheidet bereits richtig: `today` → ab `received_at`, `morgen` → ab
+  Ortsmitternacht. Es liefert für `today` allerdings eine **Dauer von 12 Stunden**, keine
+  Kalendertagsgrenze (ausführlich begründet `:1144-1149`) — siehe Risiken.
+- **`_local_midnight(date, tz)`** ist der vorgesehene Weg zur Ortsmitternacht. Rohe
+  `.astimezone()`/`date.today()`-Aufrufe sind durch den CI-Wächter
+  `tests/tdd/test_output_timezone_guard.py` gesperrt (Auflage aus `fix_1795`).
+- **Eine Rechnung, nicht zwei:** `_aggregate_day` bildet Stufe und tragende Zutat aus
+  *derselben* gefilterten Punktliste (`:1334-1348`, #1680 Spec D6). Der Quelltext markiert eine
+  dritte Eigenimplementierung derselben Regel ausdrücklich als Fehler (#1480). Für die
+  Zutaten-Vereinigung und die Hagel-Priorität existieren geteilte Helfer
+  (`union_of_max_carriers`, `hail_priority`, `thunder_ordinal` in `output/metric_format`).
+- **Zwei-Zonen-Test:** `fix_1795` AC-4 prüft `_fmt_glance` mit heute in neuseeländischer und
+  morgen in korsischer Zone in **einem** Durchgang. Dieses Muster trägt den vom Ticket
+  geforderten Nachweis „ab jetzt fasst morgen nicht an".
+
+## Dependencies
+
+**Upstream (was wir benutzen):**
+- `WeatherSnapshotService.load()` → `List[SegmentWeatherData]` mit `timeseries` + `aggregated`
+- `weather_extractor.timeline()` → `TimelineResult` mit `TimelinePoint(arrival_time, metrics)`
+- `segment_window_points()`, `compute_basis_metrics()`, `output.metric_format.*`
+- `services.trip_day`: `trip_local_now`, `anchor_tz`, `display_tz`, `local_dt`, `_local_midnight`
+
+**Downstream (was uns benutzt):**
+- Telegram: `/glance` `/s` `/status`, `/hg` `/gewitter`, `/th`, `/tm` — je als Freitext-Kommando
+  **und** als Button-Callback (`### query: …`)
+- **E-Mail:** `glance` und `gewitter` sind über `_BARE_KEYWORD_MAP` (`:104`, `:111`) auch per
+  E-Mail-Freitext erreichbar. `timeline_heute`/`timeline_morgen` sind Telegram-only.
+  → **Der Fix betrifft zwei Kanäle.** Eine reine Telegram-Prüfung misst die halbe Wirkung.
+- **Nicht betroffen:** die Mail-Renderer (`output/renderers/day_window.py`, `narrow.py`,
+  `compact_summary.py`, `outlook.py`) haben eine eigene, feste 04–19-Uhr-Fensterlogik. SMS-Tokens
+  (`tokens/builder.py`) lesen das Etappen-Aggregat, nicht `_aggregate_day`.
+
+## Existing Specs
+
+| Spec | Berührung |
+|---|---|
+| `docs/specs/modules/fix_1818_timeline_tagesaufloesung.md` | Gestufte Quellenauflösung für alle vier Formatierer. AC-1/3/4 bleiben gültig (prüfen Quellenwahl, nicht Tagesgrenze). AC-5 (`glance` unterscheidet heute/morgen) ist berührt |
+| `docs/specs/modules/fix_1795_timeline_ortszeit.md` | AC-2/3/4/5 binden den Filter an den **Ortstag** von `arrival_time`. Der Filter wandert auf `ts` — die ACs müssen mitgezogen werden. Auflage: kein rohes `.astimezone()`, CI-Wächter aktiv |
+| `docs/specs/modules/fix_1470_drilldown_ortszeit.md` | Bestätigend. AC-4: Fenstergrenze und Beschriftung stammen aus **derselben** Zonen-Auflösung — diese Pflicht erbt `_aggregate_day`, sobald es die Fensterung übernimmt |
+| `docs/specs/modules/feat_2134_adhoc_abruf_metrik_katalog.md` | Sagt ausdrücklich: „Ortstag bleibt unverändert. Diese Spec baut das nicht neu." (`:157-159`) |
+| `docs/specs/modules/feat_2185_verlauf_wechselpunkte.md` | Grenzt das „ab jetzt"-Fenster der drei Tages-Aggregat-Antworten ausdrücklich aus — das ist #2186 |
+
+**Es gibt keine Spec, die „Tages-Aggregat ab Anfragezeitpunkt" bereits festschreibt.** Freies
+Feld, nichts wird still überschrieben.
+
+## Risks & Considerations
+
+1. **🔴 Nachtstunden-Falle.** Rohe Stundenreihen statt Etappen-Aggregate verbreitern das
+   Tagesfenster still auf 24 h (siehe Messung oben). Muss als Schnittmenge gebaut und als
+   eigene AC bewacht werden. Fixtures mit kurzen Reihen fangen diesen Fehler **nicht**.
+
+2. **🔴 „Morgen" darf sich nicht ändern.** Ein Test, der nur „heute" prüft, fängt den Fehler
+   nicht — das Ticket sagt das ausdrücklich. Nachweisform steht bereit (`fix_1795` AC-4,
+   Zwei-Zonen-Aufbau).
+
+3. **🔴 Fünf Ausgabestellen, vier davon über `_aggregate_day`, eine daneben.** `_fmt_timeline`
+   (`:1448`) filtert selbst. Ein Fix, der nur `_aggregate_day` erreicht, lässt `timeline_heute`
+   falsch — das Ticket nennt das die naheliegende Mutationsfalle.
+
+4. **Offene Entscheidung: Was heißt „ab jetzt" für heute — bis Ortsmitternacht oder 12 Stunden
+   Dauer?** `_day_window("today")` liefert heute eine **Dauer von 12 Stunden**, die abends in
+   den Folgetag ragt. Für ein Tages-Aggregat geht das nicht: `glance` stellt „heute" und
+   „morgen" nebeneinander, bei 12 h Dauer überlappten beide Zeilen ab dem Nachmittag.
+   **Empfehlung: `jetzt … Ortsmitternacht`.** Bekannte Folge, die in die Spec-Freigabe gehört:
+   Ein Abruf um 22:00 zeigt für „heute" nur noch zwei Stunden. Ob dann eine Fehlanzeige oder
+   ein Zwei-Stunden-Wert erscheinen soll, ist eine Produktentscheidung.
+   *Keine Spec-Deckung für die 12-Stunden-Regel gefunden — nur ein Quelltext-Kommentar.*
+
+5. **`pop_max_pct` würde still `None`.** Braucht eine eigene AC, sonst verschwindet die
+   Regenwahrscheinlichkeit unbemerkt aus der Ausgabe.
+
+6. **Signaturänderung an vier Formatierern.** `received_at` muss durch `_fmt_glance`,
+   `_fmt_gewitter`, `_timeline_buttons`, `_fmt_timeline` und `_aggregate_day` gereicht werden.
+   Wächter liegen erfahrungsgemäß in **fremden** Testdateien → vor dem Commit `grep -rln` über
+   `tests/`.
+
+7. **Zeitzonen-Randfall.** Die Stundenreihe eines Snapshots deckt den **UTC**-Kalendertag ab
+   (00:00–23:00). Bei großem Zonenversatz (die `fix_1795`-Tests benutzen Neuseeland, UTC+12)
+   liegen Teile des **Orts**tages außerhalb dieser Reihe. Zu klären: ob der Ortstag-Rand dann
+   Punkte verliert und ob die gestufte Quellenauflösung aus `fix_1818` das auffängt.
+
+8. **Reichweite prüfen, nicht annehmen.** Der Ortsvergleich hat eigene Snapshots
+   (`compare_weather_snapshots/`). Ob dort dieselben Ad-hoc-Abrufe existieren, ist noch nicht
+   gemessen — Ortsvergleich-Themen sind ohnehin zurückgestellt, aber die Aussage „nicht
+   betroffen" braucht einen Beleg statt einer Vermutung.
+
+---
+
+# Analysis (Phase 2, 2026-09-08)
+
+## Type
+
+**Feature** (Label `enhancement`). Kein Bug: das heutige Verhalten ist spezifiziert
+(Kalendertag-Filter, `fix_1795`), es wird bewusst geändert.
+
+## Der Angriffspunkt liegt stromaufwärts
+
+`_aggregate_day` hat **keinen Zugriff auf die Stundenreihe** — nach
+`weather_extractor.timeline()` sind nur noch fertige Etappen-Aggregate übrig
+(`_punkte()`, `weather_extractor.py:102-116`: `metrics=seg.aggregated`). Die Stundenreihe
+liegt genau **eine Zeile vorher** noch vor und wird dort verworfen.
+
+Daraus folgt der Ansatz: **Die Fensterung gehört in `_punkte()`, nicht in `_aggregate_day`.**
+
+```
+timeline(trip_id, target_date, from_time=None)
+  └─ _punkte(segments, from_time)
+       für jedes Segment:
+         beschnitten = max(seg.start_time, from_time)
+         wenn beschnitten <= seg.start_time  → seg.aggregated UNVERÄNDERT übernehmen
+         wenn beschnitten >= seg.end_time    → Segment entfällt (ganz vergangen)
+         sonst                                → Aggregat NEU über [beschnitten, seg.end)
+```
+
+### Warum das die Mutationsfalle des Tickets auflöst
+
+`_handle_query` ruft `extractor.timeline(trip.id)` **genau einmal**
+(`trip_command_processor.py:802`/`:806`) und reicht dasselbe Objekt an alle fünf
+Ausgabestellen. Ein Eingriff in `_punkte()` erreicht damit alle fünf — auch `_fmt_timeline`
+(`:1462` liest `p.metrics` aus derselben `timeline`), das sonst separat hätte gefixt werden
+müssen. Das Ticket nennt „ein Fix, der nur einen Leser erreicht" als naheliegende
+Mutationsfalle; dieser Ansatz macht sie strukturell unmöglich.
+
+**Folge: Risiko 6 des Kontextteils entfällt.** Die Signaturänderung an vier Formatierern wird
+nicht gebraucht — sie bleiben unverändert, `received_at` muss nicht durchgereicht werden. Statt
+elf Testdateien wegen einer Signaturkaskade sind nur die Tests betroffen, die das *Verhalten*
+prüfen.
+
+## Die drei stillen Regressionen, die der Ansatz mitbringt
+
+Sie sind der eigentliche Inhalt der Spec — ohne eigene ACs treten sie garantiert ein.
+
+### 1. Neu rechnen heißt: die GANZE Kette, nicht ihre erste Hälfte
+
+Im Abruf-Pfad läuft das Segment-Aggregat über **zwei** Schritte
+(`segment_weather.py:310` → `:314`): `compute_basis_metrics()` und danach
+`compute_extended_metrics()`, wobei der zweite die Felder des ersten weiterträgt
+(`weather_metrics.py:1009-1011`).
+
+`compute_extended_metrics` bildet **18 weitere Felder**: `pop_max_pct`, `cape_max_jkg`,
+`uv_index_max`, `dewpoint_avg_c`, `pressure_avg_hpa`, `wind_chill_min/max_c`, `snow_depth_cm`,
+`freezing_level_m`, `snowfall_limit_m`, `cloud_low/mid/high_avg_pct`, `precip_type_dominant`,
+`wind_direction_avg`, `confidence_pct`, Frischschnee.
+
+Wer nur `compute_basis_metrics()` aufruft, leert sie alle still. `None` sieht in der Ausgabe
+aus wie „keine Daten", nicht wie ein Fehler. → **AC-Pflicht: dieselbe Kette in derselben
+Reihenfolge.**
+
+### 2. Unbeschnittene Segmente dürfen NICHT neu gerechnet werden
+
+Der naheliegende Vereinfachungsvorschlag lautet: `from_time` immer setzen, für morgen sei
+`max(seg.start, from_time)` ohnehin ein No-Op. Für die *Fenstergrenze* stimmt das — für den
+*Inhalt* nicht: Ein neu gerechnetes Aggregat ist nicht zwingend wertgleich mit dem
+gespeicherten (Snapshot-Meta trägt `model="snapshot"`, `aggregation_config` kann abweichen).
+„Morgen bleibt unberührt" wäre dann nur zufällig wahr.
+
+**Regel: Nur wenn tatsächlich beschnitten wird, wird neu gerechnet.** Damit ist die
+Unberührtheit von „morgen" strukturell garantiert und nicht bloß rechnerisch wahrscheinlich —
+und sie ist prüfbar (Identität des Objekts/der Werte).
+
+### 3. Fehlende Stundenreihe braucht einen Enthaltungs-Zweig
+
+`SegmentWeatherData.timeseries` ist `Optional` (`None` bei Provider-Fehler, und Alt-Snapshots
+könnten sie nicht tragen). `compute_extended_metrics` wirft bei leerer Reihe `ValueError`
+(`weather_metrics.py:958`).
+
+**Regel: keine Stundenreihe → `seg.aggregated` unverändert übernehmen.** Lieber ein
+ungefenstertes Aggregat wie heute als ein falsches oder ein Absturz. Das muss eine eigene AC
+tragen, sonst fällt der Fix im Bestand still auf die Nase.
+
+## Entscheidungsbedarf: Was heißt „ab jetzt" — und was NICHT
+
+Gemessen an einer echten Tour laufen die Etappen von 06:00 (Aufbruch) bis 19:00 (das letzte
+Segment „Ziel" endet am Tagesfensterende). Das heutige Tagesaggregat umfasst also faktisch
+`[Aufbruch … Tagesfensterende]` — **nicht** den Kalendertag.
+
+| Option | Fenster für „heute" | Bewertung |
+|---|---|---|
+| **A (empfohlen)** | `[max(jetzt, Aufbruch) … Tagesfensterende]` | Kleinster Eingriff. Schneidet nur die Vergangenheit weg, lässt unberührt, *was* ein Tageswert bedeutet |
+| B | `[max(jetzt, 04:00) … 19:00]` (ADR-0035) | Vereinheitlichte Semantik, aber zieht Stunden **vor dem Aufbruch** neu herein — eigene Produktänderung |
+| C | `[jetzt … Ortsmitternacht]` | Zieht die **Nachtstunden** herein. Widerspricht dem 3× bestätigten PO-Entscheid „strikt nur Tagesfenster" (#1841/#1848) und der Abwehr aus #1653 |
+| D | `[jetzt … +12 h]` | Die Vorgabe aus dem #2185-Kontextdokument. **Nicht tragfähig:** `glance` zeigt heute und morgen nebeneinander; ab dem Nachmittag enthielten beide Zeilen dieselben Stunden |
+
+**Empfehlung A.** Sie ist die einzige Option, die keine zweite Entscheidung mitschmuggelt.
+Bekannte Folge, die in die Freigabe gehört: Ein Abruf **nach** Tagesfensterende hat ein leeres
+Fenster für „heute" — was dann erscheint (Fehlanzeige oder letzter bekannter Wert), ist eine
+Produktentscheidung, keine technische.
+
+*Für D gibt es keine gültige Deckung: die einzige AC mit 12 Stunden
+(`telegram_tier3_drilldown.md` AC-1) ist seit 2026-09-07 durch #2185 abgelöst; die Begründung
+in `trip_command_processor.py:1144-1149` ist ein Quelltext-Kommentar, keine freigegebene
+Zusicherung.*
+
+## Affected Files
+
+| Datei | Änderung | Beschreibung |
+|---|---|---|
+| `src/services/weather_extractor.py` | MODIFY | `timeline()` erhält `from_time`; `_punkte()` rechnet beschnittene Segmente neu (volle Kette), lässt unbeschnittene unangetastet, enthält sich ohne Stundenreihe |
+| `src/services/trip_command_processor.py` | MODIFY | `from_time=received_at` an den `timeline()`-Aufruf (`:802`/`:806`) |
+| `tests/tdd/test_adhoc_tageswert_ab_anfragezeit.py` | CREATE | Verhaltensnachweis: Vormittag fällt raus, morgen unberührt (Zwei-Zonen-Aufbau nach `fix_1795` AC-4) |
+| `tests/tdd/test_tageswert_fenster_erhaelt_alle_metriken.py` | CREATE | Nachweis gegen die drei stillen Regressionen (volle Kette, unbeschnitten = unverändert, Enthaltung ohne Stundenreihe) |
+| `tests/unit/test_weather_extractor.py` | MODIFY | `timeline()`-Signatur, Rückwärtskompatibilität ohne `from_time` |
+| bestehende Tests | PRÜFEN | `grep -rln` über `tests/` nach `.timeline(`; laut Messung 4 Dateien, alle ohne `from_time` → Default `None` bricht sie nicht |
+
+## Scope Assessment
+
+- Produktivdateien: **2**
+- Geschätzte LoC: Produktivcode **+40/-5**, Tests **+150–200**
+- Risk Level: **MEDIUM** — kleiner Eingriff, aber an einer Stelle, die fünf Ausgaben und zwei
+  Kanäle speist; die Gefahr liegt nicht im Umfang, sondern in den drei stillen Regressionen
+
+## Open Questions (für die Spec-Freigabe)
+
+- [ ] **Fensterwahl A/B/C/D** — Empfehlung A, siehe Tabelle oben (Produktentscheidung)
+- [ ] **Abruf nach Tagesfensterende:** Fehlanzeige oder letzter bekannter Wert?
+      (Produktentscheidung)
+- [ ] Zeitzonen-Randfall (Kontext-Risiko 7): Die Stundenreihe deckt den **UTC**-Tag ab. Bei
+      großem Zonenversatz kann der Ortstag-Rand außerhalb liegen. Mit Option A entschärft, weil
+      das Fenster ohnehin innerhalb der Etappen liegt — im TDD-RED trotzdem mit der
+      neuseeländischen Zone aus `fix_1795` nachzumessen
+- [ ] Ortsvergleich (Kontext-Risiko 8): „nicht betroffen" ist noch Vermutung. Belegen oder in
+      der Spec als bewusst außerhalb führen (Ortsvergleich-Themen sind zurückgestellt)
+
+## Nächster Schritt
+
+`/30-write-spec` — Spec mit ACs auf Deutsch, Freigabe durch den PO. Die vier offenen Punkte
+oben gehören ausdrücklich in die Freigabe.

--- a/docs/specs/modules/feat_2186_tagesaggregat_ab_jetzt.md
+++ b/docs/specs/modules/feat_2186_tagesaggregat_ab_jetzt.md
@@ -1,0 +1,257 @@
+---
+entity_id: feat_2186_tagesaggregat_ab_jetzt
+type: module
+created: 2026-09-08
+updated: 2026-09-08
+status: draft
+version: "1.0"
+tags: [ad-hoc-abruf, timeline, tagesaggregat, telegram, email]
+---
+
+# Tagesaggregat ab Anfragezeitpunkt (Ad-hoc-Abruf)
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Beim Ad-hoc-Abruf (`glance`, `heute_gewitter`, `timeline_heute`) rechnet das Tages-Aggregat
+für „heute" bislang den bereits vergangenen Vormittag mit — ein Abruf um 14:00 zeigt noch den
+Regen von 08:00. Diese Spec fenstert die Tages-Aggregatbildung auf `[jetzt … Segmentende]` und
+lässt „morgen" dabei strukturell unberührt.
+
+## Offene Produktentscheidungen
+
+**(1) Was umfasst „heute"?**
+Empfehlung: `[max(jetzt, Aufbruch) … Tagesfensterende]` — dasselbe Fenster wie heute, nur vorne
+beschnitten (Schnittmenge aus Etappenfenster und `[jetzt … Ortsmitternacht]`).
+
+Verworfene Alternativen:
+- *Bis Ortsmitternacht:* zöge die Nachtstunden ins Tagesaggregat herein — widerspricht dem 3×
+  bestätigten PO-Entscheid „strikt nur Tagesfenster" (#1841/#1848) und der Abwehr aus #1653.
+- *Feste 04–19 Uhr nach ADR-0035:* zöge Stunden **vor** dem tatsächlichen Aufbruch neu herein —
+  eine eigene Produktänderung, die hier nicht verlangt ist.
+- *Feste 12 Stunden Dauer:* `glance` zeigt „heute" und „morgen" nebeneinander — ab dem
+  Nachmittag enthielten beide Zeilen dieselben Stunden.
+
+**(2) Abruf nach Tagesfensterende, wenn nichts mehr übrig ist.**
+Empfehlung: **Fehlanzeige** statt eines Werts aus vergangenen Stunden — ein Wert würde
+Gültigkeit für ein Fenster behaupten, das nicht mehr existiert (Linie aus #2167: nie Gültigkeit
+für Ungemessenes behaupten; ADR-0007: nur Daten, keine Handlungsempfehlung).
+
+## Source
+
+- **File:** `src/services/weather_extractor.py`
+- **Identifier:** `timeline()`, `_punkte()` (`:102-116`)
+
+> Python-Core / Domain-Backend (`src/services/`). Zusätzlich betroffen:
+> `src/services/trip_command_processor.py:802`/`:806` (Aufrufer, `from_time=received_at`).
+
+## Estimated Scope
+
+- **LoC:** Produktivcode ca. +40/-5, Tests +150–200
+- **Files:** 2 Produktivdateien, 2 neue Testdateien, 1 erweiterte Testdatei
+- **Effort:** medium
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `src/app/day_window.py:89` `segment_window_points()` | Helper | Exakter Stundenschnitt `[start_floor, end_floor)` — Pflicht, keine eigene Nachrechnung (Bug #806/#856) |
+| `src/services/segment_weather.py:310/:314` | Rechenkette | `compute_basis_metrics()` → `compute_extended_metrics()` — beide Stufen, in dieser Reihenfolge |
+| `src/services/weather_metrics.py:462/:1156` | Helper | `compute_basis_metrics()`, `compute_extended_metrics()` (bildet u.a. `pop_max_pct`) |
+| `src/services/trip_command_processor.py:761` `_handle_query()` | Aufrufer | Hält `received_at`, ruft `timeline()` genau einmal, reicht Ergebnis an alle 5 Ausgabestellen |
+| `src/services/trip_command_processor.py:104/:111` `_BARE_KEYWORD_MAP` | Aufrufer | Macht `glance`/`gewitter` auch per E-Mail-Freitext erreichbar |
+
+## Implementation Details
+
+```
+timeline(trip_id, target_date, from_time: datetime | None = None)
+  └─ _punkte(segments, from_time)
+       für jedes Segment:
+         wenn from_time is None oder seg.timeseries is None:
+             → seg.aggregated UNVERÄNDERT übernehmen (kein Fehler)
+         schnitt_start = max(seg.start_time, from_time)
+         wenn schnitt_start <= seg.start_time:
+             → seg.aggregated UNVERÄNDERT übernehmen (noch nicht begonnen / from_time davor)
+         wenn schnitt_start >= seg.end_time:
+             → Segment entfällt (vollständig vergangen)
+         sonst (Segment wird beschnitten):
+             punkte = segment_window_points(schnitt_start, seg.segment.end_time,
+                                            seg.timeseries.data)
+             wenn punkte leer:
+                 → seg.aggregated UNVERÄNDERT übernehmen (siehe AC-8)
+             fenster_ts = NormalizedTimeseries(meta=seg.timeseries.meta, data=punkte)
+             basis = compute_basis_metrics(
+                         fenster_ts,
+                         tz=<Ortszone dieses Segments>,
+                         day_window_start_hour=seg.segment.day_window_start_hour,
+                         day_window_end_hour=seg.segment.day_window_end_hour)
+             neu   = compute_extended_metrics(fenster_ts, basis)
+             → neu als Aggregat für dieses Segment übernehmen
+```
+
+**Signaturtreue (am Quelltext geprüft, nicht abgeleitet):**
+
+- `segment_window_points(start_time, end_time, points)` (`src/app/day_window.py:89`) nimmt eine
+  **Punktliste**, keine `NormalizedTimeseries`; Endgrenze exklusiv nach Stundenabrundung.
+- `compute_basis_metrics(timeseries, *, tz, day_window_start_hour=None, day_window_end_hour=None)`
+  (`src/services/weather_metrics.py:462`) — `tz` ist **keyword-only und Pflicht**. Die Fensterstunden
+  wirken NUR auf `thunder_onset_utc`/`precip_heavy_onset_utc`, nicht auf die übrigen Felder.
+- `compute_extended_metrics(timeseries, basis_summary)` (`src/services/weather_metrics.py:930`) —
+  nimmt **keine** Fensterstunden und wirft `ValueError` bei leerer Reihe
+  (`weather_metrics.py:958`); daher der Leer-Zweig oben.
+- Die Fensterstunden hängen am **Segment** (`seg.segment.day_window_start_hour`, so auch in
+  `weather_snapshot.py:512-517` serialisiert) — beim Implementieren gegenprüfen, ob der Wert
+  zusätzlich auf `SegmentWeatherSummary` gespiegelt ist, und die tatsächlich gefüllte Quelle
+  verwenden.
+
+**Korrekturen aus der RED-Phase (2026-09-08, am Quelltext geprüft — die Skizze oben ist an
+diesen drei Punkten ungenau):**
+
+1. `compute_basis_metrics`/`compute_extended_metrics` sind **Methoden** von
+   `WeatherMetricsService` (`weather_metrics.py:241`), keine freien Funktionen. Es braucht eine
+   Instanz.
+2. Das Vorbild `segment_weather.py:307-314` löst die Fensterstunden **erst** über
+   `resolve_configured_window(segment.day_window_start_hour, segment.day_window_end_hour)` auf
+   und übergibt `tz=location_tz(segment.start_point)`. Diesen Weg übernehmen, nicht die rohen
+   Segmentwerte durchreichen.
+3. `from_time` muss **hinter** `target_date` stehen. `tests/unit/test_ziel_segment_anzeige_invarianz.py:287`
+   ruft `timeline("anzeige-1599", TAG)` mit dem Datum als zweitem **Positions**argument — ein
+   `from_time` an zweiter Stelle bräche diesen Test.
+
+Weiter am Bestand bestätigt: Der Snapshot-Roundtrip (`save`/`load`) erhält alle Rohfelder der
+Stundenreihe (`cape_jkg`, `uv_index`, `cloud_low_pct`, `snowfall_limit_m`, `precip_type` …)
+**und** `segment.day_window_start_hour`/`_end_hour` — die Neuberechnung hat also alles, was sie
+braucht. Alle bestehenden `timeline()`-Aufrufer (2 in `src/`, 3 in `tests/`) übergeben kein
+`from_time`; der Default `None` bricht keinen davon.
+
+`trip_command_processor.py` übergibt `from_time=received_at` an den bestehenden
+`timeline()`-Aufruf (`:802`/`:806`). Die vier Formatierer (`_fmt_glance`, `_fmt_gewitter`,
+`_timeline_buttons`, `_fmt_timeline`) und `_aggregate_day` bleiben signaturunverändert — sie
+lesen alle aus demselben `TimelineResult`, das `_punkte()` bereits gefenstert liefert.
+
+## Expected Behavior
+
+- **Input:** Ad-hoc-Abruf (`glance`, `heute_gewitter`, `timeline_heute`) zu einem Zeitpunkt
+  `received_at`, der innerhalb oder nach Tourbeginn liegt.
+- **Output:** Tages-Aggregat „heute" spiegelt nur `[max(received_at, Segmentstart) …
+  Segmentende]`; vollständig vergangene Segmente entfallen aus den Wegpunkten. „morgen" bleibt
+  identisch zu einem früheren Abruf am selben Tag.
+- **Side effects:** keine — reine Lesepfad-Änderung, keine Persistenz-Schreibung.
+
+## Acceptance Criteria
+
+- **AC-1:** Given ein Abruf von `glance` am Nachmittag, When der Vormittag bereits Niederschlag
+  aufwies, Then enthält der Tageswert für „heute" den Niederschlag des Vormittags nicht mehr.
+  - Test: `tests/tdd/test_adhoc_tageswert_ab_anfragezeit.py`
+
+- **AC-2:** Given zwei Abrufe am selben Tag zu unterschiedlichen Uhrzeiten, When beide die
+  Zeile „morgen" lesen, Then sind die Werte für „morgen" bei beiden Abrufen wertgleich — „ab
+  jetzt" verändert den Folgetag nicht.
+  - Test: `tests/tdd/test_adhoc_tageswert_ab_anfragezeit.py`
+
+- **AC-3:** Given ein Segment, dessen Beginn nach dem Anfragezeitpunkt liegt, When die
+  Tages-Aggregation läuft, Then behält dieses Segment sein gespeichertes Aggregat unverändert
+  (keine Neuberechnung, Werte identisch zum ungefensterten Abruf).
+  - Test: `tests/tdd/test_tageswert_fenster_erhaelt_alle_metriken.py`
+
+- **AC-4:** Given ein Segment, das zum Anfragezeitpunkt teilweise vergangen ist, When die
+  Tages-Aggregation läuft, Then wird sein Aggregat über das mit `segment_window_points()`
+  beschnittene Fenster `[Anfragezeitpunkt, Segmentende)` neu berechnet.
+  - Test: `tests/tdd/test_adhoc_tageswert_ab_anfragezeit.py`
+
+- **AC-5:** Given ein Segment, das zum Anfragezeitpunkt vollständig vergangen ist, When die
+  Wegpunkte für „heute" gebildet werden, Then erscheint dieses Segment nicht mehr in den
+  Wegpunkten.
+  - Test: `tests/tdd/test_adhoc_tageswert_ab_anfragezeit.py`
+
+- **AC-6:** Given ein beschnittenes Segment mit vorhandener Stundenreihe, When sein Aggregat
+  neu berechnet wird, Then trägt das neue Aggregat die Felder **beider** Rechenstufen —
+  mindestens `pop_max_pct`, `cape_max_jkg`, `uv_index_max`, `cloud_low_avg_pct`,
+  `precip_type_dominant` und `snowfall_limit_m` sind belegt (nicht `None`), sofern die
+  Stundenreihe die zugehörigen Rohwerte trägt.
+  - Test: `tests/tdd/test_tageswert_fenster_erhaelt_alle_metriken.py`
+  - Wichtigste AC dieser Spec: sie bewacht 18 Felder, die bei einer unvollständigen
+    Rechenkette still `None` würden — sichtbar als „keine Daten", ohne dass etwas fehlschlägt.
+
+- **AC-7:** Given ein beschnittenes Segment mit eigenem `day_window_start_hour`/
+  `day_window_end_hour`, When sein Aggregat neu berechnet wird, Then werden diese Werte an die
+  Neuberechnung durchgereicht, sodass `thunder_onset_utc`/`precip_heavy_onset_utc` nicht auf den
+  04–19-Uhr-Default zurückfallen.
+  - Test: `tests/tdd/test_tageswert_fenster_erhaelt_alle_metriken.py`
+
+- **AC-8:** Given ein Segment ohne Stundenreihe (`seg.timeseries is None`), When die
+  Tages-Aggregation für dieses Segment läuft, Then bleibt sein gespeichertes Aggregat
+  unverändert und es entsteht kein Fehler (kein `ValueError`, kein Absturz).
+  - Test: `tests/tdd/test_tageswert_fenster_erhaelt_alle_metriken.py`
+
+- **AC-9:** Given ein Aufruf von `timeline()` ohne `from_time`, When die bestehenden vier
+  Aufrufer diesen Aufruf unverändert nutzen, Then verhält sich `timeline()` exakt wie vor
+  dieser Änderung (Rückwärtskompatibilität).
+  - Test: `tests/tdd/test_weather_extractor.py`
+
+- **AC-10:** Given einen Ad-hoc-Abruf, When er über `_fmt_glance`, `_fmt_gewitter`,
+  `_timeline_buttons`, `_fmt_timeline` oder `_aggregate_day` ausgegeben wird, Then wirkt die
+  Fensterung auf **alle fünf** Ausgabestellen gleichermaßen (kein Ausgabepfad zeigt noch den
+  ungefensterten Vormittag).
+  - Test: `tests/tdd/test_adhoc_tageswert_ab_anfragezeit.py`
+
+- **AC-11:** Given denselben `glance`- bzw. `gewitter`-Abruf einmal per Telegram-Freitext und
+  einmal per E-Mail-Freitext über `_BARE_KEYWORD_MAP`, When beide zum selben Zeitpunkt
+  abgesetzt werden, Then ist die Fensterung in beiden Kanälen identisch wirksam.
+  - Test: `tests/tdd/test_adhoc_tageswert_ab_anfragezeit.py`
+
+- **AC-12:** Given eine Tour in einer weit von UTC entfernten Ortszeitzone (Neuseeland, wie in
+  `fix_1795` AC-4), When ein Ad-hoc-Abruf zu einem Ortszeitpunkt erfolgt, Then bleibt die
+  Zuordnung „heute"/„morgen" korrekt und die Fensterung schneidet nicht in den falschen
+  Ortstag.
+  - Test: `tests/tdd/test_adhoc_tageswert_ab_anfragezeit.py`
+
+## Was sich NICHT ändern darf
+
+- **Mail-Renderer** (`src/output/renderers/day_window.py`, `narrow.py`, `compact_summary.py`,
+  `outlook.py`) — eigene, feste 04–19-Uhr-Fensterlogik, bleibt unberührt.
+- **SMS-Token-Bau** (`src/output/tokens/builder.py`) — liest Etappen-Aggregate direkt, nicht
+  `_aggregate_day`.
+- **Alarm-Pfade und tagesdatierte Anker-Snapshots** — nicht Teil dieses Ad-hoc-Abrufpfads.
+- **Das Verhalten für „morgen"** — in jeder Hinsicht wertgleich zu heute, siehe AC-2.
+
+## Known Limitations
+
+- Ein Abruf nach Tagesfensterende (kein verbleibendes Segment für „heute") liefert eine
+  Fehlanzeige statt eines veralteten Werts — siehe Produktentscheidung (2).
+- `hail_flag` fehlt im geprüften Bestand durchgehend (Serialisierung lässt `None` weg); ein
+  Test, der Hagel über echte Snapshots beweisen will, misst nichts und wird hier nicht
+  verlangt.
+- Ortsvergleich-Snapshots (`compare_weather_snapshots/`) sind nicht Teil dieser Spec —
+  Ortsvergleich-Themen sind zurückgestellt.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Reine Verhaltenspräzisierung eines bestehenden Ad-hoc-Abrufpfads
+  (Kalendertag → Restfenster ab Anfragezeitpunkt), keine neue Entscheidungsfläche (Kanäle,
+  Provider, Datenmodell, Auth, Editor-Paradigma). Der 3× bestätigte PO-Entscheid „strikt nur
+  Tagesfenster" (#1841/#1848) wird bestätigt, nicht abgelöst.
+
+## Testplan (AC-Test-Mapping)
+
+| Test | Deckt |
+|---|---|
+| `tests/tdd/test_adhoc_tageswert_ab_anfragezeit.py` (CREATE) | AC-1, AC-2, AC-4, AC-5, AC-10, AC-11, AC-12 |
+| `tests/tdd/test_tageswert_fenster_erhaelt_alle_metriken.py` (CREATE) | AC-3, AC-6, AC-7, AC-8 |
+| `tests/tdd/test_weather_extractor.py` (MODIFY) | AC-9 |
+
+Pfadkorrektur (2026-09-08, RED-Phase): Die Spec nannte für AC-9
+`tests/unit/test_weather_extractor.py`. Diese Datei existiert nicht — die
+Extractor-Suite liegt unter `tests/tdd/`. Am Bestand geprüft, nicht abgeleitet.
+
+Testdateien sind nach Verhalten benannt, nicht nach Issue-Nummer. Vor Commit `grep -rln`
+über `tests/` nach `.timeline(`, um bestehende Aufrufer auf Signaturverträglichkeit zu prüfen
+(laut Analyse 4 Dateien, alle ohne `from_time` → Default `None` bricht sie nicht).
+
+## Changelog
+
+- 2026-09-08: Initial spec created (feat-2186-tagesaggregat-ab-jetzt)

--- a/src/services/trip_command_processor.py
+++ b/src/services/trip_command_processor.py
@@ -799,11 +799,12 @@ class TripCommandProcessor:
 
         from services.weather_extractor import WeatherExtractor
         extractor = WeatherExtractor(user_id=user_id)
-        timeline = extractor.timeline(trip.id)
+        # Issue #2186: der Tageswert fuer "heute" gilt AB dem Anfragezeitpunkt.
+        timeline = extractor.timeline(trip.id, from_time=received_at)
 
         if not timeline.available:
             _fetch_and_save_snapshot(trip=trip, user_id=user_id, today=today, tomorrow=tomorrow)
-            timeline = extractor.timeline(trip.id)
+            timeline = extractor.timeline(trip.id, from_time=received_at)
 
         # Fix #1818: der undatierte Anker traegt strukturell nur EINEN Tag —
         # der jeweils fehlende wird, falls vorhanden, aus dem datierten
@@ -811,6 +812,7 @@ class TripCommandProcessor:
         timeline = self._mit_datiertem_rueckfall(
             timeline, trip.id, user_id,
             ((today, tz_heute), (tomorrow, tz_morgen)),
+            from_time=received_at,
         )
 
         if query_key == "glance":
@@ -1225,7 +1227,9 @@ class TripCommandProcessor:
         return "\n".join(lines)
 
     def _mit_datiertem_rueckfall(self, timeline: "TimelineResult", trip_id: str,
-                                 user_id: str, tage) -> "TimelineResult":
+                                 user_id: str, tage, *,
+                                 from_time: Optional[datetime] = None,
+                                 ) -> "TimelineResult":
         """Gestufte Quellenaufloesung JE angefragtem Tag (Issue #1818).
 
         Der undatierte Anker ``{trip_id}.json`` traegt strukturell nur EINEN
@@ -1243,7 +1247,10 @@ class TripCommandProcessor:
         wie in ``_aggregate_day``/``_fmt_timeline`` (Ortstag, #1795), damit
         ein Rueckfall-Wegpunkt nicht in einen fremden Tag rutscht.
 
-        ``tage`` ist eine Folge von ``(target_date, tz)``-Paaren.
+        ``tage`` ist eine Folge von ``(target_date, tz)``-Paaren. ``from_time``
+        geht unveraendert an ``timeline_dated()`` weiter (Issue #2186) — der
+        Rueckfall beantwortet dieselbe Frage wie der Anker und muss deshalb
+        dasselbe Fenster sehen.
         """
         if not timeline.available:
             return timeline
@@ -1263,7 +1270,7 @@ class TripCommandProcessor:
             # ehrliche Datenluecken-Meldung, weil die Punktliste der
             # Formatierer dann nicht leer ist.
             verworfen.update(tages_idx)
-            datiert = extractor.timeline_dated(trip_id, target_date)
+            datiert = extractor.timeline_dated(trip_id, target_date, from_time)
             ergaenzt.extend(
                 p for p in datiert.points
                 if local_dt(p.arrival_time, tz).date() == target_date

--- a/src/services/weather_extractor.py
+++ b/src/services/weather_extractor.py
@@ -6,7 +6,7 @@ Issue #652, Epic #639 Teil 3/6
 """
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, fields as dataclass_fields, replace
 from datetime import date, datetime, timedelta, timezone
 from typing import List, Optional
 
@@ -81,6 +81,7 @@ class WeatherExtractor:
         self,
         trip_id: str,
         target_date: Optional[date] = None,
+        from_time: Optional[datetime] = None,
     ) -> TimelineResult:
         segments = self._snapshots.load(trip_id)
         if not segments:
@@ -94,28 +95,96 @@ class WeatherExtractor:
         return TimelineResult(
             trip_id=trip_id,
             target_date=target_date,
-            points=self._punkte(segments),
+            points=self._punkte(segments, from_time),
             available=True,
         )
 
     @staticmethod
-    def _punkte(segments: List[SegmentWeatherData]) -> List[TimelinePoint]:
+    def _punkte(
+        segments: List[SegmentWeatherData],
+        from_time: Optional[datetime] = None,
+    ) -> List[TimelinePoint]:
         """Segmente -> Timeline-Wegpunkte. EINE Umrechnung fuer beide Quellen
         (undatierter Anker und datierter Snapshot, Issue #1818) — eine zweite
         Kopie dieser Zuordnung wuerde bei jeder Feldaenderung auseinanderlaufen.
+
+        Issue #2186: mit ``from_time`` gilt das Tages-Aggregat AB dem
+        Anfragezeitpunkt — vollstaendig vergangene Segmente entfallen, ein
+        angebrochenes wird ueber sein Restfenster neu gerechnet. Ohne
+        ``from_time`` bleibt alles wie zuvor.
         """
-        return [
-            TimelinePoint(
+        punkte: List[TimelinePoint] = []
+        for seg in segments:
+            metrics = WeatherExtractor._restfenster_aggregat(seg, from_time)
+            if metrics is None:
+                continue
+            punkte.append(TimelinePoint(
                 # Issue #1599: Anzeige-Ende statt Alarm-Obergrenze.
                 arrival_time=display_end_time(seg.segment),
                 elevation_m=seg.segment.end_point.elevation_m,
                 label=str(seg.segment.segment_id),
-                metrics=seg.aggregated,
-            )
-            for seg in segments
-        ]
+                metrics=metrics,
+            ))
+        return punkte
 
-    def timeline_dated(self, trip_id: str, target_date: date) -> TimelineResult:
+    @staticmethod
+    def _restfenster_aggregat(
+        seg: SegmentWeatherData, from_time: Optional[datetime],
+    ) -> Optional[SegmentWeatherSummary]:
+        """Aggregat des Segments ab ``from_time``; ``None`` heisst „vollstaendig
+        vergangen, faellt aus den Wegpunkten" (Issue #2186)."""
+        if from_time is None or seg.timeseries is None:
+            return seg.aggregated
+        jetzt = _to_naive_utc(from_time)
+        if jetzt <= _to_naive_utc(seg.segment.start_time):
+            return seg.aggregated
+        if jetzt >= _to_naive_utc(seg.segment.end_time):
+            return None
+
+        from app.day_window import resolve_configured_window, segment_window_points
+        from app.models import NormalizedTimeseries
+        from services.weather_metrics import WeatherMetricsService
+        from utils.timezone import location_tz
+
+        # Kein eigener Stundenschnitt: dieselbe Quelle wie die Erstberechnung
+        # (Bug #806/#856), sonst driftet die Fenstergrenze.
+        punkte = segment_window_points(jetzt, seg.segment.end_time, seg.timeseries.data)
+        if not punkte:
+            return seg.aggregated
+        fenster_ts = NormalizedTimeseries(meta=seg.timeseries.meta, data=punkte)
+        window_start, window_end = resolve_configured_window(
+            seg.segment.day_window_start_hour, seg.segment.day_window_end_hour,
+        )
+        service = WeatherMetricsService()
+        basis = service.compute_basis_metrics(
+            fenster_ts, tz=location_tz(seg.segment.start_point),
+            day_window_start_hour=window_start, day_window_end_hour=window_end,
+        )
+        neu = service.compute_extended_metrics(fenster_ts, basis)
+        # ``compute_extended_metrics`` baut ein NEUES Summary und kopiert nur
+        # eine feste Feldauswahl aus ``basis`` mit (dieselbe Naht wie
+        # #1391/#1392/#1468, s. `weather_metrics.py`). ``basis`` und ``neu``
+        # stammen hier aus DERSELBEN Zeitreihe (``fenster_ts``) -- jedes Feld,
+        # das in ``basis`` gesetzt und in ``neu`` ``None`` ist, ist deshalb
+        # zwingend ein Kopierverlust und kein legitimer Leerwert. Generisch
+        # statt feldweise, damit kuenftige Kopierluecken (wie zuletzt
+        # `hail_flag`, Issue #2186) nicht erneut manuell nachgezogen werden
+        # muessen.
+        nachgezogen = {
+            f.name: getattr(basis, f.name)
+            for f in dataclass_fields(SegmentWeatherSummary)
+            if f.init
+            and getattr(neu, f.name) is None
+            and getattr(basis, f.name) is not None
+        }
+        return replace(neu, **nachgezogen) if nachgezogen else neu
+
+    def timeline_dated(
+        self,
+        trip_id: str,
+        target_date: date,
+        from_time: Optional[datetime] = None,
+    ) -> TimelineResult:
         """Timeline-Wegpunkte aus dem TAGESDATIERTEN Snapshot
         ``{trip_id}_{YYYY-MM-DD}.json`` (Issue #1818).
 
@@ -123,6 +192,11 @@ class WeatherExtractor:
         undatierte Anker ``{trip_id}.json`` traegt strukturell nur EINEN Tag
         (``_write_briefing_anchor`` ueberschreibt ihn je Briefing-Lauf); diese
         Quelle deckt einen Tag, den der Anker verloren hat, ohne Netzabruf.
+
+        ``from_time`` wirkt hier GENAUSO wie in ``timeline()`` (Issue #2186).
+        Beide Quellen beantworten dieselbe Frage; griffe die Fensterung nur am
+        Anker, zeigte derselbe Abruf je nach tragender Datei einen anderen
+        Tageswert — nach dem Abend-Briefing wieder den Vormittag.
         """
         segments = self._snapshots.load_dated(trip_id, target_date)
         if not segments:
@@ -139,7 +213,7 @@ class WeatherExtractor:
         return TimelineResult(
             trip_id=trip_id,
             target_date=target_date,
-            points=self._punkte(segments),
+            points=self._punkte(segments, from_time),
             available=True,
         )
 

--- a/tests/tdd/test_adhoc_tageswert_ab_anfragezeit.py
+++ b/tests/tdd/test_adhoc_tageswert_ab_anfragezeit.py
@@ -1,0 +1,631 @@
+"""
+TDD RED — Ad-hoc-Abruf: der Tageswert fuer „heute" gilt AB dem Anfragezeitpunkt.
+
+SPEC: docs/specs/modules/feat_2186_tagesaggregat_ab_jetzt.md v1.0 (Issue #2186)
+Deckt AC-1, AC-2, AC-4, AC-5, AC-10, AC-11, AC-12.
+
+Beweist aus Nutzersicht ueber den ECHTEN Befehlspfad
+(``TripCommandProcessor.process()`` mit echtem Trip und echtem, auf Platte
+persistiertem Snapshot — kein Mock), dass ein Abruf am Nachmittag den bereits
+vergangenen Vormittag nicht mehr mitrechnet, waehrend „morgen" unberuehrt
+bleibt.
+
+Diese Tests MUESSEN initial fehlschlagen:
+  * ``WeatherExtractor.timeline()`` kennt den Parameter ``from_time`` noch
+    nicht, und ``_handle_query()`` reicht ``received_at`` nicht durch — der
+    Nachmittags-Abruf liefert deshalb heute noch den Vormittagsregen.
+
+Zahlenwahl: alle Niederschlagswerte sind binaer exakt darstellbar (5.0 und
+0.25 mm/h), damit die Summen ohne Toleranz verglichen werden koennen.
+"""
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from app.loader import save_trip
+from app.models import (
+    ForecastDataPoint,
+    ForecastMeta,
+    GPXPoint,
+    NormalizedTimeseries,
+    Provider,
+    SegmentWeatherData,
+    SegmentWeatherSummary,
+    ThunderLevel,
+    TripSegment,
+)
+from app.trip import Stage, Trip, Waypoint
+from services.trip_command_processor import (
+    CommandResult,
+    InboundMessage,
+    TripCommandProcessor,
+)
+from services.weather_snapshot import WeatherSnapshotService
+
+HEUTE = date(2026, 2, 14)
+MORGEN = date(2026, 2, 15)
+TRIP_ID = "tour-2186-adhoc"
+TRIP_NAME = "Tour 2186 Adhoc"
+
+# London im Februar ist GMT — Ortszeit == UTC. Der Ortstag deckt sich damit
+# mit dem UTC-Tag; AC-12 prueft den entfernten Fall separat.
+LAT, LON = 51.5, -0.13
+
+FRUEH_ABRUF = datetime(2026, 2, 14, 8, 0, tzinfo=timezone.utc)
+SPAET_ABRUF = datetime(2026, 2, 14, 14, 0, tzinfo=timezone.utc)
+
+# Vormittag: Dauerregen, Gewitterneigung, Sturm. Nachmittag: ruhig.
+STUNDE_FRUEH = dict(
+    t2m_c=5.0, wind10m_kmh=45.0, gust_kmh=70.0, precip_1h_mm=5.0, pop_pct=95,
+    cape_jkg=1800.0, cloud_total_pct=95, cloud_low_pct=90,
+    thunder_level=ThunderLevel.MED,
+)
+STUNDE_SPAET = dict(
+    t2m_c=15.0, wind10m_kmh=8.0, gust_kmh=15.0, precip_1h_mm=0.25, pop_pct=20,
+    cape_jkg=300.0, cloud_total_pct=35, cloud_low_pct=30,
+)
+
+
+# ---------------------------------------------------------------------------
+# Aufbau — echter Trip, echter Snapshot auf Platte
+# ---------------------------------------------------------------------------
+
+def _waypoint(wp_id: str, lat: float = LAT, lon: float = LON) -> Waypoint:
+    return Waypoint(id=wp_id, name=f"WP {wp_id}", lat=lat, lon=lon, elevation_m=120)
+
+
+def _trip(lat: float = LAT, lon: float = LON) -> Trip:
+    return Trip(
+        id=TRIP_ID,
+        name=TRIP_NAME,
+        stages=[
+            Stage(id="T1", name="Etappe heute", date=HEUTE,
+                  waypoints=[_waypoint("W1", lat, lon)]),
+            Stage(id="T2", name="Etappe morgen", date=MORGEN,
+                  waypoints=[_waypoint("W2", lat, lon)]),
+        ],
+    )
+
+
+def _punkte(start: datetime, anzahl: int, profil: dict) -> list[ForecastDataPoint]:
+    from datetime import timedelta
+
+    return [
+        ForecastDataPoint(ts=start + timedelta(hours=i), **profil)
+        for i in range(anzahl)
+    ]
+
+
+def _segment(
+    segment_id: int,
+    start: datetime,
+    ende: datetime,
+    *,
+    aggregiert: SegmentWeatherSummary,
+    stunden: list[ForecastDataPoint],
+    lat: float = LAT,
+    lon: float = LON,
+) -> SegmentWeatherData:
+    segment = TripSegment(
+        segment_id=segment_id,
+        start_point=GPXPoint(lat=lat, lon=lon, elevation_m=100.0),
+        end_point=GPXPoint(lat=lat, lon=lon, elevation_m=180.0),
+        start_time=start,
+        end_time=ende,
+        duration_hours=(ende - start).total_seconds() / 3600.0,
+        distance_km=7.0,
+        ascent_m=300.0,
+        descent_m=250.0,
+    )
+    return SegmentWeatherData(
+        segment=segment,
+        timeseries=NormalizedTimeseries(
+            meta=ForecastMeta(
+                provider=Provider.OPENMETEO, model="best_match", grid_res_km=2.0,
+            ),
+            data=stunden,
+        ),
+        aggregated=aggregiert,
+        fetched_at=datetime(2026, 2, 14, 5, 0, tzinfo=timezone.utc),
+        provider="openmeteo",
+    )
+
+
+def _utc(tag: date, stunde: int) -> datetime:
+    return datetime(tag.year, tag.month, tag.day, stunde, 0, tzinfo=timezone.utc)
+
+
+def _segmente_london() -> list[SegmentWeatherData]:
+    """Zwei Etappen heute (Vormittag nass, Nachmittag ruhig) + eine morgen.
+
+    Die gespeicherten Aggregate entsprechen dem VOLLEN Segmentfenster — genau
+    das, was der Snapshot heute enthaelt und was ein Abruf am Nachmittag
+    bislang unveraendert weiterreicht.
+    """
+    vormittag = _segment(
+        1, _utc(HEUTE, 6), _utc(HEUTE, 10),
+        aggregiert=SegmentWeatherSummary(
+            temp_min_c=5.0, temp_max_c=5.0, wind_max_kmh=45.0, gust_max_kmh=70.0,
+            precip_sum_mm=20.0, pop_max_pct=95, cape_max_jkg=1800.0,
+            thunder_level_max=ThunderLevel.MED,
+        ),
+        stunden=_punkte(_utc(HEUTE, 6), 4, STUNDE_FRUEH),
+    )
+    nachmittag = _segment(
+        2, _utc(HEUTE, 10), _utc(HEUTE, 16),
+        aggregiert=SegmentWeatherSummary(
+            temp_min_c=15.0, temp_max_c=15.0, wind_max_kmh=8.0, gust_max_kmh=15.0,
+            precip_sum_mm=1.5, pop_max_pct=20, cape_max_jkg=300.0,
+            thunder_level_max=ThunderLevel.NONE,
+        ),
+        stunden=_punkte(_utc(HEUTE, 10), 6, STUNDE_SPAET),
+    )
+    morgen = _segment(
+        3, _utc(MORGEN, 8), _utc(MORGEN, 12),
+        aggregiert=SegmentWeatherSummary(
+            temp_min_c=9.0, temp_max_c=12.0, wind_max_kmh=18.0, gust_max_kmh=30.0,
+            precip_sum_mm=3.0, pop_max_pct=60, cape_max_jkg=500.0,
+            thunder_level_max=ThunderLevel.LOW,
+        ),
+        stunden=_punkte(_utc(MORGEN, 8), 4, STUNDE_SPAET),
+    )
+    return [vormittag, nachmittag, morgen]
+
+
+@pytest.fixture
+def umgebung(tmp_path: Path, monkeypatch) -> Path:
+    """Lenkt das Datenverzeichnis auf tmp_path — echte Datei-I/O, kein Mock."""
+    def _ziel(user_id: str = "default") -> Path:
+        return tmp_path / user_id
+
+    monkeypatch.setattr("app.loader.get_data_dir", _ziel)
+    monkeypatch.setattr("services.trip_command_processor.get_data_dir", _ziel)
+    return tmp_path
+
+
+def _lege_an(trip: Trip, segmente: list[SegmentWeatherData]) -> None:
+    save_trip(trip, "default")
+    WeatherSnapshotService("default").save(trip.id, segmente, HEUTE)
+
+
+def _abruf(body: str, received_at: datetime, *, channel: str = "telegram") -> CommandResult:
+    return TripCommandProcessor().process(InboundMessage(
+        trip_name=TRIP_NAME, body=body, sender="123",
+        channel=channel, received_at=received_at, user_id="default",
+    ))
+
+
+def _tagesaggregat(received_at: datetime, tag: date, *, trip: Trip | None = None) -> dict | None:
+    """Das Tages-Aggregat, wie es der Abruf zu ``received_at`` bilden wuerde.
+
+    Geht ueber DIESELBE Kette wie ``_handle_query``: gefensterte Timeline ->
+    ``_aggregate_day``. ``_aggregate_day`` ist eine der fuenf Ausgabestellen
+    aus AC-10 und wird hier direkt an ihrem Ergebnis gemessen.
+    """
+    from services.trip_day import display_tz
+    from services.weather_extractor import WeatherExtractor
+
+    trip = trip or _trip()
+    timeline = WeatherExtractor(user_id="default").timeline(
+        TRIP_ID, from_time=received_at,
+    )
+    return TripCommandProcessor()._aggregate_day(timeline, tag, display_tz(trip, tag))
+
+
+# ---------------------------------------------------------------------------
+# AC-1 / AC-4 / AC-5 — die Fensterung selbst
+# ---------------------------------------------------------------------------
+
+class TestTageswertAbAnfragezeit:
+    def test_ac1_nachmittags_abruf_zeigt_den_vormittagsregen_nicht_mehr(
+        self, umgebung: Path,
+    ) -> None:
+        """
+        GIVEN einen Vormittag mit 20 mm Regen und einen ruhigen Nachmittag,
+        WHEN ``glance`` um 14:00 abgerufen wird,
+        THEN enthaelt der Tageswert fuer „heute" den Vormittagsregen nicht mehr
+             — nur noch die 0,5 mm der beiden verbleibenden Stunden.
+        """
+        _lege_an(_trip(), _segmente_london())
+
+        agg = _tagesaggregat(SPAET_ABRUF, HEUTE)
+
+        assert agg is not None
+        assert agg["precip"] == 0.5, (
+            f"Tageswert traegt noch vergangene Stunden: {agg['precip']}"
+        )
+        assert agg["precip"] != 21.5, "der volle Tag wurde unveraendert durchgereicht"
+
+    def test_ac4_teilweise_vergangenes_segment_wird_beschnitten_neu_gerechnet(
+        self, umgebung: Path,
+    ) -> None:
+        """
+        GIVEN das Nachmittags-Segment 10-16 Uhr, das um 14:00 zur Haelfte
+              vergangen ist,
+        WHEN die Tages-Aggregation laeuft,
+        THEN traegt es die Werte des Fensters [14:00, 16:00) — 0,5 mm statt
+             der gespeicherten 1,5 mm ueber das volle Segment.
+        """
+        _lege_an(_trip(), _segmente_london())
+        from services.weather_extractor import WeatherExtractor
+
+        timeline = WeatherExtractor(user_id="default").timeline(
+            TRIP_ID, from_time=SPAET_ABRUF,
+        )
+
+        heute_punkte = [p for p in timeline.points if p.arrival_time.date() == HEUTE]
+        assert len(heute_punkte) == 1, (
+            f"erwartet: nur das laufende Segment, bekommen: "
+            f"{[p.label for p in heute_punkte]}"
+        )
+        assert heute_punkte[0].metrics.precip_sum_mm == 0.5
+
+    def test_ac5_vollstaendig_vergangenes_segment_verschwindet_aus_den_wegpunkten(
+        self, umgebung: Path,
+    ) -> None:
+        """
+        GIVEN das Vormittags-Segment 06-10 Uhr, das um 14:00 vollstaendig
+              vergangen ist,
+        WHEN die Wegpunkte fuer „heute" gebildet werden,
+        THEN erscheint dieses Segment nicht mehr — waehrend es beim frueheren
+             Abruf um 08:00 noch da war.
+        """
+        _lege_an(_trip(), _segmente_london())
+        from services.weather_extractor import WeatherExtractor
+
+        extractor = WeatherExtractor(user_id="default")
+        frueh = extractor.timeline(TRIP_ID, from_time=FRUEH_ABRUF)
+        spaet = extractor.timeline(TRIP_ID, from_time=SPAET_ABRUF)
+
+        assert "1" in [str(p.label) for p in frueh.points], (
+            "das Vormittags-Segment fehlte schon beim fruehen Abruf"
+        )
+        assert "1" not in [str(p.label) for p in spaet.points], (
+            "das vollstaendig vergangene Segment steht noch in den Wegpunkten"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-2 — „morgen" bleibt unberuehrt
+# ---------------------------------------------------------------------------
+
+class TestMorgenBleibtUnberuehrt:
+    def test_ac2_morgen_ist_bei_frueh_und_spaet_abruf_wertgleich(
+        self, umgebung: Path,
+    ) -> None:
+        """
+        GIVEN zwei Abrufe am selben Tag (08:00 und 14:00),
+        WHEN beide die Zeile „morgen" lesen,
+        THEN sind die Werte fuer „morgen" wertgleich — „ab jetzt" veraendert
+             den Folgetag nicht.
+        """
+        _lege_an(_trip(), _segmente_london())
+
+        morgen_frueh = _tagesaggregat(FRUEH_ABRUF, MORGEN)
+        morgen_spaet = _tagesaggregat(SPAET_ABRUF, MORGEN)
+
+        assert morgen_frueh is not None and morgen_spaet is not None
+        assert morgen_frueh == morgen_spaet, (
+            "die Fensterung hat den Folgetag veraendert"
+        )
+        # Gegenprobe: fuer HEUTE unterscheiden sich dieselben beiden Abrufe —
+        # sonst wuerde die Gleichheit oben auch eine wirkungslose Fensterung
+        # bestehen.
+        assert _tagesaggregat(FRUEH_ABRUF, HEUTE) != _tagesaggregat(SPAET_ABRUF, HEUTE)
+
+    def test_ac2_morgen_zeile_im_glance_body_ist_bei_beiden_abrufen_gleich(
+        self, umgebung: Path,
+    ) -> None:
+        """
+        GIVEN zwei ``glance``-Abrufe zu unterschiedlichen Uhrzeiten,
+        WHEN die ausgegebenen Bodies verglichen werden,
+        THEN ist die „morgen"-Zeile identisch, die „heute"-Zeile aber nicht.
+        """
+        _lege_an(_trip(), _segmente_london())
+
+        frueh = _abruf("### query: glance", FRUEH_ABRUF).confirmation_body
+        spaet = _abruf("### query: glance", SPAET_ABRUF).confirmation_body
+
+        def _zeile(body: str, marker: str) -> str:
+            # Nur die DATENzeile, die mit dem Tageswort beginnt — die
+            # Kopfzeile „🗓 Glance — heute & morgen" enthaelt beide Woerter
+            # und wuerde einen Vergleich sonst gegen sich selbst fuehren.
+            treffer = [z for z in body.splitlines() if z.lower().startswith(marker)]
+            assert treffer, f"Datenzeile fuer {marker!r} fehlt in: {body!r}"
+            return treffer[0]
+
+        assert _zeile(frueh, "morgen") == _zeile(spaet, "morgen")
+        assert _zeile(frueh, "heute") != _zeile(spaet, "heute")
+
+
+# ---------------------------------------------------------------------------
+# AC-10 — alle fuenf Ausgabestellen
+# ---------------------------------------------------------------------------
+
+class TestAlleAusgabestellenSindGefenstert:
+    def test_ac10_aggregate_day_traegt_nur_das_restfenster(self, umgebung: Path) -> None:
+        """_aggregate_day (1/5): der Tageswert selbst."""
+        _lege_an(_trip(), _segmente_london())
+
+        agg = _tagesaggregat(SPAET_ABRUF, HEUTE)
+
+        assert agg["precip"] == 0.5
+        assert agg["pop"] == 20
+        assert agg["wind_max"] == 8.0
+        assert agg["thunder"] == ThunderLevel.NONE, (
+            "die Gewitterstufe des Vormittags steht noch im Tageswert"
+        )
+
+    def test_ac10_glance_meldet_am_nachmittag_nicht_mehr_den_vormittag(
+        self, umgebung: Path,
+    ) -> None:
+        """_fmt_glance (2/5)."""
+        _lege_an(_trip(), _segmente_london())
+
+        frueh = _abruf("### query: glance", FRUEH_ABRUF).confirmation_body
+        spaet = _abruf("### query: glance", SPAET_ABRUF).confirmation_body
+
+        assert frueh != spaet, "glance zeigt am Nachmittag unveraendert den Vormittag"
+
+    def test_ac10_gewitter_ausgabe_verliert_die_vergangene_stufe(
+        self, umgebung: Path,
+    ) -> None:
+        """_fmt_gewitter (3/5): die MED-Stufe lag ausschliesslich am Vormittag."""
+        _lege_an(_trip(), _segmente_london())
+
+        frueh = _abruf("### query: heute_gewitter", FRUEH_ABRUF).confirmation_body
+        spaet = _abruf("### query: heute_gewitter", SPAET_ABRUF).confirmation_body
+
+        assert frueh != spaet, (
+            "die Gewitter-Ausgabe meldet am Nachmittag noch die Vormittagsstufe"
+        )
+
+    def test_ac10_timeline_zeigt_nur_noch_die_verbleibenden_wegpunkte(
+        self, umgebung: Path,
+    ) -> None:
+        """_fmt_timeline (4/5)."""
+        _lege_an(_trip(), _segmente_london())
+
+        frueh = _abruf("### query: timeline_heute", FRUEH_ABRUF).confirmation_body
+        spaet = _abruf("### query: timeline_heute", SPAET_ABRUF).confirmation_body
+
+        assert len(spaet.splitlines()) < len(frueh.splitlines()), (
+            "die Timeline listet den vergangenen Wegpunkt noch mit"
+        )
+
+    def test_ac10_drilldown_buttons_folgen_dem_restfenster(self, umgebung: Path) -> None:
+        """_timeline_buttons (5/5).
+
+        Am Vormittag ueberschreiten Gewitter (MED), Wind (45 km/h) und
+        Niederschlag (1,5 mm) ihre Schwellen; im Restfenster ab 14:00 keiner
+        davon. Bleiben die Buttons stehen, ist die Fensterung an dieser
+        Ausgabestelle nicht angekommen.
+        """
+        _lege_an(_trip(), _segmente_london())
+
+        frueh = _abruf("### query: timeline_heute", FRUEH_ABRUF).reply_markup
+        spaet = _abruf("### query: timeline_heute", SPAET_ABRUF).reply_markup
+
+        def _drilldowns(markup) -> list[str]:
+            return [
+                b["text"]
+                for reihe in markup["inline_keyboard"]
+                for b in reihe
+                if str(b.get("callback_data", "")).startswith("dd_")
+            ]
+
+        assert _drilldowns(frueh), "am Vormittag fehlen die Drilldown-Buttons"
+        assert _drilldowns(spaet) == [], (
+            f"Drilldown-Buttons ueberdauern das Restfenster: {_drilldowns(spaet)}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-11 — Telegram- und E-Mail-Freitext wirken gleich
+# ---------------------------------------------------------------------------
+
+class TestKanalparitaet:
+    @pytest.mark.parametrize("freitext", ["glance", "gewitter"])
+    def test_ac11_bare_keyword_wirkt_in_telegram_und_email_identisch(
+        self, umgebung: Path, freitext: str,
+    ) -> None:
+        """
+        GIVEN denselben Freitext-Befehl ueber ``_BARE_KEYWORD_MAP``,
+        WHEN er zum selben Zeitpunkt per Telegram und per E-Mail eintrifft,
+        THEN ist die Fensterung in beiden Kanaelen identisch wirksam.
+        """
+        _lege_an(_trip(), _segmente_london())
+
+        per_telegram = _abruf(freitext, SPAET_ABRUF, channel="telegram")
+        per_email = _abruf(freitext, SPAET_ABRUF, channel="email")
+
+        assert per_telegram.success and per_email.success
+        assert per_telegram.confirmation_body == per_email.confirmation_body
+
+        # Und beide sind tatsaechlich gefenstert, nicht nur gleich falsch.
+        frueh = _abruf(freitext, FRUEH_ABRUF, channel="telegram").confirmation_body
+        assert per_telegram.confirmation_body != frueh, (
+            f"{freitext!r} zeigt am Nachmittag unveraendert den Vormittag"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-12 — entfernte Ortszeitzone
+# ---------------------------------------------------------------------------
+
+class TestEntfernteZeitzone:
+    """Neuseeland (UTC+13 im Februar): der Ortstag 14.02. laeuft von
+    13.02. 11:00 UTC bis 14.02. 11:00 UTC. Ein Schnitt, der am UTC-Tag statt
+    am Ortstag ansetzt, wuerde hier in den falschen Tag greifen."""
+
+    NZ_LAT, NZ_LON = -41.29, 174.78
+    # Ortszeit 14.02. 15:00 == 14.02. 02:00 UTC
+    ABRUF_NZ = datetime(2026, 2, 14, 2, 0, tzinfo=timezone.utc)
+
+    def _segmente_nz(self) -> list[SegmentWeatherData]:
+        vormittag = _segment(  # Ortszeit 14.02. 08:00-12:00
+            1, datetime(2026, 2, 13, 19, 0, tzinfo=timezone.utc),
+            datetime(2026, 2, 13, 23, 0, tzinfo=timezone.utc),
+            aggregiert=SegmentWeatherSummary(
+                temp_min_c=5.0, temp_max_c=5.0, wind_max_kmh=45.0,
+                precip_sum_mm=20.0, pop_max_pct=95,
+                thunder_level_max=ThunderLevel.MED,
+            ),
+            stunden=_punkte(
+                datetime(2026, 2, 13, 19, 0, tzinfo=timezone.utc), 4, STUNDE_FRUEH,
+            ),
+            lat=self.NZ_LAT, lon=self.NZ_LON,
+        )
+        nachmittag = _segment(  # Ortszeit 14.02. 13:00-17:00
+            2, datetime(2026, 2, 14, 0, 0, tzinfo=timezone.utc),
+            datetime(2026, 2, 14, 4, 0, tzinfo=timezone.utc),
+            aggregiert=SegmentWeatherSummary(
+                temp_min_c=15.0, temp_max_c=15.0, wind_max_kmh=8.0,
+                precip_sum_mm=1.0, pop_max_pct=20,
+                thunder_level_max=ThunderLevel.NONE,
+            ),
+            stunden=_punkte(
+                datetime(2026, 2, 14, 0, 0, tzinfo=timezone.utc), 4, STUNDE_SPAET,
+            ),
+            lat=self.NZ_LAT, lon=self.NZ_LON,
+        )
+        return [vormittag, nachmittag]
+
+    def test_ac12_fensterung_schneidet_nicht_in_den_falschen_ortstag(
+        self, umgebung: Path,
+    ) -> None:
+        """
+        GIVEN eine Tour in Neuseeland und einen Abruf um 15:00 Ortszeit,
+        WHEN die Tages-Aggregation laeuft,
+        THEN bleibt die Zuordnung „heute" auf dem Ortstag 14.02., das
+             vollstaendig vergangene Vormittags-Segment entfaellt, und der
+             verbleibende Wegpunkt rutscht in keinen Nachbartag.
+        """
+        trip = _trip(self.NZ_LAT, self.NZ_LON)
+        _lege_an(trip, self._segmente_nz())
+
+        agg = _tagesaggregat(self.ABRUF_NZ, HEUTE, trip=trip)
+
+        assert agg is not None, "der Ortstag 14.02. hat gar keine Wegpunkte mehr"
+        assert agg["precip"] == 0.5, (
+            f"Restfenster falsch geschnitten: {agg['precip']}"
+        )
+        assert agg["thunder"] == ThunderLevel.NONE, (
+            "der vergangene Vormittag traegt die Gewitterstufe noch bei"
+        )
+
+        # Kein Wegpunkt darf in einen Nachbartag gerutscht sein.
+        from services.trip_day import display_tz
+        from services.weather_extractor import WeatherExtractor
+
+        timeline = WeatherExtractor(user_id="default").timeline(
+            TRIP_ID, from_time=self.ABRUF_NZ,
+        )
+        tz = display_tz(trip, HEUTE)
+        ortstage = {p.arrival_time.astimezone(tz).date() for p in timeline.points}
+        assert ortstage == {HEUTE}, f"Wegpunkte in fremden Ortstagen: {ortstage}"
+
+
+# ---------------------------------------------------------------------------
+# AC-1 / AC-2 / AC-10 am ZWEITEN Datenweg — der datierte Rueckfall
+#
+# Der undatierte Anker ``{trip_id}.json`` traegt strukturell nur EINEN Tag
+# (``_write_briefing_anchor`` ueberschreibt ihn je Briefing-Lauf). Fuer den
+# fehlenden Tag zieht ``_mit_datiertem_rueckfall`` den datierten Snapshot
+# ``{trip_id}_{YYYY-MM-DD}.json``. Eine Fensterung, die nur am Anker greift,
+# zeigt nach dem Abend-Briefing wieder den Vormittag — dieselbe Frage,
+# dieselbe Uhrzeit, anderer Wert, je nachdem welche Datei gerade traegt.
+# ---------------------------------------------------------------------------
+
+def _datenzeile(body: str, marker: str) -> str:
+    """Die DATENzeile eines Glance-Bodies, die mit dem Tageswort beginnt.
+
+    Die Kopfzeile „🗓 Glance — heute & morgen" enthaelt beide Woerter und
+    wuerde einen Vergleich sonst gegen sich selbst fuehren.
+    """
+    treffer = [z for z in body.splitlines() if z.lower().startswith(marker)]
+    assert treffer, f"Datenzeile fuer {marker!r} fehlt in: {body!r}"
+    return treffer[0]
+
+
+def _lege_datiert_an(tag: date, segmente: list[SegmentWeatherData]) -> None:
+    WeatherSnapshotService("default").save_dated(TRIP_ID, tag, segmente)
+
+
+class TestDatierterRueckfallIstEbenfallsGefenstert:
+    def test_ac1_rueckfall_auf_den_datierten_snapshot_zeigt_den_vormittag_nicht_mehr(
+        self, umgebung: Path,
+    ) -> None:
+        """
+        GIVEN einen undatierten Anker, der fuer „heute" NICHTS traegt (Lage
+              nach dem Abend-Briefing), und einen datierten Snapshot fuer
+              heute mit nassem Vormittag und ruhigem Nachmittag,
+        WHEN ``glance`` um 14:00 abgerufen wird,
+        THEN ist die „heute"-Zeile dieselbe wie ueber den Anker-Weg — die
+             Fensterung haengt an der FRAGE, nicht an der Quelle.
+        """
+        vormittag, nachmittag, morgen = _segmente_london()
+
+        # 1. Rueckfall-Weg: Anker traegt nur morgen, heute kommt datiert.
+        _lege_an(_trip(), [morgen])
+        _lege_datiert_an(HEUTE, [vormittag, nachmittag])
+        ueber_rueckfall = _abruf("### query: glance", SPAET_ABRUF).confirmation_body
+
+        # 2. Anker-Weg: derselbe Bestand, aber im undatierten Anker. Dessen
+        #    Fensterung ist durch AC-1 bereits bewiesen — er ist hier der
+        #    Massstab, kein zweiter Pruefling.
+        _lege_an(_trip(), [vormittag, nachmittag, morgen])
+        ueber_anker = _abruf("### query: glance", SPAET_ABRUF).confirmation_body
+
+        assert _datenzeile(ueber_rueckfall, "heute") == _datenzeile(ueber_anker, "heute"), (
+            "der datierte Rueckfall liefert einen anderen Tageswert als der "
+            "Anker — die Fensterung greift nur an einer der beiden Quellen"
+        )
+
+    def test_ac10_rueckfall_am_nachmittag_unterscheidet_sich_vom_vormittag(
+        self, umgebung: Path,
+    ) -> None:
+        """
+        GIVEN denselben datierten Rueckfall fuer „heute",
+        WHEN ``glance`` einmal um 08:00 und einmal um 14:00 abgerufen wird,
+        THEN unterscheidet sich die „heute"-Zeile — sonst ist die Fensterung
+             auf diesem Weg wirkungslos und die Gleichheit oben nur „beide
+             gleich falsch".
+        """
+        vormittag, nachmittag, morgen = _segmente_london()
+        _lege_an(_trip(), [morgen])
+        _lege_datiert_an(HEUTE, [vormittag, nachmittag])
+
+        frueh = _abruf("### query: glance", FRUEH_ABRUF).confirmation_body
+        spaet = _abruf("### query: glance", SPAET_ABRUF).confirmation_body
+
+        assert _datenzeile(frueh, "heute") != _datenzeile(spaet, "heute"), (
+            "der datierte Rueckfall zeigt am Nachmittag unveraendert den Vormittag"
+        )
+
+    def test_ac2_morgen_aus_dem_datierten_rueckfall_bleibt_wertgleich(
+        self, umgebung: Path,
+    ) -> None:
+        """
+        GIVEN einen Anker, der nur „heute" traegt (Lage nach dem
+              Morgen-Briefing), und „morgen" aus dem datierten Snapshot,
+        WHEN zu zwei Uhrzeiten desselben Tages abgerufen wird,
+        THEN ist die „morgen"-Zeile wertgleich — der Zweig „Anfragezeit vor
+             Segmentstart" haelt auch auf diesem Weg.
+        """
+        vormittag, nachmittag, morgen = _segmente_london()
+        _lege_an(_trip(), [vormittag, nachmittag])
+        _lege_datiert_an(MORGEN, [morgen])
+
+        frueh = _abruf("### query: glance", FRUEH_ABRUF).confirmation_body
+        spaet = _abruf("### query: glance", SPAET_ABRUF).confirmation_body
+
+        assert _datenzeile(frueh, "morgen") == _datenzeile(spaet, "morgen"), (
+            "die Fensterung hat den Folgetag ueber den datierten Rueckfall veraendert"
+        )
+        # Gegenprobe: „heute" unterscheidet sich sehr wohl — sonst bestuende
+        # die Gleichheit oben auch bei einer voellig wirkungslosen Fensterung.
+        assert _datenzeile(frueh, "heute") != _datenzeile(spaet, "heute")

--- a/tests/tdd/test_tageswert_fenster_erhaelt_alle_metriken.py
+++ b/tests/tdd/test_tageswert_fenster_erhaelt_alle_metriken.py
@@ -1,0 +1,508 @@
+"""
+TDD RED — Tagesaggregat ab Anfragezeitpunkt: die Rechenkette bleibt VOLLSTAENDIG.
+
+SPEC: docs/specs/modules/feat_2186_tagesaggregat_ab_jetzt.md v1.0 (Issue #2186)
+Deckt AC-3, AC-6, AC-7, AC-8.
+
+Beweist gegen ECHTE, auf Platte persistierte Snapshots (kein Mock, kein
+Dateiinhalt-Check) ueber den realen ``WeatherSnapshotService.save/load``-
+Roundtrip, dass die Fensterung eines Segments dessen Aggregat NEU rechnet —
+und zwar ueber BEIDE Rechenstufen (``compute_basis_metrics`` UND
+``compute_extended_metrics``). Faellt die zweite Stufe weg, werden 18 Felder
+still ``None``: sichtbar als „keine Daten", ohne dass irgendetwas fehlschlaegt.
+Genau diese Stille bewacht AC-6.
+
+Diese Tests MUESSEN initial fehlschlagen:
+  * ``WeatherExtractor.timeline()`` kennt den Parameter ``from_time`` noch
+    nicht -> ``TypeError`` (alle Tests dieser Datei).
+
+Die Erwartungswerte sind LITERALE, nicht aus derselben Rechenkette abgeleitet:
+sie wurden einmalig gegen ``compute_basis_metrics``/``compute_extended_metrics``
+nachgemessen und hier fest eingetragen. Ein Test, der seinen Sollwert aus dem
+Prueflings-Code holt, bewacht nichts.
+"""
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from app.models import (
+    ForecastDataPoint,
+    ForecastMeta,
+    GPXPoint,
+    NormalizedTimeseries,
+    PrecipType,
+    Provider,
+    SegmentWeatherData,
+    SegmentWeatherSummary,
+    ThunderLevel,
+    TripSegment,
+)
+from services.weather_snapshot import WeatherSnapshotService
+
+TAG = date(2026, 2, 14)
+
+# London im Februar ist GMT — Ortszeit == UTC. Damit ist die Tagesfenster-
+# Stunde aus AC-7 ohne Zonen-Umrechnung nachvollziehbar; ein Ort mit Versatz
+# wuerde die Aussage des Tests mit einer zweiten Frage vermischen.
+ORT_LAT, ORT_LON = 51.5, -0.13
+
+# Zwei kontrastreiche Stundenprofile. Die Zahlen sind bewusst weit auseinander,
+# damit „alter Wert durchgereicht" und „neu ueber das Restfenster gerechnet"
+# an JEDEM geprueften Feld unterscheidbar sind.
+FRUEH = dict(
+    t2m_c=3.0, wind10m_kmh=45.0, gust_kmh=70.0, precip_1h_mm=5.0, pop_pct=95,
+    cape_jkg=2500.0, uv_index=2.0, cloud_low_pct=90, cloud_mid_pct=80,
+    cloud_high_pct=70, cloud_total_pct=95, snowfall_limit_m=1500,
+    precip_type=PrecipType.SNOW, dewpoint_c=1.0, pressure_msl_hpa=995.0,
+    freezing_level_m=1400, humidity_pct=95, visibility_m=600,
+)
+SPAET = dict(
+    t2m_c=15.0, wind10m_kmh=8.0, gust_kmh=15.0, precip_1h_mm=0.0, pop_pct=20,
+    cape_jkg=400.0, uv_index=7.0, cloud_low_pct=30, cloud_mid_pct=20,
+    cloud_high_pct=10, cloud_total_pct=35, snowfall_limit_m=2800,
+    precip_type=PrecipType.RAIN, dewpoint_c=6.0, pressure_msl_hpa=1018.0,
+    freezing_level_m=2900, humidity_pct=50, visibility_m=25000,
+)
+
+# Ein gespeichertes Aggregat mit unverwechselbaren Werten. Taucht eine dieser
+# Zahlen dort auf, wo eine Neuberechnung erwartet wird, ist der alte Wert
+# durchgereicht worden — und umgekehrt.
+UNVERWECHSELBAR = dict(
+    temp_max_c=21.5, temp_min_c=11.5, wind_max_kmh=33.0, precip_sum_mm=12.5,
+    pop_max_pct=77, cape_max_jkg=1234.0, uv_index_max=4.4,
+    cloud_low_avg_pct=55, snowfall_limit_m=2222, precip_type_dominant=PrecipType.MIXED,
+)
+
+
+def _punkt(stunde: int, **werte) -> ForecastDataPoint:
+    return ForecastDataPoint(
+        ts=datetime(TAG.year, TAG.month, TAG.day, stunde, 0, tzinfo=timezone.utc),
+        **werte,
+    )
+
+
+def _segment(
+    segment_id: int,
+    stunde_start: int,
+    stunde_ende: int,
+    *,
+    aggregiert: SegmentWeatherSummary,
+    stunden: list[ForecastDataPoint] | None,
+    day_window: tuple[int | None, int | None] = (None, None),
+) -> SegmentWeatherData:
+    """Ein Segment mit gespeichertem Aggregat und optionaler Stundenreihe."""
+    fenster_start, fenster_ende = day_window
+    segment = TripSegment(
+        segment_id=segment_id,
+        start_point=GPXPoint(lat=ORT_LAT, lon=ORT_LON, elevation_m=50.0),
+        end_point=GPXPoint(lat=ORT_LAT, lon=ORT_LON, elevation_m=120.0),
+        start_time=datetime(TAG.year, TAG.month, TAG.day, stunde_start, 0, tzinfo=timezone.utc),
+        end_time=datetime(TAG.year, TAG.month, TAG.day, stunde_ende, 0, tzinfo=timezone.utc),
+        duration_hours=float(stunde_ende - stunde_start),
+        distance_km=6.0,
+        ascent_m=250.0,
+        descent_m=180.0,
+        day_window_start_hour=fenster_start,
+        day_window_end_hour=fenster_ende,
+    )
+    timeseries = None
+    if stunden is not None:
+        timeseries = NormalizedTimeseries(
+            meta=ForecastMeta(
+                provider=Provider.OPENMETEO, model="best_match", grid_res_km=2.0,
+            ),
+            data=stunden,
+        )
+    return SegmentWeatherData(
+        segment=segment,
+        timeseries=timeseries,
+        aggregated=aggregiert,
+        fetched_at=datetime(TAG.year, TAG.month, TAG.day, 5, 0, tzinfo=timezone.utc),
+        provider="openmeteo",
+    )
+
+
+def _extractor(tmp_path: Path, user_id: str = "default"):
+    from services.weather_extractor import WeatherExtractor
+
+    ex = WeatherExtractor(user_id=user_id)
+    ex._snapshots._snapshots_dir = tmp_path
+    return ex
+
+
+def _speichere(tmp_path: Path, segmente: list[SegmentWeatherData]) -> None:
+    svc = WeatherSnapshotService(user_id="default")
+    svc._snapshots_dir = tmp_path
+    svc.save("tour-2186", segmente, TAG)
+
+
+def _um_zehn() -> datetime:
+    return datetime(TAG.year, TAG.month, TAG.day, 10, 0, tzinfo=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# AC-6 — beide Rechenstufen, ueber das beschnittene Fenster
+# ---------------------------------------------------------------------------
+
+class TestBeschnittenesSegmentTraegtBeideRechenstufen:
+    def test_ac6_alle_felder_beider_stufen_tragen_die_restfenster_werte(
+        self, tmp_path: Path,
+    ) -> None:
+        """
+        GIVEN ein Segment 06-12 Uhr, dessen Vormittag (06-09) Schnee, Gewitterluft
+              und hohe Regenwahrscheinlichkeit trug und dessen Rest (10-11) ruhig ist,
+        WHEN die Tages-Aggregation ab 10:00 laeuft,
+        THEN traegt das neue Aggregat die Felder BEIDER Rechenstufen — und jedes
+             davon den Wert des RESTfensters, nicht den des vollen Tages.
+        """
+        _speichere(tmp_path, [_segment(
+            1, 6, 12,
+            # Bewusst leer bis auf eine Marke: jedes gepruefte Feld kann nur
+            # durch die Neuberechnung entstehen, nicht durch Durchreichen.
+            aggregiert=SegmentWeatherSummary(temp_max_c=99.9),
+            stunden=[_punkt(h, **FRUEH) for h in (6, 7, 8, 9)]
+                    + [_punkt(h, **SPAET) for h in (10, 11)],
+        )])
+
+        ergebnis = _extractor(tmp_path).timeline("tour-2186", from_time=_um_zehn())
+
+        assert len(ergebnis.points) == 1
+        m = ergebnis.points[0].metrics
+
+        # Stufe 2 (compute_extended_metrics) — ohne sie waeren diese still None.
+        assert m.pop_max_pct == 20, "pop_max_pct traegt noch den Vormittag"
+        assert m.cape_max_jkg == 400.0, "cape_max_jkg traegt noch den Vormittag"
+        assert m.uv_index_max == 7.0, "uv_index_max ist nicht belegt"
+        assert m.cloud_low_avg_pct == 30, "cloud_low_avg_pct traegt noch den Vormittag"
+        assert m.precip_type_dominant == PrecipType.RAIN, (
+            "precip_type_dominant meldet noch den Schnee des Vormittags"
+        )
+        assert m.snowfall_limit_m == 2800, "snowfall_limit_m traegt noch den Vormittag"
+
+        # Stufe 1 (compute_basis_metrics) — dieselbe Aussage am anderen Ende
+        # der Kette: faellt Stufe 1 weg, kann Stufe 2 gar nicht erst laufen.
+        assert m.precip_sum_mm == 0.0, "der Vormittagsregen steckt noch im Tageswert"
+        assert m.temp_min_c == 15.0
+        assert m.wind_max_kmh == 8.0
+        assert m.gust_max_kmh == 15.0
+        assert m.cloud_avg_pct == 35
+        assert m.humidity_avg_pct == 50
+        assert m.visibility_min_m == 25000
+
+    def test_ac6_kein_geprueftes_feld_faellt_still_auf_none(
+        self, tmp_path: Path,
+    ) -> None:
+        """
+        GIVEN ein beschnittenes Segment mit vollstaendiger Stundenreihe,
+        WHEN sein Aggregat neu berechnet wird,
+        THEN ist KEINES der sechs Leitfelder ``None`` — der stille Ausfall
+             einer halben Rechenkette sieht sonst aus wie „keine Daten".
+        """
+        _speichere(tmp_path, [_segment(
+            1, 6, 12,
+            aggregiert=SegmentWeatherSummary(),
+            stunden=[_punkt(h, **FRUEH) for h in (6, 7, 8, 9)]
+                    + [_punkt(h, **SPAET) for h in (10, 11)],
+        )])
+
+        ergebnis = _extractor(tmp_path).timeline("tour-2186", from_time=_um_zehn())
+        m = ergebnis.points[0].metrics
+
+        leer = [
+            feld for feld in (
+                "pop_max_pct", "cape_max_jkg", "uv_index_max", "cloud_low_avg_pct",
+                "precip_type_dominant", "snowfall_limit_m",
+            )
+            if getattr(m, feld) is None
+        ]
+        assert leer == [], f"Felder still auf None gefallen: {leer}"
+
+
+# ---------------------------------------------------------------------------
+# AC-3 — noch nicht begonnenes Segment bleibt unangetastet
+# ---------------------------------------------------------------------------
+
+class TestNochNichtBegonnenesSegment:
+    def test_ac3_segment_nach_dem_anfragezeitpunkt_behaelt_sein_aggregat(
+        self, tmp_path: Path,
+    ) -> None:
+        """
+        GIVEN ein Segment 16-18 Uhr, das zum Anfragezeitpunkt 10:00 noch gar
+              nicht begonnen hat,
+        WHEN die Tages-Aggregation laeuft,
+        THEN behaelt es sein GESPEICHERTES Aggregat unveraendert — Wert fuer
+             Wert identisch zum ungefensterten Abruf, keine Neuberechnung.
+        """
+        _speichere(tmp_path, [_segment(
+            2, 16, 18,
+            aggregiert=SegmentWeatherSummary(**UNVERWECHSELBAR),
+            # Die Stundenreihe traegt ABWEICHENDE Werte: wuerde faelschlich
+            # gerechnet, kaeme etwas anderes heraus als das Gespeicherte.
+            stunden=[_punkt(h, **SPAET) for h in (16, 17)],
+        )])
+        extractor = _extractor(tmp_path)
+
+        gefenstert = extractor.timeline("tour-2186", from_time=_um_zehn())
+        ungefenstert = extractor.timeline("tour-2186")
+
+        m = gefenstert.points[0].metrics
+        for feld, erwartet in UNVERWECHSELBAR.items():
+            assert getattr(m, feld) == erwartet, (
+                f"{feld} wurde veraendert, obwohl das Segment noch nicht begonnen hat"
+            )
+        assert m == ungefenstert.points[0].metrics, (
+            "gefensterter und ungefensterter Abruf liefern verschiedene Aggregate"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-7 — die Fensterstunden des Segments werden durchgereicht
+# ---------------------------------------------------------------------------
+
+class TestFensterstundenWerdenDurchgereicht:
+    @pytest.mark.parametrize(
+        "day_window, erwarteter_onset",
+        [
+            # Eigenes Fenster 6-21: die Gewitterstunde 20 Uhr liegt DRIN.
+            ((6, 21), datetime(TAG.year, TAG.month, TAG.day, 20, 0)),
+            # Ohne eigenes Fenster gilt der Default 4-19 — 20 Uhr liegt DRAUSSEN.
+            # Diese Haelfte ist die Positivkontrolle: sie zeigt, dass der Test
+            # tatsaechlich am Fenster haengt und nicht an irgendetwas anderem.
+            ((None, None), None),
+        ],
+        ids=["eigenes_fenster_6_21", "default_fenster_4_19"],
+    )
+    def test_ac7_thunder_onset_folgt_dem_segmentfenster(
+        self, tmp_path: Path, day_window, erwarteter_onset,
+    ) -> None:
+        """
+        GIVEN ein beschnittenes Segment mit eigenem Tagesfenster und einem
+              Gewitter um 20:00 Ortszeit,
+        WHEN sein Aggregat neu berechnet wird,
+        THEN richtet sich ``thunder_onset_utc`` nach DIESEM Fenster und faellt
+             nicht still auf den 04-19-Uhr-Default zurueck.
+        """
+        stunden = (
+            [_punkt(h, **SPAET) for h in range(6, 20)]
+            + [_punkt(20, thunder_level=ThunderLevel.HIGH, **SPAET)]
+            + [_punkt(21, **SPAET)]
+        )
+        _speichere(tmp_path, [_segment(
+            3, 6, 22,
+            # Weder Onset noch Stufe vorbelegt: was unten steht, ist gerechnet.
+            aggregiert=SegmentWeatherSummary(temp_max_c=99.9),
+            stunden=stunden,
+            day_window=day_window,
+        )])
+
+        ergebnis = _extractor(tmp_path).timeline("tour-2186", from_time=_um_zehn())
+        m = ergebnis.points[0].metrics
+
+        # Beweist, dass ueberhaupt neu gerechnet wurde — sonst waere die
+        # ``None``-Haelfte oben auch durch blosses Durchreichen erfuellt.
+        assert m.thunder_level_max == ThunderLevel.HIGH, (
+            "das Segment wurde gar nicht neu gerechnet"
+        )
+        assert m.thunder_onset_utc == erwarteter_onset
+
+
+# ---------------------------------------------------------------------------
+# AC-8 — Segment ohne Stundenreihe
+# ---------------------------------------------------------------------------
+
+class TestSegmentOhneStundenreihe:
+    def test_ac8_ohne_timeseries_bleibt_das_aggregat_und_nichts_faellt_um(
+        self, tmp_path: Path,
+    ) -> None:
+        """
+        GIVEN ein Segment ohne Stundenreihe (``timeseries is None``), das zum
+              Anfragezeitpunkt bereits laeuft,
+        WHEN die Tages-Aggregation fuer dieses Segment laeuft,
+        THEN bleibt sein gespeichertes Aggregat unveraendert und es entsteht
+             kein Fehler — kein ``ValueError`` aus der leeren Rechenkette.
+        """
+        _speichere(tmp_path, [_segment(
+            4, 6, 12,
+            aggregiert=SegmentWeatherSummary(**UNVERWECHSELBAR),
+            stunden=None,
+        )])
+
+        ergebnis = _extractor(tmp_path).timeline("tour-2186", from_time=_um_zehn())
+
+        assert ergebnis.available is True
+        assert len(ergebnis.points) == 1
+        m = ergebnis.points[0].metrics
+        for feld, erwartet in UNVERWECHSELBAR.items():
+            assert getattr(m, feld) == erwartet, (
+                f"{feld} wurde veraendert, obwohl es keine Stundenreihe gibt"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Die beiden GLEICHHEITS-Grenzen
+#
+# Die Spec entscheidet sie ausdruecklich (Pseudocode Zeilen 76/78): ``jetzt ==
+# Segmentstart`` gilt als „noch nicht begonnen" (Aggregat unveraendert),
+# ``jetzt == Segmentende`` als „vollstaendig vergangen" (Segment entfaellt).
+# Beide Faelle treten real auf — Segmentgrenzen liegen auf vollen Stunden und
+# ein Abruf zur vollen Stunde trifft sie genau. Ohne diese beiden Tests
+# ueberlebt jede der beiden Grenzen eine Verschiebung um einen Punkt
+# unbemerkt (Adversary-Befund M3).
+# ---------------------------------------------------------------------------
+
+class TestGleichheitsgrenzen:
+    def test_ac3_anfrage_exakt_zum_segmentstart_rechnet_nicht_neu(
+        self, tmp_path: Path,
+    ) -> None:
+        """
+        GIVEN ein Segment 10-14 Uhr und einen Abruf um GENAU 10:00,
+        WHEN die Tages-Aggregation laeuft,
+        THEN behaelt es sein gespeichertes Aggregat — die Etappe hat noch
+             keine Minute hinter sich, es gibt nichts zu beschneiden.
+
+        Die Stundenreihe traegt ABWEICHENDE Werte: wuerde faelschlich
+        gerechnet, kaeme etwas anderes heraus als das Gespeicherte.
+        """
+        _speichere(tmp_path, [_segment(
+            5, 10, 14,
+            aggregiert=SegmentWeatherSummary(**UNVERWECHSELBAR),
+            stunden=[_punkt(h, **SPAET) for h in (10, 11, 12, 13)],
+        )])
+
+        ergebnis = _extractor(tmp_path).timeline("tour-2186", from_time=_um_zehn())
+
+        assert len(ergebnis.points) == 1, (
+            "das Segment beginnt erst jetzt und darf nicht entfallen"
+        )
+        m = ergebnis.points[0].metrics
+        for feld, erwartet in UNVERWECHSELBAR.items():
+            assert getattr(m, feld) == erwartet, (
+                f"{feld} wurde neu gerechnet, obwohl die Anfrage exakt auf dem "
+                f"Segmentstart liegt"
+            )
+
+    def test_ac5_anfrage_exakt_zum_segmentende_laesst_das_segment_entfallen(
+        self, tmp_path: Path,
+    ) -> None:
+        """
+        GIVEN ein Segment 06-10 Uhr, das um GENAU 10:00 zu Ende ist, und
+              daneben eines, das erst um 12:00 beginnt,
+        WHEN die Wegpunkte gebildet werden,
+        THEN entfaellt das abgelaufene Segment — und nur dieses.
+
+        Das zweite Segment ist die Positivkontrolle: ohne es bestuende der
+        Test auch, wenn die Fensterung ALLES verschluckte.
+        """
+        _speichere(tmp_path, [
+            _segment(
+                5, 6, 10,
+                aggregiert=SegmentWeatherSummary(**UNVERWECHSELBAR),
+                stunden=[_punkt(h, **FRUEH) for h in (6, 7, 8, 9)],
+            ),
+            _segment(
+                6, 12, 16,
+                aggregiert=SegmentWeatherSummary(temp_max_c=99.9),
+                stunden=[_punkt(h, **SPAET) for h in (12, 13, 14, 15)],
+            ),
+        ])
+
+        ergebnis = _extractor(tmp_path).timeline("tour-2186", from_time=_um_zehn())
+
+        assert [p.label for p in ergebnis.points] == ["6"], (
+            f"das um 10:00 abgelaufene Segment steht noch in den Wegpunkten: "
+            f"{[p.label for p in ergebnis.points]}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Die Gewitter-HERKUNFT ueberlebt die Neuberechnung
+#
+# ``compute_extended_metrics`` baut ein neues Summary und kopiert
+# ``thunder_level_max_signals`` NICHT mit (dieselbe Naht wie #1391/#1392/
+# #1468). Die Neuberechnung holt den Wert deshalb von Hand aus der ersten
+# Stufe zurueck. Bislang haengt dieser Schutz nur an vier fremden Tests in
+# ``test_thunder_origin_*`` — er gehoert dorthin, wo er wirkt.
+# ---------------------------------------------------------------------------
+
+class TestGewitterHerkunftUeberlebtDieNeuberechnung:
+    def test_traeger_der_hoechststufe_bleiben_am_neu_gerechneten_aggregat(
+        self, tmp_path: Path,
+    ) -> None:
+        """
+        GIVEN ein beschnittenes Segment, dessen Restfenster eine Gewitter-
+              stunde mit benannter Zutat traegt,
+        WHEN sein Aggregat neu berechnet wird,
+        THEN nennt das neue Aggregat diese Zutat — sonst verliert die
+             Ad-hoc-Antwort die Herkunft ("⛈ Gewitter heute: hoch · CAPE")
+             und meldet nur noch die nackte Stufe.
+        """
+        _speichere(tmp_path, [_segment(
+            7, 6, 14,
+            # Weder Stufe noch Traeger vorbelegt: was unten steht, ist gerechnet.
+            aggregiert=SegmentWeatherSummary(temp_max_c=99.9),
+            stunden=(
+                [_punkt(h, **FRUEH) for h in (6, 7, 8, 9)]
+                + [_punkt(10, thunder_level=ThunderLevel.HIGH,
+                          thunder_level_signals=["cape"], **SPAET)]
+                + [_punkt(h, **SPAET) for h in (11, 12, 13)]
+            ),
+        )])
+
+        ergebnis = _extractor(tmp_path).timeline("tour-2186", from_time=_um_zehn())
+        m = ergebnis.points[0].metrics
+
+        # Beweist, dass ueberhaupt neu gerechnet wurde.
+        assert m.thunder_level_max == ThunderLevel.HIGH, (
+            "das Segment wurde gar nicht neu gerechnet"
+        )
+        assert m.thunder_level_max_signals == ["cape"], (
+            f"die Traeger der Hoechststufe sind bei der Neuberechnung "
+            f"verlorengegangen: {m.thunder_level_max_signals!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Das Hagel-Kennzeichen ueberlebt die Neuberechnung
+#
+# ``compute_extended_metrics`` kopiert ``hail_flag`` NICHT mit (dieselbe Naht
+# wie ``thunder_level_max_signals`` oben, #1391/#1392/#1468). Anders als
+# dieses Feld hing der Schutz dafuer bislang an KEINEM Test in dieser Datei —
+# nur an den Kanal-Renderern in ``test_hail_flag_channel_rendering.py``, die
+# das Symptom (fehlender Hinweistext), nicht die Ursache (Restfenster-
+# Neuberechnung) bewachen.
+# ---------------------------------------------------------------------------
+
+class TestHagelKennzeichenUeberlebtDieNeuberechnung:
+    def test_hail_flag_bleibt_am_neu_gerechneten_aggregat(
+        self, tmp_path: Path,
+    ) -> None:
+        """
+        GIVEN ein beschnittenes Segment, dessen Restfenster eine bestaetigte
+              Hagelstunde traegt,
+        WHEN sein Aggregat neu berechnet wird,
+        THEN bleibt ``hail_flag`` True am neu gerechneten Aggregat.
+        """
+        _speichere(tmp_path, [_segment(
+            8, 6, 12,
+            # Weder Flag noch sonst etwas vorbelegt: was unten steht, ist
+            # gerechnet, nicht durchgereicht.
+            aggregiert=SegmentWeatherSummary(temp_max_c=99.9),
+            stunden=(
+                [_punkt(h, **FRUEH) for h in (6, 7, 8, 9)]
+                + [_punkt(10, hail_flag=True, **SPAET)]
+                + [_punkt(11, **SPAET)]
+            ),
+        )])
+
+        ergebnis = _extractor(tmp_path).timeline("tour-2186", from_time=_um_zehn())
+        m = ergebnis.points[0].metrics
+
+        # Beweist, dass ueberhaupt neu gerechnet wurde -- sonst waere
+        # ``hail_flag`` auch durch blosses Durchreichen des Alt-Werts erfuellt.
+        assert m.temp_min_c == 15.0, "das Segment wurde gar nicht neu gerechnet"
+        assert m.hail_flag is True, (
+            "hail_flag ist bei der Neuberechnung verlorengegangen"
+        )

--- a/tests/tdd/test_weather_extractor.py
+++ b/tests/tdd/test_weather_extractor.py
@@ -324,3 +324,56 @@ class TestMultiUserIsolation:
         assert res_a.points[0].metrics.temp_max_c == 20.0
         assert res_b.available is False
         assert res_b.points == []
+
+
+# ---------------------------------------------------------------------------
+# Issue #2186 AC-9 — Rueckwaertskompatibilitaet des ungefensterten Aufrufs
+#
+# SPEC: docs/specs/modules/feat_2186_tagesaggregat_ab_jetzt.md v1.0
+#
+# Die Spec verweist fuer AC-9 auf `tests/unit/test_weather_extractor.py`; die
+# Suite liegt tatsaechlich hier (`tests/tdd/`), ein `tests/unit`-Pendant gibt
+# es nicht. Verankert wird sie deshalb an der real vorhandenen Datei.
+# ---------------------------------------------------------------------------
+
+class TestTimelineOhneFromTime:
+    def test_ac9_aufruf_ohne_from_time_bleibt_unveraendert(self, tmp_path: Path) -> None:
+        """
+        GIVEN einen Snapshot, dessen Segment zum Zeitpunkt eines gedachten
+              Abrufs laengst begonnen haette,
+        WHEN timeline() OHNE `from_time` aufgerufen wird — so wie die vier
+             bestehenden Aufrufer es tun,
+        THEN liefert es die gespeicherten Aggregate unveraendert, und der
+             ausdrueckliche Default `from_time=None` ergibt exakt dasselbe.
+
+        Der zweite Teil ist der eigentliche Waechter: er faellt, solange der
+        Parameter fehlt, und schuetzt danach die Zusicherung, dass sein
+        Default nichts veraendert.
+        """
+        svc = _snapshot_service(tmp_path)
+        seg = _segment_weather(
+            1, 8, 12, end_elevation_m=1400.0, temp_max_c=17.5,
+            hourly=_hours(
+                (8, ThunderLevel.MED, 6.0),
+                (9, ThunderLevel.MED, 7.0),
+                (10, None, 15.0),
+                (11, None, 17.5),
+            ),
+        )
+        svc.save("gr20", [seg], date(2026, 2, 14))
+        extractor = _extractor(tmp_path)
+
+        ohne_argument = extractor.timeline("gr20")
+
+        assert ohne_argument.available is True
+        assert len(ohne_argument.points) == 1
+        # Das GESPEICHERTE Aggregat, nicht ein neu gerechnetes Restfenster.
+        assert ohne_argument.points[0].metrics.temp_max_c == 17.5
+        assert ohne_argument.points[0].metrics.wind_max_kmh == 22.0
+        assert ohne_argument.points[0].arrival_time == datetime(
+            2026, 2, 14, 12, 0, tzinfo=timezone.utc,
+        )
+
+        mit_default = extractor.timeline("gr20", from_time=None)
+        assert mit_default.points[0].metrics == ohne_argument.points[0].metrics
+        assert mit_default.points[0].arrival_time == ohne_argument.points[0].arrival_time


### PR DESCRIPTION
Schliesst #2186.

## Problem

Ein Ad-hoc-Abruf am Nachmittag zeigte fuer „heute" weiterhin den vollen Tageswert **inklusive des laengst vergangenen Vormittags** — 21,5 mm Vormittagsregen standen um 16 Uhr noch als Regenmenge „heute" da, Gewitterstufe und Drilldown-Buttons entsprechend.

## Loesung

`WeatherExtractor.timeline()` und `timeline_dated()` nehmen ein optionales `from_time`:

- **vollstaendig vergangenes Segment** faellt aus den Wegpunkten
- **angebrochenes Segment** wird ueber sein Restfenster neu gerechnet (`_restfenster_aggregat`), mit demselben Fenster-Helfer wie die Erstberechnung (kein eigener Stundenschnitt)
- **ohne `from_time`** bleibt das Verhalten unveraendert

Der Ad-hoc-Pfad reicht `received_at` durch — auch in den datierten Rueckfall (#1818). Griffe die Fensterung nur am Anker, zeigte derselbe Abruf je nach tragender Datei einen anderen Tageswert.

## Mitgefangene Regression

Die Neuberechnung baut ueber `compute_extended_metrics()` ein neues Summary, das einen Teil der Basis-Felder nicht mitkopiert (bekannte Naht, #1391/#1392). Statt Feld fuer Feld nachzuflicken werden **alle** Felder zurueckgeholt, die in `basis` gesetzt und in `neu` `None` sind — beide stammen aus derselben Zeitreihe, ein `None` ist dort zwingend Kopierverlust.

Betroffen sind `thunder_level_max_signals` und `hail_flag`. Ohne die Rettung verlor die `GEWITTER`-Antwort den **Hagel-Hinweis**, obwohl der Hagel im Restfenster lag. Gefunden in der Validierungsphase (zwei Tests in `test_hail_flag_channel_rendering.py` wurden rot), bewacht jetzt zusaetzlich durch einen zeitunabhaengigen Test.

## Nachweis

- Zielsuite: 33 Tests gruen
- Regressionsumfang (61 Testdateien, alle Nachbarn von `weather_extractor`/`trip_command_processor`): **756 gruen, 0 rot**
- Adversary-Dialog: VERIFIED, 17 Punkte, 3 Runden
- Mutations-Gegenprobe zur Feld-Rettung: Fix deaktiviert ⇒ 4 Tests rot
- Acceptance Criteria: 12/12 belegt

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HDM4UQfY8f5WcJB1RNn5t5