### PR TITLE
fix(#2144): kein globaler Mail-Fallback mehr fuer Nutzer ohne Empfaenger-Profil

### DIFF
--- a/docs/context/fix-2144-mail-to-fallback.md
+++ b/docs/context/fix-2144-mail-to-fallback.md
@@ -1,0 +1,94 @@
+# Context: fix-2144-mail-to-fallback
+
+## Request Summary
+Neue Nutzer, die bei der Registrierung kein explizites `mail_to` im Profil bekommen,
+erhalten ihre Briefings über den globalen `.env`-Fallback (`GZ_MAIL_TO`/`GZ_TELEGRAM_CHAT_ID`/
+`GZ_SMS_TO`) — die landen beim Betreiber. Cross-Tenant-Zustellung, Blocker, Teil von Epic #2138.
+
+## Related Files
+
+| File | Relevance |
+|------|-----------|
+| `internal/handler/auth.go:96-109` | `RegisterHandler` (Passwort-Weg) — setzt `model.User{Email: req.Email}`, **kein** `MailTo`. Feld existiert bereits im Modell (`internal/model/user.go:16 json:"mail_to"`). |
+| `internal/handler/auth_magic.go:205-213` | Magic-Link-Registrierung — analoges `model.User{}`-Literal, ebenfalls ohne `MailTo`. |
+| `internal/handler/auth_oauth.go:201-211` | OAuth-Registrierung — dito. |
+| `internal/handler/passkey.go:477,528,536,554` | Passkey-Registrierung — `newUser := model.User{...}` bei `passkey.go:536`, ebenfalls ohne `MailTo`. |
+| `internal/store/user.go:52,84` | `SaveUser` schreibt das komplette `User`-Struct nach `<DataDir>/users/<id>/user.json` — Neuanlage, kein Read-Modify-Write nötig (Datei existiert noch nicht). |
+| `src/app/config.py:365-410` (`with_user_profile`) | Liest **dieselbe** `user.json` (`get_data_dir(user_id)/"user.json"`, gleicher Pfad wie Go's `DataDir/users/<id>/user.json` — bestätigt über `GZ_DATA_DIR`/systemd-Drop-in). Überschreibt `mail_to`/`telegram_chat_id`/`sms_to` in `overrides` **nur wenn im Profil vorhanden** (`if profile.get("mail_to"): overrides["mail_to"] = ...`) — sonst bleibt der globale `.env`-Wert aus `base` (bzw. `self`) stehen. Das ist die Kernursache. |
+| `src/output/channels/base.py:66` | `ChannelBlockedError(OutputConfigError)` — bestehende Exception-Klasse für „Kanal technisch/fachlich nicht sendefähig", trägt `reason_code`. |
+| `src/output/channels/premium_sms.py:41-91` (`_resolve_recipient`) | **Referenzmuster** für „kein Empfänger bekannt": wirft `ChannelBlockedError` mit eigenem `reason_code` (`BLOCK_REASON_NO_REPLY_ADDRESS`) statt zu senden oder zu crashen. Wird von `notification_service.py` als `blocked_channels`/`blocked_reason_codes` sauber protokolliert (kein `briefing_log`-Eintrag, aber unterscheidbare Log-Zeile — vgl. #1007/#1403). |
+| `src/output/channels/email.py:431,648-650` | `self._to = settings.mail_to`; `send()` baut `recipients = [to] if to else [self._to]` — bei leerem `self._to` **kein** Skip, sondern Versand an `[None]`/`[""]`. Braucht dieselbe Resolve-mit-`ChannelBlockedError`-Behandlung wie Premium-SMS. |
+| `src/output/channels/telegram.py:209,403` | `chat_id = self._settings.telegram_chat_id` — analog ungeprüft. |
+| `src/output/channels/sms.py:42` | `return self._settings.sms_to` — analog ungeprüft. |
+| `src/services/scheduler_dispatch_service.py:412-431` | Compare-Preset-Versand: **hat bereits** einen expliziten Check (`if not default_to: raise ValueError(...)`), Issue #1452, „Fehlerverhalten bewusst unveraendert" — dieser Pfad ist NICHT Teil des Bugs, sollte aber nicht durch die config.py-Änderung in seinem Verhalten kippen. |
+| `src/services/trip_report_scheduler.py:1616-1641` | Trip-Briefing-Versand — nutzt `settings.mail_to` nur für Logging (`mail_empfaenger = self._settings.mail_to if "email" in result.sent_channels ...`), der eigentliche Versand läuft über `notification_service.py` → `email.py`. Kein eigener Fix nötig, profitiert von der Channel-Fix. |
+| `docs/reference/operations_playbook.md:616-621` | Beschreibt aktuell nur den Override-Fall (`user.json.mail_to` überschreibt `GZ_MAIL_TO`), **nicht** den Fallback-bei-Fehlen-Fall aus dem Issue — Zeilennummern im Issue (531-533) sind durch spätere Doc-Edits verschoben, inhaltlich aber dieselbe Passage. Braucht nach dem Fix eine Ergänzung: kein Fallback mehr, sondern Skip. |
+
+## Existing Patterns
+
+- **`ChannelBlockedError` + `reason_code`** (`premium_sms.py`) ist das etablierte Muster für „technisch/fachlich nicht sendefähig, kein Crash, sauberes Log" — sollte für Email/Telegram/SMS bei fehlendem Empfänger wiederverwendet werden, nicht neu erfunden.
+- **Zwei getrennte Fallback-Fragen** existieren im Code: (a) `with_user_profile()` — Profil fehlt Feld → globaler Fallback (BUG), (b) Compare-Preset-Pfad — hat schon einen expliziten `ValueError`-Guard (kein Bug, aber inkonsistentes Fehlerverhalten ggü. dem Kanal-Skip-Muster; aus Scope-Gründen vermutlich unangetastet lassen, siehe Risiken).
+- **`data/users/<id>/user.json` ist eine geteilte Datei** zwischen Go-API und Python-Core (gleicher Pfad über `DataDir`/`GZ_DATA_DIR`) — kein Sync-Mechanismus nötig, Go schreibt direkt das Feld, das Python liest.
+
+## Dependencies
+
+- Upstream: Go `RegisterHandler`-Familie (4 Wege) schreibt `user.json`; Python `with_user_profile()` liest sie.
+- Downstream: `notification_service.py` orchestriert die drei Kanal-Klassen (`email.py`, `telegram.py`, `sms.py`), wertet `blocked_channels`/`blocked_reason_codes` aus für Cockpit/Log (#393, #1007, #1403).
+
+## Existing Specs
+
+- `docs/specs/modules/user_auth_endpoints.md` — RegisterHandler-Spec, kennt bisher kein `MailTo`-AC.
+- `docs/specs/modules/scheduler_multi_user.md` — Mandanten-Dispatch, relevant für „Zwei-Nutzer-Test"-AC.
+- `docs/specs/modules/passkey_webauthn.md` — vierter Registrierungsweg.
+
+## Risks & Considerations
+
+- **Scope-Grenze:** Das Issue fordert explizit alle drei Felder (`mail_to`/`telegram_chat_id`/`sms_to`) UND alle vier Registrierungswege UND den Zwei-Nutzer-Test. Das ist mehr als eine Ein-Zeilen-Änderung — bestätigt die Standard-Track-Einstufung (nicht Fast Track).
+- **Nicht anfassen:** Der Compare-Preset-`ValueError`-Pfad (#1452) hat bewusst anderes Fehlerverhalten (hart failen statt skip) — Spec sollte klarstellen, dass dieser Pfad unverändert bleibt, sonst bricht ein bestehender Test.
+- **Telegram-Sonderfall:** `telegram_chat_id` wird beim Onboarding typischerweise erst durch eine Bot-Interaktion gelernt (nicht bei Registrierung), d.h. „explizit auf `None` setzen, wenn Profil-Feld fehlt" ist für Telegram vermutlich schon der Ist-Zustand oder nahe dran — separat verifizieren, um keinen Regressions-Fix für ein bereits korrektes Verhalten zu bauen.
+- **Bestandsnutzer:** Bereits registrierte Nutzer ohne `mail_to` im Profil sind vom Fix nicht rückwirkend betroffen (nur `with_user_profile()`-Verhalten ändert sich) — das ist erwünscht (kein Daten-Backfill nötig, das Verhalten korrigiert sich beim nächsten Versandversuch selbst: Skip statt Fehlversand).
+- **Doku:** `operations_playbook.md` braucht eine Ergänzung nach dem Fix (Fallback-Fall ist dann „Skip mit Log", nicht mehr "globaler Fallback").
+
+## Analysis
+
+### Type
+Bug (Cross-Tenant-Zustellung durch stillen globalen Fallback).
+
+### Affected Files (with changes)
+
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `internal/handler/auth.go` | MODIFY | `model.User{...}` um `MailTo: req.Email` ergänzen (Passwort-Registrierung). |
+| `internal/handler/auth_magic.go` | MODIFY | dito für Magic-Link-Registrierung. |
+| `internal/handler/auth_oauth.go` | MODIFY | dito für OAuth-Registrierung. |
+| `internal/handler/passkey.go` | MODIFY | dito für `newUser` bei Passkey-Registrierung (Zeile ~536) — `PasskeyRegisterPublicBeginHandler` validiert `req.Email` (`@`-Pflicht, Zeile ~468) und legt sie in `ChallengeEntry.Email` ab; `Finish` liest `entry.Email` bereits für `newUser.Email` (Zeile ~537) → `MailTo: entry.Email` verfügbar, keine offene Frage. |
+| `src/app/config.py` (`with_user_profile`) | MODIFY | `overrides["mail_to"] = profile.get("mail_to")` (auch wenn falsy → explizit `None`), analog für `telegram_chat_id`/`sms_to`. `GZ_MAIL_TO`/`GZ_TELEGRAM_CHAT_ID`/`GZ_SMS_TO` bleiben nur noch für Legacy-CLI ohne `with_user_profile()`-Aufruf wirksam. |
+| `src/output/channels/email.py` | MODIFY | `_resolve_recipient()`-artige Prüfung vor Versand: fehlendes `self._to` → `ChannelBlockedError("email", "...", reason_code=BLOCK_REASON_NO_RECIPIENT)` statt Versand an `[None]`. |
+| `src/output/channels/telegram.py` | MODIFY | analoge Prüfung für `chat_id`. |
+| `src/output/channels/sms.py` | MODIFY | analoge Prüfung für `sms_to`. |
+| `docs/reference/operations_playbook.md` | MODIFY (Doku, zählt nicht gegen LoC-Limit) | Fallback-Passage um den Skip-statt-Fallback-Fall ergänzen. |
+| Tests (neu, je Bereich) | CREATE | Zwei-Nutzer-Test je Registrierungsweg (mind. 1 repräsentativ + Parametrisierung möglich) + Skip-Test je Kanal + `with_user_profile()`-Unit-Test für alle drei Felder. |
+
+### Scope Assessment
+- Files: ~8 Produktionsdateien + Doku + neue/erweiterte Testdateien
+- Estimated LoC: +70/-5 Produktionscode (grobe Schätzung: 4×1 Go-Zeilen, ~20 config.py, ~45 auf 3 Kanalklassen), Tests zusätzlich ~100-150 LoC — Summe wahrscheinlich unter, aber nahe am 250-LoC-Workflow-Limit; ggf. `loc_limit_override` nötig.
+- Risk Level: HIGH (Auth + Versand-Kernpfad, alle Nutzer, alle drei Kanäle) bei niedriger technischer Unsicherheit (bestehendes Muster wiederverwendbar).
+
+### Technical Approach
+1. Go: an allen vier Registrierungs-Stellen `MailTo` mit der bekannten E-Mail-Adresse setzen (dort wo eine E-Mail vorliegt).
+2. Python `with_user_profile()`: von „nur überschreiben wenn vorhanden" auf „immer setzen, auch auf `None`" umstellen — das entfernt den stillen Fallback strukturell an der Quelle.
+3. Kanal-Klassen (`email.py`/`telegram.py`/`sms.py`): defensive Prüfung ergänzen, die bei fehlendem Empfänger sauber mit `ChannelBlockedError` abbricht (Muster aus `premium_sms.py`) statt an eine leere Adresse zu senden — nötig, weil Schritt 2 sonst bestehende Trips mit `send_email=True` aber ohne `mail_to` hart brechen lassen würde statt sauber zu skippen.
+4. Compare-Preset-Pfad (`scheduler_dispatch_service.py:412-431`) bewusst **nicht anfassen** — hat bereits sein eigenes, dokumentiert-unverändertes `ValueError`-Verhalten (#1452).
+5. Zwei-Nutzer-Test wie im Issue gefordert: Nutzer A mit `mail_to`, Nutzer B ohne → B wird übersprungen mit erkennbarer Meldung/`reason_code`, nichts geht an Nutzer A oder den Betreiber.
+
+### Dependencies
+Siehe „Dependencies" oben (Context-Sektion) — unverändert.
+
+### Open Questions
+- [x] **Geklärt:** `telegram_chat_id` wird bei **keinem** der vier Registrierungswege gesetzt (nur nachträglich über den Settings-Endpoint, `auth.go:675`). Ein frisches `user.json` hat das Feld leer → `with_user_profile()` überschreibt nicht → derselbe globale Fallback auf `GZ_TELEGRAM_CHAT_ID` (Betreiber-Chat) wie bei `mail_to`. Kein Sonderfall, sondern dieselbe Bug-Klasse — bestätigt den Scope aus dem Issue (alle drei Felder).
+
+## Track & Nächster Schritt
+
+Standard Track (Score 3) bestätigt durch Kontext-Recherche — Scope trifft 4 Go-Handler + 3 Python-Kanalklassen + `config.py` + Doku, Blast Radius bleibt hoch (Auth + alle drei Kanäle für alle Nutzer), Unsicherheit bleibt niedrig (bekanntes `ChannelBlockedError`-Muster wiederverwendbar).
+
+Weiter mit `/30-write-spec`.

--- a/docs/reference/operations_playbook.md
+++ b/docs/reference/operations_playbook.md
@@ -618,7 +618,12 @@ Es gibt **drei** Postfächer: `gregor-test@` (Test-/Gate-Mails), `gregor-staging
 `/home/hem/gregor_zwanzig_staging/data/` — der Ordner dort ist stillgelegter Altbestand.
 Der pro Nutzer abweichende Empfänger steht in
 `/var/lib/gregor-staging/users/<uid>/user.json` als `mail_to` und **überschreibt** das
-globale `GZ_MAIL_TO` aus der `.env`.
+globale `GZ_MAIL_TO` aus der `.env`. **Fehlt `mail_to`/`telegram_chat_id`/`sms_to` im
+Profil, gibt es seit Issue #2144 KEINEN Fallback mehr auf das globale `GZ_MAIL_TO`/
+`GZ_TELEGRAM_CHAT_ID`/`GZ_SMS_TO`:** der betroffene Kanal wird für diesen Nutzer sauber
+übersprungen (`ChannelBlockedError` mit `reason_code` `email_no_recipient` /
+`telegram_no_chat_id` / `sms_no_recipient`, protokolliert statt an eine fremde Adresse
+zugestellt).
 
 ```bash
 systemctl cat gregor-python-staging | grep GZ_DATA_DIR      # Wurzel feststellen

--- a/docs/specs/bugfix/user_recipient_fallback.md
+++ b/docs/specs/bugfix/user_recipient_fallback.md
@@ -1,0 +1,192 @@
+---
+entity_id: user_recipient_fallback
+type: bugfix
+created: 2026-09-08
+updated: 2026-09-08
+status: draft
+version: "1.0"
+workflow: "fix-2144-mail-to-fallback"
+tags: [auth, multi-user, email, telegram, sms, recipient-fallback, cross-tenant]
+---
+
+# User Recipient Fallback
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Neue Nutzer, deren Profil kein explizites `mail_to`/`telegram_chat_id`/`sms_to` trägt,
+bekommen ihre Briefings heute über den globalen `.env`-Fallback
+(`GZ_MAIL_TO`/`GZ_TELEGRAM_CHAT_ID`/`GZ_SMS_TO`) zugestellt — die zeigen auf die
+Betreiber-Adresse. Diese Spec schließt den Fallback an der Quelle
+(`with_user_profile()`) und macht die drei Versandkanäle robust gegen den dadurch
+entstehenden „kein Empfänger bekannt"-Fall, statt an eine leere Adresse zu senden.
+
+## Source
+
+- **File:** `src/app/config.py`
+- **Identifier:** `Settings.with_user_profile()`
+
+## Estimated Scope
+
+- **LoC:** ~90–150 Produktionscode (4× Go-Handler ~1 Zeile, `config.py` ~20–30 Zeilen,
+  3 Kanalklassen ~15–25 Zeilen je Datei), zusätzlich ~150–250 Testcode — Summe liegt
+  nahe am 250-LoC-Workflow-Limit, `loc_limit_override` ist wahrscheinlich nötig.
+- **Files:** ~9 Produktionsdateien (4 Go-Handler, `config.py`, 3 Kanalklassen,
+  `operations_playbook.md`) + ~6–9 Testdateien (neu/erweitert).
+- **Effort:** medium (bestehendes `ChannelBlockedError`-Muster wiederverwendbar, aber
+  hoher Blast Radius: Auth + alle drei Versandkanäle für alle Nutzer).
+
+### Affected Files
+
+| File | Change Type | Description |
+|------|-------------|--------------|
+| `internal/handler/auth.go` | MODIFY | `RegisterHandler`: `model.User{...}` um `MailTo: req.Email` ergänzen (Passwort-Weg). |
+| `internal/handler/auth_magic.go` | MODIFY | Magic-Link-Registrierung: analog `MailTo` setzen. |
+| `internal/handler/auth_oauth.go` | MODIFY | OAuth-Registrierung: analog `MailTo` setzen. |
+| `internal/handler/passkey.go` | MODIFY | Passkey-Registrierung (`newUser` in `PasskeyRegisterFinishHandler`, ~Zeile 536): `MailTo: entry.Email` setzen. |
+| `src/app/config.py` | MODIFY | `with_user_profile()`: `mail_to`/`sms_to` und (außerhalb `force_test`) `telegram_chat_id` immer explizit setzen (auch auf `None`), statt nur bei vorhandenem Profilwert zu überschreiben. |
+| `src/output/channels/email.py` | MODIFY | Empfänger-Prüfung vor Versand: fehlendes `self._to` (und kein `to`-Override) → `ChannelBlockedError(reason_code="email_no_recipient")` statt Versand an `[None]`. |
+| `src/output/channels/telegram.py` | MODIFY | Analoge Prüfung für `chat_id` → `ChannelBlockedError(reason_code="telegram_no_chat_id")`. |
+| `src/output/channels/sms.py` | MODIFY | `_validate_config()`/`_resolve_recipient()` differenzieren: fehlender `sms_to` bekommt eigenen `reason_code="sms_no_recipient"`, getrennt von fehlender API-Konfiguration. |
+| `docs/reference/operations_playbook.md` | MODIFY (Doku, zählt nicht gegen LoC-Limit) | Fallback-Passage korrigieren: Skip mit Log/`reason_code` statt globaler Fallback. |
+| Tests (neu/erweitert, je Bereich) | CREATE/MODIFY | Je Registrierungsweg, `with_user_profile()`-Unit-Tests für alle drei Felder, Kanal-Guard-Tests, Zwei-Nutzer-Integrationstest, Regressionstest Compare-Preset-Pfad. |
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `src/output/channels/base.py` (`ChannelBlockedError`, `OutputConfigError`) | Basisklasse | Bestehendes Sperr-Muster mit `reason_code` — wird für Email/Telegram/SMS wiederverwendet, nicht neu erfunden. |
+| `src/output/channels/premium_sms.py` (`_resolve_recipient`) | Referenzmuster | Zeigt das etablierte „kein Empfänger bekannt ⇒ `ChannelBlockedError`"-Vorgehen, das diese Spec auf Email/Telegram/SMS überträgt. |
+| `src/services/notification_service.py` (`_record_block_reason_code`, `blocked_channels`/`blocked_reason_codes`) | Aufrufer | Fängt jede Exception mit `reason_code`-Attribut bereits generisch ab und bucht sie in `NotificationResult` — keine Änderung an diesem Buchungsmechanismus nötig, er greift automatisch, sobald die Kanäle `ChannelBlockedError` werfen. |
+| `internal/store/user.go` (`SaveUser`) | Schreibpfad | Schreibt `user.json` komplett neu bei der Registrierung (kein Read-Modify-Write nötig, Datei existiert noch nicht). |
+| `src/services/scheduler_dispatch_service.py:412-431` | Abgrenzung | Compare-Preset-Versand hat bereits einen eigenen, bewusst unveränderten `ValueError`-Guard (#1452) für fehlenden `mail_to` — bleibt von dieser Spec unangetastet. |
+| `docs/specs/modules/user_auth_endpoints.md` | Verwandte Spec | RegisterHandler-Spec, kennt bisher kein `MailTo`-AC — diese Spec ergänzt das Verhalten, ohne die bestehende Spec zu ersetzen. |
+
+## Implementation Details
+
+**Go — vier Registrierungswege setzen `MailTo`:**
+
+```go
+// internal/handler/auth.go, auth_magic.go, auth_oauth.go, passkey.go
+newUser := model.User{
+    Email:  email,   // bereits vorhanden
+    MailTo: email,   // NEU — dieselbe Adresse, mit der sich der Nutzer registriert
+    // ... übrige Felder unverändert
+}
+```
+
+Bei `passkey.go` liegt die E-Mail-Adresse bereits als `entry.Email` vor (validiert mit
+`@`-Pflicht im Begin-Handler) und wird im Finish-Handler bereits für `newUser.Email`
+verwendet — `MailTo: entry.Email` ist eine reine Ergänzung derselben Zeile, keine neue
+Datenquelle.
+
+**Python — `with_user_profile()` verliert den stillen Fallback:**
+
+```python
+overrides["mail_to"] = profile.get("mail_to") or None
+overrides["sms_to"] = profile.get("sms_to") or None
+if not force_test:
+    overrides["telegram_chat_id"] = profile.get("telegram_chat_id") or None
+# bestehender force_test-Zweig (Zeile ~398) bleibt sonst unverändert:
+# Test-/Staging-Nutzer nutzen weiterhin ausschließlich for_testing()s Chat-ID.
+```
+
+Die bisherige Frühausstiegs-Bedingung `if not overrides: return base` entfällt für
+diese drei Felder faktisch, weil `overrides` jetzt immer mindestens `mail_to` und
+`sms_to` trägt — `GZ_MAIL_TO`/`GZ_TELEGRAM_CHAT_ID`/`GZ_SMS_TO` wirken damit nur noch
+dort, wo `with_user_profile()` nie aufgerufen wird (Legacy-CLI).
+
+**Kanäle — sauberer Abbruch statt Versand an leere Adresse:**
+
+Analog zu `PremiumSmsOutput._resolve_recipient()`: vor dem eigentlichen Versand prüft
+jeder Kanal seinen aufgelösten Empfänger und wirft bei Fehlen `ChannelBlockedError`
+mit einem neuen, kanalspezifischen `reason_code` (`email_no_recipient`,
+`telegram_no_chat_id`, `sms_no_recipient`) statt eine leere/`None`-Adresse an den
+Transport zu reichen. `notification_service.py` bucht das automatisch über den
+bestehenden `_record_block_reason_code()`-Mechanismus in `blocked_channels`/
+`blocked_reason_codes` — dort ist keine Änderung nötig.
+
+Diese Kanal-Guards sind nötig, weil nicht jeder Versandpfad vorab mit
+`can_send_email()`/`can_send_telegram()`/`can_send_sms()` gated ist: die
+Alarm-/Compare-Pfade tun das bereits (dort ist der Fix bereits strukturell wirksam,
+sobald `with_user_profile()` `None` statt des globalen Werts liefert), der
+Trip-Briefing-Hauptpfad (`notification_service.py`, E-Mail-Zweig ~Zeile 552) ruft
+`EmailOutput.send()` dagegen unconditional auf — ohne Kanal-Guard würde er nach der
+`config.py`-Änderung an eine leere Adresse zu senden versuchen, statt sauber zu
+überspringen.
+
+## Expected Behavior
+
+- **Input:** Registrierung über einen der vier Wege; anschließender Versandversuch für
+  einen Trip mit aktivierten Kanälen, für die das Profil keinen expliziten Empfänger
+  gesetzt hat.
+- **Output:** `user.json` enthält `mail_to = <Registrierungs-E-Mail>` sofort nach
+  Registrierung. Versandversuche mit fehlendem Empfänger werden pro Kanal sauber mit
+  `ChannelBlockedError`/`reason_code` übersprungen — nicht an den Betreiber oder einen
+  anderen Nutzer zugestellt, kein harter Absturz.
+- **Side effects:** `GZ_MAIL_TO`/`GZ_TELEGRAM_CHAT_ID`/`GZ_SMS_TO` verlieren ihre
+  Empfänger-Rolle für alle Pfade, die über `with_user_profile()` laufen (praktisch
+  alle produktiven Versandpfade); sie bleiben nur für die Legacy-CLI wirksam. Der
+  Compare-Preset-Pfad (#1452) bleibt unverändert (eigener `ValueError`-Guard).
+
+## Acceptance Criteria
+
+- **AC-1:** Given ein neuer Nutzer registriert sich über einen der vier Wege (Passwort, Magic-Link, OAuth, Passkey) / When das Nutzerkonto angelegt und `user.json` geschrieben wird / Then enthält `user.json` das Feld `mail_to` mit der bei der Registrierung verwendeten E-Mail-Adresse — für alle vier Wege, nicht nur einen.
+  - Test: vier Tests (je Registrierungsweg), die den jeweiligen HTTP-Handler mit isoliertem Test-Store aufrufen und danach `mail_to` im gespeicherten `User`-Objekt bzw. `user.json` prüfen.
+
+- **AC-2:** Given ein Nutzerprofil (`user.json`) ohne `mail_to`- und ohne `sms_to`-Feld, `GZ_MAIL_TO`/`GZ_SMS_TO` sind in der Umgebung auf die Betreiber-Adresse gesetzt / When `Settings.with_user_profile(user_id)` aufgerufen wird / Then hat das zurückgegebene `Settings`-Objekt `mail_to is None` und `sms_to is None` — nicht die globalen `.env`-Werte.
+  - Test: neuer Unit-Test, der ein Fixture-`user.json` ohne diese Felder anlegt und `with_user_profile()` gegen `None` statt gegen den globalen Wert prüft.
+
+- **AC-3:** Given ein Nutzerprofil ohne `telegram_chat_id`, der Nutzer ist KEIN Test-/Staging-Nutzer (`force_test` inaktiv), `GZ_TELEGRAM_CHAT_ID` ist auf den Betreiber-Chat gesetzt / When `with_user_profile()` aufgerufen wird / Then ist `telegram_chat_id is None` im Ergebnis; für einen Test-/Staging-Nutzer bleibt der bestehende `force_test`-Sonderfall unverändert (dort entscheidet weiterhin ausschließlich die Test-Chat-ID aus `for_testing()`, unabhängig vom Profilinhalt).
+  - Test: neuer Unit-Test mit zwei Fällen (Normal-Nutzer vs. Test-Nutzer), der beide Verhalten explizit gegeneinander prüft.
+
+- **AC-4:** Given `settings.mail_to` ist `None`, ein Trip hat `send_email=True` / When der Versand über `EmailOutput.send()` (bzw. `notification_service.send_trip_report`) ausgelöst wird / Then wird keine SMTP-Verbindung mit leerer/`None`-Empfängeradresse aufgebaut, sondern der Kanal wirft `ChannelBlockedError` mit einem neuen `reason_code` (`email_no_recipient`); die E-Mail geht an niemanden.
+  - Test: neuer Test mit `--disable-socket` (kein echter Verbindungsversuch zulässig), der `EmailOutput(settings).send(...)` mit `mail_to=None` aufruft und `ChannelBlockedError` samt `reason_code` prüft, ergänzt um einen Test auf `notification_service.send_trip_report()`-Ebene, der bestätigt, dass `sent_channels` „email" nicht enthält und kein SMTP-Aufbau erfolgt.
+
+- **AC-5:** Given `settings.telegram_chat_id` ist `None` / When `TelegramOutput(settings).send(...)` aufgerufen wird / Then wirft der Kanal `ChannelBlockedError` mit eigenem `reason_code` (`telegram_no_chat_id`) statt einen Request an die Telegram-API mit leerer `chat_id` zu senden.
+  - Test: neuer Test mit `--disable-socket`, der die Exception samt `reason_code` prüft, ohne dass ein tatsächlicher API-Call versucht wird.
+
+- **AC-6:** Given `settings.sms_to` ist `None`, `settings.seven_api_key` ist gesetzt (API-Konfiguration vollständig bis auf den Empfänger) / When `SMSOutput(settings).send(...)` aufgerufen wird / Then wirft der Kanal `ChannelBlockedError` mit `reason_code` (`sms_no_recipient`), erkennbar unterscheidbar von einer fehlenden API-Konfiguration (nicht mehr der bisherige undifferenzierte `OutputConfigError`, der beide Ursachen in einer Meldung vermischt).
+  - Test: neuer/erweiterter Test, der die zwei Fälle „fehlender `sms_to`" vs. „fehlender `seven_api_key`" an unterschiedlichen `reason_code`-Werten unterscheidet.
+
+- **AC-7:** Given Nutzer A hat `mail_to` im Profil gesetzt, Nutzer B ist frisch registriert und hat kein `mail_to` im Profil, beide haben einen Trip mit `send_email=True` / When der Versand für beide Nutzer nacheinander ausgelöst wird / Then erhält Nutzer A seine Mail an die eigene Adresse; für Nutzer B wird der Versand mit `ChannelBlockedError`/`reason_code` übersprungen — weder der Betreiber noch Nutzer A erhalten Nutzer B's Briefing.
+  - Test: neuer Integrationstest (Kern-Schicht, `--disable-socket`/lokaler Test-Sink statt echtem SMTP), der zwei `user.json`-Fixtures anlegt und die tatsächlichen Zielempfänger beider Versandversuche gegeneinander prüft.
+
+- **AC-8:** Given ein Compare-Preset ohne `mail_to` (Alt-Verhalten aus #1452) / When der Compare-Preset-Versand über `scheduler_dispatch_service.py` ausgelöst wird / Then wirft der Pfad weiterhin denselben `ValueError` wie vor diesem Fix — unverändertes Fehlerverhalten, kein Wechsel auf `ChannelBlockedError`/Skip für diesen Pfad.
+  - Test: bestehender Test zu #1452 (Compare-Preset ohne Empfänger) läuft nach diesem Fix unverändert grün, ohne Anpassung der Assertion.
+
+- **AC-9:** Given `docs/reference/operations_playbook.md` beschreibt aktuell nur den Override-Fall („`user.json.mail_to` überschreibt `GZ_MAIL_TO`") / When die Doku nach diesem Fix gelesen wird / Then beschreibt der Abschnitt zusätzlich den Fehl-Fall korrekt als „Skip mit Log/`reason_code`" statt als globalen Fallback auf `GZ_MAIL_TO`/`GZ_TELEGRAM_CHAT_ID`/`GZ_SMS_TO`.
+  - Test: `# doc-compliance-test` — prüft, dass die Passage die Skip-Formulierung enthält und nicht mehr behauptet, ein fehlender Profilwert falle auf die globale `.env`-Adresse zurück.
+
+## Known Limitations
+
+- **Kein Backfill für Bestandsnutzer:** Bereits registrierte Nutzer ohne `mail_to` im
+  Profil werden von diesem Fix nicht rückwirkend verändert — das korrigierte
+  Verhalten (Skip statt Fehlversand) greift automatisch beim nächsten Versandversuch,
+  weil `with_user_profile()` bei jedem Aufruf neu ausgewertet wird.
+- **Telegram-Onboarding bleibt zweistufig:** `telegram_chat_id` wird weiterhin bei
+  keinem der vier Registrierungswege gesetzt (das Feld wird erst durch eine
+  Bot-Interaktion gelernt, nachträglich über den Settings-Endpoint,
+  `auth.go:675`) — ein frisch registrierter Nutzer hat also bis zur ersten
+  Bot-Interaktion `telegram_chat_id = None` und wird für Telegram sauber
+  übersprungen, das ist beabsichtigt, kein Nebeneffekt dieses Fixes.
+- **LoC-Limit:** Die Gesamtänderung (Produktionscode + Tests über 9+ Dateien) liegt
+  wahrscheinlich nahe oder über dem 250-LoC-Workflow-Limit — `loc_limit_override` ist
+  im Workflow-State voraussichtlich nötig.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Kein neuer Entscheidungspunkt — die Spec korrigiert eine
+  Implementierungslücke gegen ein bereits dokumentiertes Prinzip (CLAUDE.md: „echte
+  `user_id` aus Auth-Kontext durchreichen, niemals auf `default`/globale Werte
+  zurückfallen"). Das Empfänger-Auflösungsmuster (`ChannelBlockedError` +
+  `reason_code`) ist bereits etabliert (`premium_sms.py`) und wird hier nur auf drei
+  weitere Kanäle übertragen, nicht neu entworfen.
+
+## Changelog
+
+- 2026-09-08: Initial spec created (Issue #2144)

--- a/docs/specs/modules/user_auth_endpoints.md
+++ b/docs/specs/modules/user_auth_endpoints.md
@@ -202,6 +202,7 @@ if !s.UserExists(cfg.UserID) && cfg.AuthPass != "" {
 ## Known Limitations
 
 - `bcryptCost`-Parameter in `RegisterHandler` ist notwendig fuer Tests mit `bcrypt.MinCost` — in Produktion immer `bcrypt.DefaultCost` uebergeben
+- `RegisterHandler` setzt inzwischen zusätzlich `Email` und `MailTo: req.Email` auf dem angelegten `User` (Issue #2144) — diese Spec kennt nur den Username/Password-Stand von 2026-04-15 und wurde dafür nicht aktualisiert. Details: `docs/specs/bugfix/user_recipient_fallback.md`.
 - AuthMiddleware-Exemptionliste waechst manuell — Refactoring fuer spaetere Phases vorgesehen
 - Kein Logout-Endpoint in dieser Phase — Cookie laeuft nach `MaxAge=86400` (24h) ab
 - Seed-User-Fehler beim bcrypt werden mit `_` ignoriert — unkritisch da Startup-Logik

--- a/internal/handler/auth.go
+++ b/internal/handler/auth.go
@@ -97,6 +97,7 @@ func RegisterHandler(s *store.Store, bcryptCost int, cfg config.Config) http.Han
 			ID:           req.Username,
 			PasswordHash: string(hash),
 			Email:        req.Email,
+			MailTo:       req.Email,
 			CreatedAt:    time.Now(),
 		}
 		if err := s.SaveUser(user); err != nil {

--- a/internal/handler/auth_magic.go
+++ b/internal/handler/auth_magic.go
@@ -205,6 +205,7 @@ func createMagicLinkUser(s *store.Store, email string) (*model.User, error) {
 		user := model.User{
 			ID:        id,
 			Email:     email,
+			MailTo:    email,
 			CreatedAt: time.Now(),
 		}
 		if err := s.SaveUser(user); err != nil {

--- a/internal/handler/auth_oauth.go
+++ b/internal/handler/auth_oauth.go
@@ -203,6 +203,7 @@ func createOAuthUser(s *store.Store, provider, sub, email string) (*model.User, 
 			OAuthProvider: provider,
 			OAuthSub:      sub,
 			Email:         email,
+			MailTo:        email,
 			CreatedAt:     time.Now(),
 		}
 		if err := s.SaveUser(user); err != nil {

--- a/internal/handler/passkey.go
+++ b/internal/handler/passkey.go
@@ -536,6 +536,7 @@ func PasskeyRegisterPublicFinishHandler(s *store.Store, wa *webauthn.WebAuthn, c
 		newUser := model.User{
 			ID:        entry.UserID,
 			Email:     entry.Email,
+			MailTo:    entry.Email,
 			CreatedAt: now,
 			PasskeyCredentials: []model.WebAuthnCredential{{
 				ID:              credential.ID,

--- a/internal/handler/register_mail_to_fallback_test.go
+++ b/internal/handler/register_mail_to_fallback_test.go
@@ -1,0 +1,179 @@
+package handler
+
+// TDD RED — Issue #2144: alle vier Registrierungswege müssen `MailTo` mit der
+// bei der Registrierung verwendeten E-Mail-Adresse setzen, sonst fällt der
+// Python-Kern beim Versand auf den globalen `.env`-Fallback (Betreiber-Adresse)
+// zurück (Cross-Tenant-Zustellung).
+//
+// Spec: docs/specs/bugfix/user_recipient_fallback.md, AC-1.
+// Muss FEHLSCHLAGEN bis implementiert: `MailTo` ist aktuell in keinem der vier
+// `model.User{...}`-Literale gesetzt.
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/henemm/gregor-api/internal/config"
+	"github.com/henemm/gregor-api/internal/mail"
+)
+
+// AC-1 (Passwort-Weg): RegisterHandler setzt MailTo auf die Registrierungs-Mail.
+func TestRegisterHandler_SetsMailToOnRegistration_AC1(t *testing.T) {
+	s := newTestStore(t)
+
+	calls := make(chan struct{}, 1)
+	origSend := sendVerificationMailFn
+	sendVerificationMailFn = func(cfg mail.MailConfig, to string, msg mail.Mail) error {
+		calls <- struct{}{}
+		return nil
+	}
+	defer func() { sendVerificationMailFn = origSend }()
+
+	h := RegisterHandler(s, 4, testRegisterCfg())
+
+	body := `{"username":"mailto-pw","password":"geheim123","email":"mailto-pw@beispiel.de"}`
+	req := httptest.NewRequest("POST", "/api/auth/register", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("AC-1: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	select {
+	case <-calls:
+	case <-time.After(2 * time.Second):
+		t.Fatal("AC-1: expected dispatch goroutine within 2s")
+	}
+
+	user, err := s.LoadUser("mailto-pw")
+	if err != nil || user == nil {
+		t.Fatalf("AC-1: user not found after registration: %v", err)
+	}
+	if user.MailTo != "mailto-pw@beispiel.de" {
+		t.Errorf("AC-1: expected MailTo 'mailto-pw@beispiel.de', got %q", user.MailTo)
+	}
+}
+
+// AC-1 (Magic-Link-Weg): MagicLinkRequestHandler setzt MailTo für den neu
+// angelegten User auf dieselbe Adresse, mit der er sich angemeldet hat.
+func TestMagicLinkRequestHandler_SetsMailToOnRegistration_AC1(t *testing.T) {
+	t.Cleanup(ResetOTPStoreForTest)
+
+	s := newTestStore(t)
+	cfg := &config.Config{SMTPHost: ""}
+
+	h := MagicLinkRequestHandler(s, cfg)
+
+	body := `{"email":"mailto-magic@beispiel.de"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/magic-link", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("AC-1: expected 200, got %d", w.Code)
+	}
+
+	ids, err := s.ListUserIDs()
+	if err != nil || len(ids) == 0 {
+		t.Fatalf("AC-1: expected a new user to be created: %v", err)
+	}
+	user, err := s.LoadUser(ids[0])
+	if err != nil || user == nil {
+		t.Fatalf("AC-1: user not found: %v", err)
+	}
+	if user.MailTo != "mailto-magic@beispiel.de" {
+		t.Errorf("AC-1: expected MailTo 'mailto-magic@beispiel.de', got %q", user.MailTo)
+	}
+}
+
+// AC-1 (OAuth-Weg): GoogleOAuthCallbackHandler setzt MailTo für ein neu
+// angelegtes Konto auf die vom Provider gemeldete, verifizierte Adresse.
+func TestGoogleOAuthCallback_SetsMailToOnRegistration_AC1(t *testing.T) {
+	userinfoURL, tokenURL := oauthFakeServers(t, "sub-mailto-2144", "mailto-oauth@beispiel.de")
+
+	cfg := &config.Config{
+		GoogleClientID:     "test-client-id",
+		GoogleClientSecret: "test-secret",
+		GoogleRedirectURL:  "https://example.com/callback",
+		SessionSecret:      "test-session-secret",
+		PublicHost:         "https://gregor20.henemm.com",
+		SMTPHost:           "smtp.resend.com", SMTPPort: 587, SMTPUser: "resend", SMTPPass: "re_x",
+	}
+	s := newTestStore(t)
+
+	origSend := sendVerificationMailFn
+	sendVerificationMailFn = func(cfg mail.MailConfig, to string, msg mail.Mail) error { return nil }
+	defer func() { sendVerificationMailFn = origSend }()
+
+	h := GoogleOAuthCallbackHandlerWithEndpoints(cfg, s, userinfoURL, tokenURL)
+	const state = "test-state-value"
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/google/callback?code=test-code&state="+state, nil)
+	req.AddCookie(&http.Cookie{Name: "gz_oauth_state", Value: state})
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusFound {
+		t.Fatalf("AC-1: expected 302, got %d: %s", w.Code, w.Body.String())
+	}
+
+	newUser, err := s.FindUserByOAuthSub("google", "sub-mailto-2144")
+	if err != nil || newUser == nil {
+		t.Fatalf("AC-1: new account for unknown sub must exist: %v", err)
+	}
+	if newUser.MailTo != "mailto-oauth@beispiel.de" {
+		t.Errorf("AC-1: expected MailTo 'mailto-oauth@beispiel.de', got %q", newUser.MailTo)
+	}
+}
+
+// AC-1 (Passkey-Weg): PasskeyRegisterPublicFinishHandler setzt MailTo auf die
+// im Begin-Schritt übermittelte Adresse (dieselbe, die bereits user.Email füllt).
+func TestPasskeyRegisterPublicFinish_SetsMailToOnRegistration_AC1(t *testing.T) {
+	rpID, origin := "localhost", "http://localhost"
+	s := newTestStore(t)
+	wa := newTestWebAuthn(t, rpID, origin)
+	cs := NewChallengeStore()
+	secret := "test-secret-32-chars-long-enough"
+
+	beginBody := []byte(`{"username":"mailto-pk","email":"mailto-pk@beispiel.de"}`)
+	beginReq := httptest.NewRequest("POST", "/api/auth/passkey/register/public/begin", bytes.NewReader(beginBody))
+	beginW := httptest.NewRecorder()
+	PasskeyRegisterPublicBeginHandler(s, wa, cs).ServeHTTP(beginW, beginReq)
+
+	if beginW.Code != http.StatusOK {
+		t.Fatalf("AC-1 begin: expected 200, got %d: %s", beginW.Code, beginW.Body.String())
+	}
+	var beginResp struct {
+		PublicKey struct {
+			Challenge string `json:"challenge"`
+		} `json:"publicKey"`
+	}
+	if err := json.Unmarshal(beginW.Body.Bytes(), &beginResp); err != nil {
+		t.Fatalf("AC-1 begin: cannot decode response: %v", err)
+	}
+
+	auth := newTestAuthenticator(t, rpID, origin)
+	finishBody := auth.makeAttestationResponse(t, beginResp.PublicKey.Challenge)
+
+	finishReq := httptest.NewRequest("POST", "/api/auth/passkey/register/public/finish", bytes.NewReader(finishBody))
+	finishW := httptest.NewRecorder()
+	PasskeyRegisterPublicFinishHandler(s, wa, cs, secret, config.Config{}).ServeHTTP(finishW, finishReq)
+
+	if finishW.Code != http.StatusCreated {
+		t.Fatalf("AC-1 finish: expected 201, got %d: %s", finishW.Code, finishW.Body.String())
+	}
+
+	user, err := s.LoadUser("mailto-pk")
+	if err != nil || user == nil {
+		t.Fatalf("AC-1: user not found after registration: %v", err)
+	}
+	if user.MailTo != "mailto-pk@beispiel.de" {
+		t.Errorf("AC-1: expected MailTo 'mailto-pk@beispiel.de', got %q", user.MailTo)
+	}
+}

--- a/src/app/config.py
+++ b/src/app/config.py
@@ -392,13 +392,16 @@ class Settings(BaseSettings):
         except (json.JSONDecodeError, OSError):
             return base
 
-        overrides = {}
-        if profile.get("mail_to"):
-            overrides["mail_to"] = profile["mail_to"]
-        if profile.get("telegram_chat_id") and not force_test:
-            overrides["telegram_chat_id"] = profile["telegram_chat_id"]
-        if profile.get("sms_to"):
-            overrides["sms_to"] = profile["sms_to"]
+        # Issue #2144: immer explizit setzen (auch auf None), statt nur bei
+        # vorhandenem Profilwert zu ueberschreiben -- sonst bleibt bei einem
+        # Nutzer ohne eigenen Empfaenger der globale .env-Fallback (Betreiber-
+        # Adresse) auf base/self stehen (Cross-Tenant-Zustellung).
+        overrides = {
+            "mail_to": profile.get("mail_to") or None,
+            "sms_to": profile.get("sms_to") or None,
+        }
+        if not force_test:
+            overrides["telegram_chat_id"] = profile.get("telegram_chat_id") or None
         # Issue #1676 S2a: gelernte Premium-SMS-Rueckadresse (S1 schreibt sie
         # hier hinein). Der Zeitstempel wird zu einem zeitzonenbehafteten
         # datetime aufgeloest — model_copy() unten umgeht die Feld-Validierung,
@@ -409,9 +412,6 @@ class Settings(BaseSettings):
         reply_at = _parse_learned_timestamp(profile.get("premium_sms_reply_at"))
         if reply_at is not None:
             overrides["premium_sms_reply_at"] = reply_at
-
-        if not overrides:
-            return base
 
         return base.model_copy(update=overrides)
 

--- a/src/output/channels/email.py
+++ b/src/output/channels/email.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from app.origin_guard import running_origin
-from output.channels.base import OutputConfigError, OutputError
+from output.channels.base import ChannelBlockedError, OutputConfigError, OutputError
 
 if TYPE_CHECKING:
     from app.config import Settings
@@ -399,11 +399,17 @@ class EmailOutput:
         Raises:
             OutputConfigError: If SMTP configuration is incomplete
         """
-        if not settings.can_send_email():
+        # Issue #2144: mail_to bewusst NICHT hier prüfen -- ein fehlender
+        # Empfänger ist ein legitimer Laufzeitzustand (Nutzer ohne eigenes
+        # mail_to), keine Fehlkonfiguration. Der Guard dafür sitzt in
+        # send() und wirft dort ChannelBlockedError statt hier
+        # OutputConfigError, damit der aufrufende Trip-Briefing-Pfad
+        # (notification_service.py) unconditional konstruieren kann.
+        if not (settings.smtp_host and settings.smtp_user and settings.smtp_pass):
             raise OutputConfigError(
                 "email",
                 "Incomplete SMTP configuration. "
-                "Required: smtp_host, smtp_user, smtp_pass, mail_to",
+                "Required: smtp_host, smtp_user, smtp_pass",
             )
 
         # Hard-Guard: Staging darf NIEMALS über Resend senden — unabhängig von is_test_mode.
@@ -635,6 +641,18 @@ class EmailOutput:
         Raises:
             OutputError: If sending fails after all retry attempts
         """
+        # Issue #2144: kein Empfaenger bekannt (weder Profil-mail_to noch
+        # per-Aufruf-Override) -- sauber abbrechen statt an [None] zu senden.
+        # Muss VOR jedem Verbindungsaufbau greifen (Vorbild premium_sms.py
+        # `_resolve_recipient()`).
+        if not to and not self._to:
+            raise ChannelBlockedError(
+                self.name,
+                "kein Empfaenger bekannt -- weder settings.mail_to noch ein "
+                "per-Aufruf-Override sind gesetzt.",
+                reason_code="email_no_recipient",
+            )
+
         # Build message once (outside retry loop)
         # Use inbound address as From if set (Gmail supports plus-addresses)
         from_addr = self._reply_to or self._from

--- a/src/output/channels/sms.py
+++ b/src/output/channels/sms.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Optional
 
 from app.origin_guard import running_origin
-from output.channels.base import OutputConfigError
+from output.channels.base import ChannelBlockedError
 from output.channels.seven_io_base import SevenIoChannelBase
 
 
@@ -24,12 +24,12 @@ class SMSOutput(SevenIoChannelBase):
 
     CHANNEL_NAME = "sms"
 
-    def _validate_config(self) -> None:
-        if not self._settings.can_send_sms():
-            raise OutputConfigError(
-                "sms",
-                "SMS nicht konfiguriert: sms_api_key und sms_to sind Pflichtfelder",
-            )
+    # Issue #2144: kein eigener _validate_config()-Override mehr -- der
+    # Empfaenger ist ein legitimer Laufzeitzustand (Nutzer ohne eigenes
+    # sms_to), keine Fehlkonfiguration, und wird erst in
+    # `_resolve_recipient()` geprueft (Vorbild premium_sms.py). Die Basis
+    # (`SevenIoChannelBase._validate_config`) prueft weiterhin Gateway und
+    # API-Key -- unterscheidbar von fehlendem Empfaenger.
 
     def _origin(self) -> str:
         """Herkunft DIESES Moduls — siehe `SevenIoChannelBase._origin`."""
@@ -39,4 +39,12 @@ class SMSOutput(SevenIoChannelBase):
         return self._settings.sms_from or None
 
     def _resolve_recipient(self) -> str:
-        return self._settings.sms_to
+        sms_to = self._settings.sms_to
+        if not sms_to:
+            raise ChannelBlockedError(
+                self.name,
+                "kein Empfaenger bekannt -- settings.sms_to ist nicht "
+                "gesetzt.",
+                reason_code="sms_no_recipient",
+            )
+        return sms_to

--- a/src/output/channels/telegram.py
+++ b/src/output/channels/telegram.py
@@ -10,7 +10,7 @@ import httpx
 
 from app.config import Settings
 from app.origin_guard import running_origin
-from output.channels.base import OutputConfigError, OutputError
+from output.channels.base import ChannelBlockedError, OutputConfigError, OutputError
 
 logger = logging.getLogger(__name__)
 
@@ -401,6 +401,17 @@ class TelegramOutput:
                 Test-Chat-ID (Issue #1288) — VOR jedem httpx.post.
         """
         chat_id = self._guard_code_origin(self._settings.telegram_chat_id)
+        # Issue #2144: kein Empfaenger bekannt (Nutzer ohne eigene
+        # telegram_chat_id) -- sauber abbrechen statt mit chat_id=None
+        # einen Bot-API-Call zu versuchen (Vorbild premium_sms.py
+        # `_resolve_recipient()`).
+        if not chat_id:
+            raise ChannelBlockedError(
+                self.name,
+                "kein Empfaenger bekannt -- settings.telegram_chat_id ist "
+                "nicht gesetzt.",
+                reason_code="telegram_no_chat_id",
+            )
         self._guard_test_mode_bot_token()
         self._guard_test_mode_chat_id()
         token = self._settings.telegram_bot_token

--- a/tests/helpers/alarm_pruefstrecke.py
+++ b/tests/helpers/alarm_pruefstrecke.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
     from app.trip import Trip
 
 from app.config import Settings
+from app.loader import get_data_dir
 from output.channels import telegram as telegram_mod
 from output.channels.telegram import reset_telegram_rate_limit_for_tests
 from output.channels.premium_sms import PREMIUM_SMS_SENDER
@@ -119,6 +120,25 @@ class AlarmPruefstrecke:
         _, seven_port = _start_seven_io_stub(self._seven_received)
         self._telegram_url = f"http://127.0.0.1:{telegram_port}"
         base = settings if settings is not None else Settings()
+        # Issue #2144 AC-2: `with_user_profile()` ueberschreibt mail_to/
+        # sms_to jetzt IMMER (auch auf None), wenn das Profil das Feld nicht
+        # traegt -- unconditional, bewusst OHNE force_test-Ausnahme (anders
+        # als telegram_chat_id, AC-3). Die Pruefstrecke simuliert einen
+        # Nutzer mit vollstaendig konfigurierten Kanaelen; das Profil muss
+        # diese Felder deshalb selbst tragen (Read-Modify-Write, damit
+        # `_write_tier()`/`_write_premium_profile()`-Aufrufe vor oder nach
+        # dieser Konstruktion nichts verlieren), sonst wischt
+        # `with_user_profile()` die hier uebergebenen Kanal-Ziele weg.
+        profile_path = get_data_dir(user_id) / "user.json"
+        try:
+            profile = json.loads(profile_path.read_text())
+        except (json.JSONDecodeError, OSError):
+            profile = {"id": user_id}
+        profile.setdefault("mail_to", base.mail_to)
+        profile.setdefault("sms_to", base.sms_to)
+        profile.setdefault("telegram_chat_id", base.telegram_chat_id)
+        profile_path.parent.mkdir(parents=True, exist_ok=True)
+        profile_path.write_text(json.dumps(profile))
         # Wie in Produktion (`TripAlertService(settings=None, ...)` baut sich
         # intern `Settings().with_user_profile(user_id)`, Vorbild
         # `trip_alert.py:198`): `premium_sms_reply_to`/`_at` sind KEIN

--- a/tests/tdd/test_alarm_pruefstrecke_selbstschutz.py
+++ b/tests/tdd/test_alarm_pruefstrecke_selbstschutz.py
@@ -66,6 +66,18 @@ def _settings_all_channels() -> Settings:
     })
 
 
+# Issue #2144 AC-2: `with_user_profile()` ueberschreibt mail_to/sms_to jetzt
+# IMMER (auch auf None), wenn das Profil das Feld nicht traegt. Deckungsgleich
+# mit `_settings_all_channels()` -- sonst wischt with_user_profile() die dort
+# konfigurierten Kanal-Ziele weg, sobald ein Profil (auch nur fuer Tier/
+# Premium-Rueckadresse) geschrieben wird.
+_ALL_CHANNELS_RECIPIENTS = {
+    "mail_to": "gregor-test@henemm.com",
+    "sms_to": "+41791234567",
+    "telegram_chat_id": "99999",
+}
+
+
 def _write_premium_profile(uid: str, at: datetime) -> None:
     """Lernt eine frische Garmin-Rückadresse (Pflicht für Premium-SMS,
     `output/channels/premium_sms.py`) und setzt den Tier auf `premium`
@@ -76,6 +88,7 @@ def _write_premium_profile(uid: str, at: datetime) -> None:
         "id": uid, "tier": "premium",
         "premium_sms_reply_to": "+41791234567",
         "premium_sms_reply_at": (at - timedelta(minutes=5)).isoformat().replace("+00:00", "Z"),
+        **_ALL_CHANNELS_RECIPIENTS,
     }
     (d / "user.json").write_text(json.dumps(profile), encoding="utf-8")
 
@@ -83,7 +96,8 @@ def _write_premium_profile(uid: str, at: datetime) -> None:
 def _write_tier(uid: str, tier: str) -> None:
     d = get_data_dir(uid)
     d.mkdir(parents=True, exist_ok=True)
-    (d / "user.json").write_text(json.dumps({"id": uid, "tier": tier}), encoding="utf-8")
+    profile = {"id": uid, "tier": tier, **_ALL_CHANNELS_RECIPIENTS}
+    (d / "user.json").write_text(json.dumps(profile), encoding="utf-8")
 
 
 def _radar_trip(uid: str, trip_id: str, **flags) -> object:

--- a/tests/tdd/test_issue_608_sms_seven_io.py
+++ b/tests/tdd/test_issue_608_sms_seven_io.py
@@ -85,12 +85,19 @@ class TestSmsConfigValidation:
         """
         GIVEN: sms_to fehlt
         WHEN: SMSOutput(settings) instanziiert wird
-        THEN: OutputConfigError geworfen, kein HTTP-Request
+        THEN: Konstruktion selbst wirft NICHT mehr (Issue #2144: ein
+        fehlender Empfaenger ist ein legitimer Laufzeitzustand, keine
+        Fehlkonfiguration) -- erst `send()` bricht sauber ab, mit
+        `ChannelBlockedError`/`reason_code='sms_no_recipient'` statt des
+        frueheren undifferenzierten `OutputConfigError`.
         """
+        from output.channels.base import ChannelBlockedError
         from output.channels.sms import SMSOutput
-        settings = _settings_with_sms(sms_to=None)
-        with pytest.raises(OutputConfigError):
-            SMSOutput(settings)
+        settings = _settings_with_sms(sms_to=None, seven_sandbox_key="test-key")
+        output = SMSOutput(settings)
+        with pytest.raises(ChannelBlockedError) as excinfo:
+            output.send("test", "Gregor Zwanzig Test")
+        assert excinfo.value.reason_code == "sms_no_recipient"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_operations_playbook_recipient_fallback_skip_doku.py
+++ b/tests/test_operations_playbook_recipient_fallback_skip_doku.py
@@ -1,0 +1,47 @@
+# doc-compliance-test
+"""TDD RED — Issue #2144, AC-9: Fehl-Fall-Doku im Operations-Playbook.
+
+Spec: docs/specs/bugfix/user_recipient_fallback.md, AC-9.
+
+Reiner Vorhandensein-Nachweis (Ausnahme laut CLAUDE.md-Testpolitik
+ausdruecklich fuer `# doc-compliance-test` zulaessig): der Empfaenger-Absatz
+beschreibt heute NUR den Override-Fall (`user.json.mail_to` ueberschreibt
+`GZ_MAIL_TO`) -- nach dem Fix muss er zusaetzlich den Fehl-Fall korrekt als
+"Skip mit Log/reason_code" beschreiben, statt (weiterhin unausgesprochen)
+einen globalen Fallback auf `GZ_MAIL_TO`/`GZ_TELEGRAM_CHAT_ID`/`GZ_SMS_TO`
+nahezulegen.
+
+Heute ROT: der Absatz nennt weder "reason_code" noch eine Skip-Formulierung
+fuer den Fehl-Fall.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PLAYBOOK = REPO_ROOT / "docs" / "reference" / "operations_playbook.md"
+
+
+def test_playbook_describes_skip_with_reason_code_for_missing_recipient():
+    text = PLAYBOOK.read_text(encoding="utf-8")
+
+    idx = text.find("überschreibt** das")
+    assert idx != -1, (
+        "Testaufbau defekt: der bekannte Override-Satz "
+        "('...überschreibt** das globale GZ_MAIL_TO...') wurde nicht "
+        "gefunden -- Zeilennummern haben sich verschoben, Ankertext pruefen."
+    )
+    passage = text[max(0, idx - 400):idx + 1200]
+
+    assert "reason_code" in passage, (
+        "AC-9 verletzt: der Absatz nennt keinen reason_code fuer den "
+        "Fehl-Fall (fehlendes mail_to/telegram_chat_id/sms_to)."
+    )
+    skip_marker_present = any(
+        marker in passage for marker in ("Skip", "übersprungen", "uebersprungen")
+    )
+    assert skip_marker_present, (
+        "AC-9 verletzt: der Absatz beschreibt den Fehl-Fall nicht als "
+        "Skip-mit-Log/reason_code -- ohne diese Formulierung suggeriert die "
+        "Doku weiterhin (implizit) einen globalen .env-Fallback."
+    )

--- a/tests/unit/test_briefing_cross_tenant_recipient_isolation.py
+++ b/tests/unit/test_briefing_cross_tenant_recipient_isolation.py
@@ -1,0 +1,220 @@
+"""Issue #2144: der ECHTE Trip-Briefing-Pfad darf einen Nutzer ohne eigenes
+``mail_to`` weder an die Betreiber-Adresse noch an einen anderen Nutzer
+zustellen -- er muss sauber mit ``ChannelBlockedError``/``reason_code``
+uebersprungen werden.
+
+Spec: docs/specs/bugfix/user_recipient_fallback.md, AC-4 (Ebene
+``notification_service.send_trip_report()``) und AC-7 (Zwei-Nutzer-Test).
+
+PRUEFORT = WIRKORT (Vorbild ``tests/unit/test_briefing_recipient_logging.py``,
+#1847): der Versand laeuft ueber den ECHTEN Pfad
+(``send_test_report_outcome`` -> ``_send_trip_report_outcome`` ->
+``NotificationService.send_trip_report`` -> ``EmailOutput``/``TelegramOutput``).
+Ersetzt wird AUSSCHLIESSLICH der aeusserste Netzrand (``EmailOutput.
+_dial_and_send``, ``TelegramOutput._post``) -- kein Mock, kein MagicMock,
+keine echte SMTP-/Bot-API-Verbindung.
+
+Muss FEHLSCHLAGEN bis implementiert: aktuell faellt ein Nutzer ohne eigenes
+``mail_to`` in ``with_user_profile()`` still auf ``GZ_MAIL_TO`` (Betreiber-
+Adresse) zurueck -- die SMTP-Steckdose wird erreicht, die Mail geht an den
+Betreiber statt an niemanden.
+"""
+from __future__ import annotations
+
+import json
+from datetime import date
+from pathlib import Path
+
+import httpx
+import pytest
+
+from output.channels.base import ChannelBlockedError
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+OPERATOR_MAIL = "betreiber-2144@henemm.com"
+USER_A_MAIL = "nutzer-a-2144@example.com"
+
+# Dummy-Zugangsdaten -- kein Wert erreicht ein echtes Ziel (Vorbild #1847).
+DUMMY_ENV = {
+    "GZ_MAIL_TO": OPERATOR_MAIL,
+    "GZ_SMTP_HOST": "mail.henemm.com",
+    "GZ_SMTP_PORT": "587",
+    "GZ_SMTP_USER": "tdd-2144",
+    "GZ_SMTP_PASS": "tdd-2144-kein-echtes-passwort",
+    "GZ_TEST_SMTP_HOST": "mail.henemm.com",
+    "GZ_TEST_SMTP_USER": "tdd-2144",
+    "GZ_TEST_SMTP_PASS": "tdd-2144-kein-echtes-passwort",
+    "GZ_TELEGRAM_BOT_TOKEN": "tdd-2144-kein-echter-token",
+    "GZ_TELEGRAM_CHAT_ID": "tdd-2144-chat",
+    "GZ_TELEGRAM_TEST_BOT_TOKEN": "tdd-2144-kein-echter-token",
+    "GZ_TELEGRAM_TEST_CHAT_ID": "tdd-2144-chat",
+}
+
+
+class Netzrand:
+    """Sammelt, was die beiden Steckdosen tatsaechlich zu sehen bekommen
+    (Vorbild ``test_briefing_recipient_logging.py::Netzrand``)."""
+
+    def __init__(self) -> None:
+        self.smtp: list[dict] = []
+        self.telegram: list[dict] = []
+
+
+@pytest.fixture
+def netzrand(monkeypatch) -> Netzrand:
+    for key, value in DUMMY_ENV.items():
+        monkeypatch.setenv(key, value)
+
+    from output.channels.telegram import reset_telegram_rate_limit_for_tests
+
+    reset_telegram_rate_limit_for_tests()
+
+    rand = Netzrand()
+
+    def _smtp_steckdose(self, host, port, user, password, recipients, msg,
+                        from_addr, deadline_at):
+        rand.smtp.append({"host": host, "recipients": list(recipients), "from": from_addr})
+
+    def _telegram_steckdose(self, url, payload, *, chat_id=None):
+        rand.telegram.append({"chat_id": chat_id, "payload": payload})
+        return httpx.Response(
+            200, json={"ok": True, "result": {"message_id": len(rand.telegram)}},
+        )
+
+    monkeypatch.setattr("output.channels.email.EmailOutput._dial_and_send", _smtp_steckdose)
+    monkeypatch.setattr("output.channels.telegram.TelegramOutput._post", _telegram_steckdose)
+
+    from providers.fixture import FixtureProvider
+
+    fixture = FixtureProvider(str(REPO_ROOT / "fixtures" / "openmeteo"))
+    monkeypatch.setattr("providers.base.get_provider", lambda name: fixture)
+    return rand
+
+
+def _trip_anlegen(user_id: str, trip_id: str, report_config: dict, *, mail_to: str | None) -> None:
+    """Legt Nutzerprofil (mit ODER OHNE mail_to) und Trip im isolierten
+    Datenbaum an -- Vorbild #1847, hier zusaetzlich mit optionalem
+    Empfaenger."""
+    from app.loader import get_briefings_dir, get_data_dir
+
+    profil = get_data_dir(user_id) / "user.json"
+    profil.parent.mkdir(parents=True, exist_ok=True)
+    profil_daten = {"id": user_id}
+    if mail_to is not None:
+        profil_daten["mail_to"] = mail_to
+    profil.write_text(json.dumps(profil_daten))
+
+    briefings_dir = get_briefings_dir(user_id)
+    briefings_dir.mkdir(parents=True, exist_ok=True)
+    (briefings_dir / f"{trip_id}.json").write_text(json.dumps({
+        "id": trip_id,
+        "name": "TDD-2144 Trip",
+        "kind": "route",
+        "stages": [{
+            "id": "st-heute",
+            "name": "Etappe heute",
+            "date": date.today().isoformat(),
+            "waypoints": [
+                {"id": "wp1", "name": "Innsbruck", "lat": 47.2692,
+                 "lon": 11.4041, "elevation_m": 574},
+                {"id": "wp2", "name": "Hafelekar", "lat": 47.3103,
+                 "lon": 11.3844, "elevation_m": 2269},
+            ],
+        }],
+        "official_alerts_enabled": False,
+        "report_config": report_config,
+        "alert_rules": [],
+    }))
+
+
+def _versenden(user_id: str, trip_id: str):
+    from app.loader import get_briefings_dir, load_trip
+    from services.trip_report_scheduler import TripReportSchedulerService
+
+    trip = load_trip(get_briefings_dir(user_id) / f"{trip_id}.json")
+    service = TripReportSchedulerService(user_id=user_id)
+    return service.send_test_report_outcome(trip, "morning")
+
+
+def _log_eintraege(user_id: str) -> list[dict]:
+    from app.loader import get_data_dir
+
+    pfad = get_data_dir(user_id) / "briefing_log.json"
+    if not pfad.exists():
+        return []
+    return json.loads(pfad.read_text())["entries"]
+
+
+# ---------------------------------------------------------------------------
+# AC-7: zwei Nutzer, einer ohne mail_to -- keine Zustellung an einen Dritten
+# ---------------------------------------------------------------------------
+
+
+def test_ac7_user_without_mail_to_is_blocked_not_delivered_to_anyone(netzrand):
+    user_a, trip_a = "tdd-2144-user-a", "tdd-2144-user-a-trip"
+    user_b, trip_b = "tdd-2144-user-b", "tdd-2144-user-b-trip"
+    _trip_anlegen(user_a, trip_a, {
+        "send_email": True, "send_telegram": False, "send_sms": False,
+    }, mail_to=USER_A_MAIL)
+    _trip_anlegen(user_b, trip_b, {
+        "send_email": True, "send_telegram": False, "send_sms": False,
+    }, mail_to=None)
+
+    outcome_a = _versenden(user_a, trip_a)
+    assert outcome_a == "sent", f"Nutzer A: erwartet 'sent', bekommen {outcome_a!r}"
+    assert len(netzrand.smtp) == 1, (
+        f"Nutzer A (hat eigenes mail_to) muss genau einmal zugestellt werden: {netzrand.smtp}"
+    )
+    # Hinweis: die Testlauf-Herkunftssperre (#1476, email.py:657) ersetzt JEDEN
+    # Empfaenger in diesem Worktree durch die feste Test-Adresse
+    # `gregor-test@henemm.com` -- der eigentliche Inhalt des Empfaengerfelds
+    # ist deshalb hier nicht die pruefbare Groesse, sondern OB ueberhaupt ein
+    # Dial stattfand (naechster Block).
+
+    with pytest.raises(ChannelBlockedError) as excinfo:
+        _versenden(user_b, trip_b)
+
+    assert excinfo.value.reason_code == "email_no_recipient", (
+        f"BUG #2144: erwartet reason_code='email_no_recipient', bekommen "
+        f"{getattr(excinfo.value, 'reason_code', None)!r}"
+    )
+    assert len(netzrand.smtp) == 1, (
+        "BUG #2144: Nutzer B hat einen ZWEITEN SMTP-Dial ausgeloest, obwohl "
+        "kein eigenes mail_to im Profil stand -- weder der Betreiber noch "
+        f"Nutzer A duerfen Nutzer B's Briefing bekommen: {netzrand.smtp}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-4 (notification_service-Ebene): E-Mail blockiert, Telegram bleibt aktiv
+# ---------------------------------------------------------------------------
+
+
+def test_ac4_email_without_recipient_is_skipped_other_channel_unaffected(netzrand):
+    """AC-4 zweiter Teil GIVEN ein Trip mit ``send_email=True`` UND
+    ``send_telegram=True``, aber ohne ``mail_to`` im Profil / WHEN
+    ``send_trip_report()`` (ueber den echten Pfad) laeuft / THEN enthaelt
+    ``sent_channels`` (sichtbar im briefing_log-Eintrag) 'email' NICHT, die
+    SMTP-Steckdose wird nie erreicht -- Telegram liefert unveraendert."""
+    user_id, trip_id = "tdd-2144-multi-channel", "tdd-2144-multi-channel-trip"
+    _trip_anlegen(user_id, trip_id, {
+        "send_email": True, "send_telegram": True, "send_sms": False,
+    }, mail_to=None)
+
+    outcome = _versenden(user_id, trip_id)
+
+    assert outcome == "sent", (
+        f"Telegram haette trotz blockierter E-Mail liefern muessen: {outcome!r}"
+    )
+    assert netzrand.telegram, "Telegram-Steckdose wurde nie erreicht"
+    assert netzrand.smtp == [], (
+        "BUG #2144: die SMTP-Steckdose wurde erreicht, obwohl kein mail_to "
+        f"bekannt war (Cross-Tenant-Fehlversand an die Betreiber-Adresse): {netzrand.smtp}"
+    )
+
+    eintraege = _log_eintraege(user_id)
+    assert len(eintraege) == 1, f"Erwartet genau einen briefing_log-Eintrag: {eintraege}"
+    assert eintraege[0]["channels"] == ["telegram"], (
+        f"'email' darf nicht in sent_channels stehen: {eintraege[0]}"
+    )

--- a/tests/unit/test_channel_blocked_missing_recipient.py
+++ b/tests/unit/test_channel_blocked_missing_recipient.py
@@ -1,0 +1,152 @@
+"""Issue #2144: Email/Telegram/SMS duerfen bei fehlendem Empfaenger NICHT an
+eine leere/``None``-Adresse senden -- sie muessen wie ``PremiumSmsOutput.
+_resolve_recipient()`` (Referenzmuster) sauber mit ``ChannelBlockedError``
+und einem kanalspezifischen ``reason_code`` abbrechen.
+
+Spec: docs/specs/bugfix/user_recipient_fallback.md, AC-4/AC-5/AC-6.
+
+Kein Netz erlaubt (``--disable-socket``): jeder Test beweist zugleich, dass
+KEIN Verbindungsversuch/API-Call stattfand, bevor der Guard greift.
+
+Muss FEHLSCHLAGEN bis implementiert:
+* E-Mail/SMS werfen heute den undifferenzierten ``OutputConfigError`` (kein
+  ``reason_code``-Attribut) statt ``ChannelBlockedError``.
+* Telegram prueft ``chat_id`` ueberhaupt nicht -- ohne die Herkunfts-
+  Umschaltung (Testlauf-Herkunft) wuerde heute ein echter API-Call mit
+  ``chat_id=None`` versucht.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+import pytest
+
+from app.config import Settings
+from app.origin_guard import checkout_root
+from output.channels.base import ChannelBlockedError
+
+pytestmark = pytest.mark.disable_socket
+
+
+# ---------------------------------------------------------------------------
+# AC-4: EmailOutput ohne mail_to
+# ---------------------------------------------------------------------------
+
+
+def test_email_blocked_when_mail_to_missing_no_smtp_attempt():
+    """AC-4 GIVEN ``settings.mail_to`` ist ``None``, ein Trip hat
+    ``send_email=True`` / WHEN ``EmailOutput(settings).send(...)`` aufgerufen
+    wird / THEN wirft der Kanal ``ChannelBlockedError`` mit
+    ``reason_code='email_no_recipient'`` -- ohne jeden SMTP-Verbindungsaufbau
+    (erzwungen durch ``--disable-socket``: ein echter Verbindungsversuch
+    liesse den Test mit einem Socket-Fehler statt der erwarteten Ausnahme
+    scheitern)."""
+    from output.channels.email import EmailOutput
+
+    settings = Settings(
+        smtp_host="mail.example.invalid", smtp_user="tdd-2144", smtp_pass="kein-echtes-passwort",
+        mail_to=None,
+    )
+
+    with pytest.raises(ChannelBlockedError) as excinfo:
+        EmailOutput(settings).send("Betreff", "Text")
+
+    assert excinfo.value.reason_code == "email_no_recipient", (
+        f"BUG #2144: erwartet reason_code='email_no_recipient', bekommen "
+        f"{getattr(excinfo.value, 'reason_code', None)!r} (Ausnahmetyp "
+        f"{type(excinfo.value).__name__})"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-5: TelegramOutput ohne chat_id
+# ---------------------------------------------------------------------------
+
+
+def test_telegram_blocked_when_chat_id_missing_no_api_call(monkeypatch):
+    """AC-5 GIVEN ``settings.telegram_chat_id`` ist ``None`` / WHEN
+    ``TelegramOutput(settings).send(...)`` aufgerufen wird / THEN wirft der
+    Kanal ``ChannelBlockedError`` mit ``reason_code='telegram_no_chat_id'`` --
+    kein Request an die Bot-API.
+
+    Herkunft wird wie in ``test_telegram_origin_guard.py`` AC-3 auf
+    'production' gefaked (echte ``classify_origin()``-Logik, nur die
+    Wurzel-Konstante zeigt auf dieses Worktree) -- sonst wuerde die
+    bestehende Testlauf-Herkunftssperre (#1476) auf die Test-Chat-ID
+    umschalten und die fehlende chat_id waere nie sichtbar."""
+    from app import origin_guard as origin_guard_mod
+    from output.channels import telegram as telegram_mod
+
+    monkeypatch.setattr(
+        origin_guard_mod, "PROD_ROOT", checkout_root(Path(telegram_mod.__file__)),
+    )
+
+    calls: list[dict] = []
+
+    def _sink(url, json=None, timeout=None, **kwargs):
+        calls.append({"url": url, "payload": json})
+        raise AssertionError("kein API-Call haette hier stattfinden duerfen")
+
+    monkeypatch.setattr(httpx, "post", _sink)
+
+    settings = Settings(telegram_bot_token="prod-bot-token").model_copy(
+        update={"telegram_chat_id": None},
+    )
+
+    with pytest.raises(ChannelBlockedError) as excinfo:
+        telegram_mod.TelegramOutput(settings).send("Betreff", "Text")
+
+    assert excinfo.value.reason_code == "telegram_no_chat_id", (
+        f"BUG #2144: erwartet reason_code='telegram_no_chat_id', bekommen "
+        f"{getattr(excinfo.value, 'reason_code', None)!r} (Ausnahmetyp "
+        f"{type(excinfo.value).__name__})"
+    )
+    assert calls == [], f"API-Call haette nicht stattfinden duerfen: {calls}"
+
+
+# ---------------------------------------------------------------------------
+# AC-6: SMSOutput -- fehlender sms_to unterscheidbar von fehlender API-Config
+# ---------------------------------------------------------------------------
+
+
+def test_sms_blocked_when_sms_to_missing_distinct_reason_code():
+    """AC-6 (Fall 1) GIVEN ``settings.sms_to`` ist ``None``,
+    ``settings.seven_api_key`` ist GESETZT (API-Konfiguration vollstaendig
+    bis auf den Empfaenger) / WHEN ``SMSOutput(settings).send(...)``
+    aufgerufen wird / THEN wirft der Kanal ``ChannelBlockedError`` mit
+    ``reason_code='sms_no_recipient'`` -- unterscheidbar von einer fehlenden
+    API-Konfiguration, nicht mehr der undifferenzierte ``OutputConfigError``."""
+    from output.channels.sms import SMSOutput
+
+    settings = Settings(seven_api_key="tdd-2144-key", sms_to=None)
+
+    with pytest.raises(ChannelBlockedError) as excinfo:
+        SMSOutput(settings).send("Betreff", "Text")
+
+    assert excinfo.value.reason_code == "sms_no_recipient", (
+        f"BUG #2144: erwartet reason_code='sms_no_recipient', bekommen "
+        f"{getattr(excinfo.value, 'reason_code', None)!r} (Ausnahmetyp "
+        f"{type(excinfo.value).__name__})"
+    )
+
+
+def test_sms_missing_api_key_keeps_distinct_cause_from_missing_recipient():
+    """AC-6 (Fall 2, Gegenprobe) GIVEN ``settings.sms_to`` ist GESETZT, aber
+    ``settings.seven_api_key`` FEHLT / WHEN ``SMSOutput(settings).send(...)``
+    aufgerufen wird / THEN bleibt die bisherige Fehlerursache bestehen --
+    NICHT derselbe ``reason_code`` wie beim fehlenden Empfaenger. Ohne diese
+    Gegenprobe waere Fall 1 nur zufaellig unterscheidbar (z.B. weil beide
+    Faelle ``reason_code=None`` blieben)."""
+    from output.channels.sms import SMSOutput
+
+    settings = Settings(seven_api_key=None, sms_to="+491511234567")
+
+    with pytest.raises(Exception) as excinfo:
+        SMSOutput(settings).send("Betreff", "Text")
+
+    reason_code = getattr(excinfo.value, "reason_code", None)
+    assert reason_code != "sms_no_recipient", (
+        f"Fehlende API-Konfiguration darf nicht denselben reason_code "
+        f"tragen wie ein fehlender Empfaenger: {reason_code!r}"
+    )

--- a/tests/unit/test_channel_blocked_missing_recipient.py
+++ b/tests/unit/test_channel_blocked_missing_recipient.py
@@ -119,7 +119,14 @@ def test_sms_blocked_when_sms_to_missing_distinct_reason_code():
     API-Konfiguration, nicht mehr der undifferenzierte ``OutputConfigError``."""
     from output.channels.sms import SMSOutput
 
-    settings = Settings(seven_api_key="tdd-2144-key", sms_to=None)
+    # seven_sandbox_key deckungsgleich mit seven_api_key gesetzt, damit die
+    # unabhaengige Herkunftssperre (#1476/#1336, seven_io_base.py) NICHT vor
+    # dem hier geprueften Empfaenger-Guard greift -- ohne .env (z.B. in CI)
+    # waere seven_sandbox_key sonst leer und der Test schluege an der
+    # falschen Stelle fehl.
+    settings = Settings(
+        seven_api_key="tdd-2144-key", seven_sandbox_key="tdd-2144-key", sms_to=None,
+    )
 
     with pytest.raises(ChannelBlockedError) as excinfo:
         SMSOutput(settings).send("Betreff", "Text")

--- a/tests/unit/test_premium_sms_versand.py
+++ b/tests/unit/test_premium_sms_versand.py
@@ -395,17 +395,16 @@ def test_sender_is_fixed_number_regardless_of_sms_from(stub) -> None:
 # AC-2: Empfaenger ist die gelernte Rueckadresse, nie sms_to
 # ---------------------------------------------------------------------------
 
-def test_recipient_comes_from_learned_reply_to_not_sms_to(stub, monkeypatch) -> None:
-    """AC-2: Given ``GZ_SMS_TO`` steht bewusst widersprüchlich im Prozess-
-    Environment / When das Briefing per Premium-SMS geht / Then geht der POST
+def test_recipient_comes_from_learned_reply_to_not_sms_to(stub) -> None:
+    """AC-2: Given ``sms_to`` ist bewusst auf einen widersprüchlichen Wert
+    gesetzt / When das Briefing per Premium-SMS geht / Then geht der POST
     ausschliesslich an die gelernte Rueckadresse."""
     user_id = "tdd-1676-recipient"
     contradicting = "+49111111111"
-    monkeypatch.setenv("GZ_SMS_TO", contradicting)
     _write_profile(user_id, tier="premium", reply_to=LEARNED_REPLY_TO)
-    settings = _stub_settings(stub.port, user_id, sms_to=_KEEP)
+    settings = _stub_settings(stub.port, user_id, sms_to=contradicting)
     assert settings.sms_to == contradicting, (
-        f"GZ_SMS_TO wurde nicht wirksam ({settings.sms_to!r}) — der Widerspruch, "
+        f"sms_to wurde nicht wirksam ({settings.sms_to!r}) — der Widerspruch, "
         "den dieser Test braucht, liegt nicht vor."
     )
 

--- a/tests/unit/test_with_user_profile_no_global_fallback.py
+++ b/tests/unit/test_with_user_profile_no_global_fallback.py
@@ -1,0 +1,137 @@
+"""Issue #2144: ``Settings.with_user_profile()`` darf bei fehlendem Profilfeld
+NICHT still auf den globalen ``.env``-Wert (Betreiber-Adresse) zurueckfallen.
+
+Spec: docs/specs/bugfix/user_recipient_fallback.md, AC-2 und AC-3.
+
+Kernursache (Kontext-Datei fix-2144-mail-to-fallback.md): ``with_user_profile()``
+ueberschreibt ``mail_to``/``telegram_chat_id``/``sms_to`` in ``overrides`` NUR,
+wenn das Profil den Wert traegt (``if profile.get("mail_to"): ...``) -- fehlt er,
+bleibt der globale ``.env``-Wert aus ``base``/``self`` unveraendert stehen. Das
+ist die Cross-Tenant-Zustellung: ein Nutzer ohne eigenes ``mail_to`` bekaeme sein
+Briefing an die Betreiber-Adresse zugestellt.
+
+Muss FEHLSCHLAGEN bis implementiert: aktuell liefert ``with_user_profile()`` bei
+fehlendem Profilfeld weiterhin ``self.mail_to``/``self.sms_to``/
+``self.telegram_chat_id`` (den globalen Wert), nicht ``None``.
+"""
+from __future__ import annotations
+
+import json
+
+from app.config import Settings
+from app.loader import get_data_dir
+
+OPERATOR_MAIL = "betreiber@henemm.com"
+OPERATOR_SMS = "+491700000000"
+OPERATOR_TELEGRAM_CHAT = "operator-chat-id"
+
+
+def _write_profile(user_id: str, profile: dict) -> None:
+    path = get_data_dir(user_id)
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "user.json").write_text(json.dumps(profile), encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# AC-2: mail_to/sms_to duerfen NIE auf den globalen Wert zurueckfallen
+# ---------------------------------------------------------------------------
+
+
+def test_with_user_profile_returns_none_not_global_mail_to(monkeypatch):
+    """AC-2 GIVEN ein Profil ohne ``mail_to``, ``GZ_MAIL_TO`` zeigt auf die
+    Betreiber-Adresse / WHEN ``with_user_profile()`` laeuft / THEN ist
+    ``mail_to`` am Ergebnis ``None`` -- nicht die Betreiber-Adresse."""
+    monkeypatch.setenv("GZ_MAIL_TO", OPERATOR_MAIL)
+    user_id = "no-mail-to-profile"
+    _write_profile(user_id, {"id": user_id})
+
+    settings = Settings().with_user_profile(user_id)
+
+    assert settings.mail_to is None, (
+        f"BUG #2144: mail_to ist {settings.mail_to!r} -- ein Nutzer ohne "
+        "eigenes mail_to darf NICHT an die Betreiber-Adresse zugestellt "
+        "werden (Cross-Tenant-Leck)."
+    )
+
+
+def test_with_user_profile_returns_none_not_global_sms_to(monkeypatch):
+    """AC-2 (SMS-Analogon) GIVEN ein Profil ohne ``sms_to``, ``GZ_SMS_TO``
+    zeigt auf die Betreiber-Nummer / WHEN ``with_user_profile()`` laeuft /
+    THEN ist ``sms_to`` am Ergebnis ``None``."""
+    monkeypatch.setenv("GZ_SMS_TO", OPERATOR_SMS)
+    user_id = "no-sms-to-profile"
+    _write_profile(user_id, {"id": user_id})
+
+    settings = Settings().with_user_profile(user_id)
+
+    assert settings.sms_to is None, (
+        f"BUG #2144: sms_to ist {settings.sms_to!r} -- Fallback auf die "
+        "Betreiber-Nummer statt eines sauberen Abbruchs."
+    )
+
+
+def test_with_user_profile_still_takes_over_present_mail_to(monkeypatch):
+    """Gegenprobe zu AC-2: ein GESETZTES Profil-``mail_to`` muss weiterhin
+    ankommen -- sonst waere die vorige Assertion nur ein generell
+    zerstoertes Feld, kein korrigierter Fallback."""
+    monkeypatch.setenv("GZ_MAIL_TO", OPERATOR_MAIL)
+    user_id = "with-mail-to-profile"
+    own_mail = "eigene-adresse@example.com"
+    _write_profile(user_id, {"id": user_id, "mail_to": own_mail})
+
+    settings = Settings().with_user_profile(user_id)
+
+    assert settings.mail_to == own_mail, (
+        f"Gegenprobe fehlgeschlagen: erwartet {own_mail!r}, bekommen "
+        f"{settings.mail_to!r} -- with_user_profile() darf ein vorhandenes "
+        "Profil-mail_to nicht verlieren."
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-3: telegram_chat_id -- Normal-Nutzer vs. Test-/Staging-Nutzer
+# ---------------------------------------------------------------------------
+
+
+def test_with_user_profile_returns_none_telegram_chat_id_for_normal_user(monkeypatch):
+    """AC-3 (Fall 1) GIVEN ein Profil ohne ``telegram_chat_id``, ``force_test``
+    ist INAKTIV (Normal-Nutzer-ID, kein Test-/Staging-Kontext), ``GZ_TELEGRAM_
+    CHAT_ID`` zeigt auf den Betreiber-Chat / WHEN ``with_user_profile()``
+    laeuft / THEN ist ``telegram_chat_id`` am Ergebnis ``None``."""
+    monkeypatch.setenv("GZ_TELEGRAM_CHAT_ID", OPERATOR_TELEGRAM_CHAT)
+    user_id = "normal-user-no-telegram"
+    assert "test" not in user_id and "tdd" not in user_id, (
+        "Testaufbau defekt: user_id darf force_test nicht ueber die "
+        "Namens-Heuristik ausloesen."
+    )
+    _write_profile(user_id, {"id": user_id})
+
+    settings = Settings().with_user_profile(user_id)
+
+    assert settings.telegram_chat_id in (None, ""), (
+        f"BUG #2144: telegram_chat_id ist {settings.telegram_chat_id!r} -- "
+        "ein Normal-Nutzer ohne eigene Chat-ID darf nicht an den "
+        "Betreiber-Chat zugestellt werden."
+    )
+
+
+def test_with_user_profile_keeps_force_test_chat_id_for_test_user(monkeypatch):
+    """AC-3 (Fall 2) GIVEN dieselbe Lage, aber der Nutzer ist ein
+    Test-/Staging-Nutzer (``force_test`` aktiv ueber die Namens-Heuristik
+    ``is_test_user_id``) / WHEN ``with_user_profile()`` laeuft / THEN bleibt
+    der bestehende force_test-Sonderfall UNVERAENDERT: die Chat-ID kommt
+    ausschliesslich aus ``for_testing()`` (``GZ_TELEGRAM_TEST_CHAT_ID``),
+    unabhaengig vom (hier fehlenden) Profilinhalt."""
+    test_chat_id = "test-chat-id-4711"
+    monkeypatch.setenv("GZ_TELEGRAM_CHAT_ID", OPERATOR_TELEGRAM_CHAT)
+    monkeypatch.setenv("GZ_TELEGRAM_TEST_CHAT_ID", test_chat_id)
+    user_id = "tdd-2144-force-test-user"
+    _write_profile(user_id, {"id": user_id})
+
+    settings = Settings().with_user_profile(user_id)
+
+    assert settings.telegram_chat_id == test_chat_id, (
+        f"Regression: force_test-Sonderfall veraendert -- erwartet die "
+        f"Test-Chat-ID {test_chat_id!r}, bekommen "
+        f"{settings.telegram_chat_id!r}."
+    )


### PR DESCRIPTION
Neue Nutzer ohne mail_to/telegram_chat_id/sms_to im Profil erhielten ihre
Briefings bisher ueber den globalen .env-Fallback (Cross-Tenant-Zustellung
an den Betreiber). Alle vier Registrierungswege setzen jetzt MailTo direkt,
with_user_profile() ueberschreibt die Felder immer (auch auf None), und
email/telegram/sms brechen bei fehlendem Empfaenger sauber mit
ChannelBlockedError ab statt an eine leere Adresse zu senden.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FZHcAx6djG9jZiBtt6qKkq
