### PR TITLE
feat(#2181): Gewitter-Signalherkunft-Ablation gegen KHW-Archivdaten (Scheibe S2c)

### DIFF
--- a/docs/context/feat-2181-s2c-signalherkunft.md
+++ b/docs/context/feat-2181-s2c-signalherkunft.md
@@ -1,0 +1,249 @@
+# Context: feat-2181-s2c-signalherkunft
+
+## Request Summary
+
+Scheibe S2c aus #2181: die Thesen **T1** (welcher Signalast trug die erreichte Stufe?), **T3**
+(lag das CAPE-Maximum am 29.08. vor dem Ereignis?) und **T4** (wie oft stand „hoch" bei
+vorhergesagtem Niederschlag nahe null?) prüfen — für den Karnischen Höhenweg
+(24.08.–05.09.2026, 13 Etappentage), gemessen gegen den in S1 korrigierten Maßstab.
+
+Vorarbeit auf diesem Ticket: **S1** (T6, geliefert, PR-unabhängig als Kommentar) hat den Maßstab
+von „4 eingetretene Tage" auf **2:13** korrigiert. **S2a** (`feat-2181-s2a-mitschnitt-auswertung`,
+PR #2187, `c3251097`) hat `src/analysis/thunder_replay.py` gebaut — die Auswertungsschicht für
+T2/T5, ausschließlich auf dem bereits gesicherten Vorhersage-Mitschnitt, keine Archiv-Rekonstruktion
+nötig. **S2b** (T2/T5 mit dem Werkzeug tatsächlich messen und als Protokoll kommentieren) und diese
+Scheibe **S2c** stehen beide noch aus; S2c läuft zuerst, weil die dafür gesicherte Archiv-Kopie
+(s.u.) terminlich enger ist als der reine Mitschnitt.
+
+## Ausgangslage aus S1 (bereits geliefert, Kommentar an #2181)
+
+Der Maßstab für alle Trefferquoten steht neu und ist **nicht** mehr „4 eingetretene Tage":
+
+- tagsüber nass auf der Route: **2 Tage** (29.08. 14 mm mit Gewitter · 02.09. 15,6 mm, 18 km neben
+  dem Ziel), dazu 25.08. leichter Landregen ohne Gewittercharakter
+- nachts nass: **2 Nächte** (28./29.08. · 31.08./01.09. mit dem PO-beobachteten Gewitter ab 22 h)
+- Die Überprognose steht damit bei **2:13**, nicht 4:13.
+
+Gesicherte Daten (außerhalb jeder Aufbewahrungsfrist):
+`/home/hem/gz-messdaten/khw-2026-08-mitschnitt/` (Vorhersage-Mitschnitt, 2 246 Zeilen, führt
+`thunder_level_max` + `cape_max_jkg`, **nicht** die Signalherkunft), `…-rueckblick/` (ICON-D2
+punktgenaue Rückblick-Läufe, S1-Material), `…-stationen/` (GeoSphere-Beobachtungsstationen).
+
+## Live-Machbarkeitsprüfung heute (2026-09-08) — korrigiert einen eigenen Fehlschluss
+
+Ich hatte zunächst angenommen, CIN und Blitzpotenzial (LPI) seien für den KHW-Zeitraum nicht mehr
+beschaffbar, weil sie produktiv vom DWD-OpenData-GRIB-Spiegel kommen
+(`opendata.dwd.de/weather/nwp/icon-d2/grib/`, hält nur ~48 h vor). **Das ist die falsche Quelle für
+eine Archiv-Rekonstruktion.** Direkt gegen `historical-forecast-api.open-meteo.com` geprüft
+(Modell `icon_d2`, 46.6123/12.8672 = Wolayersee-Hütte, 29.08.2026):
+
+```
+15:00  code=96  cape=0.0   cin=0.0   lpi=2.6   precip=12.0  showers=0.2
+16:00  code=99  cape=20.0  cin=65.0  lpi=0.0   precip=29.2  showers=0.1
+13:00  code=2   cape=790.0 cin=0.0   lpi=0.0   precip=0.0   showers=0.0
+```
+
+`weather_code`, `cape`, `convective_inhibition` UND `lightning_potential` sind alle vier über
+dieselbe Open-Meteo-Archiv-API abrufbar, mit plausiblen, variierenden Werten (nicht durchgehend
+Füllwert/Null — Gegenprobe an einem ruhigen Tag, 25.08., zeigt LPI durchgehend 0.0 und CIN meist
+0–1, während der Gewittertag deutlich davon abweicht). Die volle Drei-Äste-Ablation (Wettercode,
+CAPE, Blitzpotenzial — Blitzdichte bleibt strukturell FR-only, s.u.) ist damit möglich, **kein**
+eingeschränkter Ersatzbefund nötig.
+
+Rohdaten der Probe unter
+`/tmp/claude-1000/-home-hem-gregor-zwanzig/2da2a554-b229-426e-82e7-fae490715441/scratchpad/probe_29aug_wolayersee.json`
+gesichert (nur zur Nachvollziehbarkeit dieser Session, kein Repo-Artefakt).
+
+## Auf dem KHW anliegende Äste — drei, nicht vier
+
+| Ast | Auf dem KHW | Schwellen | Archiv-Feld |
+|---|---|---|---|
+| **Wettercode** | ja | binär: 95/96/99 → `HIGH`, sonst `NONE` — **kann `LOW`/`MED` nicht erzeugen** | `weather_code` |
+| **CAPE** | ja | 300 / 750 / 1200 J/kg (icon_d2 × DE_ALPEN) | `cape` |
+| **Blitzpotenzial (LPI)** | ja | 1,0 / 30 / 50 (Gebietsleiter) | `lightning_potential` |
+| **Blitzdichte** | **nein** — strukturell abwesend, ist die Météo-France-Größe | 0,003 / 0,015 / 0,075 | — |
+| *(Radar-Override)* | möglich, im Mitschnitt bereits eingerechnet | hebt auf `MED`, Träger `"radar"` | nicht rekonstruierbar |
+
+## Die CIN-Bedingung — Angelpunkt für die CAPE-Ablation
+
+CAPE eskaliert über `LOW` hinaus **genau dann**, wenn ein CIN-Wert vorliegt und `|CIN| ≤ 100`
+(`metric_format.py:377-431`, `_gedaempft_durch_cin`):
+
+- `cin_jkg is None` → Deckel `LOW` („eine fehlende Hemmungsangabe ist keine schwache Hemmung") —
+  **irrelevant für S2c**, da CIN jetzt real vorliegt (siehe Machbarkeitsprüfung)
+- `|CIN| < 50` → volle Leiterstufe
+- `50 ≤ |CIN| ≤ 100` → eine Stufe herunter
+- `|CIN| > 100` → eine Stufe herunter **und** Deckel `LOW`
+
+Produktiv liefert `dp.convective_inhibition_jkg` ausschließlich der DWD (`cin_ml`,
+`thunder_enrichment.py:44`, geholt über `de_direct`); die Rekonstruktion nimmt CIN stattdessen von
+Open-Meteos Archiv-Spiegel desselben `icon_d2`-Modells — andere Bezugsquelle, aber dieselbe
+Modellgröße, kein Verfahrenswechsel.
+
+## Related Files
+
+| File | Relevance |
+|------|-----------|
+| `src/output/metric_format.py:434` | `_signal_levels()` — übersetzt jedes Signal einzeln in ein `ThunderLevel` |
+| `src/output/metric_format.py:489` | `thunder_signal_carriers() -> list[str]` — nennt **jedes** Signal auf der Höchststufe, kürt keinen Gewinner (genau der Ablations-Baustein für T1) |
+| `src/output/metric_format.py:528` | `thunder_level_from_signals()` — Fusion, `max_thunder()` über die Signalwerte |
+| `src/output/metric_format.py:377-431` | `_gedaempft_durch_cin()` — die CIN-Dämpfung, ausschließlich um den CAPE-Ast gelegt |
+| `src/providers/openmeteo.py:269` | `THUNDER_CODES = {95, 96, 99}` — wiederverwendbare Konstante, keine zweite Kopie |
+| `src/providers/openmeteo.py:694-716` | `_parse_thunder_level()` — Referenzverfahren Wettercode → `ThunderLevel` |
+| `src/app/model_registry.py:228-243` | `cape_ladder_thresholds_jkg(model_id, region)` → (low, med, high) |
+| `src/app/model_registry.py:180-187` | `lpi_thresholds_jkg(region)` → (low, med, high) |
+| `src/providers/thunder_routing.py:80` | `thunder_region_for(lat, lon)` — Gebietszuordnung, liefert `DE_ALPEN` für den KHW |
+| `src/analysis/thunder_replay.py` | S2a-Modul (Vorlauf-Auswahl, Tages-Aggregation, Dreiwertigkeit) — Muster für S2c, ggf. Erweiterung statt Neubau |
+| `tests/tdd/test_thunder_replay.py` | S2a-Tests — Fixture-Stil, an dem sich S2c-Tests orientieren |
+| `src/services/forecast_capture.py` | Mitschnitt; führt `thunder_level_max` + `cape_max_jkg` je Etappentag, Grundlage für den Kalibrier-Abgleich |
+
+## Existing Patterns
+
+- **Die Ablation existiert bereits als Funktion.** `thunder_signal_carriers()` läuft über
+  dasselbe `_signal_levels()` wie die Fusion — für T1 muss keine zweite Fusionsregel entstehen
+  (ADR-0025), nur mit rekonstruierten Rohwerten aufgerufen werden.
+- **„Alles oder nichts" je Leiter:** fehlt eine der drei Sprossen, trägt das Signal gar nicht bei.
+  Ein fehlendes Signal erscheint nicht im Dict; sind alle abwesend, ist das Ergebnis `None` =
+  „keine Aussage", nicht `NONE` = „geprüfte Entwarnung" — dieselbe Dreiwertigkeits-Disziplin wie
+  in S2a (AC-4/AC-5 dort).
+- **S2a hat das Fixture-/Test-Muster bereits etabliert:** echte aufgezeichnete Zeilen als
+  versionierte JSON-Fixtures, reine Funktionen ohne Netz/DB, Test pro AC.
+
+## Der entscheidende Befund: der Vorlauf-Versatz (aus der Vorarbeit zu S2, übernommen)
+
+Der Mitschnitt hält Vorhersagen mit **Median 21 h Vorlauf, 36 % über 48 h** (gemessen als
+`fenster_start − fetched_at`). `historical-forecast-api` gibt dagegen je Stunde offenbar den
+**reifsten verfügbaren** Wert (der 29.08. zeigt am Nachmittag scharfe, ereignisnahe Werte). Ein
+unbesehener Abgleich Rekonstruktion ↔ Mitschnitt-Gesamtmenge misst deshalb eher
+**Vorhersagedrift als Rechenweise-Fehler** — und würde eine korrekte Rekonstruktion zu Unrecht
+verwerfen. **Konsequenz für den Kalibrier-Schritt:** der CAPE-Abgleich (Archiv gegen Mitschnitt)
+läuft NUR auf der kurzvorlauf-nächsten Teilmenge des Mitschnitts (kleinster verfügbarer Vorlauf je
+Tag/Segment — dieselbe Auswahlfunktion `waehle_vorlauf_aermste()` aus `thunder_replay.py`), nicht
+auf dem gesamten Mitschnitt.
+
+Zwei weitere Messfallen aus derselben Familie, für S2c übernommen:
+
+- **Nichtstun-Übereinstimmung:** ein Großteil der Mitschnitt-Zeilen ist `NONE`. Eine hohe
+  Trefferquote allein daraus wäre keine Leistung — der Kalibrier-Abgleich vergleicht deshalb den
+  **kontinuierlichen** `cape_max_jkg`-Wert (relative Abweichung quantifizierbar), nicht nur die
+  Dreistufigkeit.
+- **Teilmengen-Willkür:** welche `source`-Teilmenge des Mitschnitts als Vergleichsgrundlage dient,
+  muss vorab feststehen (S2a hat dafür bereits `TEILMENGE_PRIMAER` definiert) — nicht im Nachhinein
+  passend gewählt werden.
+
+## T1 — Ablation statt Gewinnerzuweisung
+
+**T1 wird als Ablation gestellt:** Für jeden Etappentag, an dem der Mitschnitt eine Stufe ≥ `LOW`
+zeigt, wird geprüft, welche(r) Ast/Äste (Wettercode/CAPE/Blitzpotenzial) bei rekonstruierten
+Rohwerten dieselbe Höchststufe allein erzeugen — via `thunder_signal_carriers()`, ungeändert
+aufgerufen. Kein neuer Gewinner wird gekürt (mehrere Äste können gleichzeitig Träger sein, exakt
+wie im Produktivpfad).
+
+**Bekannte Grenze, die in die Spec muss:** Der Radar-Override (`RadarNowcastService`) ist im
+Mitschnitt bereits eingerechnet, aber aus der Archiv-Rekonstruktion strukturell nicht sichtbar —
+ein Tag, an dem der Radar die Stufe auf `MED` gehoben hat, kann in der Ablation als „kein Ast
+erreicht die Mitschnitt-Stufe" erscheinen, ohne dass das ein Fehler der Rekonstruktion ist. Muss
+als eigene Kategorie ausgewiesen werden, nicht der Ablation angelastet werden.
+
+## T3 — CAPE-Zeitverlauf am 29.08.
+
+Braucht nur `cape` und `weather_code` aus derselben Archiv-Abfrage für die Wolayersee-Hütte,
+29.08., alle 24 Stunden. Ereignisstunden werden aus `weather_code` (Codes in `THUNDER_CODES`)
+selbst abgeleitet — keine externe Zeitangabe nötig. Frage: liegt das CAPE-Maximum 1–3 h VOR der
+ersten Ereignisstunde? Aus der Live-Probe oben bereits ablesbar: Maximum 790 J/kg um 13:00, erste
+Ereignisstunde (Code 96) um 15:00 — **2 h Vorlauf**, im behaupteten Fenster. Das ist noch keine
+Auswertung (nur eine Stichprobe aus der Machbarkeitsprüfung), muss aber als Testfall in die
+Fixtures.
+
+## T4 — Stufe vs. vorhergesagter Niederschlag
+
+Braucht **keine neue Fusion** — paart die bereits im Mitschnitt stehende `thunder_level_max` je
+Etappentag (aus `thunder_replay.tageswerte_je_teilmenge()`, S2a-Funktion, unverändert
+wiederverwendet) gegen die archiv-rekonstruierte Tagessumme von `precipitation`/`showers` an
+demselben Etappenziel. Kein Schwellenwert wird im Modul festgelegt („nahe null" ist eine
+Berichts-Interpretation, keine Modul-Konstante) — das Modul liefert die rohen Paare
+(Stufe, Niederschlagssumme, Schauersumme) je Tag, die Bewertung geschieht im Bericht außerhalb
+des Repos (S2a-Präzedenzfall: „kein Freitext-Bericht — der Bericht selbst entsteht außerhalb des
+Repos").
+
+## Affected Files (vorläufig, Bestätigung in der Spec)
+
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `src/analysis/thunder_replay.py` | MODIFY (Erweiterung) oder `src/analysis/thunder_ablation.py` CREATE | Archiv-Stundenzeilen-Verarbeitung: Ablation (T1), Ereignisfenster+CAPE-Verlauf (T3), Stufe-Niederschlag-Paarung (T4), Kalibrier-Abgleich Kurzvorlauf-CAPE |
+| `tests/tdd/test_thunder_replay.py` (Erweiterung) oder neue Testdatei | CREATE/MODIFY | Verhaltensprüfung gegen Fixtures aus echten Archiv-Antworten |
+| `tests/fixtures/khw_2026_08_archiv/*.json` | CREATE | Aufgezeichnete Archiv-Stunden (u.a. die 29.08.-Probe oben) als versionierte Fixtures |
+
+Ob Erweiterung oder neues Modul: Entscheidung gehört in die Spec (Implementation Details), nicht
+hierher vorweggenommen — Kriterium: unterschiedliche Eingangsgranularität (Stunde vs. bereits
+tagesaggregierter Mitschnitt) spricht für ein eigenes Modul, gemeinsame Hilfsfunktionen
+(`thunder_ordinal`, Dreiwertigkeits-Disziplin) sprechen für Wiederverwendung aus `thunder_replay.py`.
+
+Der Abruf-/Report-Teil (Netz, Ausgabe des Protokolls) bleibt **außerhalb** des Repos unter
+`/home/hem/gz-messdaten/`, wie bei S1/S2a — genau ein Lauf, kein Wartungswert.
+
+## Existing Specs
+
+- `docs/specs/modules/feat_2181_s2a_gewitter_mitschnitt_auswertung.md` — Vorgänger-Spec (S2a),
+  Known Limitations dort benennen explizit diese Scheibe als Folgearbeit
+- `docs/specs/modules/fix_1592_s1_cape_modellschwelle.md` — Eichung der CAPE-Schwelle
+- `docs/adr/0025-...` (eine Gewitter-Fusionsquelle) — bindend für den Ablations-Ansatz
+- `docs/adr/0048-modellabhaengige-schwellen-statt-einer-zahl.md` — widerspricht dem Ist-Zustand,
+  siehe #2182 (nicht Gegenstand dieser Scheibe)
+
+## Dependencies
+
+- **Upstream:** `output/metric_format.py` (`thunder_signal_carriers`, `_signal_levels`),
+  `app/model_registry.py` (Schwellen), `providers/thunder_routing.py` (Gebiet),
+  `providers/openmeteo.py` (`THUNDER_CODES`), `src/analysis/thunder_replay.py` (Vorlauf-Auswahl,
+  Dreiwertigkeit, `thunder_ordinal`)
+- **Downstream:** keine — kein Produktivpfad wird verändert. Die **Befunde** wirken auf #2176
+  (Gewitterstufe-als-Ansage-Formulierung), #2182 (ADR-0048-Bruch) und Epic #1419.
+
+## Risks & Considerations
+
+- **Nachrechnung ≠ Mitschnitt.** Eine Archiv-Rekonstruktion ist eine Rekonstruktion, kein Beweis
+  dessen, was der Dienst damals ausgab — der Kalibrier-Abgleich (Kurzvorlauf-CAPE) muss VOR der
+  T1-Ablation stehen und deren Aussagekraft explizit einschränken, falls er divergiert.
+- **Der Radar-Override ist aus der Rekonstruktion nicht sichtbar** — Stunden, in denen er
+  gegriffen hat, dürfen nicht einem der drei Äste zugeschlagen werden, sondern brauchen eine
+  eigene Kategorie „durch Radar gehoben, Ablation nicht aussagekräftig".
+- **`None` ≠ `NONE`.** „Keine Aussage" und „geprüfte Entwarnung" dürfen in der Auswertung nicht
+  zusammenfallen — dieselbe Disziplin wie in S2a AC-4/AC-5.
+- **Akzeptanzkriterien beschreiben die Messvorschrift, nie das Ergebnis** — ein AC der Form „Then
+  trägt CAPE ≥ 7 Tage" wäre keine Messung mehr, sondern eine vorweggenommene Antwort (S2a-Lehre).
+- **T3-Beispielwert oben ist eine Stichprobe, kein Befund** — darf nicht als vorweggenommenes
+  Ergebnis in eine Spec-Formulierung einfließen, nur als Testfall-Rohmaterial.
+
+## Analysis
+
+### Type
+
+Feature (Messwerkzeug + Auswertung). Kein Bugfix — es wird nichts repariert, sondern eine
+Zusicherung nachgemessen (identisch zur Einordnung von S2a).
+
+### Scope Assessment
+
+- Files: 3 (1-2 Code-Dateien im Repo + Fixture-Verzeichnis)
+- Estimated LoC: Modul ~120-180, Tests ~120-150 → im 250er-Limit, aber eng wie bei S2a
+  (dort musste `loc_limit_override` nicht gezogen werden — als Referenz brauchbar)
+- Risk Level: LOW für das System (kein Produktivpfad verändert, reine Funktionen ohne Netz/DB),
+  MEDIUM-HIGH für die Aussagekraft (T1 hängt am Kalibrier-Abgleich; ein zu großzügig bestandener
+  Abgleich würde einen falschen Befund erzeugen, der in #2176 weiterwirkt — dieselbe Familie von
+  Fehler, die die Untersuchung am 07.09. zweimal getroffen hat)
+
+### Empfehlung
+
+Standard Track bestätigt sich: die eigentliche Unsicherheit war die Datenverfügbarkeit (jetzt
+geklärt: JA, via Open-Meteo-Archiv, nicht DWD-Direktabruf), nicht die Code-Komplexität. Weiter mit
+`/30-write-spec` — Spec muss den Kalibrier-Abgleich als AC VOR der Ablations-ACs führen (Reihenfolge
+ist inhaltlich zwingend, nicht nur redaktionell), und die drei Known Limitations (Radar-Override,
+Vorlauf-Versatz, T3-Stichprobe-nicht-Befund) wörtlich übernehmen.
+
+## Open Questions
+
+- [x] Liefert das Archiv CIN und LPI für icon_d2? — **Ja**, heute live verifiziert
+- [x] Ist `metric_format` offline importierbar? — **Ja** (aus S2a bereits bestätigt)
+- [ ] Erweiterung von `thunder_replay.py` oder neues Modul? — Entscheidung in der Spec
+- [ ] Toleranzschwelle für den Kalibrier-Abgleich (relative CAPE-Abweichung) — Entscheidung in der
+      Spec, mit Begründung (kein willkürlicher Prozentwert ohne Bezug)

--- a/docs/features/architecture.md
+++ b/docs/features/architecture.md
@@ -150,11 +150,13 @@ Für lokale Entwicklung und Debugging existiert weiterhin die CLI in `src/app/cl
 mehr der Produktivpfad.
 
 **Analyse-Werkzeuge (kein Produktivpfad):** `src/analysis/` enthält reine
-Auswertungswerkzeuge für bereits vorhandene Wetter-Mitschnitte, aktuell
-`thunder_replay.py` (Issue #2181 Scheibe S2a). Kein anderer Code importiert das Paket
-und es hat keinen Netz-, Datei-, DB- oder Umgebungszugriff — es läuft ausschließlich,
-wenn jemand es gezielt für eine Auswertung aufruft. Spec:
-`docs/specs/modules/feat_2181_s2a_gewitter_mitschnitt_auswertung.md`.
+Auswertungswerkzeuge für bereits vorhandene Wetter-Mitschnitte bzw. Archivdaten, aktuell
+`thunder_replay.py` (Issue #2181 Scheibe S2a) und `thunder_ablation.py` (Issue #2181
+Scheibe S2c). Kein anderer Code importiert das Paket und es hat keinen Netz-, Datei-,
+DB- oder Umgebungszugriff — es läuft ausschließlich, wenn jemand es gezielt für eine
+Auswertung aufruft. Specs:
+`docs/specs/modules/feat_2181_s2a_gewitter_mitschnitt_auswertung.md`,
+`docs/specs/modules/feat_2181_s2c_gewitter_archiv_ablation.md`.
 
 ## Debug-Prinzip
 - Alle Schritte schreiben standardisierte Debug-Zeilen in den DebugBuffer

--- a/docs/specs/modules/feat_2181_s2c_gewitter_archiv_ablation.md
+++ b/docs/specs/modules/feat_2181_s2c_gewitter_archiv_ablation.md
@@ -1,0 +1,227 @@
+---
+entity_id: feat_2181_s2c_gewitter_archiv_ablation
+type: feature
+created: 2026-09-08
+updated: 2026-09-08
+status: draft
+version: "1.0"
+tags: [analysis, gewitter, cape, ablation, khw, messwerkzeug]
+---
+
+# Gewitter-Signalherkunft — Ablation, CAPE-Zeitverlauf und Stufe-vs-Niederschlag für den KHW-Archiv-Zeitraum (#2181 Scheibe S2c)
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Prüft drei Thesen aus Issue #2181 gegen den Karnischen Höhenweg (24.08.–05.09.2026, 13 Etappentage) mittels Archiv-Rekonstruktion (nicht nur dem bereits gesicherten Vorhersage-Mitschnitt wie in Scheibe S2a): **T1** (welcher Signalast — Wettercode/CAPE/Blitzpotenzial — trug die erreichte Stufe?), **T3** (lag das CAPE-Maximum am 29.08. an der Wolayersee-Hütte 1-3h vor der ersten Gewitterstunde?), **T4** (wie oft stand eine hohe Stufe bei vorhergesagtem Niederschlag nahe null?). Vorgeschaltet: ein Kalibrier-Abgleich, der prüft, ob die Archiv-Rekonstruktion den bereits gesicherten Mitschnitt überhaupt trifft — ohne bestandenen Abgleich ist die T1-Ablation nicht belastbar.
+
+## Source
+
+- **File:** `src/analysis/thunder_ablation.py` (neue Datei, kein Vorgänger)
+- **Identifier:** freie Funktionen, kein Klassen-Interface (identisch zum Muster aus S2a)
+
+**Begründung eigenes Modul statt Erweiterung von `thunder_replay.py`:** unterschiedliche Eingangsgranularität — `thunder_replay.py` verarbeitet bereits tagesaggregierte Mitschnitt-Segmente, `thunder_ablation.py` verarbeitet stündliche Archiv-Zeitreihen an einem Punkt. Gemeinsame Bausteine werden importiert, nicht dupliziert: `waehle_vorlauf_aermste()`, `tageswerte_je_teilmenge()`, `TEILMENGE_PRIMAER` aus `thunder_replay.py`; `thunder_ordinal` aus `app.thunder_scale`.
+
+> **Schicht-Hinweis:** Python-Core (`src/`), reines Analyse-Werkzeug ohne Netz-, DB- oder API-Anbindung. Kein Frontend, keine Go-API betroffen.
+
+## Estimated Scope
+
+- **LoC:** ~170-200 (Modul) + ~180-220 (Tests, 12 ACs) — Fixtures zählen nicht als LoC. **Das 250er-Gesamtlimit wird voraussichtlich überschritten** (S2a lag bei ~150+100=250 mit nur 8 ACs) — `loc_limit_override` auf 400 wird empfohlen, mit Begründung "Kalibrier-Abgleich + drei Thesen in einer Scheibe, mehr Funktionen als S2a".
+- **Files:** 2 Code-Dateien + 1 Fixture-Verzeichnis
+- **Effort:** medium
+
+### Affected Files
+
+| File | Change Type | Description |
+|------|-------------|--------------|
+| `src/analysis/thunder_ablation.py` | CREATE | Archiv-Stundenzeilen-Verarbeitung: Kalibrier-Abgleich, Ablation (T1), CAPE-Verlauf+Ereignisfenster (T3), Stufe-Niederschlag-Paarung (T4) |
+| `tests/tdd/test_thunder_ablation.py` | CREATE | Verhaltensprüfung gegen Fixtures aus echten Archiv-Antworten und Mitschnitt-Zeilen |
+| `tests/fixtures/khw_2026_08_archiv/*.json` | CREATE | Aufgezeichnete Archiv-Stunden (Ausgangsmaterial: die echte Live-Probe vom 29.08. an der Wolayersee-Hütte — als reale Rohdaten übernehmen, ergänzt um weitere Testfälle, die die einzelnen ACs gezielt abdecken, z.B. eine Stunde mit hohem LPI und niedrigem CAPE/Wettercode für AC-5) |
+
+**Nicht Teil dieser Scheibe:** der Netzabruf gegen `historical-forecast-api.open-meteo.com` selbst (bleibt außerhalb des Repos unter `/home/hem/gz-messdaten/`, wie bei S1/S2a — genau ein Lauf, kein Wartungswert), jede Änderung an `src/output/metric_format.py`, `src/providers/thunder_enrichment.py` oder anderem Produktivpfad-Code.
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `output.metric_format.thunder_signal_carriers()` | Funktion (genutzt, UNVERÄNDERT) | Nennt jedes Signal, das die Höchststufe trägt — der eigentliche Ablations-Baustein (ADR-0025: keine zweite Fusionsregel) |
+| `output.metric_format.thunder_level_from_signals()` | Funktion (genutzt, UNVERÄNDERT) | Fusion für die Stufenberechnung je Stunde |
+| `app.model_registry.cape_ladder_thresholds_jkg(model_id, region)` | Nachschlag (vom Aufrufer aufgelöst, als Tupel übergeben) | (low, med, high)-CAPE-Leiter — kein hartkodierter Wert im Modul |
+| `app.model_registry.lpi_thresholds_jkg(region)` | Nachschlag (vom Aufrufer aufgelöst, als Tupel übergeben) | (low, med, high)-Blitzpotenzial-Leiter |
+| `providers.openmeteo.THUNDER_CODES` | Konstante (importiert, NICHT kopiert) | `{95, 96, 99}` — Wettercode-Ast und T3-Ereignisstunden-Erkennung nutzen dieselbe Konstante wie der Produktivpfad |
+| `analysis.thunder_replay.waehle_vorlauf_aermste()` | Funktion (importiert, wiederverwendet) | Kurzvorlauf-Auswahl für den Kalibrier-Abgleich — keine zweite Auswahlregel |
+| `analysis.thunder_replay.tageswerte_je_teilmenge()` | Funktion (importiert, wiederverwendet) | Liefert die Mitschnitt-Tageswerte (inkl. `cape_max_jkg`, `thunder_level_max`) für Kalibrierung und T4 |
+| `app.models.ThunderLevel` | Enum (genutzt) | Gemeinsamer Stufentyp |
+| `app.thunder_scale.thunder_ordinal` | Funktion (genutzt) | Kanonische Stufenordnung für Tages-/Stundenmaximum |
+
+## Implementation Details
+
+### Archiv-Zeilenformat
+
+Aus `historical-forecast-api.open-meteo.com`, Parameter `weather_code,cape,convective_inhibition,lightning_potential,precipitation,showers`, Modell `icon_d2`. Die API liefert parallele Arrays (`hourly.time[]`, `hourly.weather_code[]`, ...). Eine reine Zip-Funktion macht daraus Stundenzeilen — das ist der einzige Parsing-Schritt, alles andere arbeitet auf dieser Zeilenform:
+
+```
+stundenzeilen_aus_archiv_antwort(antwort: dict) -> list[dict]:
+    # {"time": "2026-08-29T15:00", "weather_code": 96, "cape": 0.0,
+    #  "convective_inhibition": 0.0, "lightning_potential": 2.6,
+    #  "precipitation": 12.0, "showers": 0.2}
+    # Zip ueber antwort["hourly"][...] Arrays, Reihenfolge = Index von "time"
+```
+
+### 1. Wettercode-Ast (gemeinsam für T1 und T3)
+
+```
+wettercode_stufe(weather_code: Optional[int]) -> Optional[ThunderLevel]:
+    if weather_code is None: return None      # keine Aussage
+    return ThunderLevel.HIGH if weather_code in THUNDER_CODES else ThunderLevel.NONE
+```
+
+Spiegelt `OpenMeteoProvider._parse_thunder_level()` (openmeteo.py:694-716) exakt, als freie Funktion mit der importierten Konstante — keine zweite Kopie der Codes 95/96/99.
+
+### 2. Kalibrier-Abgleich (MUSS vor der T1-Ablation stehen und ACs vor T1 tragen)
+
+```
+kalibrier_abgleich_kurzvorlauf_cape(
+    mitschnitt_tageswerte_primaer: dict[str, dict],  # aus thunder_replay.tageswerte_je_teilmenge()["primaer"]
+    archiv_cape_tagesmaximum: dict[str, Optional[float]],  # Tag -> max(stundenzeile["cape"])
+    toleranz_jkg: float,  # vom Aufrufer uebergeben, empfohlen: cape_low_schwelle / 2
+) -> dict[str, dict]:
+    # je Tag: {"kategorie": "im_toleranzband" | "abweichend" | "kein_vergleichswert",
+    #          "differenz_jkg": float | None}
+    # "kein_vergleichswert": mitschnitt_tageswerte_primaer[tag]["cape_max_jkg"] is None
+    #   ODER Tag fehlt in einer der beiden Quellen
+```
+
+Toleranz-Begründung: die Toleranz ist die HALBE untere CAPE-Sprosse des Gebiets (`cape_ladder_thresholds_jkg("icon_d2","DE_ALPEN")[0] / 2` = 150 J/kg) — eine kleinere Abweichung kann die Stufenklassifikation strukturell nicht kippen, eine größere schon. Kein willkürlicher Prozentwert.
+
+### 3. T1 — Ablation je Stunde und Tagesverdichtung
+
+```
+ablation_je_stunde(
+    stundenzeile: dict,
+    cape_ladder: tuple[float, float, float],
+    lpi_thresholds: tuple[float, float, float],
+) -> dict:
+    # ruft thunder_level_from_signals()/thunder_signal_carriers() MIT REALEN REKONSTRUIERTEN
+    # ROHWERTEN auf (cin_jkg und lightning_potential_jkg sind NICHT None -- anders als urspruenglich
+    # befuerchtet liefert das Open-Meteo-Archiv beide fuer icon_d2, live verifiziert):
+    #   wettercode_level = wettercode_stufe(stundenzeile["weather_code"])
+    #   lightning_density = None  # FR-only, auf dem KHW strukturell abwesend
+    #   cape_jkg = stundenzeile["cape"]
+    #   lightning_potential_jkg = stundenzeile["lightning_potential"]
+    #   cin_jkg = stundenzeile["convective_inhibition"]
+    # {"stufe": ThunderLevel | None, "traeger": list[str]}
+
+ablation_tagesmaximum(
+    stundenzeilen_tag: list[dict], cape_ladder, lpi_thresholds,
+) -> dict:
+    # ruft ablation_je_stunde() fuer jede Stunde, ermittelt die Hoechststufe des Tages
+    # (thunder_ordinal), traeger = UNION aller "traeger"-Listen der Stunden, die genau diese
+    # Hoechststufe erreichen (nicht nur die erste gefundene Stunde -- AC-6)
+    # {"stufe": ThunderLevel | None, "traeger": list[str]}
+
+vergleiche_ablation_mit_mitschnitt(
+    ablation_tag: dict, mitschnitt_stufe: Optional[ThunderLevel],
+) -> dict:
+    # {"mitschnitt_stufe": ..., "ablation_stufe": ..., "traeger": [...],
+    #  "ablation_erreicht_mitschnitt_stufe": bool}
+    # False, wenn thunder_ordinal(ablation_stufe oder NONE) < thunder_ordinal(mitschnitt_stufe) --
+    # eigene, ausgewiesene Kategorie, NICHT stillschweigend einem der drei Aeste zugeschlagen
+    # (Radar-Override ist im Mitschnitt eingerechnet, aus der Rekonstruktion strukturell
+    # unsichtbar -- Known Limitations)
+```
+
+### 4. T3 — CAPE-Zeitverlauf und Ereignisfenster
+
+```
+cape_verlauf_und_ereignisfenster(stundenzeilen_tag: list[dict]) -> dict:
+    # {"stundenwerte": [(zeit, cape), ...] zeitlich sortiert,
+    #  "cape_maximum": (zeit, wert) | None,
+    #  "erste_ereignisstunde": zeit | None,  # erste Stunde mit weather_code in THUNDER_CODES
+    #  "vorlauf_stunden": float | None}  # erste_ereignisstunde - cape_maximum_zeit in Stunden
+    # None-Werte wenn keine Ereignisstunde im Tag -- kein erfundener Wert, keine Exception
+```
+
+WICHTIG: kein Sollwert "muss 1-3h sein" im Code oder in den ACs — nur die Rechnung wird geprüft (S2a-Lehre: ACs beschreiben die Messvorschrift, nie das Ergebnis).
+
+### 5. T4 — Stufe-Niederschlag-Paarung
+
+```
+niederschlag_tagessumme(stundenzeilen_tag: list[dict]) -> dict:
+    # {"niederschlag_mm": sum(precipitation), "schauer_mm": sum(showers)}
+
+stufe_gegen_niederschlag(
+    mitschnitt_tageswerte: dict[str, dict],  # thunder_level_max je Tag, aus thunder_replay
+    archiv_niederschlag_je_tag: dict[str, dict],  # aus niederschlag_tagessumme() je Tag
+) -> dict[str, dict]:
+    # je Tag NUR das rohe Tripel: {"stufe": ThunderLevel | None,
+    #   "niederschlag_mm": float | None, "schauer_mm": float | None}
+    # KEIN Schwellenwert/Interpretationsfeld ("nahe null" etc.) -- das ist Berichtssache
+    # ausserhalb des Repos (S2a-Praezedenzfall)
+```
+
+## Expected Behavior
+
+- **Input:** Archiv-Stundenzeilen (aus der Zip-Funktion, in Fixtures als versionierte JSON-Dateien mit echten aufgezeichneten Werten), Mitschnitt-Tageswerte (aus `thunder_replay`), Modell-/Gebiets-Schwellen (vom Aufrufer über `model_registry` aufgelöst, als Tupel übergeben).
+- **Output:** Kalibrier-Kategorien je Tag; Ablations-Stufe+Träger je Tag inkl. Vergleich mit dem Mitschnitt; CAPE-Verlauf+Ereignisfenster für T3; rohe Stufe-Niederschlag-Paare für T4. Kein Freitext-Bericht — der Bericht entsteht außerhalb des Repos.
+- **Side effects:** keine — reine Funktionen, kein Netz-/Datei-Schreib-/DB-Zugriff.
+
+## Acceptance Criteria
+
+- **AC-1:** Given ein Etappentag mit archiv-CAPE-Tagesmaximum und dem kurzvorlauf-nächsten Mitschnitt-`cape_max_jkg` desselben Tages, When der Kalibrier-Abgleich läuft, Then wird die absolute Differenz gegen die Toleranz (halbe LOW-Sprosse, 150 J/kg bei icon_d2×DE_ALPEN) geprüft und der Tag als "im_toleranzband" oder "abweichend" markiert.
+  - Test: Fixture-Tag mit archiv-CAPE 500 und mitschnitt-cape 550 (Differenz 50 < Toleranz 150) → "im_toleranzband"; zweiter Fixture-Tag mit Differenz 400 > Toleranz → "abweichend".
+
+- **AC-2:** Given ein Mitschnitt-Tag ohne jede Zeile mit gültigem (nicht-negativem) Vorlauf, When der Kalibrier-Abgleich für diesen Tag läuft, Then wird der Tag als "kein_vergleichswert" markiert, nicht als "im_toleranzband" oder "abweichend".
+  - Test: Fixture-Tag mit ausschließlich negativem Vorlauf in den Mitschnitt-Zeilen → Kategorie "kein_vergleichswert".
+
+- **AC-3:** Given eine Archiv-Stunde mit `weather_code=96`, When `ablation_je_stunde` sie auswertet, Then liefert das Ergebnis Stufe HIGH mit "wettercode" als Träger, unabhängig von schwächeren CAPE-/LPI-Werten derselben Stunde.
+  - Test: Fixture-Stunde `code=96, cape=0, lpi=0` → `{"stufe": HIGH, "traeger": ["wettercode"]}`.
+
+- **AC-4:** Given eine Archiv-Stunde mit CAPE über der HIGH-Sprosse und CIN > 100 J/kg, When `ablation_je_stunde` sie auswertet, Then wird die CAPE-Stufe gemäß der bestehenden CIN-Dämpfungsregel (`_gedaempft_durch_cin`, ADR-0025) auf höchstens LOW heruntergesetzt, nicht ungedämpft auf HIGH gezählt.
+  - Test: Fixture-Stunde `cape=1500` (über HIGH-Sprosse 1200), `cin=150` → CAPE-Ast liefert höchstens LOW.
+
+- **AC-5:** Given eine Archiv-Stunde mit `lightning_potential` über der HIGH-Sprosse und Wettercode/CAPE unterhalb ihrer Sprossen, When `ablation_je_stunde` sie auswertet, Then erscheint "blitzpotenzial" als alleiniger Träger der Höchststufe.
+  - Test: Fixture-Stunde `cape` niedrig, `code=2` (kein Gewittercode), `lpi=60` (über HIGH-Sprosse 50) → `traeger == ["blitzpotenzial"]`, Stufe HIGH.
+
+- **AC-6:** Given zwei Stunden desselben Tages, eine mit Träger "wettercode" auf HIGH, eine mit Träger "cape" auf derselben Höchststufe HIGH, When `ablation_tagesmaximum` den Tag verdichtet, Then enthält die Trägerliste des Tages BEIDE Namen.
+  - Test: Fixture-Tag mit zwei Stunden, unterschiedliche alleinige Träger derselben Höchststufe → beide Namen in der Tages-Trägerliste.
+
+- **AC-7:** Given ein Etappentag, dessen Mitschnitt-Stufe HIGH zeigt, aber KEINE Archiv-Stunde des Tages HIGH erreicht, When `vergleiche_ablation_mit_mitschnitt` läuft, Then wird `ablation_erreicht_mitschnitt_stufe = False` markiert — nicht stillschweigend einem der drei Äste zugeschlagen.
+  - Test: Fixture-Tag Mitschnitt-Stufe HIGH, alle Archiv-Stunden liefern höchstens LOW → `ablation_erreicht_mitschnitt_stufe` ist False, Trägerliste für HIGH bleibt leer.
+
+- **AC-8:** Given eine Archiv-Stunde mit `weather_code=None`, When `ablation_je_stunde` sie auswertet, Then trägt der Wettercode-Ast NICHT zur Stufe bei (fehlt im Signal-Dict) — anders als ein Code, der explizit "kein Gewitter" bedeutet.
+  - Test: Fixture-Stunde `weather_code=None`, alle anderen Signale ebenfalls unterhalb/fehlend → Gesamtstufe `None` ("keine Aussage"); Vergleichs-Fixture mit `weather_code=2` und sonst identischen Werten → Gesamtstufe `ThunderLevel.NONE` ("geprüfte Entwarnung").
+
+- **AC-9:** Given ein Fixture-Tag mit Archiv-Stundenwerten, dessen CAPE-Maximum zeitlich vor der ersten Ereignisstunde (Wettercode in `THUNDER_CODES`) liegt, When `cape_verlauf_und_ereignisfenster` den Tag auswertet, Then liefert es die korrekte Stundendifferenz zwischen CAPE-Maximum-Zeitpunkt und erster Ereignisstunde.
+  - Test: Fixture (Ausgangsmaterial: die reale 29.08.-Live-Probe, NICHT als vorgeschriebenes Ergebnis, nur als Rohdaten) mit CAPE-Maximum um 13:00 und erster Ereignisstunde 15:00 → `vorlauf_stunden == 2.0`; Test prüft die Rechnung, schreibt kein "muss 1-3h sein"-Kriterium fest.
+
+- **AC-10:** Given ein Fixture-Tag ohne jede Ereignisstunde, When `cape_verlauf_und_ereignisfenster` ausgewertet wird, Then liefert es `erste_ereignisstunde=None` und `vorlauf_stunden=None` — kein Rechenfehler, kein erfundener Wert.
+  - Test: Fixture-Tag ausschließlich mit Nicht-Gewitter-Codes → beide Felder `None`.
+
+- **AC-11:** Given eine Mitschnitt-Tages-Stufe HIGH und archiv-Niederschlagssummen, When `stufe_gegen_niederschlag` den Tag paart, Then liefert es NUR das rohe Tripel (Stufe, Niederschlagssumme, Schauersumme) — kein Schwellenwert-Interpretationsfeld wie "nahe null".
+  - Test: Rückgabe-Dict eines Tages enthält ausschließlich die drei benannten Rohwerte, keine weiteren bool-Interpretationsfelder.
+
+- **AC-12:** Given ein Etappentag ohne gültige Mitschnitt-Stufe (`None`, "keine Aussage"), When `stufe_gegen_niederschlag` diesen Tag paart, Then bleibt die Stufe im Ergebnis `None` — kollabiert nicht zu `ThunderLevel.NONE`.
+  - Test: Fixture-Tag mit `thunder_level_max=None` → Ausgabe-Stufe bleibt `None`.
+
+## Known Limitations
+
+- **Der Radar-Override ist aus der Rekonstruktion strukturell unsichtbar.** `RadarNowcastService` ist im Mitschnitt bereits eingerechnet, aber kein Archiv-Signal — Tage, an denen er gegriffen hat, landen in der Kategorie "ablation_erreicht_mitschnitt_stufe_nicht" (AC-7), was NICHT als Fehler der Ablation zu lesen ist.
+- **Vorlauf-Versatz:** der Mitschnitt hält Vorhersagen mit Median 21h Vorlauf, das Archiv liefert je Stunde den reifsten verfügbaren Wert — ein unbesehener Abgleich über den GESAMTEN Mitschnitt würde Vorhersagedrift messen statt Rechenweise-Fehler. Deshalb vergleicht der Kalibrier-Abgleich NUR gegen die kurzvorlauf-nächste Mitschnitt-Teilmenge (`waehle_vorlauf_aermste`).
+- **CIN und Blitzpotenzial produktiv vom DWD-Direktabruf, hier von Open-Meteos Archiv-Spiegel des gleichen Modells (`icon_d2`)** — andere Bezugsquelle, dieselbe Modellgröße, kein Verfahrenswechsel; live verifiziert (2026-09-08), dass beide Felder für `icon_d2` mit plausiblen, variierenden Werten geliefert werden (nicht durchgehend Füllwert).
+- **T3-Stichprobenwert ist kein vorweggenommener Befund.** Der Wert 2h Vorlauf aus der Live-Probe (29.08., Wolayersee-Hütte) ist Testfall-Rohmaterial für AC-9, kein in der Spec festgeschriebenes Ergebnis der eigentlichen Messung.
+- **Blitzdichte bleibt außen vor** — strukturell FR-only (Météo-France-Größe), auf dem KHW (Gebiet DE_ALPEN) nicht vorhanden; die Ablation kennt auf dem KHW nur drei Äste (Wettercode/CAPE/Blitzpotenzial).
+- **Toleranzschwelle des Kalibrier-Abgleichs ist eine Auswertungsentscheidung dieser Spec** (halbe LOW-Sprosse), keine im Datenmaterial festgeschriebene Tatsache.
+- **`stundenzeilen_aus_archiv_antwort()` (Archiv-Zeilenformat) ist bewusst NICHT im Modul implementiert.** Kein AC verlangt sie, und ihr einziger denkbarer Aufrufer — der externe, einmalige Archiv-Abruf gegen `historical-forecast-api.open-meteo.com` — liegt laut dieser Spec explizit außerhalb des Repos (genau wie schon bei S1/S2a: "genau ein Lauf, kein Wartungswert"). Wer den Bericht erstellt, schreibt diesen Zip-Schritt dort ad-hoc; eine zusätzliche, nur für diese externe Nutzung gedachte Funktion im Repo würde entweder ungetestet bleiben oder Test-LoC für einen Pfad binden, der innerhalb des Repos nichts absichert (Adversary-Finding F003, Verdict-Runde S2c).
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** ADR-0025
+- **Rationale:** ADR-0025 legt fest, dass es genau EINE Gewitter-Fusionsquelle gibt (`thunder_level_from_signals()`/`thunder_signal_carriers()` in `metric_format.py`) und keine zweite Berechnung entstehen darf. Diese Spec baut deshalb KEINE eigene Fusionslogik nach: die Ablation ruft die bestehenden Funktionen mit rekonstruierten Rohwerten auf, statt eine zweite Fusionsregel zu schreiben. Der Wettercode-Ast (`wettercode_stufe`) ist keine Ausnahme — er spiegelt `_parse_thunder_level()` mit der importierten `THUNDER_CODES`-Konstante, keine eigene Kalibrierung.
+
+## Changelog
+
+- 2026-09-08: Initial spec created (Issue #2181, Scheibe S2c) — Nachfolger von Scheibe S2a (`feat_2181_s2a_gewitter_mitschnitt_auswertung.md`), deren Known Limitations diese Scheibe explizit als Folgearbeit benennen ("S2b" in der dortigen Terminologie).

--- a/src/analysis/thunder_ablation.py
+++ b/src/analysis/thunder_ablation.py
@@ -1,0 +1,181 @@
+"""Gewitter-Signalherkunft aus der Archiv-Rekonstruktion (#2181 Scheibe S2c).
+
+Kalibrier-Abgleich gegen den Mitschnitt, Ablation der Signalherkunft (T1),
+CAPE-Zeitverlauf und Ereignisfenster (T3) sowie Stufe-Niederschlag-Paarung
+(T4) auf stuendlichen Archiv-Zeilen eines Punktes. Reine Funktionen: kein
+Netz, kein Dateizugriff.
+
+ADR-0025: Es entsteht KEINE zweite Gewitter-Fusion. Die Ablation ruft
+``thunder_level_from_signals()``/``thunder_signal_carriers()`` aus
+``output.metric_format`` mit rekonstruierten Rohwerten auf; die Schwellen
+kommen vom Aufrufer (``app.model_registry``), die Stufenordnung aus
+``app.thunder_scale`` — hier steht kein eigener Zahlenwert.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from app.models import ThunderLevel
+from app.thunder_scale import thunder_ordinal, union_of_max_carriers
+from output.metric_format import thunder_level_from_signals, thunder_signal_carriers
+from providers.openmeteo import THUNDER_CODES
+
+
+def wettercode_stufe(weather_code: Optional[int]) -> Optional[ThunderLevel]:
+    """Der Wettercode-Ast, wie ``OpenMeteoProvider._parse_thunder_level()``.
+
+    ``None`` ist "keine Aussage" und darf nicht zur geprueeften Entwarnung
+    ``ThunderLevel.NONE`` kollabieren (AC-8)."""
+    if weather_code is None:
+        return None
+    return ThunderLevel.HIGH if weather_code in THUNDER_CODES else ThunderLevel.NONE
+
+
+def kalibrier_abgleich_kurzvorlauf_cape(
+    mitschnitt_tageswerte_primaer: dict[str, dict],
+    archiv_cape_tagesmaximum: dict[str, Optional[float]],
+    toleranz_jkg: float,
+) -> dict[str, dict]:
+    """Je Tag: liegt das Archiv-CAPE-Tagesmaximum im Toleranzband um den
+    kurzvorlauf-naechsten Mitschnitt-Wert?
+
+    ``toleranz_jkg`` ist eine Entscheidung des AUFRUFERS (empfohlen: halbe
+    LOW-Sprosse der CAPE-Leiter) — kein Zahlenwert dieses Moduls. Fehlt einer
+    der beiden Werte, ist der Tag "kein_vergleichswert" und traegt keine
+    Differenz (AC-2)."""
+    ergebnis: dict[str, dict] = {}
+    for tag in sorted(set(mitschnitt_tageswerte_primaer) | set(archiv_cape_tagesmaximum)):
+        mitschnitt_cape = mitschnitt_tageswerte_primaer.get(tag, {}).get("cape_max_jkg")
+        archiv_cape = archiv_cape_tagesmaximum.get(tag)
+        if mitschnitt_cape is None or archiv_cape is None:
+            ergebnis[tag] = {"kategorie": "kein_vergleichswert", "differenz_jkg": None}
+            continue
+        differenz = abs(archiv_cape - mitschnitt_cape)
+        ergebnis[tag] = {
+            "kategorie": "im_toleranzband" if differenz <= toleranz_jkg else "abweichend",
+            "differenz_jkg": differenz,
+        }
+    return ergebnis
+
+
+def ablation_je_stunde(
+    stundenzeile: dict,
+    cape_ladder: tuple[float, float, float],
+    lpi_thresholds: tuple[float, float, float],
+) -> dict:
+    """Stufe UND tragende Signale EINER Archiv-Stunde.
+
+    Stufe und Herkunft stammen aus derselben kanonischen Fusion (ADR-0025),
+    aufgerufen mit den rekonstruierten Rohwerten der Stunde. Die Blitzdichte
+    ist strukturell abwesend (FR-only), nicht "null gemessen"."""
+    cape_low, cape_med, cape_high = cape_ladder
+    lpi_low, lpi_med, lpi_high = lpi_thresholds
+    signale = (
+        wettercode_stufe(stundenzeile["weather_code"]),
+        None,
+        stundenzeile["cape"],
+        stundenzeile["lightning_potential"],
+    )
+    leitern = {
+        "cape_threshold_jkg": cape_low,
+        "cape_med_min": cape_med,
+        "cape_high_min": cape_high,
+        "cin_jkg": stundenzeile["convective_inhibition"],
+        "lpi_low_min": lpi_low,
+        "lpi_med_min": lpi_med,
+        "lpi_high_min": lpi_high,
+    }
+    return {
+        "stufe": thunder_level_from_signals(*signale, **leitern),
+        "traeger": thunder_signal_carriers(*signale, **leitern),
+    }
+
+
+def ablation_tagesmaximum(
+    stundenzeilen_tag: list[dict],
+    cape_ladder: tuple[float, float, float],
+    lpi_thresholds: tuple[float, float, float],
+) -> dict:
+    """Hoechststufe des Tages und die VEREINIGTE Traegermenge aller Stunden,
+    die genau diese Stufe erreichen (AC-6) — nicht nur der ersten."""
+    stunden = [ablation_je_stunde(s, cape_ladder, lpi_thresholds) for s in stundenzeilen_tag]
+    stufen = [e["stufe"] for e in stunden if e["stufe"] is not None]
+    paare = [(e["stufe"], e["traeger"]) for e in stunden]
+    return {
+        "stufe": max(stufen, key=thunder_ordinal) if stufen else None,
+        "traeger": union_of_max_carriers(paare) or [],
+    }
+
+
+def vergleiche_ablation_mit_mitschnitt(
+    ablation_tag: dict, mitschnitt_stufe: Optional[ThunderLevel],
+) -> dict:
+    """Stellt Ablation und Mitschnitt nebeneinander und weist ein Zurueck-
+    bleiben als EIGENE Kategorie aus, statt es einem der Aeste zuzuschlagen.
+
+    Der Radar-Override ist im Mitschnitt eingerechnet, aus der Rekonstruktion
+    aber strukturell unsichtbar (Known Limitations) — ein ``False`` hier ist
+    kein Fehler der Ablation."""
+    return {
+        "mitschnitt_stufe": mitschnitt_stufe,
+        "ablation_stufe": ablation_tag["stufe"],
+        "traeger": ablation_tag["traeger"],
+        "ablation_erreicht_mitschnitt_stufe":
+            thunder_ordinal(ablation_tag["stufe"]) >= thunder_ordinal(mitschnitt_stufe),
+    }
+
+
+def cape_verlauf_und_ereignisfenster(stundenzeilen_tag: list[dict]) -> dict:
+    """CAPE-Zeitverlauf, CAPE-Maximum und Abstand zur ersten Ereignisstunde.
+
+    Ohne Ereignisstunde bleiben ``erste_ereignisstunde`` und
+    ``vorlauf_stunden`` ``None`` (AC-10). Es wird nur gerechnet, kein
+    Sollwert geprueft."""
+    sortiert = sorted(stundenzeilen_tag, key=lambda s: datetime.fromisoformat(s["time"]))
+    stundenwerte = [(s["time"], s["cape"]) for s in sortiert]
+    mit_cape = [p for p in stundenwerte if p[1] is not None]
+    cape_maximum = max(mit_cape, key=lambda p: p[1]) if mit_cape else None
+    ereignisstunden = [s["time"] for s in sortiert if s["weather_code"] in THUNDER_CODES]
+    erste_ereignisstunde = ereignisstunden[0] if ereignisstunden else None
+    vorlauf_stunden = None
+    if erste_ereignisstunde is not None and cape_maximum is not None:
+        abstand = (datetime.fromisoformat(erste_ereignisstunde)
+                   - datetime.fromisoformat(cape_maximum[0]))
+        vorlauf_stunden = abstand.total_seconds() / 3600
+    return {
+        "stundenwerte": stundenwerte,
+        "cape_maximum": cape_maximum,
+        "erste_ereignisstunde": erste_ereignisstunde,
+        "vorlauf_stunden": vorlauf_stunden,
+    }
+
+
+def niederschlag_tagessumme(stundenzeilen_tag: list[dict]) -> dict:
+    """Tagessummen fuer Niederschlag und Schauer aus den Archiv-Stunden."""
+    return {
+        "niederschlag_mm": sum(s["precipitation"] for s in stundenzeilen_tag),
+        "schauer_mm": sum(s["showers"] for s in stundenzeilen_tag),
+    }
+
+
+def stufe_gegen_niederschlag(
+    mitschnitt_tageswerte: dict[str, dict],
+    archiv_niederschlag_je_tag: dict[str, dict],
+) -> dict[str, dict]:
+    """Je Tag NUR das rohe Tripel Stufe/Niederschlag/Schauer (AC-11).
+
+    Kein Interpretationsfeld ("nahe null" o.ae.) — die Bewertung entsteht im
+    Bericht ausserhalb des Repos. Eine fehlende Mitschnitt-Stufe bleibt
+    ``None`` und kollabiert nicht zu ``ThunderLevel.NONE`` (AC-12)."""
+    ergebnis: dict[str, dict] = {}
+    for tag in sorted(set(mitschnitt_tageswerte) | set(archiv_niederschlag_je_tag)):
+        stufe = mitschnitt_tageswerte.get(tag, {}).get("thunder_level_max")
+        niederschlag = archiv_niederschlag_je_tag.get(tag, {})
+        ergebnis[tag] = {
+            "stufe": None if stufe is None else ThunderLevel(stufe),
+            "niederschlag_mm": niederschlag.get("niederschlag_mm"),
+            "schauer_mm": niederschlag.get("schauer_mm"),
+        }
+    return ergebnis

--- a/tests/fixtures/khw_2026_08_archiv/kalibrier_abgleich_toleranzband_und_abweichend.json
+++ b/tests/fixtures/khw_2026_08_archiv/kalibrier_abgleich_toleranzband_und_abweichend.json
@@ -1,0 +1,15 @@
+{
+ "beschreibung": "AC-1: drei Tage -- Differenz 50 J/kg (< Toleranz 150), Differenz 400 J/kg (> Toleranz) und Differenz GENAU 150 J/kg (== Toleranz, inklusive Grenze -> im_toleranzband). Zahlen exakt wie in der Spec (AC-1 Testvorgabe), der Grenzfall-Tag ergaenzt den Mutations-Fund F001.",
+ "herkunft": "Spec-Vorgabe feat_2181_s2c_gewitter_archiv_ablation.md AC-1",
+ "mitschnitt_tageswerte_primaer": {
+  "2026-08-29": {"cape_max_jkg": 550.0, "thunder_level_max": "HIGH"},
+  "2026-09-02": {"cape_max_jkg": 500.0, "thunder_level_max": "MED"},
+  "2026-09-03": {"cape_max_jkg": 500.0, "thunder_level_max": "MED"}
+ },
+ "archiv_cape_tagesmaximum": {
+  "2026-08-29": 500.0,
+  "2026-09-02": 100.0,
+  "2026-09-03": 350.0
+ },
+ "toleranz_jkg": 150.0
+}

--- a/tests/fixtures/khw_2026_08_archiv/ruhiger_tag_ohne_ereignisstunde.json
+++ b/tests/fixtures/khw_2026_08_archiv/ruhiger_tag_ohne_ereignisstunde.json
@@ -1,0 +1,9 @@
+{
+ "beschreibung": "AC-10: ein ruhiger Tag ohne jede Ereignisstunde (kein Wettercode aus THUNDER_CODES) -- angelehnt an die Gegenprobe 25.08. aus der Live-Machbarkeitspruefung (LPI durchgehend 0.0, CIN meist 0-1), Einzelwerte konstruiert.",
+ "herkunft": "konstruiert nach Spec AC-10, Groessenordnung an docs/context/feat-2181-s2c-signalherkunft.md orientiert (Gegenprobe 25.08.)",
+ "stunden": [
+  {"time": "2026-08-25T09:00", "weather_code": 1, "cape": 30.0, "convective_inhibition": 0.0, "lightning_potential": 0.0, "precipitation": 0.0, "showers": 0.0},
+  {"time": "2026-08-25T13:00", "weather_code": 3, "cape": 60.0, "convective_inhibition": 1.0, "lightning_potential": 0.0, "precipitation": 0.0, "showers": 0.0},
+  {"time": "2026-08-25T17:00", "weather_code": 2, "cape": 20.0, "convective_inhibition": 0.0, "lightning_potential": 0.0, "precipitation": 0.0, "showers": 0.0}
+ ]
+}

--- a/tests/fixtures/khw_2026_08_archiv/stufe_gegen_niederschlag_high_tag.json
+++ b/tests/fixtures/khw_2026_08_archiv/stufe_gegen_niederschlag_high_tag.json
@@ -1,0 +1,7 @@
+{
+ "beschreibung": "AC-11: Mitschnitt-Tagesstufe HIGH fuer 2026-08-29 (realer Gewittertag, PO-bestaetigt: 14mm Niederschlag mit Gewitter) -- gepaart im Test mit der archiv-Niederschlagssumme aus wolayersee_29_08_ausschnitt.json.",
+ "herkunft": "thunder_level_max konstruiert entsprechend dem bekannten realen Tagesbefund (Issue #2181 S1-Korrektur), keine rohe Mitschnitt-Zeile fuer diesen Tag im Repo verfuegbar",
+ "mitschnitt_tageswerte": {
+  "2026-08-29": {"cape_max_jkg": 840.0, "thunder_level_max": "HIGH"}
+ }
+}

--- a/tests/fixtures/khw_2026_08_archiv/stufe_gegen_niederschlag_keine_mitschnitt_stufe.json
+++ b/tests/fixtures/khw_2026_08_archiv/stufe_gegen_niederschlag_keine_mitschnitt_stufe.json
@@ -1,0 +1,10 @@
+{
+ "beschreibung": "AC-12: ein Etappentag ohne gueltige Mitschnitt-Stufe (None, keine Aussage) -- darf im Ergebnis nicht zu ThunderLevel.NONE kollabieren.",
+ "herkunft": "konstruiert nach Spec AC-12",
+ "mitschnitt_tageswerte": {
+  "2026-09-03": {"cape_max_jkg": null, "thunder_level_max": null}
+ },
+ "archiv_niederschlag_je_tag": {
+  "2026-09-03": {"niederschlag_mm": 5.0, "schauer_mm": 0.0}
+ }
+}

--- a/tests/fixtures/khw_2026_08_archiv/synthetisch_blitzpotenzial_alleiniger_traeger.json
+++ b/tests/fixtures/khw_2026_08_archiv/synthetisch_blitzpotenzial_alleiniger_traeger.json
@@ -1,0 +1,7 @@
+{
+ "beschreibung": "AC-5: konstruierte Stunde mit Blitzpotenzial ueber der HIGH-Sprosse (50 J/kg, DE_ALPEN), Wettercode und CAPE unterhalb ihrer eigenen Sprossen.",
+ "herkunft": "konstruiert nach Spec AC-5",
+ "stunden": [
+  {"time": "2026-08-30T16:00", "weather_code": 2, "cape": 50.0, "convective_inhibition": 0.0, "lightning_potential": 60.0, "precipitation": 0.0, "showers": 0.0}
+ ]
+}

--- a/tests/fixtures/khw_2026_08_archiv/synthetisch_cape_hoch_cin_stark_gedaempft.json
+++ b/tests/fixtures/khw_2026_08_archiv/synthetisch_cape_hoch_cin_stark_gedaempft.json
@@ -1,0 +1,7 @@
+{
+ "beschreibung": "AC-4: konstruierte Stunde mit CAPE ueber der HIGH-Sprosse (1200 J/kg, icon_d2xDE_ALPEN) und CIN=150 (>100) -- die CIN-Daempfung muss die Stufe auf LOW deckeln, nicht ungedaempft HIGH zaehlen.",
+ "herkunft": "konstruiert nach Spec AC-4 (keine reale Archiv-Stunde mit dieser CAPE-Hoehe im KHW-Zeitraum aufgezeichnet)",
+ "stunden": [
+  {"time": "2026-08-30T15:00", "weather_code": 2, "cape": 1500.0, "convective_inhibition": 150.0, "lightning_potential": 0.0, "precipitation": 0.0, "showers": 0.0}
+ ]
+}

--- a/tests/fixtures/khw_2026_08_archiv/synthetisch_mitschnitt_high_ohne_archiv_treffer.json
+++ b/tests/fixtures/khw_2026_08_archiv/synthetisch_mitschnitt_high_ohne_archiv_treffer.json
@@ -1,0 +1,9 @@
+{
+ "beschreibung": "AC-7: ein Etappentag, dessen Archiv-Stunden hoechstens LOW erreichen, waehrend der Mitschnitt fuer denselben Tag HIGH zeigt (z.B. durch den Radar-Override, der aus der Rekonstruktion strukturell unsichtbar ist).",
+ "herkunft": "konstruiert nach Spec AC-7 / Known Limitations (Radar-Override)",
+ "mitschnitt_stufe": "HIGH",
+ "stunden": [
+  {"time": "2026-09-01T09:00", "weather_code": 2, "cape": 350.0, "convective_inhibition": 0.0, "lightning_potential": 0.0, "precipitation": 0.0, "showers": 0.0},
+  {"time": "2026-09-01T12:00", "weather_code": 2, "cape": 0.0, "convective_inhibition": 0.0, "lightning_potential": 0.0, "precipitation": 0.0, "showers": 0.0}
+ ]
+}

--- a/tests/fixtures/khw_2026_08_archiv/synthetisch_wettercode_fehlend_vs_explizit.json
+++ b/tests/fixtures/khw_2026_08_archiv/synthetisch_wettercode_fehlend_vs_explizit.json
@@ -1,0 +1,8 @@
+{
+ "beschreibung": "AC-8: zwei Stunden, identisch bis auf den Wettercode -- einmal fehlend (None, keine Aussage), einmal explizit 'kein Gewitter' (Code 2, geprueefte Entwarnung). CAPE und Blitzpotenzial fehlen in beiden Stunden ebenfalls, damit die Gesamtstufe ausschliesslich vom Wettercode-Ast abhaengt.",
+ "herkunft": "konstruiert nach Spec AC-8",
+ "stunden": [
+  {"time": "2026-09-01T18:00", "weather_code": null, "cape": null, "convective_inhibition": null, "lightning_potential": null, "precipitation": 0.0, "showers": 0.0},
+  {"time": "2026-09-01T19:00", "weather_code": 2, "cape": null, "convective_inhibition": null, "lightning_potential": null, "precipitation": 0.0, "showers": 0.0}
+ ]
+}

--- a/tests/fixtures/khw_2026_08_archiv/synthetisch_zwei_traeger_selbe_hoechststufe.json
+++ b/tests/fixtures/khw_2026_08_archiv/synthetisch_zwei_traeger_selbe_hoechststufe.json
@@ -1,0 +1,8 @@
+{
+ "beschreibung": "AC-6: zwei Stunden desselben Tages, die HIGH ueber verschiedene, jeweils alleinige Traeger erreichen (Wettercode bzw. CAPE) -- die Tagesverdichtung muss beide Namen in der Traegerliste fuehren.",
+ "herkunft": "konstruiert nach Spec AC-6",
+ "stunden": [
+  {"time": "2026-08-31T10:00", "weather_code": 96, "cape": 0.0, "convective_inhibition": 0.0, "lightning_potential": 0.0, "precipitation": 0.0, "showers": 0.0},
+  {"time": "2026-08-31T14:00", "weather_code": 2, "cape": 1500.0, "convective_inhibition": 0.0, "lightning_potential": 0.0, "precipitation": 0.0, "showers": 0.0}
+ ]
+}

--- a/tests/fixtures/khw_2026_08_archiv/wolayersee_29_08_ausschnitt.json
+++ b/tests/fixtures/khw_2026_08_archiv/wolayersee_29_08_ausschnitt.json
@@ -1,0 +1,9 @@
+{
+ "beschreibung": "Reale Archiv-Stunden der Live-Machbarkeitspruefung 2026-09-08 (historical-forecast-api.open-meteo.com, Modell icon_d2, 46.6123/12.8672 = Wolayersee-Huette, 29.08.2026). Ausschnitt von drei Stunden, nicht der volle Tag.",
+ "herkunft": "docs/context/feat-2181-s2c-signalherkunft.md, Abschnitt 'Live-Machbarkeitspruefung' -- unveraendert uebernommen",
+ "stunden": [
+  {"time": "2026-08-29T13:00", "weather_code": 2, "cape": 790.0, "convective_inhibition": 0.0, "lightning_potential": 0.0, "precipitation": 0.0, "showers": 0.0},
+  {"time": "2026-08-29T15:00", "weather_code": 96, "cape": 0.0, "convective_inhibition": 0.0, "lightning_potential": 2.6, "precipitation": 12.0, "showers": 0.2},
+  {"time": "2026-08-29T16:00", "weather_code": 99, "cape": 20.0, "convective_inhibition": 65.0, "lightning_potential": 0.0, "precipitation": 29.2, "showers": 0.1}
+ ]
+}

--- a/tests/tdd/test_thunder_ablation.py
+++ b/tests/tdd/test_thunder_ablation.py
@@ -1,0 +1,293 @@
+"""Gewitter-Signalherkunft — Ablation, CAPE-Zeitverlauf und Stufe-vs-Niederschlag
+fuer den KHW-Archiv-Zeitraum (#2181 Scheibe S2c).
+
+Prueft T1 (welcher Signalast traegt die erreichte Stufe?), T3 (CAPE-Vorlauf vor
+der ersten Ereignisstunde) und T4 (Stufe-Niederschlag-Paarung), vorgeschaltet
+ein Kalibrier-Abgleich (Archiv-CAPE gegen kurzvorlauf-naechste Mitschnitt-
+Teilmenge). Reine Funktionen: kein Netz, kein Dateizugriff. Die Fusion selbst
+(``thunder_signal_carriers``/``thunder_level_from_signals``) ist NICHT
+Pruefling (ADR-0025) -- sie wird mit rekonstruierten Rohwerten aufgerufen.
+
+Fixtures: die 29.08.-Stunden sind reale, unveraendert uebernommene Werte aus
+der Live-Machbarkeitspruefung gegen historical-forecast-api.open-meteo.com
+(docs/context/feat-2181-s2c-signalherkunft.md). Alle anderen Archiv-Stunden
+sind konstruiert, weil die realen Werte am KHW keine der Sprossen-Kombination
+liefern, die die jeweilige AC verlangt (S2c-Spec, Implementation Details).
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.analysis.thunder_ablation import (
+    ablation_je_stunde,
+    ablation_tagesmaximum,
+    cape_verlauf_und_ereignisfenster,
+    kalibrier_abgleich_kurzvorlauf_cape,
+    niederschlag_tagessumme,
+    stufe_gegen_niederschlag,
+    vergleiche_ablation_mit_mitschnitt,
+)
+from src.analysis.thunder_replay import tageswerte_je_teilmenge
+from src.app.model_registry import cape_ladder_thresholds_jkg, lpi_thresholds_jkg
+from src.app.models import ThunderLevel
+from src.providers.openmeteo import THUNDER_CODES
+
+_FIXTURES = Path(__file__).resolve().parents[1] / "fixtures" / "khw_2026_08_archiv"
+_MITSCHNITT_FIXTURES = Path(__file__).resolve().parents[1] / "fixtures" / "khw_2026_08"
+
+_ARCHIV_STUNDENZEILEN_FIXTURES = [
+    "wolayersee_29_08_ausschnitt.json",
+    "synthetisch_cape_hoch_cin_stark_gedaempft.json",
+    "synthetisch_blitzpotenzial_alleiniger_traeger.json",
+    "synthetisch_zwei_traeger_selbe_hoechststufe.json",
+    "synthetisch_mitschnitt_high_ohne_archiv_treffer.json",
+    "synthetisch_wettercode_fehlend_vs_explizit.json",
+    "ruhiger_tag_ohne_ereignisstunde.json",
+]
+
+
+def _fixture(name: str) -> dict:
+    return json.loads((_FIXTURES / name).read_text(encoding="utf-8"))
+
+
+def _mitschnitt_zeilen(name: str) -> list[dict]:
+    return json.loads((_MITSCHNITT_FIXTURES / name).read_text(encoding="utf-8"))["zeilen"]
+
+
+def _stunde(stunden: list[dict], zeit: str) -> dict:
+    treffer = [s for s in stunden if s["time"] == zeit]
+    assert len(treffer) == 1, f"genau eine Stunde {zeit} erwartet, {len(treffer)} gefunden"
+    return treffer[0]
+
+
+def _cape_ladder() -> tuple:
+    schwellen = cape_ladder_thresholds_jkg("icon_d2", "DE_ALPEN")
+    assert schwellen is not None, "CAPE-Leiter fuer icon_d2/DE_ALPEN nicht kalibriert"
+    return schwellen
+
+
+def _lpi_leiter() -> tuple:
+    schwellen = lpi_thresholds_jkg("DE_ALPEN")
+    assert schwellen is not None, "LPI-Leiter fuer DE_ALPEN nicht kalibriert"
+    return schwellen
+
+
+def test_ac1_kalibrier_abgleich_markiert_toleranzband_und_abweichung():
+    """AC-1: Differenz 50 J/kg (< Toleranz 150) -> "im_toleranzband";
+    Differenz 400 J/kg (> Toleranz) -> "abweichend"; Differenz GENAU 150 J/kg
+    (== Toleranz) -> "im_toleranzband" (inklusive Grenze, F001-Mutationsfund:
+    ein ``<`` statt ``<=`` an dieser Stelle liefe hier unbemerkt durch)."""
+    daten = _fixture("kalibrier_abgleich_toleranzband_und_abweichend.json")
+
+    ergebnis = kalibrier_abgleich_kurzvorlauf_cape(
+        daten["mitschnitt_tageswerte_primaer"],
+        daten["archiv_cape_tagesmaximum"],
+        daten["toleranz_jkg"],
+    )
+
+    assert ergebnis["2026-08-29"]["kategorie"] == "im_toleranzband"
+    assert ergebnis["2026-08-29"]["differenz_jkg"] == pytest.approx(50.0)
+    assert ergebnis["2026-09-02"]["kategorie"] == "abweichend"
+    assert ergebnis["2026-09-02"]["differenz_jkg"] == pytest.approx(400.0)
+    assert ergebnis["2026-09-03"]["kategorie"] == "im_toleranzband"
+    assert ergebnis["2026-09-03"]["differenz_jkg"] == pytest.approx(150.0)
+
+
+def test_ac1_toleranz_ist_die_halbe_low_sprosse_nicht_hartkodiert():
+    """AC-1: die Toleranz (150 J/kg) ist die HALBE LOW-Sprosse von
+    icon_d2/DE_ALPEN -- kein freier Prozentwert im Modul."""
+    low, _, _ = _cape_ladder()
+    assert low / 2 == 150.0
+
+
+def test_ac2_tag_ohne_gueltigen_vorlauf_ist_kein_vergleichswert():
+    """AC-2: ein Mitschnitt-Tag ohne jede Zeile mit gueltigem Vorlauf fehlt in
+    ``mitschnitt_tageswerte_primaer`` komplett -- der Kalibrier-Abgleich
+    markiert ihn als "kein_vergleichswert", nie als "im_toleranzband"."""
+    zeilen = _mitschnitt_zeilen("negativer_vorlauf_einzelzeile.json")
+    mitschnitt_primaer = tageswerte_je_teilmenge(zeilen)["primaer"]
+    assert "2026-08-21" not in mitschnitt_primaer
+
+    ergebnis = kalibrier_abgleich_kurzvorlauf_cape(
+        mitschnitt_primaer, {"2026-08-21": 500.0}, toleranz_jkg=150.0,
+    )
+
+    assert ergebnis["2026-08-21"]["kategorie"] == "kein_vergleichswert"
+    assert ergebnis["2026-08-21"]["differenz_jkg"] is None
+
+
+def test_ac3_wettercode_traegt_high_unabhaengig_von_schwaecheren_signalen():
+    """AC-3: ``weather_code=96`` liefert HIGH mit Traeger "wettercode",
+    unabhaengig davon, dass CAPE (0.0) und LPI (2.6) unter ihrer HIGH-Sprosse
+    bleiben (reale 15:00-Stunde vom 29.08.)."""
+    stunde = _stunde(_fixture("wolayersee_29_08_ausschnitt.json")["stunden"], "2026-08-29T15:00")
+    assert stunde["weather_code"] == 96
+
+    ergebnis = ablation_je_stunde(stunde, _cape_ladder(), _lpi_leiter())
+
+    assert ergebnis == {"stufe": ThunderLevel.HIGH, "traeger": ["wettercode"]}
+
+
+def test_ac4_gedaempfte_cape_stufe_erreicht_hoechstens_low():
+    """AC-4: CAPE 1500 J/kg (ueber der HIGH-Sprosse 1200) mit CIN=150
+    (>100 J/kg) wird durch die CIN-Daempfung auf hoechstens LOW gedeckelt,
+    nicht ungedaempft als HIGH gezaehlt."""
+    stunde = _fixture("synthetisch_cape_hoch_cin_stark_gedaempft.json")["stunden"][0]
+
+    ergebnis = ablation_je_stunde(stunde, _cape_ladder(), _lpi_leiter())
+
+    assert ergebnis == {"stufe": ThunderLevel.LOW, "traeger": ["cape"]}
+
+
+def test_ac5_blitzpotenzial_alleiniger_traeger_der_hoechststufe():
+    """AC-5: LPI 60 (ueber der HIGH-Sprosse 50) bei code=2 (kein Gewitter)
+    und niedrigem CAPE (50) -- "blitzpotenzial" ist der ALLEINIGE Traeger."""
+    stunde = _fixture("synthetisch_blitzpotenzial_alleiniger_traeger.json")["stunden"][0]
+
+    ergebnis = ablation_je_stunde(stunde, _cape_ladder(), _lpi_leiter())
+
+    assert ergebnis == {"stufe": ThunderLevel.HIGH, "traeger": ["blitzpotenzial"]}
+
+
+def test_ac6_tagesverdichtung_vereint_alle_traeger_der_hoechststufe():
+    """AC-6: zwei Stunden desselben Tages erreichen HIGH ueber je einen
+    ANDEREN alleinigen Traeger -- die Tagesverdichtung fuehrt BEIDE Namen."""
+    stunden = _fixture("synthetisch_zwei_traeger_selbe_hoechststufe.json")["stunden"]
+    cape_ladder, lpi_leiter = _cape_ladder(), _lpi_leiter()
+
+    einzel = [ablation_je_stunde(s, cape_ladder, lpi_leiter) for s in stunden]
+    assert [e["stufe"] for e in einzel] == [ThunderLevel.HIGH, ThunderLevel.HIGH]
+    assert einzel[0]["traeger"] == ["wettercode"]
+    assert einzel[1]["traeger"] == ["cape"]
+
+    tag = ablation_tagesmaximum(stunden, cape_ladder, lpi_leiter)
+
+    assert tag["stufe"] == ThunderLevel.HIGH
+    assert set(tag["traeger"]) == {"wettercode", "cape"}
+
+
+def test_ac7_archiv_erreicht_mitschnitt_high_nicht_eigene_kategorie():
+    """AC-7: alle Archiv-Stunden des Tages bleiben hoechstens LOW, waehrend
+    der Mitschnitt HIGH zeigt -- ``ablation_erreicht_mitschnitt_stufe`` wird
+    False, statt still einem der drei Aeste zugeschlagen zu werden."""
+    daten = _fixture("synthetisch_mitschnitt_high_ohne_archiv_treffer.json")
+    cape_ladder, lpi_leiter = _cape_ladder(), _lpi_leiter()
+    stunden = daten["stunden"]
+
+    assert all(
+        ablation_je_stunde(s, cape_ladder, lpi_leiter)["stufe"] != ThunderLevel.HIGH
+        for s in stunden
+    )
+
+    tag = ablation_tagesmaximum(stunden, cape_ladder, lpi_leiter)
+    vergleich = vergleiche_ablation_mit_mitschnitt(tag, ThunderLevel(daten["mitschnitt_stufe"]))
+
+    assert vergleich == {
+        "mitschnitt_stufe": ThunderLevel.HIGH,
+        "ablation_stufe": tag["stufe"],
+        "traeger": tag["traeger"],
+        "ablation_erreicht_mitschnitt_stufe": False,
+    }
+    assert vergleich["ablation_stufe"] != ThunderLevel.HIGH
+
+
+def test_ac7_gleichstand_zaehlt_als_erreicht():
+    """AC-7 (Gegenprobe, F002-Mutationsfund): Ablation und Mitschnitt auf
+    GENAU derselben Stufe -- ``ablation_erreicht_mitschnitt_stufe`` muss
+    ``True`` sein (``>=`` statt ``>`` an dieser Stelle), nicht nur beim
+    Ueberholen der Mitschnitt-Stufe."""
+    ablation_tag = {"stufe": ThunderLevel.MED, "traeger": ["cape"]}
+
+    vergleich = vergleiche_ablation_mit_mitschnitt(ablation_tag, ThunderLevel.MED)
+
+    assert vergleich["ablation_erreicht_mitschnitt_stufe"] is True
+
+
+def test_ac8_fehlender_wettercode_traegt_nicht_explizite_entwarnung_schon():
+    """AC-8: ``weather_code=None`` fehlt im Signal-Dict (Gesamtstufe ``None``
+    = keine Aussage) -- ``weather_code=2`` liefert dagegen die geprueefte
+    Entwarnung ``ThunderLevel.NONE``, bei sonst identischen (fehlenden)
+    Signalen."""
+    fehlend, explizit = _fixture("synthetisch_wettercode_fehlend_vs_explizit.json")["stunden"]
+    cape_ladder, lpi_leiter = _cape_ladder(), _lpi_leiter()
+
+    assert fehlend["weather_code"] is None
+    assert ablation_je_stunde(fehlend, cape_ladder, lpi_leiter) == {"stufe": None, "traeger": []}
+
+    assert explizit["weather_code"] == 2
+    ergebnis = ablation_je_stunde(explizit, cape_ladder, lpi_leiter)
+    assert ergebnis == {"stufe": ThunderLevel.NONE, "traeger": []}
+
+
+def test_ac9_vorlauf_zwischen_cape_maximum_und_erster_ereignisstunde():
+    """AC-9: reale 29.08.-Stunden -- CAPE-Maximum 790 J/kg um 13:00, erste
+    Ereignisstunde (code=96, in THUNDER_CODES) um 15:00 -> 2.0h Vorlauf.
+    Reine Rechenprobe, kein festgeschriebenes "muss 1-3h sein"-Kriterium."""
+    stunden = _fixture("wolayersee_29_08_ausschnitt.json")["stunden"]
+    assert stunden[1]["weather_code"] in THUNDER_CODES
+
+    ergebnis = cape_verlauf_und_ereignisfenster(stunden)
+
+    assert ergebnis["stundenwerte"] == [
+        ("2026-08-29T13:00", 790.0), ("2026-08-29T15:00", 0.0), ("2026-08-29T16:00", 20.0),
+    ]
+    assert ergebnis["cape_maximum"] == ("2026-08-29T13:00", 790.0)
+    assert ergebnis["erste_ereignisstunde"] == "2026-08-29T15:00"
+    assert ergebnis["vorlauf_stunden"] == pytest.approx(2.0)
+
+
+def test_ac10_kein_rechenfehler_ohne_ereignisstunde():
+    """AC-10: ein Tag ganz ohne Ereignisstunde liefert ``None``/``None`` fuer
+    ``erste_ereignisstunde``/``vorlauf_stunden`` -- kein erfundener Wert."""
+    stunden = _fixture("ruhiger_tag_ohne_ereignisstunde.json")["stunden"]
+    assert all(s["weather_code"] not in THUNDER_CODES for s in stunden)
+
+    ergebnis = cape_verlauf_und_ereignisfenster(stunden)
+
+    assert ergebnis["erste_ereignisstunde"] is None
+    assert ergebnis["vorlauf_stunden"] is None
+    assert ergebnis["cape_maximum"] is not None
+
+
+def test_ac11_stufe_gegen_niederschlag_liefert_nur_das_rohe_tripel():
+    """AC-11: NUR (Stufe, Niederschlagssumme, Schauersumme) je Tag -- kein
+    Schwellenwert-Interpretationsfeld wie "nahe null"."""
+    mitschnitt = _fixture("stufe_gegen_niederschlag_high_tag.json")["mitschnitt_tageswerte"]
+    archiv_stunden = _fixture("wolayersee_29_08_ausschnitt.json")["stunden"]
+    niederschlag_tag = niederschlag_tagessumme(archiv_stunden)
+    assert niederschlag_tag["niederschlag_mm"] == pytest.approx(41.2)
+    assert niederschlag_tag["schauer_mm"] == pytest.approx(0.3)
+
+    ergebnis = stufe_gegen_niederschlag(mitschnitt, {"2026-08-29": niederschlag_tag})
+
+    assert set(ergebnis["2026-08-29"]) == {"stufe", "niederschlag_mm", "schauer_mm"}
+    assert ergebnis["2026-08-29"]["stufe"] == ThunderLevel.HIGH
+    assert ergebnis["2026-08-29"]["niederschlag_mm"] == pytest.approx(41.2)
+    assert ergebnis["2026-08-29"]["schauer_mm"] == pytest.approx(0.3)
+
+
+def test_ac12_fehlende_mitschnitt_stufe_kollabiert_nicht_zu_none_level():
+    """AC-12: eine Mitschnitt-Stufe ``None`` (keine Aussage) bleibt im
+    Ergebnis ``None`` -- kollabiert nicht zu ``ThunderLevel.NONE``."""
+    daten = _fixture("stufe_gegen_niederschlag_keine_mitschnitt_stufe.json")
+
+    ergebnis = stufe_gegen_niederschlag(
+        daten["mitschnitt_tageswerte"], daten["archiv_niederschlag_je_tag"],
+    )
+
+    assert ergebnis["2026-09-03"]["stufe"] is None
+
+
+@pytest.mark.parametrize("name", _ARCHIV_STUNDENZEILEN_FIXTURES)
+def test_fixtures_tragen_das_archiv_stundenzeilen_format(name):
+    """Waechter: jede Archiv-Stundenzeile traegt genau die sieben Felder der
+    Zip-Ausgabe (Spec Abschnitt "Archiv-Zeilenformat"), keine mehr, keine
+    weniger -- verhindert Fixture-Drift gegen die reale Antwortform."""
+    erwartete_schluessel = {
+        "time", "weather_code", "cape", "convective_inhibition",
+        "lightning_potential", "precipitation", "showers",
+    }
+    for stunde in _fixture(name)["stunden"]:
+        assert set(stunde) == erwartete_schluessel


### PR DESCRIPTION
## Summary
- Neues Analyse-Modul `src/analysis/thunder_ablation.py` prüft für #2181 (Scheibe S2c) drei Thesen gegen den KHW-Archiv-Zeitraum: T1 (Signalherkunft-Ablation), T3 (CAPE-Vorlauf vor erster Gewitterstunde), T4 (Stufe-Niederschlag-Paarung)
- Vorgeschaltet: Kalibrier-Abgleich, der die Archiv-Rekonstruktion gegen den bereits gesicherten Vorhersage-Mitschnitt prüft
- Reine Funktionen ohne Netz-/DB-Zugriff, ruft die bestehende Gewitter-Fusion unverändert auf (ADR-0025) — keine zweite Fusionsregel

## Test plan
- [x] 21 Feature-Tests grün (`tests/tdd/test_thunder_ablation.py`, alle 12 ACs abgedeckt)
- [x] 213 Regressionstests der geteilten Gewitter-Bausteine grün
- [x] Import-Check über volle Suite (1105 Einträge, `--collect-only`) fehlerfrei
- [x] Adversary-Verdict: VERIFIED
- [x] Scope-Check: nur die in der Spec genannten Dateien + eine begründete Doku-Ergänzung

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017M8SzRbBRBPiaCoQMJoS7A